### PR TITLE
Prometheus lint errors in operator metrics

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -317,6 +317,12 @@ Annotations:
 * The XDP-based prefilter is enabled for all devices specified by ``--devices``
   if ``--prefilter-device`` is set.
 
+Removed Metrics/Labels
+~~~~~~~~~~~~~~~~~~~~~~
+
+* ``cilium_operator_identity_gc_entries_total`` is removed. Please use ``cilium_operator_identity_gc_entries`` instead.
+* ``cilium_operator_identity_gc_runs_total`` is removed. Please use ``cilium_operator_identity_gc_runs`` instead.
+
 Removed Options
 ~~~~~~~~~~~~~~~
 

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -115,14 +115,14 @@ func registerMetrics() []prometheus.Collector {
 
 	IdentityGCSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
-		Name:      "identity_gc_entries_total",
+		Name:      "identity_gc_entries",
 		Help:      "The number of alive and deleted identities at the end of a garbage collector run",
 	}, []string{LabelStatus})
 	collectors = append(collectors, IdentityGCSize)
 
 	IdentityGCRuns = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
-		Name:      "identity_gc_runs_total",
+		Name:      "identity_gc_runs",
 		Help:      "The number of times identity garbage collector has run",
 	}, []string{LabelOutcome})
 	collectors = append(collectors, IdentityGCRuns)


### PR DESCRIPTION
Promtool identified following lint errors when running against operator metrics
 1) cilium_operator_identity_gc_entries_total non-counter metrics should not have "_total" suffix
 2) cilium_operator_identity_gc_runs_total non-counter metrics should not have "_total" suffix

Fixing both the non-counter metrics.

Signed-off-by: Gobinath Krishnamoorthy <gobinathk@google.com>