### PR TITLE
docs: add K8s 1.22 compatibility

### DIFF
--- a/Documentation/concepts/kubernetes/compatibility.rst
+++ b/Documentation/concepts/kubernetes/compatibility.rst
@@ -17,12 +17,12 @@ with Cilium. Older Kubernetes versions not listed in this table do not have
 Cilium support. Newer Kubernetes versions, while not listed, will depend on the
 backward compatibility offered by Kubernetes.
 
-+------------------------------------+---------------------------+----------------------------+
-| k8s Version                        | k8s NetworkPolicy API     | CiliumNetworkPolicy        |
-+------------------------------------+---------------------------+----------------------------+
-|                                    |                           | ``cilium.io/v2`` has a     |
-| 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 | * `networking.k8s.io/v1`_ | `CustomResourceDefinition` |
-+------------------------------------+---------------------------+----------------------------+
++------------------------------------------+---------------------------+----------------------------+
+| k8s Version                              | k8s NetworkPolicy API     | CiliumNetworkPolicy        |
++------------------------------------------+---------------------------+----------------------------+
+|                                          |                           | ``cilium.io/v2`` has a     |
+| 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22 | * `networking.k8s.io/v1`_ | `CustomResourceDefinition` |
++------------------------------------------+---------------------------+----------------------------+
 
 Cilium CRD schema validation
 ============================

--- a/Documentation/concepts/kubernetes/requirements.rst
+++ b/Documentation/concepts/kubernetes/requirements.rst
@@ -24,6 +24,7 @@ backward compatibility offered by Kubernetes.
 * 1.19
 * 1.20
 * 1.21
+* 1.22
 
 System Requirements
 ===================

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -136,8 +136,9 @@ The Kubernetes tests support the following Kubernetes versions:
 * 1.19
 * 1.20
 * 1.21
+* 1.22
 
-By default, the Vagrant VMs are provisioned with Kubernetes 1.20. To run with any other
+By default, the Vagrant VMs are provisioned with Kubernetes 1.21. To run with any other
 supported version of Kubernetes, run the test suite with the following format:
 
 .. code-block:: shell-session

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -77,7 +77,7 @@ Download the `cilium enhanced istioctl version 1.10.4 <https://github.com/cilium
 .. note::
 
    Cilium integration, as presented in this Getting Started Guide, has
-   been tested with Kubernetes releases 1.17, 1.18, 1.19, 1.20 and 1.21.
+   been tested with Kubernetes releases 1.17, 1.18, 1.19, 1.20, 1.21 and 1.22.
    This Istio release does not work with Kubernetes 1.16 or older.
 
 Deploy the default Istio configuration profile onto Kubernetes:


### PR DESCRIPTION
Following merge of #16989, we now support K8s 1.22 and the default K8s version for Vagrant VMs is 1.21.