### PR TITLE
bpf: Fix maglev hash with hostServices.hostNamespaceOnly

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -30,6 +30,14 @@
 #include "lib/nat46.h"
 #include "lib/identity.h"
 #include "lib/policy.h"
+
+/* Override LB_SELECTION initially defined in node_config.h to force bpf_lxc to use the random backend selection
+ * algorithm for in-cluster traffic. Otherwise, it will fail with the Maglev hash algorithm because Cilium doesn't provision
+ * the Maglev table for ClusterIP unless bpf.lbExternalClusterIP is set to true.
+ */
+#undef LB_SELECTION
+#define LB_SELECTION LB_SELECTION_RANDOM
+
 #include "lib/lb.h"
 #include "lib/drop.h"
 #include "lib/dbg.h"

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -116,7 +116,11 @@ func (svc *svcInfo) useMaglev() bool {
 	return option.Config.NodePortAlg == option.NodePortAlgMaglev &&
 		((svc.svcType == lb.SVCTypeNodePort && !isWildcardAddr(svc.frontend)) ||
 			svc.svcType == lb.SVCTypeExternalIPs ||
-			svc.svcType == lb.SVCTypeLoadBalancer)
+			svc.svcType == lb.SVCTypeLoadBalancer ||
+			// Provision the Maglev LUT for ClusterIP only if ExternalClusterIP is enabled
+			// because ClusterIP can also be accessed from outside with this setting.
+			// We don't do it unconditionally to avoid increasing memory footprint.
+			(option.Config.ExternalClusterIP && svc.svcType == lb.SVCTypeClusterIP))
 }
 
 // Service is a service handler. Its main responsibility is to reflect

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -456,6 +456,9 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			BeforeAll(func() {
 				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 					"bpf.lbExternalClusterIP": "true",
+					// Enable Maglev to check if the Maglev LUT for ClusterIP is properly populated,
+					// and external clients can access ClusterIP with it.
+					"loadBalancer.algorithm": "maglev",
 				})
 				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, appServiceName)
 				svcIP = clusterIP
@@ -489,6 +492,9 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		BeforeAll(func() {
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 				"hostServices.hostNamespaceOnly": "true",
+				// Enable Maglev to check if traffic destined to ClusterIP from Pod is properly handled
+				// by bpf_lxc.c using LB_SELECTION_RANDOM even if Maglev is enabled.
+				"loadBalancer.algorithm": "maglev",
 			})
 			demoDSYAML = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
 			res := kubectl.ApplyDefault(demoDSYAML)


### PR DESCRIPTION
This PR fixes the bug that Cilium drops packets destined to ClusterIP when configured in combination with　loadBalancer.algorithm=maglev and hostServices.hostNamespaceOnly=true. See the commit message for details.

Fixes: #17474
Fixes: #16966

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!
