### PR TITLE
v1.8 backports 2021-11-05

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2912,44 +2912,24 @@ func (kub *Kubectl) getPodRevisions() (map[string]int, error) {
 	return revisions, nil
 }
 
-func (kub *Kubectl) waitNextPolicyRevisions(podRevisions map[string]int, mustHavePolicy bool, timeout time.Duration) error {
-	npFilter := fmt.Sprintf(
-		`{range .items[*]}{"%s="}{.metadata.name}{" %s="}{.metadata.namespace}{"\n"}{end}`,
-		KubectlPolicyNameLabel, KubectlPolicyNameSpaceLabel)
-
-	knpBody := func() bool {
-		knp := kub.ExecShort(fmt.Sprintf("%s get --all-namespaces netpol -o jsonpath='%s'",
-			KubectlCmd, npFilter))
-		result := knp.ByLines()
-		if len(result) == 0 {
-			return true
-		}
-
-		for _, item := range result {
-			for ciliumPod, revision := range podRevisions {
-				if mustHavePolicy {
-					if !kub.CiliumIsPolicyLoaded(ciliumPod, item) {
-						kub.Logger().Infof("Policy '%s' is not ready on Cilium pod '%s'", item, ciliumPod)
-						return false
-					}
-				}
-
-				ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
-				defer cancel()
-				desiredRevision := revision + 1
-				res := kub.CiliumExecContext(ctx, ciliumPod, fmt.Sprintf("cilium policy wait %d --max-wait-time %d", desiredRevision, int(ShortCommandTimeout.Seconds())))
-				if res.GetExitCode() != 0 {
-					kub.Logger().Infof("Failed to wait for policy revision %d on pod %s", desiredRevision, ciliumPod)
-					return false
-				}
+func (kub *Kubectl) waitNextPolicyRevisions(podRevisions map[string]int, timeout time.Duration) error {
+	body := func() bool {
+		for ciliumPod, revision := range podRevisions {
+			ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+			defer cancel()
+			desiredRevision := revision + 1
+			res := kub.CiliumExecContext(ctx, ciliumPod, fmt.Sprintf("cilium policy wait %d --max-wait-time %d", desiredRevision, int(ShortCommandTimeout.Seconds())))
+			if res.GetExitCode() != 0 {
+				kub.Logger().Infof("Failed to wait for policy revision %d on pod %s", desiredRevision, ciliumPod)
+				return false
 			}
 		}
 		return true
 	}
 
 	err := WithTimeout(
-		knpBody,
-		"Timed out while waiting for CNP to be applied on all PODs",
+		body,
+		"Timed out while waiting for policy revisions to be increased on all Cilium PODs",
 		&TimeoutConfig{Timeout: timeout})
 	return err
 }
@@ -3025,7 +3005,7 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 		return "", nil
 	}
 
-	return "", kub.waitNextPolicyRevisions(podRevisions, action != KubectlDelete, timeout)
+	return "", kub.waitNextPolicyRevisions(podRevisions, timeout)
 }
 
 // CiliumClusterwidePolicyAction applies a clusterwide policy action as described in action argument. It
@@ -3089,7 +3069,7 @@ func (kub *Kubectl) CiliumClusterwidePolicyAction(filepath string, action Resour
 		return "", nil
 	}
 
-	return "", kub.waitNextPolicyRevisions(podRevisions, action != KubectlDelete, timeout)
+	return "", kub.waitNextPolicyRevisions(podRevisions, timeout)
 }
 
 // CiliumReport report the cilium pod to the log and appends the logs for the


### PR DESCRIPTION
* #17769 -- test: Do not require netpols in 'waitNextPolicyRevisions()' (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17769; do contrib/backporting/set-labels.py $pr done 1.8; done
```