### PR TITLE
datapath: preserve tail call maps in between replacing interface program pairs

### DIFF
--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -192,11 +192,13 @@ func (s *LoaderTestSuite) TestReload(c *C) {
 	c.Assert(err, IsNil)
 
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
-	err = replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
 	c.Assert(err, IsNil)
+	finalize()
 
-	err = replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+	finalize, err = replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
 	c.Assert(err, IsNil)
+	finalize()
 }
 
 func (s *LoaderTestSuite) testCompileFailure(c *C, ep *testutils.TestEndpoint) {
@@ -278,9 +280,11 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, ""); err != nil {
+		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+		if err != nil {
 			b.Fatal(err)
 		}
+		finalize()
 	}
 }
 

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -70,7 +70,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirectio
 
 	// Temporarily rename bpffs pins of maps whose definitions have changed in
 	// a new version of a datapath ELF.
-	if err := bpf.StartBPFFSMigration(bpf.GetMapRoot(), objPath); err != nil {
+	if err := bpf.StartBPFFSMigration(bpf.MapPrefixPath(), objPath); err != nil {
 		return fmt.Errorf("Failed to start bpffs map migration: %w", err)
 	}
 
@@ -79,7 +79,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirectio
 	// back to their initial paths.
 	var revert bool
 	defer func() {
-		if err := bpf.FinalizeBPFFSMigration(bpf.GetMapRoot(), objPath, revert); err != nil {
+		if err := bpf.FinalizeBPFFSMigration(bpf.MapPrefixPath(), objPath, revert); err != nil {
 			log.WithError(err).WithField("device", ifName).WithField("objPath", objPath).
 				Error("Could not finalize bpffs map migration")
 		}
@@ -110,13 +110,13 @@ func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirectio
 
 // graftDatapath replaces obj in tail call map
 func graftDatapath(ctx context.Context, mapPath, objPath, progSec string) error {
-	if err := bpf.StartBPFFSMigration(bpf.GetMapRoot(), objPath); err != nil {
+	if err := bpf.StartBPFFSMigration(bpf.MapPrefixPath(), objPath); err != nil {
 		return fmt.Errorf("Failed to start bpffs map migration: %w", err)
 	}
 
 	var revert bool
 	defer func() {
-		if err := bpf.FinalizeBPFFSMigration(bpf.GetMapRoot(), objPath, revert); err != nil {
+		if err := bpf.FinalizeBPFFSMigration(bpf.MapPrefixPath(), objPath, revert); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{logfields.BPFMapPath: mapPath, "objPath": objPath}).
 				Error("Could not finalize bpffs map migration")
 		}

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -118,5 +118,11 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev, xdpMode string, extraCAr
 	}
 
 	objPath := path.Join(dirs.Output, prog.Output)
-	return replaceDatapath(ctx, xdpDev, objPath, symbolFromHostNetdevEp, "", true, xdpMode)
+	finalize, err := replaceDatapath(ctx, xdpDev, objPath, symbolFromHostNetdevEp, "", true, xdpMode)
+	if err != nil {
+		return err
+	}
+	finalize()
+
+	return err
 }


### PR DESCRIPTION
To prevent unpinning tail call maps after replacing only one half of an interface's programs, e.g. `from-netdev` and `to-netdev`, allow the caller to defer finalizer operations until a batch of interfaces have been replaced.

This avoids short windows of packet drops due to missed tail calls.

Fixes #16561

Also fixed a bug where we specified the wrong bpffs path to the migration code. This causes migrations to not be executed in the currently-released version of 1.11, meaning resizing maps causes endpoints regeneration failures.

```release-note
Preserve tail call maps during resize to prevent drops during agent upgrade
```
