### PR TITLE
v1.9 backports 2021-11-26

### DIFF
--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -313,6 +313,7 @@ func runAll(commands []string, cmdDir string, k8sPods []string) {
 			continue
 		}
 
+		cmd := cmd // https://golang.org/doc/faq#closures_and_goroutines
 		err := wp.Submit(cmd, func(_ context.Context) error {
 			if strings.Contains(cmd, "xfrm state") {
 				//  Output of 'ip -s xfrm state' needs additional processing to replace

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -225,6 +225,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_PREFILTER"] = "1"
 	}
 
+	if option.Config.EnableEndpointRoutes {
+		cDefinesMap["ENABLE_ENDPOINT_ROUTES"] = "1"
+	}
+
 	if option.Config.EnableHostReachableServices {
 		if option.Config.EnableHostServicesTCP {
 			cDefinesMap["ENABLE_HOST_SERVICES_TCP"] = "1"
@@ -573,10 +577,6 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 
 	if e.RequireRouting() {
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
-	}
-
-	if e.RequireEndpointRoute() {
-		fmt.Fprintf(fw, "#define ENABLE_ENDPOINT_ROUTES 1\n")
 	}
 
 	if !option.Config.EnableHostLegacyRouting && option.Config.DirectRoutingDevice != "" {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -890,7 +890,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 
 				/* Insert wildcard policy rules for traffic skipping back through host */
 				ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
-				if err = ipsec.IpSecReplacePolicyFwd(ipsecIPv4Wildcard, ipsecRemote, ipsecLocal, ipsecRemote); err != nil {
+				if err = ipsec.IpSecReplacePolicyFwd(ipsecIPv4Wildcard, ipsecRemote, ipsecIPv4Wildcard, ipsecRemote); err != nil {
 					log.WithError(err).Warning("egress unable to replace policy fwd:")
 				}
 			}


### PR DESCRIPTION
* #17865 -- Fixes for IPsec and endpoint routes (@kkourt)
 * #17916 -- bugtool: fix data race occurring when running commands (@rolinh)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17865 17916; do contrib/backporting/set-labels.py $pr done 1.9; done
```