### PR TITLE
Improve Kubespray installation guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-kubespray.rst
+++ b/Documentation/gettingstarted/k8s-install-kubespray.rst
@@ -141,14 +141,23 @@ Installing Kubernetes cluster with Cilium as CNI
 
 Kubespray uses Ansible as its substrate for provisioning and orchestration. Once the infrastructure is created, you can run the Ansible playbook to install Kubernetes and all the required dependencies. Execute the below command in the kubespray clone repo, providing the correct path of the AWS EC2 ssh private key in ``ansible_ssh_private_key_file=<path to EC2 SSH private key file>``
 
-We recommend using the `latest released Cilium version`_ by editing ``roles/download/defaults/main.yml``. Open the file, search for ``cilium_version``, and replace the version with the latest released. As an example, the updated version entry will look like: ``cilium_version: "v1.2.0"``.
-
+We recommend using the `latest released Cilium version`_ by passing the variable when running the ``ansible-playbook`` command.
+For example, you could add the following flag to the command below: ``-e cilium_version=v1.11.0``.
 
 .. code-block:: shell-session
 
   $ ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=core -e bootstrap_os=coreos -e kube_network_plugin=cilium -b --become-user=root --flush-cache  -e ansible_ssh_private_key_file=<path to EC2 SSH private key file>
 
 .. _latest released Cilium version: https://github.com/cilium/cilium/releases
+
+If you are interested in configuring your Kubernetes cluster setup, you should consider copying the sample inventory. Then, you can edit the variables in the relevant file in the ``group_vars`` directory.
+
+.. code-block:: shell-session
+
+  $ cp -r inventory/sample inventory/my-inventory
+  $ cp ./inventory/hosts ./inventory/my-inventory/hosts
+  $ echo 'cilium_version: "v1.11.0"' >> ./inventory/my-inventory/group_vars/k8s_cluster/k8s-net-cilium.yml
+  $ ansible-playbook -i ./inventory/my-inventory/hosts ./cluster.yml -e ansible_user=core -e bootstrap_os=coreos -e kube_network_plugin=cilium -b --become-user=root --flush-cache -e ansible_ssh_private_key_file=<path to EC2 SSH private key file>
 
 Validate Cluster
 ================

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -4,7 +4,6 @@ APIEndpoint
 AdapterLimitViaAPI
 Alemayhu
 Alibaba
-Ansible
 BPF
 Bertin
 Blanco
@@ -149,6 +148,7 @@ allocator
 allocators
 amd
 analytics
+ansible
 api
 apiKeys
 apiVersion


### PR DESCRIPTION
Co-authored-by: Yasin Taha Erol <yasintahaerol@gmail.com>
Signed-off-by: necatican <necaticanyildirim@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!  <3 

<!-- Description of change -->
Current Kubespray installation documentation recommends editing the download role. However, there are a few disadvantages when it comes to editing a role directly:

1. It could mess up with the git state.
2. The variable might have a reference in another role. While this isn't the case for Kubespray 2.16, it could happen in further releases.

We should instruct users to pass it as an extra variable by using `-e` flag or copy the sample inventory and edit the group_vars.


```release-note
Changed the documentation for Kubespray installation to recommend using `-e` flag for `cilium_version` variable instead of editing the role variables.
```
