### PR TITLE
policy: Add a bpf compiling option when `enable-icmp-rules` flag is set

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -541,6 +541,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	}
 	cDefinesMap["VLAN_FILTER(ifindex, vlan_id)"] = vlanFilter
 
+	if option.Config.EnableICMPRules {
+		cDefinesMap["ENABLE_ICMP_RULE"] = "1"
+	}
+
 	// Since golang maps are unordered, we sort the keys in the map
 	// to get a consistent writtern format to the writer. This maintains
 	// the consistency when we try to calculate hash for a datapath after


### PR DESCRIPTION
By this commit, bpf program is compiled with `-DENABLE_ICMP_RULE` option when `enable-icmp-rules` flag is set.

Signed-off-by: Tomoki Sugiura <tomoki.sugiura@mail.shanpu.info>