### PR TITLE
aws: Disable flaky test

### DIFF
--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -562,6 +562,8 @@ type nodeState struct {
 // - PreAllocate 1
 // - FirstInterfaceIndex 1
 func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
+	c.Skip("This test is flaky, see https://github.com/cilium/cilium/issues/11560")
+
 	const (
 		numNodes    = 100
 		minAllocate = 10


### PR DESCRIPTION
This test has been flaky for well over a year now, see issue #11560.
Track re-enablement in https://github.com/cilium/cilium/projects/173
