### PR TITLE
helm: Fix Helm template for externalWorkloads

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
@@ -1,8 +1,8 @@
 {{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
 {{- $_ := include "clustermesh-apiserver-generate-certs.helm.setup-ca" . -}}
 {{- $cn := "clustermesh-apiserver.cilium.io" }}
-{{- $ip := prepend .Values.clustermesh.apiserver.tls.server.extraIpAddresses "127.0.0.1" "::1" }}
-{{- $dns := prepend .Values.clustermesh.apiserver.tls.server.extraDnsNames $cn "*.mesh.cilium.io" }}
+{{- $ip := concat (list "127.0.0.1" "::1") .Values.clustermesh.apiserver.tls.server.extraIpAddresses }}
+{{- $dns := concat (list $cn "*.mesh.cilium.io") .Values.clustermesh.apiserver.tls.server.extraDnsNames }}
 {{- $cert := genSignedCert $cn $ip $dns (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .cmca -}}
 ---
 apiVersion: v1


### PR DESCRIPTION
This fixes an error where instantiating the Helm chart with
`externalWorkloads.enabled=true` would fail due an invalid prefix
command in our Helm template:

```
Error: template: cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml:4:11:
 executing "cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml" at
  <prepend>: wrong number of args for prepend: want 2 got 3
```

Fixes: 4635ffaced50 ("refactor cert-gen logic")

Reported-by: Slack user `night` on cilium.slack.com
Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
