### PR TITLE
workflows: disable AKS testing with encryption enabled

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -271,35 +271,44 @@ jobs:
         run: |
           cilium connectivity test --flow-validation=disabled
 
+      # AKS testing with encryption is disabled due to https://github.com/cilium/cilium-cli/issues/342
+      # Re-enabling tracked in: https://github.com/cilium/cilium/issues/17644
       - name: Clean up Cilium
+        if: ${{ false }} # see comment above for details
         run: |
           cilium uninstall --wait
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
 
       - name: Create custom IPsec secret
+        if: ${{ false }} # see comment above for details
         run: |
           kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
       - name: Install Cilium with encryption
+        if: ${{ false }} # see comment above for details
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
             --encryption=ipsec
 
       - name: Enable Relay
+        if: ${{ false }} # see comment above for details
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
       - name: Wait for Cilium status to be ready
+        if: ${{ false }} # see comment above for details
         run: |
           cilium status --wait
 
       - name: Port forward Relay
+        if: ${{ false }} # see comment above for details
         run: |
           cilium hubble port-forward&
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
+        if: ${{ false }} # see comment above for details
         run: |
           cilium connectivity test --force-deploy --flow-validation=disabled
 

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -274,35 +274,44 @@ jobs:
         run: |
           cilium connectivity test --flow-validation=disabled
 
+      # AKS testing with encryption is disabled due to https://github.com/cilium/cilium-cli/issues/342
+      # Re-enabling tracked in: https://github.com/cilium/cilium/issues/17644
       - name: Clean up Cilium
+        if: ${{ false }} # see comment above for details
         run: |
           cilium uninstall --wait
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
 
       - name: Create custom IPsec secret
+        if: ${{ false }} # see comment above for details
         run: |
           kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
       - name: Install Cilium with encryption
+        if: ${{ false }} # see comment above for details
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
             --encryption=ipsec
 
       - name: Enable Relay
+        if: ${{ false }} # see comment above for details
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
       - name: Wait for Cilium status to be ready
+        if: ${{ false }} # see comment above for details
         run: |
           cilium status --wait
 
       - name: Port forward Relay
+        if: ${{ false }} # see comment above for details
         run: |
           cilium hubble port-forward&
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
+        if: ${{ false }} # see comment above for details
         run: |
           cilium connectivity test --force-deploy --flow-validation=disabled
 


### PR DESCRIPTION
https://github.com/cilium/cilium-cli/issues/342 is hit almost consistently on AKS when running the second `cilium connectivity test` with encryption enabled.

We disable AKS testing with encryption enabled until it is fixed.