### PR TITLE
docs: Install Cilium overlay mode on EKS

### DIFF
--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -105,7 +105,7 @@ Deploy Cilium release via Helm:
    This allows running more pods per Kubernetes worker node than the ENI limit, but means
    that pod connectivity to resources outside the cluster (e.g., VMs in the VPC or AWS managed
    services) is masqueraded (i.e., SNAT) by Cilium to use the VPC IP address of the Kubernetes worker node.
-   Excluding the lines for ``eni=true`` and ``tunnel=disabled`` from the
+   Excluding the lines for ``eni=true``, ``--set ipam.mode=eni`` and ``tunnel=disabled`` from the
    helm command will configure Cilium to use overlay routing mode (which is the helm default).
 
 .. include:: aws-create-nodegroup.rst


### PR DESCRIPTION
Once `--set ipam.mode=eni` is set in the helm install command, the Cilium CNI controller will continue to crash. Instead, run the following code snippet and the controller works fine.

```
helm install cilium cilium/cilium --version 1.9.11 \
               --namespace kube-system \
               --set egressMasqueradeInterfaces=eth0 \
               --set nodeinit.enabled=true
```

Fixes : #12981
    
Signed-off-by: Oliver Wang <<a0924100192@gmail.com>>