### PR TITLE
v1.9 backports 2021-10-28

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -65,10 +65,32 @@ process for backporting these PRs:
 One-time setup
 ~~~~~~~~~~~~~~
 
+#. Make sure you have a GitHub developer access token with the ``public_repos``
+   ``workflow`` scopes available. You can do this directly from
+   https://github.com/settings/tokens or by opening GitHub and then navigating
+   to: User Profile -> Settings -> Developer Settings -> Personal access token
+   -> Generate new token.
+
 #. The scripts referred to below need to be run on Linux, they do not work on
-   macOS. It is recommended to use the dev VM (``contrib/vagrant/start.sh``),
-   as it will have all the correct versions of dependencies / libraries. Once
-   you have a machine ready, you need to configure git to have your name and
+   macOS. It is recommended to create a container using (``contrib/backporting/Dockerfile``),
+   as it will have all the correct versions of dependencies / libraries.
+
+   .. code-block:: shell-session
+
+      $ export GITHUB_TOKEN=<YOUR_GITHUB_TOKEN>
+
+      $ docker build -t cilium-backport contrib/backporting/.
+
+      $ docker run -e GITHUB_TOKEN -v $(pwd):/cilium -v "$HOME/.ssh":/home/user/.ssh \
+            -it cilium-backport /bin/bash
+
+   .. note::
+
+      If you are running on a mac OS, and see ``/home/user/.ssh/config: line 3:
+      Bad configuration option: usekeychain`` error message while running any of
+      the backporting scripts, comment out the line ``UseKeychain yes``.
+
+#. Once you have a setup ready, you need to configure git to have your name and
    email address to be used in the commit messages:
 
    .. code-block:: bash
@@ -83,13 +105,8 @@ One-time setup
       $ git remote add johndoe git@github.com:johndoe/cilium.git
       $ git remote add upstream https://github.com/cilium/cilium.git
 
-#. Make sure you have a GitHub developer access token with the ``public_repos``
-   ``workflow`` scopes available. You can do this directly from
-   https://github.com/settings/tokens or by opening GitHub and then navigating
-   to: User Profile -> Settings -> Developer Settings -> Personal access token
-   -> Generate new token.
-
-#. This guide makes use of several tools to automate the backporting process.
+#. Skip this step if you have created a setup using the pre-defined Dockerfile.
+   This guide makes use of several tools to automate the backporting process.
    The basics require ``bash`` and ``git``, but to automate interactions with
    github, further tools are required.
 

--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -87,7 +87,7 @@ Example ConfigMap extract for ipvlan in pure L3 mode:
      --set ipvlan.masterDevice=bond0 \\
      --set tunnel=disabled \\
      --set installIptablesRules=false \\
-     --set l7Proxy.enabled=false \\
+     --set l7Proxy=false \\
      --set autoDirectNodeRoutes=true
 
 Example ConfigMap extract for ipvlan in L3S mode with iptables

--- a/contrib/backporting/Dockerfile
+++ b/contrib/backporting/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:20.04
+
+LABEL maintainer="maintainer@cilium.io"
+
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
+RUN apt-get install -y \
+  git \
+  jq \
+  python3 \
+  python3-pip \
+  curl \
+  vim
+RUN pip3 install --user PyGithub
+RUN mkdir -p /hub && \
+    cd /hub \
+    && curl -L -o hub.tgz https://github.com/github/hub/releases/download/v2.14.0/hub-linux-amd64-2.14.0.tgz \
+    && tar xfz hub.tgz \
+    && $(tar tfz hub.tgz | head -n1 | cut -f1 -d"/")/install \
+    && rm -rf /hub
+RUN useradd -m user
+USER user

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -342,7 +342,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 		externalIP = node.GetIPv6()
 	}
 	// ExternalIP could be nil but we are covering that case inside NewConfiguration
-	mtuConfig = mtu.NewConfiguration(authKeySize, option.Config.EnableIPSec, option.Config.Tunnel != option.TunnelDisabled, configuredMTU, externalIP)
+	mtuConfig = mtu.NewConfiguration(authKeySize, option.Config.EnableIPSec, option.Config.TunnelingEnabled(), configuredMTU, externalIP)
 
 	nodeMngr, err := nodemanager.NewManager("all", dp.Node(), ipcache.IPIdentityCache, option.Config)
 	if err != nil {
@@ -552,7 +552,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 	// happen after invoking initKubeProxyReplacementOptions().
 	if option.Config.Masquerade && option.Config.EnableBPFMasquerade &&
 		(!option.Config.EnableNodePort || option.Config.EgressMasqueradeInterfaces != "" || !option.Config.EnableRemoteNodeIdentity ||
-			(option.Config.Tunnel != option.TunnelDisabled && !hasFullHostReachableServices())) {
+			(option.Config.TunnelingEnabled() && !hasFullHostReachableServices())) {
 
 		var msg string
 		switch {
@@ -563,7 +563,7 @@ func NewDaemon(ctx context.Context, epMgr *endpointmanager.EndpointManager, dp d
 			msg = fmt.Sprintf("BPF masquerade requires remote node identities (--%s=\"true\").",
 				option.EnableRemoteNodeIdentity)
 		// Remove the check after https://github.com/cilium/cilium/issues/12544 is fixed
-		case option.Config.Tunnel != option.TunnelDisabled && !hasFullHostReachableServices():
+		case option.Config.TunnelingEnabled() && !hasFullHostReachableServices():
 			msg = fmt.Sprintf("BPF masquerade requires --%s to be fully enabled (TCP and UDP).",
 				option.EnableHostReachableServices)
 		case option.Config.EgressMasqueradeInterfaces != "":

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1177,7 +1177,7 @@ func initEnv(cmd *cobra.Command) {
 			}
 		}
 	case datapathOption.DatapathModeIpvlan:
-		if option.Config.Tunnel != "" && option.Config.Tunnel != option.TunnelDisabled {
+		if option.Config.Tunnel != "" && option.Config.TunnelingEnabled() {
 			log.WithField(logfields.Tunnel, option.Config.Tunnel).
 				Fatal("tunnel cannot be set in the 'ipvlan' datapath mode")
 		}
@@ -1222,7 +1222,7 @@ func initEnv(cmd *cobra.Command) {
 		log.Fatal("L7 proxy requires iptables rules (--install-iptables-rules=\"true\")")
 	}
 
-	if option.Config.EnableIPSec && option.Config.Tunnel != option.TunnelDisabled {
+	if option.Config.EnableIPSec && option.Config.TunnelingEnabled() {
 		if err := ipsec.ProbeXfrmStateOutputMask(); err != nil {
 			log.WithError(err).Fatal("IPSec with tunneling requires support for xfrm state output masks (Linux 4.19 or later).")
 		}
@@ -1231,7 +1231,7 @@ func initEnv(cmd *cobra.Command) {
 	// IPAMENI IPSec is configured from Reinitialize() to pull in devices
 	// that may be added or removed at runtime.
 	if option.Config.EnableIPSec &&
-		option.Config.Tunnel == option.TunnelDisabled &&
+		!option.Config.TunnelingEnabled() &&
 		len(option.Config.EncryptInterface) == 0 &&
 		option.Config.IPAM != ipamOption.IPAMENI {
 		link, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
@@ -1241,7 +1241,7 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.EncryptInterface = append(option.Config.EncryptInterface, link)
 	}
 
-	if option.Config.Tunnel != option.TunnelDisabled && option.Config.EnableAutoDirectRouting {
+	if option.Config.TunnelingEnabled() && option.Config.EnableAutoDirectRouting {
 		log.Fatalf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName)
 	}
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -270,7 +270,7 @@ func initKubeProxyReplacementOptions() (strict bool) {
 	}
 
 	if option.Config.EnableNodePort {
-		if option.Config.Tunnel != option.TunnelDisabled &&
+		if option.Config.TunnelingEnabled() &&
 			option.Config.NodePortMode != option.NodePortModeSNAT {
 
 			log.Warnf("Disabling NodePort's %q mode feature due to tunneling mode being enabled",
@@ -279,7 +279,7 @@ func initKubeProxyReplacementOptions() (strict bool) {
 		}
 
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
-			if option.Config.Tunnel != option.TunnelDisabled {
+			if option.Config.TunnelingEnabled() {
 				log.Fatalf("Cannot use NodePort acceleration with tunneling. Either run cilium-agent with --%s=%s or --%s=%s",
 					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.TunnelName, option.TunnelDisabled)
 			}
@@ -399,7 +399,7 @@ func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) {
 	}
 
 	if option.Config.EnableIPv4 &&
-		option.Config.Tunnel == option.TunnelDisabled &&
+		!option.Config.TunnelingEnabled() &&
 		option.Config.NodePortMode != option.NodePortModeSNAT &&
 		len(option.Config.Devices) > 1 {
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -329,7 +329,19 @@ func (m *Manager) legacyNodeIpBehavior() bool {
 	// ipcache. This resulted in a behavioral change. New deployments will
 	// provide this behavior out of the gate, existing deployments will
 	// have to opt into this by enabling remote-node identities.
-	return !m.conf.EncryptionEnabled() && !m.conf.RemoteNodeIdentitiesEnabled()
+	if m.conf.RemoteNodeIdentitiesEnabled() {
+		return false
+	}
+	// Needed to store the SPI for nodes in the ipcache.
+	if m.conf.NodeEncryptionEnabled() {
+		return false
+	}
+	// Needed to store the SPI for pod->remote node in the ipcache since
+	// that path goes through the tunnel.
+	if m.conf.EncryptionEnabled() && m.conf.TunnelingEnabled() {
+		return false
+	}
+	return true
 }
 
 // NodeUpdated is called after the information of a node has been updated. The

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -63,6 +63,7 @@ type IPCache interface {
 // Configuration is the set of configuration options the node manager depends
 // on
 type Configuration interface {
+	TunnelingEnabled() bool
 	RemoteNodeIdentitiesEnabled() bool
 	NodeEncryptionEnabled() bool
 	EncryptionEnabled() bool

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -45,9 +45,14 @@ type managerTestSuite struct{}
 var _ = check.Suite(&managerTestSuite{})
 
 type configMock struct {
+	Tunneling          bool
 	RemoteNodeIdentity bool
 	NodeEncryption     bool
 	Encryption         bool
+}
+
+func (c *configMock) TunnelingEnabled() bool {
+	return c.Tunneling
 }
 
 func (c *configMock) RemoteNodeIdentitiesEnabled() bool {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2199,6 +2199,12 @@ func (c *DaemonConfig) AlwaysAllowLocalhost() bool {
 	}
 }
 
+// TunnelingEnabled returns true if the remote-node identity feature
+// is enabled
+func (c *DaemonConfig) TunnelingEnabled() bool {
+	return c.Tunnel != TunnelDisabled
+}
+
 // RemoteNodeIdentitiesEnabled returns true if the remote-node identity feature
 // is enabled
 func (c *DaemonConfig) RemoteNodeIdentitiesEnabled() bool {

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -27,6 +27,11 @@ func (f *Config) CiliumNamespaceName() string {
 	return "kube-system"
 }
 
+// TunnelingEnabled returns true if the tunneling is used.
+func (f *Config) TunnelingEnabled() bool {
+	return true
+}
+
 // RemoteNodeIdentitiesEnabled returns true if the remote-node identity feature
 // is enabled
 func (f *Config) RemoteNodeIdentitiesEnabled() bool {


### PR DESCRIPTION
 * #17511 -- node: Skip ipcache for remote node IPs if IPsec is enabled (@pchaigno)
 * #17157 -- contrib/backporting: Dockerize backporting scripts (@aditighag)
 * #17708 -- docs: Fix helm value when deploying pure ipvlan l3 mode (@chendotjs)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17511 17157 17708; do contrib/backporting/set-labels.py $pr done 1.9; done
```
or with
```
$ make add-label branch=v1.9 issues=17511,17157,17708
```

not included: https://github.com/cilium/cilium/pull/17470 @pchaigno 