### PR TITLE
Fix Makefile.docker not to specify --load and --push flags at once

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -27,8 +27,10 @@ ifdef ARCH
   endif
   DOCKER_FLAGS += --push --platform $(DOCKER_PLATFORMS)
 else
-  # ARCH not specified, build for the host platfrom without pushing, mimicking regular docker build
-  DOCKER_FLAGS += --load
+  ifeq ($(findstring --push,$(DOCKER_FLAGS)),)
+    # ARCH and --push are not specified, build for the host platfrom without pushing, mimicking regular docker build
+    DOCKER_FLAGS += --load
+  endif
 endif
 DOCKER_BUILDER := $(shell docker buildx ls | grep -E -e "[a-zA-Z0-9-]+ \*" | cut -d ' ' -f1)
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -28,7 +28,7 @@ ifdef ARCH
   DOCKER_FLAGS += --push --platform $(DOCKER_PLATFORMS)
 else
   ifeq ($(findstring --push,$(DOCKER_FLAGS)),)
-    # ARCH and --push are not specified, build for the host platfrom without pushing, mimicking regular docker build
+    # ARCH and --push are not specified, build for the host platform without pushing, mimicking regular docker build
     DOCKER_FLAGS += --load
   endif
 endif


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

After running `make docker-images-all`, make affords us to push image by displaying the message like below.

```
Define "DOCKER_FLAGS=--push" to push the build results.
```

However, when we specify `DOCKER_FLAGS=--push` without ARCH, it conflicts with the docker buildx --load option which is specified by default. Fix Makefile.docker not to specify --load when --push is given.