### PR TITLE
Generating proper Hubble flow records in CEWs

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1037,6 +1037,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableK8sTerminatingEndpoint, true, "Enable auto-detect of terminating endpoint condition")
 	option.BindEnv(option.EnableK8sTerminatingEndpoint)
 
+	flags.Bool(option.ExternalWorkload, defaults.ExternalWorkload, "Specifies whether the agent runs in an external workload")
+	option.BindEnv(option.ExternalWorkload)
+
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
@@ -179,7 +180,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 				specialIdentities = append(specialIdentities,
 					identity.IPIdentityPair{
 						IP: ip,
-						ID: identity.ReservedIdentityHost,
+						ID: identity.GetReservedID(labels.IDNameHost),
 					})
 			}
 		}
@@ -208,7 +209,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 				specialIdentities = append(specialIdentities,
 					identity.IPIdentityPair{
 						IP: ip,
-						ID: identity.ReservedIdentityHost,
+						ID: identity.GetReservedID(labels.IDNameHost),
 					})
 			}
 		}
@@ -228,7 +229,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 
 	for _, ipIDPair := range specialIdentities {
 		hostKey := node.GetIPsecKeyIdentity()
-		isHost := ipIDPair.ID == identity.ReservedIdentityHost
+		isHost := ipIDPair.ID == identity.GetReservedID(labels.IDNameHost)
 		if isHost {
 			added, err := lxcmap.SyncHostEntry(ipIDPair.IP)
 			if err != nil {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -441,4 +441,7 @@ const (
 
 	// ARPBaseReachableTime resembles the kernel's NEIGH_VAR_BASE_REACHABLE_TIME which defaults to 30 seconds.
 	ARPBaseReachableTime = 30 * time.Second
+
+	// ExternalWorload specifies whether the agent runs in an external workload
+	ExternalWorkload = false
 )

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // Identity is the representation of the security context for a particular set of
@@ -236,8 +237,9 @@ func LookupReservedIdentityByLabels(lbls labels.Labels) *Identity {
 			// the new list of labels. This is to ensure the local node retains
 			// this identity regardless of label changes.
 			id := GetReservedID(lbl.Key)
-			if id == ReservedIdentityHost {
-				identity := NewIdentity(ReservedIdentityHost, lbls)
+
+			if id == ReservedIdentityHost || (option.Config.ExternalWorkload && (id == GetLocalNodeID())) {
+				identity := NewIdentity(id, lbls)
 				// Pre-calculate the SHA256 hash.
 				identity.GetLabelsSHA256()
 				return identity

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/model"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
@@ -104,7 +105,7 @@ func (idm *IdentityManager) RemoveOldAddNew(old, new *identity.Identity) {
 	}
 	// The host endpoint will always retain its reserved ID, but its labels may
 	// change so we need to update its identity.
-	if old != nil && new != nil && old.ID == new.ID && new.ID != identity.ReservedIdentityHost {
+	if old != nil && new != nil && old.ID == new.ID && new.ID != identity.GetReservedID(labels.IDNameHost) {
 		return
 	}
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node/addressing"
@@ -344,7 +345,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 	dpUpdate := true
 	nodeIP := n.GetNodeIP(false)
 
-	remoteHostIdentity := identity.ReservedIdentityHost
+	remoteHostIdentity := identity.GetReservedID(labels.IDNameHost)
 	if m.conf.RemoteNodeIdentitiesEnabled() {
 		nid := identity.NumericIdentity(n.NodeIdentity)
 		if nid != identity.IdentityUnknown {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -160,7 +160,12 @@ func (n *NodeDiscovery) JoinCluster(nodeName string) {
 	if resp.IPv6AllocCIDR != nil {
 		node.SetIPv6NodeRange(resp.IPv6AllocCIDR)
 	}
-	identity.SetLocalNodeID(resp.NodeIdentity)
+
+	nid := identity.NumericIdentity(resp.NodeIdentity)
+	identity.SetLocalNodeID(nid)
+	if (nid != identity.IdentityUnknown) && option.Config.ExternalWorkload {
+		identity.SetReservedHostIdentity(nid, resp.Labels)
+	}
 }
 
 // start configures the local node and starts node discovery. This is called on

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -989,6 +989,9 @@ const (
 	// EnableK8sTerminatingEndpoint enables the option to auto detect terminating
 	// state for endpoints in order to support graceful termination.
 	EnableK8sTerminatingEndpoint = "enable-k8s-terminating-endpoint"
+
+	// ExternalWorkload specifies whether the agent runs in a external worload.
+	ExternalWorkload = "external-workload"
 )
 
 // Default string arguments
@@ -2031,6 +2034,9 @@ type DaemonConfig struct {
 	// EnableK8sTerminatingEndpoint enables auto-detect of terminating state for
 	// Kubernetes service endpoints.
 	EnableK8sTerminatingEndpoint bool
+
+	// ExternalWorload specifies whether the agent runs in an external workload
+	ExternalWorkload bool
 }
 
 var (
@@ -2079,6 +2085,7 @@ var (
 		APIRateLimit:                     make(map[string]string),
 
 		ExternalClusterIP: defaults.ExternalClusterIP,
+		ExternalWorkload:  defaults.ExternalWorkload,
 	}
 )
 
@@ -2843,6 +2850,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableICMPRules = viper.GetBool(EnableICMPRules)
 	c.BypassIPAvailabilityUponRestore = viper.GetBool(BypassIPAvailabilityUponRestore)
 	c.EnableK8sTerminatingEndpoint = viper.GetBool(EnableK8sTerminatingEndpoint)
+	c.ExternalWorkload = viper.GetBool(ExternalWorkload)
 }
 
 func (c *DaemonConfig) populateDevices() {

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -10,6 +10,7 @@ import (
 
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -198,6 +199,6 @@ func (cip *cachedSelectorPolicy) Consume(owner PolicyOwner) *EndpointPolicy {
 	// TODO: This currently computes the EndpointPolicy from SelectorPolicy
 	// on-demand, however in future the cip is intended to cache the
 	// EndpointPolicy for this Identity and emit datapath deltas instead.
-	isHost := cip.identity.ID == identityPkg.ReservedIdentityHost
+	isHost := cip.identity.ID == identityPkg.GetReservedID(labels.IDNameHost)
 	return cip.getPolicy().DistillPolicy(owner, isHost)
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -675,7 +675,7 @@ func createL4IngressFilter(policyCtx PolicyContext, fromEndpoints api.EndpointSe
 	// then wildcard Host at L7.
 	if !pr.Rules.IsEmpty() && len(hostWildcardL7) > 0 {
 		for cs := range filter.L7RulesPerSelector {
-			if cs.Selects(identity.ReservedIdentityHost) {
+			if cs.Selects(identity.GetReservedID(labels.IDNameHost)) {
 				for _, name := range hostWildcardL7 {
 					selector := api.ReservedEndpointSelectors[name]
 					filter.cacheIdentitySelector(selector, policyCtx.GetSelectorCache(), policyCtx.IsDeny())

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -19,7 +19,7 @@ import (
 var (
 	// localHostKey represents an ingress L3 allow from the local host.
 	localHostKey = Key{
-		Identity:         identity.ReservedIdentityHost.Uint32(),
+		Identity:         identity.GetReservedID(labels.IDNameHost).Uint32(),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
 	// localRemoteNodeKey represents an ingress L3 allow from remote nodes.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -554,7 +554,7 @@ func (p *Repository) getMatchingRules(securityIdentity *identity.Identity) (
 
 	matchingRules = []*rule{}
 	for _, r := range p.rules {
-		isNode := securityIdentity.ID == identity.ReservedIdentityHost
+		isNode := securityIdentity.ID == identity.GetReservedID(labels.IDNameHost)
 		selectsNode := r.NodeSelector.LabelSelector != nil
 		if selectsNode != isNode {
 			continue

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -636,7 +636,7 @@ func (r *rule) matches(securityIdentity *identity.Identity) bool {
 	if ruleMatches, cached := r.metadata.IdentitySelected[securityIdentity.ID]; cached {
 		return ruleMatches
 	}
-	isNode := securityIdentity.ID == identity.ReservedIdentityHost
+	isNode := securityIdentity.ID == identity.GetReservedID(labels.IDNameHost)
 	if (r.NodeSelector.LabelSelector != nil) != isNode {
 		r.metadata.IdentitySelected[securityIdentity.ID] = false
 		return ruleMatches

--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -111,7 +112,7 @@ func (lr *LogRecord) fillEndpointInfo(info *accesslog.EndpointInfo, ip net.IP) {
 		// first we try to resolve and check if the IP is
 		// same as Host
 		if node.IsHostIPv4(ip) {
-			lr.endpointInfoRegistry.FillEndpointIdentityByID(identity.ReservedIdentityHost, info)
+			lr.endpointInfoRegistry.FillEndpointIdentityByID(identity.GetReservedID(labels.IDNameHost), info)
 		} else if !lr.endpointInfoRegistry.FillEndpointIdentityByIP(ip, info) {
 			// If we are unable to resolve the HostIP as well
 			// as the cluster IP we mark this as a 'world' identity.
@@ -121,7 +122,7 @@ func (lr *LogRecord) fillEndpointInfo(info *accesslog.EndpointInfo, ip net.IP) {
 		info.IPv6 = ip.String()
 
 		if node.IsHostIPv6(ip) {
-			lr.endpointInfoRegistry.FillEndpointIdentityByID(identity.ReservedIdentityHost, info)
+			lr.endpointInfoRegistry.FillEndpointIdentityByID(identity.GetReservedID(labels.IDNameHost), info)
 		} else if !lr.endpointInfoRegistry.FillEndpointIdentityByIP(ip, info) {
 			lr.endpointInfoRegistry.FillEndpointIdentityByID(identity.ReservedIdentityWorld, info)
 		}


### PR DESCRIPTION
#### Context 
- https://cilium.slack.com/archives/C2B917YHE/p1635882068106400
----
#### Problem
When the hubble-server runs in a CEW, the generated flows contain incorrect src/dst identities.

- Consider, there are two CEWs
  - VM1 (identity - 68901, label - deathstar)
  - VM2 (identity - 78901, label - tiefighter)
- Only on VM1, the hubble-server is enabled.

Now, for an ingress packet (VM2 --> VM1), the identity part of the flow generated by VM1 currently looks like this.
```
  "source": {
    "identity": 78901,
    "namespace": "default",
    "labels": [
      "k8s:cew=true",
      "k8s:class=tiefighter",
      "k8s:io.cilium.k8s.policy.cluster=kc1",
      "k8s:io.kubernetes.pod.name=kc1-vm2",
      "k8s:io.kubernetes.pod.namespace=default",
      "k8s:org=empire"
    ],
    "pod_name": "kc1-vm2"
  },
  "destination": {
    "identity": 1,
    "labels": [ "reserved:host" ]
  }
```
Similarly for an egress packet (VM1 --> VM2), the identity part of the flow generated by VM1 looks like this.
```
  "source": {
    "identity": 1,
    "labels": [ "reserved:host" ]
  }  
  "destination": {
    "identity": 78901,
    "namespace": "default",
    "labels": [
      "k8s:cew=true",
      "k8s:class=tiefighter",
      "k8s:io.cilium.k8s.policy.cluster=kc1",
      "k8s:io.kubernetes.pod.name=kc1-vm2",
      "k8s:io.kubernetes.pod.namespace=default",
      "k8s:org=empire"
    ],
    "pod_name": "kc1-vm2"
  }
```

So whenever VM1 represents itself in the flow records (either as source or destination), it represent itself with identity 1 (`ReservedIdentityHost`) even though it represents the peer VM with the identity and labels it got from the clustermesh-apiserver

----
#### Solution
This PR tries to fix this issue by replacing the host ID(1) with the value of node ID (which the agent gets from clustermesh-apiserver) in appropriate userspace maps.

##### Commits Summary
- Added a new runtime option in the agent `--external-workload` to explicitly specify that the agent is running in an external workload environment.
- In CEW, replace the host ID (1) with local node ID and add node labels to the host identity.
- Replaced the usage of const `ReservedIdentityHost` in the code with `GetReservedID(labels.IDNameHost)` method wherever necessary.
- Updated the k8s metadata of CEW in the `IPIdentityCache.ipToK8sMetadata` map.

Please look into individual commit messages for a detailed information.