### PR TITLE
v1.10 backports 2021-12-08

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           filters: |
             src:
+              - .github/workflows/lint-codeql.yaml
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -185,7 +185,7 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
     .. group-tab:: minikube
 
-       Install minikube >= v1.5.2 as per minikube documentation: 
+       Install minikube >= v1.12 as per minikube documentation: 
        `Install Minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
 
        .. code-block:: shell-session

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -907,8 +907,8 @@ func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user Cach
 	if exists {
 		if sel.removeUser(user, sc.localIdentityNotifier) {
 			delete(sc.selectors, key)
+			sel.releaseIdentityMappings(sc.idAllocator)
 		}
-		sel.releaseIdentityMappings(sc.idAllocator)
 	}
 }
 

--- a/test/k8sT/manifests/fqdn-proxy-multiple-specs-v2.yaml
+++ b/test/k8sT/manifests/fqdn-proxy-multiple-specs-v2.yaml
@@ -1,0 +1,34 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "fqdn-proxy-policy.yaml"
+specs:
+- description: "fqdn-proxy-policy.yaml"
+  egress:
+  - toPorts:
+    - ports:
+      - port: '53'
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  - toFQDNs:
+    - matchPattern: "vagrant-cache.ci.cilium.io"
+    - matchPattern: "www.cilium.io"
+  endpointSelector:
+    matchLabels:
+      id: app2
+- egress:
+  - toPorts:
+    - ports:
+      - port: '53'
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  - toFQDNs:
+    - matchPattern: "jenkins.cilium.io"
+  endpointSelector:
+    matchLabels:
+      id: app3
+


### PR DESCRIPTION
* #17982 -- workflows: Run CodeQL workflow is the workflow is edited (@pchaigno)
 * #18155 -- docs: Update the minimum required Minikube version (@pchaigno)
 * #18166 -- policy: Fix selector identity release for FQDN (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17982 18155 18166; do contrib/backporting/set-labels.py $pr done 1.10; done
```