### PR TITLE
install: Use secret for Azure secrets

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -135,14 +135,16 @@ spec:
         - name: AZURE_RESOURCE_GROUP
           value: {{ .Values.azure.resourceGroup }}
         {{- end }}
-        {{- if .Values.azure.clientID }}
         - name: AZURE_CLIENT_ID
-          value: {{ .Values.azure.clientID }}
-        {{- end }}
-        {{- if .Values.azure.clientSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: cilium-azure
+              key: AZURE_CLIENT_ID
         - name: AZURE_CLIENT_SECRET
-          value: {{ .Values.azure.clientSecret }}
-        {{- end }}
+          valueFrom:
+            secretKeyRef:
+              name: cilium-azure
+              key: AZURE_CLIENT_SECRET
         {{- end }}
         {{- range $key, $value := .Values.operator.extraEnv }}
         - name: {{ $key }}

--- a/install/kubernetes/cilium/templates/cilium-operator/secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.operator.enabled }}
+{{- if .Values.azure.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cilium-azure
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  AZURE_CLIENT_ID: {{ default "" .Values.azure.clientID | b64enc | quote }}
+  AZURE_CLIENT_SECRET: {{ default "" .Values.azure.clientSecret | b64enc | quote }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Previously, Azure secrets was stored as environment variables.
This commit will move the secrets to a secret resource.

Fixes: #17393

Signed-off-by: David Wolffberg <davidwolffberg@gmail.com>

```release-note
Moved Azure secrets to secret resource
```
