### PR TITLE
bpf: update dsr flag properly

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1119,19 +1119,22 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 					   verdict, policy_match_type, audited);
 	}
 
-	if (ret == CT_NEW) {
 #ifdef ENABLE_DSR
-	{
+	if (ret == CT_NEW || ret == CT_REOPENED) {
 		bool dsr = false;
+		int ret2;
 
-		ret = handle_dsr_v6(ctx, &dsr);
-		if (ret != 0)
-			return ret;
+		ret2 = handle_dsr_v6(ctx, &dsr);
+		if (ret2 != 0)
+			return ret2;
 
 		ct_state_new.dsr = dsr;
+		if (ret == CT_REOPENED)
+			ct_update6_dsr(get_ct_map6(&tuple), &tuple, dsr);
 	}
 #endif /* ENABLE_DSR */
 
+	if (ret == CT_NEW) {
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.node_port = ct_state.node_port;
 		ct_state_new.ifindex = ct_state.ifindex;
@@ -1421,19 +1424,22 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 skip_policy_enforcement:
 #endif /* !ENABLE_HOST_SERVICES_FULL && !DISABLE_LOOPBACK_LB */
 
-	if (ret == CT_NEW) {
 #ifdef ENABLE_DSR
-	{
+	if (ret == CT_NEW || ret == CT_REOPENED) {
 		bool dsr = false;
+		int ret2;
 
-		ret = handle_dsr_v4(ctx, &dsr);
-		if (ret != 0)
-			return ret;
+		ret2 = handle_dsr_v4(ctx, &dsr);
+		if (ret2 != 0)
+			return ret2;
 
 		ct_state_new.dsr = dsr;
+		if (ret == CT_REOPENED)
+			ct_update4_dsr(get_ct_map4(&tuple), &tuple, dsr);
 	}
 #endif /* ENABLE_DSR */
 
+	if (ret == CT_NEW) {
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.node_port = ct_state.node_port;
 		ct_state_new.ifindex = ct_state.ifindex;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -817,6 +817,19 @@ ct_update6_rev_nat_index(const void *map, const struct ipv6_ct_tuple *tuple,
 	entry->rev_nat_index = state->rev_nat_index;
 }
 
+static __always_inline void
+ct_update6_dsr(const void *map, const struct ipv6_ct_tuple *tuple,
+	       const bool dsr)
+{
+	struct ct_entry *entry;
+
+	entry = map_lookup_elem(map, tuple);
+	if (!entry)
+		return;
+
+	entry->dsr = dsr;
+}
+
 /* Offset must point to IPv6 */
 static __always_inline int ct_create6(const void *map_main, const void *map_related,
 				      struct ipv6_ct_tuple *tuple,
@@ -909,6 +922,19 @@ ct_update4_rev_nat_index(const void *map, const struct ipv4_ct_tuple *tuple,
 		return;
 
 	entry->rev_nat_index = state->rev_nat_index;
+}
+
+static __always_inline void
+ct_update4_dsr(const void *map, const struct ipv4_ct_tuple *tuple,
+	       const bool dsr)
+{
+	struct ct_entry *entry;
+
+	entry = map_lookup_elem(map, tuple);
+	if (!entry)
+		return;
+
+	entry->dsr = dsr;
 }
 
 static __always_inline int ct_create4(const void *map_main,
@@ -1060,6 +1086,13 @@ ct_update6_rev_nat_index(const void *map __maybe_unused,
 {
 }
 
+static __always_inline void
+ct_update6_dsr(const void *map __maybe_unused,
+	       const struct ipv6_ct_tuple *tuple __maybe_unused,
+	       const bool dsr __maybe_unused)
+{
+}
+
 static __always_inline int
 ct_create6(const void *map_main __maybe_unused,
 	   const void *map_related __maybe_unused,
@@ -1082,6 +1115,13 @@ static __always_inline void
 ct_update4_rev_nat_index(const void *map __maybe_unused,
 			 const struct ipv4_ct_tuple *tuple __maybe_unused,
 			 const struct ct_state *state __maybe_unused)
+{
+}
+
+static __always_inline void
+ct_update4_dsr(const void *map __maybe_unused,
+	       const struct ipv4_ct_tuple *tuple __maybe_unused,
+	       const bool dsr __maybe_unused)
 {
 }
 


### PR DESCRIPTION
I reproduced this [issue](#17759) and after this patch new tcp sessions with dsr flag update the already created entries in the conntrack table.

```release-note
Fix TCP connectivity issues in the DSR mode when conntrack entries with missing DSR flag are reused.
```

Fixes: #17759