### PR TITLE
test: Collect logs from init containers

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3562,7 +3562,8 @@ func (kub *Kubectl) GeneratePodLogGatheringCommands(ctx context.Context, reportC
 	}
 
 	for _, pod := range pods {
-		for _, containerStatus := range pod.Status.ContainerStatuses {
+		containerStatuses := append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...)
+		for _, containerStatus := range containerStatuses {
 			logCmd := fmt.Sprintf("%s -n %s logs --timestamps %s -c %s", KubectlCmd, pod.Namespace, pod.Name, containerStatus.Name)
 			logfileName := fmt.Sprintf("pod-%s-%s-%s.log", pod.Namespace, pod.Name, containerStatus.Name)
 			reportCmds[logCmd] = logfileName


### PR DESCRIPTION
If pods are failing to start and stay stuck in e.g. `Init:CrashLoopBackOff`, it will be useful to have the init containers' logs to investigate further.