### PR TITLE
egressgateway: fix initial reconciliation

### DIFF
--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -62,15 +61,6 @@ type parsedEgressRule struct {
 
 type k8sCacheSyncedCheckerMock struct {
 	synced bool
-}
-
-func (k *k8sCacheSyncedCheckerMock) WaitUntilK8sCacheIsSynced() {
-	for {
-		if k.synced {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
 }
 
 func (k *k8sCacheSyncedCheckerMock) K8sCacheIsSynced() bool {


### PR DESCRIPTION
When a new egress gateway manager is created, it will wait for the k8s
cache to be fully synced before running the first reconciliation.

Currently the logic is based on the WaitUntilK8sCacheIsSynced method
of the Daemon object, which waits on the k8sCachesSynced channel to be
closed (which indicates that the cache has been indeed synced).

The issue with this approach is that Daemon object is passed to
the NewEgressGatewayManager method _before_ its k8sCachesSynced
channel is properly initialized. This in turn causes the
WaitUntilK8sCacheIsSynced method to never return.

Since NewEgressGatewayManager must be called before that channel is
initialized, we need to switch to a polling approach, where the
k8sCachesSynced is checked periodically.