### PR TITLE
bpf: exclude pod's reply traffic from egress gateway logic

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -799,6 +799,14 @@ ct_recreate4:
 		if (is_cluster_destination(ip4, *dst_id, tunnel_endpoint))
 			goto skip_egress_gateway;
 
+		/* If the packet is a reply or is related, it means that outside
+		 * has initiated the connection, and so we should skip egress
+		 * gateway, since an egress policy is only matching connections
+		 * originating from a pod.
+		 */
+		if (reason == CT_REPLY || reason == CT_RELATED)
+			goto skip_egress_gateway;
+
 		info = lookup_ip4_egress_endpoint(ip4->saddr, ip4->daddr);
 		if (!info)
 			goto skip_egress_gateway;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1144,7 +1144,32 @@ static __always_inline bool snat_v4_needed(struct __ctx_buff *ctx, __be32 *addr,
 		if (identity_is_remote_node(info->sec_label))
 			return false;
 #endif
-#if defined(ENABLE_EGRESS_GATEWAY)
+
+		/* Check if this packet belongs to reply traffic coming from a
+		 * local endpoint.
+		 *
+		 * If ep is NULL, it means there's no endpoint running on the
+		 * node which matches the packet source IP, which means we can
+		 * skip the CT lookup since this cannot be reply traffic.
+		 */
+		if (ep) {
+			bool is_reply = false;
+			struct ipv4_ct_tuple tuple = {
+				.nexthdr = ip4->protocol,
+				.daddr = ip4->daddr,
+				.saddr = ip4->saddr
+			};
+
+			/* If the packet is a reply it means that outside has
+			 * initiated the connection, so no need to SNAT the
+			 * reply.
+			 */
+			if (!ct_is_reply4(get_ct_map4(&tuple), ctx, ETH_HLEN + ipv4_hdrlen(ip4),
+					  &tuple, &is_reply) && is_reply)
+				return false;
+		}
+
+ #if defined(ENABLE_EGRESS_GATEWAY)
 		/* Check egress gateway policy only for traffic which matches
 		 * one of the following conditions.
 		 *  - Not from a local endpoint (inc. local host): that tells us
@@ -1173,25 +1198,7 @@ static __always_inline bool snat_v4_needed(struct __ctx_buff *ctx, __be32 *addr,
 			}
 		}
 #endif
-
 		if (ep) {
-			bool is_reply = false;
-			struct ipv4_ct_tuple tuple = {
-				.nexthdr = ip4->protocol,
-				.daddr = ip4->daddr,
-				.saddr = ip4->saddr
-			};
-
-			/* The packet is a reply, which means that outside
-			 * has initiated the connection, so no need to SNAT
-			 * the reply.
-			 */
-			if (!ct_is_reply4(get_ct_map4(&tuple), ctx,
-					  ETH_HLEN + ipv4_hdrlen(ip4),
-					  &tuple, &is_reply) &&
-			    is_reply)
-				return false;
-
 			*from_endpoint = true;
 			*addr = IPV4_MASQUERADE;
 			return true;

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -15,6 +15,7 @@
 package k8sTest
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -22,11 +23,18 @@ import (
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 )
 
 var _ = SkipDescribeIf(func() bool {
 	return helpers.RunsOnEKS() || helpers.RunsOnGKE() || helpers.DoesNotRunWithKubeProxyReplacement() || helpers.DoesNotExistNodeWithoutCilium() || helpers.DoesNotRunOn54OrLaterKernel()
 }, "K8sEgressGatewayTest", func() {
+	const (
+		namespaceSelector = "ns=cilium-test"
+		testDS            = "zgroup=testDS"
+		testDSClient      = "zgroup=testDSClient"
+	)
+
 	var (
 		kubectl         *helpers.Kubectl
 		ciliumFilename  string
@@ -40,8 +48,6 @@ var _ = SkipDescribeIf(func() bool {
 		assignIPYAML string
 		echoPodYAML  string
 		policyYAML   string
-
-		namespaceSelector string = "ns=cilium-test"
 	)
 
 	runEchoServer := func() {
@@ -120,14 +126,14 @@ var _ = SkipDescribeIf(func() bool {
 		if fromGateway {
 			hostIP = k8s2IP
 		}
-		srcPod, _ := fetchPodsWithOffset(kubectl, randomNamespace, "client", "zgroup=testDSClient", hostIP, false, 1)
+		srcPod, _ := fetchPodsWithOffset(kubectl, randomNamespace, "client", testDSClient, hostIP, false, 1)
 
 		res := kubectl.ExecPodCmd(randomNamespace, srcPod, helpers.CurlFail("http://%s:80", outsideIP))
 		res.ExpectSuccess()
 		res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", egressIP))
 	}
 
-	testConnectivity := func(fromGateway bool) {
+	testConnectivity := func(fromGateway bool, ciliumOpts map[string]string) {
 		if fromGateway {
 			By("Check connectivity from gateway node")
 		} else {
@@ -149,6 +155,59 @@ var _ = SkipDescribeIf(func() bool {
 		// DNS query should work (pod-to-pod connectivity)
 		res = kubectl.ExecPodCmd(randomNamespace, srcPod, "dig kubernetes +time=2")
 		res.ExpectSuccess()
+
+		// When connecting from outside the cluster to a nodeport service whose pods are
+		// selected by an egress policy, the reply traffic should not be SNATed with the
+		// egress IP
+		var extIPsService v1.Service
+		err := kubectl.Get(randomNamespace, fmt.Sprintf("service %s", "test-external-ips")).Unmarshal(&extIPsService)
+		ExpectWithOffset(1, err).Should(BeNil(), "Can not retrieve service %s", "test-external-ips")
+
+		res = kubectl.Patch(randomNamespace, "service", "test-external-ips",
+			fmt.Sprintf(`{"spec":{"externalIPs":["%s"],  "externalTrafficPolicy": "Local"}}`, hostIP))
+		ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "Error patching external IP service with node IP")
+
+		outsideNodeName, outsideNodeIP := kubectl.GetNodeInfo(helpers.GetNodeWithoutCilium())
+
+		res = kubectl.ExecInHostNetNS(context.TODO(), outsideNodeName,
+			helpers.CurlFail("http://%s:%d", hostIP, extIPsService.Spec.Ports[0].Port))
+		res.ExpectSuccess()
+		res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", outsideNodeIP))
+
+		if ciliumOpts["tunnel"] == "disabled" {
+			// When connecting from outside the cluster directly to a pod which is
+			// selected by an egress policy, the reply traffic should not be SNATed with
+			// the egress IP (only connections originating from these pods should go
+			// through egress gateway).
+			//
+			// This test is executed only when Cilium is running in direct routing mode,
+			// since we can simply add a route on the node outside the cluster to direct
+			// pod's traffic to the node where the pod is running (while in tunneling
+			// mode we would need the external node to send the traffic over the tunnel)
+			_, targetPodJSON := fetchPodsWithOffset(kubectl, randomNamespace, "server", testDS, hostIP, false, 1)
+
+			targetPodHostIP, err := targetPodJSON.Filter("{.status.hostIP}")
+			Expect(err).Should(BeNil(), "Cannot get target pod host IP")
+
+			targetPodIP, err := targetPodJSON.Filter("{.status.podIP}")
+			Expect(err).Should(BeNil(), "Cannot get target pod IP")
+
+			// Add a route for the target pod's IP on the node running without Cilium to
+			// allow reaching it from outside the cluster
+			res = kubectl.AddIPRoute(outsideNodeName, targetPodIP.String(), targetPodHostIP.String(), false)
+			Expect(res).Should(helpers.CMDSuccess(),
+				"Error adding IP route for %s via %s", targetPodIP.String(), targetPodHostIP.String())
+			defer func() {
+				res := kubectl.DelIPRoute(outsideNodeName, targetPodIP.String(), targetPodHostIP.String())
+				Expect(res).Should(helpers.CMDSuccess(),
+					"Error removing IP route for %s via %s", targetPodIP.String(), targetPodHostIP.String())
+			}()
+
+			res = kubectl.ExecInHostNetNS(context.TODO(), outsideNodeName,
+				helpers.CurlFail("http://%s:%d", targetPodIP.String(), 80))
+			res.ExpectSuccess()
+			res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", outsideNodeIP))
+		}
 	}
 
 	applyEgressPolicy := func() {
@@ -181,8 +240,8 @@ var _ = SkipDescribeIf(func() bool {
 
 			Context("no egress gw policy", func() {
 				It("connectivity works", func() {
-					testConnectivity(false)
-					testConnectivity(true)
+					testConnectivity(false, ciliumOpts)
+					testConnectivity(true, ciliumOpts)
 				})
 			})
 
@@ -203,8 +262,8 @@ var _ = SkipDescribeIf(func() bool {
 				It("both egress gw and basic connectivity work", func() {
 					testEgressGateway(false)
 					testEgressGateway(true)
-					testConnectivity(false)
-					testConnectivity(true)
+					testConnectivity(false, ciliumOpts)
+					testConnectivity(true, ciliumOpts)
 				})
 			})
 		})

--- a/test/k8sT/manifests/egress-nat-policy.yaml
+++ b/test/k8sT/manifests/egress-nat-policy.yaml
@@ -31,3 +31,22 @@ spec:
   destinationCIDRs:
   - 0.0.0.0/0
   egressSourceIP: 192.0.2.13 # It's a black hole, https://datatracker.ietf.org/doc/html/rfc5737#section-3
+---
+# egress-testds is a policy matching all traffic (i.e. destination CIDR
+# 0.0.0.0/0) from the zgroup=testDS echo server pods.
+#
+# This policy is used to test that reply traffic from pods that are selected by
+# an egress policy is not SNATed with the egress IP (only connections
+# originating from these pods should go through egress gateway).
+apiVersion: cilium.io/v2alpha1
+kind: CiliumEgressNATPolicy
+metadata:
+  name: egress-testds
+spec:
+  egress:
+  - podSelector:
+      matchLabels:
+        zgroup: testDS
+  destinationCIDRs:
+  - 0.0.0.0/0
+  egressSourceIP: INPUT_EGRESS_IP


### PR DESCRIPTION
Currently all pod traffic matching source IP and destination CIDR of an
egress policy will be forwarded to an egress gateway.

This means we will incorrectly forward to an egress gateway also all
reply traffic from connections destined to a pod, breaking said
connections.

This commit fixes this by adding an additional check to make sure reply
traffic (i.e. connections not originating from a pod) is excluded from
the egress gateway logic.

Fixes: #17866
Signed-off-by: Gilberto Bertin <gilberto@isovalent.com>