### PR TITLE
test: Fix incorrect selector for netperf-service

### DIFF
--- a/test/k8sT/manifests/netperf-deployment.yaml
+++ b/test/k8sT/manifests/netperf-deployment.yaml
@@ -39,4 +39,4 @@ spec:
   ports:
   - port: 12865
   selector:
-    name: netperf-server
+    id: netperf-server


### PR DESCRIPTION
Caught by random chance when using this manifest to test something
locally. Might as well fix it in case someone uses this in the future
and the service is not working as expected.

AFAICT, no CI failures occurred from this typo because the Chaos test
suite (only suite which uses this manifest) doesn't assert any traffic
to the service, but rather to the netperf-server directly.

Fixes: b4a3cf6abc6 ("Test: Run netperf in background while Cilium pod is
being deleted")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
