### PR TITLE
docs: fix eksctl ClusterConfig to allow copy

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -164,8 +164,8 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
            - name: ng-1
              desiredCapacity: 2
              privateNetworking: true
-             # taint nodes so that application pods are
-             # not scheduled until Cilium is deployed.
+             ## taint nodes so that application pods are
+             ## not scheduled until Cilium is deployed.
              taints:
               - key: "node.cilium.io/agent-not-ready"
                 value: "true"

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -658,8 +658,8 @@ As an instance example, ``m5n.xlarge`` is used in the config ``nodegroup-config.
       desiredCapacity: 2
       ssh:
         allow: true
-      # taint nodes so that application pods are
-      # not scheduled until Cilium is deployed.
+      ## taint nodes so that application pods are
+      ## not scheduled until Cilium is deployed.
       taints:
         - key: "node.cilium.io/agent-not-ready"
           value: "true"

--- a/Documentation/gettingstarted/requirements-eks.rst
+++ b/Documentation/gettingstarted/requirements-eks.rst
@@ -37,8 +37,8 @@ install ``eksctl`` and prepare your account.
    - name: ng-1
      desiredCapacity: 2
      privateNetworking: true
-     # taint nodes so that application pods are
-     # not scheduled until Cilium is deployed.
+     ## taint nodes so that application pods are
+     ## not scheduled until Cilium is deployed.
      taints:
       - key: "node.cilium.io/agent-not-ready"
         value: "true"


### PR DESCRIPTION
This commit fixes the eksctl ClusterConfig to allow for copy. It is
merely a workaround for now until a proper fix is available.

Fixes: 706c9009dc39 ("docs: re-write docs to create clusters with tainted nodes")
Signed-off-by: André Martins <andre@cilium.io>