### PR TITLE
.github/workflows: checkout all git history for Image GC

### DIFF
--- a/.github/workflows/ci-images-garbage-collect.yaml
+++ b/.github/workflows/ci-images-garbage-collect.yaml
@@ -13,7 +13,9 @@ jobs:
     name: scruffy
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
+        with:
+          fetch-depth: 0
       - uses: docker://quay.io/cilium/scruffy:v0.0.1@sha256:15e3926d8e74aa6a278cc07fb61d5888322fabdae49637384dc6a3fb32452969
         with:
           entrypoint: scruffy


### PR DESCRIPTION
Scruffy verifies if a commit exists in the git history before it
sets the quay.io image for garbage collection. In order to guarantee
that images from the tree are not deleted, the GitHub action needs to
have all commits of branches checked out.

Signed-off-by: André Martins <andre@cilium.io>