### PR TITLE
option: Rename egress gateway flag to `enable-ipv4-egress-gateway`

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -81,7 +81,6 @@ cilium-agent [flags]
       --enable-bpf-masquerade                                Masquerade packets from endpoints leaving the host with BPF instead of iptables
       --enable-bpf-tproxy                                    Enable BPF-based proxy redirection, if support available
       --enable-custom-calls                                  Enable tail call hooks for custom eBPF programs
-      --enable-egress-gateway                                Enable egress gateway
       --enable-endpoint-health-checking                      Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                               Use per endpoint routes instead of routing via cilium_host
       --enable-external-ips                                  Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
@@ -97,6 +96,7 @@ cilium-agent [flags]
       --enable-ip-masq-agent                                 Enable BPF ip-masq-agent
       --enable-ipsec                                         Enable IPSec support
       --enable-ipv4                                          Enable IPv4 support (default true)
+      --enable-ipv4-egress-gateway                           Enable egress gateway for IPv4
       --enable-ipv4-fragment-tracking                        Enable IPv4 fragments tracking for L4-based lookups (default true)
       --enable-ipv4-masquerade                               Masquerade IPv4 traffic from endpoints leaving the host (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)

--- a/Documentation/gettingstarted/egress-gateway.rst
+++ b/Documentation/gettingstarted/egress-gateway.rst
@@ -56,7 +56,7 @@ enable all requirements is as follows.
 
        .. code-block:: shell-session
 
-          enable-egress-gateway: true
+          enable-ipv4-egress-gateway: true
           enable-bpf-masquerade: true
           kube-proxy-replacement: strict
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -353,6 +353,13 @@ New Options
   acceptable kvstore consecutive quorum errors before the agent assumes
   permanent failure.
 
+Renamed Options
+~~~~~~~~~~~~~~~
+
+The following option has been renamed:
+
+* ``enable-egress-gateway`` to ``enable-ipv4-egress-gateway``.
+
 Helm Options
 ~~~~~~~~~~~~
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -685,7 +685,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		}
 	} else if option.Config.EnableIPMasqAgent {
 		return nil, nil, fmt.Errorf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
-	} else if option.Config.EnableEgressGateway {
+	} else if option.Config.EnableIPv4EgressGateway {
 		return nil, nil, fmt.Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
 	} else if !option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {
 		// There is not yet support for option.Config.EnableIPv6Masquerade

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -688,8 +688,8 @@ func initializeFlags() {
 	flags.Bool(option.EnableIPMasqAgent, false, "Enable BPF ip-masq-agent")
 	option.BindEnv(option.EnableIPMasqAgent)
 
-	flags.Bool(option.EnableEgressGateway, false, "Enable egress gateway")
-	option.BindEnv(option.EnableEgressGateway)
+	flags.Bool(option.EnableIPv4EgressGateway, false, "Enable egress gateway for IPv4")
+	option.BindEnv(option.EnableIPv4EgressGateway)
 
 	flags.String(option.IPMasqAgentConfigPath, "/etc/config/ip-masq-agent", "ip-masq-agent configuration file path")
 	option.BindEnv(option.IPMasqAgentConfigPath)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -342,9 +342,9 @@ func initKubeProxyReplacementOptions() (bool, error) {
 					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.TunnelName, option.TunnelDisabled)
 			}
 
-			if option.Config.EnableEgressGateway {
+			if option.Config.EnableIPv4EgressGateway {
 				return false, fmt.Errorf("Cannot use NodePort acceleration with the egress gateway. Run cilium-agent with either --%s=%s or %s=false",
-					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.EnableEgressGateway)
+					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.EnableIPv4EgressGateway)
 			}
 		}
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -723,7 +723,7 @@ data:
 {{- end }}
 
 {{- if .Values.egressGateway.enabled }}
-  enable-egress-gateway: "true"
+  enable-ipv4-egress-gateway: "true"
 {{- end }}
 
 {{- if .Values.enableK8sEventHandover }}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -227,7 +227,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_PREFILTER"] = "1"
 	}
 
-	if option.Config.EnableEgressGateway {
+	if option.Config.EnableIPv4EgressGateway {
 		cDefinesMap["ENABLE_EGRESS_GATEWAY"] = "1"
 	}
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -350,7 +350,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 	args[initArgMode] = string(mode)
 
-	if option.Config.Tunnel == option.TunnelDisabled && option.Config.EnableEgressGateway {
+	if option.Config.Tunnel == option.TunnelDisabled && option.Config.EnableIPv4EgressGateway {
 		// Enable tunnel mode to vxlan if egress gateway is configured
 		// Tunnel is required for egress traffic under this config
 		args[initArgTunnelMode] = option.TunnelVXLAN

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -47,7 +47,7 @@ func agentCRDResourceNames() []string {
 	if !option.Config.DisableCiliumEndpointCRD {
 		result = append(result, CRDResourceName(v2.CEPName))
 	}
-	if option.Config.EnableEgressGateway {
+	if option.Config.EnableIPv4EgressGateway {
 		result = append(result, CRDResourceName(v2alpha1.CENPName))
 	}
 	if option.Config.EnableLocalRedirectPolicy {

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -200,7 +200,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 		}
 	}
 
-	if option.Config.EnableEgressGateway {
+	if option.Config.EnableIPv4EgressGateway {
 		k.egressGatewayManager.OnUpdateEndpoint(endpoint)
 	}
 }
@@ -233,7 +233,7 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 			k.policyManager.TriggerPolicyUpdates(true, "Named ports deleted")
 		}
 	}
-	if option.Config.EnableEgressGateway {
+	if option.Config.EnableIPv4EgressGateway {
 		k.egressGatewayManager.OnDeleteEndpoint(endpoint)
 	}
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -348,8 +348,8 @@ const (
 	// EnableIPMasqAgent enables BPF ip-masq-agent
 	EnableIPMasqAgent = "enable-ip-masq-agent"
 
-	// EnableEgressGateway enables egress-gateway
-	EnableEgressGateway = "enable-egress-gateway"
+	// EnableIPv4EgressGateway enables the IPv4 egress gateway
+	EnableIPv4EgressGateway = "enable-ipv4-egress-gateway"
 
 	// IPMasqAgentConfigPath is the configuration file path
 	IPMasqAgentConfigPath = "ip-masq-agent-config-path"
@@ -1490,7 +1490,7 @@ type DaemonConfig struct {
 	DeriveMasqIPAddrFromDevice string
 	EnableBPFClockProbe        bool
 	EnableIPMasqAgent          bool
-	EnableEgressGateway        bool
+	EnableIPv4EgressGateway    bool
 	IPMasqAgentConfigPath      string
 	InstallIptRules            bool
 	MonitorAggregation         string
@@ -2538,7 +2538,7 @@ func (c *DaemonConfig) Populate() {
 	c.LocalRouterIPv6 = viper.GetString(LocalRouterIPv6)
 	c.EnableBPFClockProbe = viper.GetBool(EnableBPFClockProbe)
 	c.EnableIPMasqAgent = viper.GetBool(EnableIPMasqAgent)
-	c.EnableEgressGateway = viper.GetBool(EnableEgressGateway)
+	c.EnableIPv4EgressGateway = viper.GetBool(EnableIPv4EgressGateway)
 	c.IPMasqAgentConfigPath = viper.GetString(IPMasqAgentConfigPath)
 	c.InstallIptRules = viper.GetBool(InstallIptRules)
 	c.IPTablesLockTimeout = viper.GetDuration(IPTablesLockTimeout)


### PR DESCRIPTION
The new name should clarify that this flag only enables an IPv4 egress gateway feature; IPv6 is not supported yet. Once IPv6 is supported, users may not want to enable it even on dual-stack clusters because SNATing is generally less frequent in IPv6. To prepare for this future addition of `enable-ipv6-egress-gateway`, it's easier to rename now while the feature is still in beta.