### PR TITLE
pkg: rename egresspolicy package to egressgateway

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -29,7 +29,7 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/egresspolicy"
+	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -169,7 +169,7 @@ type Daemon struct {
 
 	bgpSpeaker *speaker.Speaker
 
-	egressPolicyManager *egresspolicy.Manager
+	egressGatewayManager *egressgateway.Manager
 
 	apiLimiterSet *rate.APILimiterSet
 
@@ -430,7 +430,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		d.bgpSpeaker = speaker.New()
 	}
 
-	d.egressPolicyManager = egresspolicy.NewEgressPolicyManager()
+	d.egressGatewayManager = egressgateway.NewEgressGatewayManager()
 
 	d.k8sWatcher = watchers.NewK8sWatcher(
 		d.endpointManager,
@@ -441,7 +441,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		d.datapath,
 		d.redirectPolicyManager,
 		d.bgpSpeaker,
-		d.egressPolicyManager,
+		d.egressGatewayManager,
 		option.Config,
 	)
 	nd.RegisterK8sNodeGetter(d.k8sWatcher)

--- a/pkg/egressgateway/doc.go
+++ b/pkg/egressgateway/doc.go
@@ -12,6 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// Package egresspolicy defines an internal representation of the Cilium Egress
-// Policy. The structures are managed by the EgressPolicyManager.
-package egresspolicy
+// Package egressgateway defines an internal representation of the Cilium Egress
+// Policy. The structures are managed by the Manager.
+package egressgateway

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package egresspolicy
+package egressgateway
 
 import (
 	"fmt"
@@ -30,8 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// Config is the internal representation of Cilium Egress NAT Policy.
-type Config struct {
+// PolicyConfig is the internal representation of Cilium Egress NAT Policy.
+type PolicyConfig struct {
 	// id is the parsed config name and namespace
 	id types.NamespacedName
 
@@ -59,7 +59,7 @@ type endpointMetadata struct {
 
 // policyConfigSelectsEndpoint determines if the given endpoint is selected by the policy
 // config based on matching labels of config and endpoint.
-func (config *Config) policyConfigSelectsEndpoint(endpointInfo *endpointMetadata) bool {
+func (config *PolicyConfig) policyConfigSelectsEndpoint(endpointInfo *endpointMetadata) bool {
 	labelsToMatch := k8sLabels.Set(endpointInfo.labels)
 	for _, selector := range config.endpointSelectors {
 		if selector.Matches(labelsToMatch) {
@@ -69,9 +69,9 @@ func (config *Config) policyConfigSelectsEndpoint(endpointInfo *endpointMetadata
 	return false
 }
 
-// Parse takes a CiliumEgressNATPolicy CR and converts to Config, the internal
-// representation of the egress nat policy
-func Parse(cenp *v2alpha1.CiliumEgressNATPolicy) (*Config, error) {
+// ParsePolicy takes a CiliumEgressNATPolicy CR and converts to PolicyConfig,
+// the internal representation of the egress nat policy
+func ParsePolicy(cenp *v2alpha1.CiliumEgressNATPolicy) (*PolicyConfig, error) {
 	var endpointSelectorList []api.EndpointSelector
 	var dstCidrList []*net.IPNet
 
@@ -131,7 +131,7 @@ func Parse(cenp *v2alpha1.CiliumEgressNATPolicy) (*Config, error) {
 		}
 	}
 
-	return &Config{
+	return &PolicyConfig{
 		endpointSelectors: endpointSelectorList,
 		dstCIDRs:          dstCidrList,
 		egressIP:          net.ParseIP(cenp.Spec.EgressSourceIP).To4(),
@@ -141,8 +141,8 @@ func Parse(cenp *v2alpha1.CiliumEgressNATPolicy) (*Config, error) {
 	}, nil
 }
 
-// ParseConfigID takes a CiliumEgressNATPolicy CR and returns only the config id
-func ParseConfigID(cenp *v2alpha1.CiliumEgressNATPolicy) types.NamespacedName {
+// ParsePolicyConfigID takes a CiliumEgressNATPolicy CR and returns only the config id
+func ParsePolicyConfigID(cenp *v2alpha1.CiliumEgressNATPolicy) types.NamespacedName {
 	return policyID{
 		Name: cenp.Name,
 	}

--- a/pkg/k8s/watchers/cilium_egress_gateway_policy.go
+++ b/pkg/k8s/watchers/cilium_egress_gateway_policy.go
@@ -15,7 +15,7 @@
 package watchers
 
 import (
-	"github.com/cilium/cilium/pkg/egresspolicy"
+	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/informer"
@@ -94,12 +94,12 @@ func (k *K8sWatcher) addCiliumEgressNATPolicy(cenp *cilium_v2alpha1.CiliumEgress
 		logfields.K8sAPIVersion:             cenp.TypeMeta.APIVersion,
 	})
 
-	ep, err := egresspolicy.Parse(cenp)
+	ep, err := egressgateway.ParsePolicy(cenp)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to add CiliumEgressNATPolicy: malformed policy config.")
 		return err
 	}
-	if _, err := k.egressPolicyManager.AddEgressPolicy(*ep); err != nil {
+	if _, err := k.egressGatewayManager.AddEgressPolicy(*ep); err != nil {
 		scopedLog.WithError(err).Warn("Failed to add CiliumEgressNATPolicy.")
 		return err
 	}
@@ -115,8 +115,8 @@ func (k *K8sWatcher) deleteCiliumEgressNATPolicy(cenp *cilium_v2alpha1.CiliumEgr
 		logfields.K8sAPIVersion:             cenp.TypeMeta.APIVersion,
 	})
 
-	epID := egresspolicy.ParseConfigID(cenp)
-	if err := k.egressPolicyManager.DeleteEgressPolicy(epID); err != nil {
+	epID := egressgateway.ParsePolicyConfigID(cenp)
+	if err := k.egressGatewayManager.DeleteEgressPolicy(epID); err != nil {
 		scopedLog.WithError(err).Warn("Failed to delete CiliumEgressNATPolicy.")
 		return err
 	}

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -201,7 +201,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 	}
 
 	if option.Config.EnableEgressGateway {
-		k.egressPolicyManager.OnUpdateEndpoint(endpoint)
+		k.egressGatewayManager.OnUpdateEndpoint(endpoint)
 	}
 }
 
@@ -234,6 +234,6 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 		}
 	}
 	if option.Config.EnableEgressGateway {
-		k.egressPolicyManager.OnDeleteEndpoint(endpoint)
+		k.egressGatewayManager.OnDeleteEndpoint(endpoint)
 	}
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath"
-	"github.com/cilium/cilium/pkg/egresspolicy"
+	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -155,8 +155,8 @@ type bgpSpeakerManager interface {
 
 	OnUpdateNode(node *corev1.Node)
 }
-type egressPolicyManager interface {
-	AddEgressPolicy(config egresspolicy.Config) (bool, error)
+type egressGatewayManager interface {
+	AddEgressPolicy(config egressgateway.PolicyConfig) (bool, error)
 	DeleteEgressPolicy(configID types.NamespacedName) error
 	OnUpdateEndpoint(endpoint *k8sTypes.CiliumEndpoint)
 	OnDeleteEndpoint(endpoint *k8sTypes.CiliumEndpoint)
@@ -185,7 +185,7 @@ type K8sWatcher struct {
 	svcManager            svcManager
 	redirectPolicyManager redirectPolicyManager
 	bgpSpeakerManager     bgpSpeakerManager
-	egressPolicyManager   egressPolicyManager
+	egressGatewayManager  egressGatewayManager
 
 	// controllersStarted is a channel that is closed when all controllers, i.e.,
 	// k8s watchers have started listening for k8s events.
@@ -217,7 +217,7 @@ func NewK8sWatcher(
 	datapath datapath.Datapath,
 	redirectPolicyManager redirectPolicyManager,
 	bgpSpeakerManager bgpSpeakerManager,
-	egressPolicyManager egressPolicyManager,
+	egressGatewayManager egressGatewayManager,
 	cfg WatcherConfiguration,
 ) *K8sWatcher {
 	return &K8sWatcher{
@@ -232,7 +232,7 @@ func NewK8sWatcher(
 		datapath:              datapath,
 		redirectPolicyManager: redirectPolicyManager,
 		bgpSpeakerManager:     bgpSpeakerManager,
-		egressPolicyManager:   egressPolicyManager,
+		egressGatewayManager:  egressGatewayManager,
 		cfg:                   cfg,
 	}
 }


### PR DESCRIPTION
This commit does not introduce any functional change, it just renames
the package to make it explicit it relates to the egress gateway
feature.

Fixes: #17389