### PR TITLE
docs: Mention about KubeVirt in KPR docs

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -498,7 +498,8 @@ Socket LoadBalancer Bypass in Pod Namespace
 
 Cilium has built-in support for bypassing the socket-level loadbalancer and falling back
 to the tc loadbalancer at the veth interface when a custom redirection/operation relies
-on the original ClusterIP within pod namespace (e.g., Istio side-car).
+on the original ClusterIP within pod namespace (e.g., Istio side-car) or due to the Pod's
+nature the socket-level loadbalancer is ineffective (e.g., KubeVirt, Kata Containers).
 
 Setting ``hostServices.hostNamespaceOnly=true`` enables this bypassing mode. When enabled,
 this circumvents socket rewrite in the ``connect()`` and ``sendmsg()`` syscall bpf hook and


### PR DESCRIPTION
To make LB to work in KubeVirt, socket-lb has to be disabled in the pod
netns.

Fix #14563.