### PR TITLE
dependabot: disable all AWS package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       - dependency-name: "sigs.k8s.io/*"
         # cloud provider SDKs are updated too frequently, update them manually
       - dependency-name: "github.com/aliyun/alibaba-cloud-sdk-go"
-      - dependency-name: "github.com/aws/aws-sdk-go-v2"
+      - dependency-name: "github.com/aws/*"
       - dependency-name: "github.com/Azure/*"
     labels:
     - kind/enhancement


### PR DESCRIPTION
This will prevent dependabot from updating subpackages of
github.com/aws/aws-sdk-go-v2 as well as github.com/aws/smithy-go

Fixes: 4762a4abae5a ("dependabot: disable cloud provider SDK updates")
