### PR TITLE
Fix for excess IP release race condition | handshake between agent and operator

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -36,6 +36,7 @@ cilium-operator-aws [flags]
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
+      --excess-ip-release-delay int               Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
       --gops-port int                             Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator-aws
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -41,6 +41,7 @@ cilium-operator [flags]
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
+      --excess-ip-release-delay int               Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
       --gops-port int                             Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -141,6 +141,10 @@ const (
 	// the number of API calls to AWS EC2 service.
 	AWSReleaseExcessIPs = "aws-release-excess-ips"
 
+	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
+	// Defaults to 180 secs
+	ExcessIPReleaseDelay = "excess-ip-release-delay"
+
 	// ENITags are the tags that will be added to every ENI created by the
 	// AWS ENI IPAM.
 	ENITags = "eni-tags"
@@ -334,6 +338,10 @@ type OperatorConfig struct {
 	// instancetype to adapter limit mapping.
 	UpdateEC2AdapterLimitViaAPI bool
 
+	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
+	// Defaults to 180 secs
+	ExcessIPReleaseDelay int
+
 	// EC2APIEndpoint is the custom API endpoint to use for the EC2 AWS service,
 	// e.g. "ec2-fips.us-west-1.amazonaws.com" to use a FIPS endpoint in the us-west-1 region.
 	EC2APIEndpoint string
@@ -414,6 +422,7 @@ func (c *OperatorConfig) Populate() {
 	c.AWSReleaseExcessIPs = viper.GetBool(AWSReleaseExcessIPs)
 	c.UpdateEC2AdapterLimitViaAPI = viper.GetBool(UpdateEC2AdapterLimitViaAPI)
 	c.EC2APIEndpoint = viper.GetString(EC2APIEndpoint)
+	c.ExcessIPReleaseDelay = viper.GetInt(ExcessIPReleaseDelay)
 
 	// Azure options
 

--- a/operator/provider_aws_flags.go
+++ b/operator/provider_aws_flags.go
@@ -29,6 +29,9 @@ func init() {
 	flags.Bool(operatorOption.AWSReleaseExcessIPs, false, "Enable releasing excess free IP addresses from AWS ENI.")
 	option.BindEnv(operatorOption.AWSReleaseExcessIPs)
 
+	flags.Int(operatorOption.ExcessIPReleaseDelay, 180, "Number of seconds operator would wait before it releases an IP previously marked as excess")
+	option.BindEnv(operatorOption.ExcessIPReleaseDelay)
+
 	flags.Var(option.NewNamedMapOptions(operatorOption.ENITags, &operatorOption.Config.ENITags, nil),
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(operatorOption.ENITags)

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -8,10 +8,21 @@ package ipam
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/addressing"
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/fake"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	"github.com/cilium/cilium/pkg/trigger"
 
 	"github.com/stretchr/testify/assert"
+	. "gopkg.in/check.v1"
 )
 
 func TestIPNotAvailableInPoolError(t *testing.T) {
@@ -48,4 +59,72 @@ func TestIPNotAvailableInPoolError(t *testing.T) {
 	err2 = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
 	assert.NotEqual(t, err, err2)
 	assert.False(t, errors.Is(err, err2))
+}
+
+type testConfigurationCRD struct{}
+
+func (t *testConfigurationCRD) IPv4Enabled() bool                        { return true }
+func (t *testConfigurationCRD) IPv6Enabled() bool                        { return false }
+func (t *testConfigurationCRD) HealthCheckingEnabled() bool              { return true }
+func (t *testConfigurationCRD) IPAMMode() string                         { return ipamOption.IPAMCRD }
+func (t *testConfigurationCRD) BlacklistConflictingRoutesEnabled() bool  { return false }
+func (t *testConfigurationCRD) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
+func (t *testConfigurationCRD) GetIPv4NativeRoutingCIDR() *cidr.CIDR     { return nil }
+func (t *testConfigurationCRD) IPv4NativeRoutingCIDR() *cidr.CIDR        { return nil }
+
+func newFakeNodeStore(conf Configuration, c *C) *nodeStore {
+	t, err := trigger.NewTrigger(trigger.Parameters{
+		Name:        "fake-crd-allocator-node-refresher",
+		MinInterval: 3 * time.Second,
+		TriggerFunc: func(reasons []string) {},
+	})
+	if err != nil {
+		log.WithError(err).Fatal("Unable to initialize CiliumNode synchronization trigger")
+	}
+	store := &nodeStore{
+		allocators:         []*crdAllocator{},
+		allocationPoolSize: map[Family]int{},
+		conf:               conf,
+		refreshTrigger:     t,
+	}
+	return store
+}
+
+func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
+	cn := newCiliumNode("node1", 4, 4, 0)
+	dummyResource := ipamTypes.AllocationIP{Resource: "foo"}
+	for i := 1; i <= 4; i++ {
+		cn.Spec.IPAM.Pool[fmt.Sprintf("1.1.1.%d", i)] = dummyResource
+	}
+
+	fakeAddressing := fake.NewNodeAddressing()
+	conf := &testConfigurationCRD{}
+	initNodeStore.Do(func() {
+		sharedNodeStore = newFakeNodeStore(conf, c)
+		sharedNodeStore.ownNode = cn
+	})
+	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, &ownerMock{}, &mtuMock)
+	sharedNodeStore.updateLocalNodeResource(cn)
+
+	// Allocate the first 3 IPs
+	for i := 1; i <= 3; i++ {
+		epipv4, _ := addressing.NewCiliumIPv4(fmt.Sprintf("1.1.1.%d", i))
+		_, err := ipam.IPv4Allocator.Allocate(epipv4.IP(), fmt.Sprintf("test%d", i))
+		c.Assert(err, IsNil)
+	}
+
+	// Update 1.1.1.4 as marked for release like operator would.
+	cn.Status.IPAM.ReleaseIPs["1.1.1.4"] = ipamOption.IPAMMarkForRelease
+	// Attempts to allocate 1.1.1.4 should fail, since it's already marked for release
+	epipv4, _ := addressing.NewCiliumIPv4("1.1.1.4")
+	_, err := ipam.IPv4Allocator.Allocate(epipv4.IP(), "test")
+	c.Assert(err, NotNil)
+	// Call agent's CRD update function. status for 1.1.1.4 should change from marked for release to ready for release
+	sharedNodeStore.updateLocalNodeResource(cn)
+	c.Assert(string(cn.Status.IPAM.ReleaseIPs["1.1.1.4"]), checker.Equals, ipamOption.IPAMReadyForRelease)
+
+	// Verify that 1.1.1.3 is denied for release, since it's already in use
+	cn.Status.IPAM.ReleaseIPs["1.1.1.3"] = ipamOption.IPAMMarkForRelease
+	sharedNodeStore.updateLocalNodeResource(cn)
+	c.Assert(string(cn.Status.IPAM.ReleaseIPs["1.1.1.3"]), checker.Equals, ipamOption.IPAMDoNotRelease)
 }

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -257,8 +257,10 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 	}()
 	if !ok {
 		node = &Node{
-			name:    resource.Name,
-			manager: n,
+			name:                resource.Name,
+			manager:             n,
+			ipsMarkedForRelease: make(map[string]time.Time),
+			ipReleaseStatus:     make(map[string]string),
 		}
 
 		node.ops = n.instancesAPI.CreateNode(resource, node)
@@ -306,7 +308,6 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 		node.poolMaintainer = poolMaintainer
 		node.k8sSync = k8sSync
 		n.nodes[node.name] = node
-
 		log.WithField(fieldName, resource.Name).Info("Discovered new CiliumNode custom resource")
 	}
 

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -31,4 +31,5 @@ const (
 	IPAMMarkForRelease  = "marked-for-release"
 	IPAMReadyForRelease = "ready-for-release"
 	IPAMDoNotRelease    = "do-not-release"
+	IPAMReleased        = "released"
 )

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -26,3 +26,9 @@ const (
 	// IPAMAlibabaCloud is the value to select the AlibabaCloud ENI IPAM plugin for option.IPAM
 	IPAMAlibabaCloud = "alibabacloud"
 )
+
+const (
+	IPAMMarkForRelease  = "marked-for-release"
+	IPAMReadyForRelease = "ready-for-release"
+	IPAMDoNotRelease    = "do-not-release"
+)

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -102,7 +102,7 @@ type IPAMSpec struct {
 
 // IPReleaseStatus  defines the valid states in IP release handshake
 //
-// +kubebuilder:validation:Enum=marked-for-release;ready-for-release;do-not-release
+// +kubebuilder:validation:Enum=marked-for-release;ready-for-release;do-not-release;released
 type IPReleaseStatus string
 
 // IPAMStatus is the IPAM status of a node
@@ -125,6 +125,7 @@ type IPAMStatus struct {
 	// * marked-for-release : Set by operator as possible candidate for IP
 	// * ready-for-release  : Acknowledged as safe to release by agent
 	// * do-not-release     : IP already in use / not owned by the node. Set by agent
+	// * released           : IP successfully released. Set by operator
 	//
 	// +optional
 	ReleaseIPs map[string]IPReleaseStatus `json:"release-ips,omitempty"`

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -100,6 +100,11 @@ type IPAMSpec struct {
 	MaxAboveWatermark int `json:"max-above-watermark,omitempty"`
 }
 
+// IPReleaseStatus  defines the valid states in IP release handshake
+//
+// +kubebuilder:validation:Enum=marked-for-release;ready-for-release;do-not-release
+type IPReleaseStatus string
+
 // IPAMStatus is the IPAM status of a node
 //
 // This structure is embedded into v2.CiliumNode
@@ -114,6 +119,15 @@ type IPAMStatus struct {
 	//
 	// +optional
 	OperatorStatus OperatorStatus `json:"operator-status,omitempty"`
+
+	// ReleaseIPs tracks the state for every IP considered for release.
+	// value can be one of the following string :
+	// * marked-for-release : Set by operator as possible candidate for IP
+	// * ready-for-release  : Acknowledged as safe to release by agent
+	// * do-not-release     : IP already in use / not owned by the node. Set by agent
+	//
+	// +optional
+	ReleaseIPs map[string]IPReleaseStatus `json:"release-ips,omitempty"`
 }
 
 // OperatorStatus is the status used by cilium-operator to report

--- a/pkg/ipam/types/zz_generated.deepcopy.go
+++ b/pkg/ipam/types/zz_generated.deepcopy.go
@@ -85,6 +85,13 @@ func (in *IPAMStatus) DeepCopyInto(out *IPAMStatus) {
 		}
 	}
 	out.OperatorStatus = in.OperatorStatus
+	if in.ReleaseIPs != nil {
+		in, out := &in.ReleaseIPs, &out.ReleaseIPs
+		*out = make(map[string]IPReleaseStatus, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -114,6 +114,27 @@ func (in *IPAMStatus) DeepEqual(other *IPAMStatus) bool {
 		return false
 	}
 
+	if ((in.ReleaseIPs != nil) && (other.ReleaseIPs != nil)) || ((in.ReleaseIPs == nil) != (other.ReleaseIPs == nil)) {
+		in, other := &in.ReleaseIPs, &other.ReleaseIPs
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for key, inValue := range *in {
+				if otherValue, present := (*other)[key]; !present {
+					return false
+				} else {
+					if inValue != otherValue {
+						return false
+					}
+				}
+			}
+		}
+	}
+
 	return true
 }
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -527,12 +527,14 @@ spec:
                       - marked-for-release
                       - ready-for-release
                       - do-not-release
+                      - released
                       type: string
                     description: 'ReleaseIPs tracks the state for every IP considered
                       for release. value can be one of the following string : * marked-for-release
                       : Set by operator as possible candidate for IP * ready-for-release  :
                       Acknowledged as safe to release by agent * do-not-release     :
-                      IP already in use / not owned by the node. Set by agent'
+                      IP already in use / not owned by the node. Set by agent * released           :
+                      IP successfully released. Set by operator'
                     type: object
                   used:
                     additionalProperties:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -519,6 +519,21 @@ spec:
                         description: Error is the error message set by cilium-operator.
                         type: string
                     type: object
+                  release-ips:
+                    additionalProperties:
+                      description: IPReleaseStatus  defines the valid states in IP
+                        release handshake
+                      enum:
+                      - marked-for-release
+                      - ready-for-release
+                      - do-not-release
+                      type: string
+                    description: 'ReleaseIPs tracks the state for every IP considered
+                      for release. value can be one of the following string : * marked-for-release
+                      : Set by operator as possible candidate for IP * ready-for-release  :
+                      Acknowledged as safe to release by agent * do-not-release     :
+                      IP already in use / not owned by the node. Set by agent'
+                    type: object
                   used:
                     additionalProperties:
                       description: AllocationIP is an IP which is available for allocation,

--- a/pkg/testutils/ipam.go
+++ b/pkg/testutils/ipam.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Authors of Cilium
+
+package testutils
+
+import (
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+// FakeAcknowledgeReleaseIps Fake acknowledge IPs marked for release like cilium agent would.
+func FakeAcknowledgeReleaseIps(cn *v2.CiliumNode) {
+	for ip, status := range cn.Status.IPAM.ReleaseIPs {
+		if status == ipamOption.IPAMMarkForRelease {
+			cn.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMReadyForRelease
+		}
+	}
+}


### PR DESCRIPTION
Forward port of https://github.com/DataDog/cilium/pull/24

Currently there's a 15 sec delay in updating ciliumnode (CN) CRD after IP allocation to a pod, meanwhile the operator can determine that a node has excess IPs and release the IP causing pod connectivity issues.

This PR introduces a handshake between the operator and agent before releasing an excess IP to avoid the race condition. A new operator flag `excess-ip-release-delay` is added to control how long operator should wait before considering an IP for release (defaults to 180 secs). This is done to better handle IP reuse during rollouts. Operator and agent use a new map in cilium node status `.status.ipam.release-ips` to exchange information during the handshake.

Fixes: #13412

![handshake_upstream](https://user-images.githubusercontent.com/3775612/142660918-132aa9e7-d59d-466b-92e1-86492ffef213.png)

The following alternative options were considered : 

* We could force a CN write to go through before allocation but it can result in too many writes from the agent.

* The operator picks the ENI with the most free IPs to release excess IPs from, this is done so that the ENI could potentially be released in the future. We could move the excess detection logic to the agent, but this involves calling into cloud provider specific implementation, which AFAIU the agent IPAM implementation does not.


```release-note
Fix for excess IP release race condition. New operator flag excess-ip-release-delay is introduced to control waiting period before marking an IP for release.
```
Note : https://github.com/DataDog/cilium/pull/24 already received some valuable feedback from @aanm @gandro and @christarazi 