### PR TITLE
test: Extend coredns clusterrole with additional resource permissions

### DIFF
--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.17/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.18/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.19/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Commit didn't add permissions for `endpointslices` resource to the
coredns `cluterrole` on k8s < 1.20. As a result, core-dns deployments
failed on the these versions with the error -

`2021-11-30T14:09:43.349414540Z E1130 14:09:43.349292 1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:kube-system:coredns" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope`

Note : Hold off onto enabling the feature gate on older versions. - https://github.com/cilium/cilium/blob/7ed8a42ffe92887583fb901a753f6c327e623f05/test/provision/k8s_install.sh#L302-L302.

Fixes: 398d55cd
Fixes: https://github.com/cilium/cilium/issues/18086

Signed-off-by: Aditi Ghag <aditi@cilium.io>