### PR TITLE
bpf: avoid encrypt_key map lookup if IPsec is disabled

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -843,7 +843,7 @@ skip_egress_gateway:
 		key.family = ENDPOINT_KEY_IPV4;
 
 		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
-									 &key, SECLABEL, monitor);
+					     &key, SECLABEL, monitor);
 		if (ret == DROP_NO_TUNNEL_ENDPOINT)
 			goto pass_to_stack;
 		/* If not redirected noteably due to IPSEC then pass up to stack

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -98,9 +98,9 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
 	void *data, *data_end;
-	union v6addr *daddr, orig_dip;
-	__u32 tunnel_endpoint = 0;
-	__u8 encrypt_key = 0;
+	union v6addr *daddr __maybe_unused, orig_dip;
+	__u32 __maybe_unused tunnel_endpoint = 0;
+	__u8 __maybe_unused encrypt_key = 0;
 	__u32 monitor = 0;
 	__u8 reason;
 	bool hairpin_flow = false; /* endpoint wants to access itself via service IP */
@@ -522,8 +522,8 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
 	__be32 orig_dip;
-	__u32 tunnel_endpoint = 0;
-	__u8 encrypt_key = 0;
+	__u32 __maybe_unused tunnel_endpoint = 0;
+	__u8 __maybe_unused encrypt_key = 0;
 	__u32 monitor = 0;
 	__u8 reason;
 	bool hairpin_flow = false; /* endpoint wants to access itself via service IP */


### PR DESCRIPTION
Avoid an unnecessary map lookup for encrypt_key in the bpf_lxc program in case IPsec is disabled. Also fix warnings/errors when building with LLVM 14. See individual commit messages for details.
