### PR TITLE
.github: Increase reporting threshold for new flakes

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -118,7 +118,7 @@ flake-tracker:
         correlate-with-stable-jobs:
         - cilium-master-runtime-kernel-net-next
   max-flakes-per-test: 5
-  flake-similarity: 0.75
+  flake-similarity: 0.85
   ignore-failures:
   - failed due to BeforeAll failure
   - Cilium cannot be installed


### PR DESCRIPTION
MLH assumes a flake is a new one if the similarity to existing flakes is below 75%. This threshold is a bit low for flakes affecting the same test but failing with a different error message. We can adjust to 85% and see.

Related: https://github.com/cilium/cilium/issues/17270.