### PR TITLE
test: fix ensureKubectlVersion function

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4467,7 +4467,7 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 	}
 
 	versionstring := fmt.Sprintf("%s.%s", v.ClientVersion.Major, v.ClientVersion.Minor)
-	if versionstring == GetCurrentK8SEnv() {
+	if strings.HasPrefix(GetCurrentK8SEnv(), versionstring) {
 		//version available on host is matching current env
 		return nil
 	}


### PR DESCRIPTION
In RC the minor version returned by `kubectl version --client -o json`
might contain a "+" as seen in [1]. To workaround this issue we can
compare if both versions are the same by simply checking if the
Kubernetes version being tested is a prefix of the Kubernetes version
returned by `kubectl`.

[1]
```
{
  "clientVersion": {
    "major": "1",
    "minor": "20+",
    "gitVersion": "v1.20.0-rc.0",
    "gitCommit": "3321f00ed14e07f774b84d3198ede545c1dee697",
    "gitTreeState": "clean",
    "buildDate": "2020-12-01T10:39:07Z",
    "goVersion": "go1.15.5",
    "compiler": "gc",
    "platform": "linux/amd64"
  }
}
```

Fixes: 75fbebbfbb5d ("test/helpers: use rc.0 as the default version of kubectl")
Signed-off-by: André Martins <andre@cilium.io>