### PR TITLE
docs: Update the minimum required Minikube version

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -185,7 +185,7 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
     .. group-tab:: minikube
 
-       Install minikube >= v1.5.2 as per minikube documentation: 
+       Install minikube >= v1.12 as per minikube documentation: 
        `Install Minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
        The following command will bring up a single node minikube cluster prepared for installing cilium.
 


### PR DESCRIPTION
Minikube 1.12.0 or later is required to use the `--cni` flag [1].

1 - https://github.com/kubernetes/minikube/commit/9e95435e0020eed065ee0229a6a54a7e54530a6d