### PR TITLE
docs: fix small spelling mistakes in masquerading pages

### DIFF
--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -76,7 +76,7 @@ The eBPF-based masquerading can masquerade packets of the following IPv4 L4 prot
 
 By default, any packet from a pod destined to an IP address outside of the
 ``ipv4-native-routing-cidr`` range is masqueraded. The exclusion CIDR is shown
-in the above output of ``cilium status`` (``10.0.0.0.16``).  To allow more
+in the above output of ``cilium status`` (``10.0.0.0/16``).  To allow more
 fine-grained control, Cilium implements `ip-masq-agent
 <https://github.com/kubernetes-sigs/ip-masq-agent>`_ in eBPF which can be
 enabled with the ``ipMasqAgent.enabled=true`` helm option.


### PR DESCRIPTION
fix typo in masquerading documentation, on CIDR mask separator

Signed-off-by: yanhongchang <yanhongchang5@163.com>
