### PR TITLE
test: Force ginkgo to fail out on warning logs

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -300,6 +300,7 @@ var badLogMessages = map[string][]string{
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
 	"level=error": {lrpExists, opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock},
+	"level=warn":  nil,
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
Detect messages like these and cause the CI to fail when they are
detected:

    Unable to restore endpoint, ignoring
    Found incomplete restore directory /var/run/cilium/state/126_next_fail. Removing it...
