### PR TITLE
workflows: Fix concurrency groups

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-aks-1.10') ||
-        startsWith(github.event.comment.body, '/ci-aks-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-aks-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -74,10 +72,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-aks-1.10') ||
-        startsWith(github.event.comment.body, '/ci-aks-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-aks-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -116,10 +112,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-aks-1.10') ||
-        startsWith(github.event.comment.body, '/ci-aks-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.10') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-aks-1.10' ||
+        (github.event.comment.body == '/test-backport-1.10' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-aks-1.11') ||
-        startsWith(github.event.comment.body, '/ci-aks-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-aks-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -74,10 +72,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-aks-1.11') ||
-        startsWith(github.event.comment.body, '/ci-aks-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-aks-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -116,10 +112,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-aks-1.11') ||
-        startsWith(github.event.comment.body, '/ci-aks-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.11') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-aks-1.11' ||
+        (github.event.comment.body == '/test-backport-1.11' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -56,10 +56,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-aks') && !startsWith(github.event.comment.body, 'ci-aks-') ||
-        startsWith(github.event.comment.body, '/ci-aks') && !startsWith(github.event.comment.body, '/ci-aks-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-aks' ||
+        github.event.comment.body == '/test'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -77,10 +75,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-aks') && !startsWith(github.event.comment.body, 'ci-aks-') ||
-        startsWith(github.event.comment.body, '/ci-aks') && !startsWith(github.event.comment.body, '/ci-aks-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-aks' ||
+        github.event.comment.body == '/test'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -119,10 +115,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-aks') && !startsWith(github.event.comment.body, 'ci-aks-') ||
-        startsWith(github.event.comment.body, '/ci-aks') && !startsWith(github.event.comment.body, '/ci-aks-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-aks' ||
+        (github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-awscni-1.10') ||
-        startsWith(github.event.comment.body, '/ci-awscni-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-awscni-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -73,10 +71,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-awscni-1.10') ||
-        startsWith(github.event.comment.body, '/ci-awscni-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-awscni-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -115,10 +111,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-awscni-1.10') ||
-        startsWith(github.event.comment.body, '/ci-awscni-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.10') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-awscni-1.10' ||
+        (github.event.comment.body == '/test-backport-1.10' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-awscni-1.11') ||
-        startsWith(github.event.comment.body, '/ci-awscni-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-awscni-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -73,10 +71,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-awscni-1.11') ||
-        startsWith(github.event.comment.body, '/ci-awscni-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-awscni-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -115,10 +111,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-awscni-1.11') ||
-        startsWith(github.event.comment.body, '/ci-awscni-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.11') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-awscni-1.11' ||
+        (github.event.comment.body == '/test-backport-1.11' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -56,10 +56,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-awscni') && !startsWith(github.event.comment.body, 'ci-awscni-') ||
-        startsWith(github.event.comment.body, '/ci-awscni') && !startsWith(github.event.comment.body, '/ci-awscni-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-awscni') ||
+        github.event.comment.body == '/test'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -76,10 +74,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-awscni') && !startsWith(github.event.comment.body, 'ci-awscni-') ||
-        startsWith(github.event.comment.body, '/ci-awscni') && !startsWith(github.event.comment.body, '/ci-awscni-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-awscni' ||
+        github.event.comment.body == '/test'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -118,10 +114,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-awscni') && !startsWith(github.event.comment.body, 'ci-awscni-') ||
-        startsWith(github.event.comment.body, '/ci-awscni') && !startsWith(github.event.comment.body, '/ci-awscni-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-awscni' ||
+        (github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-eks-1.10') ||
-        startsWith(github.event.comment.body, '/ci-eks-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-eks-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -73,10 +71,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-eks-1.10') ||
-        startsWith(github.event.comment.body, '/ci-eks-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-eks-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -115,10 +111,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-eks-1.10') ||
-        startsWith(github.event.comment.body, '/ci-eks-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.10') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-eks-1.10' ||
+        (github.event.comment.body == '/test-backport-1.10' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-eks-1.11') ||
-        startsWith(github.event.comment.body, '/ci-eks-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-eks-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -73,10 +71,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-eks-1.11') ||
-        startsWith(github.event.comment.body, '/ci-eks-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-eks-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -115,10 +111,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-eks-1.11') ||
-        startsWith(github.event.comment.body, '/ci-eks-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.11') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-eks-1.11' ||
+        (github.event.comment.body == '/test-backport-1.11' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -56,10 +56,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-eks') && !startsWith(github.event.comment.body, 'ci-eks-') ||
-        startsWith(github.event.comment.body, '/ci-eks') && !startsWith(github.event.comment.body, '/ci-eks-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-eks' ||
+        github.event.comment.body == '/test'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -76,10 +74,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-eks') && !startsWith(github.event.comment.body, 'ci-eks-') ||
-        startsWith(github.event.comment.body, '/ci-eks') && !startsWith(github.event.comment.body, '/ci-eks-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-eks' ||
+        github.event.comment.body == '/test'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -118,10 +114,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-eks') && !startsWith(github.event.comment.body, 'ci-eks-') ||
-        startsWith(github.event.comment.body, '/ci-eks') && !startsWith(github.event.comment.body, '/ci-eks-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-eks' ||
+        (github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-external-workloads-v1.10') ||
-        startsWith(github.event.comment.body, '/ci-external-workloads-v1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-external-workloads-v1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -75,10 +73,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-external-workloads-v1.10') ||
-        startsWith(github.event.comment.body, '/ci-external-workloads-v1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-external-workloads-v1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -117,10 +113,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-external-workloads-v1.10') ||
-        startsWith(github.event.comment.body, '/ci-external-workloads-v1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.10') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-external-workloads-v1.10' ||
+        (github.event.comment.body == '/test-backport-1.10' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-externalworkloads-v1.11.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-external-workloads-v1.11') ||
-        startsWith(github.event.comment.body, '/ci-external-workloads-v1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-external-workloads-v1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -75,10 +73,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-external-workloads-v1.11') ||
-        startsWith(github.event.comment.body, '/ci-external-workloads-v1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-external-workloads-v1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -117,10 +113,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-external-workloads-v1.11') ||
-        startsWith(github.event.comment.body, '/ci-external-workloads-v1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.11') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-external-workloads-v1.11' ||
+        (github.event.comment.body == '/test-backport-1.11' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -56,10 +56,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-external-workloads') && !startsWith(github.event.comment.body, 'ci-external-workloads-') ||
-        startsWith(github.event.comment.body, '/ci-external-workloads') && !startsWith(github.event.comment.body, '/ci-external-workloads-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-external-workloads' ||
+        github.event.comment.body == '/test'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -78,10 +76,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-external-workloads') && !startsWith(github.event.comment.body, 'ci-external-workloads-') ||
-        startsWith(github.event.comment.body, '/ci-external-workloads') && !startsWith(github.event.comment.body, '/ci-external-workloads-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-external-workloads' ||
+        github.event.comment.body == '/test'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -120,10 +116,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-external-workloads') && !startsWith(github.event.comment.body, 'ci-external-workloads-') ||
-        startsWith(github.event.comment.body, '/ci-external-workloads') && !startsWith(github.event.comment.body, '/ci-external-workloads-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-external-workloads' ||
+        (github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-gke-1.10') ||
-        startsWith(github.event.comment.body, '/ci-gke-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-gke-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -73,10 +71,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-gke-1.10') ||
-        startsWith(github.event.comment.body, '/ci-gke-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-gke-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -115,10 +111,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-gke-1.10') ||
-        startsWith(github.event.comment.body, '/ci-gke-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.10') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-gke-1.10' ||
+        (github.event.comment.body == '/test-backport-1.10' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-gke-1.11') ||
-        startsWith(github.event.comment.body, '/ci-gke-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-gke-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -73,10 +71,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-gke-1.11') ||
-        startsWith(github.event.comment.body, '/ci-gke-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-gke-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -115,10 +111,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-gke-1.11') ||
-        startsWith(github.event.comment.body, '/ci-gke-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.11') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-gke-1.11' ||
+        (github.event.comment.body == '/test-backport-1.11' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -56,10 +56,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-gke') && !startsWith(github.event.comment.body, 'ci-gke-') ||
-        startsWith(github.event.comment.body, '/ci-gke') && !startsWith(github.event.comment.body, '/ci-gke-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-gke' ||
+        github.event.comment.body == '/test'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -76,10 +74,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-gke') && !startsWith(github.event.comment.body, 'ci-gke-') ||
-        startsWith(github.event.comment.body, '/ci-gke') && !startsWith(github.event.comment.body, '/ci-gke-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-gke' ||
+        github.event.comment.body == '/test'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -118,10 +114,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-gke') && !startsWith(github.event.comment.body, 'ci-gke-') ||
-        startsWith(github.event.comment.body, '/ci-gke') && !startsWith(github.event.comment.body, '/ci-gke-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-gke' ||
+        (github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-multicluster-1.10') ||
-        startsWith(github.event.comment.body, '/ci-multicluster-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-multicluster-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -75,10 +73,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-multicluster-1.10') ||
-        startsWith(github.event.comment.body, '/ci-multicluster-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-multicluster-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -117,10 +113,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-multicluster-1.10') ||
-        startsWith(github.event.comment.body, '/ci-multicluster-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.10') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-multicluster-1.10' ||
+        (github.event.comment.body == '/test-backport-1.10' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-multicluster-1.11') ||
-        startsWith(github.event.comment.body, '/ci-multicluster-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-multicluster-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -75,10 +73,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-multicluster-1.11') ||
-        startsWith(github.event.comment.body, '/ci-multicluster-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body, '/ci-multicluster-1.11' ||
+        github.event.comment.body, '/test-backport-1.11'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -117,10 +113,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-multicluster-1.11') ||
-        startsWith(github.event.comment.body, '/ci-multicluster-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.11') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body, '/ci-multicluster-1.11' ||
+        (github.event.comment.body == '/test-backport-1.11' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -56,10 +56,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-multicluster') && !startsWith(github.event.comment.body, 'ci-multicluster-') ||
-        startsWith(github.event.comment.body, '/ci-multicluster') && !startsWith(github.event.comment.body, '/ci-multicluster-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-multicluster' ||
+        github.event.comment.body == '/test'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -78,10 +76,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-multicluster') && !startsWith(github.event.comment.body, 'ci-multicluster-') ||
-        startsWith(github.event.comment.body, '/ci-multicluster') && !startsWith(github.event.comment.body, '/ci-multicluster-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-multicluster' ||
+        github.event.comment.body == '/test'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -120,10 +116,8 @@ jobs:
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-multicluster') && !startsWith(github.event.comment.body, 'ci-multicluster-') ||
-        startsWith(github.event.comment.body, '/ci-multicluster') && !startsWith(github.event.comment.body, '/ci-multicluster-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-multicluster' ||
+        (github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-l4lb-1.10') ||
-        startsWith(github.event.comment.body, '/ci-l4lb-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-l4lb-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -70,10 +68,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-l4lb-1.10') ||
-        startsWith(github.event.comment.body, '/ci-l4lb-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') ||
-        startsWith(github.event.comment.body, '/test-backport-1.10')
+        github.event.comment.body == '/ci-l4lb-1.10' ||
+        github.event.comment.body == '/test-backport-1.10'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -116,10 +112,8 @@ jobs:
     name: Setup & Test
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-l4lb-1.10') ||
-        startsWith(github.event.comment.body, '/ci-l4lb-1.10') ||
-        startsWith(github.event.comment.body, 'test-backport-1.10') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.10') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-l4lb-1.10' ||
+        (github.event.comment.body == '/test-backport-1.10' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -53,10 +53,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-l4lb-1.11') ||
-        startsWith(github.event.comment.body, '/ci-l4lb-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-l4lb-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -70,10 +68,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-l4lb-1.11') ||
-        startsWith(github.event.comment.body, '/ci-l4lb-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') ||
-        startsWith(github.event.comment.body, '/test-backport-1.11')
+        github.event.comment.body == '/ci-l4lb-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -116,10 +112,8 @@ jobs:
     name: Setup & Test
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-l4lb-1.11') ||
-        startsWith(github.event.comment.body, '/ci-l4lb-1.11') ||
-        startsWith(github.event.comment.body, 'test-backport-1.11') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test-backport-1.11') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-l4lb-1.11' ||
+        (github.event.comment.body == '/test-backport-1.11' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -56,10 +56,8 @@ concurrency:
     ${{
       (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-l4lb') && !startsWith(github.event.comment.body, 'ci-l4lb-') ||
-        startsWith(github.event.comment.body, '/ci-l4lb') && !startsWith(github.event.comment.body, '/ci-l4lb-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-l4lb' ||
+        github.event.comment.body == '/test'
       ) && github.event.issue.number) ||
       (github.event_name == 'pull_request' && github.event.pull_request.number)
     }}
@@ -73,10 +71,8 @@ jobs:
     name: Deduce required tests from code changes
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-l4lb') && !startsWith(github.event.comment.body, 'ci-l4lb-') ||
-        startsWith(github.event.comment.body, '/ci-l4lb') && !startsWith(github.event.comment.body, '/ci-l4lb-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-')
+        github.event.comment.body == '/ci-l4lb' ||
+        github.event.comment.body == '/test'
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'
@@ -119,10 +115,8 @@ jobs:
     name: Setup & Test
     if: |
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body, 'ci-l4lb') && !startsWith(github.event.comment.body, 'ci-l4lb-') ||
-        startsWith(github.event.comment.body, '/ci-l4lb') && !startsWith(github.event.comment.body, '/ci-l4lb-') ||
-        startsWith(github.event.comment.body, 'test-me-please') && !startsWith(github.event.comment.body, 'test-me-please-') && needs.check_changes.outputs.tested == 'true' ||
-        startsWith(github.event.comment.body, '/test') && !startsWith(github.event.comment.body, '/test-') && needs.check_changes.outputs.tested == 'true'
+        github.event.comment.body == '/ci-l4lb' ||
+        (github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'true')
       )) ||
       (github.event_name == 'schedule' && github.repository == 'cilium/cilium') ||
       github.event_name == 'pull_request'


### PR DESCRIPTION
Without any notice, GitHub decided to fail any workflow with a concurrency group larger than 400 characters. That affects all our
workflows with trigger phrases since they have rather complex concurrency groups that must account for various trigger phrases.

This pull request fixes it by:
1. Dropping support for all trigger phrases without a leading slash. The new trigger phrases with leading slashes have been here for a while, so folks should be using them by now.
2. Dropping support for trigger phrases followed by text. We introduced this to allow folks to add arbitrary text after their trigger phrase in comments, but this feature has never seen much usage.

Tested on my fork and it removes the error for all workflows.