### PR TITLE
test: Run ip r l if ip r a fails

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4377,7 +4377,15 @@ func (kub *Kubectl) AddIPRoute(nodeName, subnet, gw string, replace bool) *CmdRe
 	}
 	cmd := fmt.Sprintf("ip route %s %s via %s", action, subnet, gw)
 
-	return kub.ExecInHostNetNS(context.TODO(), nodeName, cmd)
+	res := kub.ExecInHostNetNS(context.TODO(), nodeName, cmd)
+
+	if !replace && res.GetExitCode() != 0 &&
+		strings.Contains(res.GetStdErr().String(), "File exists") {
+
+		kub.ExecInHostNetNS(context.TODO(), nodeName, "ip route list")
+	}
+
+	return res
 }
 
 // DelIPRoute deletes a route to a given IP address and a gateway on a given


### PR DESCRIPTION
This might help to debug such a flake as \[1\] in which adding ip route
had failed with EEXIST.

\[1\]: https://github.com/cilium/cilium/issues/18054