### PR TITLE
daemon: Fix KPR init finalisation

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -672,7 +672,9 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		log.WithError(err).Warn("failed to detect devices, disabling BPF NodePort")
 		disableNodePort()
 	}
-	finishKubeProxyReplacementInit(isKubeProxyReplacementStrict)
+	if err := finishKubeProxyReplacementInit(isKubeProxyReplacementStrict); err != nil {
+		return nil, nil, fmt.Errorf("failed to finalise LB initialization: %w", err)
+	}
 
 	if k8s.IsEnabled() {
 		bootstrapStats.k8sInit.Start()


### PR DESCRIPTION
The 16c502a260 commit normalized the KPR initialisation routines by
making them to return an error. Unfortunately, it forgot to add a check
for the error return of finishKubeProxyReplacementInit(). This made to
the agent to hide any error returned by the routine.

Fixes: 16c502a260 ("choir: normalize error handling in kube_proxy_replacement.go")
Signed-off-by: Martynas Pumputis <m@lambda.lt>

~Blocked by #18305.~
