### PR TITLE
Fixed the issue PodDisruptionBudgets not created #18303

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -141,6 +141,10 @@
      - Annotations to be added to clustermesh-apiserver pods
      - object
      - ``{}``
+   * - clustermesh.apiserver.podDisruptionBudget
+     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+     - object
+     - ``{"enabled":false,"maxUnavailable":1}``
    * - clustermesh.apiserver.podLabels
      - Labels to be added to clustermesh-apiserver pods
      - object
@@ -476,7 +480,7 @@
    * - etcd.podDisruptionBudget
      - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
      - object
-     - ``{"enabled":true,"maxUnavailable":2}``
+     - ``{"enabled":false,"maxUnavailable":1}``
    * - etcd.podLabels
      - Labels to be added to cilium-etcd-operator pods
      - object
@@ -637,6 +641,10 @@
      - Annotations to be added to hubble-relay pods
      - object
      - ``{}``
+   * - hubble.relay.podDisruptionBudget
+     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+     - object
+     - ``{"enabled":false,"maxUnavailable":1}``
    * - hubble.relay.podLabels
      - Labels to be added to hubble-relay pods
      - object
@@ -785,6 +793,10 @@
      - Annotations to be added to hubble-ui pods
      - object
      - ``{}``
+   * - hubble.ui.podDisruptionBudget
+     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+     - object
+     - ``{"enabled":false,"maxUnavailable":1}``
    * - hubble.ui.podLabels
      - Labels to be added to hubble-ui pods
      - object
@@ -1013,10 +1025,6 @@
      - Annotations to be added to node-init pods.
      - object
      - ``{}``
-   * - nodeinit.podDisruptionBudget
-     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-     - object
-     - ``{"enabled":true,"maxUnavailable":2}``
    * - nodeinit.podLabels
      - Labels to be added to node-init pods.
      - object
@@ -1153,10 +1161,6 @@
      - Annotations to be added to agent pods
      - object
      - ``{}``
-   * - podDisruptionBudget
-     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-     - object
-     - ``{"enabled":true,"maxUnavailable":2}``
    * - podLabels
      - Labels to be added to agent pods
      - object
@@ -1204,7 +1208,7 @@
    * - preflight.podDisruptionBudget
      - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
      - object
-     - ``{"enabled":true,"maxUnavailable":2}``
+     - ``{"enabled":false,"maxUnavailable":1}``
    * - preflight.podLabels
      - Labels to be added to the preflight pod.
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -141,10 +141,18 @@
      - Annotations to be added to clustermesh-apiserver pods
      - object
      - ``{}``
-   * - clustermesh.apiserver.podDisruptionBudget
-     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-     - object
-     - ``{"enabled":false,"maxUnavailable":1}``
+   * - clustermesh.apiserver.podDisruptionBudget.enabled
+     - enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+     - bool
+     - ``false``
+   * - clustermesh.apiserver.podDisruptionBudget.maxUnavailable
+     - Maximum number/percentage of pods that may be made unavailable
+     - int
+     - ``1``
+   * - clustermesh.apiserver.podDisruptionBudget.minAvailable
+     - Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by ``maxUnavailable: null``
+     - string
+     - ``nil``
    * - clustermesh.apiserver.podLabels
      - Labels to be added to clustermesh-apiserver pods
      - object
@@ -477,10 +485,18 @@
      - Annotations to be added to cilium-etcd-operator pods
      - object
      - ``{}``
-   * - etcd.podDisruptionBudget
-     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-     - object
-     - ``{"enabled":false,"maxUnavailable":1}``
+   * - etcd.podDisruptionBudget.enabled
+     - enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+     - bool
+     - ``false``
+   * - etcd.podDisruptionBudget.maxUnavailable
+     - Maximum number/percentage of pods that may be made unavailable
+     - int
+     - ``1``
+   * - etcd.podDisruptionBudget.minAvailable
+     - Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by ``maxUnavailable: null``
+     - string
+     - ``nil``
    * - etcd.podLabels
      - Labels to be added to cilium-etcd-operator pods
      - object
@@ -641,10 +657,18 @@
      - Annotations to be added to hubble-relay pods
      - object
      - ``{}``
-   * - hubble.relay.podDisruptionBudget
-     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-     - object
-     - ``{"enabled":false,"maxUnavailable":1}``
+   * - hubble.relay.podDisruptionBudget.enabled
+     - enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+     - bool
+     - ``false``
+   * - hubble.relay.podDisruptionBudget.maxUnavailable
+     - Maximum number/percentage of pods that may be made unavailable
+     - int
+     - ``1``
+   * - hubble.relay.podDisruptionBudget.minAvailable
+     - Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by ``maxUnavailable: null``
+     - string
+     - ``nil``
    * - hubble.relay.podLabels
      - Labels to be added to hubble-relay pods
      - object
@@ -793,10 +817,18 @@
      - Annotations to be added to hubble-ui pods
      - object
      - ``{}``
-   * - hubble.ui.podDisruptionBudget
-     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-     - object
-     - ``{"enabled":false,"maxUnavailable":1}``
+   * - hubble.ui.podDisruptionBudget.enabled
+     - enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+     - bool
+     - ``false``
+   * - hubble.ui.podDisruptionBudget.maxUnavailable
+     - Maximum number/percentage of pods that may be made unavailable
+     - int
+     - ``1``
+   * - hubble.ui.podDisruptionBudget.minAvailable
+     - Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by ``maxUnavailable: null``
+     - string
+     - ``nil``
    * - hubble.ui.podLabels
      - Labels to be added to hubble-ui pods
      - object
@@ -1101,10 +1133,18 @@
      - Annotations to be added to cilium-operator pods
      - object
      - ``{}``
-   * - operator.podDisruptionBudget
-     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-     - object
-     - ``{"enabled":false,"maxUnavailable":1}``
+   * - operator.podDisruptionBudget.enabled
+     - enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+     - bool
+     - ``false``
+   * - operator.podDisruptionBudget.maxUnavailable
+     - Maximum number/percentage of pods that may be made unavailable
+     - int
+     - ``1``
+   * - operator.podDisruptionBudget.minAvailable
+     - Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by ``maxUnavailable: null``
+     - string
+     - ``nil``
    * - operator.podLabels
      - Labels to be added to cilium-operator pods
      - object
@@ -1205,10 +1245,18 @@
      - Annotations to be added to preflight pods
      - object
      - ``{}``
-   * - preflight.podDisruptionBudget
-     - PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-     - object
-     - ``{"enabled":false,"maxUnavailable":1}``
+   * - preflight.podDisruptionBudget.enabled
+     - enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+     - bool
+     - ``false``
+   * - preflight.podDisruptionBudget.maxUnavailable
+     - Maximum number/percentage of pods that may be made unavailable
+     - int
+     - ``1``
+   * - preflight.podDisruptionBudget.minAvailable
+     - Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by ``maxUnavailable: null``
+     - string
+     - ``nil``
    * - preflight.podLabels
      - Labels to be added to the preflight pod.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -593,6 +593,7 @@ masqLinkLocal
 masterDevice
 matchLabels
 matchPattern
+maxUnavailable
 mc
 mediabot
 memcache
@@ -603,6 +604,7 @@ metricsServer
 microk
 microservice
 microservices
+minAvailable
 minikube
 misconfigures
 mlx

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -86,6 +86,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver","tag":"latest","useDigest":false}` | Clustermesh API server image. |
 | clustermesh.apiserver.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
+| clustermesh.apiserver.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | clustermesh.apiserver.podLabels | object | `{}` | Labels to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.priorityClassName | string | `""` | The priority class to use for clustermesh-apiserver |
 | clustermesh.apiserver.replicas | int | `1` | Number of replicas run for the clustermesh-apiserver deployment. |
@@ -169,7 +170,7 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
 | etcd.nodeSelector | object | `{}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | etcd.podAnnotations | object | `{}` | Annotations to be added to cilium-etcd-operator pods |
-| etcd.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| etcd.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | etcd.podLabels | object | `{}` | Labels to be added to cilium-etcd-operator pods |
 | etcd.priorityClassName | string | `""` | The priority class to use for cilium-etcd-operator |
 | etcd.resources | object | `{}` | cilium-etcd-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
@@ -210,6 +211,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
 | hubble.relay.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.relay.podAnnotations | object | `{}` | Annotations to be added to hubble-relay pods |
+| hubble.relay.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | hubble.relay.podLabels | object | `{}` | Labels to be added to hubble-relay pods |
 | hubble.relay.priorityClassName | string | `""` | The priority class to use for hubble-relay |
 | hubble.relay.replicas | int | `1` | Number of replicas run for the hubble-relay deployment. |
@@ -247,6 +249,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
+| hubble.ui.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | hubble.ui.podLabels | object | `{}` | Labels to be added to hubble-ui pods |
 | hubble.ui.priorityClassName | string | `""` | The priority class to use for hubble-ui |
 | hubble.ui.proxy.image | object | `{"pullPolicy":"Always","repository":"docker.io/envoyproxy/envoy","tag":"v1.18.4@sha256:e5c2bb2870d0e59ce917a5100311813b4ede96ce4eb0c6bfa879e3fbe3e83935"}` | Hubble-ui ingress proxy image. |
@@ -304,7 +307,6 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.image | object | `{"pullPolicy":"Always","repository":"quay.io/cilium/startup-script","tag":"62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"}` | node-init image. |
 | nodeinit.nodeSelector | object | `{}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
-| nodeinit.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |
 | nodeinit.priorityClassName | string | `""` | The priority class to use for the nodeinit pod. |
 | nodeinit.resources | object | `{"requests":{"cpu":"100m","memory":"100Mi"}}` | nodeinit resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
@@ -339,7 +341,6 @@ contributors across the globe, there is almost always someone available to help.
 | operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}` | cilium-operator update strategy |
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
-| podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | podLabels | object | `{}` | Labels to be added to agent pods |
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes |
 | pprof.enabled | bool | `false` | Enable Go pprof debugging |
@@ -351,7 +352,7 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
-| preflight.podDisruptionBudget | object | `{"enabled":true,"maxUnavailable":2}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| preflight.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | preflight.podLabels | object | `{}` | Labels to be added to the preflight pod. |
 | preflight.priorityClassName | string | `""` | The priority class to use for the preflight pod. |
 | preflight.resources | object | `{}` | preflight resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -86,7 +86,9 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver","tag":"latest","useDigest":false}` | Clustermesh API server image. |
 | clustermesh.apiserver.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
-| clustermesh.apiserver.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| clustermesh.apiserver.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| clustermesh.apiserver.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
+| clustermesh.apiserver.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | clustermesh.apiserver.podLabels | object | `{}` | Labels to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.priorityClassName | string | `""` | The priority class to use for clustermesh-apiserver |
 | clustermesh.apiserver.replicas | int | `1` | Number of replicas run for the clustermesh-apiserver deployment. |
@@ -170,7 +172,9 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
 | etcd.nodeSelector | object | `{}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | etcd.podAnnotations | object | `{}` | Annotations to be added to cilium-etcd-operator pods |
-| etcd.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| etcd.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| etcd.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
+| etcd.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | etcd.podLabels | object | `{}` | Labels to be added to cilium-etcd-operator pods |
 | etcd.priorityClassName | string | `""` | The priority class to use for cilium-etcd-operator |
 | etcd.resources | object | `{}` | cilium-etcd-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
@@ -211,7 +215,9 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
 | hubble.relay.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.relay.podAnnotations | object | `{}` | Annotations to be added to hubble-relay pods |
-| hubble.relay.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| hubble.relay.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| hubble.relay.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
+| hubble.relay.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | hubble.relay.podLabels | object | `{}` | Labels to be added to hubble-relay pods |
 | hubble.relay.priorityClassName | string | `""` | The priority class to use for hubble-relay |
 | hubble.relay.replicas | int | `1` | Number of replicas run for the hubble-relay deployment. |
@@ -249,7 +255,9 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
-| hubble.ui.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| hubble.ui.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| hubble.ui.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
+| hubble.ui.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | hubble.ui.podLabels | object | `{}` | Labels to be added to hubble-ui pods |
 | hubble.ui.priorityClassName | string | `""` | The priority class to use for hubble-ui |
 | hubble.ui.proxy.image | object | `{"pullPolicy":"Always","repository":"docker.io/envoyproxy/envoy","tag":"v1.18.4@sha256:e5c2bb2870d0e59ce917a5100311813b4ede96ce4eb0c6bfa879e3fbe3e83935"}` | Hubble-ui ingress proxy image. |
@@ -326,7 +334,9 @@ contributors across the globe, there is almost always someone available to help.
 | operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","pullPolicy":"Always","repository":"quay.io/cilium/operator","suffix":"","tag":"latest","useDigest":false}` | cilium-operator image. |
 | operator.nodeSelector | object | `{}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
-| operator.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| operator.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| operator.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
+| operator.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | operator.podLabels | object | `{}` | Labels to be added to cilium-operator pods |
 | operator.priorityClassName | string | `""` | The priority class to use for cilium-operator |
 | operator.prometheus | object | `{"enabled":false,"port":6942,"serviceMonitor":{"enabled":false,"labels":{}}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
@@ -352,7 +362,9 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.image | object | `{"digest":"","pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
-| preflight.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| preflight.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| preflight.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
+| preflight.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | preflight.podLabels | object | `{}` | Labels to be added to the preflight pod. |
 | preflight.priorityClassName | string | `""` | The priority class to use for the preflight pod. |
 | preflight.resources | object | `{}` | preflight resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -86,3 +86,14 @@ Return the appropriate apiVersion for cronjob.
 {{- print "batch/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for podDisruptionBudget.
+*/}}
+{{- define "podDisruptionBudget.apiVersion" -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version -}}
+{{- print "policy/v1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.operator.enabled .Values.operator.podDisruptionBudget.enabled }}
+apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: cilium-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
+spec:
+  maxUnavailable: {{ .Values.operator.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+{{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.operator.enabled .Values.operator.podDisruptionBudget.enabled }}
+{{- $component := .Values.operator.podDisruptionBudget }}
 apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -8,7 +9,12 @@ metadata:
     io.cilium/app: operator
     name: cilium-operator
 spec:
-  maxUnavailable: {{ .Values.operator.podDisruptionBudget.maxUnavailable }}
+  {{- with $component.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  {{- with $component.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       io.cilium/app: operator

--- a/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.preflight.enabled .Values.preflight.validateCNPs .Values.preflight.podDisruptionBudget.enabled }}
+{{- $component := .Values.preflight.podDisruptionBudget }}
 apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -8,7 +9,12 @@ metadata:
     k8s-app: cilium-pre-flight-check-deployment
     kubernetes.io/cluster-service: "true"
 spec:
-  maxUnavailable: {{ .Values.preflight.podDisruptionBudget.maxUnavailable }}
+  {{- with $component.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  {{- with $component.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       k8s-app: cilium-pre-flight-check-deployment

--- a/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.preflight.enabled .Values.preflight.validateCNPs .Values.preflight.podDisruptionBudget.enabled }}
+apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: cilium-pre-flight-check
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: cilium-pre-flight-check-deployment
+    kubernetes.io/cluster-service: "true"
+spec:
+  maxUnavailable: {{ .Values.preflight.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check-deployment
+      kubernetes.io/cluster-service: "true"
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
@@ -1,4 +1,5 @@
 {{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.podDisruptionBudget.enabled }}
+{{- $component := .Values.clustermesh.apiserver.podDisruptionBudget }}
 apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -7,7 +8,12 @@ metadata:
   labels:
     k8s-app: clustermesh-apiserver
 spec:
-  maxUnavailable: {{ .Values.clustermesh.apiserver.podDisruptionBudget.maxUnavailable }}
+  {{- with $component.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  {{- with $component.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       k8s-app: clustermesh-apiserver

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.podDisruptionBudget.enabled }}
+apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: clustermesh-apiserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: clustermesh-apiserver
+spec:
+  maxUnavailable: {{ .Values.clustermesh.apiserver.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      k8s-app: clustermesh-apiserver
+{{- end }}

--- a/install/kubernetes/cilium/templates/etcd-operator/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.etcd.managed .Values.etcd.podDisruptionBudget.enabled }}
+apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: cilium-etcd-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    io.cilium/app: etcd-operator
+    name: cilium-etcd-operator
+spec:
+  maxUnavailable: {{ .Values.etcd.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      io.cilium/app: etcd-operator
+      name: cilium-etcd-operator
+{{- end }}

--- a/install/kubernetes/cilium/templates/etcd-operator/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/poddisruptionbudget.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.etcd.managed .Values.etcd.podDisruptionBudget.enabled }}
+{{- $component := .Values.etcd.podDisruptionBudget }}
 apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -8,7 +9,12 @@ metadata:
     io.cilium/app: etcd-operator
     name: cilium-etcd-operator
 spec:
-  maxUnavailable: {{ .Values.etcd.podDisruptionBudget.maxUnavailable }}
+  {{- with $component.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  {{- with $component.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       io.cilium/app: etcd-operator

--- a/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.hubble.enabled .Values.hubble.relay.enabled .Values.hubble.relay.podDisruptionBudget.enabled }}
+apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: hubble-relay
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: hubble-relay
+spec:
+  maxUnavailable: {{ .Values.hubble.relay.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      k8s-app: hubble-relay
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.hubble.enabled .Values.hubble.relay.enabled .Values.hubble.relay.podDisruptionBudget.enabled }}
+{{- $component := .Values.hubble.relay.podDisruptionBudget }}
 apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -7,7 +8,12 @@ metadata:
   labels:
     k8s-app: hubble-relay
 spec:
-  maxUnavailable: {{ .Values.hubble.relay.podDisruptionBudget.maxUnavailable }}
+  {{- with $component.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  {{- with $component.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       k8s-app: hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.hubble.ui.podDisruptionBudget.enabled }}
+apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: hubble-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: hubble-ui
+spec:
+  maxUnavailable: {{ .Values.hubble.ui.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      k8s-app: hubble-ui
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
@@ -1,4 +1,5 @@
 {{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.hubble.ui.podDisruptionBudget.enabled }}
+{{- $component := .Values.hubble.ui.podDisruptionBudget }}
 apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -7,7 +8,12 @@ metadata:
   labels:
     k8s-app: hubble-ui
 spec:
-  maxUnavailable: {{ .Values.hubble.ui.podDisruptionBudget.maxUnavailable }}
+  {{- with $component.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  {{- with $component.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       k8s-app: hubble-ui

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -166,12 +166,6 @@ podAnnotations: {}
 # -- Labels to be added to agent pods
 podLabels: {}
 
-# -- PodDisruptionBudget settings
-# ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-podDisruptionBudget:
-  enabled: true
-  maxUnavailable: 2
-
 # -- Agent resource limits & requests
 # ref: https://kubernetes.io/docs/user-guide/compute-resources/
 resources: {}
@@ -705,6 +699,12 @@ hubble:
     # -- Labels to be added to hubble-relay pods
     podLabels: {}
 
+    # -- PodDisruptionBudget settings
+    # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+    podDisruptionBudget:
+      enabled: false
+      maxUnavailable: 1
+
     # -- Node tolerations for pod assignment on nodes with taints
     # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
     tolerations: []
@@ -864,6 +864,12 @@ hubble:
 
     # -- Labels to be added to hubble-ui pods
     podLabels: {}
+
+    # -- PodDisruptionBudget settings
+    # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+    podDisruptionBudget:
+      enabled: false
+      maxUnavailable: 1
 
     # -- Node labels for pod assignment
     # ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -1268,8 +1274,8 @@ etcd:
   # -- PodDisruptionBudget settings
   # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
   podDisruptionBudget:
-    enabled: true
-    maxUnavailable: 2
+    enabled: false
+    maxUnavailable: 1
 
   # -- cilium-etcd-operator resource limits & requests
   # ref: https://kubernetes.io/docs/user-guide/compute-resources/
@@ -1506,12 +1512,6 @@ nodeinit:
   # -- Labels to be added to node-init pods.
   podLabels: {}
 
-  # -- PodDisruptionBudget settings
-  # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-  podDisruptionBudget:
-    enabled: true
-    maxUnavailable: 2
-
   # -- nodeinit resource limits & requests
   # ref: https://kubernetes.io/docs/user-guide/compute-resources/
   resources:
@@ -1598,8 +1598,8 @@ preflight:
   # -- PodDisruptionBudget settings
   # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
   podDisruptionBudget:
-    enabled: true
-    maxUnavailable: 2
+    enabled: false
+    maxUnavailable: 1
 
   # -- preflight resource limits & requests
   # ref: https://kubernetes.io/docs/user-guide/compute-resources/
@@ -1679,6 +1679,12 @@ clustermesh:
 
     # -- Labels to be added to clustermesh-apiserver pods
     podLabels: {}
+
+    # -- PodDisruptionBudget settings
+    # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+    podDisruptionBudget:
+      enabled: false
+      maxUnavailable: 1
 
     # -- Resource requests and limits for the clustermesh-apiserver container of the clustermesh-apiserver deployment, such as
     #     resources:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -699,10 +699,15 @@ hubble:
     # -- Labels to be added to hubble-relay pods
     podLabels: {}
 
-    # -- PodDisruptionBudget settings
-    # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+    # PodDisruptionBudget settings
     podDisruptionBudget:
+      # -- enable PodDisruptionBudget
+      # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
       enabled: false
+      # -- Minimum number/percentage of pods that should remain scheduled.
+      # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
+      minAvailable: null
+      # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
 
     # -- Node tolerations for pod assignment on nodes with taints
@@ -865,10 +870,15 @@ hubble:
     # -- Labels to be added to hubble-ui pods
     podLabels: {}
 
-    # -- PodDisruptionBudget settings
-    # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+    # PodDisruptionBudget settings
     podDisruptionBudget:
+      # -- enable PodDisruptionBudget
+      # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
       enabled: false
+      # -- Minimum number/percentage of pods that should remain scheduled.
+      # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
+      minAvailable: null
+      # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
 
     # -- Node labels for pod assignment
@@ -1271,10 +1281,15 @@ etcd:
   # -- Labels to be added to cilium-etcd-operator pods
   podLabels: {}
 
-  # -- PodDisruptionBudget settings
-  # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  # PodDisruptionBudget settings
   podDisruptionBudget:
+    # -- enable PodDisruptionBudget
+    # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
     enabled: false
+    # -- Minimum number/percentage of pods that should remain scheduled.
+    # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
+    minAvailable: null
+    # -- Maximum number/percentage of pods that may be made unavailable
     maxUnavailable: 1
 
   # -- cilium-etcd-operator resource limits & requests
@@ -1410,10 +1425,15 @@ operator:
   # -- Labels to be added to cilium-operator pods
   podLabels: {}
 
-  # -- PodDisruptionBudget settings
-  # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  # PodDisruptionBudget settings
   podDisruptionBudget:
+    # -- enable PodDisruptionBudget
+    # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
     enabled: false
+    # -- Minimum number/percentage of pods that should remain scheduled.
+    # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
+    minAvailable: null
+    # -- Maximum number/percentage of pods that may be made unavailable
     maxUnavailable: 1
 
   # -- cilium-operator resource limits & requests
@@ -1595,10 +1615,15 @@ preflight:
   # -- Labels to be added to the preflight pod.
   podLabels: {}
 
-  # -- PodDisruptionBudget settings
-  # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  # PodDisruptionBudget settings
   podDisruptionBudget:
+    # -- enable PodDisruptionBudget
+    # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
     enabled: false
+    # -- Minimum number/percentage of pods that should remain scheduled.
+    # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
+    minAvailable: null
+    # -- Maximum number/percentage of pods that may be made unavailable
     maxUnavailable: 1
 
   # -- preflight resource limits & requests
@@ -1680,10 +1705,15 @@ clustermesh:
     # -- Labels to be added to clustermesh-apiserver pods
     podLabels: {}
 
-    # -- PodDisruptionBudget settings
-    # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+    # PodDisruptionBudget settings
     podDisruptionBudget:
+      # -- enable PodDisruptionBudget
+      # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
       enabled: false
+      # -- Minimum number/percentage of pods that should remain scheduled.
+      # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
+      minAvailable: null
+      # -- Maximum number/percentage of pods that may be made unavailable
       maxUnavailable: 1
 
     # -- Resource requests and limits for the clustermesh-apiserver container of the clustermesh-apiserver deployment, such as


### PR DESCRIPTION
Signed-off-by: Li Cheng 1076366950@qq.com

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #18303

```release-note
Fix an issue where PodDisruptionBudgets were not created by the Helm chart
```
