### PR TITLE
bpf mock test : Cleaning warnings in output of "make -C test/bpf/ nat-test"

### DIFF
--- a/bpf/include/bpf/stddef.h
+++ b/bpf/include/bpf/stddef.h
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /* Copyright (C) 2020 Authors of Cilium */
 
+#ifndef NULL
+#define NULL ((void *)0)
+#endif
+
 #ifndef __BPF_STDDEF_H_
 #define __BPF_STDDEF_H_
 
-#define NULL	((void *)0)
 
 #define bool	_Bool
 

--- a/bpf/mock/fake_maps.h
+++ b/bpf/mock/fake_maps.h
@@ -21,23 +21,26 @@ void fake_init_map(hashmap_void_t *map, size_t (*hash)(const void *key), int (*c
 }
 
 // Loop up the value of given key.
-void *fake_lookup_elem(hashmap_void_t *map, void *key) {
+void *fake_lookup_elem(hashmap_void_t *map, const void *key)
+{
   return hashmap_get(map, key);
 }
 
 // Update the value of given key.
-int fake_update_elem(hashmap_void_t *map, void *key, void *value, __u32 flags, size_t size) {
+int fake_update_elem(hashmap_void_t *map, const void *key, const void *value, __u32 flags,
+		     size_t size)
+{
   void *entry = hashmap_get(map, key);
   if (entry == NULL && hashmap_size(map) >= size) {
       printf("Update failed: Map is full\n");
       return -1;
     }
 
-  int r = hashmap_put(map, key, value);
+  int r = hashmap_put(map, key, (void *)value);
   if (r == -EEXIST) {
     if (flags == BPF_NOEXIST) return -1;
     hashmap_remove(map, key);
-    hashmap_put(map, key, value);
+    hashmap_put(map, key, (void *)value);
     return 0;
   } else if (r == 0) {
     if (flags == BPF_EXIST) {
@@ -51,6 +54,7 @@ int fake_update_elem(hashmap_void_t *map, void *key, void *value, __u32 flags, s
 }
 
 // Delete given key.
-int fake_delete_elem(hashmap_void_t *map, void *key) {
-  return hashmap_remove(map, key);
+int fake_delete_elem(hashmap_void_t *map, const void *key)
+{
+  return (int)hashmap_remove(map, key);
 }

--- a/bpf/tests/nat_test.h
+++ b/bpf/tests/nat_test.h
@@ -125,15 +125,16 @@ size_t bpf_hash_ipv4_ct_tuple(const void *key)
 // encoded in the callback functions as required by the stub functions in CMock.
 // So we need different callback funcs for different fake maps.
 void *ipv4_ct_tuple_map_lookup_elem_callback(const void* map, const void* key, int cmock_num_calls) {
-  return fake_lookup_elem(&ipv4_ct_tuple_map, key);
+  return fake_lookup_elem((hashmap_void_t *)&ipv4_ct_tuple_map, key);
 }
 
 int ipv4_ct_tuple_map_update_elem_callback(const void* map, const void* key, const void* value, __u32 flags, int cmock_num_calls) {
-  return fake_update_elem(&ipv4_ct_tuple_map, key, value, flags, SNAT_MAPPING_IPV4_SIZE);
+  return fake_update_elem((hashmap_void_t *)&ipv4_ct_tuple_map, key, value, flags,
+			 SNAT_MAPPING_IPV4_SIZE);
 }
 
 int ipv4_ct_tuple_map_delete_elem_callback(const void* map, const void* key, int cmock_num_calls) {
-  return fake_delete_elem(&ipv4_ct_tuple_map, key);
+  return fake_delete_elem((hashmap_void_t *)&ipv4_ct_tuple_map, key);
 }
 
 void test_snat_v4_new_mapping() {
@@ -143,7 +144,8 @@ void test_snat_v4_new_mapping() {
     struct ipv4_nat_target target;
 
     // Initiate the map.
-    fake_init_map(&ipv4_ct_tuple_map, bpf_hash_ipv4_ct_tuple, bpf_compare_ipv4_ct_tuple);
+    fake_init_map((hashmap_void_t *)&ipv4_ct_tuple_map, bpf_hash_ipv4_ct_tuple,
+		  bpf_compare_ipv4_ct_tuple);
 
     get_prandom_u32_ExpectAndReturn(0);
     // Stub the map helpers with the callbacks defined above.


### PR DESCRIPTION
Signed-off-by: Clément Delzotti <elk1ns@outlook.fr>

Cleaning warnings in output of `make -C test/bpf/ nat-test`

Fixes: #17991

```release-note
Fixed warnings generated by "make -C test/bpf/ nat-test" due to improper castings
```
