### PR TITLE
pkg/endpoint: Pass endpoint alive context to regeneration tasks

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -647,7 +647,7 @@ var reasonRegenRetry = "retrying regeneration"
 // ran again unless another build failure occurs. If the call to `Regenerate`
 // fails inside of the controller,
 func (e *Endpoint) startRegenerationFailureHandler() {
-	e.controllers.UpdateController(fmt.Sprintf("endpoint-%s-regeneration-recovery", e.StringID()), controller.ControllerParams{
+	e.UpdateController(fmt.Sprintf("endpoint-%s-regeneration-recovery", e.StringID()), controller.ControllerParams{
 		DoFunc: func(ctx context.Context) error {
 			select {
 			case <-e.regenFailedChan:


### PR DESCRIPTION
A per endpoint controller is started when an endpoint is being created, or restored. The controller triggers regeneration process for the endpoint that's tasked with attaching BPF programs to the endpoint device. When an endpoint is deleted, the regeneration task is expected to fail to attach BPF programs as the endpoint devices are cleaned up. In order to differentiate such expected cases from the failure ones, the code checks if the endpoint is alive via a context that's cancelled when the endpoint is deleted. However, the right context wasn't passed down to the regeneration
routines via the controller. As a result, the regeneration task would flag an error in the expected scenarios.

Fix it by calling the right function that populates the per endpoint alive context. The [other](https://github.com/cilium/cilium/blob/master/pkg/endpoint/endpoint.go#L1804-L1804) [places](https://github.com/cilium/cilium/blob/master/pkg/endpoint/endpoint.go#L1586-L1586) in pkg/endpoint already pass the correct context. 

Fixes: https://github.com/cilium/cilium/issues/18073

Signed-off-by: Aditi Ghag <aditi@cilium.io>
Signed-off-by: Joe Stringer <joe@cilium.io>

**Release note**
```release-note
Fix a bug where agent would log warnings such as "JoinEP: Failed to load program" in legitimate cases where endpoints are getting deleted.
```