### PR TITLE
clustermesh-apiserver: fix cmd-line args processing

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -89,6 +89,13 @@ var (
 
 			runServer(cmd)
 		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			option.Config.Populate()
+			if option.Config.Debug {
+				log.Logger.SetLevel(logrus.DebugLevel)
+			}
+			option.LogRegisteredOptions(log)
+		},
 	}
 
 	mockFile        string
@@ -221,7 +228,6 @@ func runApiserver() error {
 	option.BindEnv(option.AllocatorListTimeoutName)
 
 	viper.BindPFlags(flags)
-	option.Config.Populate()
 
 	if err := rootCmd.Execute(); err != nil {
 		return err
@@ -621,5 +627,4 @@ func runServer(cmd *cobra.Command) {
 
 	<-shutdownSignal
 	log.Info("Received termination signal. Shutting down")
-	return
 }


### PR DESCRIPTION
This change fixes commandline arguments processing of clustermesh-apiserver.

Commandline arguments accessed through the option.Config object
(eg. --identity-allocation-mode, --kvstore-opt) were not processed properly.
Function option.Config.Populate() was called too soon (before calling of
rootCmd.Execute(), but os.Args are processed just by rootCmd.Execute()).

Also there was missing debug log-level setting so debug messages did not work at all.

Signed-off-by: Adam Bocim <adam.bocim@seznam.cz>