### PR TITLE
Speed up build image process for PRs

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -11,6 +11,15 @@ on:
     branches:
       - master
 
+  # If the cache was cleaned we should re-build the cache with the latest commit
+  workflow_run:
+    workflows:
+     - "Image CI Cache Cleaner"
+    branches:
+     - master
+    types:
+     - completed
+
 permissions: read-all
 
 concurrency:
@@ -110,7 +119,10 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          push: true
+          # Only push when the event name was a GitHub push, this is to avoid
+          # re-pushing the image tags when we only want to re-create the Golang
+          # docker cache after the workflow "Image CI Cache Cleaner" was terminated.
+          push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64,linux/arm64
           tags: |
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest
@@ -125,7 +137,10 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          push: true
+          # Only push when the event name was a GitHub push, this is to avoid
+          # re-pushing the image tags when we only want to re-create the Golang
+          # docker cache after the workflow "Image CI Cache Cleaner" was terminated.
+          push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64
           tags: |
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest-race
@@ -293,7 +308,10 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          push: true
+          # Only push when the event name was a GitHub push, this is to avoid
+          # re-pushing the image tags when we only want to re-create the Golang
+          # docker cache after the workflow "Image CI Cache Cleaner" was terminated.
+          push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64,linux/arm64
           tags: |
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -74,6 +74,34 @@ jobs:
           persist-credentials: false
           ref: ${{ steps.tag.outputs.tag }}
 
+      # Load Golang cache build from GitHub
+      - name: Load ${{ matrix.name }} Golang cache build from GitHub
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        id: cache
+        with:
+          path: /tmp/.cache/${{ matrix.name }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.name }}-
+            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
+            ${{ runner.os }}-go-
+
+      - name: Create ${{ matrix.name }} cache directory
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/${{ matrix.name }}
+
+      # Import GitHub's cache build to docker cache
+      - name: Copy ${{ matrix.name }} Golang cache to docker cache
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        with:
+          context: /tmp/.cache/${{ matrix.name }}
+          file: ./images/cache/Dockerfile
+          push: false
+          platforms: linux/amd64
+          target: import-cache
+
       # master branch pushes
       - name: CI Build ${{ matrix.name }}
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -173,6 +201,31 @@ jobs:
           path: image-digest
           retention-days: 1
 
+      # Store docker's golang's cache build locally only on the main branch
+      - name: Store ${{ matrix.name }} Golang cache build locally
+        if: ${{ github.event_name != 'pull_request_target' && steps.cache.outputs.cache-hit != 'true' }}
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        with:
+          context: .
+          file: ./images/cache/Dockerfile
+          push: false
+          outputs: type=local,dest=/tmp/docker-cache-${{ matrix.name }}
+          platforms: linux/amd64
+          target: export-cache
+
+      # Store docker's golang's cache build locally only on the main branch
+      - name: Store ${{ matrix.name }} Golang cache in GitHub cache path
+        if: ${{ github.event_name != 'pull_request_target' && steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/${{ matrix.name }}/
+          if [ -f /tmp/docker-cache-${{ matrix.name }}/tmp/go-build-cache.tar.gz ]; then
+            cp /tmp/docker-cache-${{ matrix.name }}/tmp/go-build-cache.tar.gz /tmp/.cache/${{ matrix.name }}/
+          fi
+          if [ -f /tmp/docker-cache-${{ matrix.name }}/tmp/go-pkg-cache.tar.gz ]; then
+            cp /tmp/docker-cache-${{ matrix.name }}/tmp/go-pkg-cache.tar.gz /tmp/.cache/${{ matrix.name }}/
+          fi
+
   # we need to build cilium-test separately
   # this is caused by running apt while building the image
   # which requires qemu setup in order to avoid x86/arm64 binaries mixups
@@ -206,6 +259,34 @@ jobs:
           persist-credentials: false
           ref: ${{ github.sha }}
 
+      # Load Golang cache build from GitHub
+      - name: Load ${{ matrix.name }} Golang cache build from GitHub
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        id: cache
+        with:
+          path: /tmp/.cache/${{ matrix.name }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.name }}-
+            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
+            ${{ runner.os }}-go-
+
+      - name: Create ${{ matrix.name }} cache directory
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/${{ matrix.name }}
+
+      # Import GitHub's cache build to docker cache
+      - name: Copy ${{ matrix.name }} Golang cache to docker cache
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        with:
+          context: /tmp/.cache/${{ matrix.name }}
+          file: ./images/cache/Dockerfile
+          push: false
+          platforms: linux/amd64
+          target: import-cache
+
       - name: CI Build ${{ matrix.name }}
         uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
         id: docker_build_ci_master
@@ -232,6 +313,31 @@ jobs:
           name: image-digest ${{ matrix.name }}
           path: image-digest
           retention-days: 1
+
+      # Store docker's golang's cache build locally only on the main branch
+      - name: Store ${{ matrix.name }} Golang cache build locally
+        if: ${{ github.event_name != 'pull_request_target' && steps.cache.outputs.cache-hit != 'true' }}
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        with:
+          context: .
+          file: ./images/cache/Dockerfile
+          push: false
+          outputs: type=local,dest=/tmp/docker-cache-${{ matrix.name }}
+          platforms: linux/amd64
+          target: export-cache
+
+      # Store docker's golang's cache build locally only on the main branch
+      - name: Store ${{ matrix.name }} Golang cache in GitHub cache path
+        if: ${{ github.event_name != 'pull_request_target' && steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/${{ matrix.name }}/
+          if [ -f /tmp/docker-cache-${{ matrix.name }}/tmp/go-build-cache.tar.gz ]; then
+            cp /tmp/docker-cache-${{ matrix.name }}/tmp/go-build-cache.tar.gz /tmp/.cache/${{ matrix.name }}/
+          fi
+          if [ -f /tmp/docker-cache-${{ matrix.name }}/tmp/go-pkg-cache.tar.gz ]; then
+            cp /tmp/docker-cache-${{ matrix.name }}/tmp/go-pkg-cache.tar.gz /tmp/.cache/${{ matrix.name }}/
+          fi
 
       - name: Send slack notification
         if: ${{ !success() && (github.event_name == 'schedule' || github.event_name == 'push') }}

--- a/.github/workflows/ci-images-cache-cleaner.yaml
+++ b/.github/workflows/ci-images-cache-cleaner.yaml
@@ -1,0 +1,65 @@
+name: Image CI Cache Cleaner
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+  schedule:
+    # Run the GC every Monday at 6am
+    - cron: "0 6 * * 1"
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
+jobs:
+  cache-cleaner:
+    if: ${{ github.repository == 'cilium/cilium' }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - name: cilium
+
+          - name: operator-aws
+
+          - name: operator-azure
+
+          - name: operator-alibabacloud
+
+          - name: operator-generic
+
+          - name: hubble-relay
+
+          - name: clustermesh-apiserver
+
+          - name: docker-plugin
+
+          - name: cilium-test
+
+    steps:
+      # Load Golang cache build from GitHub
+      - name: Load ${{ matrix.name }} Golang cache build from GitHub
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        id: cache
+        with:
+          path: /tmp/.cache/${{ matrix.name }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.name }}-
+            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
+            ${{ runner.os }}-go-
+
+      - name: Create ${{ matrix.name }} cache directory
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/${{ matrix.name }}
+
+      # Clean docker's golang's cache
+      - name: Clean ${{ matrix.name }} Golang cache from GitHub
+        shell: bash
+        run: |
+          rm -f /tmp/.cache/${{ matrix.name }}/go-build-cache.tar.gz
+          rm -f /tmp/.cache/${{ matrix.name }}/go-pkg-cache.tar.gz

--- a/images/cache/Dockerfile
+++ b/images/cache/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.2
+
+# Copyright 2020-2021 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+FROM docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad as import-cache
+
+RUN --mount=type=bind,target=/host-tmp \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
+    mkdir -p /root/.cache/go-build; \
+    mkdir -p /go/pkg; \
+    if [ -f /host-tmp/go-build-cache.tar.gz ]; then \
+      tar xzf /host-tmp/go-build-cache.tar.gz --no-same-owner -C /root/.cache/go-build; \
+    fi; \
+    if [ -f /host-tmp/go-pkg-cache.tar.gz ]; then \
+      tar xzf /host-tmp/go-pkg-cache.tar.gz --no-same-owner -C /go/pkg; \
+    fi
+
+FROM docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad as cache-creator
+RUN --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
+    tar czf /tmp/go-build-cache.tar.gz -C /root/.cache/go-build . ; \
+    tar czf /tmp/go-pkg-cache.tar.gz -C /go/pkg .
+
+FROM scratch as export-cache
+
+COPY --from=cache-creator \
+        /tmp/go-build-cache.tar.gz \
+        /tmp/go-pkg-cache.tar.gz \
+        /tmp/

--- a/images/cilium-docker-plugin/Dockerfile
+++ b/images/cilium-docker-plugin/Dockerfile
@@ -21,7 +21,7 @@ ARG LOCKDEBUG
 ARG RACE
 
 WORKDIR /go/src/github.com/cilium/cilium/plugins/cilium-docker
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} \
     && mkdir -p /out/${TARGETOS}/${TARGETARCH}/usr/bin && mv cilium-docker /out/${TARGETOS}/${TARGETARCH}/usr/bin
 

--- a/images/cilium-test/Dockerfile
+++ b/images/cilium-test/Dockerfile
@@ -21,19 +21,19 @@ RUN mkdir -p /out/linux/amd64/usr/local/bin /out/linux/arm64/usr/local/bin
 
 WORKDIR /go/src/github.com/cilium/cilium/images/cilium-test
 
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
   go build -o /out/linux/amd64/usr/local/bin/ginkgo github.com/onsi/ginkgo/ginkgo
 
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
   env GOARCH=arm64 CC=aarch64-linux-gnu-gcc \
     go build -o /out/linux/arm64/usr/local/bin/ginkgo github.com/onsi/ginkgo/ginkgo
 
 WORKDIR /go/src/github.com/cilium/cilium/test
 
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
   /out/linux/amd64/usr/local/bin/ginkgo build ./ && mv test.test /out/linux/amd64/usr/local/bin/cilium-test
 
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
   env GOARCH=arm64 CC=aarch64-linux-gnu-gcc \
     /out/linux/amd64/usr/local/bin/ginkgo build ./ && mv test.test /out/linux/arm64/usr/local/bin/cilium-test
 

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -47,11 +47,11 @@ ARG LIBNETWORK_PLUGIN
 # as that will mess with caching for incremental builds!
 #
 WORKDIR /go/src/github.com/cilium/cilium
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     make IMAGE_CROSS_TARGET_PLATFORM=${TARGETOS}/${TARGETARCH} GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} PKG_BUILD=1 V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
     SKIP_DOCS=true DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} build-container install-container-binary
 
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     # install-bash-completion will execute the bash_completion script. It is
     # fine to run this with same architecture as BUILDARCH since the output of
     # bash_completion is the same for both architectures.

--- a/images/clustermesh-apiserver/Dockerfile
+++ b/images/clustermesh-apiserver/Dockerfile
@@ -22,16 +22,16 @@ ARG LOCKDEBUG
 ARG RACE
 
 WORKDIR /go/src/github.com/cilium/cilium/clustermesh-apiserver
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     mkdir -p /out/${TARGETOS}/${TARGETARCH} && cp etcd-config.yaml /out/${TARGETOS}/${TARGETARCH}/etcd-config.yaml
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} \
     && mkdir -p /out/${TARGETOS}/${TARGETARCH}/usr/bin && mv clustermesh-apiserver /out/${TARGETOS}/${TARGETARCH}/usr/bin
 
 WORKDIR /go/src/github.com/cilium/cilium
 # licenses-all is a "script" that executes "go run" so its ARCH should be set
 # to the same ARCH specified in the base image of this Docker stage (BUILDARCH)
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     make GOARCH=${BUILDARCH} licenses-all && mv LICENSE.all /out/${TARGETOS}/${TARGETARCH}
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
@@ -48,7 +48,7 @@ FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} as gops
 # build-gops.sh will build both archs at the same time
 WORKDIR /go/src/github.com/cilium/cilium/images/runtime
 RUN apt-get update && apt-get install -y binutils-aarch64-linux-gnu
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     ./build-gops.sh
 
 FROM ${BASE_IMAGE}

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -22,14 +22,14 @@ ARG LOCKDEBUG
 ARG RACE
 
 WORKDIR /go/src/github.com/cilium/cilium/hubble-relay
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} \
     && mkdir -p /out/${TARGETOS}/${TARGETARCH}/usr/bin && mv hubble-relay /out/${TARGETOS}/${TARGETARCH}/usr/bin
 
 WORKDIR /go/src/github.com/cilium/cilium
 # licenses-all is a "script" that executes "go run" so its ARCH should be set
 # to the same ARCH specified in the base image of this Docker stage (BUILDARCH)
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     make GOARCH=${BUILDARCH} licenses-all && mv LICENSE.all /out/${TARGETOS}/${TARGETARCH}
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
@@ -46,7 +46,7 @@ FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} as gops
 # build-gops.sh will build both archs at the same time
 WORKDIR /go/src/github.com/cilium/cilium/images/runtime
 RUN apt-get update && apt-get install -y binutils-aarch64-linux-gnu
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     ./build-gops.sh
 
 FROM ${BASE_IMAGE}

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -23,14 +23,19 @@ ARG RACE
 ARG OPERATOR_VARIANT
 
 WORKDIR /go/src/github.com/cilium/cilium/operator
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
     make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} cilium-${OPERATOR_VARIANT} \
     && mkdir -p /out/${TARGETOS}/${TARGETARCH}/usr/bin && mv cilium-${OPERATOR_VARIANT} /out/${TARGETOS}/${TARGETARCH}/usr/bin
 
 WORKDIR /go/src/github.com/cilium/cilium
 # licenses-all is a "script" that executes "go run" so its ARCH should be set
 # to the same ARCH specified in the base image of this Docker stage (BUILDARCH)
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
     make GOARCH=${BUILDARCH} licenses-all && mv LICENSE.all /out/${TARGETOS}/${TARGETARCH}
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
@@ -47,7 +52,9 @@ FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} as gops
 # build-gops.sh will build both archs at the same time
 WORKDIR /go/src/github.com/cilium/cilium/images/runtime
 RUN apt-get update && apt-get install -y binutils-aarch64-linux-gnu
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
     ./build-gops.sh
 
 FROM ${BASE_IMAGE}


### PR DESCRIPTION
Most of the PRs use the same code base. Thus, we can store Golang's
build cache on GitHub and re-use it for PR builds to speed up the
building process of the PRs code.

Since Docker buildx share the mount of type 'cache' across image builds,
the GitHub workflow to build images will populate its cache using a
'dummy' Dockerfile located in 'images/cache/Dockerfile'. This cache will
always be updated every time a build is executed in the master branch
and all PRs will reuse this cache to build their images.

The times that take each build process are:
```
Current build process     - master branch - ~ 11m3s
Build with cache hit      - master branch - ~ 9m26s (-14.63%)
Build with cache miss [1] - master branch - ~ 12m (+8.59%)

Current build process     - Pull Request  - ~ 11m1s
Cache hit PR [2]          - Pull Request  - ~ 4m17 (-61.11%)
```
[1] A cache miss will only happen if the cache is cleaned up / deleted
will only be deliberate.

[2] This was tested on a source code where there was a new line added
in the cilium-agent source code. Adding a new line meant that most of
the build cache was reused. The best case scenario are PRs that don't
change a single line of the Golang's source code, where the build
process will take less than 4m17s. The worst case scenario will be a PR
that change all of the source code for which the build time will be no
worse than 11m1s.

The reason why it takes more time on a cache hit on the master branch
than on a PR cache hit is due to the fact that the master branch will
spend the time storing the new cache where the PR will not store any
cache

Fixes https://github.com/cilium/cilium/issues/14928