### PR TITLE
docs: Fix helm value when deploying pure ipvlan l3 mode

### DIFF
--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -87,7 +87,7 @@ Example ConfigMap extract for ipvlan in pure L3 mode:
      --set ipvlan.masterDevice=bond0 \\
      --set tunnel=disabled \\
      --set installIptablesRules=false \\
-     --set l7Proxy.enabled=false \\
+     --set l7Proxy=false \\
      --set autoDirectNodeRoutes=true
 
 Example ConfigMap extract for ipvlan in L3S mode with iptables


### PR DESCRIPTION
Suppress warning message from helm:

warning: skipped value for l7Proxy: Not a table.

Signed-off-by: Chen Yaqi <chendotjs@gmail.com>


