### PR TITLE
CI: add CIFuzz integration

### DIFF
--- a/.github/workflows/tests-cifuzz.yaml
+++ b/.github/workflows/tests-cifuzz.yaml
@@ -1,0 +1,30 @@
+name: CIFuzz
+on:
+  pull_request:
+    paths-ignore:
+      - 'Documentation/**'
+permissions: read-all
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@723bdbc7a8ee1e95af24284583b25d41efc0bd41
+      with:
+        oss-fuzz-project-name: 'cilium'
+        dry-run: false
+        language: go
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@723bdbc7a8ee1e95af24284583b25d41efc0bd41
+      with:
+        oss-fuzz-project-name: 'cilium'
+        fuzz-seconds: 600
+        dry-run: false
+        language: go
+    - name: Upload Crash
+      uses: actions/upload-artifact@da838ae9595ac94171fa2d4de5a2f117b3e7ac32
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Add [CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/) workflow action to have fuzzers build and run on each PR.
This is a service offered by OSS-Fuzz, on which cilium already runs.

CIFuzz can help detect catch regressions and fuzzing build issues early, and has a variety of features (see the URL above). 

CC @twpayne (saw you on OSS-Fuzz)

Signed-off-by: David Korczynski <david@adalogics.com>