### PR TITLE
test: Fix graceful termination test flake

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1580,12 +1580,11 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			By("Waiting until server is terminating")
 			ctx, cancel := context.WithCancel(context.Background())
 			res := kubectl.LogsStream(helpers.DefaultNamespace, serverPod, ctx)
-			Expect(res.WaitUntilMatch("terminating")).To(BeNil(),
-				"%s is not in the output after timeout", res.GetStdOut())
-			defer func() {
-				cancel()
-				res.WaitUntilFinish()
-			}()
+			find := "terminating"
+			Eventually(func() bool {
+				return strings.Contains(res.OutputPrettyPrint(), find)
+			}, 60*time.Second, time.Second).Should(BeTrue(), "[%s] is not in the output after timeout\n%s", find, res.Stdout())
+			defer cancel()
 		}
 
 		BeforeAll(func() {
@@ -1633,12 +1632,11 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			ctx, cancel := context.WithCancel(context.Background())
 			res := kubectl.LogsStream(helpers.DefaultNamespace, clientPod, ctx)
 			// Check if the client pod is able to get a response from the server once it's up and running
-			Expect(res.WaitUntilMatch("client received")).To(BeNil(),
-				"%s is not in the output after timeout", res.GetStdOut())
-			defer func() {
-				cancel()
-				res.WaitUntilFinish()
-			}()
+			find := "client received"
+			Eventually(func() bool {
+				return strings.Contains(res.OutputPrettyPrint(), find)
+			}, 60*time.Second, time.Second).Should(BeTrue(), "[%s] is not in the output after timeout\n%s", find, res.Stdout())
+			defer cancel()
 
 			terminateServiceEndpointPod()
 
@@ -1648,12 +1646,11 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			// The log message indicates that the connectivity between client and
 			// server was intact even after the service endpoint pod was terminated,
 			// and that the client connection terminated gracefully.
-			Expect(res.WaitUntilMatch("exiting on graceful termination")).To(BeNil(),
-				"%s is not in the output after timeout", res.GetStdOut())
-			defer func() {
-				cancel()
-				res.WaitUntilFinish()
-			}()
+			find = "exiting on graceful termination"
+			Eventually(func() bool {
+				return strings.Contains(res.OutputPrettyPrint(), find)
+			}, 60*time.Second, time.Second).Should(BeTrue(), "[%s] is not in the output after timeout\n%s", find, res.Stdout())
+			defer cancel()
 
 			// The client pod exits with status code 0 on graceful termination.
 			By("Checking if client pod exited successfully")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1552,7 +1552,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 	SkipContextIf(func() bool {
 		// The graceful termination feature depends on enabling an alpha feature
 		// EndpointSliceTerminatingCondition in Kubernetes.
-		return helpers.SkipK8sVersions("<1.20.0") || helpers.RunsOnGKE() || helpers.RunsOnEKS() || helpers.SkipQuarantined()
+		return helpers.SkipK8sVersions("<1.20.0") || helpers.RunsOnGKE() || helpers.RunsOnEKS()
 	}, "Checks graceful termination of service endpoints", func() {
 		const (
 			clientPodLabel = "app=graceful-term-client"

--- a/test/k8sT/manifests/graceful-termination.yaml
+++ b/test/k8sT/manifests/graceful-termination.yaml
@@ -23,9 +23,9 @@ spec:
         - containerPort: 8081
           protocol: TCP
       command: [ "/server", "8081" ]
-  # The server pod gracefully terminates client connections upon receiving SIGTERM.
-  # It then waits for terminationGracePeriodSeconds duration so that CI
-  # assertions can be made before exiting.
+  # The server signals shutdown to client upon receiving SIGTERM, waits for
+  # the terminationGracePeriodSeconds duration, and then gracefully closes client connection.
+  # The duration is configured such so that CI assertions can be made before exiting.
   terminationGracePeriodSeconds: 15
   tolerations:
     - effect: NoSchedule
@@ -41,7 +41,7 @@ metadata:
   labels:
     app: graceful-term-client
 spec:
-  # The client exits with status code 0 on graceful termination so no need to restart the pod for success cases.
+  # The client exits with status code 0 on graceful termination so no need to restart the pod on success.
   restartPolicy: OnFailure
   terminationGracePeriodSeconds: 0
   containers:


### PR DESCRIPTION
The graceful termination test apps [1] are updated to fix a flake. Specifically, added read and write deadlines while making socket calls on the server side. This way the server doesn't block on the socket calls when `SIGTERM` event is received on termination.

While at it, also updated the test logic to validate that connectivity between client and server is intact at least for the configured `terminationGracePeriodInSeconds` duration.

Ran the test locally a few times, and it passed every time. 

[1] https://github.com/cilium/graceful-termination-test-apps

Signed-off-by: Aditi Ghag <aditi@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/18045