### PR TITLE
bpf: Quieten mock targets

### DIFF
--- a/bpf/mock/Makefile
+++ b/bpf/mock/Makefile
@@ -22,23 +22,23 @@ check_helper_headers: generate_helper_headers mock_helpers
 	# Generate temp headers from lib/helpers.h, lib/helpers_skb.h and lib/helpers_xdp.h.
 	# Compare them to the headers within the current directory.
 	# The temp headers are removed after finishing.
-	$(QUIET)rm -r mocks;
+	$(QUIET)rm -r mocks
 
 generate_helper_headers:
 	# Auto-generate helpers.h, helpers_skb.h, and helpers_xdp.h.
 	# Take contents from bpf/helpers.h, bpf/helpers_skb.h and bpf/helpers_xdp.h.
 	# Prune to be ready to mock and save to the current directory.
-	$(QUIET)mkdir -p mocks; \
-	sed -f helpers.sed ../include/bpf/helpers.h > mocks/helpers.h; \
-	sed -f helpers_skb.sed ../include/bpf/helpers_skb.h > mocks/helpers_skb.h; \
-	sed -f helpers_xdp.sed ../include/bpf/helpers_xdp.h > mocks/helpers_xdp.h;
+	$(QUIET)mkdir -p mocks
+	$(QUIET)sed -f helpers.sed ../include/bpf/helpers.h > mocks/helpers.h
+	$(QUIET)sed -f helpers_skb.sed ../include/bpf/helpers_skb.h > mocks/helpers_skb.h
+	$(QUIET)sed -f helpers_xdp.sed ../include/bpf/helpers_xdp.h > mocks/helpers_xdp.h
 
 mock_helpers: builder-image
 	# Generate mock libraries for helpers.h, helpers_skb.h and helpers_xdp.h with CMock.
-	$(QUIET) $(DOCKER_RUN) ./mock_helpers.sh;
+	$(QUIET) $(DOCKER_RUN) ./mock_helpers.sh
 
 mock_customized: builder-image
 	# Take the name of the header to be mocked.
 	# Generate the corresponding mock library.
-	$(QUIET) $(DOCKER_RUN) ./mock_customized.sh $(filename);
+	$(QUIET) $(DOCKER_RUN) ./mock_customized.sh $(filename)
 

--- a/bpf/mock/Makefile
+++ b/bpf/mock/Makefile
@@ -22,13 +22,13 @@ check_helper_headers: generate_helper_headers mock_helpers
 	# Generate temp headers from lib/helpers.h, lib/helpers_skb.h and lib/helpers_xdp.h.
 	# Compare them to the headers within the current directory.
 	# The temp headers are removed after finishing.
-	rm -r mocks;
+	$(QUIET)rm -r mocks;
 
 generate_helper_headers:
 	# Auto-generate helpers.h, helpers_skb.h, and helpers_xdp.h.
 	# Take contents from bpf/helpers.h, bpf/helpers_skb.h and bpf/helpers_xdp.h.
 	# Prune to be ready to mock and save to the current directory.
-	mkdir -p mocks; \
+	$(QUIET)mkdir -p mocks; \
 	sed -f helpers.sed ../include/bpf/helpers.h > mocks/helpers.h; \
 	sed -f helpers_skb.sed ../include/bpf/helpers_skb.h > mocks/helpers_skb.h; \
 	sed -f helpers_xdp.sed ../include/bpf/helpers_xdp.h > mocks/helpers_xdp.h;

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -43,15 +43,15 @@ elf-demo.o: elf-demo.c
 
 nat-test: nat-test.c $(LIB)
 	@$(ECHO_CC)
-	make -C $(ROOT_DIR)/bpf/mock generate_helper_headers
-	make -C $(ROOT_DIR)/bpf/mock mock_helpers
-	make -C $(ROOT_DIR)/bpf/mock mock_customized filename=conntrack_stub.h
+	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock generate_helper_headers
+	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock mock_helpers
+	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock mock_customized filename=conntrack_stub.h
 	$(QUIET) $(DOCKER_RUN) $(CLANG) $(FLAGS) -I../../bpf/mock -I $../../bpf/ -I../../../CMock/src -I../../../CMock/vendor/unity/src -I../../../hashmap/include  $< ../../../CMock/vendor/unity/src/unity.c ../../../CMock/src/cmock.c ../../../hashmap/src/hashmap.c ../../bpf/mock/mocks/mock_helpers.c ../../bpf/mock/mocks/mock_helpers_skb.c ../../bpf/mock/mocks/mock_conntrack_stub.c -o $@
 
 drop-notify-test: drop-notify-test.c $(LIB)
 	@$(ECHO_CC)
-	make -C $(ROOT_DIR)/bpf/mock generate_helper_headers
-	make -C $(ROOT_DIR)/bpf/mock mock_helpers
+	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock generate_helper_headers
+	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock mock_helpers
 	$(QUIET) $(DOCKER_RUN) $(CLANG) $(FLAGS) -I../../bpf/mock -I $../../bpf/ -I../../../CMock/src -I../../../CMock/vendor/unity/src  $< ../../../CMock/vendor/unity/src/unity.c ../../../CMock/src/cmock.c ../../bpf/mock/mocks/mock_helpers.c ../../bpf/mock/mocks/mock_helpers_skb.c -o $@
 
 unit-tests: $(ALL_TESTS)


### PR DESCRIPTION
Make the bpf mock testing framework targets respect the user's verbosity
flag.
