### PR TITLE
policy: Fix selector identity release for FQDN

### DIFF
--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -896,8 +896,8 @@ func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user Cach
 	if exists {
 		if sel.removeUser(user, sc.localIdentityNotifier) {
 			delete(sc.selectors, key)
+			sel.releaseIdentityMappings(sc.idAllocator)
 		}
-		sel.releaseIdentityMappings(sc.idAllocator)
 	}
 }
 

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -279,4 +279,47 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 			helpers.CurlFail(world1Target))
 		res.ExpectFail("Can connect to to a valid target when it should NOT work")
 	})
+
+	It("Validate that FQDN policy continues to work after being updated", func() {
+		// To make sure that UUID in multiple specs are plumbed correctly to
+		// Cilium Policy
+		fqdnPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs.yaml")
+		world1Target := worldTarget
+		world2Target := worldInvalidTarget
+
+		_, err := kubectl.CiliumPolicyAction(
+			helpers.DefaultNamespace, fqdnPolicy,
+			helpers.KubectlApply, helpers.HelperTimeout)
+		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
+
+		By("Validating APP2 policy connectivity")
+		res := kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlFail("--retry 5 "+world1Target))
+		res.ExpectSuccess("Can't connect to to a valid target when it should work")
+
+		res = kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlFail(world2Target))
+		res.ExpectFail("Can connect to a valid target when it should NOT work")
+
+		By("Updating the policy to include an extra FQDN allow statement")
+		fqdnPolicy2 := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs-v2.yaml")
+		_, err = kubectl.CiliumPolicyAction(
+			helpers.DefaultNamespace, fqdnPolicy2,
+			helpers.KubectlApply, helpers.HelperTimeout)
+		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
+
+		By("Validating APP2 policy connectivity after policy change")
+		res = kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlFail("--retry 5 "+world1Target))
+		res.ExpectSuccess("Can't connect to to a valid target when it should work")
+
+		res = kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlFail(world2Target))
+		res.ExpectFail("Can connect to a valid target when it should NOT work")
+	})
+
 })

--- a/test/k8sT/manifests/fqdn-proxy-multiple-specs-v2.yaml
+++ b/test/k8sT/manifests/fqdn-proxy-multiple-specs-v2.yaml
@@ -1,0 +1,34 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "fqdn-proxy-policy.yaml"
+specs:
+- description: "fqdn-proxy-policy.yaml"
+  egress:
+  - toPorts:
+    - ports:
+      - port: '53'
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  - toFQDNs:
+    - matchPattern: "vagrant-cache.ci.cilium.io"
+    - matchPattern: "www.cilium.io"
+  endpointSelector:
+    matchLabels:
+      id: app2
+- egress:
+  - toPorts:
+    - ports:
+      - port: '53'
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  - toFQDNs:
+    - matchPattern: "jenkins.cilium.io"
+  endpointSelector:
+    matchLabels:
+      id: app3
+


### PR DESCRIPTION
Alexander reports in issue #18023 that establishing a connection
via an FQDN policy, then modifying that FQDN policy, would cause
subsequent traffic to the FQDN to be dropped, even if the new policy
still allowed the same traffic via a `toFQDNs` statement.

This was caused by overzealous release of CIDR identities while
generating a new policy. Although the policy calculation itself keeps
all `SelectorCache` entries alive during the policy generation phase (see
`cachedSelectorPolicy.setPolicy()`), after the new policy is inserted
into the `PolicyCache`, the `distillery` would clean up the old
policy. As part of that cleanup, it would call into the individual
selector to call the `RemoveSelectors()` function.

The previous implementation of this logic unintentionally released the
underlying identities any time a user of a selector was released, rather
than only releasing the underlying identities when the number of users
reached zero and the selector itself would be released. This meant that
rather than the `SelectorCache` retaining references to the underlying
identities when a policy was updated, instead the references would be
released (and all corresponding eBPF resources cleaned up) at the end of
the process. This then triggered subsequent connectivity outages.

Fix it by only releasing the identity references once the cached
selector itself is removed from the `SelectorCache`.

Fixes: f559cf1cecb0 ("selectorcache: Release identities on selector removal")
Reported-by: Alexander Block <ablock84@gmail.com>
Suggested-by: Jarno Rajahalme <jarno@cilium.io>

Fixes: #18023 