### PR TITLE
operator: Hidden flags for egress gateway and LRPs

### DIFF
--- a/operator/flags.go
+++ b/operator/flags.go
@@ -68,13 +68,20 @@ func init() {
 	flags.BoolP(option.DebugArg, "D", false, "Enable debugging mode")
 	option.BindEnv(option.DebugArg)
 
-	// We need to obtain from Cilium ConfigMap if the CiliumEndpointCRD option
-	// is enabled or disabled. This option is marked as hidden because the
-	// Cilium Endpoint CRD controller is not in this program and by having it
+	// We need to obtain from Cilium ConfigMap if these options are enabled
+	// or disabled. These options are marked as hidden because having it
 	// being printed by operator --help could confuse users.
 	flags.Bool(option.DisableCiliumEndpointCRDName, false, "")
 	flags.MarkHidden(option.DisableCiliumEndpointCRDName)
 	option.BindEnv(option.DisableCiliumEndpointCRDName)
+
+	flags.Bool(option.EnableIPv4EgressGateway, false, "")
+	flags.MarkHidden(option.EnableIPv4EgressGateway)
+	option.BindEnv(option.EnableIPv4EgressGateway)
+
+	flags.Bool(option.EnableLocalRedirectPolicy, false, "")
+	flags.MarkHidden(option.EnableLocalRedirectPolicy)
+	option.BindEnv(option.EnableLocalRedirectPolicy)
 
 	flags.Duration(operatorOption.EndpointGCInterval, operatorOption.EndpointGCIntervalDefault, "GC interval for cilium endpoints")
 	option.BindEnv(operatorOption.EndpointGCInterval)


### PR DESCRIPTION
Some of the CRD registrations (e.g., CENP and CLRP) are conditioned on feature flags. In some cases, that registration happens in the operator, in which case it needs to be possible to enable the features there.

Reproduced and tested in the development VM where the operator is in charge of registering the CRDs. Without this patch, the CRDs are never created and the agent waits indefinitely when e.g. the egress gateway is enabled. With this patch, the egress gateway can be enabled in the operator via a flag to trigger the registration of the CRD.

```release-note
Define operator feature flags to allow the operator to register related CRDs.
```