### PR TITLE
daemon: Fatal on BPF masquerade + IPv6 masquerade

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1411,6 +1411,10 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.EnableBandwidthManager = false
 	}
 
+	if option.Config.EnableIPv6Masquerade && option.Config.EnableBPFMasquerade {
+		log.Fatal("BPF masquerade is not supported for IPv6.")
+	}
+
 	// If there is one device specified, use it to derive better default
 	// allocation prefixes
 	node.InitDefaultPrefix(option.Config.DirectRoutingDevice)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2370,6 +2370,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 
 		if RunsOn419OrLaterKernel() {
 			opts["bpf.masquerade"] = "true"
+			opts["enableIPv6Masquerade"] = "false"
 		}
 
 		for key, value := range opts {


### PR DESCRIPTION
BPF masquerading for IPv6 isn't supported yet, so we should fatal early if the user asks for both BPF and IPv6 masquerade. They can use iptables-based masquerading for IPv6 instead.

Since we enable BPF-based masquerading in all tests with 4.19+ kernels, we also need to disable IPv6 masquerading there. That should be fine since we rarely rely on IPv6 masquerading anyway.

```release-note
Fix bug where the agents would silently skip all IPv6 masquerading due to an incorrect configuration.
```