### PR TITLE
v1.11 backports 2021-12-02

### DIFF
--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -562,6 +562,8 @@ type nodeState struct {
 // - PreAllocate 1
 // - FirstInterfaceIndex 1
 func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
+	c.Skip("This test is flaky, see https://github.com/cilium/cilium/issues/11560")
+
 	const (
 		numNodes    = 100
 		minAllocate = 10

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -355,7 +355,7 @@ func CreateKubectl(vmName string, log *logrus.Entry) (k *Kubectl) {
 		}
 		k.setBasePath()
 		if err := k.ensureKubectlVersion(); err != nil {
-			ginkgoext.Failf("failed to ensure kubectl version")
+			ginkgoext.Failf("failed to ensure kubectl version: %s", err)
 		}
 	}
 
@@ -4476,9 +4476,17 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 		return err
 	}
 	path := path.Join(GetKubectlPath(), "kubectl")
+	rcVersion := fmt.Sprintf("v%s.0-rc.0", GetCurrentK8SEnv())
+	switch GetCurrentK8SEnv() {
+	// These versions never released a ".0". Only since 1.19 Kubernetes started
+	// to release RC starting from '0'. We can then use the '.0' release for
+	// these versions.
+	case "1.16", "1.17", "1.18":
+		rcVersion = fmt.Sprintf("v%s.0", GetCurrentK8SEnv())
+	}
 	res = kub.Exec(
-		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/v%s.0/bin/linux/amd64/kubectl && chmod +x %s",
-			path, GetCurrentK8SEnv(), path))
+		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
+			path, rcVersion, path))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("failed to download kubectl")
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -355,7 +355,7 @@ func CreateKubectl(vmName string, log *logrus.Entry) (k *Kubectl) {
 		}
 		k.setBasePath()
 		if err := k.ensureKubectlVersion(); err != nil {
-			ginkgoext.Failf("failed to ensure kubectl version: %s", err)
+			ginkgoext.Failf("failed to ensure kubectl version")
 		}
 	}
 
@@ -4449,9 +4449,8 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 	//check current kubectl version
 	type Version struct {
 		ClientVersion struct {
-			Major      string `json:"major"`
-			Minor      string `json:"minor"`
-			GitVersion string `json:"gitVersion"`
+			Major string `json:"major"`
+			Minor string `json:"minor"`
 		} `json:"clientVersion"`
 	}
 	res := kub.ExecShort(fmt.Sprintf("%s version --client -o json", KubectlCmd))
@@ -4478,8 +4477,8 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 	}
 	path := path.Join(GetKubectlPath(), "kubectl")
 	res = kub.Exec(
-		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
-			path, v.ClientVersion.GitVersion, path))
+		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/v%s.0/bin/linux/amd64/kubectl && chmod +x %s",
+			path, GetCurrentK8SEnv(), path))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("failed to download kubectl")
 	}

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1409,9 +1409,9 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 				SkipItIf(func() bool {
 					// Quarantine when running with the third node as it's
-					// flaky. See #12511.
-					return helpers.GetCurrentIntegration() != "" ||
-						(helpers.SkipQuarantined() && helpers.ExistNodeWithoutCilium())
+					// flaky. See GH-12511.
+					// It's also flaky for IPv6 traffic, see GH-18072
+					return helpers.SkipQuarantined()
 				}, "Tests with secondary NodePort device", func() {
 					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 						"tunnel":               "disabled",

--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -123,7 +123,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.16/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/eks/coredns_deployment.yaml
@@ -118,7 +118,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.17/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/eks/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.18/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/eks/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.19/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/coredns_deployment.yaml
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.19/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.19/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/eks/coredns_deployment.yaml
@@ -138,7 +138,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.20/coredns_deployment.yaml
+++ b/test/provision/manifest/1.20/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -138,7 +145,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.20/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.20/eks/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -138,7 +145,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.21/coredns_deployment.yaml
+++ b/test/provision/manifest/1.21/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -140,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.21/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.21/eks/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -140,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.22/coredns_deployment.yaml
+++ b/test/provision/manifest/1.22/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -140,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.22/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.22/eks/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -140,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/coredns_deployment.yaml
+++ b/test/provision/manifest/coredns_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: docker.io/coredns/coredns:1.0.6
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -121,6 +121,13 @@ rules:
   - services
   - pods
   - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - list
   - watch


### PR DESCRIPTION
 * #18018 -- test/contrib: Bump CoreDNS version to 1.8.3 (@brb)
 * #18087 -- Fix kubectl CI flakiness (@aanm)
 * #18104 -- test: Extend coredns clusterrole with additional resource permissions (@aditighag)
 * #18091 -- test: Quarantine Secondary nodeport device tests (@joestringer)
 * #18092 -- aws: Disable flaky test (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18018 18087 18104 18091 18092; do contrib/backporting/set-labels.py $pr done 1.11; done
```
or with
```
$ make add-label branch=v1.11 issues=18018,18087,18104,18091,18092
```