### PR TITLE
test/helpers: fix kubectl version detection for RCs

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"text/tabwriter"
 	"time"
+	"unicode"
 
 	"github.com/cilium/cilium/api/v1/models"
 	cnpv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -4466,7 +4467,12 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 		return err
 	}
 
-	versionstring := fmt.Sprintf("%s.%s", v.ClientVersion.Major, v.ClientVersion.Minor)
+	// For some -rc versions we observe minor versions with trailing non-numeric characters,
+	// e.g. minor: "23+". Strip these.
+	minor := strings.TrimRightFunc(v.ClientVersion.Minor, func(r rune) bool {
+		return !unicode.IsNumber(r)
+	})
+	versionstring := fmt.Sprintf("%s.%s", v.ClientVersion.Major, minor)
 	if versionstring == GetCurrentK8SEnv() {
 		//version available on host is matching current env
 		return nil


### PR DESCRIPTION
It seems that in some cases (e.g. for RCs) the minor version reported by
`kubectl version --client -o json` contains trailing non-numeric
characters, e.g.

```
{
  "clientVersion": {
    "major": "1",
    "minor": "23+",
    "gitVersion": "v1.23.0-rc.0",
    "gitCommit": "a117a51aa497a516106a3115963437218493c8d2",
    "gitTreeState": "clean",
    "buildDate": "2021-11-24T05:31:49Z",
    "goVersion": "go1.17.3",
    "compiler": "gc",
    "platform": "linux/amd64"
  }
}
```

This breaks the check where the reported version is compared against the
current k8s env version, leading to `kubectl` being downloaded by each
test and creating flakes such as

```
cmd: "curl --output /tmp/kubectl/1.23/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.0-rc.0/bin/linux/amd64/kubectl && chmod +x /tmp/kubectl/1.23/kubectl" exitCode: 23 duration: 90.516369ms stdout:

err:
exit status 23
stderr:
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
^M  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to create the file /tmp/kubectl/1.23/kubectl: Text file busy
^M  0 44.4M    0  1177    0     0  14530      0  0:53:25 --:--:--  0:53:25 14530
curl: (23) Failed writing body (0 != 1177)

FAIL: failed to ensure kubectl version: failed to download kubectl
```

Where `kubectl` from another test is still in use and attempted to be
overwritten by the current test.

Fix this by stripping any trailing non-numeric characters from the k8s
minor version for the purpose of version comparison.

Fixes: 75fbebbfbb5d ("test/helpers: use rc.0 as the default version of kubectl")
Fixes: #18060