### PR TITLE
nodediscovery: Fix local host identity propagation

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -176,7 +176,7 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.LocalNode.EncryptionKey = node.GetIPsecKeyIdentity()
 	n.LocalNode.WireguardPubKey = node.GetWireguardPubKey()
 	n.LocalNode.Labels = node.GetLabels()
-	n.LocalNode.NodeIdentity = identity.GetLocalNodeID().Uint32()
+	n.LocalNode.NodeIdentity = uint32(identity.ReservedIdentityHost)
 
 	if node.GetK8sExternalIPv4() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{


### PR DESCRIPTION
The local NodeDiscovery implementation was previously informing the rest
of the Cilium agent that the local node's identity is "Remote Node"
because of the statically initialized "identity.GetLocalNodeID" value.
However, that value should only ever be used for external workloads
cases in order to prepare the source identity used for transmitting
traffic to other Cilium nodes. It should not be used for locally
determining the identity of traffic coming from the host itself.

Fix this by hardcoding the identity to "Host" identity.

Fixes: c864fd3cf5cd ("daemon: Split IPAM bootstrap, join cluster in between")

```release-note
Fix issue where local host IPs may be briefly associated with the remote-node identity, causing policy drops when policy should allow traffic from the host.
```