### PR TITLE
docs: prevent search engines from indexing old branches

### DIFF
--- a/Documentation/_html/robots.txt
+++ b/Documentation/_html/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+
+Disallow: /
+
+Allow: /en/stable
+
+Allow: /en/latest
+
+Sitemap: https://docs.cilium.io/en/latest/sitemap-index.xml

--- a/Documentation/_html/sitemap-index.html
+++ b/Documentation/_html/sitemap-index.html
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+    <url>
+        <loc>https://docs.cilium.io/en/stable/</loc>
+        <changefreq>daily</changefreq>
+        <priority>1</priority>
+    </url>
+    <url>
+        <loc>https://docs.cilium.io/en/latest/</loc>
+        <changefreq>daily</changefreq>
+        <priority>0.9</priority>
+    </url>
+</urlset>

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -147,6 +147,9 @@ language = None
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# Add static html files
+html_extra_path = ["_html"]
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 


### PR DESCRIPTION
To avoid users find on old results on search engines, this commit adds
the required configuration for that to happen.

Based on https://stackoverflow.com/questions/63542354/readthedocs-robots-txt-and-sitemap-xml

Signed-off-by: André Martins <andre@cilium.io>