### PR TITLE
Makefile: Push image in 'kind-image' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,6 +505,7 @@ kind-image:
 	@kind get clusters >/dev/null
 	$(QUIET)$(MAKE) dev-docker-image DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
 	@echo "  DEPLOY image to kind ($(LOCAL_IMAGE))"
+	$(QUIET)$(CONTAINER_ENGINE) push $(LOCAL_IMAGE)
 	$(QUIET)kind load docker-image $(LOCAL_IMAGE)
 
 precheck: logging-subsys-field ## Peform build precheck for the source code.


### PR DESCRIPTION
If the developer set the `imagePullPolicy` to `Always`, then kind would
always end up pulling the image version from the `localhost:5000` registry
instead of using the version we sideload in the final step here. Avoid
this by unconditionally pushing the image to the local registry.
