### PR TITLE
.travis.yml: Disable arm64-graviton2-race

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,17 @@ jobs:
         - RACE=1
         - BASE_IMAGE=quay.io/cilium/cilium-runtime:f6698fe61dbe11019946e5cf5a92077cc8d4a6a9@sha256:9acfa5f4c64482d3dbe19c319f135f5e856f02b479b5eba06efa8691d74e1d4d
         - LOCKDEBUG=1
-    - arch: arm64-graviton2
-      name: "arm64-graviton2-race"
-      if: type != pull_request
-      env:
-        - RACE=1
-        - BASE_IMAGE=quay.io/cilium/cilium-runtime:f6698fe61dbe11019946e5cf5a92077cc8d4a6a9@sha256:9acfa5f4c64482d3dbe19c319f135f5e856f02b479b5eba06efa8691d74e1d4d
-        - LOCKDEBUG=1
-      virt: vm
-      group: edge
+
+# Disabled due to a compilation issue: https://github.com/cilium/cilium/issues/13252
+#    - arch: arm64-graviton2
+#      name: "arm64-graviton2-race"
+#      if: type != pull_request
+#      env:
+#        - RACE=1
+#        - BASE_IMAGE=quay.io/cilium/cilium-runtime:f6698fe61dbe11019946e5cf5a92077cc8d4a6a9@sha256:9acfa5f4c64482d3dbe19c319f135f5e856f02b479b5eba06efa8691d74e1d4d
+#        - LOCKDEBUG=1
+#      virt: vm
+#      group: edge
 
 if: branch = master OR type = pull_request
 


### PR DESCRIPTION
As reported in #13252 the test fails due to a compilation issue.
Disable it until the issue has been resolved to avoid unnecessarily
failing master branch checks.