### PR TITLE
v1.8 backports 2021-11-26

### DIFF
--- a/.github/ISSUE_TEMPLATE/failing_test_template.md
+++ b/.github/ISSUE_TEMPLATE/failing_test_template.md
@@ -2,7 +2,7 @@
 name: Failing Test
 about: Report test failures in Cilium CI jobs
 title: 'CI: '
-labels: area/CI
+labels: area/CI, ci/flake
 assignees: ''
 
 ---

--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -15,7 +15,7 @@ block-pr-with:
 flake-tracker:
   issue-tracker-config:
     issue-labels:
-    - project/ci-force
+    - ci/flake
   jenkins-config:
     jenkins-url: https://jenkins.cilium.io
     regex-trigger: (^/?test-backport-1.8)

--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -92,7 +92,7 @@ flake-tracker:
         correlate-with-stable-jobs:
         - cilium-v1.8-runtime-kernel-4.9
   max-flakes-per-test: 5
-  flake-similarity: 0.75
+  flake-similarity: 0.85
   ignore-failures:
   - failed due to BeforeAll failure
   - Cilium cannot be installed


### PR DESCRIPTION
* #17344 -- .github: Rename `project/ci-force` to `ci/flake` (@pchaigno)
 * #17812 -- .github: Increase reporting threshold for new flakes (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17344 17812; do contrib/backporting/set-labels.py $pr done 1.8; done
```