### PR TITLE
test: use stable zookeeper image

### DIFF
--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -22,7 +22,7 @@ const (
 	KafkaClientImage = "docker.io/cilium/kafkaclient2:1.0"
 
 	// Zookeeper image is the image used for running Zookeeper.
-	ZookeeperImage = "docker.io/digitalwonderland/zookeeper:latest"
+	ZookeeperImage = "docker.io/cilium/zookeeper:1.0"
 
 	// BuxyboxImage is a space efficient-image used for basic testing.
 	BusyboxImage = "docker.io/library/busybox:1.31.1"


### PR DESCRIPTION
Commit f66515219c21 ("test: Use stable tags instead of :latest")
switched most use of image tags to stable tags, but omitted one
occurrence of the zookeeper image in the runtime kafka tests. Switch it
to the stable docker.io/cilium/zookeeper:1.0 as well.

Fixes: f66515219c21 ("test: Use stable tags instead of :latest")
