### PR TITLE
v1.10 backports 2021-10-28

### DIFF
--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -87,7 +87,7 @@ Example ConfigMap extract for ipvlan in pure L3 mode:
      --set ipvlan.masterDevice=bond0 \\
      --set tunnel=disabled \\
      --set installIptablesRules=false \\
-     --set l7Proxy.enabled=false \\
+     --set l7Proxy=false \\
      --set autoDirectNodeRoutes=true
 
 Example ConfigMap extract for ipvlan in L3S mode with iptables

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -974,63 +974,44 @@ were started before Cilium was deployed.
 Reporting a problem
 ===================
 
+Before you report a problem, make sure to retrieve the necessary information
+from your cluster before the failure state is lost.
+
 Automatic log & state collection
 --------------------------------
 
-Before you report a problem, make sure to retrieve the necessary information
-from your cluster before the failure state is lost. Cilium provides a script
-to automatically grab logs and retrieve debug information from all Cilium pods
-in the cluster.
+.. include:: ../gettingstarted/cli-download.rst
 
-The script has the following list of prerequisites:
-
-* Requires Python >= 2.7.*
-* Requires ``kubectl``.
-* ``kubectl`` should be pointing to your cluster before running the tool.
-
-You can download the latest version of the ``cilium-sysdump`` tool using the
-following command:
+Then, execute ``cilium sysdump`` command to collect troubleshooting information
+from your Kubernetes cluster:
 
 .. code-block:: shell-session
 
-   curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
-   python cilium-sysdump.zip
+   cilium sysdump
 
-You can specify from which nodes to collect the system dumps by passing
-node IP addresses via the ``--nodes`` argument and the duration of the time
-window for collecting logs via the ``--since`` argument (e.g. ``2m``, ``3h``).
+Note that by default ``cilium sysdump`` will attempt to collect as much logs as
+possible and for all the nodes in the cluster. If your cluster size is above 20
+nodes, consider setting the following options to limit the size of the sysdump.
+This is not required, but useful for those who have a constraint on bandwidth or
+upload size.
 
-.. code-block:: shell-session
-
-   python cilium-sysdump.zip --nodes $NODE1_IP,$NODE2_IP2 --since $LOG_DURATION
-
-Note that by default ``cilium-sysdump`` will attempt to collect as much logs as
-possible and for all the nodes in the cluster.
-
-If your cluster size is above 20 nodes, consider setting the following options
-to limit the size of the sysdump. This is not required, but useful for those
-who have a constraint on bandwidth or upload size.
-
-To make sure the tool collects as much relevant logs as possible, and to reduce
-the time required for this operation, it is advised to:
-
-* set the ``--since`` option to go back in time to when the issues started.
-* set the ``--nodes`` option to pick only a few nodes in case the cluster has
+* set the ``--node-list`` option to pick only a few nodes in case the cluster has
   many of them.
-* set the ``--size-limit`` option to limit the size of the log files (note:
+* set the ``--logs-since-time`` option to go back in time to when the issues started.
+* set the ``--logs-limit-bytes`` option to limit the size of the log files (note:
   passed onto ``kubectl logs``; does not apply to entire collection archive).
 
 Ideally, a sysdump that has a full history of select nodes, rather than a brief
-history of all the nodes, would be preferred (by using ``--nodes``). The second
-recommended way would be to use ``--since`` if you are able to narrow down when
-the issues started. Lastly, if the Cilium agent and Operator logs are too
-large, consider ``--size-limit``.
+history of all the nodes, would be preferred (by using ``--node-list``). The second
+recommended way would be to use ``--logs-since-time`` if you are able to narrow down
+when the issues started. Lastly, if the Cilium agent and Operator logs are too
+large, consider ``--logs-limit-bytes``.
 
 Use ``--help`` to see more options:
 
 .. code-block:: shell-session
 
-   python cilium-sysdump.zip --help
+   cilium sysdump --help
 
 Single Node Bugtool
 ~~~~~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -400,6 +400,10 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		apiLimiterSet:     apiLimiterSet,
 	}
 
+	if option.Config.RunMonitorAgent {
+		d.monitorAgent = monitoragent.NewAgent(ctx)
+	}
+
 	d.configModifyQueue = eventqueue.NewEventQueueBuffered("config-modify-queue", ConfigModifyQueueSize)
 	d.configModifyQueue.Run()
 
@@ -834,16 +838,15 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		return nil, restoredEndpoints, err
 	}
 
-	// We can only start monitor agent once cilium_event has been set up.
+	// We can only attach the monitor agent once cilium_event has been set up.
 	if option.Config.RunMonitorAgent {
-		monitorAgent, err := monitoragent.NewAgent(d.ctx, defaults.MonitorBufferPages)
+		err = d.monitorAgent.AttachToEventsMap(defaults.MonitorBufferPages)
 		if err != nil {
 			return nil, nil, err
 		}
-		d.monitorAgent = monitorAgent
 
 		if option.Config.EnableMonitor {
-			err = monitoragent.ServeMonitorAPI(monitorAgent)
+			err = monitoragent.ServeMonitorAPI(d.monitorAgent)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -40,7 +40,7 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/egresspolicy"
+	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -178,7 +178,7 @@ type Daemon struct {
 
 	bgpSpeaker *speaker.Speaker
 
-	egressPolicyManager *egresspolicy.Manager
+	egressGatewayManager *egressgateway.Manager
 
 	apiLimiterSet *rate.APILimiterSet
 
@@ -436,7 +436,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		d.bgpSpeaker = speaker.New()
 	}
 
-	d.egressPolicyManager = egresspolicy.NewEgressPolicyManager()
+	d.egressGatewayManager = egressgateway.NewEgressGatewayManager()
 
 	d.k8sWatcher = watchers.NewK8sWatcher(
 		d.endpointManager,
@@ -447,7 +447,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		d.datapath,
 		d.redirectPolicyManager,
 		d.bgpSpeaker,
-		d.egressPolicyManager,
+		d.egressGatewayManager,
 		option.Config,
 	)
 	nd.RegisterK8sNodeGetter(d.k8sWatcher)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -141,17 +141,6 @@ var (
 	bootstrapStats = bootstrapStatistics{}
 )
 
-func init() {
-	RootCmd.SetFlagErrorFunc(func(_ *cobra.Command, e error) error {
-		time.Sleep(fatalSleep)
-		return e
-	})
-	logrus.RegisterExitHandler(func() {
-		time.Sleep(fatalSleep)
-	},
-	)
-}
-
 // Execute sets up gops, installs the cleanup signal handler and invokes
 // the root command. This function only returns when an interrupt
 // signal has been received. This is intended to be called by main.main().
@@ -176,6 +165,23 @@ func skipInit(basePath string) bool {
 }
 
 func init() {
+	setupSleepBeforeFatal()
+	initializeFlags()
+	registerBootstrapMetrics()
+}
+
+func setupSleepBeforeFatal() {
+	RootCmd.SetFlagErrorFunc(func(_ *cobra.Command, e error) error {
+		time.Sleep(fatalSleep)
+		return e
+	})
+	logrus.RegisterExitHandler(func() {
+		time.Sleep(fatalSleep)
+	},
+	)
+}
+
+func initializeFlags() {
 	if skipInit(path.Base(os.Args[0])) {
 		log.Debug("Skipping preparation of cilium-agent environment")
 		return

--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -118,7 +118,7 @@ var (
 	metricBootstrapTimes prometheus.ObserverVec
 )
 
-func init() {
+func registerBootstrapMetrics() {
 	metricBootstrapTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metrics.Namespace,
 		Subsystem: metrics.SubsystemAgent,

--- a/pkg/egressgateway/doc.go
+++ b/pkg/egressgateway/doc.go
@@ -12,6 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// Package egresspolicy defines an internal representation of the Cilium Egress
-// Policy. The structures are managed by the EgressPolicyManager.
-package egresspolicy
+// Package egressgateway defines an internal representation of the Cilium Egress
+// Policy. The structures are managed by the Manager.
+package egressgateway

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package egresspolicy
+package egressgateway
 
 import (
 	"fmt"
@@ -30,8 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// Config is the internal representation of Cilium Egress NAT Policy.
-type Config struct {
+// PolicyConfig is the internal representation of Cilium Egress NAT Policy.
+type PolicyConfig struct {
 	// id is the parsed config name and namespace
 	id types.NamespacedName
 
@@ -59,7 +59,7 @@ type endpointMetadata struct {
 
 // policyConfigSelectsEndpoint determines if the given endpoint is selected by the policy
 // config based on matching labels of config and endpoint.
-func (config *Config) policyConfigSelectsEndpoint(endpointInfo *endpointMetadata) bool {
+func (config *PolicyConfig) policyConfigSelectsEndpoint(endpointInfo *endpointMetadata) bool {
 	labelsToMatch := k8sLabels.Set(endpointInfo.labels)
 	for _, selector := range config.endpointSelectors {
 		if selector.Matches(labelsToMatch) {
@@ -69,9 +69,9 @@ func (config *Config) policyConfigSelectsEndpoint(endpointInfo *endpointMetadata
 	return false
 }
 
-// Parse takes a CiliumEgressNATPolicy CR and converts to Config, the internal
-// representation of the egress nat policy
-func Parse(cenp *v2alpha1.CiliumEgressNATPolicy) (*Config, error) {
+// ParsePolicy takes a CiliumEgressNATPolicy CR and converts to PolicyConfig,
+// the internal representation of the egress nat policy
+func ParsePolicy(cenp *v2alpha1.CiliumEgressNATPolicy) (*PolicyConfig, error) {
 	var endpointSelectorList []api.EndpointSelector
 	var dstCidrList []*net.IPNet
 
@@ -131,7 +131,7 @@ func Parse(cenp *v2alpha1.CiliumEgressNATPolicy) (*Config, error) {
 		}
 	}
 
-	return &Config{
+	return &PolicyConfig{
 		endpointSelectors: endpointSelectorList,
 		dstCIDRs:          dstCidrList,
 		egressIP:          net.ParseIP(cenp.Spec.EgressSourceIP).To4(),
@@ -141,8 +141,8 @@ func Parse(cenp *v2alpha1.CiliumEgressNATPolicy) (*Config, error) {
 	}, nil
 }
 
-// ParseConfigID takes a CiliumEgressNATPolicy CR and returns only the config id
-func ParseConfigID(cenp *v2alpha1.CiliumEgressNATPolicy) types.NamespacedName {
+// ParsePolicyConfigID takes a CiliumEgressNATPolicy CR and returns only the config id
+func ParsePolicyConfigID(cenp *v2alpha1.CiliumEgressNATPolicy) types.NamespacedName {
 	return policyID{
 		Name: cenp.Name,
 	}

--- a/pkg/k8s/watchers/cilium_egress_gateway_policy.go
+++ b/pkg/k8s/watchers/cilium_egress_gateway_policy.go
@@ -15,7 +15,7 @@
 package watchers
 
 import (
-	"github.com/cilium/cilium/pkg/egresspolicy"
+	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/informer"
@@ -94,12 +94,12 @@ func (k *K8sWatcher) addCiliumEgressNATPolicy(cenp *cilium_v2alpha1.CiliumEgress
 		logfields.K8sAPIVersion:             cenp.TypeMeta.APIVersion,
 	})
 
-	ep, err := egresspolicy.Parse(cenp)
+	ep, err := egressgateway.ParsePolicy(cenp)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to add CiliumEgressNATPolicy: malformed policy config.")
 		return err
 	}
-	if _, err := k.egressPolicyManager.AddEgressPolicy(*ep); err != nil {
+	if _, err := k.egressGatewayManager.AddEgressPolicy(*ep); err != nil {
 		scopedLog.WithError(err).Warn("Failed to add CiliumEgressNATPolicy.")
 		return err
 	}
@@ -115,8 +115,8 @@ func (k *K8sWatcher) deleteCiliumEgressNATPolicy(cenp *cilium_v2alpha1.CiliumEgr
 		logfields.K8sAPIVersion:             cenp.TypeMeta.APIVersion,
 	})
 
-	epID := egresspolicy.ParseConfigID(cenp)
-	if err := k.egressPolicyManager.DeleteEgressPolicy(epID); err != nil {
+	epID := egressgateway.ParsePolicyConfigID(cenp)
+	if err := k.egressGatewayManager.DeleteEgressPolicy(epID); err != nil {
 		scopedLog.WithError(err).Warn("Failed to delete CiliumEgressNATPolicy.")
 		return err
 	}

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -212,7 +212,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 	}
 
 	if option.Config.EnableEgressGateway {
-		k.egressPolicyManager.OnUpdateEndpoint(endpoint)
+		k.egressGatewayManager.OnUpdateEndpoint(endpoint)
 	}
 }
 
@@ -239,6 +239,6 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 		}
 	}
 	if option.Config.EnableEgressGateway {
-		k.egressPolicyManager.OnDeleteEndpoint(endpoint)
+		k.egressGatewayManager.OnDeleteEndpoint(endpoint)
 	}
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath"
-	"github.com/cilium/cilium/pkg/egresspolicy"
+	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -162,8 +162,8 @@ type bgpSpeakerManager interface {
 
 	OnUpdateNode(node *corev1.Node)
 }
-type egressPolicyManager interface {
-	AddEgressPolicy(config egresspolicy.Config) (bool, error)
+type egressGatewayManager interface {
+	AddEgressPolicy(config egressgateway.PolicyConfig) (bool, error)
 	DeleteEgressPolicy(configID types.NamespacedName) error
 	OnUpdateEndpoint(endpoint *k8sTypes.CiliumEndpoint)
 	OnDeleteEndpoint(endpoint *k8sTypes.CiliumEndpoint)
@@ -192,7 +192,7 @@ type K8sWatcher struct {
 	svcManager            svcManager
 	redirectPolicyManager redirectPolicyManager
 	bgpSpeakerManager     bgpSpeakerManager
-	egressPolicyManager   egressPolicyManager
+	egressGatewayManager  egressGatewayManager
 
 	// controllersStarted is a channel that is closed when all controllers, i.e.,
 	// k8s watchers have started listening for k8s events.
@@ -224,7 +224,7 @@ func NewK8sWatcher(
 	datapath datapath.Datapath,
 	redirectPolicyManager redirectPolicyManager,
 	bgpSpeakerManager bgpSpeakerManager,
-	egressPolicyManager egressPolicyManager,
+	egressGatewayManager egressGatewayManager,
 	cfg WatcherConfiguration,
 ) *K8sWatcher {
 	return &K8sWatcher{
@@ -239,7 +239,7 @@ func NewK8sWatcher(
 		datapath:              datapath,
 		redirectPolicyManager: redirectPolicyManager,
 		bgpSpeakerManager:     bgpSpeakerManager,
-		egressPolicyManager:   egressPolicyManager,
+		egressGatewayManager:  egressGatewayManager,
 		cfg:                   cfg,
 	}
 }


### PR DESCRIPTION
 * #17402 -- docs: Use cilium sysdump instead of python sysdump (@michi-covalent)
 * #17407 -- monitor: Initialize agent in deamon early (@gandro)
 * #17616 -- daemons: name init functions and have one `init` (@nebril)
 * #17630 -- pkg: rename egresspolicy package to egressgateway (@jibi)
 * #17708 -- docs: Fix helm value when deploying pure ipvlan l3 mode (@chendotjs)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17402 17407 17616 17630 17708; do contrib/backporting/set-labels.py $pr done 1.10; done
```
or with
```
$ make add-label branch=v1.10 issues=17402,17407,17616,17630,17708
```