### PR TITLE
Add few values in CiliumEndpointPropagation metric bucket.

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1260,6 +1260,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Namespace: Namespace,
 				Name:      "endpoint_propagation_delay_seconds",
 				Help:      "CiliumEndpoint roundtrip propagation delay in seconds",
+				Buckets:   []float64{.05, .1, 1, 5, 30, 60, 120, 240, 300, 600},
 			}, []string{})
 
 			collectors = append(collectors, EndpointPropagationDelay)


### PR DESCRIPTION
Add customized timings to measure the propagation delay
for ciliumEndpoint.

Signed-off-by: Gobinath Krishnamoorthy <gobinathk@google.com>