### PR TITLE
workflows: disable `no-policies/pod-to-service` in clustermesh

### DIFF
--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -297,7 +297,11 @@ jobs:
             --context ${{ steps.contexts.outputs.context1 }} \
             --multi-cluster ${{ steps.contexts.outputs.context2 }} \
             --test '!/pod-to-.*-nodeport' \
-             --flow-validation=disabled
+            --test '!no-policies/pod-to-service' \
+            --flow-validation=disabled
+        # TODO: Remove `no-policies/pod-to-service` test exception (unreliable
+        # on clustermesh) once https://github.com/cilium/cilium-cli/issues/600
+        # is fixed.
 
       - name: Post-test information gathering
         if: ${{ !success() }}

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -300,7 +300,11 @@ jobs:
             --context ${{ steps.contexts.outputs.context1 }} \
             --multi-cluster ${{ steps.contexts.outputs.context2 }} \
             --test '!/pod-to-.*-nodeport' \
-             --flow-validation=disabled
+            --test '!no-policies/pod-to-service' \
+            --flow-validation=disabled
+        # TODO: Remove `no-policies/pod-to-service` test exception (unreliable
+        # on clustermesh) once https://github.com/cilium/cilium-cli/issues/600
+        # is fixed.
 
       - name: Enable WireGuard
         run: |
@@ -314,13 +318,17 @@ jobs:
 
       - name: Run connectivity test with WireGuard
         run: |
-          # TODO: Once WireGuard supports the L7 proxy, the L7 tests can be
-          # included here. See cilium/cilium#15462
           cilium connectivity test \
             --context ${{ steps.contexts.outputs.context1 }} \
             --multi-cluster ${{ steps.contexts.outputs.context2 }} \
             --test '!/pod-to-.*-nodeport,!client-egress-l7,!echo-ingress-l7,!to-fqdns,!dns-only' \
-             --flow-validation=disabled
+            --test '!no-policies/pod-to-service' \
+            --flow-validation=disabled
+        # TODO: Once WireGuard supports the L7 proxy, the L7 tests can be
+        # included here. See cilium/cilium#15462
+        # TODO: Remove `no-policies/pod-to-service` test exception (unreliable
+        # on clustermesh) once https://github.com/cilium/cilium-cli/issues/600
+        # is fixed.
 
       - name: Post-test information gathering
         if: ${{ !success() }}

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -321,7 +321,8 @@ jobs:
           cilium connectivity test \
             --context ${{ steps.contexts.outputs.context1 }} \
             --multi-cluster ${{ steps.contexts.outputs.context2 }} \
-            --test '!/pod-to-.*-nodeport,!client-egress-l7,!echo-ingress-l7,!to-fqdns,!dns-only' \
+            --test '!/pod-to-.*-nodeport' \
+            --test '!client-egress-l7,!echo-ingress-l7,!to-fqdns,!dns-only' \
             --test '!no-policies/pod-to-service' \
             --flow-validation=disabled
         # TODO: Once WireGuard supports the L7 proxy, the L7 tests can be


### PR DESCRIPTION
The clustermesh workflow is currently disabled on `cilium/cilium` due to too many failures. After investigating, almost all of the failures come from the same test `no-policies/pod-to-service` during a `curl` action.

Tracking issue: cilium/cilium-cli#600

In order to re-enable the workflow, we disable the unreliable test.