### PR TITLE
docs: Warn against Helm's `--reuse-values` in Cilium upgrades

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -220,6 +220,24 @@ version which was installed in this cluster. Valid options are:
         --namespace=kube-system \\
         -f my-values.yaml
 
+When upgrading from one minor release to another minor release using
+``helm upgrade``, do *not* use Helm's ``--reuse-values`` flag.
+The ``--reuse-values`` flag ignores any newly introduced values present in
+the new release and thus may cause the Helm template to render incorrectly.
+Instead, if you want to reuse the values from your existing installation,
+save the old values in a values file, check the file for any renamed or
+deprecated values, and then pass it to the ``helm upgrade`` command as
+described above. You can retrieve and save the values from an existing
+installation with the following command:
+
+.. code-block:: shell-session
+
+  helm get values cilium --namespace=kube-system -o yaml > old-values.yaml
+
+The ``--reuse-values`` flag may only be safely used if the Cilium chart version
+remains unchanged, for example when ``helm upgrade`` is used to apply
+configuration changes without upgrading Cilium.
+
 Step 3: Rolling Back
 --------------------
 


### PR DESCRIPTION
Using `--reuse-values` to upgrade to a new minor Cilium version is never been supported and may break the Helm template in subtle ways due to the lack of new default values. Adding this in the docs after a user on Slack reported multiple problems by using this flag, as supporting the flag in the chart is a rather large task and likely requires some automation and testing to ensure it remains supported.

For more details, see also https://github.com/helm/helm/issues/3957#issuecomment-384685681