### PR TITLE
daemons: name init functions and have one `init`

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -130,17 +130,6 @@ var (
 	bootstrapStats = bootstrapStatistics{}
 )
 
-func init() {
-	RootCmd.SetFlagErrorFunc(func(_ *cobra.Command, e error) error {
-		time.Sleep(fatalSleep)
-		return e
-	})
-	logrus.RegisterExitHandler(func() {
-		time.Sleep(fatalSleep)
-	},
-	)
-}
-
 // Execute sets up gops, installs the cleanup signal handler and invokes
 // the root command. This function only returns when an interrupt
 // signal has been received. This is intended to be called by main.main().
@@ -165,6 +154,23 @@ func skipInit(basePath string) bool {
 }
 
 func init() {
+	setupSleepBeforeFatal()
+	initializeFlags()
+	registerBootstrapMetrics()
+}
+
+func setupSleepBeforeFatal() {
+	RootCmd.SetFlagErrorFunc(func(_ *cobra.Command, e error) error {
+		time.Sleep(fatalSleep)
+		return e
+	})
+	logrus.RegisterExitHandler(func() {
+		time.Sleep(fatalSleep)
+	},
+	)
+}
+
+func initializeFlags() {
 	if skipInit(path.Base(os.Args[0])) {
 		log.Debug("Skipping preparation of cilium-agent environment")
 		return

--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -107,7 +107,7 @@ var (
 	metricBootstrapTimes prometheus.ObserverVec
 )
 
-func init() {
+func registerBootstrapMetrics() {
 	metricBootstrapTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metrics.Namespace,
 		Subsystem: metrics.SubsystemAgent,


### PR DESCRIPTION
This change refactors and names 3 of `cmd/daemon` `init` functions so
that the order of their execution and what they do is clearer.