### PR TITLE
Fix identity leak via FQDN selectors

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/hubble/observer"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -147,7 +146,7 @@ type Daemon struct {
 
 	endpointManager *endpointmanager.EndpointManager
 
-	identityAllocator *cache.CachingIdentityAllocator
+	identityAllocator CachingIdentityAllocator
 
 	k8sWatcher *watchers.K8sWatcher
 
@@ -409,7 +408,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		return nil, nil, fmt.Errorf("error while initializing BPF pcap recorder: %w", err)
 	}
 
-	d.identityAllocator = cache.NewCachingIdentityAllocator(&d)
+	d.identityAllocator = NewCachingIdentityAllocator(&d)
 	d.policy = policy.NewPolicyRepository(d.identityAllocator,
 		d.identityAllocator.GetIdentityCache(),
 		certificatemanager.NewManager(option.Config.CertDirectory, k8s.Client()))
@@ -832,7 +831,8 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		// well known identities have already been initialized above.
 		// Ignore the channel returned by this function, as we want the global
 		// identity allocator to run asynchronously.
-		d.identityAllocator.InitIdentityAllocator(k8s.CiliumClient(), nil)
+		realIdentityAllocator := d.identityAllocator
+		realIdentityAllocator.InitIdentityAllocator(k8s.CiliumClient(), nil)
 
 		d.bootstrapClusterMesh(nodeMngr)
 	}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -410,7 +410,8 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	d.identityAllocator = cache.NewCachingIdentityAllocator(&d)
-	d.policy = policy.NewPolicyRepository(d.identityAllocator.GetIdentityCache(),
+	d.policy = policy.NewPolicyRepository(d.identityAllocator,
+		d.identityAllocator.GetIdentityCache(),
 		certificatemanager.NewManager(option.Config.CertDirectory, k8s.Client()))
 	d.policy.SetEnvoyRulesFunc(envoy.GetEnvoyHTTPRules)
 

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -55,7 +55,7 @@ const (
 	dnsSourceConnection = "connection"
 )
 
-func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, identityAllocator *secIDCache.CachingIdentityAllocator) (map[policyApi.FQDNSelector][]*identity.Identity, map[string]*identity.Identity, error) {
+func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, identityAllocator secIDCache.IdentityAllocator) (map[policyApi.FQDNSelector][]*identity.Identity, map[string]*identity.Identity, error) {
 	var err error
 
 	// Used to track identities which are allocated in calls to
@@ -73,7 +73,7 @@ func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSel
 			"ips":          selectorIPs,
 		}).Debug("getting identities for IPs associated with FQDNSelector")
 		var currentlyAllocatedIdentities []*identity.Identity
-		if currentlyAllocatedIdentities, err = ipcache.AllocateCIDRsForIPs(selectorIPs, newlyAllocatedIdentities); err != nil {
+		if currentlyAllocatedIdentities, err = identityAllocator.AllocateCIDRsForIPs(selectorIPs, newlyAllocatedIdentities); err != nil {
 			identityAllocator.ReleaseSlice(context.TODO(), nil, usedIdentities)
 			log.WithError(err).WithField("prefixes", selectorIPs).Warn(
 				"failed to allocate identities for IPs")

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -7,14 +7,116 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
+	"github.com/cilium/cilium/pkg/allocator"
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn"
+	"github.com/cilium/cilium/pkg/fqdn/dns"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+
 	. "gopkg.in/check.v1"
+	k8sCache "k8s.io/client-go/tools/cache"
 )
+
+type DaemonFQDNSuite struct {
+	d *Daemon
+}
+
+var _ = Suite(&DaemonFQDNSuite{})
+
+type FakeRefcountingIdentityAllocator struct {
+	*testidentity.FakeIdentityAllocator
+
+	// We create a simple identity allocator here to validate that identity
+	// allocation and release are balanced.
+	currentID     int
+	ipToIdentity  map[string]int
+	identityCount counter.IntCounter
+}
+
+func NewFakeIdentityAllocator(c cache.IdentityCache) *FakeRefcountingIdentityAllocator {
+	return &FakeRefcountingIdentityAllocator{
+		FakeIdentityAllocator: testidentity.NewFakeIdentityAllocator(c),
+		currentID:             1000,
+		ipToIdentity:          make(map[string]int),
+		identityCount:         make(counter.IntCounter),
+	}
+}
+
+// AllocateCIDRsForIPs performs reference counting for IP/identity allocation,
+// but doesn't interact with pkg/identity or pkg/ipcache.
+// 'newlyAllocatedIdentities' is not properly mocked out.
+//
+// The resulting identities are not guaranteed to have all fields populated.
+func (f *FakeRefcountingIdentityAllocator) AllocateCIDRsForIPs(IPs []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error) {
+	result := make([]*identity.Identity, 0, len(IPs))
+	for _, ip := range IPs {
+		id, ok := f.ipToIdentity[ip.String()]
+		if !ok {
+			id = f.currentID
+			f.ipToIdentity[ip.String()] = id
+			f.currentID = id + 1
+		}
+		f.identityCount.Add(id)
+		cidrLabels := append([]string{}, ip.String())
+		result = append(result, &identity.Identity{
+			ID:        identity.NumericIdentity(id),
+			CIDRLabel: labels.NewLabelsFromModel(cidrLabels),
+		})
+	}
+	return result, nil
+}
+
+// ReleaseCIDRIdentitiesByID performs reference counting for IP/identity
+// allocation, but doesn't interact with pkg/identity or pkg/ipcache.
+func (f *FakeRefcountingIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
+	// Leave the ipToIdentity mapping alone since we don't have enough info
+	// to clean it up. That's fine, it's not necessary for current testing.
+	for _, id := range identities {
+		f.identityCount.Delete(int(id))
+	}
+}
+
+func (f *FakeRefcountingIdentityAllocator) IdentityReferenceCounter() counter.IntCounter {
+	return f.identityCount
+}
+
+func (f *FakeRefcountingIdentityAllocator) Close() {
+}
+func (f *FakeRefcountingIdentityAllocator) InitIdentityAllocator(versioned.Interface, k8sCache.Store) <-chan struct{} {
+	return nil
+}
+func (f *FakeRefcountingIdentityAllocator) WatchRemoteIdentities(kvstore.BackendOperations) (*allocator.RemoteCache, error) {
+	return nil, nil
+}
+
+func (ds *DaemonFQDNSuite) SetUpTest(c *C) {
+	d := &Daemon{}
+	d.identityAllocator = NewFakeIdentityAllocator(nil)
+	d.policy = policy.NewPolicyRepository(d.identityAllocator, nil, nil)
+	d.dnsNameManager = fqdn.NewNameManager(fqdn.Config{
+		MinTTL:          1,
+		Cache:           fqdn.NewDNSCache(0),
+		UpdateSelectors: d.updateSelectors,
+	})
+	d.endpointManager = WithCustomEndpointManager(&dummyEpSyncher{})
+	d.policy.GetSelectorCache().SetLocalIdentityNotifier(d.dnsNameManager)
+	ds.d = d
+}
 
 // makeIPs generates count sequential IPv4 IPs
 func makeIPs(count uint32) []net.IP {
@@ -46,4 +148,66 @@ func (ds *DaemonSuite) BenchmarkFqdnCache(c *C) {
 	c.StartTimer()
 
 	extractDNSLookups(endpoints, "0.0.0.0/0", "*")
+}
+
+func (ds *DaemonFQDNSuite) TestFQDNIdentityReferenceCounting(c *C) {
+	var (
+		idAllocator             = ds.d.identityAllocator.(*FakeRefcountingIdentityAllocator)
+		nameManager             = ds.d.dnsNameManager
+		ciliumIOSel             = api.FQDNSelector{MatchName: "cilium.io"}
+		ciliumIOSelMatchPattern = api.FQDNSelector{MatchPattern: "*cilium.io."}
+		ebpfIOSel               = api.FQDNSelector{MatchName: "ebpf.io"}
+		ciliumDNSRecord         = map[string]*fqdn.DNSIPRecords{
+			dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("192.0.2.3")}},
+		}
+		ebpfDNSRecord = map[string]*fqdn.DNSIPRecords{
+			dns.FQDN("ebpf.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("192.0.2.4")}},
+		}
+	)
+
+	// add rules
+	selectorsToAdd := api.FQDNSelectorSlice{ciliumIOSel, ciliumIOSelMatchPattern, ebpfIOSel}
+	nameManager.Lock()
+	for _, sel := range selectorsToAdd {
+		ids := nameManager.RegisterForIdentityUpdatesLocked(idAllocator, sel)
+		c.Assert(ids, Not(IsNil))
+	}
+	nameManager.Unlock()
+
+	// poll DNS once, check that we only generate 1 IP for cilium.io
+	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ciliumDNSRecord)
+	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	c.Assert(len(idAllocator.IdentityReferenceCounter()), Equals, 1,
+		Commentf("Unexpected number of identities allocated during DNS name event handler"))
+
+	// Same thing, new reference for same identity but otherwise the same.
+	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ciliumDNSRecord)
+	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	c.Assert(len(idAllocator.IdentityReferenceCounter()), Equals, 1,
+		Commentf("Unexpected number of identities allocated during DNS name event handler"))
+
+	// poll DNS for ebpf.io, check that we now have two different identities referenced
+	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ebpfDNSRecord)
+	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	c.Assert(len(idAllocator.IdentityReferenceCounter()), Equals, 2,
+		Commentf("Unexpected number of identities allocated during DNS name event handler"))
+
+	// Two selectors are selecting the same identity. If we remove one of
+	// them, then the identity should remain referenced by the other
+	// existing selector.
+	var wg sync.WaitGroup
+	ds.d.policy.GetSelectorCache().UpdateFQDNSelector(ciliumIOSel, nil, &wg)
+	wg.Wait()
+	c.Assert(len(idAllocator.IdentityReferenceCounter()), Equals, 2,
+		Commentf("Unexpected number of identities allocated during DNS name event handler"))
+
+	// Similar to FQDN garbage collection, set the list of identities that
+	// each selector would select to the empty set and then observe that
+	// the outstanding identity references are released.
+	for _, sel := range selectorsToAdd {
+		ds.d.policy.GetSelectorCache().UpdateFQDNSelector(sel, nil, &wg)
+	}
+	wg.Wait()
+	c.Assert(idAllocator.IdentityReferenceCounter(), checker.DeepEquals, counter.IntCounter{},
+		Commentf("The Daemon code leaked references to one or more identities"))
 }

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"context"
 	"net"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -110,4 +111,8 @@ func NewCachingIdentityAllocator(d *Daemon) cachingIdentityAllocator {
 
 func (c cachingIdentityAllocator) AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error) {
 	return ipcache.AllocateCIDRsForIPs(ips, newlyAllocatedIdentities)
+}
+
+func (c cachingIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
+	ipcache.ReleaseCIDRIdentitiesByID(ctx, identities)
 }

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -291,6 +291,9 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	// With SelectiveRegeneration this is postponed to the rule reaction queue to be done
 	// after the affected endpoints have been regenerated, otherwise new identities are
 	// upserted to the ipcache before we return.
+	//
+	// Release of these identities will be tied to the corresponding policy
+	// in the policy.Repository and released upon policyDelete().
 	newlyAllocatedIdentities := make(map[string]*identity.Identity)
 	if _, err := ipcache.AllocateCIDRs(prefixes, newlyAllocatedIdentities); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -386,7 +386,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	// and will trigger deletions for those that are no longer used.
 	if len(removedPrefixes) > 0 {
 		logger.WithField("prefixes", removedPrefixes).Debug("Decrementing replaced CIDR refcounts when adding rules")
-		ipcache.ReleaseCIDRs(removedPrefixes)
+		ipcache.ReleaseCIDRIdentitiesByCIDR(removedPrefixes)
 		d.prefixLengths.Delete(removedPrefixes)
 	}
 
@@ -473,7 +473,7 @@ func reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev u
 	// the stale identities are not used in policy map classifications after we regenerate the
 	// endpoints below.
 	if len(releasePrefixes) != 0 {
-		ipcache.ReleaseCIDRs(releasePrefixes)
+		ipcache.ReleaseCIDRIdentitiesByCIDR(releasePrefixes)
 	}
 
 	// Bump revision of endpoints which don't need to be regenerated.
@@ -652,7 +652,7 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 			log.WithError(err).WithField(logfields.PolicyRevision, rev).Error("enqueue of RuleReactionEvent failed")
 		}
 	} else {
-		ipcache.ReleaseCIDRs(prefixes)
+		ipcache.ReleaseCIDRIdentitiesByCIDR(prefixes)
 		d.TriggerPolicyUpdates(true, "policy rules deleted")
 	}
 

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -1009,11 +1009,11 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 							},
 						},
 					},
-					repo: policy.NewPolicyRepository(nil, nil),
+					repo: policy.NewPolicyRepository(nil, nil, nil),
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				r.AddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
@@ -1042,7 +1042,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 		{
 			name: "have a rule with user labels and update it without user labels, all other rules should be deleted",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository(nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.AddList(api.Rules{
@@ -1085,7 +1085,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				r.AddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
@@ -1114,7 +1114,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 		{
 			name: "have a rule without user labels and update it with user labels, all other rules should be deleted",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository(nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				r.AddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
@@ -1156,7 +1156,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.AddList(api.Rules{
@@ -1182,7 +1182,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 		{
 			name: "have a rule policy installed with multiple rules and apply an empty spec should delete all rules installed",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository(nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				r.AddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
@@ -1229,7 +1229,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil)
 				r.AddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/testutils"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	"github.com/cilium/cilium/pkg/testutils/identity"
 
 	. "gopkg.in/check.v1"
 )
@@ -94,7 +94,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	<-mgr.InitIdentityAllocator(nil, nil)
 	defer mgr.Close()
 

--- a/pkg/clustermesh/config_test.go
+++ b/pkg/clustermesh/config_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/testutils"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	"github.com/cilium/cilium/pkg/testutils/identity"
 
 	. "gopkg.in/check.v1"
 )
@@ -65,7 +65,7 @@ func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
 	createFile(c, file1)
 	createFile(c, file2)
 
-	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	<-mgr.InitIdentityAllocator(nil, nil)
 

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -26,7 +26,7 @@ import (
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/testutils"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	"github.com/cilium/cilium/pkg/testutils/identity"
 
 	. "gopkg.in/check.v1"
 )
@@ -59,7 +59,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	s.svcCache = k8s.NewServiceCache(fakeDatapath.NewNodeAddressing())
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 
-	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	<-mgr.InitIdentityAllocator(nil, nil)
 	dir, err := os.MkdirTemp("", "multicluster")

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
-	e := NewEndpointWithState(s, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, &FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 100, StateWaitingForIdentity)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
@@ -28,7 +28,7 @@ func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
 type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
-	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 100, StateWaitingForIdentity)
 	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil, nil)
 
 	targetComments := func(w io.Writer) error {

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/datapath/linux"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	. "gopkg.in/check.v1"
 )
 
 func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
-	e := NewEndpointWithState(s, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
@@ -28,7 +28,7 @@ func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
 type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
-	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
 	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil, nil)
 
 	targetComments := func(w io.Writer) error {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -33,7 +33,7 @@ import (
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	"github.com/prometheus/client_golang/prometheus"
 	. "gopkg.in/check.v1"
@@ -122,7 +122,7 @@ func (s *EndpointSuite) SetUpTest(c *C) {
 	kvstore.SetupDummy("etcd")
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	<-mgr.InitIdentityAllocator(nil, nil)
 	s.mgr = mgr
 }
@@ -232,7 +232,7 @@ func (s *EndpointSuite) TestEndpointStatus(c *C) {
 }
 
 func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
-	e := NewEndpointWithState(s, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
 
 	// Test that inserting identity labels works
 	rev := e.replaceIdentityLabels(labels.Map2Labels(map[string]string{"foo": "bar", "zip": "zop"}, "cilium"))
@@ -256,7 +256,7 @@ func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 }
 
 func (s *EndpointSuite) TestEndpointState(c *C) {
-	e := NewEndpointWithState(s, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
 	e.unconditionalLock()
 	defer e.unlock()
 
@@ -629,7 +629,7 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponStop(c *C) {
 		s.datapath = oldDatapath
 	}()
 
-	ep := NewEndpointWithState(s, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 12345, StateReady)
+	ep := NewEndpointWithState(s, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 12345, StateReady)
 
 	// In case deadlock occurs, provide a timeout of 3 (number of events) *
 	// deadlockTimeout + 1 seconds to ensure that we are actually testing for
@@ -700,7 +700,7 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponStop(c *C) {
 }
 
 func BenchmarkEndpointGetModel(b *testing.B) {
-	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 123, StateWaitingForIdentity)
+	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 123, StateWaitingForIdentity)
 
 	for i := 0; i < 256; i++ {
 		e.LogStatusOK(BPF, "Hello World!")

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -232,7 +232,7 @@ func (s *EndpointSuite) TestEndpointStatus(c *C) {
 }
 
 func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
-	e := NewEndpointWithState(s, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, &FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 100, StateWaitingForIdentity)
 
 	// Test that inserting identity labels works
 	rev := e.replaceIdentityLabels(labels.Map2Labels(map[string]string{"foo": "bar", "zip": "zop"}, "cilium"))
@@ -256,7 +256,7 @@ func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 }
 
 func (s *EndpointSuite) TestEndpointState(c *C) {
-	e := NewEndpointWithState(s, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, &FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 100, StateWaitingForIdentity)
 	e.unconditionalLock()
 	defer e.unlock()
 
@@ -629,7 +629,7 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponStop(c *C) {
 		s.datapath = oldDatapath
 	}()
 
-	ep := NewEndpointWithState(s, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 12345, StateReady)
+	ep := NewEndpointWithState(s, &FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 12345, StateReady)
 
 	// In case deadlock occurs, provide a timeout of 3 (number of events) *
 	// deadlockTimeout + 1 seconds to ensure that we are actually testing for
@@ -700,7 +700,7 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponStop(c *C) {
 }
 
 func BenchmarkEndpointGetModel(b *testing.B) {
-	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 123, StateWaitingForIdentity)
+	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 123, StateWaitingForIdentity)
 
 	for i := 0; i < 256; i++ {
 		e.LogStatusOK(BPF, "Hello World!")

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -66,12 +66,12 @@ type EndpointSuite struct {
 }
 
 // suite can be used by testing.T benchmarks or tests as a mock regeneration.Owner
-var suite = EndpointSuite{repo: policy.NewPolicyRepository(nil, nil)}
+var suite = EndpointSuite{repo: policy.NewPolicyRepository(nil, nil, nil)}
 var _ = Suite(&suite)
 
 func (s *EndpointSuite) SetUpSuite(c *C) {
 	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
-	s.repo = policy.NewPolicyRepository(nil, nil)
+	s.repo = policy.NewPolicyRepository(nil, nil, nil)
 	// GetConfig the default labels prefix filter
 	err := labelsfilter.ParseLabelPrefixCfg(nil, "")
 	if err != nil {

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (s *EndpointSuite) TestPolicyLog(c *C) {
-	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil)}, nil, &testidentity.FakeIdentityAllocator{}, 12345, StateReady)
+	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil)}, nil, testidentity.NewFakeIdentityAllocator(nil), 12345, StateReady)
 
 	// Initially nil
 	policyLogger := ep.getPolicyLogger()

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -13,14 +13,14 @@ import (
 
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
 func (s *EndpointSuite) TestPolicyLog(c *C) {
-	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil)}, nil, &allocator.FakeIdentityAllocator{}, 12345, StateReady)
+	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil)}, nil, &testidentity.FakeIdentityAllocator{}, 12345, StateReady)
 
 	// Initially nil
 	policyLogger := ep.getPolicyLogger()

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (s *EndpointSuite) TestPolicyLog(c *C) {
-	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil)}, nil, testidentity.NewFakeIdentityAllocator(nil), 12345, StateReady)
+	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}, nil, testidentity.NewFakeIdentityAllocator(nil), 12345, StateReady)
 
 	// Initially nil
 	policyLogger := ep.getPolicyLogger()

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -8,14 +8,14 @@ package endpoint
 
 import (
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/u8proto"
 
 	"gopkg.in/check.v1"
 )
 
 func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
-	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil)}, nil, &allocator.FakeIdentityAllocator{}, 12345, StateReady)
+	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil)}, nil, &testidentity.FakeIdentityAllocator{}, 12345, StateReady)
 	ep.UpdateVisibilityPolicy(func(_, _ string) (string, error) {
 		return "", nil
 	})

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
-	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil)}, nil, &testidentity.FakeIdentityAllocator{}, 12345, StateReady)
+	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil)}, nil, testidentity.NewFakeIdentityAllocator(nil), 12345, StateReady)
 	ep.UpdateVisibilityPolicy(func(_, _ string) (string, error) {
 		return "", nil
 	})

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
-	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil)}, nil, testidentity.NewFakeIdentityAllocator(nil), 12345, StateReady)
+	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}, nil, testidentity.NewFakeIdentityAllocator(nil), 12345, StateReady)
 	ep.UpdateVisibilityPolicy(func(_, _ string) (string, error) {
 		return "", nil
 	})

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -142,7 +142,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	defer mgr.Close()
 
 	do := &DummyOwner{
-		repo: policy.NewPolicyRepository(nil, nil),
+		repo: policy.NewPolicyRepository(nil, nil, nil),
 	}
 	identitymanager.Subscribe(do.repo)
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -137,7 +137,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
 
-	mgr := cache.NewCachingIdentityAllocator(idAllocatorOwner)
+	mgr := NewCachingIdentityAllocator(idAllocatorOwner)
 	<-mgr.InitIdentityAllocator(nil, nil)
 	defer mgr.Close()
 

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	. "gopkg.in/check.v1"
 )
 
@@ -62,7 +62,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	repo := ds.GetPolicyRepository()
 	repo.GetPolicyCache().LocalEndpointIdentityAdded(identity)
 
-	ep := NewEndpointWithState(ds, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, id, StateReady)
+	ep := NewEndpointWithState(ds, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.dockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -62,7 +62,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	repo := ds.GetPolicyRepository()
 	repo.GetPolicyCache().LocalEndpointIdentityAdded(identity)
 
-	ep := NewEndpointWithState(ds, &FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, id, StateReady)
+	ep := NewEndpointWithState(ds, &FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.dockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -39,7 +39,7 @@ func (s *EndpointManagerSuite) TestmarkAndSweep(c *C) {
 	healthyEndpointIDs := []uint16{1, 3, 5, 7}
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
-		ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, id, endpoint.StateReady)
+		ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), id, endpoint.StateReady)
 		mgr.expose(ep)
 	}
 	c.Assert(len(mgr.GetEndpoints()), Equals, len(allEndpointIDs))

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/endpoint"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	. "gopkg.in/check.v1"
 )
@@ -39,7 +39,7 @@ func (s *EndpointManagerSuite) TestmarkAndSweep(c *C) {
 	healthyEndpointIDs := []uint16{1, 3, 5, 7}
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
-		ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, id, endpoint.StateReady)
+		ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, id, endpoint.StateReady)
 		mgr.expose(ep)
 	}
 	c.Assert(len(mgr.GetEndpoints()), Equals, len(allEndpointIDs))

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	. "gopkg.in/check.v1"
 )
@@ -117,7 +117,7 @@ func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) 
 }
 
 func (s *EndpointManagerSuite) TestLookup(c *C) {
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	type args struct {
 		id string
@@ -171,7 +171,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
 				ep.ID = 0
 			},
 		},
@@ -194,7 +194,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
 				ep.ID = 0
 			},
 		},
@@ -218,7 +218,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
 				ep.SetContainerID("")
 			},
 		},
@@ -242,7 +242,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
 				ep.SetDockerEndpointID("")
 			},
 		},
@@ -266,7 +266,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
 				ep.SetContainerName("")
 			},
 		},
@@ -291,7 +291,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
 				ep.SetK8sPodName("")
 			},
 		},
@@ -317,7 +317,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
 				ep.IPv4 = nil
 			},
 		},
@@ -371,7 +371,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 2, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 2, endpoint.StateReady)
 	type args struct {
 		id uint16
 	}
@@ -440,7 +440,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 3, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 3, endpoint.StateReady)
 	type args struct {
 		id string
 	}
@@ -507,7 +507,7 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 4, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 4, endpoint.StateReady)
 	type args struct {
 		ip string
 	}
@@ -576,7 +576,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 5, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 5, endpoint.StateReady)
 	type args struct {
 		podName string
 	}
@@ -644,7 +644,7 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 
 func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 6, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 6, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -722,7 +722,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 
 func (s *EndpointManagerSuite) TestRemove(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 7, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 7, endpoint.StateReady)
 	type args struct {
 	}
 	type want struct {
@@ -762,7 +762,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 
 func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -790,7 +790,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -810,7 +810,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -827,7 +827,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 
 func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
 	type args struct {
 		ctx    context.Context
 		rev    uint64
@@ -865,7 +865,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -891,7 +891,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -917,7 +917,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
 			},
 		},
 	}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -117,7 +117,7 @@ func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) 
 }
 
 func (s *EndpointManagerSuite) TestLookup(c *C) {
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 10, endpoint.StateReady)
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	type args struct {
 		id string
@@ -171,7 +171,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.ID = 0
 			},
 		},
@@ -194,7 +194,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.ID = 0
 			},
 		},
@@ -218,7 +218,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetContainerID("")
 			},
 		},
@@ -242,7 +242,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetDockerEndpointID("")
 			},
 		},
@@ -266,7 +266,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetContainerName("")
 			},
 		},
@@ -291,7 +291,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetK8sPodName("")
 			},
 		},
@@ -317,7 +317,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.IPv4 = nil
 			},
 		},
@@ -371,7 +371,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 2, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 2, endpoint.StateReady)
 	type args struct {
 		id uint16
 	}
@@ -440,7 +440,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 3, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 3, endpoint.StateReady)
 	type args struct {
 		id string
 	}
@@ -507,7 +507,7 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 4, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 4, endpoint.StateReady)
 	type args struct {
 		ip string
 	}
@@ -576,7 +576,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 5, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 5, endpoint.StateReady)
 	type args struct {
 		podName string
 	}
@@ -644,7 +644,7 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 
 func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 6, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 6, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -722,7 +722,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 
 func (s *EndpointManagerSuite) TestRemove(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 7, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 7, endpoint.StateReady)
 	type args struct {
 	}
 	type want struct {
@@ -762,7 +762,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 
 func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 1, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -790,7 +790,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -810,7 +810,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -827,7 +827,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 
 func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 1, endpoint.StateReady)
 	type args struct {
 		ctx    context.Context
 		rev    uint64
@@ -865,7 +865,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -891,7 +891,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -917,7 +917,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 	}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -53,7 +53,8 @@ type EndpointManagerSuite struct {
 var _ = Suite(&EndpointManagerSuite{})
 
 func (s *EndpointManagerSuite) SetUpSuite(c *C) {
-	s.repo = policy.NewPolicyRepository(nil, nil)
+	idAllocator := testidentity.NewFakeIdentityAllocator(nil)
+	s.repo = policy.NewPolicyRepository(idAllocator, nil, nil)
 }
 
 func (s *EndpointManagerSuite) GetPolicyRepository() *policy.Repository {

--- a/pkg/envoy/server_test.go
+++ b/pkg/envoy/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api/kafka"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/proxy/logger/test"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/u8proto"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
@@ -170,8 +171,8 @@ var (
 			labels.NewLabel("version", "v1", labels.LabelSourceK8s),
 		},
 	}
-
-	testSelectorCache = policy.NewSelectorCache(IdentityCache)
+	identityAllocator = testidentity.NewFakeIdentityAllocator(IdentityCache)
+	testSelectorCache = policy.NewSelectorCache(identityAllocator, IdentityCache)
 
 	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, api.WildcardEndpointSelector)
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/source"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
 
 	"github.com/golang/groupcache/lru"
 	"github.com/miekg/dns"
@@ -147,7 +146,7 @@ func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.Cached
 
 // Setup identities, ports and endpoint IDs we will need
 var (
-	cacheAllocator          = cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	cacheAllocator          = cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	testSelectorCache       = policy.NewSelectorCache(cacheAllocator.GetIdentityCache())
 	dummySelectorCacheUser  = &DummySelectorCacheUser{}
 	DstID1Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst1=test"))
@@ -193,7 +192,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 			if s.restoring {
 				return nil, fmt.Errorf("No EPs available when restoring")
 			}
-			return endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, uint16(epID1), endpoint.StateReady), nil
+			return endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, uint16(epID1), endpoint.StateReady), nil
 		},
 		// LookupSecIDByIP
 		func(ip net.IP) (ipcache.Identity, bool) {
@@ -725,7 +724,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Restore rules
-	ep1 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, uint16(epID1), endpoint.StateReady)
 	ep1.DNSRules = restored1
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
@@ -771,7 +770,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Restore rules for epID3
-	ep3 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, uint16(epID3), endpoint.StateReady)
+	ep3 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, uint16(epID3), endpoint.StateReady)
 	ep3.DNSRules = restored3
 	s.proxy.RestoreRules(ep3)
 	_, exists = s.proxy.restored[epID3]
@@ -955,7 +954,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 
 	// restore rules, set the mock to restoring state
 	s.restoring = true
-	ep1 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, uint16(epID1), endpoint.StateReady)
 	ep1.IPv4, _ = addressing.NewCiliumIPv4("127.0.0.1")
 	ep1.IPv6, _ = addressing.NewCiliumIPv6("::1")
 	ep1.DNSRules = restored

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -181,7 +181,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 	}, nil, wg)
 	wg.Wait()
 
-	s.repo = policy.NewPolicyRepository(nil, nil)
+	s.repo = policy.NewPolicyRepository(nil, nil, nil)
 	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: time.Second, SingleInflight: true}
 	s.dnsServer = setupServer(c)
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -192,7 +192,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 			if s.restoring {
 				return nil, fmt.Errorf("No EPs available when restoring")
 			}
-			return endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, uint16(epID1), endpoint.StateReady), nil
+			return endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), uint16(epID1), endpoint.StateReady), nil
 		},
 		// LookupSecIDByIP
 		func(ip net.IP) (ipcache.Identity, bool) {
@@ -724,7 +724,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Restore rules
-	ep1 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
 	ep1.DNSRules = restored1
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
@@ -770,7 +770,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Restore rules for epID3
-	ep3 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, uint16(epID3), endpoint.StateReady)
+	ep3 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), uint16(epID3), endpoint.StateReady)
 	ep3.DNSRules = restored3
 	s.proxy.RestoreRules(ep3)
 	_, exists = s.proxy.restored[epID3]
@@ -954,7 +954,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 
 	// restore rules, set the mock to restoring state
 	s.restoring = true
-	ep1 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &testidentity.FakeIdentityAllocator{}, uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, testidentity.NewFakeIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
 	ep1.IPv4, _ = addressing.NewCiliumIPv4("127.0.0.1")
 	ep1.IPv6, _ = addressing.NewCiliumIPv6("::1")
 	ep1.DNSRules = restored

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/source"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	"github.com/golang/groupcache/lru"
 	"github.com/miekg/dns"
@@ -147,7 +148,8 @@ func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.Cached
 // Setup identities, ports and endpoint IDs we will need
 var (
 	cacheAllocator          = cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
-	testSelectorCache       = policy.NewSelectorCache(cacheAllocator.GetIdentityCache())
+	fakeAllocator           = testidentity.NewFakeIdentityAllocator(cacheAllocator.GetIdentityCache())
+	testSelectorCache       = policy.NewSelectorCache(fakeAllocator, cacheAllocator.GetIdentityCache())
 	dummySelectorCacheUser  = &DummySelectorCacheUser{}
 	DstID1Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst1=test"))
 	cachedDstID1Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, DstID1Selector)

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -147,6 +147,9 @@ type IdentityAllocator interface {
 	// 'newlyAllocatedIdentities' and it is the caller's responsibility to
 	// upsert them into ipcache by calling UpsertGeneratedIdentities().
 	//
+	// Upon success, the caller must also arrange for the resulting identities to
+	// be released via a subsequent call to ReleaseCIDRIdentitiesByID().
+	//
 	// The implementation for this function currently lives in pkg/ipcache.
 	AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error)
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -149,6 +149,10 @@ type IdentityAllocator interface {
 	//
 	// The implementation for this function currently lives in pkg/ipcache.
 	AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error)
+
+	// ReleaseCIDRIdentitiesByID() is a wrapper for ReleaseSlice() that
+	// also handles ipcache entries.
+	ReleaseCIDRIdentitiesByID(context.Context, []identity.NumericIdentity)
 }
 
 // InitIdentityAllocator creates the the identity allocator. Only the first

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -35,6 +35,17 @@ func (s IdentitiesModel) Less(i, j int) bool {
 	return s[i].ID < s[j].ID
 }
 
+// FromIdentityCache populates the provided model from an identity cache.
+func (s IdentitiesModel) FromIdentityCache(cache IdentityCache) IdentitiesModel {
+	for id, lbls := range cache {
+		s = append(s, identitymodel.CreateModel(&identity.Identity{
+			ID:     id,
+			Labels: lbls.Labels(),
+		}))
+	}
+	return s
+}
+
 // GetIdentityCache returns a cache of all known identities
 func (m *CachingIdentityAllocator) GetIdentityCache() IdentityCache {
 	log.Debug("getting identity cache for identity allocator manager")

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -22,7 +22,7 @@ var (
 	// identities for CIDRs.
 	// TODO: plumb an allocator in from callers of these functions vs. having
 	// this as a package-level variable.
-	IdentityAllocator *cache.CachingIdentityAllocator
+	IdentityAllocator cache.IdentityAllocator
 )
 
 // AllocateCIDRs attempts to allocate identities for a list of CIDRs. If any

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -112,9 +112,9 @@ func allocateCIDRs(prefixes []*net.IPNet, newlyAllocatedIdentities map[string]*i
 	return allocatedIdentitiesSlice, nil
 }
 
-// ReleaseCIDRs releases the identities of a list of CIDRs. When the last use
+// ReleaseCIDRIdentitiesByCIDR releases the identities of a list of CIDRs. When the last use
 // of the identity is released, the ipcache entry is deleted.
-func ReleaseCIDRs(prefixes []*net.IPNet) {
+func ReleaseCIDRIdentitiesByCIDR(prefixes []*net.IPNet) {
 	for _, prefix := range prefixes {
 		if prefix == nil {
 			continue

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/testutils"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	. "gopkg.in/check.v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -93,7 +93,7 @@ type DummySelectorCacheUser struct{}
 
 func testNewPolicyRepository() *policy.Repository {
 	repo := policy.NewPolicyRepository(nil, nil)
-	repo.GetSelectorCache().SetLocalIdentityNotifier(testutils.NewDummyIdentityNotifier())
+	repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return repo
 }
 

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -92,7 +92,8 @@ var (
 type DummySelectorCacheUser struct{}
 
 func testNewPolicyRepository() *policy.Repository {
-	repo := policy.NewPolicyRepository(nil, nil)
+	idAllocator := testidentity.NewFakeIdentityAllocator(nil)
+	repo := policy.NewPolicyRepository(idAllocator, nil, nil)
 	repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return repo
 }

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -208,7 +208,7 @@ func deleteToCidrFromEndpoint(
 			delSlice = append(delSlice, *delCIDRRule)
 		}
 		prefixes := policy.GetPrefixesFromCIDRSet(delSlice)
-		ipcache.ReleaseCIDRs(prefixes)
+		ipcache.ReleaseCIDRIdentitiesByCIDR(prefixes)
 	}
 
 	// if endpoint is not in CIDR or it's not generated it's ok to retain it

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -15,12 +15,14 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	. "gopkg.in/check.v1"
 )
 
 func (s *K8sSuite) TestTranslatorDirect(c *C) {
-	repo := policy.NewPolicyRepository(nil, nil)
+	idAllocator := testidentity.NewFakeIdentityAllocator(nil)
+	repo := policy.NewPolicyRepository(idAllocator, nil, nil)
 
 	tag1 := labels.LabelArray{labels.ParseLabel("tag1")}
 	serviceInfo := ServiceID{
@@ -123,7 +125,8 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 }
 
 func (s *K8sSuite) TestTranslatorLabels(c *C) {
-	repo := policy.NewPolicyRepository(nil, nil)
+	idAllocator := testidentity.NewFakeIdentityAllocator(nil)
+	repo := policy.NewPolicyRepository(idAllocator, nil, nil)
 	svcLabels := map[string]string{
 		"app": "tested-service",
 	}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/testutils"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	. "gopkg.in/check.v1"
 )
@@ -39,7 +40,7 @@ var (
 )
 
 func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	cache := repo.policyCache
 	identity := ep1.GetSecurityIdentity()
 	c.Assert(ep2.GetSecurityIdentity(), Equals, identity)
@@ -75,7 +76,7 @@ func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
 }
 
 func (s *DistilleryTestSuite) TestCachePopulation(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.revision = 42
 	cache := repo.policyCache
 
@@ -347,8 +348,9 @@ type policyDistillery struct {
 }
 
 func newPolicyDistillery(selectorCache *SelectorCache) *policyDistillery {
+	identityAllocator := testidentity.NewFakeIdentityAllocator(nil)
 	ret := &policyDistillery{
-		Repository: NewPolicyRepository(nil, nil),
+		Repository: NewPolicyRepository(identityAllocator, nil, nil),
 	}
 	ret.selectorCache = selectorCache
 	return ret

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/api/kafka"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/proxy/go/cilium/api"
 
 	. "gopkg.in/check.v1"
@@ -28,7 +28,7 @@ var (
 	toFoo        = &SearchContext{To: labels.ParseSelectLabelArray("foo")}
 
 	dummySelectorCacheUser = &DummySelectorCacheUser{}
-	c                      = cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	c                      = cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	testSelectorCache      = testNewSelectorCache(c.GetIdentityCache())
 
 	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, api.WildcardEndpointSelector)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -154,7 +154,7 @@ func (p *Repository) GetPolicyCache() *PolicyCache {
 }
 
 // NewPolicyRepository creates a new policy repository.
-func NewPolicyRepository(idCache cache.IdentityCache, certManager CertificateManager) *Repository {
+func NewPolicyRepository(idAllocator cache.IdentityAllocator, idCache cache.IdentityCache, certManager CertificateManager) *Repository {
 	repoChangeQueue := eventqueue.NewEventQueueBuffered("repository-change-queue", option.Config.PolicyQueueSize)
 	ruleReactionQueue := eventqueue.NewEventQueueBuffered("repository-reaction-queue", option.Config.PolicyQueueSize)
 	repoChangeQueue.Run()

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -159,7 +159,7 @@ func NewPolicyRepository(idAllocator cache.IdentityAllocator, idCache cache.Iden
 	ruleReactionQueue := eventqueue.NewEventQueueBuffered("repository-reaction-queue", option.Config.PolicyQueueSize)
 	repoChangeQueue.Run()
 	ruleReactionQueue.Run()
-	selectorCache := NewSelectorCache(idCache)
+	selectorCache := NewSelectorCache(idAllocator, idCache)
 
 	repo := &Repository{
 		revision:              1,

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -30,7 +30,7 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooSelectLabel := labels.ParseSelectLabel("foo")
@@ -251,7 +251,7 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestGetRulesMatching(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -319,7 +319,7 @@ func (ds *PolicyTestSuite) TestGetRulesMatching(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestDeniesIngress(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -418,7 +418,7 @@ func (ds *PolicyTestSuite) TestDeniesIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestDeniesEgress(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -526,7 +526,7 @@ func (ds *PolicyTestSuite) TestDeniesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
@@ -573,7 +573,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDeny(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -661,7 +661,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3DependentL4IngressDenyFromRequires(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -730,7 +730,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressDenyFromRequires(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3DependentL4EgressDenyFromRequires(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -821,7 +821,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressDenyFromRequires(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -879,7 +879,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -973,7 +973,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
@@ -1071,7 +1071,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1126,7 +1126,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1183,7 +1183,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	app2Selector := labels.ParseSelectLabelArray("id=app2")
@@ -1314,7 +1314,7 @@ func buildDenyRule(from, to, port string) api.Rule {
 }
 
 func (ds *PolicyTestSuite) TestPolicyDenyTrace(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	// Add rules to allow foo=>bar

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -34,7 +34,7 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooSelectLabel := labels.ParseSelectLabel("foo")
@@ -240,7 +240,7 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	// cannot add empty rule
@@ -326,7 +326,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 }
 
 func BenchmarkParseLabel(b *testing.B) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	b.ResetTimer()
@@ -365,7 +365,7 @@ func BenchmarkParseLabel(b *testing.B) {
 }
 
 func (ds *PolicyTestSuite) TestAllowsIngress(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -464,7 +464,7 @@ func (ds *PolicyTestSuite) TestAllowsIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestAllowsEgress(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -572,7 +572,7 @@ func (ds *PolicyTestSuite) TestAllowsEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
@@ -740,7 +740,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -890,7 +890,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -959,7 +959,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1050,7 +1050,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1190,7 +1190,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1346,7 +1346,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgress(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
@@ -1462,7 +1462,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1600,7 +1600,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1738,7 +1738,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	app2Selector := labels.ParseSelectLabelArray("id=app2")
@@ -1925,7 +1925,7 @@ func (repo *Repository) checkTrace(c *C, ctx *SearchContext, trace string,
 }
 
 func (ds *PolicyTestSuite) TestPolicyTrace(c *C) {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	// Add rules to allow foo=>bar

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
-	"github.com/cilium/cilium/pkg/testutils/allocator"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
@@ -193,7 +193,7 @@ func (d DummyOwner) PolicyDebug(fields logrus.Fields, msg string) {
 }
 
 func bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, c *C) *Repository {
-	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	testRepo := NewPolicyRepository(mgr.GetIdentityCache(), nil)
 
 	SetPolicyEnabled(option.DefaultEnforcement)

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -194,7 +194,9 @@ func (d DummyOwner) PolicyDebug(fields logrus.Fields, msg string) {
 
 func bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, c *C) *Repository {
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
-	testRepo := NewPolicyRepository(mgr.GetIdentityCache(), nil)
+	ids := mgr.GetIdentityCache()
+	fakeAllocator := testidentity.NewFakeIdentityAllocator(ids)
+	testRepo := NewPolicyRepository(fakeAllocator, ids, nil)
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 	GenerateNumIdentities(3000)

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1601,7 +1601,7 @@ func checkEgress(c *C, repo *Repository, ctx *SearchContext, verdict api.Decisio
 }
 
 func parseAndAddRules(c *C, rules api.Rules) *Repository {
-	repo := NewPolicyRepository(nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	_, _ = repo.AddList(rules)

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/testutils"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	. "gopkg.in/check.v1"
 )
@@ -615,7 +615,7 @@ func (ds *SelectorCacheTestSuite) TestIdentityUpdatesMultipleUsers(c *C) {
 
 func (ds *SelectorCacheTestSuite) TestIdentityNotifier(c *C) {
 	sc := testNewSelectorCache(cache.IdentityCache{})
-	idNotifier, ok := sc.localIdentityNotifier.(*testutils.DummyIdentityNotifier)
+	idNotifier, ok := sc.localIdentityNotifier.(*testidentity.DummyIdentityNotifier)
 	c.Assert(ok, Equals, true)
 	c.Assert(idNotifier, Not(IsNil))
 
@@ -674,6 +674,6 @@ func (ds *SelectorCacheTestSuite) TestIdentityNotifier(c *C) {
 
 func testNewSelectorCache(ids cache.IdentityCache) *SelectorCache {
 	sc := NewSelectorCache(ids)
-	sc.SetLocalIdentityNotifier(testutils.NewDummyIdentityNotifier())
+	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return sc
 }

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -673,7 +673,7 @@ func (ds *SelectorCacheTestSuite) TestIdentityNotifier(c *C) {
 }
 
 func testNewSelectorCache(ids cache.IdentityCache) *SelectorCache {
-	sc := NewSelectorCache(ids)
+	sc := NewSelectorCache(testidentity.NewFakeIdentityAllocator(ids), ids)
 	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return sc
 }

--- a/pkg/proxy/epinfo.go
+++ b/pkg/proxy/epinfo.go
@@ -23,7 +23,7 @@ var (
 	// identities from their numeric representation.
 	// TODO: plumb an allocator in from callers of these functions vs. having
 	// this as a package-level variable.
-	Allocator *cache.CachingIdentityAllocator
+	Allocator cache.IdentityAllocator
 )
 
 // EndpointLookup is any type which maps from IP to the endpoint owning that IP.

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -5,6 +5,7 @@ package testidentity
 
 import (
 	"context"
+	"net"
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -38,6 +39,11 @@ func (f *FakeIdentityAllocator) WaitForInitialGlobalIdentities(context.Context) 
 	return nil
 }
 
+func (f *FakeIdentityAllocator) GetIdentities() cache.IdentitiesModel {
+	result := cache.IdentitiesModel{}
+	return result.FromIdentityCache(f.IdentityCache)
+}
+
 // AllocateIdentity does nothing.
 func (f *FakeIdentityAllocator) AllocateIdentity(context.Context, labels.Labels, bool) (*identity.Identity, bool, error) {
 	return nil, true, nil
@@ -48,6 +54,16 @@ func (f *FakeIdentityAllocator) Release(context.Context, *identity.Identity) (re
 	return true, nil
 }
 
+// ReleaseSlice does nothing.
+func (f *FakeIdentityAllocator) ReleaseSlice(context.Context, cache.IdentityAllocatorOwner, []*identity.Identity) error {
+	return nil
+}
+
+// LookupIdentity is a no-op.
+func (f *FakeIdentityAllocator) LookupIdentity(ctx context.Context, lbls labels.Labels) *identity.Identity {
+	return nil
+}
+
 // LookupIdentityByID returns the identity corresponding to the id if the
 // identity is a reserved identity. Otherwise, returns nil.
 func (f *FakeIdentityAllocator) LookupIdentityByID(ctx context.Context, id identity.NumericIdentity) *identity.Identity {
@@ -55,4 +71,12 @@ func (f *FakeIdentityAllocator) LookupIdentityByID(ctx context.Context, id ident
 		return identity
 	}
 	return nil
+}
+
+func (f *FakeIdentityAllocator) AllocateCIDRsForIPs(IPs []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error) {
+	return nil, nil
+}
+
+func (f *FakeIdentityAllocator) GetIdentityCache() cache.IdentityCache {
+	return f.IdentityCache
 }

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -77,6 +77,9 @@ func (f *FakeIdentityAllocator) AllocateCIDRsForIPs(IPs []net.IP, newlyAllocated
 	return nil, nil
 }
 
+func (f *FakeIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
+}
+
 func (f *FakeIdentityAllocator) GetIdentityCache() cache.IdentityCache {
 	return f.IdentityCache
 }

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -20,7 +20,18 @@ func (i *IdentityAllocatorOwnerMock) GetNodeSuffix() string {
 }
 
 // FakeIdentityAllocator is used as a mock identity allocator for unit tests.
-type FakeIdentityAllocator struct{}
+type FakeIdentityAllocator struct {
+	cache.IdentityCache
+}
+
+func NewFakeIdentityAllocator(c cache.IdentityCache) *FakeIdentityAllocator {
+	if c == nil {
+		c = cache.IdentityCache{}
+	}
+	return &FakeIdentityAllocator{
+		IdentityCache: c,
+	}
+}
 
 // WaitForInitialGlobalIdentities does nothing.
 func (f *FakeIdentityAllocator) WaitForInitialGlobalIdentities(context.Context) error {

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2018-2019 Authors of Cilium
 
-package allocator
+package testidentity
 
 import (
 	"context"

--- a/pkg/testutils/identity/notifier.go
+++ b/pkg/testutils/identity/notifier.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 Authors of Cilium
 
-package testutils
+package testidentity
 
 import (
 	"github.com/cilium/cilium/pkg/identity"

--- a/pkg/testutils/identity/notifier.go
+++ b/pkg/testutils/identity/notifier.go
@@ -5,6 +5,7 @@ package testidentity
 
 import (
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -33,7 +34,9 @@ func (d *DummyIdentityNotifier) Unlock() {
 }
 
 // RegisterForIdentityUpdatesLocked starts managing this selector.
-func (d *DummyIdentityNotifier) RegisterForIdentityUpdatesLocked(selector api.FQDNSelector) (identities []identity.NumericIdentity) {
+//
+// It doesn't implement the identity allocation semantics of the interface.
+func (d *DummyIdentityNotifier) RegisterForIdentityUpdatesLocked(allocator cache.IdentityAllocator, selector api.FQDNSelector) (identities []identity.NumericIdentity) {
 	ids, ok := d.selectors[selector]
 	if !ok {
 		d.selectors[selector] = []identity.NumericIdentity{}


### PR DESCRIPTION
Review commit by commit.

Main bugfix commit message included here for review convenience:

    Users recently reported an issue where pods could not be deployed into
    their Cilium cluster, because the datapath regeneration for new Cilium
    endpoints would fail. The reason for the failure was that while
    attempting to initially provision the datapath for the new endpoint,
    Cilium would attempt to populate the endpoint's PolicyMap, but reach the
    limit of the total number of entries that the PolicyMap could contain.
    As such, in abundance of caution, Cilium backed off on attempting to
    provision the network for that pod and returned an error back up to the
    Kubelet and prevented subsequent pod provisioning.
    
    The reason for reaching the PolicyMap size was partially due to the node
    containing a large number of Identities, and partially due to an overly
    permissive network policy that programmed the new endpoints to allow
    traffic from all of these identities (individually). Typically this sort
    of problem is not present if the user specifies a `toEntities: all`
    policy to explicitly allow everything, but it can occasionally occur if
    the policy is very permissive but more complex than this explicit
    allow-all policy. One such example would be using `toFQDNs` policy with
    a MatchPattern on all domains.
    
    One of the curious aspects that we discovered while investigating this
    issue was that if the cilium-agent pods were restarted, the issue would
    disappear. This is indeed one potential mitigation for the issue.
    Furthermore, when comparing the `cilium policy selectors` output between
    sysdump output of a node where the problem is present vs. where the
    problem is not present, we discovered that there were CIDR identities
    derived from `toFQDNs` policy even when `toFQDNs` policy was not present.
    
    Upon further code inspection along with Chris Tarazi, we observed that
    the NameManager is responsible for handling allocation of Identities to
    associate with CIDR policies, and that the name manager then hands those
    identities over to the SelectorCache in order to be associated with
    individual toFQDNs policy selectors, and then passes a final list of
    identities up to the Daemon in order to plumb the underlying IPCache
    map. However, none of these layers were taking responsibility for
    releasing references to these Identities upon expiry of the entry that
    triggered the CIDR Identity allocation.
    
    Allocation path:
    
        Daemon.notifyOnDNSMsg()
        -> NameManager.UpdateGenerateDNS()
           -> NameManager.Config.UpdateSelectors -> Daemon.updateSelectors()
              -> identitiesForFQDNSelectorIPs() (in daemon/cmd/fqdn.go)
    
    This leaves us with a couple of options for releasing these references:
    * Associate each identity with the NameManager and have the NameManager
      release the references when the entry expires
    * Associate each identity with the FQDN selectors that are actively
      using it, and release the references when the FQDN selectors are
      released.
    
    Although I can see arguments for perhaps associating these references
    with the NameManager itself as it tracks the usage of each IP for FQDN
    policy and hence could tie the reference to the lifetime of the usage of
    the IP overall in the agent, so far the code has implicitly tied the
    allocation of each identity to its usage in each selector. As such, this
    commit attempts to simply acknowledge this reality and extend the
    update/release of the selectors in the NameManager to also release those
    same references that each selector holds.
    
    Practically speaking this means passing the allocated references from:
    identitiesForFQDNSelectorIPs() through to the sibling function
    updateSelectorCacheFQDNs():
    
        Daemon.notifyOnDNSMsg()
        -> NameManager.UpdateGenerateDNS()
           -> NameManager.Config.UpdateSelectors -> Daemon.updateSelectors()
              -> identitiesForFQDNSelectorIPs() (allocation)
              -> updateSelectorCacheFQDNs()
                 -> SelectorCache.{U,u}pdateFQDNSelector()
    
    Here we're basically just taking the new complete set of identities to
    be associated with the selector, and merging them into the existing
    selector in the cache. As such, we need to handle each case where an
    identity may have a duplicate reference between the existing cache and
    the new list, or any case where an identity is removed from the
    selector, and then collect those for subsequent release of the identity.
    
    Conveniently for the above approach, the release of the selectors is
    handled through the same core function, just coming from the caller
    SelectorCache.RemoveIdentitiesFQDNSelectors(). So this means we can
    contain the modifications necessary to resolve this bug to the
    selectorcache code.