### PR TITLE
bugtool: fix IP route debug gathering commands

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -258,8 +258,8 @@ func routeCommands() []string {
 	routes, _ := execCommand("ip route show table all | grep -E --only-matching 'table [0-9]+'")
 
 	for _, r := range bytes.Split(bytes.TrimSuffix(routes, []byte("\n")), []byte("\n")) {
-		routeTablev4 := fmt.Sprintf("ip -4 route show %v", r)
-		routeTablev6 := fmt.Sprintf("ip -6 route show %v", r)
+		routeTablev4 := fmt.Sprintf("ip -4 route show %s", r)
+		routeTablev6 := fmt.Sprintf("ip -6 route show %s", r)
 		commands = append(commands, routeTablev4, routeTablev6)
 	}
 	return commands

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -399,7 +399,7 @@ func writeCmdToFile(cmdDir, prompt string, k8sPods []string, enableMarkdown bool
 		// produced might have useful information
 		if bytes.Contains(output, []byte("```")) || !enableMarkdown {
 			// Already contains Markdown, print as is.
-			fmt.Fprint(f, output)
+			fmt.Fprint(f, string(output))
 		} else if enableMarkdown && len(output) > 0 {
 			// Write prompt as header and the output as body, and/or error but delete empty output.
 			fmt.Fprint(f, fmt.Sprintf("# %s\n\n```\n%s\n```\n", prompt, output))


### PR DESCRIPTION
Commit 8bcc4e5dd830 ("bugtool: avoid allocation on conversion of
execCommand result to string") broke the `ip route show` commands
because the change from `[]byte` to `string` causes the `%v` formatting
verb to emit the raw byte slice, not the string. Fix this by using the
`%s` formatting verb to make sure the argument gets interpreted as a
string.

Also fix another instance in `writeCmdToFile` where `fmt.Fprint` is now
invoked with a byte slice.

Grepping for `%v` in bugtool sources and manually inspecting all changes
from commit 8bcc4e5dd830 showed no other instances where a byte slice
could potentially end up being formatted in a wrong way.

Fixes: 8bcc4e5dd830 ("bugtool: avoid allocation on conversion of execCommand result to string")
Fixes: #17546
Closes: #17896