### PR TITLE
v1.9 backports 2021-12-06

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -451,8 +451,6 @@ original author of that PR directly so they can backport the PR themselves.
 
 Follow the :ref:`backport_process` guide to know how to perform this task.
 
-.. _dev_coo:
-
 Coordination
 ++++++++++++
 
@@ -481,6 +479,8 @@ been merged, then please coordinate with the previous / next backporter to
 check what the status is and establish who will work on getting the backports
 into the tree (for instance by investigating CI failures and addressing review
 feedback). There's leeway to negotiate depending on who has time available.
+
+.. _dev_coo:
 
 Developer's Certificate of Origin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -55,6 +55,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	AfterAll(func() {
 		deploymentManager.DeleteCilium()
+		kubectl.RedeployDNS()
 		kubectl.CloseSSHClient()
 	})
 

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -163,13 +163,36 @@ func RedeployCiliumWithMerge(vm *helpers.Kubectl,
 	RedeployCilium(vm, ciliumFilename, newOpts)
 }
 
+// optionChangeRequiresPodRedeploy returns true if the difference between the
+// specified options requires redeployment of all pods to ensure that the
+// datapath is operating consistently.
+func optionChangeRequiresPodRedeploy(prev, next map[string]string) bool {
+	// See GH-16717, as of v1.10.x Cilium does not support migrating
+	// between endpointRoutes modes without restarting pods.
+	// Also, the default setting for endpointRoutes is disabled.
+	// If either of these properties change, this logic needs updating!
+	a := "false"
+	if opt, ok := prev["endpointRoutes.enabled"]; ok {
+		a = opt
+	}
+	b := "false"
+	if opt, ok := next["endpointRoutes.enabled"]; ok {
+		b = opt
+	}
+
+	return a != b
+}
+
 // DeployCiliumOptionsAndDNS deploys DNS and cilium with options into the kubernetes cluster
 func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, options map[string]string) {
+	prevOptions := vm.CiliumOptions()
+
 	redeployCilium(vm, ciliumFilename, options)
 
 	vm.RestartUnmanagedPodsInNamespace(helpers.LogGathererNamespace)
 
-	vm.RedeployKubernetesDnsIfNecessary()
+	forceDNSRedeploy := optionChangeRequiresPodRedeploy(prevOptions, options)
+	vm.RedeployKubernetesDnsIfNecessary(forceDNSRedeploy)
 
 	switch helpers.GetCurrentIntegration() {
 	case helpers.CIIntegrationGKE:

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -180,7 +180,29 @@ func optionChangeRequiresPodRedeploy(prev, next map[string]string) bool {
 		b = opt
 	}
 
-	return a != b
+	if a != b {
+		return true
+	}
+
+	// Switching on and off KPR affects who is handling service traffic.
+	// E.g., off => on some traffic might be handled by iptables. For existing
+	// connections it might not have enough of state information which could
+	// lead to connection interruptions. To avoid it, restart the pods to restart
+	// such connections.
+	a = "disabled"
+	if opt, ok := prev["kubeProxyReplacement"]; ok {
+		a = opt
+	}
+	b = "disabled"
+	if opt, ok := next["kubeProxyReplacement"]; ok {
+		b = opt
+	}
+
+	if a != b {
+		return true
+	}
+
+	return false
 }
 
 // DeployCiliumOptionsAndDNS deploys DNS and cilium with options into the kubernetes cluster

--- a/test/k8sT/manifests/netperf-deployment.yaml
+++ b/test/k8sT/manifests/netperf-deployment.yaml
@@ -36,4 +36,4 @@ spec:
   ports:
   - port: 12865
   selector:
-    name: netperf-server
+    id: netperf-server

--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -123,7 +123,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.16/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/eks/coredns_deployment.yaml
@@ -118,7 +118,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.17/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/eks/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.18/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/eks/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.19/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/coredns_deployment.yaml
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.19/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/coredns_deployment.yaml
@@ -35,6 +35,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/provision/manifest/1.19/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/eks/coredns_deployment.yaml
@@ -138,7 +138,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.7.0
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/coredns_deployment.yaml
+++ b/test/provision/manifest/coredns_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: docker.io/coredns/coredns:1.0.6
+        image: k8s.gcr.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -121,6 +121,13 @@ rules:
   - services
   - pods
   - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - list
   - watch


### PR DESCRIPTION
 * #18018 -- test/contrib: Bump CoreDNS version to 1.8.3 (@brb)
 * #18006 -- test: Fix incorrect selector for netperf-service (@christarazi)
 * #18104 -- test: Extend coredns clusterrole with additional resource permissions (@aditighag)
 * #18123 -- docs: fix link to signoff / certificate of origin section (@timoreimann)
 * #16767 -- test: Redeploy DNS after endpointRoutes reconfiguration (@joestringer)
 * #16835 -- test: Delete DNS pods in AfterAll for datapath tests (@joestringer)
 * #18031 -- ci: Restart pods when toggling KPR switch (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18018 18006 18104 18123 16767 16835 18031; do contrib/backporting/set-labels.py $pr done 1.9; done
```
or with
```
$ make add-label branch=v1.9 issues=18018,18006,18104,18123,16767,16835,18031
```