### PR TITLE
elf: skip TestWrite if ELF file wasn't built

### DIFF
--- a/pkg/elf/elf_test.go
+++ b/pkg/elf/elf_test.go
@@ -76,7 +76,13 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 	defer os.RemoveAll(tmpDir)
 
 	elf, err := Open(baseObjPath)
-	c.Assert(err, IsNil)
+	if errors.Is(err, fs.ErrNotExist) {
+		// If the ELF file couldn't be found most likely it
+		// wasn't built. See https://github.com/cilium/cilium/issues/17535
+		c.Skip("ELF file not found, skipping test")
+	} else {
+		c.Assert(err, IsNil)
+	}
 	defer elf.Close()
 
 	validOptions := IsNil


### PR DESCRIPTION
This will skip the test when running the tests standalone (i.e. via `go test` and not via Makefile). See #17536 for more details about this particular file, which applied the same principle to the benchmark in that test suite.

See also #16914

Reported-by: Hemanth Malla <hemanth.malla@datadoghq.com>
Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
