### PR TITLE
bug/pkg/health: Fix Nil Address Issue in Node Update Mechanism

### DIFF
--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -182,16 +182,15 @@ func (p *prober) setNodes(added nodeMap, removed nodeMap) {
 	for _, n := range added {
 		for elem, primary := range n.Addresses() {
 			_, addr := resolveIP(&n, elem, "icmp", primary)
+			if addr == nil {
+				continue
+			}
 
 			ip := ipString(elem.IP)
 			result := &models.ConnectivityStatus{}
-			if addr == nil {
-				result.Status = "Failed to resolve IP"
-			} else {
-				result.Status = "Connection timed out"
-				p.AddIPAddr(addr)
-				p.nodes[ip] = n
-			}
+			result.Status = "Connection timed out"
+			p.AddIPAddr(addr)
+			p.nodes[ip] = n
 
 			if p.results[ip] == nil {
 				p.results[ip] = &models.PathStatus{

--- a/pkg/health/server/prober_test.go
+++ b/pkg/health/server/prober_test.go
@@ -53,6 +53,26 @@ func makeHealthNode(nodeIdx, healthIdx int) (healthNode, net.IP, net.IP) {
 	}, net.ParseIP(nodeIP), net.ParseIP(healthIP)
 }
 
+func makeHealthNodeNil(nodeIdx, healthIdx int) (healthNode, net.IP, net.IP) {
+	nodeIP := fmt.Sprintf("192.0.2.%d", nodeIdx)
+	healthIP := fmt.Sprintf("10.0.2.%d", healthIdx)
+	return healthNode{
+		NodeElement: &models.NodeElement{
+			Name:           fmt.Sprintf("node-%d", nodeIdx),
+			PrimaryAddress: nil,
+			HealthEndpointAddress: &models.NodeAddressing{
+				IPV4: &models.NodeAddressingElement{
+					IP:      healthIP,
+					Enabled: true,
+				},
+				IPV6: &models.NodeAddressingElement{
+					Enabled: false,
+				},
+			},
+		},
+	}, net.ParseIP(nodeIP), net.ParseIP(healthIP)
+}
+
 func sortNodes(nodes map[string][]*net.IPAddr) map[string][]*net.IPAddr {
 	for _, slice := range nodes {
 		sort.Slice(slice, func(i, j int) bool {
@@ -161,4 +181,18 @@ func (s *HealthServerTestSuite) TestProbersetNodes(c *check.C) {
 		}},
 	}
 	c.Assert(sortNodes(nodes), checker.DeepEquals, sortNodes(expected))
+
+	// check if primary node is nil (it shouldn't show up)
+	node3, _, node3HealthIP := makeHealthNodeNil(1, 1)
+
+	newNodes3 := nodeMap{
+		ipString(node3.Name): node3,
+	}
+	nodes3 := newProber(&Server{}, newNodes3).getIPsByNode()
+	expected3 := map[string][]*net.IPAddr{
+		node3.Name: {{
+			IP: node3HealthIP,
+		}},
+	}
+	c.Assert(sortNodes(nodes3), checker.DeepEquals, sortNodes(expected3))
 }


### PR DESCRIPTION
It is possible for a node with a "<nil>" primary address to
be "added" to the health pkg cache. When this happens subsequent
updates **will not** flush out the bad value and thus it will
persist as a valid status for a node until the entire cilium
daemon is reset.

This fixes the bug by not caching nil values at all.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>
