### PR TITLE
pkg/k8s: fix invalid memory address or nil pointer dereference

### DIFF
--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -211,7 +211,7 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 		for _, pair := range endpoint.Networking.Addressing {
 			if pair.IPV4 != "" {
 				k8sMeta := ipcache.IPIdentityCache.GetK8sMetadata(pair.IPV4)
-				if k8sMeta.Namespace == endpoint.Namespace && k8sMeta.PodName == endpoint.Name {
+				if k8sMeta != nil && k8sMeta.Namespace == endpoint.Namespace && k8sMeta.PodName == endpoint.Name {
 					portsChanged := ipcache.IPIdentityCache.Delete(pair.IPV4, source.CustomResource)
 					if portsChanged {
 						namedPortsChanged = true
@@ -221,7 +221,7 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 
 			if pair.IPV6 != "" {
 				k8sMeta := ipcache.IPIdentityCache.GetK8sMetadata(pair.IPV6)
-				if k8sMeta.Namespace == endpoint.Namespace && k8sMeta.PodName == endpoint.Name {
+				if k8sMeta != nil && k8sMeta.Namespace == endpoint.Namespace && k8sMeta.PodName == endpoint.Name {
 					portsChanged := ipcache.IPIdentityCache.Delete(pair.IPV6, source.CustomResource)
 					if portsChanged {
 						namedPortsChanged = true


### PR DESCRIPTION
Since k8sMeta might return nil, we should check for it before accessing
the fields of that structure otherwise we will risk on panic for a nil
pointer dereference.

Fixes: 63c0b29787e6 ("Checks k8s metadata for pod before removing IP from ipccahe")
Signed-off-by: André Martins <andre@cilium.io>

```
2021-10-18T14:33:44.882292070Z Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
2021-10-18T14:33:44.882354474Z goroutine 269 [running]:
2021-10-18T14:33:44.882361875Z k8s.io/apimachinery/pkg/util/runtime.logPanic({0x226b480, 0x4037bc0})
2021-10-18T14:33:44.882367475Z 	/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x85
2021-10-18T14:33:44.882374176Z k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc00013ebe0})
2021-10-18T14:33:44.882382676Z 	/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
2021-10-18T14:33:44.882388577Z panic({0x226b480, 0x4037bc0})
2021-10-18T14:33:44.882392477Z 	/usr/local/go/src/runtime/panic.go:1038 +0x215
2021-10-18T14:33:44.882396577Z github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).endpointDeleted(0xc0009ec380, 0xc001f31bc0)
2021-10-18T14:33:44.882412178Z 	/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_endpoint.go:214 +0xc5
2021-10-18T14:33:44.882416979Z github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumEndpointsInit.func3({0x25f7ce0, 0xc001f31bc0})
2021-10-18T14:33:44.882421779Z 	/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_endpoint.go:71 +0xa5
2021-10-18T14:33:44.882425479Z k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
2021-10-18T14:33:44.882429380Z 	/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:245
2021-10-18T14:33:44.882434180Z github.com/cilium/cilium/pkg/k8s/informer.NewInformerWithStore.func1({0x22ae5a0, 0xc001e70708})
2021-10-18T14:33:44.882437880Z 	/go/src/github.com/cilium/cilium/pkg/k8s/informer/informer.go:114 +0x216
2021-10-18T14:33:44.882441380Z k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc00013ebe0, 0xc0000b1300)
2021-10-18T14:33:44.882444981Z 	/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:544 +0x2ea
2021-10-18T14:33:44.882448781Z k8s.io/client-go/tools/cache.(*controller).processLoop(0xc00041d440)
2021-10-18T14:33:44.882452581Z 	/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:183 +0x36
2021-10-18T14:33:44.882456081Z k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x7f0cdf4d71e0)
2021-10-18T14:33:44.882459382Z 	/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x67
2021-10-18T14:33:44.882462982Z k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xf579c8, {0x2a4b760, 0xc0004c6870}, 0x1, 0xc0000565a0)
2021-10-18T14:33:44.882466282Z 	/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xb6
2021-10-18T14:33:44.882469682Z k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00041d4a8, 0x3b9aca00, 0x0, 0x80, 0x7f0cdf2e81e8)
2021-10-18T14:33:44.882497484Z 	/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x89
2021-10-18T14:33:44.882501484Z k8s.io/apimachinery/pkg/util/wait.Until(...)
2021-10-18T14:33:44.882504985Z 	/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
2021-10-18T14:33:44.882508685Z k8s.io/client-go/tools/cache.(*controller).Run(0xc00041d440, 0xc0000565a0)
2021-10-18T14:33:44.882512485Z 	/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:154 +0x2fb
2021-10-18T14:33:44.882515885Z created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).ciliumEndpointsInit
2021-10-18T14:33:44.882519986Z 	/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_endpoint.go:87 +0x65
```