### PR TITLE
workflows: Run CodeQL workflow is the workflow is edited

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           filters: |
             src:
+              - .github/workflows/lint-codeql.yaml
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'


### PR DESCRIPTION
We use path filters in the CodeQL workflow to avoid running it for unrelated changes. We're however missing the workflow file itself in the path filters. As a result, the CodeQL workflow isn't run when the GitHub Actions it uses are updated by dependabot (e.g., https://github.com/cilium/cilium/pull/17977). This pull request fixes it.