### PR TITLE
Revert "test/Services: Quarantine 'Checks service on same node'"

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -362,7 +362,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				ciliumDelService(kubectl, 20069)
 			})
 
-			SkipItIf(helpers.SkipQuarantined, "Checks service on same node", func() {
+			It("Checks service on same node", func() {
 				status := kubectl.ExecInHostNetNS(context.TODO(), ni.k8s1NodeName,
 					helpers.CurlFail(`"http://[%s]/"`, demoClusterIPv6))
 				status.ExpectSuccess("cannot curl to service IP from host")


### PR DESCRIPTION
This reverts commit ca4ed8dac7f7 ("test/Services: Quarantine 'Checks service on
same node'"). The original intention was to quarantine the test from #17919.
However, ca4ed8dac7f7 quarantined the /wrong/ test case which was not the failing
one since the code in mentioned commit only covers the IPv6 one and in the test
the IPv4 one was failing. Meanwhile, the IPv4 test for 'Checks service on same
node' was still left active on master, and looking at CI dashboard from last few
days on master there has been no failure related to any of the 'Checks service on
same node' tests.