### PR TITLE
health: Fix cluster-health-port for health endpoint

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -304,7 +304,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 
 	pidfile := filepath.Join(option.Config.StateDir, PidfilePath)
 	prog := "ip"
-	args := []string{"netns", "exec", netNSName, binaryName, "--pidfile", pidfile}
+	args := []string{"netns", "exec", netNSName, binaryName, "--listen", strconv.Itoa(option.Config.ClusterHealthPort), "--pidfile", pidfile}
 	cmd.SetTarget(prog)
 	cmd.SetArgs(args)
 	log.Debugf("Spawning health endpoint with command %q %q", prog, args)

--- a/cilium-health/responder/main.go
+++ b/cilium-health/responder/main.go
@@ -22,15 +22,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func cancelOnSignal(cancel context.CancelFunc, sig ...os.Signal) {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, sig...)
-	go func() {
-		<-c
-		cancel()
-	}()
-}
-
 func main() {
 	var (
 		pidfilePath string
@@ -41,8 +32,7 @@ func main() {
 	flag.Parse()
 
 	// Shutdown gracefully to halt server and remove pidfile
-	ctx, cancel := context.WithCancel(context.Background())
-	cancelOnSignal(cancel, unix.SIGINT, unix.SIGHUP, unix.SIGTERM, unix.SIGQUIT)
+	ctx, cancel := signal.NotifyContext(context.Background(), unix.SIGINT, unix.SIGHUP, unix.SIGTERM, unix.SIGQUIT)
 
 	srv := responder.NewServer(listen)
 	defer srv.Shutdown()

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -26,7 +26,9 @@ var _ = Describe("K8sHealthTest", func() {
 			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
 			ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-			DeployCiliumAndDNS(kubectl, ciliumFilename)
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"clusterHealthPort": "9940", // tests use of custom port
+			})
 		})
 
 		AfterFailed(func() {


### PR DESCRIPTION
To determine cluster health, Cilium exposes a HTTP server both on each
node, as well as on the artificial health endpoint running on each node.
The port used for this HTTP server is the same and can be configured via
`cluster-health-port` (introduced in #16926) and defaults to 4240.

This commit fixes a bug where the port specified by
`cluster-health-port` was not passed to the Cilium health endpoint
responder. Which meant that `cilium-health-responder` was always
listening on the default port instead of the one configured by the user,
while the probe tried to connect via `cluster-health-port`. This
resulted in the cluster being reported us unhealthy whenever
`cluster-health-port` was set to a non-default value (which is the case
our OpenShift OLM for v1.11):

```
Nodes:
  gandro-7bmc2-worker-2-blgxf.c.cilium-dev.internal (localhost):
    Host connectivity to 10.0.128.2:
      ICMP to stack:   OK, RTT=634.746µs
      HTTP to agent:   OK, RTT=228.066µs
    Endpoint connectivity to 10.128.11.73:
      ICMP to stack:   OK, RTT=666.83µs
      HTTP to agent:   Get "http://10.128.11.73:9940/hello": dial tcp 10.128.11.73:9940: connect: connection refused
```

Fixes: e624868 ("health: Add a flag to set HTTP port")

:warning:  Marking as release blocker since this is required for our v1.11 OpenShift OLM templates.