### PR TITLE
vendor: Bump github.com/cilium/ipam

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cilium/customvet v0.0.0-20201209211516-9852765c1ac4
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
 	github.com/cilium/ebpf v0.7.0
-	github.com/cilium/ipam v0.0.0-20201106170308-4184bc4bf9d6
+	github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c
 	github.com/cilium/proxy v0.0.0-20210511221533-82a70d56bf32
 	github.com/cilium/workerpool v1.1.0
 	github.com/cncf/udpa/go v0.0.0-20201211205326-cc1b757b3edd // indirect

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3 h1:wenYMyWJ08dgEUUj0I
 github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3/go.mod h1:cXN7jgo+gsGlNvQ7Vqu2ELdc3f7i7PPgupHqSkLzzBo=
 github.com/cilium/ebpf v0.7.0 h1:1k/q3ATgxSXRdrmPfH8d7YK0GfqVsEKZAX9dQZvs56k=
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
-github.com/cilium/ipam v0.0.0-20201106170308-4184bc4bf9d6 h1:FhiaMJPUHPEw5pjoTfChDYVYiRWTrkJAX+PYEXAEMic=
-github.com/cilium/ipam v0.0.0-20201106170308-4184bc4bf9d6/go.mod h1:Ascfar4FtgB+K+mwqbZpSb3WVZ5sPFIarg+iAOXNZqI=
+github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c h1:BNplQ8/gUxxF3ISPjM5h6+e/r1lld3VhGEjj2S02/7c=
+github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c/go.mod h1:Ascfar4FtgB+K+mwqbZpSb3WVZ5sPFIarg+iAOXNZqI=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyRem1awcpz3icz/HoL8Dxg/m6a4=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
 github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d h1:skjwi8X3DdLWRI4AFmiAn83ruNoAw4f2kvdBlM8EI8c=

--- a/vendor/github.com/cilium/ipam/service/ipallocator/allocator.go
+++ b/vendor/github.com/cilium/ipam/service/ipallocator/allocator.go
@@ -230,17 +230,17 @@ func (r *Range) contains(ip net.IP) (bool, int) {
 
 // bigForIP creates a big.Int based on the provided net.IP
 func bigForIP(ip net.IP) *big.Int {
-	b := ip.To4()
-	if b == nil {
-		b = ip.To16()
-	}
-	return big.NewInt(0).SetBytes(b)
+	// NOTE: Convert to 16-byte representation so we can
+	// handle v4 and v6 values the same way.
+	return big.NewInt(0).SetBytes(ip.To16())
 }
 
-// addIPOffset adds the provided integer offset to a base big.Int representing a
-// net.IP
+// addIPOffset adds the provided integer offset to a base big.Int representing a net.IP
+// NOTE: If you started with a v4 address and overflow it, you get a v6 result.
 func addIPOffset(base *big.Int, offset int) net.IP {
-	return net.IP(big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes())
+	r := big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes()
+	r = append(make([]byte, 16), r...)
+	return net.IP(r[len(r)-16:])
 }
 
 // calculateIPOffset calculates the integer offset of ip from base such that

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -169,7 +169,7 @@ github.com/cilium/ebpf/internal
 github.com/cilium/ebpf/internal/btf
 github.com/cilium/ebpf/internal/unix
 github.com/cilium/ebpf/perf
-# github.com/cilium/ipam v0.0.0-20201106170308-4184bc4bf9d6
+# github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c
 ## explicit; go 1.14
 github.com/cilium/ipam/cidrset
 github.com/cilium/ipam/service/allocator


### PR DESCRIPTION
```release-note
Fixes a bug where IPv6 pod CIDRs with leading zeros where not supported
```

See also: https://github.com/cilium/ipam/pull/4
