### PR TITLE
allocator: fix out-of-valid-range identities being allocated

### DIFF
--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -371,6 +371,16 @@ func IsUserReservedIdentity(id NumericIdentity) bool {
 		id.Uint32() < MinimalNumericIdentity.Uint32()
 }
 
+// IsInClusterIdentityRange returns true if the given identity is in the
+// valid identity range of this cluster.
+func IsInClusterIdentityRange(id NumericIdentity) bool {
+	if id < MinimalAllocationIdentity || id > MaximumAllocationIdentity {
+		return false
+	}
+
+	return true
+}
+
 // AddUserDefinedNumericIdentity adds the given numeric identity and respective
 // label to the list of reservedIdentities. If the numeric identity is not
 // between UserReservedNumericIdentity and MinimalNumericIdentity it will return


### PR DESCRIPTION
When multiple cilium clusters share the same KVStore ("<clustername>" prefix
prevents them from being overlapped), the identity allocator inside each
cilium agent may allocate out identities that are out of the cluster's
valid range.

This patch fixed the problem by validating the identity at two places:

1. the place where an identity is just allocated out
2. the place before an identity is enqueued into available idpool

Adapted from Jaff Cheng's internal patch at trip.com.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>