### PR TITLE
v1.10 backports 2021-11-23

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -34,6 +34,7 @@
 #include "lib/dbg.h"
 #include "lib/trace.h"
 #include "lib/csum.h"
+#include "lib/egress_policies.h"
 #include "lib/encap.h"
 #include "lib/eps.h"
 #include "lib/nat.h"

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -526,7 +526,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 	__u32 tunnel_endpoint = 0;
 	__u8 encrypt_key = 0;
 	__u32 monitor = 0;
-	__u8 reason;
+	__u8 ct_ret;
 	bool hairpin_flow = false; /* endpoint wants to access itself via service IP */
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 	__u8 audited = 0;
@@ -601,15 +601,13 @@ skip_service_lookup:
 	 * POLICY_SKIP if the packet is a reply packet to an existing incoming
 	 * connection.
 	 */
-	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
-			 &ct_state, &monitor);
-	if (ret < 0)
-		return ret;
-
-	reason = ret;
+	ct_ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
+			    &ct_state, &monitor);
+	if (ct_ret < 0)
+		return ct_ret;
 
 	/* Check it this is return traffic to an ingress proxy. */
-	if ((ret == CT_REPLY || ret == CT_RELATED) && ct_state.proxy_redirect) {
+	if ((ct_ret == CT_REPLY || ct_ret == CT_RELATED) && ct_state.proxy_redirect) {
 		/* Stack will do a socket match and deliver locally. */
 		return ctx_redirect_to_proxy4(ctx, &tuple, 0, false);
 	}
@@ -659,7 +657,7 @@ skip_service_lookup:
 	verdict = policy_can_egress4(ctx, &tuple, SECLABEL, *dstID,
 				     &policy_match_type, &audited);
 
-	if (ret != CT_REPLY && ret != CT_RELATED && verdict < 0) {
+	if (ct_ret != CT_REPLY && ct_ret != CT_RELATED && verdict < 0) {
 		send_policy_verdict_notify(ctx, *dstID, tuple.dport,
 					   tuple.nexthdr, POLICY_EGRESS, 0,
 					   verdict, policy_match_type, audited);
@@ -667,7 +665,7 @@ skip_service_lookup:
 	}
 
 skip_policy_enforcement:
-	switch (ret) {
+	switch (ct_ret) {
 	case CT_NEW:
 		if (!hairpin_flow)
 			send_policy_verdict_notify(ctx, *dstID, tuple.dport,
@@ -737,10 +735,10 @@ ct_recreate4:
 
 	hairpin_flow |= ct_state.loopback;
 
-	if (redirect_to_proxy(verdict, reason)) {
+	if (redirect_to_proxy(verdict, ct_ret)) {
 		/* Trace the packet before it is forwarded to proxy */
 		send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL, 0,
-				  0, 0, reason, monitor);
+				  0, 0, ct_ret, monitor);
 		return ctx_redirect_to_proxy4(ctx, &tuple, verdict, false);
 	}
 
@@ -806,7 +804,7 @@ ct_recreate4:
 		 * gateway, since an egress policy is only matching connections
 		 * originating from a pod.
 		 */
-		if (reason == CT_REPLY || reason == CT_RELATED)
+		if (ct_ret == CT_REPLY || ct_ret == CT_RELATED)
 			goto skip_egress_gateway;
 
 		info = lookup_ip4_egress_endpoint(ip4->saddr, ip4->daddr);
@@ -866,7 +864,7 @@ skip_egress_gateway:
 to_host:
 	if (is_defined(ENABLE_HOST_FIREWALL) && *dstID == HOST_ID) {
 		send_trace_notify(ctx, TRACE_TO_HOST, SECLABEL, HOST_ID, 0,
-				  HOST_IFINDEX, reason, monitor);
+				  HOST_IFINDEX, ct_ret, monitor);
 		return redirect(HOST_IFINDEX, BPF_F_INGRESS);
 	}
 #endif
@@ -908,7 +906,7 @@ pass_to_stack:
 encrypt_to_stack:
 #endif
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL, *dstID, 0, 0,
-			  reason, monitor);
+			  ct_ret, monitor);
 	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, 0);
 	return CTX_ACT_OK;
 }

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -801,6 +801,14 @@ ct_recreate4:
 		if (is_cluster_destination(ip4, *dstID, tunnel_endpoint))
 			goto skip_egress_gateway;
 
+		/* If the packet is a reply or is related, it means that outside
+		 * has initiated the connection, and so we should skip egress
+		 * gateway, since an egress policy is only matching connections
+		 * originating from a pod.
+		 */
+		if (reason == CT_REPLY || reason == CT_RELATED)
+			goto skip_egress_gateway;
+
 		info = lookup_ip4_egress_endpoint(ip4->saddr, ip4->daddr);
 		if (!info)
 			goto skip_egress_gateway;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -798,17 +798,7 @@ ct_recreate4:
 		struct egress_info *info;
 		struct endpoint_key key = {};
 
-		/* If tunnel endpoint is found in ipcache, it means the remote endpoint is
-		 * in cluster. In this case, we should skip egress gateway. If destination
-		 * is either remote node or host node, also skip egress gateway.
-		 */
-		if (tunnel_endpoint != 0 || *dstID == REMOTE_NODE_ID || *dstID == HOST_ID)
-			goto skip_egress_gateway;
-
-		/* If destination ip matches a local endpoint, we should also
-		 * skip egress gateway.
-		 */
-		if (lookup_ip4_endpoint(ip4))
+		if (is_cluster_destination(ip4, *dstID, tunnel_endpoint))
 			goto skip_egress_gateway;
 
 		info = lookup_ip4_egress_endpoint(ip4->saddr, ip4->daddr);

--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2021 Authors of Cilium */
+
+#ifndef __LIB_EGRESS_POLICIES_H_
+#define __LIB_EGRESS_POLICIES_H_
+
+#ifdef ENABLE_EGRESS_GATEWAY
+/* EGRESS_STATIC_PREFIX gets sizeof non-IP, non-prefix part of egress_key */
+# define EGRESS_STATIC_PREFIX							\
+	(8 * (sizeof(struct egress_key) - sizeof(struct bpf_lpm_trie_key)	\
+	      - 4))
+# define EGRESS_PREFIX_LEN(PREFIX) (EGRESS_STATIC_PREFIX + (PREFIX))
+# define EGRESS_IPV4_PREFIX EGRESS_PREFIX_LEN(32)
+
+static __always_inline __maybe_unused struct egress_info *
+egress_lookup4(const void *map, __be32 sip, __be32 dip)
+{
+	struct egress_key key = {
+		.lpm_key = { EGRESS_IPV4_PREFIX, {} },
+		.sip = sip,
+		.dip = dip,
+	};
+	return map_lookup_elem(map, &key);
+}
+
+# define lookup_ip4_egress_endpoint(sip, dip) \
+	egress_lookup4(&EGRESS_MAP, sip, dip)
+#endif /* ENABLE_EGRESS_GATEWAY */
+#endif /* __LIB_EGRESS_POLICIES_H_ */

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -62,13 +62,6 @@ lookup_ip4_endpoint_policy_map(__u32 ip)
 	      - sizeof(union v6addr)))
 #define IPCACHE_PREFIX_LEN(PREFIX) (IPCACHE_STATIC_PREFIX + (PREFIX))
 
-/* EGRESS_STATIC_PREFIX gets sizeof non-IP, non-prefix part of ipcache_key */
-#define EGRESS_STATIC_PREFIX							\
-	(8 * (sizeof(struct egress_key) - sizeof(struct bpf_lpm_trie_key)	\
-	      - 4))
-#define EGRESS_PREFIX_LEN(PREFIX) (EGRESS_STATIC_PREFIX + (PREFIX))
-#define EGRESS_IPV4_PREFIX EGRESS_PREFIX_LEN(32)
-
 #define V6_CACHE_KEY_LEN (sizeof(union v6addr)*8)
 
 static __always_inline __maybe_unused struct remote_endpoint_info *
@@ -137,21 +130,5 @@ LPM_LOOKUP_FN(lookup_ip4_remote_endpoint, __be32, IPCACHE4_PREFIXES,
 #define lookup_ip4_remote_endpoint(addr) \
 	ipcache_lookup4(&IPCACHE_MAP, addr, V4_CACHE_KEY_LEN)
 #endif /* HAVE_LPM_TRIE_MAP_TYPE */
-
-#ifdef ENABLE_EGRESS_GATEWAY
-static __always_inline __maybe_unused struct egress_info *
-egress_lookup4(struct bpf_elf_map *map, __be32 sip, __be32 dip)
-{
-	struct egress_key key = {
-		.lpm_key = { EGRESS_IPV4_PREFIX, {} },
-		.sip = sip,
-		.dip = dip,
-	};
-	return map_lookup_elem(map, &key);
-}
-
-#define lookup_ip4_egress_endpoint(sip, dip) \
-	egress_lookup4(&EGRESS_MAP, sip, dip)
-#endif /* ENABLE_EGRESS_GATEWAY */
 
 #endif /* __LIB_EPS_H_ */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -13,6 +13,7 @@
 #include "lb.h"
 #include "common.h"
 #include "overloadable.h"
+#include "egress_policies.h"
 #include "eps.h"
 #include "conntrack.h"
 #include "csum.h"

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -312,6 +312,7 @@ func runAll(commands []string, cmdDir string, k8sPods []string) {
 			continue
 		}
 
+		cmd := cmd // https://golang.org/doc/faq#closures_and_goroutines
 		err := wp.Submit(cmd, func(_ context.Context) error {
 			if strings.Contains(cmd, "xfrm state") {
 				//  Output of 'ip -s xfrm state' needs additional processing to replace

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1384,6 +1384,10 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.EnableBandwidthManager = false
 	}
 
+	if option.Config.EnableIPv6Masquerade && option.Config.EnableBPFMasquerade {
+		log.Fatal("BPF masquerade is not supported for IPv6.")
+	}
+
 	// If there is one device specified, use it to derive better default
 	// allocation prefixes
 	node.InitDefaultPrefix(option.Config.DirectRoutingDevice)

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -34,7 +34,9 @@
 
 {{- /* Default values when 1.10 was initially deployed */ -}}
 {{- if semverCompare ">=1.10" (default "1.10" .Values.upgradeCompatibility) -}}
-{{- $defaultKubeProxyReplacement = "disabled" -}}
+  {{- $defaultKubeProxyReplacement = "disabled" -}}
+  {{- /* Needs to be explicitly disabled because it was enabled on all versions >=v1.8 above. */ -}}
+  {{- $defaultBpfMasquerade = "false" -}}
 {{- end -}}
 
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -72,7 +72,7 @@ spec:
             - mountPath: /run/xtables.lock
               name: xtables-lock
           lifecycle:
-{{- if and (.Values.eni.enabled) (not .Values.enableIPv4Masquerade) }}
+{{- if .Values.eni.enabled }}
             postStart:
               exec:
                 command:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -275,7 +275,7 @@ bpf:
   lbExternalClusterIP: false
 
   # -- Enable native IP masquerade support in eBPF
-  #masquerade: true
+  #masquerade: false
 
   # -- Configure whether direct routing mode should route traffic via
   # host stack (true) or directly and more efficiently out of BPF (false) if

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -242,6 +242,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_EGRESS_GATEWAY"] = "1"
 	}
 
+	if option.Config.EnableEndpointRoutes {
+		cDefinesMap["ENABLE_ENDPOINT_ROUTES"] = "1"
+	}
+
 	if option.Config.EnableHostReachableServices {
 		if option.Config.EnableHostServicesTCP {
 			cDefinesMap["ENABLE_HOST_SERVICES_TCP"] = "1"
@@ -751,10 +755,6 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 
 	if e.RequireRouting() {
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
-	}
-
-	if e.RequireEndpointRoute() {
-		fmt.Fprintf(fw, "#define ENABLE_ENDPOINT_ROUTES 1\n")
 	}
 
 	if !option.Config.EnableHostLegacyRouting && option.Config.DirectRoutingDevice != "" {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -893,7 +893,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 
 				/* Insert wildcard policy rules for traffic skipping back through host */
 				ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
-				if err = ipsec.IpSecReplacePolicyFwd(ipsecIPv4Wildcard, ipsecRemote, ipsecLocal, ipsecRemote); err != nil {
+				if err = ipsec.IpSecReplacePolicyFwd(ipsecIPv4Wildcard, ipsecRemote, ipsecIPv4Wildcard, ipsecRemote); err != nil {
 					log.WithError(err).Warning("egress unable to replace policy fwd:")
 				}
 			}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2379,6 +2379,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 
 		if RunsOn419OrLaterKernel() {
 			opts["bpf.masquerade"] = "true"
+			opts["enableIPv6Masquerade"] = "false"
 		}
 
 		for key, value := range opts {

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -15,6 +15,7 @@
 package k8sTest
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -22,11 +23,18 @@ import (
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 )
 
 var _ = SkipDescribeIf(func() bool {
 	return helpers.RunsOnEKS() || helpers.RunsOnGKE() || helpers.DoesNotRunWithKubeProxyReplacement() || helpers.DoesNotExistNodeWithoutCilium() || helpers.DoesNotRunOn54OrLaterKernel()
 }, "K8sEgressGatewayTest", func() {
+	const (
+		namespaceSelector = "ns=cilium-test"
+		testDS            = "zgroup=testDS"
+		testDSClient      = "zgroup=testDSClient"
+	)
+
 	var (
 		kubectl         *helpers.Kubectl
 		ciliumFilename  string
@@ -40,8 +48,6 @@ var _ = SkipDescribeIf(func() bool {
 		assignIPYAML string
 		echoPodYAML  string
 		policyYAML   string
-
-		namespaceSelector string = "ns=cilium-test"
 	)
 
 	runEchoServer := func() {
@@ -120,14 +126,14 @@ var _ = SkipDescribeIf(func() bool {
 		if fromGateway {
 			hostIP = k8s2IP
 		}
-		srcPod, _ := fetchPodsWithOffset(kubectl, randomNamespace, "client", "zgroup=testDSClient", hostIP, false, 1)
+		srcPod, _ := fetchPodsWithOffset(kubectl, randomNamespace, "client", testDSClient, hostIP, false, 1)
 
 		res := kubectl.ExecPodCmd(randomNamespace, srcPod, helpers.CurlFail("http://%s:80", outsideIP))
 		res.ExpectSuccess()
 		res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", egressIP))
 	}
 
-	testConnectivity := func(fromGateway bool) {
+	testConnectivity := func(fromGateway bool, ciliumOpts map[string]string) {
 		if fromGateway {
 			By("Check connectivity from gateway node")
 		} else {
@@ -149,6 +155,59 @@ var _ = SkipDescribeIf(func() bool {
 		// DNS query should work (pod-to-pod connectivity)
 		res = kubectl.ExecPodCmd(randomNamespace, srcPod, "dig kubernetes +time=2")
 		res.ExpectSuccess()
+
+		// When connecting from outside the cluster to a nodeport service whose pods are
+		// selected by an egress policy, the reply traffic should not be SNATed with the
+		// egress IP
+		var extIPsService v1.Service
+		err := kubectl.Get(randomNamespace, fmt.Sprintf("service %s", "test-external-ips")).Unmarshal(&extIPsService)
+		ExpectWithOffset(1, err).Should(BeNil(), "Can not retrieve service %s", "test-external-ips")
+
+		res = kubectl.Patch(randomNamespace, "service", "test-external-ips",
+			fmt.Sprintf(`{"spec":{"externalIPs":["%s"],  "externalTrafficPolicy": "Local"}}`, hostIP))
+		ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "Error patching external IP service with node IP")
+
+		outsideNodeName, outsideNodeIP := kubectl.GetNodeInfo(helpers.GetNodeWithoutCilium())
+
+		res = kubectl.ExecInHostNetNS(context.TODO(), outsideNodeName,
+			helpers.CurlFail("http://%s:%d", hostIP, extIPsService.Spec.Ports[0].Port))
+		res.ExpectSuccess()
+		res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", outsideNodeIP))
+
+		if ciliumOpts["tunnel"] == "disabled" {
+			// When connecting from outside the cluster directly to a pod which is
+			// selected by an egress policy, the reply traffic should not be SNATed with
+			// the egress IP (only connections originating from these pods should go
+			// through egress gateway).
+			//
+			// This test is executed only when Cilium is running in direct routing mode,
+			// since we can simply add a route on the node outside the cluster to direct
+			// pod's traffic to the node where the pod is running (while in tunneling
+			// mode we would need the external node to send the traffic over the tunnel)
+			_, targetPodJSON := fetchPodsWithOffset(kubectl, randomNamespace, "server", testDS, hostIP, false, 1)
+
+			targetPodHostIP, err := targetPodJSON.Filter("{.status.hostIP}")
+			Expect(err).Should(BeNil(), "Cannot get target pod host IP")
+
+			targetPodIP, err := targetPodJSON.Filter("{.status.podIP}")
+			Expect(err).Should(BeNil(), "Cannot get target pod IP")
+
+			// Add a route for the target pod's IP on the node running without Cilium to
+			// allow reaching it from outside the cluster
+			res = kubectl.AddIPRoute(outsideNodeName, targetPodIP.String(), targetPodHostIP.String(), false)
+			Expect(res).Should(helpers.CMDSuccess(),
+				"Error adding IP route for %s via %s", targetPodIP.String(), targetPodHostIP.String())
+			defer func() {
+				res := kubectl.DelIPRoute(outsideNodeName, targetPodIP.String(), targetPodHostIP.String())
+				Expect(res).Should(helpers.CMDSuccess(),
+					"Error removing IP route for %s via %s", targetPodIP.String(), targetPodHostIP.String())
+			}()
+
+			res = kubectl.ExecInHostNetNS(context.TODO(), outsideNodeName,
+				helpers.CurlFail("http://%s:%d", targetPodIP.String(), 80))
+			res.ExpectSuccess()
+			res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", outsideNodeIP))
+		}
 	}
 
 	applyEgressPolicy := func() {
@@ -181,8 +240,8 @@ var _ = SkipDescribeIf(func() bool {
 
 			Context("no egress gw policy", func() {
 				It("connectivity works", func() {
-					testConnectivity(false)
-					testConnectivity(true)
+					testConnectivity(false, ciliumOpts)
+					testConnectivity(true, ciliumOpts)
 				})
 			})
 
@@ -203,8 +262,8 @@ var _ = SkipDescribeIf(func() bool {
 				It("both egress gw and basic connectivity work", func() {
 					testEgressGateway(false)
 					testEgressGateway(true)
-					testConnectivity(false)
-					testConnectivity(true)
+					testConnectivity(false, ciliumOpts)
+					testConnectivity(true, ciliumOpts)
 				})
 			})
 		})

--- a/test/k8sT/bookinfo.go
+++ b/test/k8sT/bookinfo.go
@@ -25,7 +25,12 @@ import (
 
 // The 5.4 CI job is intended to catch BPF complexity regressions and as such
 // doesn't need to execute this test suite.
-var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sBookInfoDemoTest", func() {
+//
+// This test is quarantined because it is unreliable, see:
+// https://github.com/cilium/cilium/issues/17401
+var _ = SkipDescribeIf(func() bool {
+	return helpers.SkipQuarantined() || helpers.RunsOn54Kernel()
+}, "K8sBookInfoDemoTest", func() {
 	var (
 		kubectl        *helpers.Kubectl
 		ciliumFilename string

--- a/test/k8sT/manifests/egress-nat-policy.yaml
+++ b/test/k8sT/manifests/egress-nat-policy.yaml
@@ -31,3 +31,22 @@ spec:
   destinationCIDRs:
   - 0.0.0.0/0
   egressSourceIP: 192.0.2.13 # It's a black hole, https://datatracker.ietf.org/doc/html/rfc5737#section-3
+---
+# egress-testds is a policy matching all traffic (i.e. destination CIDR
+# 0.0.0.0/0) from the zgroup=testDS echo server pods.
+#
+# This policy is used to test that reply traffic from pods that are selected by
+# an egress policy is not SNATed with the egress IP (only connections
+# originating from these pods should go through egress gateway).
+apiVersion: cilium.io/v2alpha1
+kind: CiliumEgressNATPolicy
+metadata:
+  name: egress-testds
+spec:
+  egress:
+  - podSelector:
+      matchLabels:
+        zgroup: testDS
+  destinationCIDRs:
+  - 0.0.0.0/0
+  egressSourceIP: INPUT_EGRESS_IP


### PR DESCRIPTION
* #17550 -- test: Disable unreliable K8sBookInfoDemoTest test (@twpayne)
 * #17868 -- bpf: Refactoring egress gateway datapath (@pchaigno) **⚠️ Please review carefully, had to resolve conflicts**
 * #17865 -- Fixes for IPsec and endpoint routes (@kkourt)
 * #17824 -- helm: Disable BPF masquerading in v1.10+ (@pchaigno)
 * #17916 -- bugtool: fix data race occurring when running commands (@rolinh)
 * #17906 -- daemon: Fatal on BPF masquerade + IPv6 masquerade (@pchaigno)
 * #17845 -- Always remove `AWS-SNAT-CHAIN` rules when running in ENI mode. (@bmcustodio) **⚠️ Please review carefully, had to resolve conflicts. I skipped the second commit as it is not applicable to v1.10**
 * #17869 -- bpf: exclude pod's reply traffic from egress gateway logic (@jibi) **⚠️ Please review carefully, had to resolve conflicts**

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17550 17868 17865 17824 17916 17906 17845 17869; do contrib/backporting/set-labels.py $pr done 1.10; done
```