### PR TITLE
CI: update cilium-cli to v0.9.2

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -66,7 +66,7 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -257,10 +257,6 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
-
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -294,11 +290,6 @@ jobs:
         if: ${{ false }} # see comment above for details
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        if: ${{ false }} # see comment above for details
-        run: |
-          cilium status --wait
 
       - name: Port forward Relay
         if: ${{ false }} # see comment above for details

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -69,7 +69,7 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -260,10 +260,6 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
-
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -297,11 +293,6 @@ jobs:
         if: ${{ false }} # see comment above for details
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        if: ${{ false }} # see comment above for details
-        run: |
-          cilium status --wait
 
       - name: Port forward Relay
         if: ${{ false }} # see comment above for details

--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -65,7 +65,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -68,7 +68,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -65,7 +65,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -231,10 +231,6 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
-
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -262,10 +258,6 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
 
       - name: Port forward Relay
         run: |

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -68,7 +68,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -234,10 +234,6 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
-
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -265,10 +261,6 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
 
       - name: Port forward Relay
         run: |

--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -67,7 +67,7 @@ env:
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -241,10 +241,6 @@ jobs:
       - name: Install Cilium in cluster
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
 
       - name: Enable cluster mesh
         run: |

--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -70,7 +70,7 @@ env:
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -244,10 +244,6 @@ jobs:
       - name: Install Cilium in cluster
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
 
       - name: Enable cluster mesh
         run: |

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -65,7 +65,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -215,10 +215,6 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
-
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -242,10 +238,6 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
 
       - name: Port forward Relay
         run: |
@@ -280,10 +272,6 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
-
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -314,10 +302,6 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
 
       - name: Port forward Relay
         run: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -68,7 +68,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -218,10 +218,6 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
-
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -245,10 +241,6 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
 
       - name: Port forward Relay
         run: |
@@ -283,10 +275,6 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
-
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -317,10 +305,6 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
 
       - name: Port forward Relay
         run: |

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -22,7 +22,7 @@ concurrency:
 env:
   kind_version: v0.11.1
   kind_config: .github/kind-config.yaml
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
 
 jobs:
   installation-and-connectivity:
@@ -84,10 +84,6 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
-      - name: Status
-        run: |
-          cilium status --wait
-
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -111,10 +107,6 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
-
-      - name: Wait for Cilium status to be ready
-        run: |
-          cilium status --wait
 
       - name: Port forward Relay
         run: |

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -67,7 +67,7 @@ env:
   clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
   zone: us-west2-a
   firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -260,13 +260,9 @@ jobs:
 
       - name: Enable Relay
         run: |
-          cilium hubble enable --context ${{ steps.contexts.outputs.context1 }} ${{ steps.vars.outputs.hubble_enable_defaults }}
+          cilium hubble enable --context ${{ steps.contexts.outputs.context1 }} ${{ steps.vars.outputs.hubble_enable_defaults }} --wait=false
           cilium hubble enable --context ${{ steps.contexts.outputs.context2 }} ${{ steps.vars.outputs.hubble_enable_defaults }} --relay=false
-
-      - name: Wait for Cilium status to be ready
-        run: |
           cilium status --wait --context ${{ steps.contexts.outputs.context1 }}
-          cilium status --wait --context ${{ steps.contexts.outputs.context2 }}
 
       - name: Enable cluster mesh
         run: |

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -70,7 +70,7 @@ env:
   clusterName2: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh-2
   zone: us-west2-a
   firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
-  cilium_cli_version: v0.9.1
+  cilium_cli_version: v0.9.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -263,13 +263,9 @@ jobs:
 
       - name: Enable Relay
         run: |
-          cilium hubble enable --context ${{ steps.contexts.outputs.context1 }} ${{ steps.vars.outputs.hubble_enable_defaults }}
+          cilium hubble enable --context ${{ steps.contexts.outputs.context1 }} ${{ steps.vars.outputs.hubble_enable_defaults }} --wait=false
           cilium hubble enable --context ${{ steps.contexts.outputs.context2 }} ${{ steps.vars.outputs.hubble_enable_defaults }} --relay=false
-
-      - name: Wait for Cilium status to be ready
-        run: |
           cilium status --wait --context ${{ steps.contexts.outputs.context1 }}
-          cilium status --wait --context ${{ steps.contexts.outputs.context2 }}
 
       - name: Enable cluster mesh
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
     packages:
       - kernel-package
       - gnupg
+      - ipset
       - libelf-dev
       - libncurses5
 


### PR DESCRIPTION
`cilium hubble enable` now correctly waits for Cilium status to be
ready. Thus, the extra `cilium status --wait` after enabling Hubble can
be avoided.