### PR TITLE
veth: Avoid spammy dmesg info messages

### DIFF
--- a/pkg/datapath/connector/veth.go
+++ b/pkg/datapath/connector/veth.go
@@ -75,6 +75,7 @@ func SetupVethWithNames(lxcIfName, tmpIfName string, mtu int, ep *models.Endpoin
 		LinkAttrs: netlink.LinkAttrs{
 			Name:         lxcIfName,
 			HardwareAddr: net.HardwareAddr(epHostMAC),
+			TxQLen:       1000,
 		},
 		PeerName:         tmpIfName,
 		PeerHardwareAddr: net.HardwareAddr(epLXCMAC),

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -202,6 +202,7 @@ func setupVethPair(name, peerName string) error {
 			LinkAttrs: netlink.LinkAttrs{
 				Name:         name,
 				HardwareAddr: net.HardwareAddr(hostMac),
+				TxQLen:       1000,
 			},
 			PeerName:         peerName,
 			PeerHardwareAddr: net.HardwareAddr(peerMac),


### PR DESCRIPTION
Avoid spamming the kernel log with below messages as reported by @mukeshkwm:

  [...]
  [Mon Oct 25 06:48:03 2021] cilium_host: Caught tx_queue_len zero misconfig
  [Mon Oct 25 06:48:03 2021] cilium_net: Caught tx_queue_len zero misconfig
  [Mon Oct 25 06:48:08 2021] lxc_health: Caught tx_queue_len zero misconfig
  [...]
  [Mon Oct 25 07:22:27 2021] lxc667d091cb0ea: Caught tx_queue_len zero misconfig
  [Mon Oct 25 07:22:27 2021] lxc742557edbdd8: Caught tx_queue_len zero misconfig
  [Mon Oct 25 07:22:27 2021] lxc_health: Caught tx_queue_len zero misconfig
  [Mon Oct 25 07:22:27 2021] lxcb7215aa13fc7: Caught tx_queue_len zero misconfig
  [...]

These are harmless and the kernel will internally fix up dev->tx_queue_len
to DEFAULT_TX_QUEUE_LEN (== 1000). Avoid the messages by explicitly setting
the dev->tx_queue_len upon veth creation.

Fixes: #17703
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>