### PR TITLE
bgp: Add support for ClusterPool pod CIDRs

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -508,7 +508,12 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	d.k8sWatcher.NodeChain.Register(d.endpointManager)
 	if option.Config.BGPAnnounceLBIP || option.Config.BGPAnnouncePodCIDR {
-		d.k8sWatcher.NodeChain.Register(d.bgpSpeaker)
+		switch option.Config.IPAMMode() {
+		case ipamOption.IPAMKubernetes:
+			d.k8sWatcher.NodeChain.Register(d.bgpSpeaker)
+		case ipamOption.IPAMClusterPool:
+			d.k8sWatcher.CiliumNodeChain.Register(d.bgpSpeaker)
+		}
 	}
 	if option.Config.EnableServiceTopology {
 		d.k8sWatcher.NodeChain.Register(&d.k8sWatcher.K8sSvcCache)

--- a/pkg/bgp/mock/gen.go
+++ b/pkg/bgp/mock/gen.go
@@ -4,8 +4,12 @@
 package mock
 
 import (
+	"fmt"
+
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/k8s"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	nodetypes "github.com/cilium/cilium/pkg/node/types"
@@ -49,6 +53,46 @@ func GenTestNodeAndAdvertisements() (v1.Node, []*metallbbgp.Advertisement) {
 		{
 			Prefix: cidr.MustParseCIDR(CIDR).IPNet,
 		},
+	}
+	return node, advertisements
+}
+
+// GenTestCiliumNodeAndAdvertisements generates a ciliumv2.CiliumNode with
+// numPodCIDRs podCIDRs and the corresponding MetalLB Advertisements that would
+// be announced by this node.
+//
+// The returned Node's name is set to nodetypes.GetName()
+// to simulate it being the node the Cilium agent is running on.
+//
+// See definition for details.
+func GenTestCiliumNodeAndAdvertisements(numPodCIDRs int) (ciliumv2.CiliumNode, []*metallbbgp.Advertisement) {
+	podCIDRs := make([]string, numPodCIDRs)
+	for i := 0; i < numPodCIDRs; i++ {
+		podCIDRs[i] = fmt.Sprintf("10.%d.0.0/16", i)
+	}
+
+	meta := metav1.ObjectMeta{
+		Name: nodetypes.GetName(),
+		Labels: map[string]string{
+			"TestLabel": "TestLabel",
+		},
+		ResourceVersion: "1",
+	}
+	spec := ciliumv2.NodeSpec{
+		IPAM: types.IPAMSpec{
+			PodCIDRs: podCIDRs,
+		},
+	}
+	node := ciliumv2.CiliumNode{
+		ObjectMeta: meta,
+		Spec:       spec,
+	}
+
+	advertisements := make([]*metallbbgp.Advertisement, 0, numPodCIDRs)
+	for _, podCIDR := range podCIDRs {
+		advertisements = append(advertisements, &metallbbgp.Advertisement{
+			Prefix: cidr.MustParseCIDR(podCIDR).IPNet,
+		})
 	}
 	return node, advertisements
 }

--- a/pkg/bgp/speaker/events.go
+++ b/pkg/bgp/speaker/events.go
@@ -6,6 +6,7 @@ package speaker
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cilium/cilium/pkg/bgp/fence"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -25,6 +26,21 @@ const (
 	Update
 	Delete
 )
+
+func (o Op) String() string {
+	switch o {
+	case Undefined:
+		return "Undefined"
+	case Add:
+		return "Add"
+	case Update:
+		return "Update"
+	case Delete:
+		return "Delete"
+	default:
+		return fmt.Sprintf("Unknown(%d)", o)
+	}
+}
 
 // svcEvent holds the extracted fields from a K8s service event
 // which are of interest to the BGP package.

--- a/pkg/k8s/watchers/subscriber/ciliumnode.go
+++ b/pkg/k8s/watchers/subscriber/ciliumnode.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of Cilium
+
+package subscriber
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/lock"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+var _ CiliumNode = (*CiliumNodeChain)(nil)
+
+// CiliumNode is implemented by event handlers responding to CiliumNode events.
+type CiliumNode interface {
+	OnAddCiliumNode(node *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error
+	OnUpdateCiliumNode(oldObj, newObj *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error
+	OnDeleteCiliumNode(node *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error
+}
+
+// CiliumNodeChain holds the subsciber.CiliumNode implementations that are
+// notified when reacting to CiliumNode resource / object changes in the K8s
+// watchers.
+//
+// CiliumNodeChain itself is an implementation of subscriber.CiliumNodeChain
+// with an additional Register method for attaching children subscribers to the
+// chain.
+type CiliumNodeChain struct {
+	list
+
+	subs []CiliumNode
+}
+
+// NewCiliumNodeChain creates a CiliumNodeChain ready for its
+// Register method to be called.
+func NewCiliumNodeChain() *CiliumNodeChain {
+	return &CiliumNodeChain{}
+}
+
+// Register registers s as a subscriber for reacting to CiliumNode objects
+// into the list.
+func (l *CiliumNodeChain) Register(s CiliumNode) {
+	l.Lock()
+	l.subs = append(l.subs, s)
+	l.Unlock()
+}
+
+// OnAddCiliumNode notifies all the subscribers of an add event to a CiliumNode.
+func (l *CiliumNodeChain) OnAddCiliumNode(node *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error {
+	l.RLock()
+	defer l.RUnlock()
+	errs := []error{}
+	for _, s := range l.subs {
+		if err := s.OnAddCiliumNode(node, swg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("Errors: %v", errs)
+	}
+	return nil
+}
+
+// OnUpdateCiliumNode notifies all the subscribers of an update event to a CiliumNode.
+func (l *CiliumNodeChain) OnUpdateCiliumNode(oldNode, newNode *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error {
+	l.RLock()
+	defer l.RUnlock()
+	errs := []error{}
+	for _, s := range l.subs {
+		if err := s.OnUpdateCiliumNode(oldNode, newNode, swg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("Errors: %v", errs)
+	}
+	return nil
+}
+
+// OnDeleteCiliumNode notifies all the subscribers of an update event to a CiliumNode.
+func (l *CiliumNodeChain) OnDeleteCiliumNode(node *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error {
+	l.RLock()
+	defer l.RUnlock()
+	errs := []error{}
+	for _, s := range l.subs {
+		if err := s.OnDeleteCiliumNode(node, swg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("Errors: %v", errs)
+	}
+	return nil
+}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -185,6 +185,12 @@ type K8sWatcher struct {
 	// have their event handling methods called in order of registration.
 	NodeChain *subscriber.NodeChain
 
+	// CiliumNodeChain is the root of a notification chain for CiliumNode events.
+	// This CiliumNodeChain allows registration of subscriber.CiliumNode implementations.
+	// On CiliumNode events all registered subscriber.CiliumNode implementations will
+	// have their event handling methods called in order of registration.
+	CiliumNodeChain *subscriber.CiliumNodeChain
+
 	endpointManager endpointManager
 
 	nodeDiscoverManager   nodeDiscoverManager
@@ -242,6 +248,7 @@ func NewK8sWatcher(
 		bgpSpeakerManager:     bgpSpeakerManager,
 		egressGatewayManager:  egressGatewayManager,
 		NodeChain:             subscriber.NewNodeChain(),
+		CiliumNodeChain:       subscriber.NewCiliumNodeChain(),
 		cfg:                   cfg,
 	}
 }


### PR DESCRIPTION
This commit extends the BGP pod CIDR announcement logic to also parse
pod CIDRs used by ClusterPool IPAM. In contrast to the Kubernetes IPAM
mode (where pod CIDRs are stored native Kubernetes Node resources),
ClusterPool IPAM stores the allocated pod CIDRs in the CiliumNode
object.

Therefore, this commit extends the BGP speaker logic to also receive
CiliumNode updates.
