### PR TITLE
make: merge Go update targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -566,34 +566,28 @@ postcheck: build ## Run Cilium build postcheck (update-cmdref, build documentati
 licenses-all: ## Generate file with all the License from dependencies.
 	@$(GO) run ./tools/licensegen > LICENSE.all || ( rm -f LICENSE.all ; false )
 
-update-go-version: update-dev-doctor-go-version update-gh-actions-go-version update-main-go-version update-travis-go-version update-test-go-version update-images-go-version ## Update Go version for all the components (travis, dev-doctor, gh-actions etc.).
-
-update-dev-doctor-go-version: ## Update dev-doctor Go version.
+update-go-version: ## Update Go version for all the components (images, CI, dev-doctor etc.).
+	# Update dev-doctor Go version.
 	$(QUIET) sed -i 's/^const minGoVersionStr = ".*"/const minGoVersionStr = "$(GO_MAJOR_AND_MINOR_VERSION)"/' tools/dev-doctor/config.go
 	@echo "Updated go version in tools/dev-doctor to $(GO_MAJOR_AND_MINOR_VERSION)"
-
-update-gh-actions-go-version: ## Update Go version in GitHub action config.
+	# Update Go version in GitHub action config.
 	$(QUIET) for fl in $(shell find .github/workflows -name "*.yaml" -print) ; do sed -i 's/go-version: .*/go-version: $(GO_IMAGE_VERSION)/g' $$fl ; done
 	@echo "Updated go version in GitHub Actions to $(GO_IMAGE_VERSION)"
-
-update-main-go-version: ## Update Go version in main.go.
+	# Update Go version in main.go.
 	$(QUIET) for fl in $(shell find .  -name main.go -not -path "./vendor/*" -print); do \
 		sed -i \
 			-e 's|^//go:build go.*|//go:build go$(GO_MAJOR_AND_MINOR_VERSION)|g' \
 			-e 's|^// +build go.*|// +build go$(GO_MAJOR_AND_MINOR_VERSION)|g' \
 			$$fl ; \
 	done
-
-update-travis-go-version: ## Update Go version in TravisCI config.
+	# Update Go version in Travis CI config.
 	$(QUIET) sed -i 's/go: ".*/go: "$(GO_VERSION)"/g' .travis.yml
 	@echo "Updated go version in .travis.yml to $(GO_VERSION)"
-
-update-test-go-version: ## Update Go version in test scripts.
+	# Update Go version in test scripts.
 	$(QUIET) sed -i 's/GO_VERSION=.*/GO_VERSION="$(GO_VERSION)"/g' test/kubernetes-test.sh
 	$(QUIET) sed -i 's/GOLANG_VERSION=.*/GOLANG_VERSION="$(GO_VERSION)"/g' test/packet/scripts/install.sh
 	@echo "Updated go version in test scripts to $(GO_VERSION)"
-
-update-images-go-version: ## Update Go version in Dockerfiles.
+	# Update Go version in Dockerfiles.
 	$(QUIET) sed -i 's/^go_version=.*/go_version=$(GO_IMAGE_VERSION)/g' images/scripts/update-golang-image.sh
 	$(QUIET) $(MAKE) -C images update-golang-image
 	@echo "Updated go version in image Dockerfiles to $(GO_IMAGE_VERSION)"


### PR DESCRIPTION
There is not much point in having a separate make target to update Go in
different components. We want to update Go versions for all components
at the same time. Thus, inline all `update-*-go-version` targets into
the `update-go-version` target.

NOTE: no need to run full CI. This change only affects the developer workflow when updating Go.
