### PR TITLE
test: Support multiple nodes without Cilium

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -28,7 +28,7 @@ $HUBBLE_RELAY_TAG = ENV['HUBBLE_RELAY_TAG'] || ""
 $PRELOAD_VM = ENV['PRELOAD_VM'] || "false"
 $PROVISION_EXTERNAL_WORKLOAD = ENV['PROVISION_EXTERNAL_WORKLOAD'] || "false"
 $SKIP_K8S_PROVISION = ENV['SKIP_K8S_PROVISION'] || "false"
-$NO_CILIUM_ON_NODE = ENV['NO_CILIUM_ON_NODE'] || ""
+$NO_CILIUM_ON_NODES = ENV['NO_CILIUM_ON_NODES'] || ENV['NO_CILIUM_ON_NODE'] || ""
 $KUBEPROXY = (ENV['KUBEPROXY'] || "1")
 $RACE = ENV['RACE'] || ""
 $LOCKDEBUG = ENV['LOCKDEBUG'] || ""
@@ -145,7 +145,8 @@ Vagrant.configure("2") do |config|
                 vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
                 vb.cpus = $CPU
                 vb.memory = $MEMORY
-                if "k8s#{i}" == $NO_CILIUM_ON_NODE
+                no_cilium_nodes = $NO_CILIUM_ON_NODES.split(',')
+                if no_cilium_nodes.include? "k8s#{i}"
                   vb.memory = $MEMORY / 2
                   vb.cpus = 1
                 end

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -635,18 +635,9 @@ func (kub *Kubectl) labelNodes() error {
 		return fmt.Errorf("unable to unmarshal string slice '%#v': %s", nodesList, err)
 	}
 
-	var (
-		index int = 1
-
-		noCiliumNode     = GetNodeWithoutCilium()
-		noCiliumNodeName string
-	)
+	index := 1
 	for _, nodeName := range nodesList {
 		ciNodeName := fmt.Sprintf("k8s%d", index)
-		if GetNodeWithoutCilium() == ciNodeName {
-			noCiliumNodeName = nodeName
-		}
-
 		cmd := fmt.Sprintf("%s label --overwrite node %s cilium.io/ci-node=%s", KubectlCmd, nodeName, ciNodeName)
 		res := kub.ExecShort(cmd)
 		if !res.WasSuccessful() {
@@ -655,10 +646,11 @@ func (kub *Kubectl) labelNodes() error {
 		index++
 	}
 
-	if noCiliumNode != "" {
+	noCiliumNodeNames := strings.Join(GetNodesWithoutCilium(), " ")
+	if noCiliumNodeNames != "" {
 		// Prevent scheduling any pods on the node, as it will be used as an external client
 		// to send requests to k8s{1,2}
-		cmd := fmt.Sprintf("%s taint --overwrite nodes %s key=value:NoSchedule", KubectlCmd, noCiliumNodeName)
+		cmd := fmt.Sprintf("%s taint --overwrite nodes %s key=value:NoSchedule", KubectlCmd, noCiliumNodeNames)
 		res := kub.ExecMiddle(cmd)
 		if !res.WasSuccessful() {
 			return fmt.Errorf("unable to taint node with '%s': %s", cmd, res.OutputPrettyPrint())
@@ -720,12 +712,7 @@ func (kub *Kubectl) GetNumCiliumNodes() int {
 	if !res.WasSuccessful() {
 		return 0
 	}
-	sub := 0
-	if ExistNodeWithoutCilium() {
-		sub = 1
-	}
-
-	return len(strings.Split(res.SingleOut(), " ")) - sub
+	return len(strings.Split(res.SingleOut(), " ")) - len(GetNodesWithoutCilium())
 }
 
 // CountMissedTailCalls returns the number of the sum of all drops due to
@@ -2338,12 +2325,16 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		options = addIfNotOverwritten(options, key, value)
 	}
 
-	// Do not schedule cilium-agent on the NO_CILIUM_ON_NODE node
-	if node := GetNodeWithoutCilium(); node != "" {
+	// Do not schedule cilium-agent on the NO_CILIUM_ON_NODE nodes
+	noCiliumNodes := GetNodesWithoutCilium()
+	if len(noCiliumNodes) > 0 {
 		opts := map[string]string{
-			"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key":       "cilium.io/ci-node",
-			"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator":  "NotIn",
-			"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]": node,
+			"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key":      "cilium.io/ci-node",
+			"affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator": "NotIn",
+		}
+		for i, n := range noCiliumNodes {
+			key := fmt.Sprintf("affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[%d]", i)
+			opts[key] = n
 		}
 		for key, value := range opts {
 			options = addIfNotOverwritten(options, key, value)
@@ -2826,9 +2817,8 @@ func (kub *Kubectl) CiliumNodesWait() (bool, error) {
 			return false
 		}
 		result := data.KVOutput()
-		ignoreNode := GetNodeWithoutCilium()
 		for k, v := range result {
-			if k == ignoreNode {
+			if IsNodeWithoutCilium(k) {
 				continue
 			}
 			if v == "" {
@@ -4333,8 +4323,13 @@ func logGathererSelector(allNodes bool) string {
 		return selector
 	}
 
-	if nodeName := GetNodeWithoutCilium(); nodeName != "" {
-		selector = fmt.Sprintf("%s --field-selector='spec.nodeName!=%s'", selector, nodeName)
+	noCiliumNodes := GetNodesWithoutCilium()
+	if len(noCiliumNodes) > 0 {
+		var fieldSelectors []string
+		for _, n := range noCiliumNodes {
+			fieldSelectors = append(fieldSelectors, fmt.Sprintf("spec.nodeName!=%s", n))
+		}
+		selector = fmt.Sprintf("%s --field-selector='%s'", selector, strings.Join(fieldSelectors, ","))
 	}
 
 	return selector

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -601,12 +601,12 @@ func RunsWithoutKubeProxy() bool {
 }
 
 // ExistNodeWithoutCilium returns true if there is a node in a cluster which does
-// not run cilium.
+// not run Cilium.
 func ExistNodeWithoutCilium() bool {
-	return GetNodeWithoutCilium() != ""
+	return len(GetNodesWithoutCilium()) > 0
 }
 
-// DoesNotExistNodeWithoutCilium is the complement function of ExistNodeWithoutCilium
+// DoesNotExistNodeWithoutCilium is the complement function of ExistNodeWithoutCilium.
 func DoesNotExistNodeWithoutCilium() bool {
 	return !ExistNodeWithoutCilium()
 }
@@ -641,9 +641,34 @@ func (kub *Kubectl) HasBPFNodePort(pod string) bool {
 	return strings.Contains(lines[0], "true")
 }
 
-// GetNodeWithoutCilium returns a name of a node which does not run cilium.
-func GetNodeWithoutCilium() string {
-	return os.Getenv("NO_CILIUM_ON_NODE")
+// GetNodesWithoutCilium returns a slice of names for nodes that do not run
+// Cilium.
+func GetNodesWithoutCilium() []string {
+	if os.Getenv("NO_CILIUM_ON_NODES") == "" {
+		if os.Getenv("NO_CILIUM_ON_NODE") == "" {
+			return []string{}
+		}
+		return []string{os.Getenv("NO_CILIUM_ON_NODE")}
+	}
+	return strings.Split(os.Getenv("NO_CILIUM_ON_NODES"), ",")
+}
+
+// GetFirstNodeWithoutCilium returns the first node that does not run Cilium.
+// It's the responsibility of the caller to check that there are nodes without
+// Cilium.
+func GetFirstNodeWithoutCilium() string {
+	noCiliumNodes := GetNodesWithoutCilium()
+	return noCiliumNodes[0]
+}
+
+// IsNodeWithoutCilium returns true if node node doesn't run Cilium.
+func IsNodeWithoutCilium(node string) bool {
+	for _, n := range GetNodesWithoutCilium() {
+		if n == node {
+			return true
+		}
+	}
+	return false
 }
 
 // GetLatestImageVersion infers which docker tag should be used

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -396,7 +396,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			res.ExpectSuccess()
 			tmpEchoPodPath = strings.Trim(res.Stdout(), "\n")
 			kubectl.ExecMiddle(fmt.Sprintf("sed 's/NODE_WITHOUT_CILIUM/%s/' %s > %s",
-				helpers.GetNodeWithoutCilium(), echoPodPath, tmpEchoPodPath)).ExpectSuccess()
+				helpers.GetFirstNodeWithoutCilium(), echoPodPath, tmpEchoPodPath)).ExpectSuccess()
 			kubectl.ApplyDefault(tmpEchoPodPath).ExpectSuccess("Cannot install echoserver application")
 			Expect(kubectl.WaitforPods(helpers.DefaultNamespace, "-l name=echoserver-hostnetns",
 				helpers.HelperTimeout)).Should(BeNil())
@@ -439,7 +439,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		testIPMasqAgent := func() {
 			// Check that requests to the echoserver from client pods are masqueraded.
-			nodeIP, err := kubectl.GetNodeIPByLabel(helpers.GetNodeWithoutCilium(), false)
+			nodeIP, err := kubectl.GetNodeIPByLabel(helpers.GetFirstNodeWithoutCilium(), false)
 			Expect(err).Should(BeNil())
 			Expect(testPodHTTPToOutside(kubectl,
 				fmt.Sprintf("http://%s:80", nodeIP), true, false)).Should(BeTrue(),
@@ -1115,10 +1115,10 @@ func testPodHTTPToOutside(kubectl *helpers.Kubectl, outsideURL string, expectNod
 
 		if expectPodIP {
 			// Make pods reachable from the host which doesn't run Cilium
-			kubectl.AddIPRoute(helpers.GetNodeWithoutCilium(), podIP, hostIP, false).
+			kubectl.AddIPRoute(helpers.GetFirstNodeWithoutCilium(), podIP, hostIP, false).
 				ExpectSuccess("Failed to add ip route")
 			defer func() {
-				kubectl.DelIPRoute(helpers.GetNodeWithoutCilium(), podIP, hostIP).
+				kubectl.DelIPRoute(helpers.GetFirstNodeWithoutCilium(), podIP, hostIP).
 					ExpectSuccess("Failed to del ip route")
 			}()
 		}

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -57,7 +57,7 @@ var _ = SkipDescribeIf(func() bool {
 		res.ExpectSuccess()
 		echoPodYAML = strings.Trim(res.Stdout(), "\n")
 		kubectl.ExecMiddle(fmt.Sprintf("sed 's/NODE_WITHOUT_CILIUM/%s/' %s > %s",
-			helpers.GetNodeWithoutCilium(), originalEchoPodPath, echoPodYAML)).ExpectSuccess()
+			helpers.GetFirstNodeWithoutCilium(), originalEchoPodPath, echoPodYAML)).ExpectSuccess()
 		kubectl.ApplyDefault(echoPodYAML).ExpectSuccess("Cannot install echoserver application")
 		Expect(kubectl.WaitforPods(helpers.DefaultNamespace, "-l name=echoserver-hostnetns",
 			helpers.HelperTimeout)).Should(BeNil())
@@ -88,7 +88,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		_, k8s1IP = kubectl.GetNodeInfo(helpers.K8s1)
 		_, k8s2IP = kubectl.GetNodeInfo(helpers.K8s2)
-		_, outsideIP = kubectl.GetNodeInfo(helpers.GetNodeWithoutCilium())
+		_, outsideIP = kubectl.GetNodeInfo(helpers.GetFirstNodeWithoutCilium())
 
 		egressIP = getEgressIP(k8s1IP)
 
@@ -167,7 +167,7 @@ var _ = SkipDescribeIf(func() bool {
 			fmt.Sprintf(`{"spec":{"externalIPs":["%s"],  "externalTrafficPolicy": "Local"}}`, hostIP))
 		ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "Error patching external IP service with node IP")
 
-		outsideNodeName, outsideNodeIP := kubectl.GetNodeInfo(helpers.GetNodeWithoutCilium())
+		outsideNodeName, outsideNodeIP := kubectl.GetNodeInfo(helpers.GetFirstNodeWithoutCilium())
 
 		res = kubectl.ExecInHostNetNS(context.TODO(), outsideNodeName,
 			helpers.CurlFail("http://%s:%d", hostIP, extIPsService.Spec.Ports[0].Port))

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1360,7 +1360,7 @@ var _ = SkipDescribeIf(func() bool {
 					})
 
 				By("Retrieving backend pod and outside node IP addresses")
-				outsideNodeName, outsideIP = kubectl.GetNodeInfo(helpers.GetNodeWithoutCilium())
+				outsideNodeName, outsideIP = kubectl.GetNodeInfo(helpers.GetFirstNodeWithoutCilium())
 
 				var demoPods v1.PodList
 				kubectl.GetPods(testNamespace, fmt.Sprintf("-l %s", testDS)).Unmarshal(&demoPods)
@@ -1613,7 +1613,7 @@ var _ = SkipDescribeIf(func() bool {
 				_, k8s2PodIP = kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s2, testDS, 0)
 
 				if helpers.ExistNodeWithoutCilium() {
-					outsideNodeName, _ = kubectl.GetNodeInfo(helpers.GetNodeWithoutCilium())
+					outsideNodeName, _ = kubectl.GetNodeInfo(helpers.GetFirstNodeWithoutCilium())
 				}
 
 				// Masquerade function should be disabled

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -99,7 +99,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		ni.k8s1NodeName, ni.k8s1IP = kubectl.GetNodeInfo(helpers.K8s1)
 		ni.k8s2NodeName, ni.k8s2IP = kubectl.GetNodeInfo(helpers.K8s2)
 		if helpers.ExistNodeWithoutCilium() {
-			ni.outsideNodeName, ni.outsideIP = kubectl.GetNodeInfo(helpers.GetNodeWithoutCilium())
+			ni.outsideNodeName, ni.outsideIP = kubectl.GetNodeInfo(helpers.GetFirstNodeWithoutCilium())
 		}
 
 		ni.privateIface, err = kubectl.GetPrivateIface()


### PR DESCRIPTION
This pull request introduces a new environment variable `NO_CILIUM_ON_NODES` which can take one of several node names where Cilium shouldn't be installed. The environment variable `NO_CILIUM_ON_NODE` (no `S`) remains supported.

The new environment variable is not used in tests, but is useful to spawn a network of Kubernetes nodes with several not  running Cilium. I needed that for a demo which requires IPv6 support and two nodes without Cilium.

All tests currently using `NO_CILIUM_ON_NODE` only need a single such node. Therefore, a new helper function  `GetFirstNodeWithoutCilium` is introduced and used in those tests.

This pull request was tested locally with:
- `K8S_NODES=3 NO_CILIUM_ON_NODES=k8s2,k8s3`
- `K8S_NODES=3 NO_CILIUM_ON_NODES=k8s3`
- `K8S_NODES=3 NO_CILIUM_ON_NODE=k8s3`