### PR TITLE
docs: fix a block directive in OpenShift GSG

### DIFF
--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -57,7 +57,7 @@ if [ -n "${SKIP_LINT-}" ]; then
 else
   echo "Running linter..."
   CONF_PY_ROLES=$(sed -n "/^extlinks = {$/,/^}$/ s/^ *'\([^']\+\)':.*/\1/p" conf.py | tr '\n' ',')
-  CONF_PY_SUBSTITUTIONS=$(sed -n 's/^\.\. |\([^|]\+\)|.*/\1/p' conf.py | tr '\n' ',')
+  CONF_PY_SUBSTITUTIONS="$(sed -n 's/^\.\. |\([^|]\+\)|.*/\1/p' conf.py | tr '\n' ',')release"
   ignored_messages="("
   ignored_messages="${ignored_messages}bpf.rst:.*: \(INFO/1\) Enumerated list start value not ordinal"
   ignored_messages="${ignored_messages}|Hyperlink target .*is not referenced\."

--- a/Documentation/gettingstarted/k8s-install-openshift-okd.rst
+++ b/Documentation/gettingstarted/k8s-install-openshift-okd.rst
@@ -129,7 +129,7 @@ Next, generate OpenShift manifests:
 
 Next, obtain Cilium manifest from ``cilium/cilium-olm`` repository and copy to ``${CLUSTER_NAME}/manifests``:
 
-.. code-block:: shell-session
+.. parsed-literal::
 
    cilium_olm_rev="master"
    cilium_version="\ |release|\ "


### PR DESCRIPTION
A previous commit aimed at cleaning up the guide for OpenShift, but it wrongly turned a `parsed-literal` block into a `code-block`, dropping the evaluation of the `|release|` substitution. Let's restore it.

This also requires us to tell the RST linter that the `|release|` substitution is valid.

Fixes: #16006
