### PR TITLE
bpf: use ctx_redirect{,_peer}() instead of redirect{,_peer}()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -812,7 +812,7 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 	 * PACKET_HOST or otherwise fixup MAC addresses.
 	 */
 	if (encrypt_iface)
-		return redirect(encrypt_iface, 0);
+		return ctx_redirect(ctx, encrypt_iface, 0);
 #endif
 	return CTX_ACT_OK;
 }

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -404,7 +404,7 @@ to_host:
 	if (is_defined(ENABLE_HOST_FIREWALL) && *dst_id == HOST_ID) {
 		send_trace_notify(ctx, TRACE_TO_HOST, SECLABEL, HOST_ID, 0,
 				  HOST_IFINDEX, reason, monitor);
-		return redirect(HOST_IFINDEX, BPF_F_INGRESS);
+		return ctx_redirect(ctx, HOST_IFINDEX, BPF_F_INGRESS);
 	}
 #endif
 
@@ -868,7 +868,7 @@ to_host:
 	if (is_defined(ENABLE_HOST_FIREWALL) && *dst_id == HOST_ID) {
 		send_trace_notify(ctx, TRACE_TO_HOST, SECLABEL, HOST_ID, 0,
 				  HOST_IFINDEX, reason, monitor);
-		return redirect(HOST_IFINDEX, BPF_F_INGRESS);
+		return ctx_redirect(ctx, HOST_IFINDEX, BPF_F_INGRESS);
 	}
 #endif
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -140,7 +140,7 @@ to_host:
 			return ret;
 
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
-		return redirect(HOST_IFINDEX, 0);
+		return ctx_redirect(ctx, HOST_IFINDEX, 0);
 	}
 #else
 	return CTX_ACT_OK;
@@ -263,7 +263,7 @@ to_host:
 			return ret;
 
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
-		return redirect(HOST_IFINDEX, 0);
+		return ctx_redirect(ctx, HOST_IFINDEX, 0);
 	}
 #else
 	return CTX_ACT_OK;

--- a/bpf/include/bpf/ctx/skb.h
+++ b/bpf/include/bpf/ctx/skb.h
@@ -57,9 +57,15 @@
 #define get_hash_recalc(ctx)	get_hash(ctx)
 
 static __always_inline __maybe_unused int
-ctx_redirect(struct __sk_buff *ctx __maybe_unused, int ifindex, __u32 flags)
+ctx_redirect(const struct __sk_buff *ctx __maybe_unused, int ifindex, __u32 flags)
 {
 	return redirect(ifindex, flags);
+}
+
+static __always_inline __maybe_unused int
+ctx_redirect_peer(const struct __sk_buff *ctx __maybe_unused, int ifindex, __u32 flags)
+{
+	return redirect_peer(ifindex, flags);
 }
 
 static __always_inline __maybe_unused int

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -258,6 +258,15 @@ ctx_redirect(const struct xdp_md *ctx, int ifindex, const __u32 flags)
 	return redirect(ifindex, flags);
 }
 
+static __always_inline __maybe_unused int
+ctx_redirect_peer(const struct xdp_md *ctx __maybe_unused,
+		  int ifindex __maybe_unused,
+		  const __u32 flags __maybe_unused)
+{
+	/* bpf_redirect_peer() is available only in TC BPF. */
+	return -ENOTSUP;
+}
+
 static __always_inline __maybe_unused __u64
 ctx_full_len(const struct xdp_md *ctx)
 {

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -911,7 +911,7 @@ static __always_inline int redirect_ep(struct __ctx_buff *ctx __maybe_unused,
 	 */
 #ifdef ENABLE_HOST_REDIRECT
 	if (needs_backlog || !is_defined(ENABLE_REDIRECT_FAST)) {
-		return redirect(ifindex, 0);
+		return ctx_redirect(ctx, ifindex, 0);
 	} else {
 # ifdef ENCAP_IFINDEX
 		/* When coming from overlay, we need to set packet type
@@ -919,16 +919,7 @@ static __always_inline int redirect_ep(struct __ctx_buff *ctx __maybe_unused,
 		 */
 		ctx_change_type(ctx, PACKET_HOST);
 # endif /* ENCAP_IFINDEX */
-#if __ctx_is == __ctx_skb
-		return redirect_peer(ifindex, 0);
-#else
-		/* bpf_redirect_peer() is available only in TC BPF. However,
-		 * this path is not used by bpf_xdp. So to avoid compilation
-		 * errors protect it with #if until we have replaced all usage
-		 * of redirect{,_peer}() with ctx_redirect{,_peer}().
-		 */
-		return -ENOTSUP;
-#endif /* __ctx_is == __ctx_skb */
+		return ctx_redirect_peer(ctx, ifindex, 0);
 	}
 #else
 	return CTX_ACT_OK;

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -151,7 +151,7 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 	if (ret != 0)
 		return ret;
 
-	return redirect(ENCAP_IFINDEX, 0);
+	return ctx_redirect(ctx, ENCAP_IFINDEX, 0);
 }
 
 /* encap_and_redirect_with_nodeid returns IPSEC_ENDPOINT after ctx meta-data is

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -70,7 +70,7 @@ do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 #ifdef ENABLE_ENDPOINT_ROUTES
 	return CTX_ACT_OK;
 #else
-	return redirect(CILIUM_IFINDEX, 0);
+	return ctx_redirect(ctx, CILIUM_IFINDEX, 0);
 #endif /* ENABLE_ROUTING */
 }
 #else

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -60,7 +60,7 @@ redirect_direct_v6(struct __ctx_buff *ctx __maybe_unused,
 		return CTX_ACT_DROP;
 	if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 		return CTX_ACT_DROP;
-	return redirect(oif, 0);
+	return ctx_redirect(ctx, oif, 0);
 # endif /* ENABLE_SKIP_FIB */
 	return CTX_ACT_DROP;
 }
@@ -120,7 +120,7 @@ redirect_direct_v4(struct __ctx_buff *ctx __maybe_unused,
 		return CTX_ACT_DROP;
 	if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 		return CTX_ACT_DROP;
-	return redirect(oif, 0);
+	return ctx_redirect(ctx, oif, 0);
 # endif /* ENABLE_SKIP_FIB */
 	return CTX_ACT_DROP;
 }

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2135,7 +2135,7 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused)
 		if (ret != 0)
 			return ret;
 		ctx->mark |= MARK_MAGIC_HEALTH_IPIP_DONE;
-		return redirect(ENCAP4_IFINDEX, 0);
+		return ctx_redirect(ctx, ENCAP4_IFINDEX, 0);
 	}
 #endif
 #if defined(ENABLE_IPV6) && DSR_ENCAP_MODE == DSR_ENCAP_IPIP
@@ -2150,7 +2150,7 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused)
 		if (ret != 0)
 			return ret;
 		ctx->mark |= MARK_MAGIC_HEALTH_IPIP_DONE;
-		return redirect(ENCAP6_IFINDEX, 0);
+		return ctx_redirect(ctx, ENCAP6_IFINDEX, 0);
 	}
 #endif
 	default:

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -83,9 +83,9 @@ redirect_self(const struct __sk_buff *ctx)
 	 * slave in netns already.
 	 */
 #ifdef ENABLE_HOST_REDIRECT
-	return redirect(ctx->ifindex, 0);
+	return ctx_redirect(ctx, ctx->ifindex, 0);
 #else
-	return redirect(ctx->ifindex, BPF_F_INGRESS);
+	return ctx_redirect(ctx, ctx->ifindex, BPF_F_INGRESS);
 #endif
 }
 

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -58,7 +58,7 @@ ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port, const b
 	 * ctx_redirect_to_proxy_first().
 	 */
 
-	return redirect(HOST_IFINDEX, 0);
+	return ctx_redirect(ctx, HOST_IFINDEX, 0);
 }
 
 #ifdef ENABLE_IPV4


### PR DESCRIPTION
Use the ctx-specific helpers. This also allows to drop the __ctx_is
check in redirect_ep().

Fixes #17682