### PR TITLE
docs: Remove instructions for nodeinit on various platforms

### DIFF
--- a/Documentation/gettingstarted/alibabacloud-eni.rst
+++ b/Documentation/gettingstarted/alibabacloud-eni.rst
@@ -174,8 +174,7 @@ Deploy Cilium release via Helm:
      --set alibabacloud.enabled=true \\
      --set ipam.mode=alibabacloud \\
      --set enableIPv4Masquerade=false \\
-     --set tunnel=disabled \\
-     --set nodeinit.enabled=true
+     --set tunnel=disabled
 
 .. note::
 

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -60,8 +60,7 @@ Deploy Cilium via Helm:
      --namespace kube-system \\
      --set cni.chainingMode=aws-cni \\
      --set enableIPv4Masquerade=false \\
-     --set tunnel=disabled \\
-     --set nodeinit.enabled=true
+     --set tunnel=disabled
 
 This will enable chaining with the AWS VPC CNI plugin. It will also disable
 tunneling, as it's not required since ENI IP addresses can be directly routed

--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -166,8 +166,7 @@ Install Cilium
             --set eni.enabled=true \\
             --set ipam.mode=eni \\
             --set egressMasqueradeInterfaces=eth0 \\
-            --set tunnel=disabled \\
-            --set nodeinit.enabled=true
+            --set tunnel=disabled
 
        .. note::
 

--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -43,7 +43,6 @@ Then, install Cilium release via Helm:
 
    helm install cilium |CHART_RELEASE| \\
       --namespace kube-system \\
-      --set nodeinit.enabled=true \\
       --set kubeProxyReplacement=partial \\
       --set hostServices.enabled=false \\
       --set externalIPs.enabled=true \\
@@ -172,7 +171,6 @@ Make sure context is set to ``kind-cluster2`` cluster.
 
    helm install cilium |CHART_RELEASE| \\
       --namespace kube-system \\
-      --set nodeinit.enabled=true \\
       --set kubeProxyReplacement=partial \\
       --set hostServices.enabled=false \\
       --set externalIPs.enabled=true \\
@@ -191,7 +189,6 @@ Change the kubectl context to ``kind-cluster1`` cluster:
 
    helm install cilium |CHART_RELEASE| \\
       --namespace kube-system \\
-      --set nodeinit.enabled=true \\
       --set kubeProxyReplacement=partial \\
       --set hostServices.enabled=false \\
       --set externalIPs.enabled=true \\

--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -47,6 +47,7 @@ iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq: ensure nat POST
 date > {{ .Values.nodeinit.bootstrapFile }}
 {{- end }}
 
+{{- if .Values.azure.enabled }}
 # AKS: If azure-vnet is installed on the node, and (still) configured in bridge mode,
 # configure it as 'transparent' to be consistent with Cilium's CNI chaining config.
 # If the azure-vnet CNI config is not removed, kubelet will execute CNI CHECK commands
@@ -57,7 +58,6 @@ if [ -f /etc/cni/net.d/10-azure.conflist ]; then
   sed -i 's/"mode":\s*"bridge"/"mode":"transparent"/g' /etc/cni/net.d/10-azure.conflist
 fi
 
-{{- if .Values.azure.enabled }}
 # The azure0 interface being present means the node was booted with azure-vnet configured
 # in bridge mode. This means there might be ebtables rules and neight entries interfering
 # with pod connectivity if we deploy with Azure IPAM.


### PR DESCRIPTION
*nodeinit: Move azure bridge handing under azure.enabled*

    The azure bridge handling code in nodeinit was previously run in every
    environment where nodeinit is enabled instead of only when azure.enabled
    was set. Move this set of code inside the azure conditional section of the
    template.

*docs: Remove nodeinit instructions where unused*

    * The install/kubernetes/cilium/files/nodeinit/startup.bash template
      file is primarily dependent on explicit nodeinit configurations for it
      to have any effect, eg:
      * .Values.nodeinit.removeCbrBridge
      * .Values.nodeinit.reconfigureKubelet
      * .Values.gke.enabled ...
      * .Values.azure.enabled
      * .Values.nodeinit.revertReconfigureKubelet
    * The install/kubernetes/cilium/files/nodeinit/prestop.bash template
      file is also similarly mainly dependent on other options, with one
      exception: it can delete the cilium_host device.

    Given that the alibaba ENI, aws-cni, AWS ENI mode, and kind installation
    instructions don't configure these other options, the nodeinit daemonset
    does not need to be installed on these systems. The only case that
    should differ is upon shutdown of the nodeinit DS, which doesn't fully
    clean up Cilium state anyway so users should use 'cilium uninstall' CLI
    to clean up such clusters.
