### PR TITLE
Gracefully terminate service endpoints

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -105,6 +105,7 @@ cilium-agent [flags]
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                            Enable k8s event handover to kvstore for improved scalability
+      --enable-k8s-terminating-endpoint                      Enable auto-detect of terminating endpoint condition (default true)
       --enable-l2-neigh-discovery                            Enables L2 neighbor discovery used by kube-proxy-replacement and IPsec (default true)
       --enable-l7-proxy                                      Enable L7 proxy for L7 policy enforcement (default true)
       --enable-local-node-route                              Enable installation of the route which points the allocation prefix of the local node (default true)

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1159,6 +1159,22 @@ The current Cilium kube-proxy replacement mode can also be introspected through 
     $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep KubeProxyReplacement
     KubeProxyReplacement:   Strict	[eth0 (DR)]
 
+Graceful Termination
+********************
+
+Cilium's eBPF kube-proxy replacement supports graceful termination of service
+endpoints deletion. The feature requires at least Kubernetes version 1.20, and
+the feature gate ``EndpointSliceTerminatingCondition`` needs to be enabled.
+By default, the Cilium agent then detects such terminating Pod state. If needed,
+the feature can be disabled with the configuration option ``enable-k8s-terminating-endpoint``.
+When Cilium agent receives a Kubernetes update event for a terminating endpoint,
+the datapath state for the endpoint is removed such that it won't service new
+connections, but the endpoint's active connections are able to terminate
+gracefully. The endpoint state is fully removed when the agent receives
+a Kubernetes delete event for the endpoint. The `Kubernetes
+pod termination <https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination>`_
+documentation contains more background on the behavior and configuration using ``terminationGracePeriodSeconds``.
+
 .. _session-affinity:
 
 Session Affinity

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -325,6 +325,10 @@
      - Configures the use of the KVStore to optimize Kubernetes event handling by mirroring it into the KVstore for reduced overhead in large clusters.
      - bool
      - ``false``
+   * - enableK8sTerminatingEndpoint
+     - Configure whether to enable auto detect of terminating state for endpoints in order to support graceful termination.
+     - bool
+     - ``true``
    * - enableXTSocketFallback
      - Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: http://docs.cilium.io/en/stable/install/system_requirements/#admin-kernel-version.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -765,6 +765,7 @@ sNodes
 sService
 sServiceHost
 sServicePort
+sTerminatingEndpoint
 sa
 sandboxing
 scalability

--- a/contrib/vagrant/scripts/02-install-kubernetes-master.sh
+++ b/contrib/vagrant/scripts/02-install-kubernetes-master.sh
@@ -76,6 +76,7 @@ ExecStart=/usr/bin/kube-apiserver \\
   --etcd-keyfile='/var/lib/kubernetes/etcd-k8s-api-server-key.pem' \\
   --etcd-servers=https://${controllers_ips[0]}:2379 \\
   --feature-gates=EndpointSlice=true \\
+  --feature-gates=EndpointSliceTerminatingCondition=true \\
   --kubelet-certificate-authority='/var/lib/kubernetes/ca-kubelet.pem' \\
   --kubelet-client-certificate='/var/lib/kubernetes/k8s-api-server.pem' \\
   --kubelet-client-key='/var/lib/kubernetes/k8s-api-server-key.pem' \\

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1034,6 +1034,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableCiliumEndpointSlice, false, "If set to true, CiliumEndpointSlice feature is enabled and cilium agent watch for CiliumEndpointSlice instead of CiliumEndpoint to update the IPCache.")
 	option.BindEnv(option.EnableCiliumEndpointSlice)
 
+	flags.Bool(option.EnableK8sTerminatingEndpoint, true, "Enable auto-detect of terminating endpoint condition")
+	option.BindEnv(option.EnableK8sTerminatingEndpoint)
+
 	viper.BindPFlags(flags)
 }
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -132,6 +132,7 @@ contributors across the globe, there is almost always someone available to help.
 | enableIPv4Masquerade | bool | `true` | Enables masquerading of IPv4 traffic leaving the node from endpoints. |
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
 | enableK8sEventHandover | bool | `false` | Configures the use of the KVStore to optimize Kubernetes event handling by mirroring it into the KVstore for reduced overhead in large clusters. |
+| enableK8sTerminatingEndpoint | bool | `true` | Configure whether to enable auto detect of terminating state for endpoints in order to support graceful termination. |
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: http://docs.cilium.io/en/stable/install/system_requirements/#admin-kernel-version. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
 | encryption.interface | string | `""` | Deprecated in favor of encryption.ipsec.interface. The interface to use for encrypted traffic. This option is only effective when encryption.type is set to ipsec. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -775,6 +775,10 @@ data:
   enable-cilium-endpoint-slice: "true"
 {{- end }}
 
+{{- if hasKey .Values "enableK8sTerminatingEndpoint" }}
+  enable-k8s-terminating-endpoint: {{ .Values.enableK8sTerminatingEndpoint | quote }}
+{{- end }}
+
 {{- if .Values.extraConfig }}
   {{ toYaml .Values.extraConfig | nindent 2 }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1774,3 +1774,7 @@ cgroup:
     enabled: true
   # -- Configure cgroup root where cgroup2 filesystem is mounted on the host (see also: `cgroup.autoMount`)
   hostRoot: /run/cilium/cgroupv2
+
+# -- Configure whether to enable auto detect of terminating state for endpoints
+# in order to support graceful termination.
+enableK8sTerminatingEndpoint: true

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -162,7 +162,7 @@ func ParseEndpointSliceV1Beta1(ep *slim_discovery_v1beta1.EndpointSlice) (Endpoi
 		// according to whatever system is managing the endpoint. A nil value
 		// indicates an unknown state. In most cases consumers should interpret this
 		// unknown state as ready.
-		// More info: vendor/k8s.io/api/discovery/v1beta1/types.go:114
+		// More info: vendor/k8s.io/api/discovery/v1beta1/types.go
 		if sub.Conditions.Ready != nil && !*sub.Conditions.Ready {
 			continue
 		}
@@ -222,7 +222,7 @@ func ParseEndpointSliceV1(ep *slim_discovery_v1.EndpointSlice) (EndpointSliceID,
 		// according to whatever system is managing the endpoint. A nil value
 		// indicates an unknown state. In most cases consumers should interpret this
 		// unknown state as ready.
-		// More info: vendor/k8s.io/api/discovery/v1/types.go:117
+		// More info: vendor/k8s.io/api/discovery/v1/types.go
 		if sub.Conditions.Ready != nil && !*sub.Conditions.Ready {
 			continue
 		}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -631,6 +631,7 @@ func genCartesianProduct(
 						IP:     parsedIP,
 						L4Addr: *backendPort,
 					},
+					Terminating: backend.Terminating,
 				})
 			}
 		}

--- a/pkg/k8s/zz_generated.deepequal.go
+++ b/pkg/k8s/zz_generated.deepequal.go
@@ -39,6 +39,9 @@ func (in *Backend) DeepEqual(other *Backend) bool {
 	if in.NodeName != other.NodeName {
 		return false
 	}
+	if in.Terminating != other.Terminating {
+		return false
+	}
 
 	return true
 }

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -190,6 +190,9 @@ type Backend struct {
 	// a node.
 	NodeName string
 	L3n4Addr
+	// State indicating whether backend is terminating so that it can be
+	// gracefully removed
+	Terminating bool
 }
 
 func (b *Backend) String() string {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -985,6 +985,10 @@ const (
 	// within IPAM upon endpoint restore and allows the use of the restored IP
 	// regardless of whether it's available in the pool.
 	BypassIPAvailabilityUponRestore = "bypass-ip-availability-upon-restore"
+
+	// EnableK8sTerminatingEndpoint enables the option to auto detect terminating
+	// state for endpoints in order to support graceful termination.
+	EnableK8sTerminatingEndpoint = "enable-k8s-terminating-endpoint"
 )
 
 // Default string arguments
@@ -2023,6 +2027,10 @@ type DaemonConfig struct {
 	// within IPAM upon endpoint restore and allows the use of the restored IP
 	// regardless of whether it's available in the pool.
 	BypassIPAvailabilityUponRestore bool
+
+	// EnableK8sTerminatingEndpoint enables auto-detect of terminating state for
+	// Kubernetes service endpoints.
+	EnableK8sTerminatingEndpoint bool
 }
 
 var (
@@ -2834,6 +2842,7 @@ func (c *DaemonConfig) Populate() {
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)
 	c.EnableICMPRules = viper.GetBool(EnableICMPRules)
 	c.BypassIPAvailabilityUponRestore = viper.GetBool(BypassIPAvailabilityUponRestore)
+	c.EnableK8sTerminatingEndpoint = viper.GetBool(EnableK8sTerminatingEndpoint)
 }
 
 func (c *DaemonConfig) populateDevices() {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -61,10 +61,11 @@ type monitorNotify interface {
 }
 
 type svcInfo struct {
-	hash          string
-	frontend      lb.L3n4AddrID
-	backends      []lb.Backend
-	backendByHash map[string]*lb.Backend
+	hash                string
+	frontend            lb.L3n4AddrID
+	backends            []lb.Backend
+	activeBackendsCount int // Non-terminating backends count
+	backendByHash       map[string]*lb.Backend
 
 	svcType                   lb.SVCType
 	svcTrafficPolicy          lb.SVCTrafficPolicy
@@ -355,7 +356,7 @@ func (s *Service) UpsertService(params *lb.SVC) (bool, lb.ID, error) {
 	scopedLog.Debug("Acquired service ID")
 
 	onlyLocalBackends, filterBackends := svc.requireNodeLocalBackends(params.Frontend)
-	prevBackendCount := len(svc.backends)
+	prevActiveBackendCount := svc.activeBackendsCount
 
 	backendsCopy := []lb.Backend{}
 	for _, b := range params.Backends {
@@ -380,10 +381,9 @@ func (s *Service) UpsertService(params *lb.SVC) (bool, lb.ID, error) {
 	}
 
 	// Update lbmaps (BPF service maps)
-	if err = s.upsertServiceIntoLBMaps(svc, onlyLocalBackends, prevBackendCount, newBackends,
-		obsoleteBackendIDs, prevSessionAffinity,
-		prevLoadBalancerSourceRanges, obsoleteSVCBackendIDs,
-		scopedLog); err != nil {
+	if err = s.upsertServiceIntoLBMaps(svc, onlyLocalBackends, prevActiveBackendCount,
+		newBackends, obsoleteBackendIDs, prevSessionAffinity, prevLoadBalancerSourceRanges,
+		obsoleteSVCBackendIDs, scopedLog); err != nil {
 
 		return false, lb.ID(0), err
 	}
@@ -718,7 +718,7 @@ func (s *Service) addBackendsToAffinityMatchMap(svcID lb.ID, backendIDs []lb.Bac
 }
 
 func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, onlyLocalBackends bool,
-	prevBackendCount int, newBackends []lb.Backend, obsoleteBackendIDs []lb.BackendID,
+	prevActiveBackendCount int, newBackends []lb.Backend, obsoleteBackendIDs []lb.BackendID,
 	prevSessionAffinity bool, prevLoadBalancerSourceRanges []*cidr.CIDR,
 	obsoleteSVCBackendIDs []lb.BackendID, scopedLog *logrus.Entry) error {
 
@@ -786,6 +786,7 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, onlyLocalBackends bool,
 
 	// Upsert service entries into BPF maps
 	backends := make(map[string]lb.BackendID, len(svc.backends))
+	activeBackendsCount := 0
 	for _, b := range svc.backends {
 		// Skip adding the terminating backend to the service map so that it
 		// won't be selected to serve new requests. However, the backend is still
@@ -796,15 +797,17 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, onlyLocalBackends bool,
 		// list passed to this function.
 		if !b.Terminating {
 			backends[b.String()] = b.ID
+			activeBackendsCount++
 		}
 	}
+	svc.activeBackendsCount = activeBackendsCount
 
 	p := &lbmap.UpsertServiceParams{
 		ID:                        uint16(svc.frontend.ID),
 		IP:                        svc.frontend.L3n4Addr.IP,
 		Port:                      svc.frontend.L3n4Addr.L4Addr.Port,
 		Backends:                  backends,
-		PrevBackendCount:          prevBackendCount,
+		PrevActiveBackendCount:    prevActiveBackendCount,
 		IPv6:                      ipv6,
 		Type:                      svc.svcType,
 		Local:                     onlyLocalBackends,
@@ -897,12 +900,13 @@ func (s *Service) restoreServicesLocked() error {
 		}
 
 		newSVC := &svcInfo{
-			hash:             svc.Frontend.Hash(),
-			frontend:         svc.Frontend,
-			backends:         svc.Backends,
-			backendByHash:    map[string]*lb.Backend{},
-			svcType:          svc.Type,
-			svcTrafficPolicy: svc.TrafficPolicy,
+			hash:                svc.Frontend.Hash(),
+			frontend:            svc.Frontend,
+			backends:            svc.Backends,
+			activeBackendsCount: len(svc.Backends),
+			backendByHash:       map[string]*lb.Backend{},
+			svcType:             svc.Type,
+			svcTrafficPolicy:    svc.TrafficPolicy,
 
 			sessionAffinity:           svc.SessionAffinity,
 			sessionAffinityTimeoutSec: svc.SessionAffinityTimeoutSec,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -485,24 +485,11 @@ func (s *Service) RestoreServices() error {
 		return err
 	}
 
-	// Remove no longer existing affinity matches
-	if option.Config.EnableSessionAffinity {
-		if err := s.deleteOrphanAffinityMatchesLocked(); err != nil {
-			return err
-		}
-	}
-
 	// Remove LB source ranges for no longer existing services
 	if option.Config.EnableSVCSourceRangeCheck {
 		if err := s.restoreAndDeleteOrphanSourceRanges(); err != nil {
 			return err
 		}
-	}
-
-	// Remove obsolete backends and release their IDs
-	if err := s.deleteOrphanBackends(); err != nil {
-		log.WithError(err).Warn("Failed to remove orphan backends")
-
 	}
 
 	return nil
@@ -600,6 +587,19 @@ func (s *Service) SyncWithK8sFinished() error {
 				return fmt.Errorf("Unable to remove service %+v: %s", svc, err)
 			}
 		}
+	}
+
+	// Remove no longer existing affinity matches
+	if option.Config.EnableSessionAffinity {
+		if err := s.deleteOrphanAffinityMatchesLocked(); err != nil {
+			return err
+		}
+	}
+
+	// Remove obsolete backends and release their IDs
+	if err := s.deleteOrphanBackends(); err != nil {
+		log.WithError(err).Warn("Failed to remove orphan backends")
+
 	}
 
 	return nil

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -45,8 +45,8 @@ func (m *LBMockMap) UpsertService(p *lbmap.UpsertServiceParams) error {
 		frontend := lb.NewL3n4AddrID(lb.NONE, p.IP, p.Port, p.Scope, lb.ID(p.ID))
 		svc = &lb.SVC{Frontend: *frontend}
 	} else {
-		if p.PrevBackendCount != len(svc.Backends) {
-			return fmt.Errorf("Invalid backends count: %d vs %d", p.PrevBackendCount, len(svc.Backends))
+		if p.PrevActiveBackendCount != len(svc.Backends) {
+			return fmt.Errorf("Invalid backends count: %d vs %d", p.PrevActiveBackendCount, len(svc.Backends))
 		}
 	}
 	svc.Backends = backendsList

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -39,7 +39,11 @@ func (m *LBMockMap) UpsertService(p *lbmap.UpsertServiceParams) error {
 		}
 		backendsList = append(backendsList, *b)
 	}
-
+	if p.UseMaglev && len(p.Backends) != 0 {
+		if err := m.UpsertMaglevLookupTable(p.ID, p.Backends, p.IPv6); err != nil {
+			return err
+		}
+	}
 	svc, found := m.ServiceByID[p.ID]
 	if !found {
 		frontend := lb.NewL3n4AddrID(lb.NONE, p.IP, p.Port, p.Scope, lb.ID(p.ID))

--- a/test/k8sT/manifests/graceful-termination.yaml
+++ b/test/k8sT/manifests/graceful-termination.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: graceful-term-svc
+spec:
+  ports:
+    - port: 8081
+  selector:
+    app: graceful-term-server
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: graceful-term-server
+  labels:
+    app: graceful-term-server
+spec:
+  containers:
+    - name: server
+      image: docker.io/cilium/graceful-termination-test-apps:latest
+      imagePullPolicy: IfNotPresent
+      ports:
+        - containerPort: 8081
+          protocol: TCP
+      command: [ "/server", "8081" ]
+  # The server pod gracefully terminates client connections upon receiving SIGTERM.
+  # It then waits for terminationGracePeriodSeconds duration so that CI
+  # assertions can be made before exiting.
+  terminationGracePeriodSeconds: 15
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node.cloudprovider.kubernetes.io/uninitialized
+      value: "true"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: graceful-term-client
+  labels:
+    app: graceful-term-client
+spec:
+  # The client exits with status code 0 on graceful termination so no need to restart the pod for success cases.
+  restartPolicy: OnFailure
+  terminationGracePeriodSeconds: 0
+  containers:
+    - name: client
+      image: docker.io/cilium/graceful-termination-test-apps:latest
+      imagePullPolicy: IfNotPresent
+      command: [ "/client", "graceful-term-svc.default.svc.cluster.local.:8081" ]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: testclient
+spec:
+  selector:
+    matchLabels:
+      zgroup: testDSClient
+  template:
+    metadata:
+      labels:
+        zgroup: testDSClient
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: web
+          image: docker.io/cilium/demo-client:1.0
+          imagePullPolicy: IfNotPresent
+          command: [ "sleep" ]
+          args:
+            - "1000h"

--- a/test/k8sT/service_helpers.go
+++ b/test/k8sT/service_helpers.go
@@ -1307,3 +1307,21 @@ func testDSR(kubectl *helpers.Kubectl, ni *nodesInfo, sourcePortForCTGCtest int)
 	res = kubectl.CiliumExecContext(context.TODO(), pod, fmt.Sprintf("cilium bpf nat list | grep %d", sourcePortForCTGCtest))
 	res.ExpectFail("NAT entry was not evicted")
 }
+
+func waitForServiceBackendPods(kubectl *helpers.Kubectl, podLabel string, expectedPodCount int) (pods []string) {
+	filter := "-l " + podLabel
+	err := kubectl.WaitforPods(helpers.DefaultNamespace, filter, helpers.HelperTimeout)
+	ExpectWithOffset(1, err).Should(BeNil(), "Pods [%s] failed to come up", podLabel)
+	pods, err = kubectl.GetPodNames(helpers.DefaultNamespace, podLabel)
+	ExpectWithOffset(1, err).Should(BeNil(), "Cannot retrieve pod names by filter %s", podLabel)
+	ExpectWithOffset(1, len(pods)).To(Equal(expectedPodCount), "Unexpected number of service backend pods")
+	podIPs, err := kubectl.GetPodsIPs(helpers.DefaultNamespace, podLabel)
+	ExpectWithOffset(1, err).Should(BeNil(), "Cannot retrieve pod IPs for %s", podLabel)
+	for _, ip := range podIPs {
+		err = kubectl.WaitForServiceBackend(helpers.K8s1, ip)
+		ExpectWithOffset(1, err).Should(BeNil(), "Failed waiting for %s backend entry on k8s1", ip)
+		err = kubectl.WaitForServiceBackend(helpers.K8s2, ip)
+		ExpectWithOffset(1, err).Should(BeNil(), "Failed waiting for %s backend entry on k8s2", ip)
+	}
+	return
+}

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -327,8 +327,8 @@ case $K8S_VERSION in
         KUBEADM_WORKER_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification,swap"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
         KUBEADM_CONFIG="${KUBEADM_CONFIG_V1BETA2}"
-        CONTROLLER_FEATURE_GATES="EndpointSlice=true"
-        API_SERVER_FEATURE_GATES="EndpointSlice=true"
+        CONTROLLER_FEATURE_GATES="EndpointSlice=true,EndpointSliceTerminatingCondition=true"
+        API_SERVER_FEATURE_GATES="EndpointSlice=true,EndpointSliceTerminatingCondition=true"
         ;;
     "1.21")
         # kubeadm 1.21 requires conntrack to be installed, we can remove this
@@ -341,8 +341,8 @@ case $K8S_VERSION in
         KUBEADM_WORKER_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification,swap"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
         KUBEADM_CONFIG="${KUBEADM_CONFIG_V1BETA2}"
-        CONTROLLER_FEATURE_GATES="EndpointSlice=true"
-        API_SERVER_FEATURE_GATES="EndpointSlice=true"
+        CONTROLLER_FEATURE_GATES="EndpointSlice=true,EndpointSliceTerminatingCondition=true"
+        API_SERVER_FEATURE_GATES="EndpointSlice=true,EndpointSliceTerminatingCondition=true"
         ;;
     "1.22")
         # kubeadm 1.22 requires conntrack to be installed, we can remove this
@@ -355,8 +355,8 @@ case $K8S_VERSION in
         KUBEADM_WORKER_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification,swap"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
         KUBEADM_CONFIG="${KUBEADM_CONFIG_V1BETA3}"
-        CONTROLLER_FEATURE_GATES="EndpointSlice=true"
-        API_SERVER_FEATURE_GATES="EndpointSlice=true"
+        CONTROLLER_FEATURE_GATES="EndpointSlice=true,EndpointSliceTerminatingCondition=true"
+        API_SERVER_FEATURE_GATES="EndpointSlice=true,EndpointSliceTerminatingCondition=true"
         ;;
 esac
 


### PR DESCRIPTION
Objective:
Upon removal of a service backend, drain all the existing connections to the backend, and ensure that the backend is
not selected for new connections.

Implementation:
Backend selection in the datapath is done using `lb service` map lookups, and backend information is retrieved via `lb backend` maps. Earlier, we removed the backend entry from the maps as soon as it was deleted. This can break existing active connections to the backend for per-packet based load-balancing, or unconnected UDP, wherein backend information retrieval lookups fail, and connections are redirected to other backends.

Kubernetes allows users to specify `terminationGracefulPeriod` in the pod spec in order to allow server pods to gracefully terminate active connections. In k8s v1.20, a new endpoint condition called as `Terminating` [1] was added. When we receive an update for a terminating backend, we skip adding it to the service map so that the backends isn't selected for new connections. But we keep the entry in the backend and affinity maps so that active connections continue are not disrupted. Once the endpoint deletion event is received, the backend state is fully removed.

See commit description for more details.

[1] https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/#terminating

Fixes : #14844 

**Release note**
```release-note
Support graceful termination for service load-balancing such that active connections don't break when endpoints are deleted. 
```