### PR TITLE
Reduce datapath from_lxc complexity

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -123,8 +123,8 @@ ipv6_l3_from_lxc(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	if (unlikely(!is_valid_lxc_src_ip(ip6)))
 		return DROP_INVALID_SIP;
 
-	ipv6_addr_copy(&tuple->daddr, (union v6addr *) &ip6->daddr);
-	ipv6_addr_copy(&tuple->saddr, (union v6addr *) &ip6->saddr);
+	ipv6_addr_copy(&tuple->daddr, (union v6addr *)&ip6->daddr);
+	ipv6_addr_copy(&tuple->saddr, (union v6addr *)&ip6->saddr);
 
 	hdrlen = ipv6_hdrlen(ctx, &tuple->nexthdr);
 	if (hdrlen < 0)
@@ -174,7 +174,7 @@ skip_service_lookup:
 	 * logic re-writes the tuple daddr. In "theory" however the assignment
 	 * should be OK to move above goto label.
 	 */
-	ipv6_addr_copy(&orig_dip, (union v6addr *) &tuple->daddr);
+	ipv6_addr_copy(&orig_dip, (union v6addr *)&tuple->daddr);
 
 
 	/* WARNING: ip6 offset check invalidated, revalidate before use */
@@ -426,7 +426,7 @@ to_host:
 
 pass_to_stack:
 #ifdef ENABLE_ROUTING
-	ret = ipv6_l3(ctx, l3_off, NULL, (__u8 *) &router_mac.addr, METRIC_EGRESS);
+	ret = ipv6_l3(ctx, l3_off, NULL, (__u8 *)&router_mac.addr, METRIC_EGRESS);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 #endif
@@ -923,7 +923,7 @@ to_host:
 
 pass_to_stack:
 #ifdef ENABLE_ROUTING
-	ret = ipv4_l3(ctx, l3_off, NULL, (__u8 *) &router_mac.addr, ip4);
+	ret = ipv4_l3(ctx, l3_off, NULL, (__u8 *)&router_mac.addr, ip4);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 #endif
@@ -1108,9 +1108,9 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 	policy_clear_mark(ctx);
 	tuple.nexthdr = ip6->nexthdr;
 
-	ipv6_addr_copy(&tuple.daddr, (union v6addr *) &ip6->daddr);
-	ipv6_addr_copy(&tuple.saddr, (union v6addr *) &ip6->saddr);
-	ipv6_addr_copy(&orig_sip, (union v6addr *) &ip6->saddr);
+	ipv6_addr_copy(&tuple.daddr, (union v6addr *)&ip6->daddr);
+	ipv6_addr_copy(&tuple.saddr, (union v6addr *)&ip6->saddr);
+	ipv6_addr_copy(&orig_sip, (union v6addr *)&ip6->saddr);
 
 	/* If packet is coming from the ingress proxy we have to skip
 	 * redirection to the ingress proxy as we would loop forever.
@@ -1308,7 +1308,7 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 
 	/* Packets from the proxy will already have a real identity. */
 	if (identity_is_reserved(src_identity)) {
-		union v6addr *src = (union v6addr *) &ip6->saddr;
+		union v6addr *src = (union v6addr *)&ip6->saddr;
 		struct remote_endpoint_info *info;
 
 		info = lookup_ip6_remote_endpoint(src);
@@ -1329,7 +1329,7 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 			}
 		}
 		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
-			   ((__u32 *) src)[3], src_identity);
+			   ((__u32 *)src)[3], src_identity);
 	}
 
 	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, LXC_ID, SECLABEL);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -52,7 +52,7 @@
 #include "lib/policy_log.h"
 
 #if !defined(ENABLE_HOST_SERVICES_FULL) || defined(ENABLE_SOCKET_LB_HOST_ONLY)
-# define ENABLE_PER_PACKET_LB
+# define ENABLE_PER_PACKET_LB 1
 #endif
 
 #if defined(ENABLE_ARP_PASSTHROUGH) && defined(ENABLE_ARP_RESPONDER)

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -490,8 +490,7 @@ encrypt_to_stack:
 	return CTX_ACT_OK;
 }
 
-declare_tailcall_if(__or3(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6),
-			  is_defined(DEBUG)), CILIUM_CALL_IPV6_FROM_LXC)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_LXC)
 int tail_handle_ipv6(struct __ctx_buff *ctx)
 {
 	__u32 dst_id = 0;
@@ -953,8 +952,7 @@ encrypt_to_stack:
 	return CTX_ACT_OK;
 }
 
-declare_tailcall_if(__or3(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6),
-			  is_defined(DEBUG)), CILIUM_CALL_IPV4_FROM_LXC)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_FROM_LXC)
 int tail_handle_ipv4(struct __ctx_buff *ctx)
 {
 	__u32 dst_id = 0;
@@ -1035,17 +1033,15 @@ int handle_xgress(struct __ctx_buff *ctx)
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
 		edt_set_aggregate(ctx, LXC_ID);
-		invoke_tailcall_if(__or3(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6),
-					 is_defined(DEBUG)),
-				   CILIUM_CALL_IPV6_FROM_LXC, tail_handle_ipv6);
+		ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_LXC);
+		ret = DROP_MISSED_TAIL_CALL;
 		break;
 #endif /* ENABLE_IPV6 */
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
 		edt_set_aggregate(ctx, LXC_ID);
-		invoke_tailcall_if(__or3(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6),
-					 is_defined(DEBUG)),
-				   CILIUM_CALL_IPV4_FROM_LXC, tail_handle_ipv4);
+		ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_LXC);
+		ret = DROP_MISSED_TAIL_CALL;
 		break;
 #ifdef ENABLE_ARP_PASSTHROUGH
 	case bpf_htons(ETH_P_ARP):
@@ -1276,8 +1272,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	return ret;
 }
 
-declare_tailcall_if(__or(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
-		    CILIUM_CALL_IPV6_TO_ENDPOINT)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_TO_ENDPOINT)
 int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 {
 	__u32 src_identity = ctx_load_meta(ctx, CB_SRC_LABEL);
@@ -1601,8 +1596,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	return ret;
 }
 
-declare_tailcall_if(__or(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
-		    CILIUM_CALL_IPV4_TO_ENDPOINT)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_TO_ENDPOINT)
 int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 {
 	__u32 src_identity = ctx_load_meta(ctx, CB_SRC_LABEL);
@@ -1743,11 +1737,12 @@ int tail_ipv6_to_ipv4(struct __ctx_buff *ctx)
 
 	ctx_store_meta(ctx, CB_NAT46_STATE, NAT64);
 
-	invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
-			   CILIUM_CALL_IPV4_FROM_LXC, tail_handle_ipv4);
+#ifdef ENABLE_IPV4
+	ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_LXC);
+	ret = DROP_MISSED_TAIL_CALL;
+#endif
 drop_err:
-	return send_drop_notify(ctx, SECLABEL, 0, 0, ret, CTX_ACT_DROP,
-				METRIC_EGRESS);
+	return send_drop_notify_error(ctx, SECLABEL, ret, CTX_ACT_DROP, METRIC_EGRESS);
 }
 
 static __always_inline int handle_ipv4_to_ipv6(struct __ctx_buff *ctx)
@@ -1835,14 +1830,14 @@ int handle_to_container(struct __ctx_buff *ctx)
 #endif
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		invoke_tailcall_if(__or(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
-				   CILIUM_CALL_IPV6_TO_ENDPOINT, tail_ipv6_to_endpoint);
+		ep_tail_call(ctx, CILIUM_CALL_IPV6_TO_ENDPOINT);
+		ret = DROP_MISSED_TAIL_CALL;
 		break;
 #endif /* ENABLE_IPV6 */
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		invoke_tailcall_if(__or(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
-				   CILIUM_CALL_IPV4_TO_ENDPOINT, tail_ipv4_to_endpoint);
+		ep_tail_call(ctx, CILIUM_CALL_IPV4_TO_ENDPOINT);
+		ret = DROP_MISSED_TAIL_CALL;
 		break;
 #endif /* ENABLE_IPV4 */
 	default:

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -96,7 +96,9 @@
 #define CILIUM_CALL_IPV4_FROM_HOST		22
 #define CILIUM_CALL_IPV6_FROM_HOST		23
 #define CILIUM_CALL_IPV6_ENCAP_NODEPORT_NAT	24
-#define CILIUM_CALL_SIZE			25
+#define CILIUM_CALL_IPV4_FROM_LXC_CONT		25
+#define CILIUM_CALL_IPV6_FROM_LXC_CONT		26
+#define CILIUM_CALL_SIZE			27
 
 typedef __u64 mac_t;
 
@@ -587,6 +589,7 @@ enum {
 #define	CB_IPCACHE_SRC_LABEL	CB_IFINDEX	/* Alias, non-overlapping */
 	CB_POLICY,
 #define	CB_ADDR_V6_2		CB_POLICY	/* Alias, non-overlapping */
+#define	CB_BACKEND_ID		CB_POLICY	/* Alias, non-overlapping */
 	CB_NAT46_STATE,
 #define CB_NAT			CB_NAT46_STATE	/* Alias, non-overlapping */
 #define	CB_ADDR_V6_3		CB_NAT46_STATE	/* Alias, non-overlapping */

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1452,8 +1452,8 @@ update_state:
 			 tuple->nexthdr, l3_off, l4_off, csum_off, key,
 			 backend, has_l4_header, skip_l3_xlate);
 drop_no_service:
-		tuple->flags = flags;
-		return DROP_NO_SERVICE;
+	tuple->flags = flags;
+	return DROP_NO_SERVICE;
 }
 #endif /* ENABLE_IPV4 */
 #endif /* __LB_H_ */

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -873,7 +873,42 @@ drop_no_service:
 	tuple->flags = flags;
 	return DROP_NO_SERVICE;
 }
+
+/* lb6_ctx_store_state() stores per packet load balancing state to be picked
+ * up on the continuation tail call.
+ * Note that the IP headers are already xlated and the tuple is re-initialized
+ * from the xlated headers before restoring state.
+ * NOTE: if lb_skip_l4_dnat() this is not the case as xlate is skipped. We
+ * lose the updated tuple daddr in that case.
+ */
+static __always_inline void lb6_ctx_store_state(struct __ctx_buff *ctx,
+						const struct ct_state *state)
+{
+	ctx_store_meta(ctx, CB_BACKEND_ID, state->backend_id);
+	ctx_store_meta(ctx, CB_CT_STATE, (__u32)state->rev_nat_index);
+}
+
+/* lb6_ctx_restore_state() restores per packet load balancing state from the
+ * previous tail call.
+ * tuple->flags does not need to be restored, as it will be reinitialized from
+ * the packet.
+ */
+static __always_inline void lb6_ctx_restore_state(struct __ctx_buff *ctx,
+						  struct ct_state *state)
+{
+	state->rev_nat_index = (__u16)ctx_load_meta(ctx, CB_CT_STATE);
+	/* Clear to not leak state to later stages of the datapath. */
+	ctx_store_meta(ctx, CB_CT_STATE, 0);
+
+	/* No loopback support for IPv6, see lb6_local() above. */
+
+	state->backend_id = ctx_load_meta(ctx, CB_BACKEND_ID);
+	/* Must clear to avoid policy bypass as CB_BACKEND_ID aliases CB_POLICY. */
+	ctx_store_meta(ctx, CB_BACKEND_ID, 0);
+}
+
 #else
+
 /* Stubs for v4-in-v6 socket cgroup hook case when only v4 is enabled to avoid
  * additional map management.
  */
@@ -1454,6 +1489,48 @@ update_state:
 drop_no_service:
 	tuple->flags = flags;
 	return DROP_NO_SERVICE;
+}
+
+/* lb4_ctx_store_state() stores per packet load balancing state to be picked
+ * up on the continuation tail call.
+ * Note that the IP headers are already xlated and the tuple is re-initialized
+ * from the xlated headers before restoring state.
+ * NOTE: if lb_skip_l4_dnat() this is not the case as xlate is skipped. We
+ * lose the updated tuple daddr in that case.
+ */
+static __always_inline void lb4_ctx_store_state(struct __ctx_buff *ctx,
+						const struct ct_state *state)
+{
+	ctx_store_meta(ctx, CB_BACKEND_ID, state->backend_id);
+	ctx_store_meta(ctx, CB_CT_STATE, (__u32)state->rev_nat_index << 16 |
+		       state->loopback);
+}
+
+/* lb4_ctx_restore_state() restores per packet load balancing state from the
+ * previous tail call.
+ * tuple->flags does not need to be restored, as it will be reinitialized from
+ * the packet.
+ */
+static __always_inline void lb4_ctx_restore_state(struct __ctx_buff *ctx,
+						  struct ct_state *state,
+						  const struct ipv4_ct_tuple *tuple  __maybe_unused)
+{
+	__u32 meta = ctx_load_meta(ctx, CB_CT_STATE);
+#ifndef DISABLE_LOOPBACK_LB
+	if (meta & 1) {
+		state->loopback = 1;
+		state->addr = IPV4_LOOPBACK;
+		state->svc_addr = tuple->daddr; /* backend address after xlate */
+	}
+#endif
+	state->rev_nat_index = meta >> 16;
+
+	/* Clear to not leak state to later stages of the datapath. */
+	ctx_store_meta(ctx, CB_CT_STATE, 0);
+
+	state->backend_id = ctx_load_meta(ctx, CB_BACKEND_ID);
+	/* must clear to avoid policy bypass as CB_BACKEND_ID aliases CB_POLICY. */
+	ctx_store_meta(ctx, CB_BACKEND_ID, 0);
 }
 #endif /* ENABLE_IPV4 */
 #endif /* __LB_H_ */

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -320,8 +320,8 @@ static __always_inline int policy_can_egress4(struct __ctx_buff *ctx,
  * Mark ctx to skip policy enforcement
  * @arg ctx	packet
  *
- * Will cause the packet to ignore the policy enforcement layer and
- * be considered accepted despite of the policy outcome.
+ * Will cause the packet to ignore the policy enforcement verdict for allow rules and
+ * be considered accepted despite of the policy outcome. Has no effect on deny rules.
  */
 static __always_inline void policy_mark_skip(struct __ctx_buff *ctx)
 {

--- a/test/bpf/check-complexity.sh
+++ b/test/bpf/check-complexity.sh
@@ -38,9 +38,11 @@ function annotate_section_names {
 	    -e "s/\(section '2\/22'\)/\1 (tail_call IPV4_FROM_HOST)/" \
 	    -e "s/\(section '2\/23'\)/\1 (tail_call IPV6_FROM_HOST)/" \
 	    -e "s/\(section '2\/24'\)/\1 (tail_call IPV6_ENCAP_NODEPORT_NAT)/"
+	    -e "s/\(section '2\/25'\)/\1 (tail_call IPV4_FROM_LXC_CONT)/" \
+	    -e "s/\(section '2\/26'\)/\1 (tail_call IPV6_FROM_LXC_CONT)/" \
 }
 
-if ! grep -q "CILIUM_CALL_SIZE.*25" "$BPFDIR/lib/common.h" ; then
+if ! grep -q "CILIUM_CALL_SIZE.*27" "$BPFDIR/lib/common.h" ; then
 	echo "This script is out of date compared to CILIUM_CALL_SIZE." 1>&2
 	exit 1
 fi


### PR DESCRIPTION
Split per packet load balancing into a separate tail call. This reduces datapath complexity when per packet load balancing is needed.

Preparatory commits simplify tail call logic and refactors IPv6 from LXC code paths to be more similar to IPv4. This makes edits and reviews on the functional change commits easier.

This PR should have minimal effect on the code when per packet load balancing is not required. On IPv4 there should be no change, and on IPv6 there is one extra data revalidation due to logic being split into two tail callable functions.

This is a prerequisite for #18894