### PR TITLE
docs: add registry (quay.io/) for pre-loading images for kind

### DIFF
--- a/Documentation/gettingstarted/kind-preload.rst
+++ b/Documentation/gettingstarted/kind-preload.rst
@@ -2,5 +2,5 @@ Preload the ``cilium`` image into each worker node in the kind cluster:
 
 .. parsed-literal::
 
-  docker pull cilium/cilium:|IMAGE_TAG|
-  kind load docker-image cilium/cilium:|IMAGE_TAG|
+  docker pull quay.io/cilium/cilium:|IMAGE_TAG|
+  kind load docker-image quay.io/cilium/cilium:|IMAGE_TAG|


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

in doc, it recommends docker pull image, but the command is :
```
docker pull cilium/cilium:|IMAGE_TAG|
```
this will download from docker.io
However, in operator, it loads images from quay.io
we should keep them the same, otherwise, we download for nothing.


Signed-off-by: adamzhoul adamzhoul186@gmail.com