### PR TITLE
test: Do not redeploy Cilium in Egress GW suite

### DIFF
--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -238,7 +238,6 @@ var _ = SkipDescribeIf(func() bool {
 
 			AfterAll(func() {
 				deploymentManager.DeleteAll()
-				DeployCiliumAndDNS(kubectl, ciliumFilename)
 			})
 
 			Context("no egress gw policy", func() {


### PR DESCRIPTION
After each doContext() there is no point to redeploy Cilium in AfterAll,
as it's going to be deployed anyway during next doContext() execution
and Cilium is uninstalled anyway once Egress GW suite is done.

Blocked by https://github.com/cilium/cilium/pull/18180.