### PR TITLE
docs: Fix `first-interface-index` documentation

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -187,11 +187,11 @@ allocation:
 
 ``spec.eni.first-interface-index``
   The index of the first ENI to use for IP allocation, e.g. if the node has
-  ``eth0``, ``eth1``, ``eth2`` and FirstInterfaceIndex is set to 0, then only
+  ``eth0``, ``eth1``, ``eth2`` and FirstInterfaceIndex is set to 1, then only
   ``eth1`` and ``eth2`` will be used for IP allocation, ``eth0`` will be
   ignored for PodIP allocation.
 
-  If unspecified, this value defaults to 1 which means that ``eth0`` will not
+  If unspecified, this value defaults to 0 which means that ``eth0`` will
   be used for pod IPs.
 
 ``spec.eni.security-group-tags``


### PR DESCRIPTION
This fixes the `first-interface-index` section in the ENI docs where we
introduced a new default value and wanted to document that new default,
but by doing that accidentally changed a value in the examples.

This commit actually fixes the default value and reverts the example to
its proper meaning.

Ref: https://github.com/cilium/cilium/pull/14801
Fixes: 231a217ea99d ("docs: first-interface-index new ENI default")
