### PR TITLE
workflows: retrieve 1.10 branch code for L4LB test

### DIFF
--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -154,6 +154,7 @@ jobs:
 
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
         with:
+          ref: v1.10
           persist-credentials: false
 
       - name: Boot Fedora


### PR DESCRIPTION
The L4LB workflow requires checking out the repository to access the Vagrant and test files used for running the test.

For 1.10 backport PRs, we need the checkout to be done against `v1.10` and not against `master`, which is where the workflow lives and is the thus default SHA referenced by `actions/checkout` if none is provided.