### PR TITLE
service: Always allocate higher ID for svc/backend

### DIFF
--- a/pkg/service/id_local.go
+++ b/pkg/service/id_local.go
@@ -72,6 +72,12 @@ func (alloc *IDAllocator) acquireLocalID(svc loadbalancer.L3n4Addr, desiredID ui
 	if desiredID != 0 {
 		foundSVC, ok := alloc.entitiesID[desiredID]
 		if !ok {
+			if desiredID >= alloc.nextID {
+				// We don't set nextID to desiredID+1 here, as we don't want to
+				// duplicate the logic which deals with the rollover. Next
+				// invocation of acquireLocalID(..., 0) will fix the nextID.
+				alloc.nextID = desiredID
+			}
 			return alloc.addID(svc, desiredID), nil
 		}
 		return nil, fmt.Errorf("Service ID %d is already registered to %q",

--- a/pkg/service/id_test.go
+++ b/pkg/service/id_test.go
@@ -27,10 +27,12 @@ var _ = Suite(&IDAllocTestSuite{})
 
 func (e *IDAllocTestSuite) SetUpTest(c *C) {
 	serviceIDAlloc.resetLocalID()
+	backendIDAlloc.resetLocalID()
 }
 
 func (e *IDAllocTestSuite) TearDownTest(c *C) {
 	serviceIDAlloc.resetLocalID()
+	backendIDAlloc.resetLocalID()
 }
 
 var (
@@ -48,6 +50,14 @@ var (
 	}
 	l3n4Addr4 = loadbalancer.L3n4Addr{
 		IP:     net.IPv6loopback,
+		L4Addr: loadbalancer.L4Addr{Port: 2, Protocol: "UDP"},
+	}
+	l3n4Addr5 = loadbalancer.L3n4Addr{
+		IP:     net.ParseIP("::2"),
+		L4Addr: loadbalancer.L4Addr{Port: 2, Protocol: "UDP"},
+	}
+	l3n4Addr6 = loadbalancer.L3n4Addr{
+		IP:     net.ParseIP("::3"),
 		L4Addr: loadbalancer.L4Addr{Port: 2, Protocol: "UDP"},
 	}
 	wantL3n4AddrID = &loadbalancer.L3n4AddrID{
@@ -178,6 +188,14 @@ func (s *IDAllocTestSuite) TestBackendID(c *C) {
 	existingID1, err := LookupBackendID(l3n4Addr1)
 	c.Assert(err, Equals, nil)
 	c.Assert(existingID1, Equals, id1)
+
+	// Check that the backend ID restoration advances the nextID
+	err = RestoreBackendID(l3n4Addr5, firstBackendID+10)
+	c.Assert(err, Equals, nil)
+	id3, err := AcquireBackendID(l3n4Addr6)
+	c.Assert(err, Equals, nil)
+	c.Assert(id3, Equals, firstBackendID+11)
+
 }
 
 func (s *IDAllocTestSuite) BenchmarkAllocation(c *C) {


### PR DESCRIPTION
Previously, it was possible that a backend or a service would get
allocated ID, which would be ID_backend_A < ID < ID_backend_B. This
could have happened after cilium-agent restart, as the nextID was not
advanced upon the restoration of IDs.

This could have led to situations in which the per-packet LB could
selected a backend which did not belong to a requested service when the
following was fulfilled in the chronological order:

1. Previously the same client made the request to the service and the
   backend with ID_x was chosen.
2. The service endpoint (backend) with ID_x was removed.
3. cilium-agent was restarted.
4. A new service backend which does not belong to the initial service
   was created and got the ID_x allocated.
5. The CT_SERVICE entry for the old connection was not removed by the CT
   GC.
6. The same client made a new connection to the same service from the
   same src port.

The above led the lb{4,6}_local() to select the wrong backend, as it
found the CT_SERVICE entry with the backend ID_x.

The advancement of the nextID upon the restoration only partly mitigates
the issue. The real fix would be to introduce a match map which key
would be (svc_id, backend_id), and it would be populated by the agent.
The lb{4,6}_local() routines would consult the map to detect whether the
backend belongs to the service.