### PR TITLE
helm: Add bpf-root configuration value in helms

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -81,6 +81,10 @@
      - Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency.
      - bool
      - ``false``
+   * - bpf.root
+     - Configure the mount point for the BPF filesystem
+     - string
+     - ``"/sys/fs/bpf"``
    * - certgen
      - Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually.
      - object

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1259,7 +1259,7 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	// The standard operation is to mount the BPF filesystem to the
-	// standard location (/sys/fs/bpf). The user may chose to specify
+	// standard location (/sys/fs/bpf). The user may choose to specify
 	// the path to an already mounted filesystem instead. This is
 	// useful if the daemon is being round inside a namespace and the
 	// BPF filesystem is mapped into the slave namespace.

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -71,6 +71,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
+| bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |
 | certgen | object | `{"image":{"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.5"},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.podLabels | object | `{}` | Labels to be added to hubble-certgen pods |
 | certgen.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -779,6 +779,10 @@ data:
   bgp-announce-pod-cidr: {{ .Values.bgp.announce.podCIDR | quote }}
 {{- end}}
 
+{{- if hasKey .Values.bpf "root" }}
+  bpf-root: {{ .Values.bpf.root | quote }}
+{{- end }}
+
 {{- if hasKey .Values.cgroup "hostRoot" }}
   cgroup-root: {{ .Values.cgroup.hostRoot | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -229,6 +229,9 @@ bgp:
     podCIDR: false
 
 bpf:
+  # -- Configure the mount point for the BPF filesystem
+  root: /sys/fs/bpf
+
   # -- Enable BPF clock source probing for more efficient tick retrieval.
   clockProbe: false
 


### PR DESCRIPTION
This commit is to allow user to configure bpf root filesystem mount, the
default value will be still /sys/fs/bpf.

Fixes https://github.com/cilium/cilium/issues/16751

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
helm: Add bpf-root configuration value in helms
```
