### PR TITLE
docs: Use git+https in requirements.txt

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -20,7 +20,7 @@ snowballstemmer==1.2.1
 Sphinx==1.8.1
 sphinx-autobuild==0.7.1
 # forked read the docs themez
-git+git://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
+git+https://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
 sphinx-rtd-theme==0.2.4; platform_machine == "aarch64"
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2


### PR DESCRIPTION
Netlify preview is currently failing with the following error:

```
Collecting git+git://github.com/cilium/sphinx_rtd_theme.git@v0.7 (from -r requirements.txt (line 23))
  Cloning git://github.com/cilium/sphinx_rtd_theme.git (to revision v0.7) ...
  Running command git clone -q git://github.com/cilium/sphinx_rtd_theme.git ...
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>