### PR TITLE
k8s/watchers: Add missing v1 EndpointSlice group on init

### DIFF
--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -323,6 +323,8 @@ func (k *K8sWatcher) resourceGroups() []string {
 	// with the right service -> backend (k8s endpoints) translation.
 	if k8s.SupportsEndpointSlice() {
 		k8sGroups = append(k8sGroups, K8sAPIGroupEndpointSliceV1Beta1Discovery)
+	} else if k8s.SupportsEndpointSliceV1() {
+		k8sGroups = append(k8sGroups, K8sAPIGroupEndpointSliceV1Discovery)
 	}
 	k8sGroups = append(k8sGroups, K8sAPIGroupEndpointV1Core)
 


### PR DESCRIPTION
The K8sWatcher's InitK8sSubsystem() calls resourceGroups() which returns
a list of resources that should be waited on via WaitForCacheSync(). The
v1 version of EndpointSlice was missing from this list. This commit adds
it.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
