### PR TITLE
test: temporary increase Hubble buffer size to 64k

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -92,6 +92,7 @@ var (
 		"hubble.relay.image.repository": "k8s1:5000/cilium/hubble-relay",
 		"hubble.relay.image.tag":        "latest",
 		"hubble.relay.image.useDigest":  "false",
+		"hubble.eventBufferCapacity":    "65535",
 		"debug.enabled":                 "true",
 		"k8s.requireIPv4PodCIDR":        "true",
 		"pprof.enabled":                 "true",


### PR DESCRIPTION
Temporary increase the Hubble buffer size in order to capture more
flows. This will hopefully help us understand why the
K8sEgressGatewayTest is occasionally failing (#18012)