### PR TITLE
hubble: Fix misclassification of `to-network` reply packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -950,8 +950,7 @@ handle_netdev(struct __ctx_buff *ctx, const bool from_host)
 		return send_drop_notify(ctx, SECLABEL, WORLD_ID, 0, ret,
 					CTX_ACT_DROP, METRIC_EGRESS);
 #else
-		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, 0, 0, 0,
-				  REASON_FORWARDED, 0);
+		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, 0, 0, 0, 0, 0);
 		/* Pass unknown traffic to the stack */
 		return CTX_ACT_OK;
 #endif /* ENABLE_HOST_FIREWALL */
@@ -1098,7 +1097,7 @@ out:
 					      METRIC_EGRESS);
 #endif
 	send_trace_notify(ctx, TRACE_TO_NETWORK, src_id, 0, 0,
-			  0, ret, monitor);
+			  0, 0, monitor);
 
 	return ret;
 }
@@ -1145,7 +1144,7 @@ int to_host(struct __ctx_buff *ctx)
 
 	if (!traced)
 		send_trace_notify(ctx, TRACE_TO_STACK, src_id, 0, 0,
-				  CILIUM_IFINDEX, ret, 0);
+				  CILIUM_IFINDEX, 0, 0);
 
 #ifdef ENABLE_HOST_FIREWALL
 	if (!validate_ethertype(ctx, &proto)) {

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -7,6 +7,16 @@
  * API:
  * void send_trace_notify(ctx, obs_point, src, dst, dst_id, ifindex, reason, monitor)
  *
+ * @ctx:	socket buffer
+ * @obs_point:	observation point (TRACE_*)
+ * @src:	source identity
+ * @dst:	destination identity
+ * @dst_id:	destination endpoint id or proxy destination port
+ * @ifindex:	network interface index
+ * @reason:	reason for forwarding the packet (TRACE_REASON_*),
+ *		e.g. return value of ct_lookup or TRACE_REASON_ENCRYPTED
+ * @monitor:	monitor aggregation value, e.g. the 'monitor' output of ct_lookup
+ *
  * If TRACE_NOTIFY is not defined, the API will be compiled in as a NOP.
  */
 #ifndef __LIB_TRACE__

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -45,15 +45,14 @@ enum {
 };
 
 /* Reasons for forwarding a packet. */
-enum {
+enum trace_reason {
 	TRACE_REASON_POLICY = CT_NEW,
 	TRACE_REASON_CT_ESTABLISHED = CT_ESTABLISHED,
 	TRACE_REASON_CT_REPLY = CT_REPLY,
 	TRACE_REASON_CT_RELATED = CT_RELATED,
 	TRACE_REASON_CT_REOPENED = CT_REOPENED,
-};
-
-#define TRACE_REASON_ENCRYPTED	    0x80
+	TRACE_REASON_ENCRYPTED = 0x80
+} __packed;
 
 /* Trace aggregation levels. */
 enum {
@@ -75,7 +74,7 @@ enum {
  * Update metrics based on a trace event
  */
 static __always_inline void
-update_trace_metrics(struct __ctx_buff *ctx, __u8 obs_point, __u8 reason)
+update_trace_metrics(struct __ctx_buff *ctx, __u8 obs_point, enum trace_reason reason)
 {
 	__u8 encrypted;
 
@@ -166,7 +165,7 @@ static __always_inline bool emit_trace_notify(__u8 obs_point, __u32 monitor)
 
 static __always_inline void
 send_trace_notify(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
-		   __u16 dst_id, __u32 ifindex, __u8 reason, __u32 monitor)
+		   __u16 dst_id, __u32 ifindex, enum trace_reason reason, __u32 monitor)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
@@ -196,7 +195,7 @@ send_trace_notify(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
 
 static __always_inline void
 send_trace_notify4(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
-		   __be32 orig_addr, __u16 dst_id, __u32 ifindex, __u8 reason,
+		   __be32 orig_addr, __u16 dst_id, __u32 ifindex, enum trace_reason reason,
 		   __u32 monitor)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
@@ -229,7 +228,7 @@ send_trace_notify4(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
 static __always_inline void
 send_trace_notify6(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
 		   union v6addr *orig_addr, __u16 dst_id, __u32 ifindex,
-		   __u8 reason, __u32 monitor)
+		   enum trace_reason reason, __u32 monitor)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
@@ -263,7 +262,7 @@ static __always_inline void
 send_trace_notify(struct __ctx_buff *ctx, __u8 obs_point,
 		  __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		  __u16 dst_id __maybe_unused, __u32 ifindex __maybe_unused,
-		  __u8 reason, __u32 monitor __maybe_unused)
+		  enum trace_reason reason, __u32 monitor __maybe_unused)
 {
 	update_trace_metrics(ctx, obs_point, reason);
 }
@@ -272,7 +271,7 @@ static __always_inline void
 send_trace_notify4(struct __ctx_buff *ctx, __u8 obs_point,
 		   __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		   __be32 orig_addr __maybe_unused, __u16 dst_id __maybe_unused,
-		   __u32 ifindex __maybe_unused, __u8 reason,
+		   __u32 ifindex __maybe_unused, enum trace_reason reason,
 		   __u32 monitor __maybe_unused)
 {
 	update_trace_metrics(ctx, obs_point, reason);
@@ -283,7 +282,7 @@ send_trace_notify6(struct __ctx_buff *ctx, __u8 obs_point,
 		   __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		   union v6addr *orig_addr __maybe_unused,
 		   __u16 dst_id __maybe_unused, __u32 ifindex __maybe_unused,
-		   __u8 reason, __u32 monitor __maybe_unused)
+		   enum trace_reason reason, __u32 monitor __maybe_unused)
 {
 	update_trace_metrics(ctx, obs_point, reason);
 }

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -173,8 +173,7 @@ func TraceObservationPointHasConnState(obsPoint uint8) bool {
 	case TraceToLxc,
 		TraceToProxy,
 		TraceToHost,
-		TraceToStack,
-		TraceToNetwork:
+		TraceToStack:
 		return true
 	default:
 		return false


### PR DESCRIPTION
This fixes a bug where Hubble wrongly populated the `is_reply` field for `to-network` trace events. This caused the Hubble UI to populate the service map destination ports with ephemeral source ports. 

![image](https://user-images.githubusercontent.com/50564/145387508-19f20947-f3af-4110-9831-7ed8e5f9e904.png)

This PR removes the erroneously populated values in the datapath and improves the source documentation and function signature to avoid similar bugs in the future. See individual commits for details. 
