### PR TITLE
test: Disable CES for Egress GW suite

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2413,7 +2413,9 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		options["imagePullSecrets[0].name"] = config.RegistrySecretName
 	}
 
-	if CiliumEndpointSliceFeatureEnabled() {
+	if _, found := options["enableCiliumEndpointSlice"]; !found &&
+		CiliumEndpointSliceFeatureEnabled() {
+
 		options["enableCiliumEndpointSlice"] = "true"
 	}
 	return nil

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -97,7 +97,10 @@ var _ = SkipDescribeIf(func() bool {
 		// We deploy cilium, to run the echo server and assign egress IP, and redeploy with
 		// different configurations for the tests.
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-		DeployCiliumAndDNS(kubectl, ciliumFilename)
+		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename,
+			// TODO Disable CES until https://github.com/cilium/cilium/issues/17669
+			//      has been resolved
+			map[string]string{"enableCiliumEndpointSlice": "false"})
 
 		runEchoServer()
 		assignEgressIP()
@@ -276,6 +279,7 @@ var _ = SkipDescribeIf(func() bool {
 			"tunnel":                 "disabled",
 			"autoDirectNodeRoutes":   "true",
 			"endpointRoutes.enabled": "true",
+			"ciliumEndpointSlices":   "false",
 		},
 	)
 
@@ -286,6 +290,7 @@ var _ = SkipDescribeIf(func() bool {
 			"tunnel":                 "disabled",
 			"autoDirectNodeRoutes":   "true",
 			"endpointRoutes.enabled": "false",
+			"ciliumEndpointSlices":   "false",
 		},
 	)
 
@@ -296,6 +301,7 @@ var _ = SkipDescribeIf(func() bool {
 			"tunnel":                 "vxlan",
 			"autoDirectNodeRoutes":   "false",
 			"endpointRoutes.enabled": "true",
+			"ciliumEndpointSlices":   "false",
 		},
 	)
 
@@ -306,6 +312,7 @@ var _ = SkipDescribeIf(func() bool {
 			"tunnel":                 "vxlan",
 			"autoDirectNodeRoutes":   "false",
 			"endpointRoutes.enabled": "false",
+			"ciliumEndpointSlices":   "false",
 		},
 	)
 })


### PR DESCRIPTION
We need to disable CiliumEndpointSlice (CES) until \[1\] has been
resolved. Otherwise, once we switch the net-next CI job's k8s vsn to
1.23, the Egress GW suite will start failing.

Also, make sure that we don't unconditionally enable the CES if user
instructs to not enable.

\[1\]: https://github.com/cilium/cilium/issues/17669

Reported-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Martynas Pumputis <m@lambda.lt>