### PR TITLE
[proxy] Fix proxy nil check

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -151,7 +151,7 @@ func (e *Endpoint) useCurrentNetworkPolicy(proxyWaitGroup *completion.WaitGroup)
 		return
 	}
 
-	if e.proxy != nil {
+	if !e.isProxyDisabled() {
 		// Wait for the current network policy to be acked
 		e.proxy.UseCurrentNetworkPolicy(e, e.desiredPolicy.L4Policy, proxyWaitGroup)
 	}


### PR DESCRIPTION
cilium-agent panic when `enable-l7-proxy` is toggled

This PR fixes the proxy check condition by calling `!isProxyDisabled()` on the endpoint instead of doing a nil check on the interface because the type exists but value is nil.

Fixes: #18195


Signed-off-by: chaosbox <raamnathmani@gmail.com>

```release-note
Fix crash on startup if proxy is disabled
```