### PR TITLE
mlh: swap net-next kernel from K8s 1.16 to 1.23

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -53,7 +53,7 @@ flake-tracker:
     regex-trigger: (^/?test(-me-please)?)
     stable-jobs:
     - cilium-master-gke
-    - cilium-master-k8s-1.16-kernel-net-next
+    - cilium-master-k8s-1.16-kernel-4.9
     - cilium-master-k8s-1.17-kernel-4.9
     - cilium-master-k8s-1.18-kernel-4.9
     - cilium-master-k8s-1.19-kernel-4.9
@@ -61,67 +61,67 @@ flake-tracker:
     - cilium-master-k8s-1.21-kernel-4.9
     - cilium-master-k8s-1.21-kernel-5.4
     - cilium-master-k8s-1.22-kernel-4.19
-    - cilium-master-k8s-1.23-kernel-4.9
+    - cilium-master-k8s-1.23-kernel-net-next
     - cilium-master-k8s-upstream
     - cilium-master-runtime-kernel-net-next
     pr-jobs:
-      Cilium-PR-K8s-1.16-net-next:
+      Cilium-PR-K8s-1.16-kernel-4.9:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-net-next
+        - cilium-master-k8s-1.16-kernel-4.9
+        - cilium-master-k8s-1.17-kernel-4.9
+        - cilium-master-k8s-1.18-kernel-4.9
+        - cilium-master-k8s-1.19-kernel-4.9
+        - cilium-master-k8s-1.20-kernel-4.9
+        - cilium-master-k8s-1.21-kernel-4.9
       Cilium-PR-K8s-1.17-kernel-4.9:
         correlate-with-stable-jobs:
+        - cilium-master-k8s-1.16-kernel-4.9
         - cilium-master-k8s-1.17-kernel-4.9
         - cilium-master-k8s-1.18-kernel-4.9
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.18-kernel-4.9:
         correlate-with-stable-jobs:
+        - cilium-master-k8s-1.16-kernel-4.9
         - cilium-master-k8s-1.17-kernel-4.9
         - cilium-master-k8s-1.18-kernel-4.9
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.19-kernel-4.9:
         correlate-with-stable-jobs:
+        - cilium-master-k8s-1.16-kernel-4.9
         - cilium-master-k8s-1.17-kernel-4.9
         - cilium-master-k8s-1.18-kernel-4.9
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.20-kernel-4.9:
         correlate-with-stable-jobs:
+        - cilium-master-k8s-1.16-kernel-4.9
         - cilium-master-k8s-1.17-kernel-4.9
         - cilium-master-k8s-1.18-kernel-4.9
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.21-kernel-4.9:
         correlate-with-stable-jobs:
+        - cilium-master-k8s-1.16-kernel-4.9
         - cilium-master-k8s-1.17-kernel-4.9
         - cilium-master-k8s-1.18-kernel-4.9
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.21-kernel-5.4:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.21-kernel-5.4
       Cilium-PR-K8s-1.22-kernel-4.19:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.22-kernel-4.19
-      Cilium-PR-K8s-1.23-kernel-4.9:
+      Cilium-PR-K8s-1.23-kernel-net-next:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.17-kernel-4.9
-        - cilium-master-k8s-1.18-kernel-4.9
-        - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.20-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
+        - cilium-master-k8s-1.23-kernel-net-next
       Cilium-PR-K8s-GKE:
         correlate-with-stable-jobs:
         - cilium-master-gke


### PR DESCRIPTION
As discussed in community meeting, we are swapping the net-next kernel to run on the latest supported K8s version rather than the oldest supported one.

Rationale:

- Will allow elimination of duplicate and redundant tests.
- Currently IPv6 services are manually provisioned.
- New feature developments often need latest kernel as kernel changes are needed.

This change is only made on master, and is not backported to stable branches (not even 1.11).

The Jenkins triggers and Cilium CI Matrix have been updated accordingly:
https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0/edit#gid=0