### PR TITLE
test: Clarify performance test names

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -650,20 +650,20 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(testPodNetperfSameNodes(kubectl, namespace, helpers.TCP_STREAM)).Should(BeTrue(), "Connectivity test TCP_STREAM on same node failed")
 		}, 600)
 
-		It("Check performance with sockops and direct routing", func() {
+		It("Check performance with sockops and direct routing TCP_CRR", func() {
 			Skip("Skipping TCP_CRR until fix reaches upstream")
 			deploymentManager.DeployCilium(sockopsEnabledOptions, DeployCiliumOptionsAndDNS)
 			namespace := deployNetperf()
 			Expect(testPodNetperfSameNodes(kubectl, namespace, helpers.TCP_CRR)).Should(BeTrue(), "Connectivity test TCP_CRR on same node failed")
 		}, 600)
 
-		It("Check performance with sockops and direct routing", func() {
+		It("Check performance with sockops and direct routing TCP_RR", func() {
 			deploymentManager.DeployCilium(sockopsEnabledOptions, DeployCiliumOptionsAndDNS)
 			namespace := deployNetperf()
 			Expect(testPodNetperfSameNodes(kubectl, namespace, helpers.TCP_RR)).Should(BeTrue(), "Connectivity test TCP_RR on same node failed")
 		}, 600)
 
-		It("Check performance with sockops and direct routing", func() {
+		It("Check performance with sockops and direct routing TCP_STREAM", func() {
 			deploymentManager.DeployCilium(sockopsEnabledOptions, DeployCiliumOptionsAndDNS)
 			namespace := deployNetperf()
 			Expect(testPodNetperfSameNodes(kubectl, namespace, helpers.TCP_STREAM)).Should(BeTrue(), "Connectivity test TCP_STREAM on same node failed")


### PR DESCRIPTION
These tests were showing up in failures (due to provisioning issues) in
the CI dashboard and appeared as though they were failing more
frequently than other tests. However, the problem was actually that
three different tests all had the same name so they all contributed to
the same count in the dashboard.

Since they're targeting different performance metrics, add the
particular metric into the test name here.

No need to run CI against this PR, the benchmarks tests are not run
by the regular CI anyway.
