### PR TITLE
Add support to connect Clustermesh clusters through Helm Chart

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -225,6 +225,22 @@
      - clustermesh-apiserver update strategy
      - object
      - ``{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}``
+   * - clustermesh.config
+     - Clustermesh explicit configuration.
+     - object
+     - ``{"clusters":[],"domain":"mesh.cilium.io","enabled":false}``
+   * - clustermesh.config.clusters
+     - List of clusters to be peered in the mesh.
+     - list
+     - ``[]``
+   * - clustermesh.config.domain
+     - Default dns domain for the Clustermesh API servers This is used in the case cluster addresses are not provided and IPs are used.
+     - string
+     - ``"mesh.cilium.io"``
+   * - clustermesh.config.enabled
+     - Enable the Clustermesh explicit configuration.
+     - bool
+     - ``false``
    * - clustermesh.useAPIServer
      - Deploy clustermesh-apiserver for clustermesh
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -107,6 +107,10 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.tls.server.extraIpAddresses | list | `[]` | Extra IP addresses added to certificate when it's auto generated |
 | clustermesh.apiserver.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | clustermesh.apiserver.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | clustermesh-apiserver update strategy |
+| clustermesh.config | object | `{"clusters":[],"domain":"mesh.cilium.io","enabled":false}` | Clustermesh explicit configuration. |
+| clustermesh.config.clusters | list | `[]` | List of clusters to be peered in the mesh. |
+| clustermesh.config.domain | string | `"mesh.cilium.io"` | Default dns domain for the Clustermesh API servers This is used in the case cluster addresses are not provided and IPs are used. |
+| clustermesh.config.enabled | bool | `false` | Enable the Clustermesh explicit configuration. |
 | clustermesh.useAPIServer | bool | `false` | Deploy clustermesh-apiserver for clustermesh |
 | cni.binPath | string | `"/opt/cni/bin"` | Configure the path to the CNI binary directory on the host. |
 | cni.chainingMode | string | `"none"` | Configure chaining on top of other CNI plugins. Possible values:  - none  - generic-veth  - aws-cni  - portmap |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -447,6 +447,15 @@ spec:
       tolerations:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
+      {{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.config.enabled }}
+      hostAliases:
+      {{- range $cluster := .Values.clustermesh.config.clusters }}
+      {{- range $ip := $cluster.ips }}
+      - ip: {{ $ip }}
+        hostnames: [ "{{ $cluster.name }}.{{ $.Values.clustermesh.config.domain }}" ]
+      {{- end }}
+      {{- end }}
+      {{- end }}
       volumes:
         # To keep state between restarts / upgrades
       - name: cilium-run

--- a/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
@@ -1,0 +1,14 @@
+{{- define "clustermesh-config-generate-etcd-cfg" }}
+{{- $cluster := index . 0 -}}
+{{- $domain := index . 1 -}}
+
+endpoints:
+{{- if $cluster.ips }}
+- https://{{ $cluster.name }}.{{ $domain }}:{{ $cluster.port }}
+{{ else }}
+- https://{{ $cluster.address | required "missing clustermesh.apiserver.config.clusters.address" }}:{{ $cluster.port }}
+{{- end }}
+trusted-ca-file: /var/lib/cilium/clustermesh/{{ $cluster.name }}.etcd-client-ca.crt
+key-file: /var/lib/cilium/clustermesh/{{ $cluster.name }}.etcd-client.key
+cert-file: /var/lib/cilium/clustermesh/{{ $cluster.name }}.etcd-client.crt
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.config.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cilium-clustermesh
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- range .Values.clustermesh.config.clusters }}
+  {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain) | b64enc }}
+  {{ .name }}.etcd-client-ca.crt: {{ $.Values.clustermesh.apiserver.tls.ca.cert }}
+  {{ .name }}.etcd-client.key: {{ .tls.key }}
+  {{ .name }}.etcd-client.crt: {{ .tls.cert }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1617,6 +1617,33 @@ clustermesh:
   # -- Deploy clustermesh-apiserver for clustermesh
   useAPIServer: false
 
+  # -- Clustermesh explicit configuration.
+  config:
+    # -- Enable the Clustermesh explicit configuration.
+    enabled: false
+    # -- Default dns domain for the Clustermesh API servers
+    # This is used in the case cluster addresses are not provided
+    # and IPs are used.
+    domain: mesh.cilium.io
+    # -- List of clusters to be peered in the mesh.
+    clusters: []
+    # clusters: 
+    # # -- Name of the cluster
+    # - name: cluster1
+    # # -- Address of the cluster, use this if you created DNS records for
+    # # the cluster Clustermesh API server.
+    #   address: cluster1.mesh.cilium.io 
+    # # -- Port of the cluster Clustermesh API server.
+    #   port: 2379
+    # # -- IPs of the cluster Clustermesh API server, use multiple ones when
+    # # you have multiple IPs to access the Clustermesh API server.
+    #   ips:
+    #   - 172.18.255.201
+    # # -- base64 encoded PEM values for the cluster client certificate, private key and certificate authority.
+    #   tls:
+    #     cert: ""
+    #     key: ""
+  
   apiserver:
     # -- Clustermesh API server image.
     image:


### PR DESCRIPTION
This PR aims to add support to connect multiple Clustermesh clusters using the Helm Chart, instead of doing it manually / using the cilium-cli.

<!-- Description of change -->

Fixes: #[17811](https://github.com/cilium/cilium/issues/17811)

```release-note
Adds support to connect Clustermesh clusters through Helm Chart.
```
