### PR TITLE
daemon: Support the wildcard option for directRoutingDevice

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -838,9 +838,12 @@ via ``devices`` then Cilium will use that device for direct routing.
 Otherwise, Cilium will use a device with Kubernetes InternalIP or ExternalIP
 being set. InternalIP is preferred over ExternalIP if both exist. To change
 the direct routing device, set the ``nodePort.directRoutingDevice`` Helm
-option, e.g. ``nodePort.directRoutingDevice=eth1``. If the direct
-routing device does not exist within ``devices``, Cilium will add the
-device to the latter list. The direct routing device is used for
+option, e.g. ``nodePort.directRoutingDevice=eth1``. The wildcard option can be
+used as well as the devices option, e.g. ``directRoutingDevice=eth+``.
+If more than one devices match the wildcard option, Cilium will sort them
+in increasing alphanumerical order and pick the first one. If the direct routing
+device does not exist within ``devices``, Cilium will add the device to the latter
+list. The direct routing device is used for
 :ref:`the NodePort XDP acceleration<XDP Acceleration>` as well (if enabled).
 
 In addition, thanks to the :ref:`host-services` feature, the NodePort service can

--- a/daemon/cmd/devices.go
+++ b/daemon/cmd/devices.go
@@ -287,7 +287,7 @@ func (dm *DeviceManager) updateDevicesFromRoutes(l3DevOK bool, routes []netlink.
 // expandDevices expands all wildcard device names to concrete devices.
 // e.g. device "eth+" expands to "eth0,eth1" etc. Non-matching wildcards are ignored.
 func expandDevices() error {
-	expandedDevices, err := expand(option.Config.Devices)
+	expandedDevices, err := expandDeviceWildcards(option.Config.Devices, option.Devices)
 	if err != nil {
 		return err
 	}
@@ -300,7 +300,7 @@ func expandDirectRoutingDevice() error {
 	if option.Config.DirectRoutingDevice == "" {
 		return nil
 	}
-	expandedDevices, err := expand([]string{option.Config.DirectRoutingDevice})
+	expandedDevices, err := expandDeviceWildcards([]string{option.Config.DirectRoutingDevice}, option.DirectRoutingDevice)
 	if err != nil {
 		return err
 	}
@@ -308,7 +308,7 @@ func expandDirectRoutingDevice() error {
 	return nil
 }
 
-func expand(devices []string) ([]string, error) {
+func expandDeviceWildcards(devices []string, option string) ([]string, error) {
 	allLinks, err := netlink.LinkList()
 	if err != nil {
 		return nil, fmt.Errorf("Device wildcard expansion failed to fetch devices: %w", err)
@@ -331,7 +331,7 @@ func expand(devices []string) ([]string, error) {
 		// User defined devices, but expansion yielded no devices. Fail here to not
 		// surprise with auto-detection.
 		return nil, fmt.Errorf("Device wildcard expansion failed to detect devices. Please verify --%s option.",
-			devices)
+			option)
 	}
 
 	expandedDevices := make([]string, 0, len(expandedDevicesMap))

--- a/daemon/cmd/devices_test.go
+++ b/daemon/cmd/devices_test.go
@@ -175,6 +175,23 @@ func (s *DevicesSuite) TestExpandDevices(c *C) {
 	})
 }
 
+func (s *DevicesSuite) TestExpandDirectRoutingDevice(c *C) {
+	s.withFreshNetNS(c, func() {
+		c.Assert(createDummy("dummy0", "192.168.0.1/24", false), IsNil)
+		c.Assert(createDummy("dummy1", "192.168.1.2/24", false), IsNil)
+		c.Assert(createDummy("unmatched", "192.168.4.5/24", false), IsNil)
+
+		// 1. Check expansion works and non-matching prefixes are ignored
+		option.Config.DirectRoutingDevice = "dummy+"
+		c.Assert(expandDirectRoutingDevice(), IsNil)
+		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
+
+		// 2. Check that expansion fails if directRoutingDevice is specified but yields empty expansion
+		option.Config.DirectRoutingDevice = "none+"
+		c.Assert(expandDirectRoutingDevice(), NotNil)
+	})
+}
+
 func (s *DevicesSuite) withFreshNetNS(c *C, test func()) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()


### PR DESCRIPTION
This PR implements support for the wildcard option for directRoutingDevice.

Fixes: #17852

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!