### PR TITLE
bugtool: fix data race occurring when running commands

### DIFF
--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -307,6 +307,7 @@ func runAll(commands []string, cmdDir string, k8sPods []string) {
 			continue
 		}
 
+		cmd := cmd // https://golang.org/doc/faq#closures_and_goroutines
 		err := wp.Submit(cmd, func(_ context.Context) error {
 			if strings.Contains(cmd, "xfrm state") {
 				//  Output of 'ip -s xfrm state' needs additional processing to replace


### PR DESCRIPTION
A version of the classic closure with concurrency gotcha. Bind the value of cmd in the loop to a new variable to address the issue.

Fixes: #17915
