### PR TITLE
egressgateway: Allow several CENPs with same egress IP

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -71,11 +71,6 @@ func (manager *Manager) AddEgressPolicy(config PolicyConfig) (bool, error) {
 		return false, errors.New("already exists")
 	}
 
-	err := manager.isValidPolicyConfig(config)
-	if err != nil {
-		return false, err
-	}
-
 	manager.policyConfigs[config.id] = &config
 	for _, endpoint := range manager.epDataStore {
 		if config.policyConfigSelectsEndpoint(endpoint) {
@@ -244,19 +239,6 @@ func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint) (*endpointMetadata, 
 	}
 
 	return data, nil
-}
-
-// isValidPolicyConfig validates the given policy config.
-func (manager *Manager) isValidPolicyConfig(config PolicyConfig) error {
-	for _, policyConfig := range manager.policyConfigs {
-		if policyConfig.egressIP.String() == config.egressIP.String() {
-			return fmt.Errorf(
-				"CiliumEgressNatPolicy for egress IP %v already exists",
-				config.egressIP.String())
-
-		}
-	}
-	return nil
 }
 
 // upsertPolicyEndpoint updates or insert to endpoint policy mapping for given policy config and endpoints,


### PR DESCRIPTION
In commit a783f7c5 ("k8s/cilium Event handlers and processing logic for egress nat policy"), having several CENPs with the same egress IP was explicitly disallowed. As explained in https://github.com/cilium/cilium/issues/17678, the rationale was that those egress IPs are sometimes associated with security identities in external applications. However, this limitation is also preventing legitimate use cases. Users who would like to prevent this can implement it on top of Cilium.

This pull request removes the restriction.

Fixes: https://github.com/cilium/cilium/pull/15134.
Fixes: https://github.com/cilium/cilium/issues/17678.