### PR TITLE
docs: Update the kind documentation with cgroup requirements

### DIFF
--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -54,9 +54,20 @@ Then, install Cilium release via Helm:
 
 .. note::
 
-   To fully enable Cilium's kube-proxy replacement (:ref:`kubeproxy-free`), cgroup v1
-   controllers ``net_cls`` and ``net_prio`` have to be disabled, or cgroup v1 has
-   to be disabled (e.g. by setting the kernel ``cgroup_no_v1="all"`` parameter).
+   To fully enable Cilium's kube-proxy replacement (:ref:`kubeproxy-free`), cgroup v2
+   needs to be enabled by setting the kernel ``systemd.unified_cgroup_hierarchy=1`` parameter.
+   Also, cgroup v1 controllers ``net_cls`` and ``net_prio`` have to be disabled, or
+   cgroup v1 has to be disabled (e.g. by setting the kernel ``cgroup_no_v1="all"`` parameter).
+   This ensures that Kind nodes have their own cgroup namespace, and Cilium can
+   attach BPF programs at the right cgroup hierarchy. To verify this, run the
+   following commands on the host, and check that the output values are different.
+
+   .. code-block:: shell-session
+
+      $ sudo ls -al /proc/$(docker inspect -f '{{.State.Pid}}' kind-control-plane)/ns/cgroup
+      $ sudo ls -al /proc/self/ns/cgroup
+
+   See the `Pull Request <https://github.com/cilium/cilium/pull/16259>`__ for more details.
 
 .. include:: k8s-install-validate.rst
 


### PR DESCRIPTION
For kube-proxy replacement (specifically, socket-based load-balancing)
to work correctly in KIND clusters, the BPF cgroup programs need to be
attached at the correct cgroup hierarchy. For this to happen, the KIND
nodes need to have their own separate cgroup namespace.
More details in PR - https://github.com/cilium/cilium/pull/16259.

While cgroup namespaces are supported across both cgroup v1 and v2 modes,
container runtimes like Docker enable private cgroup namespace mode
by default only with cgroup v2 [1]. With cgroup v1, the default is host
cgroup namespace, whereby KIND node containers (and also cilium agent pods)
are created in the same cgroup namespace as the underlying host.

[1] https://docs.docker.com/config/containers/runmetrics/#running-docker-on-cgroup-v2

Signed-off-by: Aditi Ghag <aditi@cilium.io>