### PR TITLE
mlh: update Jenkins jobs following 1.22 support

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -57,9 +57,10 @@ flake-tracker:
     - cilium-master-k8s-1.17-kernel-4.9
     - cilium-master-k8s-1.18-kernel-4.9
     - cilium-master-k8s-1.19-kernel-4.9
-    - cilium-master-k8s-1.19-kernel-5.4
-    - cilium-master-k8s-1.20-kernel-4.19
-    - cilium-master-k8s-1.21-kernel-4.9
+    - cilium-master-k8s-1.20-kernel-4.9
+    - cilium-master-k8s-1.20-kernel-5.4
+    - cilium-master-k8s-1.21-kernel-4.19
+    - cilium-master-k8s-1.22-kernel-4.9
     - cilium-master-k8s-upstream
     - cilium-master-runtime-kernel-net-next
     pr-jobs:
@@ -71,31 +72,42 @@ flake-tracker:
         - cilium-master-k8s-1.17-kernel-4.9
         - cilium-master-k8s-1.18-kernel-4.9
         - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
+        - cilium-master-k8s-1.20-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
       Cilium-PR-K8s-1.18-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.17-kernel-4.9
         - cilium-master-k8s-1.18-kernel-4.9
         - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
+        - cilium-master-k8s-1.20-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
       Cilium-PR-K8s-1.19-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.17-kernel-4.9
         - cilium-master-k8s-1.18-kernel-4.9
         - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-      Cilium-PR-K8s-1.19-kernel-5.4:
-        correlate-with-stable-jobs:
-        - cilium-master-k8s-1.19-kernel-5.4
-      Cilium-PR-K8s-1.20-kernel-4.19:
-        correlate-with-stable-jobs:
-        - cilium-master-k8s-1.20-kernel-4.19
-      Cilium-PR-K8s-1.21-kernel-4.9:
+        - cilium-master-k8s-1.20-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
+      Cilium-PR-K8s-1.20-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.17-kernel-4.9
         - cilium-master-k8s-1.18-kernel-4.9
         - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
+        - cilium-master-k8s-1.20-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
+      Cilium-PR-K8s-1.20-kernel-5.4:
+        correlate-with-stable-jobs:
+        - cilium-master-k8s-1.20-kernel-5.4
+      Cilium-PR-K8s-1.21-kernel-4.19:
+        correlate-with-stable-jobs:
+        - cilium-master-k8s-1.21-kernel-4.19
+      Cilium-PR-K8s-1.22-kernel-4.9:
+        correlate-with-stable-jobs:
+        - cilium-master-k8s-1.17-kernel-4.9
+        - cilium-master-k8s-1.18-kernel-4.9
+        - cilium-master-k8s-1.19-kernel-4.9
+        - cilium-master-k8s-1.20-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
       Cilium-PR-K8s-GKE:
         correlate-with-stable-jobs:
         - cilium-master-gke


### PR DESCRIPTION
Following merge of #16989, we now support K8s 1.22 and have rotated the Jenkins test jobs as follow:

- Added: Kernel 4.9 testing on K8s 1.22
- Changed: Kernel 4.19 testing on K8s 1.21 (instead of 1.20)
- Changed: Kernel 5.4 testing on K8s 1.20 (instead of 1.19)
- Added: Kernel 4.9 testing on K8s 1.20
- Removed: Kernel 4.9 testing on K8s 1.21

See the Table of Truth:tm: for up to date status on all trigger phrases: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0/edit#gid=0