### PR TITLE
daemon: Fix multi-dev XDP check

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -628,10 +628,6 @@ func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) error {
 		}
 	}
 
-	if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled &&
-		len(option.Config.Devices) != 1 {
-		return fmt.Errorf("Cannot set NodePort acceleration due to multi-device setup (%q). Specify --%s with a single device to enable NodePort acceleration.", option.Config.Devices, option.Devices)
-	}
 	return nil
 }
 


### PR DESCRIPTION
The 0ffa7c60e1 commit didn't remove all guards which previously were
used to check that XDP is enabled only with |--devices| == 1.

The last guard was not visible on v1.11 due to
https://github.com/cilium/cilium/pull/18304, while on v1.10 it failed on
the multi-dev XDP setups.

Fixes: 0ffa7c60e1 ("datapath,daemon: Enable multi-dev XDP")
Reported-by: Tobias Klauser <tobias@cilium.io>
Reported-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Martynas Pumputis <m@lambda.lt>

Fix #18211