### PR TITLE
docs: Replace 'micro version' with 'patch version'

### DIFF
--- a/Documentation/contributing/release/organization.rst
+++ b/Documentation/contributing/release/organization.rst
@@ -25,10 +25,10 @@ by incrementing the ``Y`` in the version format ``X.Y.Z``.
 Three stable branches are maintained at a time: One for the most recent minor
 release, and two for the prior two minor releases. For each minor release that
 is currently maintained, the stable branch ``vX.Y`` on github contains the code
-for the next stable release. New micro releases for an existing stable version
+for the next stable release. New patch releases for an existing stable version
 ``X.Y.Z`` are published incrementing the ``Z`` in the version format.
 
-New micro releases for stable branches are made periodically to provide
+New patch releases for stable branches are made periodically to provide
 security and bug fixes, based upon community demand and bugfix severity.
 Potential fixes for an upcoming release are first merged into the ``master``
 branch, then backported to the relevant stable branches using the following

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -136,14 +136,14 @@ one stable release to a later stable release.
 
 .. include:: upgrade-warning.rst
 
-Step 1: Upgrade to latest micro version (Recommended)
+Step 1: Upgrade to latest patch version (Recommended)
 -----------------------------------------------------
 
 When upgrading from one minor release to another minor release, for example
-1.x to 1.y, it is recommended to upgrade to the latest micro release for a
-Cilium release series first. The latest micro releases for each supported
+1.x to 1.y, it is recommended to upgrade to the latest patch release for a
+Cilium release series first. The latest patch releases for each supported
 version of Cilium are `here <https://github.com/cilium/cilium#stable-releases>`_.
-Upgrading to the latest micro release ensures the most seamless experience if a
+Upgrading to the latest patch release ensures the most seamless experience if a
 rollback is required following the minor release upgrade. The upgrade guides
 for previous versions can be found for each minor version at the bottom left
 corner.


### PR DESCRIPTION
In a version vX.Y.Z, X is called the major version, Y the minor version, and Z the patch version with this commit. Before this commit, Z was the micro version, but that's a bit confusing given we already have 'minor'.

The patch terminology also matches semantics documented at https://semver.org.