### PR TITLE
[v1.10] Additional FQDN selector identity tracking fixes

### DIFF
--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -181,6 +181,7 @@ func (m *VMManager) OnUpdate(k store.Key) {
 			nk := nodeOverrideFromCEW(n, cew)
 
 			log.Debugf("CEW: VM Cilium Node updated: %v -> %v", n, nk)
+			// FIXME: GH-17909 Balance this call with a call to release the identity.
 			id := m.AllocateNodeIdentity(nk)
 			if id != nil {
 				nid := id.ID.Uint32()

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -179,8 +179,7 @@ func (ds *DaemonFQDNSuite) TestFQDNIdentityReferenceCounting(c *C) {
 	selectorsToAdd := api.FQDNSelectorSlice{ciliumIOSel, ciliumIOSelMatchPattern, ebpfIOSel}
 	nameManager.Lock()
 	for _, sel := range selectorsToAdd {
-		ids := nameManager.RegisterForIdentityUpdatesLocked(idAllocator, sel)
-		c.Assert(ids, Not(IsNil))
+		nameManager.RegisterForIdentityUpdatesLocked(sel)
 	}
 	nameManager.Unlock()
 

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -289,23 +289,23 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	prodBarLbls := labels.Labels{lblBar.Key: lblBar, lblProd.Key: lblProd}
 	prodBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), prodBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), prodBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 	prodFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd}
 	prodFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), prodFooSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), prodFooSecLblsCtx, false)
 	prodFooJoeLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd, lblJoe.Key: lblJoe}
 	prodFooJoeSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodFooJoeLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), prodFooJoeSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), prodFooJoeSecLblsCtx, false)
 
 	// Prepare endpoints
 	cleanup, err2 := prepareEndpointDirs()
@@ -423,11 +423,11 @@ func (ds *DaemonSuite) TestL4_L7_Shadowing(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -508,11 +508,11 @@ func (ds *DaemonSuite) TestL4_L7_ShadowingShortCircuit(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -586,15 +586,15 @@ func (ds *DaemonSuite) TestL3_dependent_L7(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 	qaJoeLbls := labels.Labels{lblJoe.Key: lblJoe, lblQA.Key: lblQA}
 	qaJoeSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaJoeLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaJoeSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaJoeSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -748,7 +748,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -833,7 +833,7 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx)
+	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -922,7 +922,7 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooID, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
 	c.Assert(err, Equals, nil)
-	defer ds.d.identityAllocator.Release(context.Background(), qaFooID)
+	defer ds.d.identityAllocator.Release(context.Background(), qaFooID, false)
 
 	// Regenerate endpoint
 	ds.regenerateEndpoint(c, e)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1862,7 +1862,16 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 	allocateCtx, cancel := context.WithTimeout(ctx, option.Config.KVstoreConnectivityTimeout)
 	defer cancel()
 
-	allocatedIdentity, _, err := e.allocator.AllocateIdentity(allocateCtx, newLabels, true)
+	// Typically, SelectorCache notification happens from the identityWatcher,
+	// requiring a round-trip to the kvstore to start updating policies for
+	// other endpoints on the node.
+	//
+	// To get a jump start on plumbing the handling of the identity for
+	// this endpoint, trigger the early notification via this call. If the
+	// identity is new, then this will start updating the policy for other
+	// co-located endpoints without having to wait for that RTT.
+	notifySelectorCache := true
+	allocatedIdentity, _, err := e.allocator.AllocateIdentity(allocateCtx, newLabels, notifySelectorCache)
 	if err != nil {
 		err = fmt.Errorf("unable to resolve identity: %s", err)
 		e.LogStatus(Other, Warning, fmt.Sprintf("%s (will retry)", err.Error()))

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1158,7 +1158,7 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 		releaseCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
 		defer cancel()
 
-		_, err := e.allocator.Release(releaseCtx, e.SecurityIdentity)
+		_, err := e.allocator.Release(releaseCtx, e.SecurityIdentity, false)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("unable to release identity: %s", err))
 		}
@@ -1878,7 +1878,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 	defer cancel()
 
 	releaseNewlyAllocatedIdentity := func() {
-		_, err := e.allocator.Release(releaseCtx, allocatedIdentity)
+		_, err := e.allocator.Release(releaseCtx, allocatedIdentity, false)
 		if err != nil {
 			// non fatal error as keys will expire after lease expires but log it
 			elog.WithFields(logrus.Fields{logfields.Identity: allocatedIdentity.ID}).
@@ -1938,7 +1938,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 	e.SetIdentity(allocatedIdentity, false)
 
 	if oldIdentity != nil {
-		_, err := e.allocator.Release(releaseCtx, oldIdentity)
+		_, err := e.allocator.Release(releaseCtx, oldIdentity, false)
 		if err != nil {
 			elog.WithFields(logrus.Fields{logfields.Identity: oldIdentity.ID}).
 				WithError(err).Warn("Unable to release old endpoint identity")

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -273,7 +273,7 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 	fooLbls := labels.Labels{"": labels.ParseLabel("foo")}
 	fooIdentity, _, err := e.allocator.AllocateIdentity(context.Background(), fooLbls, false)
 	c.Assert(err, check.Equals, nil)
-	defer s.mgr.Release(context.Background(), fooIdentity)
+	defer s.mgr.Release(context.Background(), fooIdentity, false)
 
 	e.desiredPolicy = policy.NewEndpointPolicy(s.repo)
 	e.desiredPolicy.IngressPolicyEnabled = true

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -96,22 +96,26 @@ func (ds *DNSCacheTestSuite) BenchmarkKeepUniqueNames(c *C) {
 func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 
 	var (
-		ciliumIP1 = net.ParseIP("1.2.3.4")
-		ciliumIP2 = net.ParseIP("1.2.3.5")
+		ciliumIP1   = net.ParseIP("1.2.3.4")
+		ciliumIP2   = net.ParseIP("1.2.3.5")
+		nameManager = NewNameManager(Config{
+			MinTTL: 1,
+			Cache:  NewDNSCache(0),
+		})
 	)
 
 	log.Level = logrus.DebugLevel
 
 	// Create DNS cache
 	now := time.Now()
-	cache := NewDNSCache(60)
+	cache := nameManager.cache
 
 	selectors := map[api.FQDNSelector]struct{}{
 		ciliumIOSel: {},
 	}
 
 	// Empty cache.
-	selsMissingIPs, selIPMapping := mapSelectorsToIPs(selectors, cache)
+	selsMissingIPs, selIPMapping := nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 1)
 	c.Assert(selsMissingIPs[0], Equals, ciliumIOSel)
 	c.Assert(len(selIPMapping), Equals, 0)
@@ -119,7 +123,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	// Just one IP.
 	changed := cache.Update(now, prepareMatchName(ciliumIOSel.MatchName), []net.IP{ciliumIP1}, 100)
 	c.Assert(changed, Equals, true)
-	selsMissingIPs, selIPMapping = mapSelectorsToIPs(selectors, cache)
+	selsMissingIPs, selIPMapping = nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 0)
 	c.Assert(len(selIPMapping), Equals, 1)
 	ciliumIPs, ok := selIPMapping[ciliumIOSel]
@@ -130,7 +134,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	// Two IPs now.
 	changed = cache.Update(now, prepareMatchName(ciliumIOSel.MatchName), []net.IP{ciliumIP1, ciliumIP2}, 100)
 	c.Assert(changed, Equals, true)
-	selsMissingIPs, selIPMapping = mapSelectorsToIPs(selectors, cache)
+	selsMissingIPs, selIPMapping = nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 0)
 	c.Assert(len(selIPMapping), Equals, 1)
 	ciliumIPs, ok = selIPMapping[ciliumIOSel]
@@ -143,7 +147,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	selectors = map[api.FQDNSelector]struct{}{
 		ciliumIOSelMatchPattern: {},
 	}
-	selsMissingIPs, selIPMapping = mapSelectorsToIPs(selectors, cache)
+	selsMissingIPs, selIPMapping = nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 0)
 	c.Assert(len(selIPMapping), Equals, 1)
 	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]
@@ -156,7 +160,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 		ciliumIOSelMatchPattern: {},
 		ciliumIOSel:             {},
 	}
-	selsMissingIPs, selIPMapping = mapSelectorsToIPs(selectors, cache)
+	selsMissingIPs, selIPMapping = nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 0)
 	c.Assert(len(selIPMapping), Equals, 2)
 	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -94,11 +93,11 @@ func (n *NameManager) Unlock() {
 // the FQDNSelector. All IPs which correspond to the DNS names which match this
 // Selector will be returned as CIDR identities, as other DNS Names which have
 // already been resolved may match this FQDNSelector.
-func (n *NameManager) RegisterForIdentityUpdatesLocked(idAllocator cache.IdentityAllocator, selector api.FQDNSelector) []identity.NumericIdentity {
+func (n *NameManager) RegisterForIdentityUpdatesLocked(selector api.FQDNSelector) {
 	_, exists := n.allSelectors[selector]
 	if exists {
 		log.WithField("fqdnSelector", selector).Warning("FQDNSelector was already registered for updates, returning without any identities")
-		return nil
+		return
 	}
 
 	// This error should never occur since the FQDNSelector has already been
@@ -106,40 +105,15 @@ func (n *NameManager) RegisterForIdentityUpdatesLocked(idAllocator cache.Identit
 	regex, err := selector.ToRegex()
 	if err != nil {
 		log.WithError(err).WithField("fqdnSelector", selector).Error("FQDNSelector did not compile to valid regex")
-		return nil
+		return
 	}
 
 	n.allSelectors[selector] = regex
-	_, selectorIPMapping := mapSelectorsToIPs(map[api.FQDNSelector]struct{}{selector: {}}, n.cache)
-
-	// Allocate identities for each IPNet and then map to selector
-	selectorIPs := selectorIPMapping[selector]
-	log.WithFields(logrus.Fields{
-		"fqdnSelector": selector,
-		"ips":          selectorIPs,
-	}).Debug("getting identities for IPs associated with FQDNSelector")
-	var currentlyAllocatedIdentities []*identity.Identity
-	// TODO: Consider if upserts to ipcache should be delayed until endpoint policies have been
-	// updated. This is the path from policy updates rather than for DNS proxy results. Hence
-	// any existing IPs would typically already have been pushed to the ipcache as they would
-	// not be newly allocated. We need the 'allocation' here to get a reference count on the
-	// allocations.
-	if currentlyAllocatedIdentities, err = idAllocator.AllocateCIDRsForIPs(selectorIPs, nil); err != nil {
-		log.WithError(err).WithField("prefixes", selectorIPs).Warn(
-			"failed to allocate identities for IPs")
-		return nil
-	}
-	numIDs := make([]identity.NumericIdentity, 0, len(currentlyAllocatedIdentities))
-	for i := range currentlyAllocatedIdentities {
-		numIDs = append(numIDs, currentlyAllocatedIdentities[i].ID)
-	}
-
-	return numIDs
 }
 
 // UnregisterForIdentityUpdatesLocked removes this FQDNSelector from the set of
-// FQDNSelectors which are being tracked by the NameManager. No more updates for IPs
-// which correspond to said selector are propagated.
+// FQDNSelectors which are being tracked by the NameManager. No more updates
+// for IPs which correspond to said selector are propagated.
 func (n *NameManager) UnregisterForIdentityUpdatesLocked(selector api.FQDNSelector) {
 	delete(n.allSelectors, selector)
 }
@@ -214,7 +188,7 @@ func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []strin
 		}
 	}
 
-	namesMissingIPs, selectorIPMapping := mapSelectorsToIPs(affectedFQDNSels, n.cache)
+	namesMissingIPs, selectorIPMapping := n.MapSelectorsToIPsLocked(affectedFQDNSels)
 	if len(namesMissingIPs) != 0 {
 		log.WithField(logfields.DNSName, namesMissingIPs).
 			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
@@ -280,7 +254,7 @@ perDNSName:
 // map. Returns the set of FQDNSelectors which map to no IPs, and a mapping
 // of FQDNSelectors to IPs.
 func (n *NameManager) generateSelectorUpdates(fqdnSelectors map[api.FQDNSelector]struct{}) (namesMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
-	return mapSelectorsToIPs(fqdnSelectors, n.cache)
+	return n.MapSelectorsToIPsLocked(fqdnSelectors)
 }
 
 // updateIPsName will update the IPs for dnsName. It always retains a copy of

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -277,10 +277,10 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(id1a.ID, Equals, id1b.ID)
 
-	released, err := mgr.Release(context.Background(), id1a)
+	released, err := mgr.Release(context.Background(), id1a, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, false)
-	released, err = mgr.Release(context.Background(), id1b)
+	released, err = mgr.Release(context.Background(), id1b, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 	// KV-store still keeps the ID even when a single node has released it.
@@ -322,13 +322,13 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	c.Assert(owner.WaitUntilID(id3.ID), Not(Equals), 0)
 	c.Assert(owner.GetIdentity(id3.ID), checker.DeepEquals, lbls3.LabelArray())
 
-	released, err = mgr.Release(context.Background(), id1b)
+	released, err = mgr.Release(context.Background(), id1b, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
-	released, err = mgr.Release(context.Background(), id2)
+	released, err = mgr.Release(context.Background(), id2, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
-	released, err = mgr.Release(context.Background(), id3)
+	released, err = mgr.Release(context.Background(), id3, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 
@@ -366,7 +366,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(cache[id.ID], Not(IsNil))
 
 	// 1st Release, not released
-	released, err := mgr.Release(context.Background(), id)
+	released, err := mgr.Release(context.Background(), id, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, false)
 
@@ -374,7 +374,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(owner.GetIdentity(id.ID), checker.DeepEquals, lbls1.LabelArray())
 
 	// 2nd Release, released
-	released, err = mgr.Release(context.Background(), id)
+	released, err = mgr.Release(context.Background(), id, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 
@@ -392,7 +392,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(isNew, Equals, true)
 	c.Assert(id.ID.HasLocalScope(), Equals, true)
 
-	released, err = mgr.Release(context.Background(), id)
+	released, err = mgr.Release(context.Background(), id, false)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -460,7 +460,7 @@ func (m *CachingIdentityAllocator) ReleaseSlice(ctx context.Context, owner Ident
 		if id == nil {
 			continue
 		}
-		_, err2 := m.Release(ctx, id, true)
+		_, err2 := m.Release(ctx, id, false)
 		if err2 != nil {
 			log.WithError(err2).WithFields(logrus.Fields{
 				logfields.Identity: id,

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -129,7 +129,7 @@ type IdentityAllocator interface {
 
 	// Release is the reverse operation of AllocateIdentity() and releases the
 	// specified identity.
-	Release(context.Context, *identity.Identity) (released bool, err error)
+	Release(context.Context, *identity.Identity, bool) (released bool, err error)
 
 	// ReleaseSlice is the slice variant of Release().
 	ReleaseSlice(context.Context, IdentityAllocatorOwner, []*identity.Identity) error
@@ -408,10 +408,16 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 // Release is the reverse operation of AllocateIdentity() and releases the
 // identity again. This function may result in kvstore operations.
 // After the last user has released the ID, the returned lastUse value is true.
-func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Identity) (released bool, err error) {
+func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Identity, notifyOwner bool) (released bool, err error) {
 	defer func() {
 		if released {
 			metrics.Identity.Dec()
+		}
+		if m.owner != nil && released && notifyOwner {
+			deleted := IdentityCache{
+				id.ID: id.LabelArray,
+			}
+			m.owner.UpdateIdentities(nil, deleted)
 		}
 	}()
 
@@ -422,15 +428,7 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 
 	if !identity.RequiresGlobalIdentity(id.Labels) {
 		<-m.localIdentityAllocatorInitialized
-		lastUse := m.localIdentities.release(id)
-		// Notify release of locally managed identities on last use
-		if m.owner != nil && lastUse {
-			deleted := IdentityCache{
-				id.ID: id.LabelArray,
-			}
-			m.owner.UpdateIdentities(nil, deleted)
-		}
-		return lastUse, nil
+		return m.localIdentities.release(id), nil
 	}
 
 	// This will block until the kvstore can be accessed and all identities
@@ -462,7 +460,7 @@ func (m *CachingIdentityAllocator) ReleaseSlice(ctx context.Context, owner Ident
 		if id == nil {
 			continue
 		}
-		_, err2 := m.Release(ctx, id)
+		_, err2 := m.Release(ctx, id, true)
 		if err2 != nil {
 			log.WithError(err2).WithFields(logrus.Fields{
 				logfields.Identity: id,

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -135,7 +135,7 @@ func allocateCIDRs(prefixes []*net.IPNet, newlyAllocatedIdentities map[string]*i
 
 func releaseCIDRIdentities(ctx context.Context, identities map[string]*identity.Identity) {
 	for prefix, id := range identities {
-		released, err := IdentityAllocator.Release(ctx, id, true)
+		released, err := IdentityAllocator.Release(ctx, id, false)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				logfields.Identity: id,

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -135,7 +135,7 @@ func allocateCIDRs(prefixes []*net.IPNet, newlyAllocatedIdentities map[string]*i
 
 func releaseCIDRIdentities(ctx context.Context, identities map[string]*identity.Identity) {
 	for prefix, id := range identities {
-		released, err := IdentityAllocator.Release(ctx, id)
+		released, err := IdentityAllocator.Release(ctx, id, true)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				logfields.Identity: id,

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -460,6 +460,16 @@ func (f *fqdnSelector) notifyUsers(sc *SelectorCache, added, deleted []identity.
 // previously-cached selector (for example the same toFQDNs match pattern in
 // different rules).
 func (f *fqdnSelector) allocateIdentityMappings(idAllocator cache.IdentityAllocator, selectorIPMapping map[api.FQDNSelector][]net.IP) {
+	// We don't know whether the IPs are associated with this selector
+	// until we map those IPs to identities, which requires potentially
+	// allocating a CIDR identity for those IPs. Therefore, below we
+	// unconditionally allocate identities for all IPs in
+	// 'selectorIPMapping', then find out if any are duplicated with the
+	// existing selector content, and then release any that are already
+	// referenced by this selector. The new IPs will be then added to the
+	// cached selections and the corresponding identity reference will be
+	// released in releaseIdentityMappings(). This balances the
+	// allocation/release of all identities allocated from this function.
 	var (
 		currentlyAllocatedIdentities []*identity.Identity
 		selectorIPs                  []net.IP
@@ -489,9 +499,17 @@ func (f *fqdnSelector) allocateIdentityMappings(idAllocator cache.IdentityAlloca
 		ids = append(ids, currentlyAllocatedIdentities[i].ID)
 	}
 
+	identitiesToRelease := make([]identity.NumericIdentity, 0, len(ids))
 	for _, id := range ids {
+		if _, exists := f.cachedSelections[id]; exists {
+			identitiesToRelease = append(identitiesToRelease, id)
+		}
 		f.cachedSelections[id] = struct{}{}
 	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
+	defer cancel()
+	idAllocator.ReleaseCIDRIdentitiesByID(ctx, identitiesToRelease)
 }
 
 // identityNotifier provides a means for other subsystems to be made aware of a

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"sort"
 	"strings"
 	"sync"
@@ -450,6 +451,49 @@ func (f *fqdnSelector) notifyUsers(sc *SelectorCache, added, deleted []identity.
 	}
 }
 
+// allocateIdentityMappings is an initializer for 'fqdnSelector' that takes a
+// slice of IPs that should be associated with the selector and caches those
+// selections. No notifications are propagated to the users.
+//
+// This function may be called at initialization for a new fqdnSelector, or
+// upon new use of an FQDN selector with the same string representation of a
+// previously-cached selector (for example the same toFQDNs match pattern in
+// different rules).
+func (f *fqdnSelector) allocateIdentityMappings(idAllocator cache.IdentityAllocator, selectorIPMapping map[api.FQDNSelector][]net.IP) {
+	var (
+		currentlyAllocatedIdentities []*identity.Identity
+		selectorIPs                  []net.IP
+		ids                          []identity.NumericIdentity
+		err                          error
+	)
+
+	// Allocate identities for each IPNet and then map to selector
+	selectorIPs = selectorIPMapping[f.selector]
+	log.WithFields(logrus.Fields{
+		"fqdnSelector": f.selector,
+		"ips":          selectorIPs,
+	}).Debug("getting identities for IPs associated with FQDNSelector")
+
+	// TODO: Consider if upserts to ipcache should be delayed until endpoint policies have been
+	// updated. This is the path from policy updates rather than for DNS proxy results. Hence
+	// any existing IPs would typically already have been pushed to the ipcache as they would
+	// not be newly allocated. We need the 'allocation' here to get a reference count on the
+	// allocations.
+	if currentlyAllocatedIdentities, err = idAllocator.AllocateCIDRsForIPs(selectorIPs, nil); err != nil {
+		log.WithError(err).WithField("prefixes", selectorIPs).Warn(
+			"failed to allocate identities for IPs")
+		return
+	}
+	ids = make([]identity.NumericIdentity, 0, len(currentlyAllocatedIdentities))
+	for i := range currentlyAllocatedIdentities {
+		ids = append(ids, currentlyAllocatedIdentities[i].ID)
+	}
+
+	for _, id := range ids {
+		f.cachedSelections[id] = struct{}{}
+	}
+}
+
 // identityNotifier provides a means for other subsystems to be made aware of a
 // given FQDNSelector (currently pkg/fqdn) so that said subsystems can notify
 // the SelectorCache about new IPs (via CIDR Identities) which correspond to
@@ -458,36 +502,20 @@ func (f *fqdnSelector) notifyUsers(sc *SelectorCache, added, deleted []identity.
 // relationship is contained only via DNS responses, which are handled
 // externally.
 type identityNotifier interface {
-	// Lock must be held during any calls to RegisterForIdentityUpdatesLocked or
-	// UnregisterForIdentityUpdatesLocked.
+	// Lock must be held during any calls to *Locked functions below.
 	Lock()
 
-	// Unlock must be called after calls to RegisterForIdentityUpdatesLocked or
-	// UnregisterForIdentityUpdatesLocked are done.
+	// Unlock must be called after calls to *Locked functions below.
 	Unlock()
 
 	// RegisterForIdentityUpdatesLocked exposes this FQDNSelector so that identities
-	// for IPs contained in a DNS response that matches said selector can be
-	// propagated back to the SelectorCache via `UpdateFQDNSelector`. When called,
-	// implementers (currently `pkg/fqdn/RuleGen`) should iterate over all DNS
-	// names that they are aware of, and see if they match the FQDNSelector.
-	// All IPs which correspond to the DNS names which match this Selector will
-	// be returned as CIDR identities, as other DNS Names which have already
-	// been resolved may match this FQDNSelector.
-	// Once this function is called, the SelectorCache will be updated any time
-	// new IPs are resolved for DNS names which match this FQDNSelector.
-	// This function is only called when the SelectorCache has been made aware
-	// of this FQDNSelector for the first time, since we only need to get the
-	// set of CIDR identities which match this FQDNSelector already from the
-	// identityNotifier on the first pass; any subsequent updates will eventually
-	// call `UpdateFQDNSelector`.
+	// for IPs contained in a DNS response that matches said selector can
+	// be propagated back to the SelectorCache via `UpdateFQDNSelector`.
 	//
-	// The code currently allocates identities inside this function, but
-	// relies on the caller handling the identity release themselves.
-	// In future it likely makes sense to move that code out of the
-	// identityNotifier implementation into the caller to better balance
-	// the allocate/release calls.
-	RegisterForIdentityUpdatesLocked(allocator cache.IdentityAllocator, selector api.FQDNSelector) (identities []identity.NumericIdentity)
+	// This function should only be called when the SelectorCache has been
+	// made aware of the FQDNSelector for the first time; subsequent
+	// updates to the selectors should be made via `UpdateFQDNSelector`.
+	RegisterForIdentityUpdatesLocked(selector api.FQDNSelector)
 
 	// UnregisterForIdentityUpdatesLocked removes this FQDNSelector from the set of
 	// FQDNSelectors which are being tracked by the identityNotifier. The result
@@ -496,6 +524,12 @@ type identityNotifier interface {
 	// This occurs when there are no more users of a given FQDNSelector for the
 	// SelectorCache.
 	UnregisterForIdentityUpdatesLocked(selector api.FQDNSelector)
+
+	// MapSelectorsToIPsLocked returns a slice of IPs that may be
+	// associated with the specified FQDN selector, based on the
+	// currently-known DNS mappings for the IPs held inside the
+	// identityNotifier.
+	MapSelectorsToIPsLocked(map[api.FQDNSelector]struct{}) (selectorsMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP)
 }
 
 type labelIdentitySelector struct {
@@ -721,15 +755,9 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 	// If this is called twice, one of the results will arbitrarily contain
 	// a real slice of ids, while the other will receive nil. We must fold
 	// them together below.
-	ids := sc.localIdentityNotifier.RegisterForIdentityUpdatesLocked(sc.idAllocator, newFQDNSel.selector)
-
-	// Do not go through the identity cache to see what identities "match" this
-	// selector. This has to be updated via whatever is getting the CIDR identities
-	// which correspond go this FQDNSelector.
-	// Alternatively , we could go through the CIDR identities in the cache
-	// provided they have some 'field' which shows which FQDNs they correspond
-	// to? This would require we keep some set in the Identity for the CIDR.
-	// Is this feasible?
+	sc.localIdentityNotifier.RegisterForIdentityUpdatesLocked(newFQDNSel.selector)
+	selectors := map[api.FQDNSelector]struct{}{newFQDNSel.selector: {}}
+	_, selectorIPMapping := sc.localIdentityNotifier.MapSelectorsToIPsLocked(selectors)
 
 	// Note: No notifications are sent for the existing
 	// identities. Caller must use GetSelections() to get the
@@ -749,13 +777,12 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 		sc.selectors[key] = newFQDNSel
 	}
 
-	// Add the ids from the slice above to the FQDN selector in the cache.
-	// This could plausibly happen twice, once with an empty 'ids' slice
-	// and once with the real 'ids' slice. Either way, they are added to
-	// the selector that is stored in 'sc.selectors[]'
-	for _, id := range ids {
-		newFQDNSel.cachedSelections[id] = struct{}{}
-	}
+	// Allocate identities corresponding to the slice of IPs identified as
+	// being selected by this FQDN selector above. This could plausibly
+	// happen twice, once with an empty 'ids' slice and once with the real
+	// 'ids' slice. Either way, they are added to the selector that is
+	// stored in 'sc.selectors[]'.
+	newFQDNSel.allocateIdentityMappings(sc.idAllocator, selectorIPMapping)
 	newFQDNSel.updateSelections()
 
 	return newFQDNSel, newFQDNSel.addUser(user)

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -155,6 +155,11 @@ type identitySelector interface {
 	// Called with NameManager and SelectorCache locks held
 	removeUser(CachedSelectionUser, identityNotifier) (last bool)
 
+	// releaseIdentityMappings must be called exactly once upon release of
+	// this selector to ensure that resources are cleaned up upon deletion
+	// of the selector.
+	releaseIdentityMappings(cache.IdentityAllocator)
+
 	// This may be called while the NameManager lock is held. wg.Wait()
 	// returns after user notifications have been completed, which may require
 	// taking Endpoint and SelectorCache locks, so these locks must not be
@@ -459,6 +464,11 @@ func (f *fqdnSelector) notifyUsers(sc *SelectorCache, added, deleted []identity.
 // upon new use of an FQDN selector with the same string representation of a
 // previously-cached selector (for example the same toFQDNs match pattern in
 // different rules).
+//
+// Calls to allocateIdentityMappings() will allocate identities and associate
+// them with the fqdnSelector, therefore the corresponding
+// releaseIdentityMappings() function must also be eventually called to clean
+// up this selector.
 func (f *fqdnSelector) allocateIdentityMappings(idAllocator cache.IdentityAllocator, selectorIPMapping map[api.FQDNSelector][]net.IP) {
 	// We don't know whether the IPs are associated with this selector
 	// until we map those IPs to identities, which requires potentially
@@ -510,6 +520,20 @@ func (f *fqdnSelector) allocateIdentityMappings(idAllocator cache.IdentityAlloca
 	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
 	defer cancel()
 	idAllocator.ReleaseCIDRIdentitiesByID(ctx, identitiesToRelease)
+}
+
+// releaseIdentityMappings must be called exactly once for the received
+// 'fqdnSelector' in order to release CIDR identity references held in this
+// selector's cachedSelections.
+func (f *fqdnSelector) releaseIdentityMappings(idAllocator cache.IdentityAllocator) {
+	ids := make([]identity.NumericIdentity, 0, len(f.cachedSelections))
+	for id := range f.cachedSelections {
+		ids = append(ids, id)
+	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
+	defer cancel()
+	idAllocator.ReleaseCIDRIdentitiesByID(ctx, ids)
 }
 
 // identityNotifier provides a means for other subsystems to be made aware of a
@@ -591,6 +615,10 @@ func (l *labelIdentitySelector) matchesNamespace(ns string) bool {
 
 func (l *labelIdentitySelector) matches(identity scIdentity) bool {
 	return l.matchesNamespace(identity.namespace) && l.selector.Matches(identity.lbls)
+}
+
+func (l *labelIdentitySelector) releaseIdentityMappings(idAllocator cache.IdentityAllocator) {
+	// labelIdentitySelectors don't retain identity references, so no-op.
 }
 
 //
@@ -880,6 +908,7 @@ func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user Cach
 		if sel.removeUser(user, sc.localIdentityNotifier) {
 			delete(sc.selectors, key)
 		}
+		sel.releaseIdentityMappings(sc.idAllocator)
 	}
 }
 

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -623,65 +623,6 @@ func (ds *SelectorCacheTestSuite) TestIdentityUpdatesMultipleUsers(c *C) {
 	c.Assert(len(sc.selectors), Equals, 0)
 }
 
-func (ds *SelectorCacheTestSuite) TestIdentityNotifier(c *C) {
-	sc := testNewSelectorCache(cache.IdentityCache{})
-	idNotifier, ok := sc.localIdentityNotifier.(*testidentity.DummyIdentityNotifier)
-	c.Assert(ok, Equals, true)
-	c.Assert(idNotifier, Not(IsNil))
-
-	// Add some identities to the identity cache
-	googleSel := api.FQDNSelector{MatchName: "google.com"}
-	ciliumSel := api.FQDNSelector{MatchName: "cilium.io"}
-
-	// Nothing should be registered yet.
-	c.Assert(idNotifier.IsRegistered(ciliumSel), Equals, false)
-	c.Assert(idNotifier.IsRegistered(googleSel), Equals, false)
-
-	injectedIDs := []identity.NumericIdentity{1000, 1001, 1002}
-	idNotifier.InjectIdentitiesForSelector(ciliumSel, injectedIDs)
-
-	// Add a user without adding identities explicitly. The identityNotifier
-	// should have populated them for us.
-	user1 := newUser(c, "user1", sc)
-	cached := user1.AddFQDNSelector(ciliumSel)
-	_, exists := sc.selectors[ciliumSel.String()]
-	c.Assert(exists, Equals, true)
-
-	selections := cached.GetSelections()
-	c.Assert(len(selections), Equals, 3)
-	for i, selection := range selections {
-		c.Assert(selection, Equals, injectedIDs[i])
-	}
-
-	// Add another selector from the same user
-	cached2 := user1.AddFQDNSelector(googleSel)
-	c.Assert(cached2, Not(Equals), cached)
-
-	selections2 := cached2.GetSelections()
-	c.Assert(len(selections2), Equals, 0)
-
-	wg := &sync.WaitGroup{}
-	sc.RemoveIdentitiesFQDNSelectors([]api.FQDNSelector{
-		googleSel,
-		ciliumSel,
-	}, wg)
-	wg.Wait()
-
-	selections = cached.GetSelections()
-	c.Assert(len(selections), Equals, 0)
-
-	selections2 = cached2.GetSelections()
-	c.Assert(len(selections2), Equals, 0)
-
-	sc.RemoveSelector(cached, user1)
-	c.Assert(idNotifier.IsRegistered(ciliumSel), Equals, false)
-	c.Assert(idNotifier.IsRegistered(googleSel), Equals, true)
-
-	sc.RemoveSelector(cached2, user1)
-	c.Assert(idNotifier.IsRegistered(googleSel), Equals, false)
-
-}
-
 func testNewSelectorCache(ids cache.IdentityCache) *SelectorCache {
 	sc := NewSelectorCache(testidentity.NewFakeIdentityAllocator(ids), ids)
 	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -61,7 +61,7 @@ func (f *FakeIdentityAllocator) AllocateIdentity(context.Context, labels.Labels,
 }
 
 // Release does nothing.
-func (f *FakeIdentityAllocator) Release(context.Context, *identity.Identity) (released bool, err error) {
+func (f *FakeIdentityAllocator) Release(context.Context, *identity.Identity, bool) (released bool, err error) {
 	return true, nil
 }
 

--- a/pkg/testutils/identity/notifier.go
+++ b/pkg/testutils/identity/notifier.go
@@ -15,8 +15,9 @@
 package testidentity
 
 import (
+	"net"
+
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -47,12 +48,10 @@ func (d *DummyIdentityNotifier) Unlock() {
 // RegisterForIdentityUpdatesLocked starts managing this selector.
 //
 // It doesn't implement the identity allocation semantics of the interface.
-func (d *DummyIdentityNotifier) RegisterForIdentityUpdatesLocked(allocator cache.IdentityAllocator, selector api.FQDNSelector) (identities []identity.NumericIdentity) {
-	ids, ok := d.selectors[selector]
-	if !ok {
+func (d *DummyIdentityNotifier) RegisterForIdentityUpdatesLocked(selector api.FQDNSelector) {
+	if _, ok := d.selectors[selector]; !ok {
 		d.selectors[selector] = []identity.NumericIdentity{}
 	}
-	return ids
 }
 
 // UnregisterForIdentityUpdatesLocked stops managing this selector.
@@ -60,12 +59,8 @@ func (d *DummyIdentityNotifier) UnregisterForIdentityUpdatesLocked(selector api.
 	delete(d.selectors, selector)
 }
 
-func (d *DummyIdentityNotifier) InjectIdentitiesForSelector(fqdnSel api.FQDNSelector, ids []identity.NumericIdentity) {
-	d.selectors[fqdnSel] = ids
-}
-
-// IsRegistered returns whether this selector is being managed.
-func (d *DummyIdentityNotifier) IsRegistered(selector api.FQDNSelector) bool {
-	_, ok := d.selectors[selector]
-	return ok
+// MapSelectorsToIPsLocked is a dummy implementation that does not implement
+// the selectors of the real implementation.
+func (d *DummyIdentityNotifier) MapSelectorsToIPsLocked(fqdnSelectors map[api.FQDNSelector]struct{}) (selectorsMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
+	return nil, nil
 }


### PR DESCRIPTION
* #17788 -- Additional FQDN selector identity tracking fixes (@joestringer)
  * Had a few conflicts with v1.10 branch due to changes in the v1.11/master branch.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17788; do contrib/backporting/set-labels.py $pr done 1.10; done
```