### PR TITLE
v1.10 backports 2021-11-30

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -117,6 +117,7 @@ cilium-agent [flags]
       --enable-tracing                                       Enable tracing while determining policy (debugging)
       --enable-well-known-identities                         Enable well-known identities for known Kubernetes components (default true)
       --enable-wireguard                                     Enable wireguard
+      --enable-xdp-prefilter                                 Enable XDP prefiltering
       --enable-xt-socket-fallback                            Enable fallback for missing xt_socket module (default true)
       --encrypt-interface string                             Transparent encryption interface
       --encrypt-node                                         Enables encrypting traffic from non-Cilium pods and host networking
@@ -213,8 +214,6 @@ cilium-agent [flags]
       --pprof                                                Enable serving the pprof debugging API
       --pprof-port int                                       Port that the pprof listens on (default 6060)
       --preallocate-bpf-maps                                 Enable BPF map pre-allocation (default true)
-      --prefilter-device string                              Device facing external network for XDP prefiltering (default "undefined")
-      --prefilter-mode string                                Prefilter mode via XDP ("native", "generic") (default "native")
       --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
       --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)

--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -396,7 +396,7 @@ ENI Deletion Policy
 ENIs can be marked for deletion when the EC2 instance to which the ENI is
 attached to is terminated. In order to enable this, the option
 ``spec.eni.delete-on-termination`` can be enabled. If enabled, the ENI
-is modifying after creation using ``ModifyNetworkInterface`` to specify this
+is modified after creation using ``ModifyNetworkInterfaceAttribute`` to specify this
 deletion policy.
 
 Node Termination
@@ -421,7 +421,7 @@ perform ENI creation and IP allocation:
  * ``DescribeSecurityGroups``
  * ``CreateNetworkInterface``
  * ``AttachNetworkInterface``
- * ``ModifyNetworkInterface``
+ * ``ModifyNetworkInterfaceAttribute``
  * ``AssignPrivateIpAddresses``
  * ``CreateTags``
 

--- a/Documentation/gettingstarted/kind-preload.rst
+++ b/Documentation/gettingstarted/kind-preload.rst
@@ -2,5 +2,5 @@ Preload the ``cilium`` image into each worker node in the kind cluster:
 
 .. parsed-literal::
 
-  docker pull cilium/cilium:|IMAGE_TAG|
-  kind load docker-image cilium/cilium:|IMAGE_TAG|
+  docker pull quay.io/cilium/cilium:|IMAGE_TAG|
+  kind load docker-image quay.io/cilium/cilium:|IMAGE_TAG|

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -525,9 +525,8 @@ LoadBalancer & NodePort XDP Acceleration
 
 Cilium has built-in support for accelerating NodePort, LoadBalancer services and
 services with externalIPs for the case where the arriving request needs to be
-pushed back out of the node when the backend is located on a remote node. This
-ability to act as a "one-legged" / hairpin load balancer can be handled by Cilium
-starting from version `1.8 <https://cilium.io/blog/2020/06/22/cilium-18/#kube-proxy-replacement-at-the-xdp-layer>`_ at
+forwarded and the backend is located on a remote node. This feature was introduced
+in Cilium version `1.8 <https://cilium.io/blog/2020/06/22/cilium-18/#kube-proxy-replacement-at-the-xdp-layer>`_ at
 the XDP (eXpress Data Path) layer where eBPF is operating directly in the networking
 driver instead of a higher layer.
 
@@ -560,11 +559,11 @@ modes and can be enabled as follows for ``loadBalancer.mode=hybrid`` in this exa
         --set k8sServicePort=REPLACE_WITH_API_SERVER_PORT
 
 In case of a multi-device environment, where Cilium's device auto-detection selects
-more than a single device to expose NodePort, for example, the Helm option
-``devices=eth0`` must be additionally specified for the enablement, where
-``eth0`` is the native XDP supported networking device. In that case, the device
-name ``eth0`` must be the same on all Cilium managed nodes. Similarly, the underlying
-driver for ``eth0`` must have native XDP support on all Cilium managed nodes.
+more than a single device to expose NodePort or a user specifies multiple devices
+with ``devices``, the XDP acceleration is enabled on all devices. This means that
+each underlying device's driver must have native XDP support on all Cilium managed
+nodes. In addition, for the performance reasons we recommend kernel >= 5.5 for
+the multi-device XDP acceleration.
 
 A list of drivers supporting native XDP can be found in the table below. The
 corresponding network driver name of an interface can be determined as follows:
@@ -625,9 +624,6 @@ is shown:
 
     $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium status --verbose | grep XDP
       XDP Acceleration:    Native
-
-In the example above, the NodePort XDP acceleration is enabled on the ``eth0`` device
-which is also used for direct routing (``DR``).
 
 Note that packets which have been pushed back out of the device for NodePort handling
 right at the XDP layer are not visible in tcpdump since packet taps come at a much
@@ -1312,11 +1308,6 @@ Limitations
       which uses eBPF cgroup hooks to implement the service translation. Using it with libceph
       deployments currently requires support for the getpeername(2) hook address translation in
       eBPF, which is only available for kernels v5.8 and higher.
-    * Cilium's eBPF kube-proxy acceleration in XDP can only be used in a single device setup
-      as a "one-legged" / hairpin load balancer scenario. In case of a multi-device environment,
-      where auto-detection selects more than a single device to expose NodePort, the option
-      ``devices=eth0`` must be specified in Helm in order to work, where ``eth0``
-      is the native XDP supported networking device.
     * Cilium's DSR NodePort mode currently does not operate well in environments with
       TCP Fast Open (TFO) enabled. It is recommended to switch to ``snat`` mode in this
       situation.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -313,6 +313,19 @@ Annotations:
 
 .. _1.10_upgrade_notes:
 
+1.10.6 Upgrade Notes
+--------------------
+
+* The XDP-based prefilter is enabled for all devices specified by ``--devices``
+  if ``--prefilter-device`` is set.
+
+Deprecated Options
+~~~~~~~~~~~~~~~~~~
+
+* ``prefilter-device`` and ``prefilter-mode``: These options have been
+  deprecated in favor of ``enable-xdp-prefilter`` and ``bpf-lb-acceleration``,
+  and will be removed in 1.12.
+
 1.10 Upgrade Notes
 ------------------
 

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -249,17 +249,13 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 	return ret;
 }
 
-#define redirect			redirect__stub
-#define redirect_peer			redirect
-
 static __always_inline __maybe_unused int
 ctx_redirect(const struct xdp_md *ctx, int ifindex, const __u32 flags)
 {
-	if (unlikely(flags))
-		return -ENOTSUPP;
-	if ((__u32)ifindex != ctx->ingress_ifindex)
-		return -ENOTSUPP;
-	return XDP_TX;
+	if ((__u32)ifindex == ctx->ingress_ifindex)
+		return XDP_TX;
+
+	return redirect(ifindex, flags);
 }
 
 static __always_inline __maybe_unused __u64

--- a/bpf/include/bpf/helpers_xdp.h
+++ b/bpf/include/bpf/helpers_xdp.h
@@ -18,7 +18,7 @@ static int BPF_FUNC(xdp_adjust_head, struct xdp_md *xdp, int delta);
 static int BPF_FUNC(xdp_adjust_tail, struct xdp_md *xdp, int delta);
 
 /* Packet redirection */
-static int BPF_STUB(redirect, int ifindex, __u32 flags);
+static int BPF_FUNC(redirect, int ifindex, __u32 flags);
 
 /* Packet manipulation */
 static int BPF_STUB(xdp_load_bytes, struct xdp_md *xdp, __u32 off,

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -908,7 +908,16 @@ static __always_inline int redirect_ep(struct __ctx_buff *ctx __maybe_unused,
 		 */
 		ctx_change_type(ctx, PACKET_HOST);
 # endif /* ENCAP_IFINDEX */
+#if __ctx_is == __ctx_skb
 		return redirect_peer(ifindex, 0);
+#else
+		/* bpf_redirect_peer() is available only in TC BPF. However,
+		 * this path is not used by bpf_xdp. So to avoid compilation
+		 * errors protect it with #if until we have replaced all usage
+		 * of redirect{,_peer}() with ctx_redirect{,_peer}().
+		 */
+		return -ENOTSUP;
+#endif /* __ctx_is == __ctx_skb */
 	}
 #else
 	return CTX_ACT_OK;

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -274,8 +274,8 @@ func routeCommands() []string {
 	routes, _ := execCommand("ip route show table all | grep -E --only-matching 'table [0-9]+'")
 
 	for _, r := range bytes.Split(bytes.TrimSuffix(routes, []byte("\n")), []byte("\n")) {
-		routeTablev4 := fmt.Sprintf("ip -4 route show %v", r)
-		routeTablev6 := fmt.Sprintf("ip -6 route show %v", r)
+		routeTablev4 := fmt.Sprintf("ip -4 route show %s", r)
+		routeTablev6 := fmt.Sprintf("ip -6 route show %s", r)
 		commands = append(commands, routeTablev4, routeTablev6)
 	}
 	return commands

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -404,7 +404,7 @@ func writeCmdToFile(cmdDir, prompt string, k8sPods []string, enableMarkdown bool
 		// produced might have useful information
 		if bytes.Contains(output, []byte("```")) || !enableMarkdown {
 			// Already contains Markdown, print as is.
-			fmt.Fprint(f, output)
+			fmt.Fprint(f, string(output))
 		} else if enableMarkdown && len(output) > 0 {
 			// Write prompt as header and the output as body, and/or error but delete empty output.
 			fmt.Fprint(f, fmt.Sprintf("# %s\n\n```\n%s\n```\n", prompt, output))

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -777,11 +777,21 @@ func initializeFlags() {
 	flags.Int(option.PProfPort, 6060, "Port that the pprof listens on")
 	option.BindEnv(option.PProfPort)
 
+	flags.Bool(option.EnableXDPPrefilter, false, "Enable XDP prefiltering")
+	option.BindEnv(option.EnableXDPPrefilter)
+
 	flags.String(option.PrefilterDevice, "undefined", "Device facing external network for XDP prefiltering")
 	option.BindEnv(option.PrefilterDevice)
+	flags.MarkHidden(option.PrefilterDevice)
+	flags.MarkDeprecated(option.PrefilterDevice,
+		fmt.Sprintf("This option will be removed in v1.12. Use --%s and --%s instead.",
+			option.EnableXDPPrefilter, option.Devices))
 
 	flags.String(option.PrefilterMode, option.ModePreFilterNative, "Prefilter mode via XDP (\"native\", \"generic\")")
 	option.BindEnv(option.PrefilterMode)
+	flags.MarkHidden(option.PrefilterMode)
+	flags.MarkDeprecated(option.PrefilterMode,
+		fmt.Sprintf("This option will be removed in v1.12. Use --%s instead.", option.LoadBalancerAcceleration))
 
 	flags.Bool(option.PreAllocateMapsName, defaults.PreAllocateMaps, "Enable BPF map pre-allocation")
 	option.BindEnv(option.PreAllocateMapsName)
@@ -1209,6 +1219,7 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if option.Config.DevicePreFilter != "undefined" {
+		option.Config.EnableXDPPrefilter = true
 		found := false
 		for _, dev := range option.Config.Devices {
 			if dev == option.Config.DevicePreFilter {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1209,7 +1209,16 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if option.Config.DevicePreFilter != "undefined" {
-		option.Config.XDPDevice = option.Config.DevicePreFilter
+		found := false
+		for _, dev := range option.Config.Devices {
+			if dev == option.Config.DevicePreFilter {
+				found = true
+				break
+			}
+		}
+		if !found {
+			option.Config.Devices = append(option.Config.Devices, option.Config.DevicePreFilter)
+		}
 		if err := loader.SetXDPMode(option.Config.ModePreFilter); err != nil {
 			scopedLog.WithError(err).Fatal("Cannot set prefilter XDP mode")
 		}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -594,13 +594,6 @@ func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) {
 	}
 
 	if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
-		if option.Config.XDPDevice != "undefined" &&
-			(option.Config.DirectRoutingDevice == "" ||
-				option.Config.XDPDevice != option.Config.DirectRoutingDevice) {
-			log.Fatalf("Cannot set NodePort acceleration device: mismatch between Prefilter device %s and NodePort device %s",
-				option.Config.XDPDevice, option.Config.DirectRoutingDevice)
-		}
-		option.Config.XDPDevice = option.Config.DirectRoutingDevice
 		if err := loader.SetXDPMode(option.Config.NodePortAcceleration); err != nil {
 			log.WithError(err).Fatal("Cannot set NodePort acceleration")
 		}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -234,7 +234,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENCRYPT_NODE"] = "1"
 	}
 
-	if option.Config.DevicePreFilter != "undefined" {
+	if option.Config.EnableXDPPrefilter {
 		cDefinesMap["ENABLE_PREFILTER"] = "1"
 	}
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -111,7 +111,7 @@ func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
 	defer f.Close()
 	fw := bufio.NewWriter(f)
 	fmt.Fprint(fw, "/*\n")
-	fmt.Fprintf(fw, " * XDP device: %s\n", option.Config.DevicePreFilter)
+	fmt.Fprintf(fw, " * XDP devices: %s\n", strings.Join(option.Config.Devices, " "))
 	fmt.Fprintf(fw, " * XDP mode: %s\n", option.Config.ModePreFilter)
 	fmt.Fprint(fw, " */\n\n")
 	preFilter.WriteConfig(fw)
@@ -216,9 +216,12 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 }
 
 func (l *Loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string) error {
-	maybeUnloadObsoleteXDPPrograms(option.Config.XDPDevice, option.Config.XDPMode)
-	if option.Config.XDPDevice != "undefined" {
-		if err := compileAndLoadXDPProg(ctx, option.Config.XDPDevice, option.Config.XDPMode, extraCArgs); err != nil {
+	maybeUnloadObsoleteXDPPrograms(option.Config.Devices, option.Config.XDPMode)
+	if option.Config.XDPMode == option.XDPModeDisabled {
+		return nil
+	}
+	for _, dev := range option.Config.Devices {
+		if err := compileAndLoadXDPProg(ctx, dev, option.Config.XDPMode, extraCArgs); err != nil {
 			return err
 		}
 	}
@@ -266,7 +269,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	if option.Config.DevicePreFilter != "undefined" {
-		scopedLog := log.WithField(logfields.XDPDevice, option.Config.XDPDevice)
+		scopedLog := log.WithField(logfields.Devices, option.Config.Devices)
 
 		preFilter, err := prefilter.NewPreFilter()
 		if err != nil {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -268,7 +268,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return err
 	}
 
-	if option.Config.DevicePreFilter != "undefined" {
+	if option.Config.EnableXDPPrefilter {
 		scopedLog := log.WithField(logfields.Devices, option.Config.Devices)
 
 		preFilter, err := prefilter.NewPreFilter()

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -221,7 +221,7 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 		maps = append(maps, ipmasq.MapName)
 	}
 
-	if option.Config.DevicePreFilter == "undefined" {
+	if !option.Config.EnableXDPPrefilter {
 		maps = append(maps, []string{
 			cidrmap.MapName + "v4_dyn",
 			cidrmap.MapName + "v4_fix",

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -294,9 +294,6 @@ const (
 	// BPFMapValue is a value from a BPF map
 	BPFMapValue = "bpfMapValue"
 
-	// XDPDevice is the device name
-	XDPDevice = "xdpDevice"
-
 	// Device is the device name
 	Device = "device"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1195,7 +1195,6 @@ type DaemonConfig struct {
 	LBDevInheritIPAddr  string     // Device which IP addr used by bpf_host devices
 	DevicePreFilter     string     // Prefilter device
 	ModePreFilter       string     // Prefilter mode
-	XDPDevice           string     // XDP device
 	XDPMode             string     // XDP mode, values: { xdpdrv | xdpgeneric | none }
 	HostV4Addr          net.IP     // Host v4 address of the snooping device
 	HostV6Addr          net.IP     // Host v6 address of the snooping device
@@ -2636,7 +2635,6 @@ func (c *DaemonConfig) Populate() {
 	}
 	c.IPv6PodSubnets = subnets
 
-	c.XDPDevice = "undefined"
 	c.XDPMode = XDPModeLinkNone
 
 	err = c.populateNodePortRange()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -410,6 +410,9 @@ const (
 	// PProfPort is the port that the pprof listens on
 	PProfPort = "pprof-port"
 
+	// EnableXDPPrefilter enables XDP-based prefiltering
+	EnableXDPPrefilter = "enable-xdp-prefilter"
+
 	// PrefilterDevice is the device facing external network for XDP prefiltering
 	PrefilterDevice = "prefilter-device"
 
@@ -1193,6 +1196,7 @@ type DaemonConfig struct {
 	Devices             []string   // bpf_host device
 	DirectRoutingDevice string     // Direct routing device (used only by NodePort BPF)
 	LBDevInheritIPAddr  string     // Device which IP addr used by bpf_host devices
+	EnableXDPPrefilter  bool       // Enable XDP-based prefiltering
 	DevicePreFilter     string     // Prefilter device
 	ModePreFilter       string     // Prefilter mode
 	XDPMode             string     // XDP mode, values: { xdpdrv | xdpgeneric | none }
@@ -2435,6 +2439,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableWireguard = viper.GetBool(EnableWireguard)
 	c.EnableWellKnownIdentities = viper.GetBool(EnableWellKnownIdentities)
 	c.EndpointInterfaceNamePrefix = viper.GetString(EndpointInterfaceNamePrefix)
+	c.EnableXDPPrefilter = viper.GetBool(EnableXDPPrefilter)
 	c.DevicePreFilter = viper.GetString(PrefilterDevice)
 	c.DisableCiliumEndpointCRD = viper.GetBool(DisableCiliumEndpointCRDName)
 	c.EgressMasqueradeInterfaces = viper.GetString(EgressMasqueradeInterfaces)

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -31,6 +31,19 @@ clang -O2 -Wall -target bpf -c test_tc_tunnel.c -o test_tc_tunnel.o
 # The LB cilium does not connect to the kube-apiserver. For now we use Kind
 # just to create Docker-in-Docker containers.
 kind create cluster --config kind-config.yaml
+
+# Create additional veth pair which is going to be used to test XDP_REDIRECT.
+ip l a l4lb-veth0 type veth peer l4lb-veth1
+SECOND_LB_NODE_IP=3.3.3.2
+ip a a "3.3.3.1/24" dev l4lb-veth0
+CONTROL_PLANE_PID=$(docker inspect kind-control-plane -f '{{ .State.Pid }}')
+ip l s dev l4lb-veth1 netns $CONTROL_PLANE_PID
+ip l s dev l4lb-veth0 up
+nsenter -t $CONTROL_PLANE_PID -n /bin/sh -c "\
+    ip a a "${SECOND_LB_NODE_IP}/24" dev l4lb-veth1 && \
+    ip l s dev l4lb-veth1 up"
+
+# Install Cilium as standalone L4LB
 helm install cilium ../../install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
@@ -44,7 +57,8 @@ helm install cilium ../../install/kubernetes/cilium \
     --set loadBalancer.mode=dsr \
     --set loadBalancer.acceleration=native \
     --set loadBalancer.dsrDispatch=ipip \
-    --set devices=eth0 \
+    --set devices='{eth0,l4lb-veth1}' \
+    --set nodePort.directRoutingDevice=eth0 \
     --set ipv6.enabled=false \
     --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key="kubernetes.io/hostname" \
     --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In \
@@ -53,11 +67,13 @@ helm install cilium ../../install/kubernetes/cilium \
 IFIDX=$(docker exec -i kind-control-plane \
     /bin/sh -c 'echo $(( $(ip -o l show eth0 | awk "{print $1}" | cut -d: -f1) ))')
 LB_VETH_HOST=$(ip -o l | grep "if$IFIDX" | awk '{print $2}' | cut -d@ -f1)
-ip l set dev $LB_VETH_HOST  xdp obj bpf_xdp_veth_host.o
+ip l set dev $LB_VETH_HOST xdp obj bpf_xdp_veth_host.o
+ip l set dev l4lb-veth0 xdp obj bpf_xdp_veth_host.o
 
 # Disable TX and RX csum offloading, as veth does not support it. Otherwise,
 # the forwarded packets by the LB to the worker node will have invalid csums.
 ethtool -K $LB_VETH_HOST rx off tx off
+ethtool -K l4lb-veth0 rx off tx off
 
 docker exec kind-worker /bin/sh -c 'apt-get update && apt-get install -y nginx && systemctl start nginx'
 WORKER_IP=$(docker exec kind-worker ip -o -4 a s eth0 | awk '{print $4}' | cut -d/ -f1)
@@ -81,6 +97,16 @@ kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- \
 
 LB_NODE_IP=$(docker exec kind-control-plane ip -o -4 a s eth0 | awk '{print $4}' | cut -d/ -f1)
 ip r a "${LB_VIP}/32" via "$LB_NODE_IP"
+
+# Issue 10 requests to LB
+for i in $(seq 1 10); do
+    curl -o /dev/null "${LB_VIP}:80"
+done
+
+# Now steer the traffic to LB_VIP via the secondary device so that XDP_REDIRECT
+# can be tested on the L4LB node
+ip r d "${LB_VIP}/32"
+ip r a "${LB_VIP}/32" via "$SECOND_LB_NODE_IP"
 
 # Issue 10 requests to LB
 for i in $(seq 1 10); do


### PR DESCRIPTION
 * [x] #17655 (@brb)
   (Some minor conflicts occurred)
 * [ ] #17958 (@austince)
 * [ ] #18017 (@adamzhoul)
 * [x] ~#18018 (@brb)
   (Skipping `test/provision/manifest/1.22/{,eks/}coredns_deployment.yaml`, missing on v1.10)~
   Removed because of #18086.
 * [x] #18059 (@tklauser)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17655 17958 18017 18059; do contrib/backporting/set-labels.py $pr done 1.10; done
```