### PR TITLE
ci: set PR base for codeql workflow

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -1,7 +1,9 @@
 name: codeql
 
 on:
-  pull_request: {}
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master

--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   check_changes:
     name: Deduce required tests from code changes
-    if: github.repository == 'cilium/cilium'
+    if: ${{ github.repository == 'cilium/cilium' && github.event_name == 'pull_request' }}
     runs-on: ubuntu-18.04
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}
@@ -27,6 +27,8 @@ jobs:
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: go-changes
         with:
+          base: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           filters: |
             src:
               - .github/workflows/lint-codeql.yaml
@@ -36,7 +38,7 @@ jobs:
 
   analyze:
     needs: check_changes
-    if: github.repository == 'cilium/cilium' && needs.check_changes.outputs.go-changes == 'true'
+    if: ${{ github.repository == 'cilium/cilium' && (needs.check_changes.outputs.go-changes == 'true' || github.event_name != 'pull_request') }}
     runs-on: ubuntu-18.04
     permissions:
       security-events: write


### PR DESCRIPTION
This fixes the following error on scheduled runs:

    This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload"

This makes sure only code changed by the CL is flagged by CodeQL,
but not existing issues in the repo.

Moreover, run the paths-filter action only on pull_request events. This
should fix scheduled run of the workflow.

Noticed while investigating #18282.