### PR TITLE
mlh: switch runtime from kernel 4.9 to net-next

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -29,7 +29,7 @@ flake-tracker:
     - cilium-v1.10-k8s-1.20-kernel-4.19
     - cilium-v1.10-k8s-1.21-kernel-4.9
     - cilium-v1.10-k8s-upstream
-    - cilium-v1.10-runtime-kernel-4.9
+    - cilium-v1.10-runtime-kernel-net-next
     pr-jobs:
       Cilium-PR-K8s-1.16-net-next:
         correlate-with-stable-jobs:
@@ -70,9 +70,9 @@ flake-tracker:
       Cilium-PR-K8s-Upstream:
         correlate-with-stable-jobs:
         - cilium-v1.10-k8s-upstream
-      Cilium-PR-Runtime-4.9:
+      Cilium-PR-Runtime-net-next:
         correlate-with-stable-jobs:
-        - cilium-v1.10-runtime-kernel-4.9
+        - cilium-v1.10-runtime-kernel-net-next
   max-flakes-per-test: 5
   flake-similarity: 0.85
   ignore-failures:


### PR DESCRIPTION
This backports #17186 to `v1.10`.

Rationale: the original PR was required on `master` for #17813. #18082 is backporting #17813 to `v1.10`, thus it also requires similar changes.

As we previously did on `master`, we switch the runtime tests to run on net-next instead of 4.9 due to new unit tests requirements.