### PR TITLE
contrib: Fix backport submission for own PRs

### DIFF
--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -32,15 +32,20 @@ get_remote () {
   echo "$remote"
 }
 
+get_user() {
+  gh_username=$(hub api user --flat | awk '/.login/ {print $2}')
+  if [ "$gh_username" = "" ]; then
+    echo "Error: could not get user info from hub" 1>&2
+    exit 1
+  fi
+  echo $gh_username
+}
+
 # $1 - override
 get_user_remote() {
   USER_REMOTE=${1:-}
   if [ "$USER_REMOTE" = "" ]; then
-      gh_username=$(hub api user --flat | awk '/.login/ {print $2}')
-      if [ "$gh_username" = "" ]; then
-          echo "Error: could not get user info from hub" 1>&2
-          exit 1
-      fi
+      gh_username=$(get_user)
       USER_REMOTE=$(get_remote "$gh_username")
       echo "Using GitHub repository ${gh_username}/cilium (git remote: ${USER_REMOTE})" 1>&2
   fi

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -47,7 +47,7 @@ if ! git branch -a | grep -q "${UPSTREAM_REMOTE}/v${BRANCH}$" || [ ! -e "$SUMMAR
     echo "(branch version: ${BRANCH}, pr-summary: ${SUMMARY}, upstream remote: ${UPSTREAM_REMOTE})" 1>&2
     exit 1
 fi
-AUTHORS="$(grep -ho "@[^)]*" "$SUMMARY" | sort -u | tr '\n' ',' | sed -e 's/@//g' -e 's/,$//')"
+AUTHORS="$(grep -ho "@[^)]*" "$SUMMARY" | grep -v "$(get_user)" | sort -u | tr '\n' ',' | sed -e 's/@//g' -e 's/,$//')"
 
 echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
@@ -55,7 +55,11 @@ echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git config --local "branch.${PR_BRANCH}.remote" "$USER_REMOTE"
 git push -q "$USER_REMOTE" "$PR_BRANCH"
-hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $AUTHORS
+if [ -z "$AUTHORS" ]; then
+  hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
+else
+  hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $AUTHORS
+fi
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
 echo -e "\nUpdating labels for PRs $prs\n" 2>&1


### PR DESCRIPTION
On GitHub, one cannot request oneself to review one's own PR. This
results in the following problem when submitting a backport PR:

    $ submit-backport
    Using GitHub repository joestringer/cilium (git remote: origin)
    Sending PR for branch v1.10:

    v1.10 backports 2021-11-23

     * #17788 -- Additional FQDN selector identity tracking fixes (@joestringer)

    Once this PR is merged, you can update the PR labels via:
    ```upstream-prs
    $ for pr in 17788; do contrib/backporting/set-labels.py $pr done 1.10; done
    ```

    Sending pull request...
    remote:
    remote: Create a pull request for 'pr/v1.10-backport-2021-11-23' on GitHub by visiting:
    remote:      https://github.com/joestringer/cilium/pull/new/pr/v1.10-backport-2021-11-23
    remote:
    Error requesting reviewer: Unprocessable Entity (HTTP 422)
    Review cannot be requested from pull request author.

    Signal ERR caught!

    Traceback (line function script):
    58 main /home/joe/git/cilium/contrib/backporting/submit-backport

Fix this by excluding ones own username from the reviewers list.
