### PR TITLE
test: Enable debug for l4lb test

### DIFF
--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -47,6 +47,7 @@ nsenter -t $CONTROL_PLANE_PID -n /bin/sh -c "\
 helm install cilium ../../install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
+    --set debug.enabled=true \
     --set image.repository="quay.io/${IMG_OWNER}/cilium-ci" \
     --set image.tag="${IMG_TAG}" \
     --set image.useDigest=false \


### PR DESCRIPTION
Enable Cilium debug to get debug logs for diagnozing test fails.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
