### PR TITLE
helm: Fix operator cloud image digests

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
@@ -13,11 +13,11 @@
 {{- define "cilium.operator.imageDigestName" -}}
 {{- $imageDigest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.genericDigest) "" -}}
 {{- if .Values.eni.enabled -}}
-  {{- $imageDigest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.awsDigest) "" -}}
+  {{- $imageDigest = (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.awsDigest) "" -}}
 {{- else if .Values.azure.enabled -}}
-  {{- $imageDigest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.azureDigest) "" -}}
+  {{- $imageDigest = (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.azureDigest) "" -}}
 {{- else if .Values.alibabacloud.enabled -}}
-  {{- $imageDigest := (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.alibabacloudDigest) "" -}}
+  {{- $imageDigest = (.Values.operator.image.useDigest | default false) | ternary (printf "@%s" .Values.operator.image.alibabacloudDigest) "" -}}
 {{- end -}}
 {{- $imageDigest -}}
 {{- end -}}


### PR DESCRIPTION
Tested by applying this patch to v1.11 branch and validating that the
digest matches the correct cloud image vs. the v1.11.0-rc3 images on
Quay.io:

```
   $ helm template cilium ./install/kubernetes/cilium/ --version 1.10.0-rc3 \
          --namespace kube-system --set eni.enabled=true --set ipam.mode=eni \
          --set egressMasqueradeInterfaces=eth0 --set tunnel=disabled \
     | grep operator.*sha
          image: quay.io/cilium/operator-aws:v1.11.0-rc3@sha256:5ea0ccb6a866a5fb13f4bdfcf1ed8bce12a1355cb10a0914ea52af25f3a8f931
```

Fixes: 4638de2 ("cleanup the cilium helm chart:")
Fixes: 1ccb8457d53c ("install/kubernetes: fix helm generation for operator image digest")