### PR TITLE
Enable CiliumEndpointSlice feature testing on Kuberneres version 1.21

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2395,6 +2395,9 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		options["imagePullSecrets[0].name"] = config.RegistrySecretName
 	}
 
+	if CiliumEndpointSliceFeatureEnabled() {
+		options["enableCiliumEndpointSlice"] = "true"
+	}
 	return nil
 }
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -699,3 +699,14 @@ func DualStackSupportBeta() bool {
 
 	return GetCurrentIntegration() == "" && supportedVersions(k8sVersion)
 }
+
+// CiliumEndpointSliceFeatureEnabled returns true only if the environment has a kubernetes version
+// greater than or equal to 1.21.
+func CiliumEndpointSliceFeatureEnabled() bool {
+	k8sVersionGreaterEqual121 := versioncheck.MustCompile(">=1.21.0")
+	k8sVersion, err := versioncheck.Version(GetCurrentK8SEnv())
+	if err != nil {
+		return false
+	}
+	return k8sVersionGreaterEqual121(k8sVersion) && GetCurrentIntegration() == ""
+}


### PR DESCRIPTION
Enable CiliumEndpointSlice feature, CI testing only on Kubernetes
version 1.21.

Signed-off-by: Gobinath Krishnamoorthy <gobinathk@google.com>