### PR TITLE
helm: Fix hubble-ui clusterrole guard

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.serviceAccounts.ui.create }}
+{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.serviceAccounts.ui.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
This fixes a bug where the hubble-ui cluster role was created even if
Hubble UI was disabled (i.e. `hubble.ui.enabled=false`). The cluster
role should only be created if the UI is deployed.

This guard used to exist, but got accidentally removed when we added
support for Hubble UI standalone installation mode.

Fixes: cc09bde89733 ("feat: allow installing hubble ui as standalone")

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
