### PR TITLE
operator: remove deprecated Azure cloud name flag

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -336,6 +336,8 @@ Removed Options
   please use the ``--kube-version`` flag (introduced in Helm 3.6.0) instead.
 * The deprecated ``hubble-ca-cert`` configmap has been removed. Use
   ``hubble-ca-secret`` secret instead.
+* The ``azure-cloud-name`` option for cilium-operator-azure was deprecated in
+  1.10 and is now removed.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -152,9 +152,6 @@ const (
 
 	// Azure options
 
-	// AzureCloudName is the name of the cloud being used
-	AzureCloudName = "azure-cloud-name"
-
 	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
 	AzureSubscriptionID = "azure-subscription-id"
 
@@ -331,9 +328,6 @@ type OperatorConfig struct {
 
 	// Azure options
 
-	// AzureCloudName is the name of the cloud being used
-	AzureCloudName string
-
 	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
 	AzureSubscriptionID string
 
@@ -403,7 +397,6 @@ func (c *OperatorConfig) Populate() {
 
 	// Azure options
 
-	c.AzureCloudName = viper.GetString(AzureCloudName)
 	c.AzureSubscriptionID = viper.GetString(AzureSubscriptionID)
 	c.AzureResourceGroup = viper.GetString(AzureResourceGroup)
 	c.AzureUsePrimaryAddress = viper.GetBool(AzureUsePrimaryAddress)

--- a/operator/provider_azure_flags.go
+++ b/operator/provider_azure_flags.go
@@ -16,10 +16,6 @@ import (
 func init() {
 	flags := rootCmd.Flags()
 
-	flags.String(operatorOption.AzureCloudName, "AzurePublicCloud", "Name of the Azure cloud being used")
-	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureCloudName, "AZURE_CLOUD_NAME")
-	flags.MarkDeprecated(operatorOption.AzureCloudName, "This option will be removed in v1.11")
-
 	flags.String(operatorOption.AzureSubscriptionID, "", "Subscription ID to access Azure API")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureSubscriptionID, "AZURE_SUBSCRIPTION_ID")
 

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -17,7 +17,6 @@ import (
 	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/spf13/viper"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-allocator-azure")
@@ -38,14 +37,10 @@ func (*AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 
 	log.Info("Starting Azure IP allocator...")
 
-	azureCloudName := operatorOption.Config.AzureCloudName
-	if !viper.IsSet(operatorOption.AzureCloudName) {
-		log.Debug("Azure cloud name was not specified via CLI, retrieving it via Azure IMS")
-		var err error
-		azureCloudName, err = azureAPI.GetAzureCloudName(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("unsable to retrieve Azure cloud name: %w", err)
-		}
+	log.Debug("Retrieving Azure cloud name via Azure IMS")
+	azureCloudName, err := azureAPI.GetAzureCloudName(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve Azure cloud name: %w", err)
 	}
 
 	subscriptionID := operatorOption.Config.AzureSubscriptionID


### PR DESCRIPTION
Commit b29389d50f97 ("Auto-detect Azure cloud name via IMDS") marked the
flag as deprecated in 1.10 and to be removed in 1.11.

