### PR TITLE
v1.10 backports 2021-12-16

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -242,6 +242,24 @@ version which was installed in this cluster. Valid options are:
         --namespace=kube-system \\
         -f my-values.yaml
 
+When upgrading from one minor release to another minor release using
+``helm upgrade``, do *not* use Helm's ``--reuse-values`` flag.
+The ``--reuse-values`` flag ignores any newly introduced values present in
+the new release and thus may cause the Helm template to render incorrectly.
+Instead, if you want to reuse the values from your existing installation,
+save the old values in a values file, check the file for any renamed or
+deprecated values, and then pass it to the ``helm upgrade`` command as
+described above. You can retrieve and save the values from an existing
+installation with the following command:
+
+.. code-block:: shell-session
+
+  helm get values cilium --namespace=kube-system -o yaml > old-values.yaml
+
+The ``--reuse-values`` flag may only be safely used if the Cilium chart version
+remains unchanged, for example when ``helm upgrade`` is used to apply
+configuration changes without upgrading Cilium.
+
 Step 3: Rolling Back
 --------------------
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -924,8 +924,7 @@ handle_netdev(struct __ctx_buff *ctx, const bool from_host)
 		return send_drop_notify(ctx, SECLABEL, WORLD_ID, 0, ret,
 					CTX_ACT_DROP, METRIC_EGRESS);
 #else
-		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, 0, 0, 0,
-				  REASON_FORWARDED, 0);
+		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, 0, 0, 0, 0, 0);
 		/* Pass unknown traffic to the stack */
 		return CTX_ACT_OK;
 #endif /* ENABLE_HOST_FIREWALL */
@@ -1055,7 +1054,8 @@ out:
 					      METRIC_EGRESS);
 #endif
 	send_trace_notify(ctx, TRACE_TO_NETWORK, src_id, 0, 0,
-			  0, ret, 0);
+			  0, 0, 0);
+
 	return ret;
 }
 
@@ -1101,7 +1101,7 @@ int to_host(struct __ctx_buff *ctx)
 
 	if (!traced)
 		send_trace_notify(ctx, TRACE_TO_STACK, srcID, 0, 0,
-				  CILIUM_IFINDEX, ret, 0);
+				  CILIUM_IFINDEX, 0, 0);
 
 #ifdef ENABLE_HOST_FIREWALL
 	if (!validate_ethertype(ctx, &proto)) {

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1121,19 +1121,22 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 					   verdict, policy_match_type, audited);
 	}
 
-	if (ret == CT_NEW) {
 #ifdef ENABLE_DSR
-	{
+	if (ret == CT_NEW || ret == CT_REOPENED) {
 		bool dsr = false;
+		int ret2;
 
-		ret = handle_dsr_v6(ctx, &dsr);
-		if (ret != 0)
-			return ret;
+		ret2 = handle_dsr_v6(ctx, &dsr);
+		if (ret2 != 0)
+			return ret2;
 
 		ct_state_new.dsr = dsr;
+		if (ret == CT_REOPENED)
+			ct_update6_dsr(get_ct_map6(&tuple), &tuple, dsr);
 	}
 #endif /* ENABLE_DSR */
 
+	if (ret == CT_NEW) {
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.node_port = ct_state.node_port;
 		ct_state_new.ifindex = ct_state.ifindex;
@@ -1423,19 +1426,22 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 skip_policy_enforcement:
 #endif /* !ENABLE_HOST_SERVICES_FULL && !DISABLE_LOOPBACK_LB */
 
-	if (ret == CT_NEW) {
 #ifdef ENABLE_DSR
-	{
+	if (ret == CT_NEW || ret == CT_REOPENED) {
 		bool dsr = false;
+		int ret2;
 
-		ret = handle_dsr_v4(ctx, &dsr);
-		if (ret != 0)
-			return ret;
+		ret2 = handle_dsr_v4(ctx, &dsr);
+		if (ret2 != 0)
+			return ret2;
 
 		ct_state_new.dsr = dsr;
+		if (ret == CT_REOPENED)
+			ct_update4_dsr(get_ct_map4(&tuple), &tuple, dsr);
 	}
 #endif /* ENABLE_DSR */
 
+	if (ret == CT_NEW) {
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.node_port = ct_state.node_port;
 		ct_state_new.ifindex = ct_state.ifindex;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -819,6 +819,19 @@ ct_update6_rev_nat_index(const void *map, const struct ipv6_ct_tuple *tuple,
 	entry->rev_nat_index = state->rev_nat_index;
 }
 
+static __always_inline void
+ct_update6_dsr(const void *map, const struct ipv6_ct_tuple *tuple,
+	       const bool dsr)
+{
+	struct ct_entry *entry;
+
+	entry = map_lookup_elem(map, tuple);
+	if (!entry)
+		return;
+
+	entry->dsr = dsr;
+}
+
 /* Offset must point to IPv6 */
 static __always_inline int ct_create6(const void *map_main, const void *map_related,
 				      struct ipv6_ct_tuple *tuple,
@@ -913,6 +926,19 @@ ct_update4_rev_nat_index(const void *map, const struct ipv4_ct_tuple *tuple,
 		return;
 
 	entry->rev_nat_index = state->rev_nat_index;
+}
+
+static __always_inline void
+ct_update4_dsr(const void *map, const struct ipv4_ct_tuple *tuple,
+	       const bool dsr)
+{
+	struct ct_entry *entry;
+
+	entry = map_lookup_elem(map, tuple);
+	if (!entry)
+		return;
+
+	entry->dsr = dsr;
 }
 
 static __always_inline int ct_create4(const void *map_main,
@@ -1068,6 +1094,13 @@ ct_update6_rev_nat_index(const void *map __maybe_unused,
 {
 }
 
+static __always_inline void
+ct_update6_dsr(const void *map __maybe_unused,
+	       const struct ipv6_ct_tuple *tuple __maybe_unused,
+	       const bool dsr __maybe_unused)
+{
+}
+
 static __always_inline int
 ct_create6(const void *map_main __maybe_unused,
 	   const void *map_related __maybe_unused,
@@ -1090,6 +1123,13 @@ static __always_inline void
 ct_update4_rev_nat_index(const void *map __maybe_unused,
 			 const struct ipv4_ct_tuple *tuple __maybe_unused,
 			 const struct ct_state *state __maybe_unused)
+{
+}
+
+static __always_inline void
+ct_update4_dsr(const void *map __maybe_unused,
+	       const struct ipv4_ct_tuple *tuple __maybe_unused,
+	       const bool dsr __maybe_unused)
 {
 }
 

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -7,6 +7,16 @@
  * API:
  * void send_trace_notify(ctx, obs_point, src, dst, dst_id, ifindex, reason, monitor)
  *
+ * @ctx:	socket buffer
+ * @obs_point:	observation point (TRACE_*)
+ * @src:	source identity
+ * @dst:	destination identity
+ * @dst_id:	destination endpoint id or proxy destination port
+ * @ifindex:	network interface index
+ * @reason:	reason for forwarding the packet (TRACE_REASON_*),
+ *		e.g. return value of ct_lookup or TRACE_REASON_ENCRYPTED
+ * @monitor:	monitor aggregation value, e.g. the 'monitor' output of ct_lookup
+ *
  * If TRACE_NOTIFY is not defined, the API will be compiled in as a NOP.
  */
 #ifndef __LIB_TRACE__

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -45,15 +45,14 @@ enum {
 };
 
 /* Reasons for forwarding a packet. */
-enum {
+enum trace_reason {
 	TRACE_REASON_POLICY = CT_NEW,
 	TRACE_REASON_CT_ESTABLISHED = CT_ESTABLISHED,
 	TRACE_REASON_CT_REPLY = CT_REPLY,
 	TRACE_REASON_CT_RELATED = CT_RELATED,
 	TRACE_REASON_CT_REOPENED = CT_REOPENED,
-};
-
-#define TRACE_REASON_ENCRYPTED	    0x80
+	TRACE_REASON_ENCRYPTED = 0x80
+} __packed;
 
 /* Trace aggregation levels. */
 enum {
@@ -75,7 +74,7 @@ enum {
  * Update metrics based on a trace event
  */
 static __always_inline void
-update_trace_metrics(struct __ctx_buff *ctx, __u8 obs_point, __u8 reason)
+update_trace_metrics(struct __ctx_buff *ctx, __u8 obs_point, enum trace_reason reason)
 {
 	__u8 encrypted;
 
@@ -159,7 +158,7 @@ static __always_inline bool emit_trace_notify(__u8 obs_point, __u32 monitor)
 
 static __always_inline void
 send_trace_notify(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
-		   __u16 dst_id, __u32 ifindex, __u8 reason, __u32 monitor)
+		   __u16 dst_id, __u32 ifindex, enum trace_reason reason, __u32 monitor)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
@@ -189,7 +188,7 @@ send_trace_notify(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
 
 static __always_inline void
 send_trace_notify4(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
-		   __be32 orig_addr, __u16 dst_id, __u32 ifindex, __u8 reason,
+		   __be32 orig_addr, __u16 dst_id, __u32 ifindex, enum trace_reason reason,
 		   __u32 monitor)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
@@ -222,7 +221,7 @@ send_trace_notify4(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
 static __always_inline void
 send_trace_notify6(struct __ctx_buff *ctx, __u8 obs_point, __u32 src, __u32 dst,
 		   union v6addr *orig_addr, __u16 dst_id, __u32 ifindex,
-		   __u8 reason, __u32 monitor)
+		   enum trace_reason reason, __u32 monitor)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
@@ -256,7 +255,7 @@ static __always_inline void
 send_trace_notify(struct __ctx_buff *ctx, __u8 obs_point,
 		  __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		  __u16 dst_id __maybe_unused, __u32 ifindex __maybe_unused,
-		  __u8 reason, __u32 monitor __maybe_unused)
+		  enum trace_reason reason, __u32 monitor __maybe_unused)
 {
 	update_trace_metrics(ctx, obs_point, reason);
 }
@@ -265,7 +264,7 @@ static __always_inline void
 send_trace_notify4(struct __ctx_buff *ctx, __u8 obs_point,
 		   __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		   __be32 orig_addr __maybe_unused, __u16 dst_id __maybe_unused,
-		   __u32 ifindex __maybe_unused, __u8 reason,
+		   __u32 ifindex __maybe_unused, enum trace_reason reason,
 		   __u32 monitor __maybe_unused)
 {
 	update_trace_metrics(ctx, obs_point, reason);
@@ -276,7 +275,7 @@ send_trace_notify6(struct __ctx_buff *ctx, __u8 obs_point,
 		   __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		   union v6addr *orig_addr __maybe_unused,
 		   __u16 dst_id __maybe_unused, __u32 ifindex __maybe_unused,
-		   __u8 reason, __u32 monitor __maybe_unused)
+		   enum trace_reason reason, __u32 monitor __maybe_unused)
 {
 	update_trace_metrics(ctx, obs_point, reason);
 }

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -320,8 +320,11 @@ func (d *Daemon) initMaps() error {
 		return err
 	}
 
-	if _, err := tunnel.TunnelMap.OpenOrCreate(); err != nil {
-		return err
+	if option.Config.TunnelingEnabled() || option.Config.EnableEgressGateway {
+		// The IPv4 egress gateway feature also uses tunnel map
+		if _, err := tunnel.TunnelMap.OpenOrCreate(); err != nil {
+			return err
+		}
 	}
 
 	if option.Config.EnableEgressGateway {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -169,14 +169,20 @@ func deleteTunnelMapping(oldCIDR *cidr.CIDR, quietMode bool) {
 		return
 	}
 
-	log.WithField("allocCIDR", oldCIDR).Debug("Deleting tunnel map entry")
+	log.WithFields(logrus.Fields{
+		"allocCIDR": oldCIDR,
+		"quietMode": quietMode,
+	}).Debug("Deleting tunnel map entry")
 
-	if err := tunnel.TunnelMap.DeleteTunnelEndpoint(oldCIDR.IP); err != nil {
-		if !quietMode {
+	if !quietMode {
+		if err := tunnel.TunnelMap.DeleteTunnelEndpoint(oldCIDR.IP); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				"allocCIDR": oldCIDR,
 			}).Error("Unable to delete in tunnel endpoint map")
 		}
+	} else {
+		_ = tunnel.TunnelMap.SilentDeleteTunnelEndpoint(oldCIDR.IP)
+
 	}
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1011,11 +1011,6 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 
 		return nil
 	} else if firstAddition {
-		// When encapsulation is disabled, then the initial node addition
-		// triggers a removal of eventual old tunnel map entries.
-		deleteTunnelMapping(newNode.IPv4AllocCIDR, true)
-		deleteTunnelMapping(newNode.IPv6AllocCIDR, true)
-
 		if rt, _ := n.lookupNodeRoute(newNode.IPv4AllocCIDR, isLocalNode); rt != nil {
 			n.deleteNodeRoute(newNode.IPv4AllocCIDR, isLocalNode)
 		}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -162,7 +162,7 @@ func (e *Endpoint) useCurrentNetworkPolicy(proxyWaitGroup *completion.WaitGroup)
 		return
 	}
 
-	if e.proxy != nil {
+	if !e.isProxyDisabled() {
 		// Wait for the current network policy to be acked
 		e.proxy.UseCurrentNetworkPolicy(e, e.desiredPolicy.L4Policy, proxyWaitGroup)
 	}

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -98,3 +98,11 @@ func (m *Map) DeleteTunnelEndpoint(prefix net.IP) error {
 	log.WithField(fieldPrefix, prefix).Debug("Deleting tunnel map entry")
 	return TunnelMap.Delete(newTunnelEndpoint(prefix))
 }
+
+// SilentDeleteTunnelEndpoint removes a prefix => tunnel-endpoint mapping.
+// If the prefix is not found no error is returned.
+func (m *Map) SilentDeleteTunnelEndpoint(prefix net.IP) error {
+	log.WithField(fieldPrefix, prefix).Debug("Silently deleting tunnel map entry")
+	_, err := TunnelMap.SilentDelete(newTunnelEndpoint(prefix))
+	return err
+}

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -51,12 +51,8 @@ func NewTunnelMap(name string) *Map {
 		MaxEntries,
 		0, 0,
 		bpf.ConvertKeyValue,
-	).WithCache().WithPressureMetric(),
+	).WithCache().WithPressureMetric().WithNonPersistent(),
 	}
-}
-
-func init() {
-	TunnelMap.NonPersistent = true
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -184,8 +184,7 @@ func TraceObservationPointHasConnState(obsPoint uint8) bool {
 	case TraceToLxc,
 		TraceToProxy,
 		TraceToHost,
-		TraceToStack,
-		TraceToNetwork:
+		TraceToStack:
 		return true
 	default:
 		return false

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2122,8 +2122,7 @@ func (c *DaemonConfig) AlwaysAllowLocalhost() bool {
 	}
 }
 
-// TunnelingEnabled returns true if the remote-node identity feature
-// is enabled
+// TunnelingEnabled returns true if tunneling is enabled, i.e. not set to "disabled".
 func (c *DaemonConfig) TunnelingEnabled() bool {
 	return c.Tunnel != TunnelDisabled
 }


### PR DESCRIPTION
* #18196 -- hubble: Fix misclassification of `to-network` reply packets (@gandro)
   - Please review carefully, had to resolve a merge conflict in the first commit in bpf/bpf_host.c
 * #18041 -- bpf: update dsr flag properly (@Inode1)
 * #18198 -- [proxy] Fix proxy nil check (@chaosbox)
 * #18259 -- docs: Warn against Helm's `--reuse-values` in Cilium upgrades (@gandro)
 * #18247 -- Avoid tunnel map sync controller errors (@tklauser)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18196 18041 18198 18259 18247; do contrib/backporting/set-labels.py $pr done 1.10; done
```