### PR TITLE
Revert "test/Services: Quarantine 'Tests with direct routing'"

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1072,7 +1072,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 					})
 				})
 
-				SkipContextIf(helpers.SkipQuarantined, "Tests with direct routing", func() {
+				Context("Tests with direct routing", func() {
 
 					var directRoutingOpts = map[string]string{
 						"tunnel":               "disabled",


### PR DESCRIPTION
This un-quarantines the direct routing K8sServices test suite, which was fixed by #18153.

[Cilium-master-k8s-1.23-kernel-net-next-quarantine](https://jenkins.cilium.io/view/Quarantine%20Pipelines/job/cilium-master-k8s-1.23-kernel-net-next-quarantine/) has not had any failures due to missing routes on Cilium nodes since the fix was merged, so the fix seems to be successful.

Note: The K8sServices test suites with `across nodes` are still failing with `Can not connect to service "http://[ipv6]:30882" from outside cluster (1/10)`) in the quarantine pipeline - but these tests remain quarantined due to cb1d3b34b75c91c9875caa90f6888cf65b03f86c according to @brb  and are _not_ re-enabled by this PR.

This PR only re-enables tests that were failing with ` Request from k8s1 to service http://[ipv6]:31872 failed`, which #18153 seems to have fixed, as that particular error has not occurred anymore.

Fixes: #17895

