### PR TITLE
Quarantine frequent failures

### DIFF
--- a/contrib/scripts/quarantine.sh
+++ b/contrib/scripts/quarantine.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+indent() {
+    sed 's/^/  /'
+}
+
+main() {
+    tmpfile=$(mktemp)
+    trap 'rm -f -- $tmpfile' EXIT
+
+    if [ $# -lt 1 ] || [ $# -gt 1 ]; then
+        >&2 echo "usage: $0 <focus-phrase>"
+        return 1
+    fi
+
+    if ! git grep -q "$1"; then
+        >&2 echo "Unable to find phrase."
+        return 1
+    fi
+
+    if ! git diff --quiet || ! git diff --quiet --cached; then
+        >&2 echo "Local changes in the git tree break this script. Stage your changes to continue."
+        return 1
+    fi
+
+    files=( $(git grep -l "$1" test/*/*go) )
+    for f in "${files[@]}"; do
+        commits=( $(git blame $f | grep "$1" |  awk '{ print $1; }') )
+        authors=()
+        for c in "${commits[@]}"; do
+            authors+=( "$(git log -1 $c --pretty='%aN <%aE>')" )
+        done
+
+        sed -i '/Quarantine/b; s/\(SkipItIf([^,]*\),\(.*'"$1"'.*\)/\1 || helpers.SkipQuarantined,\2/g' $f
+        sed -i '/Quarantine/b; s/\(SkipContextIf([^,]*\),\(.*'"$1"'.*\)/\1 || helpers.SkipQuarantined,\2/g' $f
+        sed -i 's/It(\(.*'"$1"'.*\)$/SkipItIf(helpers.SkipQuarantined, \1/g' $f
+        sed -i 's/Context(\(.*'"$1"'.*\)$/SkipContextIf(helpers.SkipQuarantined, \1/g' $f
+
+        git add $f || ( >&2 echo "Unable to disable test, maybe the declaration is multi-line?" && return 1 )
+
+        >$tmpfile echo "test/$(basename $f | sed 's/\.go//'): Quarantine '$1'"
+        >>$tmpfile echo
+        for a in "${authors[@]}"; do
+            if grep -q "$a" $tmpfile; then
+                continue
+            fi
+            >>$tmpfile echo "CC: $a"
+        done
+        git commit --signoff --quiet --message "$(cat $tmpfile)"
+    done
+}
+
+main "$@"

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -169,7 +169,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
-	Context("Encapsulation", func() {
+	SkipContextIf(helpers.SkipQuarantined, "Encapsulation", func() {
 		validateBPFTunnelMap := func() {
 			By("Checking that BPF tunnels are in place")
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -658,7 +658,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 		})
 
 		SkipContextIf(func() bool {
-			return helpers.RunsWithKubeProxyReplacement() || helpers.GetCurrentIntegration() != ""
+			return helpers.RunsWithKubeProxyReplacement() || helpers.GetCurrentIntegration() != "" || helpers.SkipQuarantined()
 		}, "IPv6 masquerading", func() {
 			var (
 				k8s1EndpointIPs map[string]string

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1037,7 +1037,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 					})
 				})
 
-				Context("Tests with direct routing", func() {
+				SkipContextIf(helpers.SkipQuarantined, "Tests with direct routing", func() {
 
 					var directRoutingOpts = map[string]string{
 						"tunnel":               "disabled",

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -362,7 +362,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				ciliumDelService(kubectl, 20069)
 			})
 
-			It("Checks service on same node", func() {
+			SkipItIf(helpers.SkipQuarantined, "Checks service on same node", func() {
 				status := kubectl.ExecInHostNetNS(context.TODO(), ni.k8s1NodeName,
 					helpers.CurlFail(`"http://[%s]/"`, demoClusterIPv6))
 				status.ExpectSuccess("cannot curl to service IP from host")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1552,7 +1552,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 	SkipContextIf(func() bool {
 		// The graceful termination feature depends on enabling an alpha feature
 		// EndpointSliceTerminatingCondition in Kubernetes.
-		return helpers.SkipK8sVersions("<1.20.0") || helpers.RunsOnGKE() || helpers.RunsOnEKS()
+		return helpers.SkipK8sVersions("<1.20.0") || helpers.RunsOnGKE() || helpers.RunsOnEKS() || helpers.SkipQuarantined()
 	}, "Checks graceful termination of service endpoints", func() {
 		const (
 			clientPodLabel = "app=graceful-term-client"


### PR DESCRIPTION
This PR quarantines many of the test groups that have been frequently failing,
so that we can stabilize the master branch. With the master branch stable, we
can assign quarantined tests to individuals to further inspect and make
progress on re-establishing test coverage.

From there we can establish which category the test failures fall under:

* *Genuine bug*. It may be that the test failure is due to a genuine bug in
  Cilium. We can then determine the severity and consider whether it should
  block the upcoming release or be treated as a standard bug report.
* *Fixable*. The test can be made reliable with relatively few changes. In this
  case, we can fix and re-enables the test, and close the GitHub issue as
  “fixed”. Note that once the fix is merged, we may want to keep the test in
  quarantine for some time longer to ensure that the fix will properly resolve
  the flakiness.
* *No longer needed*. If the functionality covered by the test is covered by
  other existing tests, then the test can be deleted completely and the GitHub
  issue closed as “won’t fix”.
* *Important, but not fixable*. If the functionality covered by the test is
  important and not covered by other tests, then we can leave the corresponding
  GitHub issue open and come up with a plan to address the test failure during
  the next development cycle.

(Props to @twpayne who wrote up the initial proposal of the above
classification, which I've made minor tweaks to here)

This PR is split into the following commits, based primarily on cross-referencing the [recently updated Cilium Github
Issues](https://github.com/cilium/cilium/issues?q=is%3Aopen+is%3Aissue+label%3Aci%2Fflake+sort%3Aupdated-desc) against the CI dashboard and quarantining the most frequent failures.

- contrib: Add quarantine commit creation script
  - Rough script to help quarantine tests by check name, works in a fair number
    of cases but the results do need to be checked to determine whether the
    quarantine selected the correct test.
- test/Services: Quarantine 'Checks service on same node'
  - Example failures: #17919
  - 24 failures recorded on master since Nov 10
- test/Services: Quarantine 'Tests with direct routing'
  - Example failures: #18014 (IPv6), #17895 (IPv6), #13839, #12690
  - 46 (k8s-1.21) + 22 (k8s-1.22) failures recorded on master since Nov 10
- test/Services: Quarantine 'Checks graceful termination'
  - Example failures: #18045
  - 42 (k8s-1.21) + 39 (k8s-1.22) failures recorded on master since Nov 10
- test/Services: Quarantine 'IPv6 masquerading across K8s nodes'
  - Example failures: #17942
  - 20 failures recorded on master since Nov 10
- test/DatapathConfiguration: Quarantine 'Encapsulation'
  - Example failures: #17545, #17353, #17069 (low hanging fruit)
  - 64 failures recorded on master since Nov 10 across four tests

The above tests were selected for quarantine primarily based on exceeding a
threshold on failure frequency over the past couple of weeks and based on
community members actively engaging with the corresponding GitHub issues in the
past week. It is not comprehensive, CI dashboard for instance shows a long tail
of less frequent failures. However, this will hopefully help to stabilize CI
for the immediate term and provide a focus for us to evaluate the stability of
the branch in the short term, and start to point towards ways to improve the
codebase in the medium term.
