### PR TITLE
Adds a warning in the upgrade doc about split cluster

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -128,6 +128,12 @@ you can delete the cilium-preflight and proceed with the upgrade.
 Upgrading Cilium
 ================
 
+During normal cluster operations, all Cilium components should run the same
+version. Upgrading just one of them (e.g., upgrading the agent without
+upgrading the operator) could result in unexpected cluster behavior.
+The following steps will describe how to upgrade all of the components from
+one stable release to a later stable release.
+
 .. include:: upgrade-warning.rst
 
 Step 1: Upgrade to latest micro version (Recommended)


### PR DESCRIPTION
See commit msg.

We saw "split" cluster (mismatching agent and operator versions) causing weird behaviors (e.g., https://github.com/cilium/cilium/issues/17192), adding a warning in upgrade guide to discourage running "split" clusters.
