### PR TITLE
Remove Kubernetes leases discovery

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -131,9 +131,6 @@ func initEnv() {
 	}
 
 	option.LogRegisteredOptions(log)
-	// Enable fallback to direct API probing to check for support of Leases in
-	// case Discovery API fails.
-	option.Config.EnableK8sLeasesFallbackDiscovery()
 }
 
 func initK8s(k8sInitDone chan struct{}) {
@@ -273,15 +270,6 @@ func runOperator() {
 		}
 	} else {
 		log.Info("Skipping creation of CRDs")
-	}
-
-	// We only support Operator in HA mode for Kubernetes Versions having support for
-	// LeasesResourceLock.
-	// See docs on capabilities.LeasesResourceLock for more context.
-	if !capabilities.LeasesResourceLock {
-		log.Info("Support for coordination.k8s.io/v1 not present, fallback to non HA mode")
-		onOperatorStartLeading(leaderElectionCtx)
-		return
 	}
 
 	// Get hostname for identity name of the lease lock holder.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -410,15 +410,10 @@ const (
 	// for local traffic
 	EnableIdentityMark = true
 
-	// K8sEnableLeasesFallbackDiscovery enables k8s to fallback to API probing to check
-	// for the support of Leases in Kubernetes when there is an error in discovering
-	// API groups using Discovery API.
-	K8sEnableLeasesFallbackDiscovery = false
-
 	// KubeProxyReplacementHealthzBindAddr is the default kubeproxyReplacement healthz server bind addr
 	KubeProxyReplacementHealthzBindAddr = ""
 
-	// InstallNoConntrackRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
+	// InstallNoConntrackIptRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules = false
 
 	// WireguardSubnetV4 is a default wireguard tunnel subnet

--- a/pkg/k8s/config/config.go
+++ b/pkg/k8s/config/config.go
@@ -10,8 +10,6 @@ import (
 // Configuration is the configuration interface for the k8s package
 type Configuration interface {
 	K8sAPIDiscoveryEnabled() bool
-
-	K8sLeasesFallbackDiscoveryEnabled() bool
 }
 
 // DefaultConfiguration is an implementation of Configuration with default
@@ -28,11 +26,4 @@ func NewDefaultConfiguration() Configuration {
 // resources is enabled
 func (d *DefaultConfiguration) K8sAPIDiscoveryEnabled() bool {
 	return defaults.K8sEnableAPIDiscovery
-}
-
-// K8sLeasesFallbackDiscoveryEnabled returns true if we should fallback to direct API
-// probing when checking for support of Leases in case Discovery API fails to discover
-// required groups.
-func (d *DefaultConfiguration) K8sLeasesFallbackDiscoveryEnabled() bool {
-	return defaults.K8sEnableLeasesFallbackDiscovery
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1964,14 +1964,6 @@ type DaemonConfig struct {
 
 	K8sEnableAPIDiscovery bool
 
-	// k8sEnableLeasesFallbackDiscovery enables k8s to fallback to API probing to check
-	// for the support of Leases in Kubernetes when there is an error in discovering
-	// API groups using Discovery API.
-	// We require to check for Leases capabilities in operator only, which uses Leases for leader
-	// election purposes in HA mode.
-	// This is only enabled for cilium-operator
-	K8sEnableLeasesFallbackDiscovery bool
-
 	// LBMapEntries is the maximum number of entries allowed in BPF lbmap.
 	LBMapEntries int
 
@@ -2085,8 +2077,7 @@ var (
 		AllocatorListTimeout:         defaults.AllocatorListTimeout,
 		EnableICMPRules:              defaults.EnableICMPRules,
 
-		K8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
-		APIRateLimit:                     make(map[string]string),
+		APIRateLimit: make(map[string]string),
 
 		ExternalClusterIP: defaults.ExternalClusterIP,
 	}
@@ -2233,19 +2224,6 @@ func (c *DaemonConfig) CiliumNamespaceName() string {
 // resources is enabled
 func (c *DaemonConfig) K8sAPIDiscoveryEnabled() bool {
 	return c.K8sEnableAPIDiscovery
-}
-
-// K8sLeasesFallbackDiscoveryEnabled returns true if we should fallback to direct API
-// probing when checking for support of Leases in case Discovery API fails to discover
-// required groups.
-func (c *DaemonConfig) K8sLeasesFallbackDiscoveryEnabled() bool {
-	return c.K8sEnableAPIDiscovery
-}
-
-// EnableK8sLeasesFallbackDiscovery enables using direct API probing as a fallback to check
-// for the support of Leases when discovering API groups is not possible.
-func (c *DaemonConfig) EnableK8sLeasesFallbackDiscovery() {
-	c.K8sEnableAPIDiscovery = true
 }
 
 func (c *DaemonConfig) validateIPv6ClusterAllocCIDR() error {


### PR DESCRIPTION
With Cilium's minimum supported Kubernetes version being 1.16 and support for leases in Kubernetes having been around since 1.14, we can drop the discovery logic to check for the availability of leases. Instead, we will assume that the capability always exists.

The assumption helps with enforcing HA mode in cilium-operator at times when the API server is temporarily unavailable, preventing the case where multiple HA operator may run in leader mode concurrently and thereby breaking networking.

Fixes: #17870

```release-note
Remove Kubernetes leases discovery to enforce HA mode in cilium-operator when the API server is unavailable
```