### PR TITLE
mlh: update Jenkins jobs following 1.23 support

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -26,9 +26,10 @@ flake-tracker:
     - cilium-v1.11-k8s-1.18-kernel-4.9
     - cilium-v1.11-k8s-1.19-kernel-4.9
     - cilium-v1.11-k8s-1.20-kernel-4.9
-    - cilium-v1.11-k8s-1.20-kernel-5.4
-    - cilium-v1.11-k8s-1.21-kernel-4.19
-    - cilium-v1.11-k8s-1.22-kernel-4.9
+    - cilium-v1.11-k8s-1.21-kernel-4.9
+    - cilium-v1.11-k8s-1.21-kernel-5.4
+    - cilium-v1.11-k8s-1.22-kernel-4.19
+    - cilium-v1.11-k8s-1.23-kernel-4.9
     - cilium-v1.11-k8s-upstream
     - cilium-v1.11-runtime-kernel-net-next
     pr-jobs:
@@ -41,41 +42,54 @@ flake-tracker:
         - cilium-v1.11-k8s-1.18-kernel-4.9
         - cilium-v1.11-k8s-1.19-kernel-4.9
         - cilium-v1.11-k8s-1.20-kernel-4.9
-        - cilium-v1.11-k8s-1.22-kernel-4.9
+        - cilium-v1.11-k8s-1.21-kernel-4.9
+        - cilium-v1.11-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.18-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-v1.11-k8s-1.17-kernel-4.9
         - cilium-v1.11-k8s-1.18-kernel-4.9
         - cilium-v1.11-k8s-1.19-kernel-4.9
         - cilium-v1.11-k8s-1.20-kernel-4.9
-        - cilium-v1.11-k8s-1.22-kernel-4.9
+        - cilium-v1.11-k8s-1.21-kernel-4.9
+        - cilium-v1.11-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.19-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-v1.11-k8s-1.17-kernel-4.9
         - cilium-v1.11-k8s-1.18-kernel-4.9
         - cilium-v1.11-k8s-1.19-kernel-4.9
         - cilium-v1.11-k8s-1.20-kernel-4.9
-        - cilium-v1.11-k8s-1.22-kernel-4.9
+        - cilium-v1.11-k8s-1.21-kernel-4.9
+        - cilium-v1.11-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.20-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-v1.11-k8s-1.17-kernel-4.9
         - cilium-v1.11-k8s-1.18-kernel-4.9
         - cilium-v1.11-k8s-1.19-kernel-4.9
         - cilium-v1.11-k8s-1.20-kernel-4.9
-        - cilium-v1.11-k8s-1.22-kernel-4.9
-      Cilium-PR-K8s-1.20-kernel-5.4:
-        correlate-with-stable-jobs:
-        - cilium-v1.11-k8s-1.20-kernel-5.4
-      Cilium-PR-K8s-1.21-kernel-4.19:
-        correlate-with-stable-jobs:
-        - cilium-v1.11-k8s-1.21-kernel-4.19
-      Cilium-PR-K8s-1.22-kernel-4.9:
+        - cilium-v1.11-k8s-1.21-kernel-4.9
+        - cilium-v1.11-k8s-1.23-kernel-4.9
+      Cilium-PR-K8s-1.21-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-v1.11-k8s-1.17-kernel-4.9
         - cilium-v1.11-k8s-1.18-kernel-4.9
         - cilium-v1.11-k8s-1.19-kernel-4.9
         - cilium-v1.11-k8s-1.20-kernel-4.9
-        - cilium-v1.11-k8s-1.22-kernel-4.9
+        - cilium-v1.11-k8s-1.21-kernel-4.9
+        - cilium-v1.11-k8s-1.23-kernel-4.9
+      Cilium-PR-K8s-1.21-kernel-5.4:
+        correlate-with-stable-jobs:
+        - cilium-v1.11-k8s-1.21-kernel-5.4
+      Cilium-PR-K8s-1.22-kernel-4.19:
+        correlate-with-stable-jobs:
+        - cilium-v1.11-k8s-1.22-kernel-4.19
+      Cilium-PR-K8s-1.23-kernel-4.9:
+        correlate-with-stable-jobs:
+        - cilium-v1.11-k8s-1.17-kernel-4.9
+        - cilium-v1.11-k8s-1.18-kernel-4.9
+        - cilium-v1.11-k8s-1.19-kernel-4.9
+        - cilium-v1.11-k8s-1.20-kernel-4.9
+        - cilium-v1.11-k8s-1.21-kernel-4.9
+        - cilium-v1.11-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-GKE:
         correlate-with-stable-jobs:
         - cilium-v1.11-gke


### PR DESCRIPTION
Following merge of #18027, we now support K8s 1.23 on branch 1.11 and have rotated the Jenkins test jobs as follow:

- Changed: Kernel 4.9 testing on K8s 1.23 (instead of 1.22)
- Changed: Kernel 4.19 testing on K8s 1.22 (instead of 1.21)
- Changed: Kernel 5.4 testing on K8s 1.21 (instead of 1.20)
- Added: Kernel 4.9 testing on K8s 1.21

See the Table of Truth™️ for up to date status on CI testing: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0/edit#gid=0