### PR TITLE
pkg/endpoint: Fix circularity in the endpoint delete handler leading to incorrect errors

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -362,8 +362,8 @@ func compileDatapath(ctx context.Context, dirs *directoryInfo, isHost bool, logg
 			if ctx.Err() == nil {
 				scopedLog.WithField(logfields.Params, logfields.Repr(p)).
 					WithError(err).Debug("JoinEP: Failed to compile")
+				return err
 			}
-			return err
 		}
 	}
 
@@ -379,8 +379,8 @@ func compileDatapath(ctx context.Context, dirs *directoryInfo, isHost bool, logg
 		if ctx.Err() == nil {
 			scopedLog.WithField(logfields.Params, logfields.Repr(prog)).
 				WithError(err).Warn("JoinEP: Failed to compile")
+			return err
 		}
-		return err
 	}
 
 	return nil

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -265,8 +265,8 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 			// loading the program.
 			if ctx.Err() == nil {
 				scopedLog.WithError(err).Warningf("JoinEP: Failed to load program for host endpoint (%s)", symbol)
+				return err
 			}
-			return err
 		}
 	}
 
@@ -298,8 +298,8 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 			// loading the program.
 			if ctx.Err() == nil {
 				scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+				return err
 			}
-			return err
 		}
 	} else {
 		if err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, ""); err != nil {
@@ -312,8 +312,8 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 			// loading the program.
 			if ctx.Err() == nil {
 				scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+				return err
 			}
-			return err
 		}
 
 		if ep.RequireEgressProg() {
@@ -327,8 +327,8 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 				// loading the program.
 				if ctx.Err() == nil {
 					scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+					return err
 				}
-				return err
 			}
 		} else {
 			err := RemoveTCFilters(ep.InterfaceName(), netlink.HANDLE_MIN_EGRESS)

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -109,7 +109,7 @@ func (e *Endpoint) PolicyRevisionBumpEvent(rev uint64) {
 	}
 }
 
-/// EndpointNoTrackEvent contains all fields necessary to update the NOTRACK rules.
+// EndpointNoTrackEvent contains all fields necessary to update the NOTRACK rules.
 type EndpointNoTrackEvent struct {
 	ep     *Endpoint
 	annoCB AnnotationsResolverCB
@@ -361,6 +361,9 @@ func (e *Endpoint) Start(id uint16) {
 // datapath state (for instance, because the daemon is shutting down but the
 // endpoint should remain operational while the daemon is not running).
 func (e *Endpoint) Stop() {
+	// Cancel active controllers for the endpoint tied to e.aliveCtx.
+	e.aliveCancel()
+
 	// Since the endpoint is being deleted, we no longer need to run events
 	// in its event queue. This is a no-op if the queue has already been
 	// closed elsewhere.
@@ -379,7 +382,4 @@ func (e *Endpoint) Stop() {
 	// if anything is blocking on it. If a delete request has already been
 	// enqueued for this endpoint, this is a no-op.
 	e.closeBPFProgramChannel()
-
-	// Cancel active controllers for the endpoint tied to e.aliveCtx.
-	e.aliveCancel()
 }


### PR DESCRIPTION
A per endpoint controller is started when an endpoint is being created, or restored. The controller triggers regeneration process for the endpoint that's tasked with attaching BPF programs to the endpoint device. When an endpoint is deleted, the regeneration task is expected to fail to attach BPF programs as the endpoint devices are cleaned up. In order to differentiate such expected cases from the failure ones, the code checks if the endpoint is alive via a context that's cancelled when the endpoint is deleted.
However, the handler that's invoked when an endpoint is deleted first waits on the endpoint's event queue to be completely drained [1]. This also includes the in-flight tasks like regeneration. But there is a limit on the total number of regeneration tasks can be run in parallel [2] on a host. The regeneration tasks when fail to attach BPF program for an endpoint also checks the endpoint's alive context to differentiate legitimate failures from
the expected endpoint deletion cases. But the endpoint's alive context is cancelled after the queue is drained [3].

Fix the circularity by first cancelling an endpoint's alive context in the endpoint delete handler.

This should avoid incorrect errors seen in the agent logs - `JoinEP: Failed to load program`.

Fixes: https://github.com/cilium/cilium/issues/18073

[1] https://github.com/cilium/cilium/blob/master/pkg/endpoint/events.go#L377-L377
[2] https://github.com/cilium/cilium/blob/e1f4120efdf38657cc72d64825b233447952588d/daemon/cmd/endpoint.go#L1047
[3] https://github.com/cilium/cilium/blob/master/pkg/endpoint/events.go#L384-L384

Signed-off-by: Aditi Ghag <aditi@cilium.io>