### PR TITLE
Additional FQDN selector identity tracking fixes

### DIFF
--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -170,6 +170,7 @@ func (m *VMManager) OnUpdate(k store.Key) {
 			nk := nodeOverrideFromCEW(n, cew)
 
 			log.Debugf("CEW: VM Cilium Node updated: %v -> %v", n, nk)
+			// FIXME: GH-17909 Balance this call with a call to release the identity.
 			id := m.AllocateNodeIdentity(nk)
 			if id != nil {
 				nid := id.ID.Uint32()

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -169,8 +169,7 @@ func (ds *DaemonFQDNSuite) TestFQDNIdentityReferenceCounting(c *C) {
 	selectorsToAdd := api.FQDNSelectorSlice{ciliumIOSel, ciliumIOSelMatchPattern, ebpfIOSel}
 	nameManager.Lock()
 	for _, sel := range selectorsToAdd {
-		ids := nameManager.RegisterForIdentityUpdatesLocked(idAllocator, sel)
-		c.Assert(ids, Not(IsNil))
+		nameManager.RegisterForIdentityUpdatesLocked(sel)
 	}
 	nameManager.Unlock()
 

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -278,23 +278,23 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	prodBarLbls := labels.Labels{lblBar.Key: lblBar, lblProd.Key: lblProd}
 	prodBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), prodBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), prodBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 	prodFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd}
 	prodFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), prodFooSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), prodFooSecLblsCtx, false)
 	prodFooJoeLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd, lblJoe.Key: lblJoe}
 	prodFooJoeSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodFooJoeLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), prodFooJoeSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), prodFooJoeSecLblsCtx, false)
 
 	// Prepare endpoints
 	cleanup, err2 := prepareEndpointDirs()
@@ -411,11 +411,11 @@ func (ds *DaemonSuite) TestL4_L7_Shadowing(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -495,11 +495,11 @@ func (ds *DaemonSuite) TestL4_L7_ShadowingShortCircuit(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -573,15 +573,15 @@ func (ds *DaemonSuite) TestL3_dependent_L7(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 	qaJoeLbls := labels.Labels{lblJoe.Key: lblJoe, lblQA.Key: lblQA}
 	qaJoeSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaJoeLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaJoeSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaJoeSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -735,7 +735,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -820,7 +820,7 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -909,7 +909,7 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooID, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaFooID)
+	defer ds.d.identityAllocator.Release(context.Background(), qaFooID, false)
 
 	// Regenerate endpoint
 	ds.regenerateEndpoint(c, e)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1131,7 +1131,7 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 		releaseCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
 		defer cancel()
 
-		_, err := e.allocator.Release(releaseCtx, e.SecurityIdentity)
+		_, err := e.allocator.Release(releaseCtx, e.SecurityIdentity, false)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("unable to release identity: %s", err))
 		}
@@ -1872,7 +1872,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 	defer cancel()
 
 	releaseNewlyAllocatedIdentity := func() {
-		_, err := e.allocator.Release(releaseCtx, allocatedIdentity)
+		_, err := e.allocator.Release(releaseCtx, allocatedIdentity, false)
 		if err != nil {
 			// non fatal error as keys will expire after lease expires but log it
 			elog.WithFields(logrus.Fields{logfields.Identity: allocatedIdentity.ID}).
@@ -1932,7 +1932,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 	e.SetIdentity(allocatedIdentity, false)
 
 	if oldIdentity != nil {
-		_, err := e.allocator.Release(releaseCtx, oldIdentity)
+		_, err := e.allocator.Release(releaseCtx, oldIdentity, false)
 		if err != nil {
 			elog.WithFields(logrus.Fields{logfields.Identity: oldIdentity.ID}).
 				WithError(err).Warn("Unable to release old endpoint identity")

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -263,7 +263,7 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 	fooLbls := labels.Labels{"": labels.ParseLabel("foo")}
 	fooIdentity, _, err := e.allocator.AllocateIdentity(context.Background(), fooLbls, false)
 	c.Assert(err, check.Equals, nil)
-	defer s.mgr.Release(context.Background(), fooIdentity)
+	defer s.mgr.Release(context.Background(), fooIdentity, false)
 
 	e.desiredPolicy = policy.NewEndpointPolicy(s.repo)
 	e.desiredPolicy.IngressPolicyEnabled = true

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -14,13 +14,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// mapSelectorsToIPs iterates through a set of FQDNSelectors and evalutes whether
-// they match the DNS Names in the cache. If so, the set of IPs which the cache
-// maintains as mapping to each DNS Name are mapped to the matching FQDNSelector.
-// Returns the mapping of DNSName to set of IPs which back said DNS name, the
-// set of FQDNSelectors which do not map to any IPs, and the set of
-// FQDNSelectors mapping to a set of IPs.
-func mapSelectorsToIPs(fqdnSelectors map[api.FQDNSelector]struct{}, cache *DNSCache) (selectorsMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
+// MapSelectorsToIPsLocked iterates through a set of FQDNSelectors and evalutes
+// whether they match the DNS Names in the cache. If so, the set of IPs which
+// the cache maintains as mapping to each DNS Name are mapped to the matching
+// FQDNSelector. Returns the mapping of DNSName to set of IPs which back said
+// DNS name, the set of FQDNSelectors which do not map to any IPs, and the set
+// of FQDNSelectors mapping to a set of IPs.
+func (n *NameManager) MapSelectorsToIPsLocked(fqdnSelectors map[api.FQDNSelector]struct{}) (selectorsMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
 	missing := make(map[api.FQDNSelector]struct{}) // a set to dedup missing dnsNames
 	selectorIPMapping = make(map[api.FQDNSelector][]net.IP)
 
@@ -32,7 +32,7 @@ func mapSelectorsToIPs(fqdnSelectors map[api.FQDNSelector]struct{}, cache *DNSCa
 		// lookup matching DNS names
 		if len(ToFQDN.MatchName) > 0 {
 			dnsName := prepareMatchName(ToFQDN.MatchName)
-			lookupIPs := cache.Lookup(dnsName)
+			lookupIPs := n.cache.Lookup(dnsName)
 
 			// Mark this FQDNSelector as having no IPs corresponding to it.
 			// FQDNSelectors are guaranteed to have only their MatchName OR
@@ -62,7 +62,7 @@ func mapSelectorsToIPs(fqdnSelectors map[api.FQDNSelector]struct{}, cache *DNSCa
 			if patternRE, err = regexp.Compile(patternREStr); err != nil {
 				log.WithError(err).Error("Error compiling matchPattern")
 			}
-			lookupIPs := cache.LookupByRegexp(patternRE)
+			lookupIPs := n.cache.LookupByRegexp(patternRE)
 
 			// Mark this pattern missing; it will be unmarked in the loop below
 			missing[ToFQDN] = struct{}{}

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -86,22 +86,26 @@ func (ds *DNSCacheTestSuite) BenchmarkKeepUniqueNames(c *C) {
 func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 
 	var (
-		ciliumIP1 = net.ParseIP("1.2.3.4")
-		ciliumIP2 = net.ParseIP("1.2.3.5")
+		ciliumIP1   = net.ParseIP("1.2.3.4")
+		ciliumIP2   = net.ParseIP("1.2.3.5")
+		nameManager = NewNameManager(Config{
+			MinTTL: 1,
+			Cache:  NewDNSCache(0),
+		})
 	)
 
 	log.Level = logrus.DebugLevel
 
 	// Create DNS cache
 	now := time.Now()
-	cache := NewDNSCache(60)
+	cache := nameManager.cache
 
 	selectors := map[api.FQDNSelector]struct{}{
 		ciliumIOSel: {},
 	}
 
 	// Empty cache.
-	selsMissingIPs, selIPMapping := mapSelectorsToIPs(selectors, cache)
+	selsMissingIPs, selIPMapping := nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 1)
 	c.Assert(selsMissingIPs[0], Equals, ciliumIOSel)
 	c.Assert(len(selIPMapping), Equals, 0)
@@ -109,7 +113,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	// Just one IP.
 	changed := cache.Update(now, prepareMatchName(ciliumIOSel.MatchName), []net.IP{ciliumIP1}, 100)
 	c.Assert(changed, Equals, true)
-	selsMissingIPs, selIPMapping = mapSelectorsToIPs(selectors, cache)
+	selsMissingIPs, selIPMapping = nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 0)
 	c.Assert(len(selIPMapping), Equals, 1)
 	ciliumIPs, ok := selIPMapping[ciliumIOSel]
@@ -120,7 +124,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	// Two IPs now.
 	changed = cache.Update(now, prepareMatchName(ciliumIOSel.MatchName), []net.IP{ciliumIP1, ciliumIP2}, 100)
 	c.Assert(changed, Equals, true)
-	selsMissingIPs, selIPMapping = mapSelectorsToIPs(selectors, cache)
+	selsMissingIPs, selIPMapping = nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 0)
 	c.Assert(len(selIPMapping), Equals, 1)
 	ciliumIPs, ok = selIPMapping[ciliumIOSel]
@@ -133,7 +137,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	selectors = map[api.FQDNSelector]struct{}{
 		ciliumIOSelMatchPattern: {},
 	}
-	selsMissingIPs, selIPMapping = mapSelectorsToIPs(selectors, cache)
+	selsMissingIPs, selIPMapping = nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 0)
 	c.Assert(len(selIPMapping), Equals, 1)
 	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]
@@ -146,7 +150,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 		ciliumIOSelMatchPattern: {},
 		ciliumIOSel:             {},
 	}
-	selsMissingIPs, selIPMapping = mapSelectorsToIPs(selectors, cache)
+	selsMissingIPs, selIPMapping = nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 0)
 	c.Assert(len(selIPMapping), Equals, 2)
 	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -267,10 +267,10 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(id1a.ID, Equals, id1b.ID)
 
-	released, err := mgr.Release(context.Background(), id1a)
+	released, err := mgr.Release(context.Background(), id1a, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, false)
-	released, err = mgr.Release(context.Background(), id1b)
+	released, err = mgr.Release(context.Background(), id1b, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 	// KV-store still keeps the ID even when a single node has released it.
@@ -312,13 +312,13 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	c.Assert(owner.WaitUntilID(id3.ID), Not(Equals), 0)
 	c.Assert(owner.GetIdentity(id3.ID), checker.DeepEquals, lbls3.LabelArray())
 
-	released, err = mgr.Release(context.Background(), id1b)
+	released, err = mgr.Release(context.Background(), id1b, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
-	released, err = mgr.Release(context.Background(), id2)
+	released, err = mgr.Release(context.Background(), id2, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
-	released, err = mgr.Release(context.Background(), id3)
+	released, err = mgr.Release(context.Background(), id3, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 
@@ -356,7 +356,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(cache[id.ID], Not(IsNil))
 
 	// 1st Release, not released
-	released, err := mgr.Release(context.Background(), id)
+	released, err := mgr.Release(context.Background(), id, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, false)
 
@@ -364,7 +364,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(owner.GetIdentity(id.ID), checker.DeepEquals, lbls1.LabelArray())
 
 	// 2nd Release, released
-	released, err = mgr.Release(context.Background(), id)
+	released, err = mgr.Release(context.Background(), id, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 
@@ -382,7 +382,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(isNew, Equals, true)
 	c.Assert(id.ID.HasLocalScope(), Equals, true)
 
-	released, err = mgr.Release(context.Background(), id)
+	released, err = mgr.Release(context.Background(), id, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -456,7 +456,7 @@ func (m *CachingIdentityAllocator) ReleaseSlice(ctx context.Context, owner Ident
 		if id == nil {
 			continue
 		}
-		_, err2 := m.Release(ctx, id, true)
+		_, err2 := m.Release(ctx, id, false)
 		if err2 != nil {
 			log.WithError(err2).WithFields(logrus.Fields{
 				logfields.Identity: id,

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -140,7 +140,7 @@ func allocate(prefix *net.IPNet, lbls labels.Labels) (*identity.Identity, bool, 
 
 func releaseCIDRIdentities(ctx context.Context, identities map[string]*identity.Identity) {
 	for prefix, id := range identities {
-		released, err := IdentityAllocator.Release(ctx, id, true)
+		released, err := IdentityAllocator.Release(ctx, id, false)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				logfields.Identity: id,

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -140,7 +140,7 @@ func allocate(prefix *net.IPNet, lbls labels.Labels) (*identity.Identity, bool, 
 
 func releaseCIDRIdentities(ctx context.Context, identities map[string]*identity.Identity) {
 	for prefix, id := range identities {
-		released, err := IdentityAllocator.Release(ctx, id)
+		released, err := IdentityAllocator.Release(ctx, id, true)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				logfields.Identity: id,

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -138,7 +138,7 @@ func InjectLabels(src source.Source, updater identityUpdater, triggerer policyTr
 			// Unlikely, but to balance the allocation / release
 			// we must either add the identity to `toUpsert`, or
 			// immediately release it again. Otherwise it will leak.
-			if _, err := IdentityAllocator.Release(context.TODO(), id, true); err != nil {
+			if _, err := IdentityAllocator.Release(context.TODO(), id, false); err != nil {
 				log.WithError(err).WithFields(logrus.Fields{
 					logfields.IPAddr: prefix,
 					logfields.Labels: lbls,
@@ -193,7 +193,7 @@ func injectLabels(prefix string, lbls labels.Labels) (*identity.Identity, bool, 
 				logfields.IdentityLabels: realID.Labels,
 			})
 
-			released, err := IdentityAllocator.Release(context.TODO(), realID, true)
+			released, err := IdentityAllocator.Release(context.TODO(), realID, false)
 			if err != nil {
 				scopedLog.WithError(err).Warn(
 					"Failed to release previously assigned identity to IP, this might be a leak.",
@@ -365,7 +365,7 @@ func RemoveLabels(prefix string, lbls labels.Labels, src source.Source) labels.L
 	if realID == nil {
 		return nil
 	}
-	released, err := IdentityAllocator.Release(context.TODO(), realID, true)
+	released, err := IdentityAllocator.Release(context.TODO(), realID, false)
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
 			logfields.IPAddr:         prefix,

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -138,7 +138,7 @@ func InjectLabels(src source.Source, updater identityUpdater, triggerer policyTr
 			// Unlikely, but to balance the allocation / release
 			// we must either add the identity to `toUpsert`, or
 			// immediately release it again. Otherwise it will leak.
-			if _, err := IdentityAllocator.Release(context.TODO(), id); err != nil {
+			if _, err := IdentityAllocator.Release(context.TODO(), id, true); err != nil {
 				log.WithError(err).WithFields(logrus.Fields{
 					logfields.IPAddr: prefix,
 					logfields.Labels: lbls,
@@ -193,7 +193,7 @@ func injectLabels(prefix string, lbls labels.Labels) (*identity.Identity, bool, 
 				logfields.IdentityLabels: realID.Labels,
 			})
 
-			released, err := IdentityAllocator.Release(context.TODO(), realID)
+			released, err := IdentityAllocator.Release(context.TODO(), realID, true)
 			if err != nil {
 				scopedLog.WithError(err).Warn(
 					"Failed to release previously assigned identity to IP, this might be a leak.",
@@ -365,7 +365,7 @@ func RemoveLabels(prefix string, lbls labels.Labels, src source.Source) labels.L
 	if realID == nil {
 		return nil
 	}
-	released, err := IdentityAllocator.Release(context.TODO(), realID)
+	released, err := IdentityAllocator.Release(context.TODO(), realID, true)
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
 			logfields.IPAddr:         prefix,

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"sort"
 	"strings"
 	"sync"
@@ -439,6 +440,49 @@ func (f *fqdnSelector) notifyUsers(sc *SelectorCache, added, deleted []identity.
 	}
 }
 
+// allocateIdentityMappings is an initializer for 'fqdnSelector' that takes a
+// slice of IPs that should be associated with the selector and caches those
+// selections. No notifications are propagated to the users.
+//
+// This function may be called at initialization for a new fqdnSelector, or
+// upon new use of an FQDN selector with the same string representation of a
+// previously-cached selector (for example the same toFQDNs match pattern in
+// different rules).
+func (f *fqdnSelector) allocateIdentityMappings(idAllocator cache.IdentityAllocator, selectorIPMapping map[api.FQDNSelector][]net.IP) {
+	var (
+		currentlyAllocatedIdentities []*identity.Identity
+		selectorIPs                  []net.IP
+		ids                          []identity.NumericIdentity
+		err                          error
+	)
+
+	// Allocate identities for each IPNet and then map to selector
+	selectorIPs = selectorIPMapping[f.selector]
+	log.WithFields(logrus.Fields{
+		"fqdnSelector": f.selector,
+		"ips":          selectorIPs,
+	}).Debug("getting identities for IPs associated with FQDNSelector")
+
+	// TODO: Consider if upserts to ipcache should be delayed until endpoint policies have been
+	// updated. This is the path from policy updates rather than for DNS proxy results. Hence
+	// any existing IPs would typically already have been pushed to the ipcache as they would
+	// not be newly allocated. We need the 'allocation' here to get a reference count on the
+	// allocations.
+	if currentlyAllocatedIdentities, err = idAllocator.AllocateCIDRsForIPs(selectorIPs, nil); err != nil {
+		log.WithError(err).WithField("prefixes", selectorIPs).Warn(
+			"failed to allocate identities for IPs")
+		return
+	}
+	ids = make([]identity.NumericIdentity, 0, len(currentlyAllocatedIdentities))
+	for i := range currentlyAllocatedIdentities {
+		ids = append(ids, currentlyAllocatedIdentities[i].ID)
+	}
+
+	for _, id := range ids {
+		f.cachedSelections[id] = struct{}{}
+	}
+}
+
 // identityNotifier provides a means for other subsystems to be made aware of a
 // given FQDNSelector (currently pkg/fqdn) so that said subsystems can notify
 // the SelectorCache about new IPs (via CIDR Identities) which correspond to
@@ -447,36 +491,20 @@ func (f *fqdnSelector) notifyUsers(sc *SelectorCache, added, deleted []identity.
 // relationship is contained only via DNS responses, which are handled
 // externally.
 type identityNotifier interface {
-	// Lock must be held during any calls to RegisterForIdentityUpdatesLocked or
-	// UnregisterForIdentityUpdatesLocked.
+	// Lock must be held during any calls to *Locked functions below.
 	Lock()
 
-	// Unlock must be called after calls to RegisterForIdentityUpdatesLocked or
-	// UnregisterForIdentityUpdatesLocked are done.
+	// Unlock must be called after calls to *Locked functions below.
 	Unlock()
 
 	// RegisterForIdentityUpdatesLocked exposes this FQDNSelector so that identities
-	// for IPs contained in a DNS response that matches said selector can be
-	// propagated back to the SelectorCache via `UpdateFQDNSelector`. When called,
-	// implementers (currently `pkg/fqdn/RuleGen`) should iterate over all DNS
-	// names that they are aware of, and see if they match the FQDNSelector.
-	// All IPs which correspond to the DNS names which match this Selector will
-	// be returned as CIDR identities, as other DNS Names which have already
-	// been resolved may match this FQDNSelector.
-	// Once this function is called, the SelectorCache will be updated any time
-	// new IPs are resolved for DNS names which match this FQDNSelector.
-	// This function is only called when the SelectorCache has been made aware
-	// of this FQDNSelector for the first time, since we only need to get the
-	// set of CIDR identities which match this FQDNSelector already from the
-	// identityNotifier on the first pass; any subsequent updates will eventually
-	// call `UpdateFQDNSelector`.
+	// for IPs contained in a DNS response that matches said selector can
+	// be propagated back to the SelectorCache via `UpdateFQDNSelector`.
 	//
-	// The code currently allocates identities inside this function, but
-	// relies on the caller handling the identity release themselves.
-	// In future it likely makes sense to move that code out of the
-	// identityNotifier implementation into the caller to better balance
-	// the allocate/release calls.
-	RegisterForIdentityUpdatesLocked(allocator cache.IdentityAllocator, selector api.FQDNSelector) (identities []identity.NumericIdentity)
+	// This function should only be called when the SelectorCache has been
+	// made aware of the FQDNSelector for the first time; subsequent
+	// updates to the selectors should be made via `UpdateFQDNSelector`.
+	RegisterForIdentityUpdatesLocked(selector api.FQDNSelector)
 
 	// UnregisterForIdentityUpdatesLocked removes this FQDNSelector from the set of
 	// FQDNSelectors which are being tracked by the identityNotifier. The result
@@ -485,6 +513,12 @@ type identityNotifier interface {
 	// This occurs when there are no more users of a given FQDNSelector for the
 	// SelectorCache.
 	UnregisterForIdentityUpdatesLocked(selector api.FQDNSelector)
+
+	// MapSelectorsToIPsLocked returns a slice of IPs that may be
+	// associated with the specified FQDN selector, based on the
+	// currently-known DNS mappings for the IPs held inside the
+	// identityNotifier.
+	MapSelectorsToIPsLocked(map[api.FQDNSelector]struct{}) (selectorsMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP)
 }
 
 type labelIdentitySelector struct {
@@ -710,15 +744,9 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 	// If this is called twice, one of the results will arbitrarily contain
 	// a real slice of ids, while the other will receive nil. We must fold
 	// them together below.
-	ids := sc.localIdentityNotifier.RegisterForIdentityUpdatesLocked(sc.idAllocator, newFQDNSel.selector)
-
-	// Do not go through the identity cache to see what identities "match" this
-	// selector. This has to be updated via whatever is getting the CIDR identities
-	// which correspond go this FQDNSelector.
-	// Alternatively , we could go through the CIDR identities in the cache
-	// provided they have some 'field' which shows which FQDNs they correspond
-	// to? This would require we keep some set in the Identity for the CIDR.
-	// Is this feasible?
+	sc.localIdentityNotifier.RegisterForIdentityUpdatesLocked(newFQDNSel.selector)
+	selectors := map[api.FQDNSelector]struct{}{newFQDNSel.selector: {}}
+	_, selectorIPMapping := sc.localIdentityNotifier.MapSelectorsToIPsLocked(selectors)
 
 	// Note: No notifications are sent for the existing
 	// identities. Caller must use GetSelections() to get the
@@ -738,13 +766,12 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 		sc.selectors[key] = newFQDNSel
 	}
 
-	// Add the ids from the slice above to the FQDN selector in the cache.
-	// This could plausibly happen twice, once with an empty 'ids' slice
-	// and once with the real 'ids' slice. Either way, they are added to
-	// the selector that is stored in 'sc.selectors[]'
-	for _, id := range ids {
-		newFQDNSel.cachedSelections[id] = struct{}{}
-	}
+	// Allocate identities corresponding to the slice of IPs identified as
+	// being selected by this FQDN selector above. This could plausibly
+	// happen twice, once with an empty 'ids' slice and once with the real
+	// 'ids' slice. Either way, they are added to the selector that is
+	// stored in 'sc.selectors[]'.
+	newFQDNSel.allocateIdentityMappings(sc.idAllocator, selectorIPMapping)
 	newFQDNSel.updateSelections()
 
 	return newFQDNSel, newFQDNSel.addUser(user)

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -98,7 +98,7 @@ func (f *MockIdentityAllocator) AllocateIdentity(_ context.Context, lbls labels.
 
 // Release releases a fake identity. It is meant to generally mock the
 // canonical identity release logic.
-func (f *MockIdentityAllocator) Release(_ context.Context, id *identity.Identity) (released bool, err error) {
+func (f *MockIdentityAllocator) Release(_ context.Context, id *identity.Identity, _ bool) (released bool, err error) {
 	count, ok := f.idRefCount[int(id.ID)]
 	if !ok {
 		return false, nil
@@ -118,7 +118,7 @@ func (f *MockIdentityAllocator) Release(_ context.Context, id *identity.Identity
 // ReleaseSlice wraps Release for slices.
 func (f *MockIdentityAllocator) ReleaseSlice(ctx context.Context, _ cache.IdentityAllocatorOwner, identities []*identity.Identity) error {
 	for _, id := range identities {
-		if _, err := f.Release(ctx, id); err != nil {
+		if _, err := f.Release(ctx, id, false); err != nil {
 			return err
 		}
 	}

--- a/pkg/testutils/identity/notifier.go
+++ b/pkg/testutils/identity/notifier.go
@@ -4,8 +4,9 @@
 package testidentity
 
 import (
+	"net"
+
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -36,12 +37,10 @@ func (d *DummyIdentityNotifier) Unlock() {
 // RegisterForIdentityUpdatesLocked starts managing this selector.
 //
 // It doesn't implement the identity allocation semantics of the interface.
-func (d *DummyIdentityNotifier) RegisterForIdentityUpdatesLocked(allocator cache.IdentityAllocator, selector api.FQDNSelector) (identities []identity.NumericIdentity) {
-	ids, ok := d.selectors[selector]
-	if !ok {
+func (d *DummyIdentityNotifier) RegisterForIdentityUpdatesLocked(selector api.FQDNSelector) {
+	if _, ok := d.selectors[selector]; !ok {
 		d.selectors[selector] = []identity.NumericIdentity{}
 	}
-	return ids
 }
 
 // UnregisterForIdentityUpdatesLocked stops managing this selector.
@@ -49,12 +48,8 @@ func (d *DummyIdentityNotifier) UnregisterForIdentityUpdatesLocked(selector api.
 	delete(d.selectors, selector)
 }
 
-func (d *DummyIdentityNotifier) InjectIdentitiesForSelector(fqdnSel api.FQDNSelector, ids []identity.NumericIdentity) {
-	d.selectors[fqdnSel] = ids
-}
-
-// IsRegistered returns whether this selector is being managed.
-func (d *DummyIdentityNotifier) IsRegistered(selector api.FQDNSelector) bool {
-	_, ok := d.selectors[selector]
-	return ok
+// MapSelectorsToIPsLocked is a dummy implementation that does not implement
+// the selectors of the real implementation.
+func (d *DummyIdentityNotifier) MapSelectorsToIPsLocked(fqdnSelectors map[api.FQDNSelector]struct{}) (selectorsMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
+	return nil, nil
 }


### PR DESCRIPTION
Review commit-by-commit.

Here's the top bugfix commit message:

    FQDN selectors hold references to CIDR identities, one for each
    'fqdnSelector.cachedSelections' entry. Previously, these would be
    associated with the fqdnSelector during creation of the selector but
    they were not released when the fqdnSelector is deleted from the cache.
    
    Commit de10e82639cc ("fqdn: Move identity allocation to FQDN selector")
    fixed a similar bug recently during the update of existing selectors;
    this code is balancing the release for identities allocated during the
    initial creation of each FQDN selector.