### PR TITLE
bpf: Refactoring egress gateway datapath

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -34,6 +34,7 @@
 #include "lib/dbg.h"
 #include "lib/trace.h"
 #include "lib/csum.h"
+#include "lib/egress_policies.h"
 #include "lib/encap.h"
 #include "lib/eps.h"
 #include "lib/nat.h"

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -798,17 +798,7 @@ ct_recreate4:
 		struct egress_info *info;
 		struct endpoint_key key = {};
 
-		/* If tunnel endpoint is found in ipcache, it means the remote endpoint is
-		 * in cluster. In this case, we should skip egress gateway. If destination
-		 * is either remote node or host node, also skip egress gateway.
-		 */
-		if (tunnel_endpoint != 0 || *dst_id == REMOTE_NODE_ID || *dst_id == HOST_ID)
-			goto skip_egress_gateway;
-
-		/* If destination ip matches a local endpoint, we should also
-		 * skip egress gateway.
-		 */
-		if (lookup_ip4_endpoint(ip4))
+		if (is_cluster_destination(ip4, *dst_id, tunnel_endpoint))
 			goto skip_egress_gateway;
 
 		info = lookup_ip4_egress_endpoint(ip4->saddr, ip4->daddr);

--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+#ifndef __LIB_EGRESS_POLICIES_H_
+#define __LIB_EGRESS_POLICIES_H_
+
+#ifdef ENABLE_EGRESS_GATEWAY
+/* EGRESS_STATIC_PREFIX gets sizeof non-IP, non-prefix part of egress_key */
+# define EGRESS_STATIC_PREFIX							\
+	(8 * (sizeof(struct egress_key) - sizeof(struct bpf_lpm_trie_key)	\
+	      - 4))
+# define EGRESS_PREFIX_LEN(PREFIX) (EGRESS_STATIC_PREFIX + (PREFIX))
+# define EGRESS_IPV4_PREFIX EGRESS_PREFIX_LEN(32)
+
+static __always_inline __maybe_unused struct egress_info *
+egress_lookup4(const void *map, __be32 sip, __be32 dip)
+{
+	struct egress_key key = {
+		.lpm_key = { EGRESS_IPV4_PREFIX, {} },
+		.sip = sip,
+		.dip = dip,
+	};
+	return map_lookup_elem(map, &key);
+}
+
+# define lookup_ip4_egress_endpoint(sip, dip) \
+	egress_lookup4(&EGRESS_MAP, sip, dip)
+#endif /* ENABLE_EGRESS_GATEWAY */
+#endif /* __LIB_EGRESS_POLICIES_H_ */

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -62,13 +62,6 @@ lookup_ip4_endpoint_policy_map(__u32 ip)
 	      - sizeof(union v6addr)))
 #define IPCACHE_PREFIX_LEN(PREFIX) (IPCACHE_STATIC_PREFIX + (PREFIX))
 
-/* EGRESS_STATIC_PREFIX gets sizeof non-IP, non-prefix part of ipcache_key */
-#define EGRESS_STATIC_PREFIX							\
-	(8 * (sizeof(struct egress_key) - sizeof(struct bpf_lpm_trie_key)	\
-	      - 4))
-#define EGRESS_PREFIX_LEN(PREFIX) (EGRESS_STATIC_PREFIX + (PREFIX))
-#define EGRESS_IPV4_PREFIX EGRESS_PREFIX_LEN(32)
-
 #define V6_CACHE_KEY_LEN (sizeof(union v6addr)*8)
 
 static __always_inline __maybe_unused struct remote_endpoint_info *
@@ -137,21 +130,4 @@ LPM_LOOKUP_FN(lookup_ip4_remote_endpoint, __be32, IPCACHE4_PREFIXES,
 #define lookup_ip4_remote_endpoint(addr) \
 	ipcache_lookup4(&IPCACHE_MAP, addr, V4_CACHE_KEY_LEN)
 #endif /* HAVE_LPM_TRIE_MAP_TYPE */
-
-#ifdef ENABLE_EGRESS_GATEWAY
-static __always_inline __maybe_unused struct egress_info *
-egress_lookup4(const void *map, __be32 sip, __be32 dip)
-{
-	struct egress_key key = {
-		.lpm_key = { EGRESS_IPV4_PREFIX, {} },
-		.sip = sip,
-		.dip = dip,
-	};
-	return map_lookup_elem(map, &key);
-}
-
-#define lookup_ip4_egress_endpoint(sip, dip) \
-	egress_lookup4(&EGRESS_MAP, sip, dip)
-#endif /* ENABLE_EGRESS_GATEWAY */
-
 #endif /* __LIB_EPS_H_ */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -13,6 +13,7 @@
 #include "lb.h"
 #include "common.h"
 #include "overloadable.h"
+#include "egress_policies.h"
 #include "eps.h"
 #include "conntrack.h"
 #include "csum.h"


### PR DESCRIPTION
This pull request performs just a bit of refactoring on the egress gateway's code in the datapath. This refactoring was prepared for the SRv6 work (cf. https://github.com/cilium/cilium/issues/17646) but is independent so sending it's own pull request.

See commits for details.