### PR TITLE
ci: Restart pods when toggling KPR switch

### DIFF
--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -174,7 +174,29 @@ func optionChangeRequiresPodRedeploy(prev, next map[string]string) bool {
 		b = opt
 	}
 
-	return a != b
+	if a != b {
+		return true
+	}
+
+	// Switching on and off KPR affects who is handling service traffic.
+	// E.g., off => on some traffic might be handled by iptables. For existing
+	// connections it might not have enough of state information which could
+	// lead to connection interruptions. To avoid it, restart the pods to restart
+	// such connections.
+	a = "disabled"
+	if opt, ok := prev["kubeProxyReplacement"]; ok {
+		a = opt
+	}
+	b = "disabled"
+	if opt, ok := next["kubeProxyReplacement"]; ok {
+		b = opt
+	}
+
+	if a != b {
+		return true
+	}
+
+	return false
 }
 
 // DeployCiliumOptionsAndDNS deploys DNS and cilium with options into the kubernetes cluster


### PR DESCRIPTION
Previously, in the graceful backend termination test we switched to
KPR=disabled and we didn't restart CoreDNS. Before the switch,
CoreDNS@k8s2 -> kube-apiserver@k8s1 was handled by the socket-lb, so the
outgoing packet was $CORE_DNS_IP -> $KUBE_API_SERVER_NODE_IP. The packet
should have been BPF masq-ed. After the switch, the BPF masq is no
longer in place, so the packets from CoreDNS are subject to the
iptables' masquerading (they can be either dropped by the invalid rule
or masqueraded to some other port). Combined with CoreDNS unable to
recover from connectivity errors \[1\], the CoreDNS was no longer able to
receive updates from the kube-apiserver, thus NXDOMAIN errors for the
new service name.

To avoid such flakes, forcefully restart the DNS pods if the KPR setting
change is detected.

\[1\]: https://github.com/cilium/cilium/pull/18018

Fix https://github.com/cilium/cilium/issues/17881