### PR TITLE
Add consistency checks for the `CODEOWNERS` file

### DIFF
--- a/.github/workflows/lint-codeowners.yaml
+++ b/.github/workflows/lint-codeowners.yaml
@@ -1,0 +1,101 @@
+name: CODEOWNERS checks
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    runs-on: ubuntu-latest
+    outputs:
+      added-files: ${{ steps.changes.outputs.added-files }}
+      deleted-files: ${{ steps.changes.outputs.deleted-files }}
+    steps:
+      - name: Check code changes
+        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
+        id: changes
+        with:
+          filters: |
+            added-files:
+              - added: '**'
+            deleted-files:
+              - deleted: '**'
+
+  codeowners:
+    needs: check_changes
+    if: ${{ needs.check_changes.outputs.added-files == 'true' || needs.check_changes.outputs.deleted-files == 'true' }}
+    name: Check CODEOWNERS consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+          # Hard-code the path instead of using ${{ github.repository }}
+          # to make sure it works for forked repo as well.
+          path: src/github.com/cilium/cilium
+
+      - name: Check if all files have attributed code owners
+        if: ${{ needs.check_changes.outputs.added-files == 'true' }}
+        run: |
+          # CODEOWNERS patterns follows nearly the same syntax as a .gitignore.
+          # To check if all files are covered by patterns other than the
+          # catch-all '*', we turn the file into a .gitignore and list
+          # unmatched files.
+          cd src/github.com/cilium/cilium
+          # Copy all patterns from CODEOWNERS, but skipping the comments
+          # ('^[^#]') and the catch-all '*' rule (the only one with a single
+          # character, we skip it with '^.[^ ]').
+          awk '/^[^#][^ ]/ {print $1}' CODEOWNERS > .gitignore
+          # Reinitialize the repo and list all files NOT covered by .gitignore.
+          rm -rf .git
+          git init -q
+          if [[ -n "$(git ls-files --others -X .gitignore)" ]]; then
+              echo '::error title=missing_code_owners::Following files have no owners in CODEOWNERS:'
+              git ls-files --others -X .gitignore
+              exit 1
+          fi
+
+      - name: Check if CODEOWNERS has stale entries
+        if: ${{ needs.check_changes.outputs.deleted-files == 'true' }}
+        run: |
+          cd src/github.com/cilium/cilium
+          EXIT_STATUS=0
+          # We go through the patterns in CODEOWNERS, and for each of them we
+          # search for corresponding files in the repo.
+          while read l; do
+              case "${l}" in
+                  /*)
+                      # The pattern should match from the root of the repo,
+                      # we'll use 'ls'. For now, just append pattern to $LIST.
+                      LIST+=" ${l#/}"
+                      ;;
+                  *)
+                      # No leading slash: may not be at the root of the repo,
+                      # search with 'find'. Print pattern if no file found.
+                      if [[ -z $(find . -path "*${l}*" -print -quit) ]]; then
+                          echo "${l}"
+                          EXIT_STATUS=1
+                      fi
+                      ;;
+              esac
+          done <<< $(awk '/^[^#][^ ]/ {print $1}' CODEOWNERS)
+          # Just one final call to 'ls' with all /* patterns found. Catch
+          # patterns with no corresponding files/directories from stderr.
+          STALE_PATTERNS="$(ls -- ${LIST} 2>&1 >/dev/null | sed "s|.*'\(.*\)':.*|/\1|")"
+          if [[ -n "${STALE_PATTERNS}" ]]; then
+              echo "${STALE_PATTERNS}" | sed 's/ /\n/g'
+              EXIT_STATUS=1
+          fi
+          if [[ ${EXIT_STATUS} -ne 0 ]]; then
+              echo '::error title=stale_patterns::The patterns above should be removed from CODEOWNERS.'
+              exit ${EXIT_STATUS}
+          fi

--- a/.github/workflows/lint-codeowners.yaml
+++ b/.github/workflows/lint-codeowners.yaml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       added-files: ${{ steps.changes.outputs.added-files }}
       deleted-files: ${{ steps.changes.outputs.deleted-files }}
+      codeowners-changed: ${{ steps.changes.outputs.codeowners-changed }}
     steps:
       - name: Check code changes
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
@@ -29,6 +30,8 @@ jobs:
               - added: '**'
             deleted-files:
               - deleted: '**'
+            codeowners-changed:
+              - 'CODEOWNERS'
 
   codeowners:
     needs: check_changes
@@ -97,5 +100,26 @@ jobs:
           fi
           if [[ ${EXIT_STATUS} -ne 0 ]]; then
               echo '::error title=stale_patterns::The patterns above should be removed from CODEOWNERS.'
+              exit ${EXIT_STATUS}
+          fi
+
+      - name: Check if all teams in CODEOWNERS rules are documented in the file
+        if: ${{ needs.check_changes.outputs.codeowners-changed == 'true' }}
+        run: |
+          EXIT_STATUS=0
+          # List all teams used in CODEOWNERS rules: discard comments and empty
+          # lines, discard the first field (pattern to match) for the remaining
+          # rules, split the list of teams by replacing spaces with line
+          # breaks, sort the results. Then grep for each team name among
+          # CODEOWNERS's comments.
+          cd src/github.com/cilium/cilium
+          for team in $(sed -e '/^\(#\|$\)/d' -e 's/^[^ #]\+ //' -e 's/ /\n/g' CODEOWNERS | sort -u); do
+              if ! grep -q "^# ${team} " CODEOWNERS; then
+                  echo "${team}";
+                  EXIT_STATUS=1
+              fi;
+          done
+          if [[ ${EXIT_STATUS} -ne 0 ]]; then
+              echo '::error title=missing_team::The teams above are not documented in CODEOWNERS. Typo?'
               exit ${EXIT_STATUS}
           fi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,17 +15,21 @@
 # @cilium/endpoint           Endpoint package
 # @cilium/github-sec         GitHub security (handling of secrets, consequences of pull_request_target, etc.)
 # @cilium/health             Cilium cluster health tool
+# @cilium/helm               Helm charts and best practices
 # @cilium/hubble             Hubble integration
 # @cilium/ipam               IPAM
+# @cilium/ipcache            Maintenance of pkg/ipcache
 # @cilium/kubernetes         K8s integration, K8s CNI plugin
 # @cilium/kvstore            Key/Value store: Consul, etcd
 # @cilium/loadbalancer       Load balancer
 # @cilium/loader             All related to LLVM, bpftool, Cilium loader, templating, etc.
+# @cilium/metrics            Metrics of the Cilium Agent
 # @cilium/operator           Cilium operator
 # @cilium/policy             Policy behaviour
 # @cilium/proxy              L7 proxy, Envoy
 # @cilium/vendor             Vendoring, dependency management
 # @cilium/wireguard          Wireguard integration
+# @cilium/nonexistantteam    Fake team to tell GitHub to skip assignment
 
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,9 +31,17 @@
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
 * @cilium/tophat
+/AUTHORS @cilium/tophat
+/CODE_OF_CONDUCT.md @cilium/contributing
 /CODEOWNERS @cilium/contributing
+/CONTRIBUTING.md @cilium/contributing
+/.authors.aux @cilium/tophat
+/.gitattributes @cilium/tophat
 /.github/ @cilium/contributing
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
+/.gitignore @cilium/tophat
+/.golangci.yaml @cilium/ci-structure
+/.mailmap @cilium/tophat
 /.travis/ @cilium/ci-structure
 /.travis.yml @cilium/ci-structure
 /api/ @cilium/api
@@ -50,11 +58,13 @@ Makefile* @cilium/build
 /bpf/init.sh @cilium/loader
 /bpf/custom/Makefile* @cilium/build @cilium/loader
 /bpf/sockops/Makefile* @cilium/build @cilium/loader
+/bugtool/ @cilium/tophat
 /bugtool/cmd/ @cilium/cli
 /cilium/ @cilium/cli
 /cilium/cmd/preflight_k8s_valid_cnp.go @cilium/kubernetes
 /cilium-health/ @cilium/health
 /cilium-health/cmd/ @cilium/health @cilium/cli
+/clustermesh-apiserver @cilium/tophat
 /contrib/ @cilium/contributing
 /contrib/packaging/ @cilium/build
 /contrib/vagrant/ @cilium/contributing
@@ -134,13 +144,20 @@ Makefile* @cilium/build
 /examples/ @cilium/docs-structure
 /examples/kubernetes/ @cilium/kubernetes
 /examples/minikube/ @cilium/kubernetes
+/FURTHER_READINGS.rst @cilium/docs-structure
+/hack/ @cilium/tophat
+/GO_VERSION @cilium/agent
 *.Jenkinsfile @cilium/ci-structure
 /hubble-relay/ @cilium/hubble
 /images @cilium/build
 /install/kubernetes/ @cilium/kubernetes @cilium/helm
 /install/kubernetes/cilium/templates/hubble* @cilium/kubernetes @cilium/helm @cilium/hubble
 jenkinsfiles @cilium/ci-structure
+/LICENSE @cilium/tophat
+/MAINTAINERS.md @cilium/contributing
+/netlify.toml @cilium/ci-structure
 /operator/ @cilium/operator
+/pkg/ @cilium/tophat
 /pkg/annotation @cilium/kubernetes
 /pkg/alibabacloud/ @cilium/alibabacloud
 /pkg/api/ @cilium/api
@@ -224,6 +241,8 @@ jenkinsfiles @cilium/ci-structure
 /plugins/cilium-docker/ @cilium/docker
 /proxylib/ @cilium/proxy
 /README.rst @cilium/docs-structure
+/SECURITY.md @cilium/contributing
+/stable.txt @cilium/tophat
 /test/ @cilium/ci-structure
 /test/Makefile* @cilium/ci-structure @cilium/build
 # Service handling tests
@@ -268,9 +287,11 @@ jenkinsfiles @cilium/ci-structure
 /test/runtime/chaos_agent.go @cilium/agent @cilium/ci-structure
 /test/runtime/chaos_endpoint.go @cilium/endpoint @cilium/ci-structure
 /tools/ @cilium/contributing
+/USERS.md @cilium/tophat
 Vagrantfile @cilium/ci-structure
 /Vagrantfile @cilium/contributing
 /go.sum @cilium/vendor
 /go.mod @cilium/vendor
 /vagrant_box_defaults.rb @cilium/ci-structure
 /vendor/ @cilium/vendor
+/VERSION @cilium/tophat


### PR DESCRIPTION
This PR adds a new GitHub workflow to check the entries in `CODEOWNERS`.

The workflow runs on PRs on the `master` branch (not for backports, not for pushes to `master`).

On PRs that add new files, it checks that these files are covered by at least one pattern other than the `*` catch-all pattern in `CODEOWNERS`. This is to help detect new files that should have their own dedicated entry.

On PRs that remove files, the workflow checks that all patterns in the file still have corresponding entries in the repository, to avoid keeping stale entries.

In a last step which runs for PRs where `CODEOWNERS` is changed, the teams assigned to each pattern are compared with the teams documented at the beginning of `CODEOWNERS`. This should help ensure that no typo sneaks in for the names of the teams assigned to each pattern.

Note: Checking that all files are covered in the `CODEOWNERS` file, other than by the catch-all `*`, required adding new entries. I left most of them (but not all) with `@cilium/janitors`. There is one in particular that got me hesitating: I used a rather generic `/pkg/` pattern, where we could alternatively explode it into all the different `/pkg/<pkg_name>` that are not currently covered in the file, so that the workflow would catch the addition of new packages. I have preferred to keep things simple for now, but I am open to listing all those packages, depending on reviewers' feedback.

Cc @jrajahalme for the first commit.
Fixes: #18036 