### PR TITLE
dependabot: disable cloud provider SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
         # k8s dependencies will be updated manually along with tests
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
+        # cloud provider SDKs are updated too frequently, update them manually
+      - dependency-name: "github.com/aliyun/alibaba-cloud-sdk-go"
+      - dependency-name: "github.com/aws/aws-sdk-go-v2"
+      - dependency-name: "github.com/Azure/*"
     labels:
     - kind/enhancement
     - release-note/misc


### PR DESCRIPTION
The cloud provider SDKs are updated too frequently, often times without
any code changes affecting Cilium. However, these PRs still require
developer's time reviewing/approving such PRs and increase CI cost.

Thus, exclude these dependencies from automatic updates and instead
update them manually once every month.