### PR TITLE
Avoid tunnel map sync controller errors

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -310,8 +310,11 @@ func (d *Daemon) initMaps() error {
 		return err
 	}
 
-	if _, err := tunnel.TunnelMap.OpenOrCreate(); err != nil {
-		return err
+	if option.Config.TunnelingEnabled() || option.Config.EnableIPv4EgressGateway {
+		// The IPv4 egress gateway feature also uses tunnel map
+		if _, err := tunnel.TunnelMap.OpenOrCreate(); err != nil {
+			return err
+		}
 	}
 
 	if option.Config.EnableIPv4EgressGateway {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -156,14 +156,20 @@ func deleteTunnelMapping(oldCIDR *cidr.CIDR, quietMode bool) {
 		return
 	}
 
-	log.WithField("allocCIDR", oldCIDR).Debug("Deleting tunnel map entry")
+	log.WithFields(logrus.Fields{
+		"allocCIDR": oldCIDR,
+		"quietMode": quietMode,
+	}).Debug("Deleting tunnel map entry")
 
-	if err := tunnel.TunnelMap.DeleteTunnelEndpoint(oldCIDR.IP); err != nil {
-		if !quietMode {
+	if !quietMode {
+		if err := tunnel.TunnelMap.DeleteTunnelEndpoint(oldCIDR.IP); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				"allocCIDR": oldCIDR,
 			}).Error("Unable to delete in tunnel endpoint map")
 		}
+	} else {
+		_ = tunnel.TunnelMap.SilentDeleteTunnelEndpoint(oldCIDR.IP)
+
 	}
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1104,11 +1104,6 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 
 		return nil
 	} else if firstAddition {
-		// When encapsulation is disabled, then the initial node addition
-		// triggers a removal of eventual old tunnel map entries.
-		deleteTunnelMapping(newNode.IPv4AllocCIDR, true)
-		deleteTunnelMapping(newNode.IPv6AllocCIDR, true)
-
 		if rt, _ := n.lookupNodeRoute(newNode.IPv4AllocCIDR, isLocalNode); rt != nil {
 			n.deleteNodeRoute(newNode.IPv4AllocCIDR, isLocalNode)
 		}

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -87,3 +87,11 @@ func (m *Map) DeleteTunnelEndpoint(prefix net.IP) error {
 	log.WithField(fieldPrefix, prefix).Debug("Deleting tunnel map entry")
 	return TunnelMap.Delete(newTunnelEndpoint(prefix))
 }
+
+// SilentDeleteTunnelEndpoint removes a prefix => tunnel-endpoint mapping.
+// If the prefix is not found no error is returned.
+func (m *Map) SilentDeleteTunnelEndpoint(prefix net.IP) error {
+	log.WithField(fieldPrefix, prefix).Debug("Silently deleting tunnel map entry")
+	_, err := TunnelMap.SilentDelete(newTunnelEndpoint(prefix))
+	return err
+}

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -40,12 +40,8 @@ func NewTunnelMap(name string) *Map {
 		MaxEntries,
 		0, 0,
 		bpf.ConvertKeyValue,
-	).WithCache().WithPressureMetric(),
+	).WithCache().WithPressureMetric().WithNonPersistent(),
 	}
-}
-
-func init() {
-	TunnelMap.NonPersistent = true
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2172,8 +2172,7 @@ func (c *DaemonConfig) AlwaysAllowLocalhost() bool {
 	}
 }
 
-// TunnelingEnabled returns true if the remote-node identity feature
-// is enabled
+// TunnelingEnabled returns true if tunneling is enabled, i.e. not set to "disabled".
 func (c *DaemonConfig) TunnelingEnabled() bool {
 	return c.Tunnel != TunnelDisabled
 }


### PR DESCRIPTION
Several users [reported issues](https://github.com/cilium/cilium/issues/16488) with `bpf-map-sync-cilium_tunnel_map` controller in an error state even though tunneling is disabled in their setup.

While the exact condition causing these error states could not be reproduced, there are several counter-measures that can be taken to avoid these issues: most importantly disabling the `bpf-map-sync-cilium_tunnel_map` altogether in case tunneling (or the egress gateway, which also makes use of the tunnel map) is not enabled.

See commit messages for more details on the individual changes.

Fixes: #16488

```release-note
Fix an issue where the tunnel map sync controller causes errors even though tunneling is disabled.
```
