### PR TITLE
k8s: keep CiliumNode labels synced with Node object

### DIFF
--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -4,102 +4,74 @@
 package watchers
 
 import (
-	"sync"
-
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/informer"
-	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/lock"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 )
 
-func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncControllers *sync.WaitGroup) {
-	// CiliumNode objects are used for node discovery until the key-value
-	// store is connected
-	var once sync.Once
-	for {
-		swgNodes := lock.NewStoppableWaitGroup()
-		_, ciliumNodeInformer := informer.NewInformer(
-			cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
-				cilium_v2.CNPluralName, v1.NamespaceAll, fields.Everything()),
-			&cilium_v2.CiliumNode{},
-			0,
-			cache.ResourceEventHandlerFuncs{
-				AddFunc: func(obj interface{}) {
-					var valid, equal bool
-					defer func() { k.K8sEventReceived(metricCiliumNode, metricCreate, valid, equal) }()
-					if ciliumNode := k8s.ObjToCiliumNode(obj); ciliumNode != nil {
+func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient) {
+	ciliumNodeStore, ciliumNodeInformer := informer.NewInformer(
+		cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
+			cilium_v2.CNPluralName, v1.NamespaceAll, fields.Everything()),
+		&cilium_v2.CiliumNode{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				var valid, equal bool
+				defer func() { k.K8sEventReceived(metricCiliumNode, metricCreate, valid, equal) }()
+				if ciliumNode := k8s.ObjToCiliumNode(obj); ciliumNode != nil {
+					valid = true
+					n := nodeTypes.ParseCiliumNode(ciliumNode)
+					if n.IsLocal() {
+						return
+					}
+					k.nodeDiscoverManager.NodeUpdated(n)
+					k.K8sEventProcessed(metricCiliumNode, metricCreate, true)
+				}
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				var valid, equal bool
+				defer func() { k.K8sEventReceived(metricCiliumNode, metricUpdate, valid, equal) }()
+				if oldCN := k8s.ObjToCiliumNode(oldObj); oldCN != nil {
+					if ciliumNode := k8s.ObjToCiliumNode(newObj); ciliumNode != nil {
 						valid = true
+						if oldCN.DeepEqual(ciliumNode) {
+							equal = true
+							return
+						}
 						n := nodeTypes.ParseCiliumNode(ciliumNode)
 						if n.IsLocal() {
 							return
 						}
 						k.nodeDiscoverManager.NodeUpdated(n)
-						k.K8sEventProcessed(metricCiliumNode, metricCreate, true)
+						k.K8sEventProcessed(metricCiliumNode, metricUpdate, true)
 					}
-				},
-				UpdateFunc: func(oldObj, newObj interface{}) {
-					var valid, equal bool
-					defer func() { k.K8sEventReceived(metricCiliumNode, metricUpdate, valid, equal) }()
-					if oldCN := k8s.ObjToCiliumNode(oldObj); oldCN != nil {
-						if ciliumNode := k8s.ObjToCiliumNode(newObj); ciliumNode != nil {
-							valid = true
-							if oldCN.DeepEqual(ciliumNode) {
-								equal = true
-								return
-							}
-							n := nodeTypes.ParseCiliumNode(ciliumNode)
-							if n.IsLocal() {
-								return
-							}
-							k.nodeDiscoverManager.NodeUpdated(n)
-							k.K8sEventProcessed(metricCiliumNode, metricUpdate, true)
-						}
-					}
-				},
-				DeleteFunc: func(obj interface{}) {
-					var valid, equal bool
-					defer func() { k.K8sEventReceived(metricCiliumNode, metricDelete, valid, equal) }()
-					ciliumNode := k8s.ObjToCiliumNode(obj)
-					if ciliumNode == nil {
-						return
-					}
-					valid = true
-					n := nodeTypes.ParseCiliumNode(ciliumNode)
-					k.nodeDiscoverManager.NodeDeleted(n)
-				},
+				}
 			},
-			k8s.ConvertToCiliumNode,
-		)
-		isConnected := make(chan struct{})
-		// once isConnected is closed, it will stop waiting on caches to be
-		// synchronized.
-		k.blockWaitGroupToSyncResources(isConnected, swgNodes, ciliumNodeInformer.HasSynced, k8sAPIGroupCiliumNodeV2)
+			DeleteFunc: func(obj interface{}) {
+				var valid, equal bool
+				defer func() { k.K8sEventReceived(metricCiliumNode, metricDelete, valid, equal) }()
+				ciliumNode := k8s.ObjToCiliumNode(obj)
+				if ciliumNode == nil {
+					return
+				}
+				valid = true
+				n := nodeTypes.ParseCiliumNode(ciliumNode)
+				k.nodeDiscoverManager.NodeDeleted(n)
+			},
+		},
+		k8s.ConvertToCiliumNode,
+	)
 
-		once.Do(func() {
-			// Signalize that we have put node controller in the wait group
-			// to sync resources.
-			asyncControllers.Done()
-		})
-		k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumNodeV2)
-		go ciliumNodeInformer.Run(isConnected)
+	k.ciliumNodeStore = ciliumNodeStore
 
-		<-kvstore.Connected()
-		close(isConnected)
-
-		log.Info("Connected to key-value store, stopping CiliumNode watcher")
-
-		k.cancelWaitGroupToSyncResources(k8sAPIGroupCiliumNodeV2)
-		k.k8sAPIGroups.RemoveAPI(k8sAPIGroupCiliumNodeV2)
-		// Create a new node controller when we are disconnected with the
-		// kvstore
-		<-kvstore.Client().Disconnected()
-
-		log.Info("Disconnected from key-value store, restarting CiliumNode watcher")
-	}
+	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, ciliumNodeInformer.HasSynced, k8sAPIGroupCiliumNodeV2)
+	go ciliumNodeInformer.Run(wait.NeverStop)
+	k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumNodeV2)
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -202,6 +202,8 @@ type K8sWatcher struct {
 
 	nodeStore cache.Store
 
+	ciliumNodeStore cache.Store
+
 	namespaceStore cache.Store
 	datapath       datapath.Datapath
 
@@ -417,8 +419,7 @@ func (k *K8sWatcher) EnableK8sWatcher(ctx context.Context, resources []string) e
 			asyncControllers.Add(1)
 			go k.namespacesInit(k8s.WatcherClient(), asyncControllers)
 		case k8sAPIGroupCiliumNodeV2:
-			asyncControllers.Add(1)
-			go k.ciliumNodeInit(ciliumNPClient, asyncControllers)
+			go k.ciliumNodeInit(ciliumNPClient)
 		// Kubernetes built-in resources
 		case k8sAPIGroupNetworkingV1Core:
 			swgKNP := lock.NewStoppableWaitGroup()


### PR DESCRIPTION
This commit ensures that any update to the labels of a k8s Node object
is reflected in the corresponding CiliumNode one.