### PR TITLE
Skip node ipset updates if iptables masquerading is disabled

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -552,8 +552,7 @@ func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) error {
 		case option.Config.EnableIPSec:
 			msg = fmt.Sprintf("BPF host routing is incompatible with %s.", option.EnableIPSecName)
 		// Non-BPF masquerade requires netfilter and hence CT.
-		case (option.Config.EnableIPv4Masquerade || option.Config.EnableIPv6Masquerade) &&
-			!option.Config.EnableBPFMasquerade:
+		case option.Config.IptablesMasqueradingEnabled():
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
 		// All cases below still need to be implemented ...
 		case option.Config.EnableEndpointRoutes:

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	oldCiliumPrefix       = "OLD_CILIUM_"
+	oldCiliumPrefix       = "OLD_"
 	ciliumInputChain      = "CILIUM_INPUT"
 	ciliumOutputChain     = "CILIUM_OUTPUT"
 	ciliumOutputRawChain  = "CILIUM_OUTPUT_raw"
@@ -497,19 +497,19 @@ func (m *IptablesManager) removeOldRules(quiet bool) {
 	// Set of tables that have had iptables rules in any Cilium version
 	tables := []string{"nat", "mangle", "raw", "filter"}
 	for _, t := range tables {
-		m.removeCiliumRules(t, ip4tables, oldCiliumPrefix)
+		m.removeCiliumRules(t, ip4tables, oldCiliumPrefix+"CILIUM_")
 	}
 
 	// Set of tables that have had ip6tables rules in any Cilium version
 	if m.haveIp6tables {
 		tables6 := []string{"nat", "mangle", "raw", "filter"}
 		for _, t := range tables6 {
-			m.removeCiliumRules(t, ip6tables, oldCiliumPrefix)
+			m.removeCiliumRules(t, ip6tables, oldCiliumPrefix+"CILIUM_")
 		}
 	}
 
 	for _, c := range ciliumChains {
-		c.name = "OLD_" + c.name
+		c.name = oldCiliumPrefix + c.name
 		c.remove(quiet)
 	}
 }
@@ -1283,7 +1283,7 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 
 	// Rename any old chains we may have
 	for _, c := range ciliumChains {
-		c.rename("OLD_"+c.name, quiet)
+		c.rename(oldCiliumPrefix+c.name, quiet)
 	}
 
 	// install rules if needed
@@ -1294,7 +1294,7 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 		if firstInitialization {
 			match = "cilium-dns-egress"
 		}
-		m.copyProxyRules("OLD_"+ciliumPreMangleChain, match)
+		m.copyProxyRules(oldCiliumPrefix+ciliumPreMangleChain, match)
 	}
 
 	// only remove old rules if new ones were successfully installed

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1074,9 +1074,16 @@ func RemoveFromNodeIpset(nodeIP net.IP) {
 	}
 }
 
+// useNodeIpset returns true if the ipset for node IP addresses should be
+// used to skip masquerading.
+func useNodeIpset() bool {
+	return option.Config.Tunnel == option.TunnelDisabled &&
+		option.Config.IptablesMasqueradingEnabled()
+}
+
 func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName, localDeliveryInterface,
 	snatDstExclusionCIDR, allocRange, hostMasqueradeIP string) error {
-	if option.Config.Tunnel == option.TunnelDisabled {
+	if useNodeIpset() {
 		// Exclude traffic to nodes from masquerade.
 		if err := createIpset(prog.getIpset(), prog.getProg() == "ip6tables"); err != nil {
 			return err

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1339,7 +1339,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 			return err
 		}
 
-		if option.Config.EnableIPv4Masquerade && !option.Config.EnableBPFMasquerade {
+		if option.Config.IptablesMasqueradingIPv4Enabled() {
 			if err := m.installMasqueradeRules(ip4tables, ifName, localDeliveryInterface,
 				datapath.RemoteSNATDstAddrExclusionCIDRv4().String(),
 				node.GetIPv4AllocRange().String(),
@@ -1355,7 +1355,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 			return err
 		}
 
-		if option.Config.EnableIPv6Masquerade && !option.Config.EnableBPFMasquerade {
+		if option.Config.IptablesMasqueradingIPv6Enabled() {
 			if err := m.installMasqueradeRules(ip6tables, ifName, localDeliveryInterface,
 				datapath.RemoteSNATDstAddrExclusionCIDRv6().String(),
 				node.GetIPv6AllocRange().String(),

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -475,7 +475,7 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
 	}
 
 	// Only removes Cilium chains with the OLD_ prefix
-	mockManager.removeCiliumRules("mangle", mockIp4tables, oldCiliumPrefix)
+	mockManager.removeCiliumRules("mangle", mockIp4tables, oldCiliumPrefix+"CILIUM_")
 	err := mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }
@@ -522,7 +522,7 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv6(c *check.C) {
 	}
 
 	// Only removes Cilium chains with the OLD_ prefix
-	mockManager.removeCiliumRules("mangle", mockIp6tables, oldCiliumPrefix)
+	mockManager.removeCiliumRules("mangle", mockIp6tables, oldCiliumPrefix+"CILIUM_")
 	err := mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -411,7 +411,8 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			tunnelIP = nodeIP
 		}
 
-		if address.Type != addressing.NodeCiliumInternalIP {
+		if option.Config.IptablesMasqueradingEnabled() &&
+			address.Type != addressing.NodeCiliumInternalIP {
 			iptables.AddToNodeIpset(address.IP)
 		}
 
@@ -594,7 +595,8 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 	}
 
 	for _, address := range entry.node.IPAddresses {
-		if address.Type != addressing.NodeCiliumInternalIP {
+		if option.Config.IptablesMasqueradingEnabled() &&
+			address.Type != addressing.NodeCiliumInternalIP {
 			iptables.RemoveFromNodeIpset(address.IP)
 		}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2180,6 +2180,24 @@ func (c *DaemonConfig) TunnelingEnabled() bool {
 	return c.Tunnel != TunnelDisabled
 }
 
+// IptablesMasqueradingIPv4Enabled returns true if iptables-based
+// masquerading is enabled for IPv4.
+func (c *DaemonConfig) IptablesMasqueradingIPv4Enabled() bool {
+	return !c.EnableBPFMasquerade && c.EnableIPv4Masquerade
+}
+
+// IptablesMasqueradingIPv6Enabled returns true if iptables-based
+// masquerading is enabled for IPv6.
+func (c *DaemonConfig) IptablesMasqueradingIPv6Enabled() bool {
+	return !c.EnableBPFMasquerade && c.EnableIPv6Masquerade
+}
+
+// IptablesMasqueradingEnabled returns true if iptables-based
+// masquerading is enabled.
+func (c *DaemonConfig) IptablesMasqueradingEnabled() bool {
+	return c.IptablesMasqueradingIPv4Enabled() || c.IptablesMasqueradingIPv6Enabled()
+}
+
 // RemoteNodeIdentitiesEnabled returns true if the remote-node identity feature
 // is enabled
 func (c *DaemonConfig) RemoteNodeIdentitiesEnabled() bool {


### PR DESCRIPTION
First commit introduces a helper function, the second skips all updates/creation of the node ipset if iptables-based masquerading is not used.

Fixes: https://github.com/cilium/cilium/issues/17711.