### PR TITLE
hubble: Add "flows-to-world" metric

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -565,6 +565,32 @@ Options
 
 This metric supports :ref:`Context Options<hubble_context_options>`.
 
+``flows-to-world``
+~~~~~~~~~~~~~~~~~~
+
+This metric counts all non-reply flows containing the ``reserved:world`` label in their
+destination identity. By default, dropped flows are counted if and only if the drop reason
+is ``Policy denied``. Set ``any-drop`` option to count all dropped flows.
+
+================================ ======================================== ============================================
+Name                             Labels                                   Description
+================================ ======================================== ============================================
+``flows_to_world_total``         ``protocol``, ``verdict``                Total number of flows to ``reserved:world``.
+================================ ======================================== ============================================
+
+Options
+"""""""
+
+============== ============= ======================================================
+Option Key     Option Value  Description
+============== ============= ======================================================
+``any-drop``   N/A           Count any dropped flows regardless of the drop reason.
+``port``       N/A           Include the destination port as label ``port``.
+============== ============= ======================================================
+
+
+This metric supports :ref:`Context Options<hubble_context_options>`.
+
 ``http``
 ~~~~~~~~
 

--- a/pkg/hubble/metrics/flows-to-world/handler.go
+++ b/pkg/hubble/metrics/flows-to-world/handler.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of Cilium
+
+package flows_to_world
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+	pkglabels "github.com/cilium/cilium/pkg/labels"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type flowsToWorldHandler struct {
+	flowsToWorld *prometheus.CounterVec
+	context      *api.ContextOptions
+	worldLabel   string
+	anyDrop      bool
+	port         bool
+}
+
+func (h *flowsToWorldHandler) Init(registry *prometheus.Registry, options api.Options) error {
+	c, err := api.ParseContextOptions(options)
+	if err != nil {
+		return err
+	}
+	h.context = c
+	for key := range options {
+		switch strings.ToLower(key) {
+		case "any-drop":
+			h.anyDrop = true
+		case "port":
+			h.port = true
+		}
+	}
+	labels := []string{"protocol", "verdict"}
+	if h.port {
+		labels = append(labels, "port")
+	}
+	labels = append(labels, h.context.GetLabelNames()...)
+
+	h.flowsToWorld = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: api.DefaultPrometheusNamespace,
+		Name:      "flows_to_world_total",
+		Help:      "Total number of flows to reserved:world",
+	}, labels)
+	h.worldLabel = fmt.Sprintf("%s:%s", pkglabels.LabelSourceReserved, pkglabels.IDNameWorld)
+	registry.MustRegister(h.flowsToWorld)
+	return nil
+}
+
+func (h *flowsToWorldHandler) Status() string {
+	return h.context.Status()
+}
+
+func (h *flowsToWorldHandler) isReservedWorld(endpoint *flowpb.Endpoint) bool {
+	for _, label := range endpoint.Labels {
+		if label == h.worldLabel {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *flowsToWorldHandler) ProcessFlow(_ context.Context, flow *flowpb.Flow) {
+	l4 := flow.GetL4()
+	if flow.GetDestination() == nil ||
+		!h.isReservedWorld(flow.GetDestination()) ||
+		flow.GetEventType() == nil ||
+		l4 == nil {
+		return
+	}
+	// if "any-drop" option is not set, non-policy drops are ignored.
+	if flow.GetVerdict() == flowpb.Verdict_DROPPED && !h.anyDrop && flow.GetDropReasonDesc() != flowpb.DropReason_POLICY_DENIED {
+		return
+	}
+	// if this is potentially a forwarded reply packet, ignore it to avoid collecting statistics about ephemeral ports
+	isReply := flow.GetIsReply() == nil || flow.GetIsReply().GetValue()
+	if flow.GetVerdict() != flowpb.Verdict_DROPPED && isReply {
+		return
+	}
+	labels := []string{v1.FlowProtocol(flow), flow.GetVerdict().String()}
+
+	// if "port" option is set, add port to the label.
+	if h.port {
+		port := ""
+		if tcp := l4.GetTCP(); tcp != nil {
+			port = strconv.Itoa(int(tcp.GetDestinationPort()))
+		} else if udp := l4.GetUDP(); udp != nil {
+			port = strconv.Itoa(int(udp.GetDestinationPort()))
+		}
+		labels = append(labels, port)
+	}
+	labels = append(labels, h.context.GetLabelValues(flow)...)
+	h.flowsToWorld.WithLabelValues(labels...).Inc()
+}

--- a/pkg/hubble/metrics/flows-to-world/handler_test.go
+++ b/pkg/hubble/metrics/flows-to-world/handler_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of Cilium
+
+//go:build !privileged_tests
+// +build !privileged_tests
+
+package flows_to_world
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestFlowsToWorldHandler_MatchingFlow(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	opts := api.Options{"sourceContext": "namespace", "destinationContext": "dns|ip"}
+	h := &flowsToWorldHandler{}
+	assert.NoError(t, h.Init(registry, opts))
+	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, strings.NewReader("")))
+	flow := flowpb.Flow{
+		Verdict:        flowpb.Verdict_DROPPED,
+		DropReasonDesc: flowpb.DropReason_POLICY_DENIED,
+		EventType:      &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{DestinationPort: 80},
+			},
+		},
+		Source: &flowpb.Endpoint{Namespace: "src-a"},
+		Destination: &flowpb.Endpoint{
+			Labels: []string{"reserved:world"},
+		},
+		DestinationNames: []string{"cilium.io"},
+	}
+
+	h.ProcessFlow(context.Background(), &flow)
+	flow.L4 = &flowpb.Layer4{
+		Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 53}},
+	}
+	h.ProcessFlow(context.Background(), &flow)
+	flow.L4 = &flowpb.Layer4{
+		Protocol: &flowpb.Layer4_ICMPv4{ICMPv4: &flowpb.ICMPv4{}},
+	}
+	h.ProcessFlow(context.Background(), &flow)
+	flow.L4 = &flowpb.Layer4{
+		Protocol: &flowpb.Layer4_ICMPv6{ICMPv6: &flowpb.ICMPv6{}},
+	}
+	h.ProcessFlow(context.Background(), &flow)
+	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world
+# TYPE hubble_flows_to_world_total counter
+hubble_flows_to_world_total{destination="cilium.io",protocol="ICMPv4",source="src-a",verdict="DROPPED"} 1
+hubble_flows_to_world_total{destination="cilium.io",protocol="ICMPv6",source="src-a",verdict="DROPPED"} 1
+hubble_flows_to_world_total{destination="cilium.io",protocol="UDP",source="src-a",verdict="DROPPED"} 1
+hubble_flows_to_world_total{destination="cilium.io",protocol="TCP",source="src-a",verdict="DROPPED"} 1
+`)
+	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, expected))
+}
+
+func TestFlowsToWorldHandler_NonMatchingFlows(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	opts := api.Options{"sourceContext": "namespace", "destinationContext": "dns|ip"}
+	h := &flowsToWorldHandler{}
+	assert.NoError(t, h.Init(registry, opts))
+
+	// destination is missing.
+	h.ProcessFlow(context.Background(), &flowpb.Flow{
+		Verdict: flowpb.Verdict_FORWARDED,
+		Source:  &flowpb.Endpoint{Namespace: "src-a"},
+	})
+	// destination is not reserved:world
+	h.ProcessFlow(context.Background(), &flowpb.Flow{
+		Verdict: flowpb.Verdict_FORWARDED,
+		Source:  &flowpb.Endpoint{Namespace: "src-a"},
+		Destination: &flowpb.Endpoint{
+			Labels: []string{"reserved:host"},
+		},
+	})
+	// L4 information is missing.
+	h.ProcessFlow(context.Background(), &flowpb.Flow{
+		Verdict: flowpb.Verdict_FORWARDED,
+		Source:  &flowpb.Endpoint{Namespace: "src-a"},
+		Destination: &flowpb.Endpoint{
+			Labels: []string{"reserved:world"},
+		},
+	})
+	// EventType is missing.
+	h.ProcessFlow(context.Background(), &flowpb.Flow{
+		Verdict: flowpb.Verdict_FORWARDED,
+		Source:  &flowpb.Endpoint{Namespace: "src-a"},
+		Destination: &flowpb.Endpoint{
+			Labels: []string{"reserved:world"},
+		},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{DestinationPort: 80},
+			},
+		},
+	})
+	// Drop reason is not "Policy denied".
+	h.ProcessFlow(context.Background(), &flowpb.Flow{
+		Verdict:        flowpb.Verdict_DROPPED,
+		EventType:      &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
+		DropReasonDesc: flowpb.DropReason_STALE_OR_UNROUTABLE_IP,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{DestinationPort: 80},
+			},
+		},
+		Source: &flowpb.Endpoint{Namespace: "src-a"},
+		Destination: &flowpb.Endpoint{
+			Labels: []string{"reserved:world"},
+		},
+		DestinationNames: []string{"cilium.io"},
+	})
+	// Flow is a reply.
+	h.ProcessFlow(context.Background(), &flowpb.Flow{
+		Verdict:   flowpb.Verdict_FORWARDED,
+		EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeTrace},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{DestinationPort: 80},
+			},
+		},
+		Source: &flowpb.Endpoint{Namespace: "src-a"},
+		Destination: &flowpb.Endpoint{
+			Labels: []string{"reserved:world"},
+		},
+		DestinationNames: []string{"cilium.io"},
+		IsReply:          wrapperspb.Bool(true),
+	})
+	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, strings.NewReader("")))
+}
+
+func TestFlowsToWorldHandler_AnyDrop(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	opts := api.Options{"sourceContext": "namespace", "destinationContext": "dns|ip", "any-drop": ""}
+	h := &flowsToWorldHandler{}
+	assert.NoError(t, h.Init(registry, opts))
+	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, strings.NewReader("")))
+	flow := flowpb.Flow{
+		Verdict:        flowpb.Verdict_DROPPED,
+		DropReasonDesc: flowpb.DropReason_STALE_OR_UNROUTABLE_IP,
+		EventType:      &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{DestinationPort: 80},
+			},
+		},
+		Source: &flowpb.Endpoint{Namespace: "src-a"},
+		Destination: &flowpb.Endpoint{
+			Labels: []string{"reserved:world"},
+		},
+		DestinationNames: []string{"cilium.io"},
+	}
+	h.ProcessFlow(context.Background(), &flow)
+	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world
+# TYPE hubble_flows_to_world_total counter
+hubble_flows_to_world_total{destination="cilium.io",protocol="TCP",source="src-a",verdict="DROPPED"} 1
+`)
+	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, expected))
+}
+
+func TestFlowsToWorldHandler_IncludePort(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	opts := api.Options{"sourceContext": "namespace", "destinationContext": "dns|ip", "port": ""}
+	h := &flowsToWorldHandler{}
+	assert.NoError(t, h.Init(registry, opts))
+	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, strings.NewReader("")))
+	flow := flowpb.Flow{
+		Verdict:   flowpb.Verdict_FORWARDED,
+		EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeTrace},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{DestinationPort: 80},
+			},
+		},
+		Source: &flowpb.Endpoint{Namespace: "src-a"},
+		Destination: &flowpb.Endpoint{
+			Labels: []string{"reserved:world"},
+		},
+		DestinationNames: []string{"cilium.io"},
+		IsReply:          wrapperspb.Bool(false),
+	}
+	h.ProcessFlow(context.Background(), &flow)
+	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world
+# TYPE hubble_flows_to_world_total counter
+hubble_flows_to_world_total{destination="cilium.io",port="80",protocol="TCP",source="src-a",verdict="FORWARDED"} 1
+`)
+	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, expected))
+}

--- a/pkg/hubble/metrics/flows-to-world/plugin.go
+++ b/pkg/hubble/metrics/flows-to-world/plugin.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of Cilium
+
+package flows_to_world
+
+import (
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+)
+
+type flowsToWorldPlugin struct{}
+
+func (p *flowsToWorldPlugin) NewHandler() api.Handler {
+	return &flowsToWorldHandler{}
+}
+
+func (p *flowsToWorldPlugin) HelpText() string {
+	return `flows-to-world - External flow metrics
+Reports metrics related to flows to reserved:world.
+
+Metrics:
+  hubble_flows_to_world_total  Number of flows to reserved:world.
+
+Options:
+ any-drop - By default, this metric counts dropped flows if and only
+            if the drop_reason is "Policy denied". Set this option to
+            count any dropped flows to reserved:world.
+ port     - Include destination port as a label.` +
+		api.ContextOptionsHelp
+}
+
+func init() {
+	api.DefaultRegistry().Register("flows-to-world", &flowsToWorldPlugin{})
+}

--- a/pkg/hubble/metrics/metrics.go
+++ b/pkg/hubble/metrics/metrics.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/dns"               // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/drop"              // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/flow"              // invoke init
+	_ "github.com/cilium/cilium/pkg/hubble/metrics/flows-to-world"    // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/http"              // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/icmp"              // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/port-distribution" // invoke init


### PR DESCRIPTION
This metric counts flows to external services (i.e. the destination
identity contains `reserved:world`) with protocol and policy verdict
as labels. The primary use case for this metric is to monitor policy
decisions on traffic that reaches outside the cluster.

Options:

- any-drop: Count all drops regardless of the drop reason. By default,
            this metric counts dropped flows if and only if the drop
            reason is "Policy denied".

- port    : Include the destination port as as a label. Use this option
            with caution; using the destination port as a label could
            potentially cause high cardinality depending on the traffic
            pattern.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

```release-note
hubble: Add "flows-to-world" metric to monitor policy decisions on traffic that reaches outside the cluster.
```
