### PR TITLE
helm: Disable BPF masquerading in v1.10+

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -34,7 +34,9 @@
 
 {{- /* Default values when 1.10 was initially deployed */ -}}
 {{- if semverCompare ">=1.10" (default "1.10" .Values.upgradeCompatibility) -}}
-{{- $defaultKubeProxyReplacement = "disabled" -}}
+  {{- $defaultKubeProxyReplacement = "disabled" -}}
+  {{- /* Needs to be explicitly disabled because it was enabled on all versions >=v1.8 above. */ -}}
+  {{- $defaultBpfMasquerade = "false" -}}
 {{- end -}}
 
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -277,7 +277,7 @@ bpf:
   lbExternalClusterIP: false
 
   # -- Enable native IP masquerade support in eBPF
-  #masquerade: true
+  #masquerade: false
 
   # -- Configure whether direct routing mode should route traffic via
   # host stack (true) or directly and more efficiently out of BPF (false) if


### PR DESCRIPTION
In Cilium v1.10, we disabled kube-proxy-replacement by default but left BPF masquerading enabled. Since the latter requires the former, the default installation results in a warning.

This pull request fixes the warning by disabling BPF masquerading as well on new v1.10+ deployments.

Fixes: https://github.com/cilium/cilium/pull/15422.