### PR TITLE
v1.9 backports 2021-11-30

### DIFF
--- a/Documentation/gettingstarted/kind-preload.rst
+++ b/Documentation/gettingstarted/kind-preload.rst
@@ -2,5 +2,5 @@ Preload the ``cilium`` image into each worker node in the kind cluster:
 
 .. parsed-literal::
 
-  docker pull cilium/cilium:|IMAGE_TAG|
-  kind load docker-image cilium/cilium:|IMAGE_TAG|
+  docker pull quay.io/cilium/cilium:|IMAGE_TAG|
+  kind load docker-image quay.io/cilium/cilium:|IMAGE_TAG|

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -275,8 +275,8 @@ func routeCommands() []string {
 	routes, _ := execCommand("ip route show table all | grep -E --only-matching 'table [0-9]+'")
 
 	for _, r := range bytes.Split(bytes.TrimSuffix(routes, []byte("\n")), []byte("\n")) {
-		routeTablev4 := fmt.Sprintf("ip -4 route show %v", r)
-		routeTablev6 := fmt.Sprintf("ip -6 route show %v", r)
+		routeTablev4 := fmt.Sprintf("ip -4 route show %s", r)
+		routeTablev6 := fmt.Sprintf("ip -6 route show %s", r)
 		commands = append(commands, routeTablev4, routeTablev6)
 	}
 	return commands

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -405,7 +405,7 @@ func writeCmdToFile(cmdDir, prompt string, k8sPods []string, enableMarkdown bool
 		// produced might have useful information
 		if bytes.Contains(output, []byte("```")) || !enableMarkdown {
 			// Already contains Markdown, print as is.
-			fmt.Fprint(f, output)
+			fmt.Fprint(f, string(output))
 		} else if enableMarkdown && len(output) > 0 {
 			// Write prompt as header and the output as body, and/or error but delete empty output.
 			fmt.Fprint(f, fmt.Sprintf("# %s\n\n```\n%s\n```\n", prompt, output))


### PR DESCRIPTION
 * [ ] #18017 (@adamzhoul)
 * [x] ~#18018 (@brb)
   (Skipping `test/provision/manifest/1.2[0-2]{,/eks}/coredns_deployment.yaml`, missing on v1.9)~
   Removed because of #18086.
 * [x] #18059 (@tklauser)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18017 18059; do contrib/backporting/set-labels.py $pr done 1.9; done
```