### PR TITLE
Revert PR #17145

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -562,7 +562,7 @@ func runServer(cmd *cobra.Command) {
 		if err := k8s.Init(k8sconfig.NewDefaultConfiguration()); err != nil {
 			log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 		}
-		synced.SyncCRDs(context.TODO(), synced.AllCRDResourceNames(), &synced.Resources{}, &synced.APIGroups{})
+		synced.SyncCRDs(context.TODO(), synced.AllCRDResourceNames, &synced.Resources{}, &synced.APIGroups{})
 		ciliumK8sClient = k8s.CiliumClient()
 	}
 

--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 
 	v1 "k8s.io/api/core/v1"
-	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -167,24 +166,5 @@ func (k *K8sWatcher) updateK8sEndpointSliceV1Beta1(eps *slim_discover_v1beta1.En
 
 	if option.Config.BGPAnnounceLBIP {
 		k.bgpSpeakerManager.OnUpdateEndpointSliceV1Beta1(eps)
-	}
-}
-
-// initEndpointsOrSlices initializes either the "Endpoints" or "EndpointSlice"
-// resources for Kubernetes service backends.
-func (k *K8sWatcher) initEndpointsOrSlices(k8sClient kubernetes.Interface, serviceOptModifier func(*v1meta.ListOptions)) {
-	swgEps := lock.NewStoppableWaitGroup()
-	switch {
-	case k8s.SupportsEndpointSlice():
-		// We don't add the service option modifier here, as endpointslices do not
-		// mirror service proxy name label present in the corresponding service.
-		connected := k.endpointSlicesInit(k8sClient, swgEps)
-		// The cluster has endpoint slices so we should not check for v1.Endpoints
-		if connected {
-			break
-		}
-		fallthrough
-	default:
-		k.endpointsInit(k8sClient, swgEps, serviceOptModifier)
 	}
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4411,7 +4411,7 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"resourcequota":      "cilium-resource-quota cilium-operator-resource-quota",
 		}
 
-		crdsToDelete = synced.AllCRDResourceNames()
+		crdsToDelete = synced.AllCRDResourceNames
 	)
 
 	wg.Add(len(resourcesToDelete))


### PR DESCRIPTION
This reverts commits b5c9b5528304ce0814ca2412a27a88288bd86454 through 5a2c8165b4102a09871ef06b2c31ef9e3dcb8cc9.

Rationale: it seems this broke clustermesh functionality, as both external workloads and multicluster testing workflows are consistently failing since merge. The two workflows also did not pass in the original PR, with the same errors.

- External workloads: standalone Cilium agent is unable to come up while trying to reach clustermesh apiserver.
- Multicluster: cross-cluster traffic not being able to reach the other cluster during connectivity test.
