### PR TITLE
install/kubernetes: fix helm generation for operator image digest

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
@@ -10,11 +10,23 @@
 {{- $cloud -}}
 {{- end -}}
 
+{{- define "cilium.operator.imageDigestName" -}}
+{{- $imageDigest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.genericDigest) "" -}}
+{{- if .Values.eni.enabled -}}
+  {{- $imageDigest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.awsDigest) "" -}}
+{{- else if .Values.azure.enabled -}}
+  {{- $imageDigest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.azureDigest) "" -}}
+{{- else if .Values.alibabacloud.enabled -}}
+  {{- $imageDigest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.alibabacloudDigest) "" -}}
+{{- end -}}
+{{- $imageDigest -}}
+{{- end -}}
+
 {{/*
 Return cilium operator image
 */}}
 {{- define "cilium.operator.image" -}}
 {{- $cloud := include "cilium.operator.cloud" . }}
-{{- $digest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.digest) "" -}}
-{{- printf "%s-%s%s:%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $digest -}}
+{{- $imageDigest := include "cilium.operator.imageDigestName" . }}
+{{- printf "%s-%s%s:%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $imageDigest -}}
 {{- end -}}


### PR DESCRIPTION
This commit fixes the image digest as part of the operator deployment.

Fixes: 4638de2ad17b ("cleanup the cilium helm chart:")
Signed-off-by: André Martins <andre@cilium.io>

The published v1.11.0-rc3 helm charts already contain this patch

This was caught by the smoke test we have for helm charts https://github.com/cilium/charts/actions/runs/1492998266