### PR TITLE
docs: update CODEOWNERS feature release instructions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 # Code owners groups and a brief description of their areas:
 # @cilium/janitors           Catch-all for code not otherwise owned
+# @cilium/api                API stability guarantees
 # @cilium/agent              Cilium Agent
 # @cilium/alibabacloud       Integration with AlibabaCloud
 # @cilium/aws                Integration with AWS

--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -26,18 +26,14 @@ On Freeze date
 #. Protect the branch using the GitHub UI to disallow direct push and require
    merging via PRs with proper reviews. `Direct link <https://github.com/cilium/cilium/settings/branches>`_
 
-#. Replace the contents of the ``CODEOWNERS`` file with the following to reduce
-   code reviews to essential approvals:
+#. Update the contents of the ``CODEOWNERS`` file to reduce code reviews to
+   essential approvals:
 
-   ::
-
-        * @cilium/janitors
-        .github/workflows/ @cilium/cilium-maintainers
-        api/ @cilium/api
-        pkg/apisocket/ @cilium/api
-        pkg/monitor/payload @cilium/api
-        pkg/policy/api/ @cilium/api
-        pkg/proxy/accesslog @cilium/api
+   #. Keep ``* @cilium/janitors`` fallback entry.
+   #. Keep ``/.github/workflows/`` entry for CI/CD security.
+   #. Keep all ``@cilium/api`` assignments for API stability on the release
+      branch.
+   #. Remove everything else so that it is handled by janitors / Top Hat.
 
 #. Delete the ``stable.txt`` file.
 


### PR DESCRIPTION
Documenting the general strategy should be more resistant to changes over time than storing a snippet that folks might copy/paste by mistake without looking at the current file from `master`.

Also add missing `@cilium/api` comment to `CODEOWNERS`.