### PR TITLE
datapath: Check for L7 LB in endpoint route mode

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1043,6 +1043,20 @@ int to_netdev(struct __ctx_buff *ctx __maybe_unused)
 		}
 	}
 
+#if defined(ENABLE_L7_LB)
+	{
+		__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
+
+		if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
+			__u32 lxc_id = get_epid(ctx);
+
+			ctx->mark = 0;
+			tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);
+			return DROP_MISSED_TAIL_CALL;
+		}
+	}
+#endif
+
 #ifdef ENABLE_HOST_FIREWALL
 	if (!proto && !validate_ethertype(ctx, &proto)) {
 		ret = DROP_UNSUPPORTED_L2;

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1047,8 +1047,12 @@ int to_netdev(struct __ctx_buff *ctx __maybe_unused)
 	{
 		__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
 
+		cilium_dbg3(ctx, DBG_L7_LB, 0x01010101, 0x02020202, magic);
+
 		if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
 			__u32 lxc_id = get_epid(ctx);
+
+			cilium_dbg3(ctx, DBG_L7_LB, 0x01010101, 0x03030303, lxc_id);
 
 			ctx->mark = 0;
 			tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -625,6 +625,9 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,	__u32 *d
 	 */
 	ct_ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
 			    &ct_state, &monitor);
+
+	cilium_dbg3(ctx, DBG_L7_LB, 0x03030303, 0x05050505, ct_ret);
+
 	if (ct_ret < 0)
 		return ct_ret;
 
@@ -789,8 +792,10 @@ ct_recreate4:
 		send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL, 0,
 				  bpf_ntohs(verdict), 0, ct_ret, monitor);
 #if defined(ENABLE_L7_LB)
-		if (from_l7lb)
+		if (from_l7lb) {
+			cilium_dbg3(ctx, DBG_L7_LB, 0x03030303, 0x06060606, verdict);
 			return ctx_redirect_to_proxy_hairpin_ipv4(ctx, verdict);
+		}
 #endif
 		return ctx_redirect_to_proxy4(ctx, &tuple, verdict, false);
 	}
@@ -1809,6 +1814,8 @@ int handle_policy_egress(struct __ctx_buff *ctx)
 	edt_set_aggregate(ctx, 0); /* do not count this traffic again */
 	send_trace_notify(ctx, TRACE_FROM_PROXY, SECLABEL, 0, 0,
 			  ifindex, 0, TRACE_PAYLOAD_LEN);
+
+	cilium_dbg3(ctx, DBG_L7_LB, 0x02020202, 0x04040404, ifindex);
 
 	switch (proto) {
 #ifdef ENABLE_IPV6

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1909,6 +1909,20 @@ int handle_to_container(struct __ctx_buff *ctx)
 
 	bpf_clear_meta(ctx);
 
+#if defined(ENABLE_L7_LB)
+	{
+		__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
+
+		if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
+			__u32 lxc_id = get_epid(ctx);
+
+			ctx->mark = 0;
+			tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);
+			return DROP_MISSED_TAIL_CALL;
+		}
+	}
+#endif
+
 	if (inherit_identity_from_host(ctx, &identity))
 		trace = TRACE_FROM_PROXY;
 


### PR DESCRIPTION
The check traffic from L7 LB listener is currently only done when
datapath is in tunneling mode. Add checks for endpoint routes mode in
to to-container and to-netdev programs, for traffic routed to a local
or remote pod, respectively.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
