### PR TITLE
Bugfix:LB service redirect to a wrong backend

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -746,8 +746,9 @@ struct lb6_service {
 struct lb6_backend {
 	union v6addr address;
 	__be16 port;
+	__u16 rev_nat_index;	/* Reverse NAT ID in lb4_reverse_nat */
 	__u8 proto;
-	__u8 pad;
+	__u8 pad[3];
 };
 
 struct lb6_health {
@@ -799,8 +800,9 @@ struct lb4_service {
 struct lb4_backend {
 	__be32 address;		/* Service endpoint IPv4 address */
 	__be16 port;		/* L4 port filter */
+	__u16 rev_nat_index;	/* Reverse NAT ID in lb4_reverse_nat */
 	__u8 proto;		/* L4 protocol, currently not used (set to 0) */
-	__u8 pad;
+	__u8 pad[3];
 };
 
 struct lb4_health {

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -215,7 +215,7 @@ func (*LBBPFMap) DeleteService(svc loadbalancer.L3n4AddrID, backendCount int, us
 }
 
 // AddBackend adds a backend into a BPF map.
-func (*LBBPFMap) AddBackend(id loadbalancer.BackendID, ip net.IP, port uint16, ipv6 bool) error {
+func (*LBBPFMap) AddBackend(id loadbalancer.BackendID, ip net.IP, port uint16, revNATID uint16, ipv6 bool) error {
 	var (
 		backend Backend
 		err     error
@@ -226,9 +226,9 @@ func (*LBBPFMap) AddBackend(id loadbalancer.BackendID, ip net.IP, port uint16, i
 	}
 
 	if ipv6 {
-		backend, err = NewBackend6V2(loadbalancer.BackendID(id), ip, port, u8proto.ANY)
+		backend, err = NewBackend6V2(loadbalancer.BackendID(id), ip, port, revNATID, u8proto.ANY)
 	} else {
-		backend, err = NewBackend4V2(loadbalancer.BackendID(id), ip, port, u8proto.ANY)
+		backend, err = NewBackend4V2(loadbalancer.BackendID(id), ip, port, revNATID, u8proto.ANY)
 	}
 	if err != nil {
 		return fmt.Errorf("Unable to create backend (%d, %s, %d, %t): %s",

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -38,7 +38,7 @@ type LBMap interface {
 	UpsertMaglevLookupTable(uint16, map[string]lb.BackendID, bool) error
 	IsMaglevLookupTableRecreated(bool) bool
 	DeleteService(lb.L3n4AddrID, int, bool) error
-	AddBackend(lb.BackendID, net.IP, uint16, bool) error
+	AddBackend(lb.BackendID, net.IP, uint16, uint16, bool) error
 	DeleteBackendByID(lb.BackendID, bool) error
 	AddAffinityMatch(uint16, lb.BackendID) error
 	DeleteAffinityMatch(uint16, lb.BackendID) error
@@ -779,7 +779,7 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, onlyLocalBackends bool,
 		}).Debug("Adding new backend")
 
 		if err := s.lbmap.AddBackend(b.ID, b.L3n4Addr.IP,
-			b.L3n4Addr.L4Addr.Port, ipv6); err != nil {
+			b.L3n4Addr.L4Addr.Port, uint16(svc.frontend.ID), ipv6); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When a endpoint was removed, but its CT entries were not, another
endpoint maybe use the same backend_id,then a wrong backend can
be selected.

This patch check that reverse NAT index of backend match service
entry. If not,select a new backend.

Fixes: #17729

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
