### PR TITLE
datapath: Add ctx_redirect_to_proxy_hairpin_ipv6

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1260,7 +1260,7 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 	ret = ipv6_policy(ctx, 0, src_identity, &reason, NULL,
 			  &proxy_port, true);
 	if (ret == POLICY_ACT_PROXY_REDIRECT) {
-		ret = ctx_redirect_to_proxy_hairpin(ctx, proxy_port);
+		ret = ctx_redirect_to_proxy_hairpin_ipv6(ctx, proxy_port);
 		proxy_redirect = true;
 	}
 out:
@@ -1568,7 +1568,7 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 	ret = ipv4_policy(ctx, 0, src_identity, &reason, NULL,
 			  &proxy_port, true);
 	if (ret == POLICY_ACT_PROXY_REDIRECT) {
-		ret = ctx_redirect_to_proxy_hairpin(ctx, proxy_port);
+		ret = ctx_redirect_to_proxy_hairpin_ipv4(ctx, proxy_port);
 		proxy_redirect = true;
 	}
 out:

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+#ifndef __LIB_PROXY_HAIRPIN_H_
+#define __LIB_PROXY_HAIRPIN_H_
+
+#include "common.h"
+#include "utils.h"
+#include "ipv6.h"
+#include "ipv4.h"
+#include "eth.h"
+#include "dbg.h"
+#include "trace.h"
+#include "csum.h"
+#include "l4.h"
+
+/**
+ * ctx_redirect_to_proxy_hairpin redirects to the proxy by hairpining the
+ * packet out the incoming interface
+ */
+static __always_inline int
+ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port)
+{
+	union macaddr host_mac = HOST_IFINDEX_MAC;
+	union macaddr router_mac = NODE_MAC;
+	void *data_end = (void *)(long)ctx->data_end;
+	void *data = (void *)(long)ctx->data;
+	struct iphdr *ip4;
+	int ret;
+
+	ctx_store_meta(ctx, CB_PROXY_MAGIC,
+		       MARK_MAGIC_TO_PROXY | (proxy_port << 16));
+	bpf_barrier(); /* verifier workaround */
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+	ret = ipv4_l3(ctx, ETH_HLEN, (__u8 *)&router_mac, (__u8 *)&host_mac, ip4);
+	if (IS_ERR(ret))
+		return ret;
+
+	cilium_dbg(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port, 0);
+
+	/* Note that the actual __ctx_buff preparation for submitting the
+	 * packet to the proxy will occur in a subsequent program via
+	 * ctx_redirect_to_proxy_first().
+	 */
+
+	return redirect(HOST_IFINDEX, 0);
+}
+
+#endif /* __LIB_PROXY_HAIRPIN_H_ */


### PR DESCRIPTION
Add IPv6 version of ctx_redirect_to_proxy_hairpin() and use it in IPv6 path.

Move ctx_redirect_to_proxy_hairpin functions to a new
lib/proxy_hairpin.h so that they can be used from other bpf programs
as well.

Fixes: #17717
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
L7 proxy redirection on IPv6 ingress to a pod is fixed to properly update IPv6 hop limit.
```
