### PR TITLE
daemon: Add --disable-sip-verification flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -71,6 +71,7 @@ cilium-agent [flags]
       --disable-conntrack                                    Disable connection tracking
       --disable-endpoint-crd                                 Disable use of CiliumEndpoint CRD
       --disable-iptables-feeder-rules strings                Chains to ignore when installing feeder rules.
+      --disable-sip-verification                             Disable source ip verification
       --dns-max-ips-per-restored-rule int                    Maximum number of IPs to maintain for each restored DNS rule (default 1000)
       --egress-masquerade-interfaces string                  Limit egress masquerading to interface selector
       --egress-multi-home-ip-rule-compat                     Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1047,6 +1047,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableK8sTerminatingEndpoint, true, "Enable auto-detect of terminating endpoint condition")
 	option.BindEnv(option.EnableK8sTerminatingEndpoint)
 
+	flags.Bool(option.DisableSipVerification, defaults.DisableSipVerification, "Disable source ip verification")
+	option.BindEnv(option.DisableSipVerification)
+
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1047,8 +1047,8 @@ func initializeFlags() {
 	flags.Bool(option.EnableK8sTerminatingEndpoint, true, "Enable auto-detect of terminating endpoint condition")
 	option.BindEnv(option.EnableK8sTerminatingEndpoint)
 
-	flags.Bool(option.DisableSipVerification, defaults.DisableSipVerification, "Disable source ip verification")
-	option.BindEnv(option.DisableSipVerification)
+	flags.Bool(option.EnableeSipVerification, defaults.EnableSipVerification, "Enable source ip verification")
+	option.BindEnv(option.EnableSipVerification)
 
 	viper.BindPFlags(flags)
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -441,4 +441,7 @@ const (
 
 	// ARPBaseReachableTime resembles the kernel's NEIGH_VAR_BASE_REACHABLE_TIME which defaults to 30 seconds.
 	ARPBaseReachableTime = 30 * time.Second
+
+	// DisableSipVerification disables source ip verification
+	DisableSipVerification = false
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -994,6 +994,9 @@ const (
 	// regardless of whether it's available in the pool.
 	BypassIPAvailabilityUponRestore = "bypass-ip-availability-upon-restore"
 
+	// DisableSipVerification disable sip verification
+	DisableSipVerification = "disable-sip-verification"
+
 	// EnableK8sTerminatingEndpoint enables the option to auto detect terminating
 	// state for endpoints in order to support graceful termination.
 	EnableK8sTerminatingEndpoint = "enable-k8s-terminating-endpoint"
@@ -2044,6 +2047,9 @@ type DaemonConfig struct {
 	// regardless of whether it's available in the pool.
 	BypassIPAvailabilityUponRestore bool
 
+	// DisableSipVerification bypasses sip verification
+	DisableSipVerification bool
+
 	// EnableK8sTerminatingEndpoint enables auto-detect of terminating state for
 	// Kubernetes service endpoints.
 	EnableK8sTerminatingEndpoint bool
@@ -2090,6 +2096,7 @@ var (
 		K8sEnableAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
 		AllocatorListTimeout:         defaults.AllocatorListTimeout,
 		EnableICMPRules:              defaults.EnableICMPRules,
+		DisableSipVerification:       defaults.DisableSipVerification,
 
 		K8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
 		APIRateLimit:                     make(map[string]string),
@@ -2892,6 +2899,7 @@ func (c *DaemonConfig) Populate() {
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)
 	c.EnableICMPRules = viper.GetBool(EnableICMPRules)
 	c.BypassIPAvailabilityUponRestore = viper.GetBool(BypassIPAvailabilityUponRestore)
+	c.DisableSipVerification = viper.GetBool(DisableSipVerification)
 	c.EnableK8sTerminatingEndpoint = viper.GetBool(EnableK8sTerminatingEndpoint)
 }
 


### PR DESCRIPTION
Add flag to disable sip verification.
This will allow to configure the datapath so it doesn't drop packets due to invalid source IP in the datapath.
This is helpful when routing IP payload from external ip networks through kubernets via ip tunnels. See #16134 for more information.

Signed-off-by: Michael Raskansky <michaelraskansky@gmail.com>
