### PR TITLE
Fix helm chart annotations for CRDs installed by Cilium

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -92,7 +92,12 @@ update-versions:
 		sed -i '/# operator-generic-digest.*/{!b;n;s/genericDigest.*/genericDigest: "'$(OPERATOR_GENERIC_DIGEST)'"/}' $(CILIUM_VALUES); \
 		sed -i '/# clustermesh-apiserver-digest.*/{!b;n;s/digest.*/digest: "'$(CLUSTERMESH_APISERVER_DIGEST)'"/}' $(CILIUM_VALUES)
 
+CRDS = $(foreach path,$(patsubst %.yaml,%,$(shell find $(ROOT_DIR)/examples/crds/*/ -type f)),$(shell basename $(path)))
 lint:
+	$(QUIET)for crd in $(CRDS); do \
+		grep -q $$crd $(CHART_FILE) \
+		|| (echo -e "$$crd not found in $(CHART_FILE).\nPlease update the chart to include $$crd."; exit 1); \
+	done
 	$(QUIET)helm lint --with-subcharts --values ./cilium/values.yaml ./cilium
 
 docs:

--- a/install/kubernetes/cilium/Chart.yaml
+++ b/install/kubernetes/cilium/Chart.yaml
@@ -75,3 +75,10 @@ annotations:
         Cilium Endpoint represents the status of individual pods or nodes in
         the cluster which are managed by Cilium, including enforcement status,
         IP addressing and whether the networking is succesfully operational.
+    - kind: CiliumEgressNATPolicy
+      version: v2alpha1
+      name: ciliumegressnatpolicies.cilium.io
+      displayName: Cilium Egress NAT Policy
+      description: |
+        Cilium Egress NAT Policy provides control over the way that traffic
+        leaves the cluster and which source addresses to use for that traffic.

--- a/install/kubernetes/cilium/Chart.yaml
+++ b/install/kubernetes/cilium/Chart.yaml
@@ -24,7 +24,7 @@ annotations:
   artifacthub.io/crds: |
     - kind: CiliumNetworkPolicy
       version: v2
-      name: ciliumnetworkpolicy
+      name: ciliumnetworkpolicies.cilium.io
       displayName: Cilium Network Policy
       description: |
         Cilium Network Policies provide additional functionality beyond what
@@ -32,28 +32,28 @@ annotations:
         to allow traffic based on FQDNs, or to filter at Layer 7.
     - kind: CiliumClusterwideNetworkPolicy
       version: v2
-      name: ciliumclusterwidenetworkpolicy
+      name: ciliumclusterwidenetworkpolicies.cilium.io
       displayName: Cilium Clusterwide Network Policy
       description: |
         Cilium Clusterwide Network Policies support configuring network traffic
         policiies across the entire cluster, including applying node firewalls.
     - kind: CiliumExternalWorkload
       version: v2
-      name: ciliumnetworkpolicy
+      name: ciliumexternalworkloads.cilium.io
       displayName: Cilium External Workload
       description: |
         Cilium External Workload supports configuring the ability for external
         non-Kubernetes workloads to join the cluster.
     - kind: CiliumLocalRedirectPolicy
       version: v2
-      name: ciliumlocalredirectpolicy
+      name: ciliumlocalredirectpolicies.cilium.io
       displayName: Cilium Local Redirect Policy
       description: |
         Cilium Local Redirect Policy allows local redirects to be configured
         within a node to support use cases like Node-Local DNS or KIAM.
     - kind: CiliumNode
       version: v2
-      name: ciliumnode
+      name: ciliumnodes.cilium.io
       displayName: Cilium Node
       description: |
         Cilium Node represents a node managed by Cilium. It contains a
@@ -61,7 +61,7 @@ annotations:
         and a status section to represent the status of the node.
     - kind: CiliumIdentity
       version: v2
-      name: ciliumidentity
+      name: ciliumidentities.cilium.io
       displayName: Cilium Identity
       description: |
         Cilium Identity allows introspection into security identities that
@@ -69,7 +69,7 @@ annotations:
         individual endpoints in the cluster.
     - kind: CiliumEndpoint
       version: v2
-      name: ciliumendpoint
+      name: ciliumendpoints.cilium.io
       displayName: Cilium Endpoint
       description: |
         Cilium Endpoint represents the status of individual pods or nodes in

--- a/install/kubernetes/cilium/Chart.yaml
+++ b/install/kubernetes/cilium/Chart.yaml
@@ -75,6 +75,14 @@ annotations:
         Cilium Endpoint represents the status of individual pods or nodes in
         the cluster which are managed by Cilium, including enforcement status,
         IP addressing and whether the networking is succesfully operational.
+    - kind: CiliumEndpointSlice
+      version: v2alpha1
+      name: ciliumendpointslices.cilium.io
+      displayName: Cilium Endpoint Slice
+      description: |
+        Cilium Endpoint Slice represents the status of groups of pods or nodes
+        in the cluster which are managed by Cilium, including enforcement status,
+        IP addressing and whether the networking is succesfully operational.
     - kind: CiliumEgressNATPolicy
       version: v2alpha1
       name: ciliumegressnatpolicies.cilium.io


### PR DESCRIPTION
- install: Use proper crd names in Chart.yaml annotations
- install: Add EgressNATPolicy to Helm charts
- install: Add CiliumEndpointSlices to Helm charts
- install: Lint for missing CRDs in charts
