### PR TITLE
cilium: fix ipv6 neighbor discovery

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1267,8 +1267,9 @@ the neighbor resolution from BPF programs in the fast-path e.g. at the XDP layer
 
 From Cilium 1.11 onwards, the neighbor discovery has been fully reworked and the Cilium
 internal ARP resolution library has been removed from the agent. The agent now fully
-relies on the Linux kernel to discover gateways or hosts on the same L2 network. As per
-our recent kernel work `presented at Plumbers <https://linuxplumbersconf.org/event/11/contributions/953/>`__,
+relies on the Linux kernel to discover gateways or hosts on the same L2 network. Both
+IPv4 and IPv6 neighbor discovery is supported in the Cilium agent. As per our recent
+kernel work `presented at Plumbers <https://linuxplumbersconf.org/event/11/contributions/953/>`__,
 "managed" neighbor entries have been `upstreamed <https://lore.kernel.org/netdev/20211011121238.25542-1-daniel@iogearbox.net/>`__
 and will be available in Linux kernel v5.16 or later which the Cilium agent will detect
 and transparently use. In this case, the agent pushes down L3 addresses of new nodes

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ SWAGGER := $(CONTAINER_ENGINE) run -u $(shell id -u):$(shell id -g) --rm -v $(CU
 
 COVERPKG_EVAL := $(shell if [ $$(echo "$(TESTPKGS)" | wc -w) -gt 1 ]; then echo "./..."; else echo "github.com/cilium/cilium/$(TESTPKGS)"; fi)
 COVERPKG ?= $(COVERPKG_EVAL)
-GOTEST_BASE := -test.v -timeout 420s
+GOTEST_BASE := -test.v -timeout 500s
 GOTEST_UNIT_BASE := $(GOTEST_BASE) -check.vv
 GOTEST_COVER_OPTS += -coverprofile=coverage.out -coverpkg $(COVERPKG)
 BENCH_EVAL := "."

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1449,7 +1449,7 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 	prevConfig := n.nodeConfig
 	n.nodeConfig = newConfig
 
-	if n.nodeConfig.EnableIPv4 {
+	if n.nodeConfig.EnableIPv4 || n.nodeConfig.EnableIPv6 {
 		ifaceName := ""
 		switch {
 		case !option.Config.EnableL2NeighDiscovery:

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1619,8 +1619,7 @@ func (n *linuxNodeHandler) NodeCleanNeighbors(migrateOnly bool) {
 	}
 
 	neighList, err := netlink.NeighListExecute(netlink.Ndmsg{
-		Family: netlink.FAMILY_V4,
-		Index:  uint32(l.Attrs().Index),
+		Index: uint32(l.Attrs().Index),
 	})
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1201,7 +1201,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 				}
 			}
 			return false
-		}, 20*time.Second, 200*time.Millisecond)
+		}, 25*time.Second, 200*time.Millisecond)
 		c.Assert(err, check.IsNil)
 		c.Assert(found, check.Equals, true)
 	}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1043,7 +1043,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		err := testutils.WaitUntil(func() bool {
 			linuxNodeHandler.neighLock.Lock()
 			defer linuxNodeHandler.neighLock.Unlock()
-			nextHop, found := linuxNodeHandler.neighNextHopByNode[nodeID]
+			nextHop, found := linuxNodeHandler.neighNextHopByNode4[nodeID]
 			if !found {
 				return waitForDelete
 			}


### PR DESCRIPTION
It was never working in KPR due to the historic use of the ARPing library. Now that we moved to managed neighbors in https://github.com/cilium/cilium/pull/17713, we can make KPR working with backends in same L2 and piggy-back on kernel for discovery.