### PR TITLE
set base-version in 1.10 workflows

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -142,7 +142,8 @@ jobs:
             --azure-resource-group ${{ env.name }} \
             --wait=false \
             --rollback=false \
-            --config monitor-aggregation=none"
+            --config monitor-aggregation=none" \
+            --base-version=v1.10
           HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -142,7 +142,8 @@ jobs:
             --azure-resource-group ${{ env.name }} \
             --wait=false \
             --rollback=false \
-            --config monitor-aggregation=none"
+            --config monitor-aggregation=none" \
+            --base-version=v1.11
           HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -140,7 +140,8 @@ jobs:
             --version=${SHA} \
             --wait=false \
             --rollback=false \
-            --config monitor-aggregation=none"
+            --config monitor-aggregation=none" \
+            --base-version=v1.10
           HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -140,7 +140,8 @@ jobs:
             --version=${SHA} \
             --wait=false \
             --rollback=false \
-            --config monitor-aggregation=none"
+            --config monitor-aggregation=none" \
+            --base-version=v1.11
           HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}

--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -144,7 +144,8 @@ jobs:
             --rollback=false \
             --config monitor-aggregation=none \
             --config tunnel=vxlan \
-            --kube-proxy-replacement=strict"
+            --kube-proxy-replacement=strict" \
+            --base-version=v1.10
           HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --relay-version=${SHA}"
           CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \

--- a/.github/workflows/conformance-externalworkloads-v1.11.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yml
@@ -144,7 +144,8 @@ jobs:
             --rollback=false \
             --config monitor-aggregation=none \
             --config tunnel=vxlan \
-            --kube-proxy-replacement=strict"
+            --kube-proxy-replacement=strict" \
+            --base-version=v1.11
           HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --relay-version=${SHA}"
           CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -140,7 +140,8 @@ jobs:
             --version=${SHA} \
             --wait=false \
             --rollback=false \
-            --config monitor-aggregation=none"
+            --config monitor-aggregation=none" \
+            --base-version=v1.10
           HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -140,7 +140,8 @@ jobs:
             --version=${SHA} \
             --wait=false \
             --rollback=false \
-            --config monitor-aggregation=none"
+            --config monitor-aggregation=none" \
+            --base-version=v1.11
           HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --relay-version=${SHA}"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -141,7 +141,8 @@ jobs:
             --version=${SHA} \
             --wait=false \
             --rollback=false \
-            --config monitor-aggregation=none"
+            --config monitor-aggregation=none" \
+            --base-version=v1.10
           HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --relay-version=${SHA}"
           CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -141,7 +141,8 @@ jobs:
             --version=${SHA} \
             --wait=false \
             --rollback=false \
-            --config monitor-aggregation=none"
+            --config monitor-aggregation=none" \
+            --base-version=v1.11
           HUBBLE_ENABLE_DEFAULTS="--relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --relay-version=${SHA}"
           CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \


### PR DESCRIPTION
0.10.0 cli version is not compatible with 1.10 Cilium and results in
  breakages (e.g. incorrect setting of native routing CIDR in GKE).