### PR TITLE
[v1.10] neigh: Add clean up of stale/untracked neighbors after resync

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1751,10 +1751,13 @@ func runDaemon() {
 		log.WithError(err).Warn("Failed to send agent start monitor message")
 	}
 
-	// clean up all arp PERM entries that might have previously set by
-	// a Cilium instance
 	if !d.datapath.Node().NodeNeighDiscoveryEnabled() {
-		d.datapath.Node().NodeCleanNeighbors()
+		// Clean up all arp PERM entries that might have previously
+		// set by a Cilium instance.
+		d.datapath.Node().NodeCleanNeighbors(false)
+	} else {
+		// Only clean up stale entries that are not relevant anymore.
+		d.datapath.Node().NodeCleanNeighbors(true)
 	}
 	// Start periodical arping to refresh neighbor table
 	if d.datapath.Node().NodeNeighDiscoveryEnabled() && option.Config.ARPPingRefreshPeriod != 0 {

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -496,7 +496,7 @@ func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeT
 	return
 }
 
-func (c *clusterNodesClient) NodeCleanNeighbors() {
+func (c *clusterNodesClient) NodeCleanNeighbors(migrateOnly bool) {
 	// no-op
 	return
 }

--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -56,6 +56,6 @@ func (n *fakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeType
 	return
 }
 
-func (n *fakeNodeHandler) NodeCleanNeighbors() {
+func (n *fakeNodeHandler) NodeCleanNeighbors(migrateOnly bool) {
 	return
 }

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1439,7 +1439,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	c.Assert(found, check.Equals, true)
 
 	// We have stored the devices in NodeConfigurationChanged
-	linuxNodeHandler.NodeCleanNeighbors()
+	linuxNodeHandler.NodeCleanNeighbors(false)
 
 	neighs, err = netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
 	c.Assert(err, check.IsNil)

--- a/pkg/datapath/node.go
+++ b/pkg/datapath/node.go
@@ -143,5 +143,5 @@ type NodeHandler interface {
 
 	// NodeCleanNeighbors cleans all neighbor entries for the direct routing device
 	// and the encrypt interface.
-	NodeCleanNeighbors()
+	NodeCleanNeighbors(migrateOnly bool)
 }

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -131,7 +131,7 @@ func (h handler) NodeNeighborRefresh(_ context.Context, _ types.Node) {
 	return
 }
 
-func (h handler) NodeCleanNeighbors() {
+func (h handler) NodeCleanNeighbors(migrateOnly bool) {
 	// no-op
 	return
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -152,7 +152,7 @@ func (n *signalNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTy
 	return
 }
 
-func (n *signalNodeHandler) NodeCleanNeighbors() {
+func (n *signalNodeHandler) NodeCleanNeighbors(migrateOnly bool) {
 	return
 }
 


### PR DESCRIPTION
[ custom backport, 5ecc8b6e06b74ed7b51cee0bf538603fd56e1472 ]

The NodeNeighDiscoveryEnabled() is called after we completed a resync of all
nodes with kubeapi-server. (See initRestore() -> SyncWithK8sFinished() and the
agent's wait in runDaemon() for restoreComplete channel to finish in non-dry
mode.)

Given that, neighLastPingByNextHop map is populated at that time, so when doing
migration of neighbor entries in NodeCleanNeighbors() we can remove unrelevant
ones at the same time to not let garbage neighbor entries pile up in the neighbor
hash table and/or avoid that the kernel needs to do periodic work for them in
case of NTF_EXT_MANAGED ones.

neighLastPingByNextHop holds both the v4 and v6 entries as a string for the key,
so it's enough to just check it there.

Fixes: #17905
Fixes: #17923
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>