### PR TITLE
ipvlan: Avoid spammy dmesg info messages

### DIFF
--- a/pkg/datapath/connector/ipvlan.go
+++ b/pkg/datapath/connector/ipvlan.go
@@ -156,6 +156,7 @@ func createIpvlanSlave(lxcIfName string, mtu, masterDev int, mode string, ep *mo
 		LinkAttrs: netlink.LinkAttrs{
 			Name:        lxcIfName,
 			ParentIndex: masterDev,
+			TxQLen:      1000,
 		},
 		Mode: ipvlanMode,
 	}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -240,6 +240,7 @@ func setupIpvlan(name string, nativeLink netlink.Link) (*netlink.IPVlan, error) 
 		LinkAttrs: netlink.LinkAttrs{
 			Name:        name,
 			ParentIndex: nativeLink.Attrs().Index,
+			TxQLen:      1000,
 		},
 		Mode: netlink.IPVLAN_MODE_L3,
 	}


### PR DESCRIPTION
Avoid spamming the kernel log with below messages when creating ipvlan slave:

[Tue Oct 26 14:20:38 2021] cilium: renamed from tmp_svwpi
[Tue Oct 26 14:20:38 2021] cilium: Caught tx_queue_len zero misconfig
[Tue Oct 26 14:20:46 2021] cilium_host: Caught tx_queue_len zero misconfig
[Tue Oct 26 14:32:11 2021] eth0: renamed from tmp6fed1
[Tue Oct 26 14:32:11 2021] eth0: Caught tx_queue_len zero misconfig

@mukeshkwm reported similar issue on veth datapath, which also applies to ipvlan datapath.

Fixes: #17703
Signed-off-by: Chen Yaqi <chendotjs@gmail.com>


