### PR TITLE
Don't hold idMDMU lock while calling UpdateIdentities from InjectLabels

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -41,6 +41,9 @@ var (
 	// policy and propagated in monitor output.
 	identityMetadata = make(map[string]labels.Labels)
 
+	// applyIDMDChangesMutex protects InjectLabels and RemoveLabelsExcluded from being run in parallel
+	applyIDMDChangesMutex lock.Mutex
+
 	// ErrLocalIdentityAllocatorUninitialized is an error that's returned when
 	// the local identity allocator is uninitialized.
 	ErrLocalIdentityAllocatorUninitialized = errors.New("local identity allocator uninitialized")
@@ -101,6 +104,9 @@ func InjectLabels(src source.Source, updater identityUpdater, triggerer policyTr
 		// selector cache.
 		idsToPropagate = make(map[identity.NumericIdentity]labels.LabelArray)
 	)
+
+	applyIDMDChangesMutex.Lock()
+	defer applyIDMDChangesMutex.Unlock()
 
 	idMDMU.Lock()
 
@@ -280,6 +286,9 @@ func RemoveLabelsExcluded(
 	updater identityUpdater,
 	triggerer policyTriggerer,
 ) {
+	applyIDMDChangesMutex.Lock()
+	defer applyIDMDChangesMutex.Unlock()
+
 	idMDMU.Lock()
 	defer idMDMU.Unlock()
 


### PR DESCRIPTION
UpdateIdentities needs to lock SelectorCache.mutex, which might be held
by SelectorCache.AddFQDNSelector while endpoints/policies are being
regenerated. If in that situation idMDMU is locked already, AddFQDNSelector
will deadlock while calling ipcache.GetIDMetadataByIP deep inside the
call chain.

Example stacktraces of 2 goroutines that show the deadlock:

```
goroutine 236 [semacquire, 61 minutes]:
sync.runtime_SemacquireMutex(0x5000107, 0x0, 0xffffffffffffffff)
	/usr/local/go/src/runtime/sema.go:71 +0x25
sync.(*Mutex).lockSlow(0xc0004d13b0)
	/usr/local/go/src/sync/mutex.go:138 +0x165
sync.(*Mutex).Lock(...)
	/usr/local/go/src/sync/mutex.go:81
sync.(*RWMutex).Lock(0xc001365f58)
	/usr/local/go/src/sync/rwmutex.go:111 +0x36
github.com/cilium/cilium/pkg/policy.(*SelectorCache).UpdateIdentities(0xc0004d13b0, 0xc001f0dbf0, 0x0, 0x8)
	/go/src/github.com/cilium/cilium/pkg/policy/selectorcache.go:949 +0x65
github.com/cilium/cilium/pkg/ipcache.InjectLabels({0x27fe323, 0xf}, {0x2bfdbe0, 0xc0004d13b0}, {0x7f1837d6d080, 0xc0009e0e20})
	/go/src/github.com/cilium/cilium/pkg/ipcache/metadata.go:179 +0xa53
github.com/cilium/cilium/pkg/ipcache.(*IPCache).TriggerLabelInjection.func1({0xc0013674d0, 0xc001367190})
	/go/src/github.com/cilium/cilium/pkg/ipcache/metadata.go:550 +0x31
github.com/cilium/cilium/pkg/controller.(*Controller).runController(0xc0005a4360)
	/go/src/github.com/cilium/cilium/pkg/controller/controller.go:206 +0x1cb
created by github.com/cilium/cilium/pkg/controller.(*Manager).updateController
	/go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0xb67

goroutine 2578413 [semacquire, 61 minutes]:
sync.runtime_SemacquireMutex(0xe, 0x0, 0xc000c76000)
	/usr/local/go/src/runtime/sema.go:71 +0x25
sync.(*RWMutex).RLock(...)
	/usr/local/go/src/sync/rwmutex.go:63
github.com/cilium/cilium/pkg/ipcache.GetIDMetadataByIP({0xc001c5b830, 0x17})
	/go/src/github.com/cilium/cilium/pkg/ipcache/metadata.go:68 +0x68
github.com/cilium/cilium/pkg/ipcache.AllocateCIDRs({0xc0018ca660, 0x4, 0xc00041fce0}, 0x0)
	/go/src/github.com/cilium/cilium/pkg/ipcache/cidr.go:62 +0x20a
github.com/cilium/cilium/pkg/ipcache.AllocateCIDRsForIPs({0xc00009bc20, 0x5, 0xc003a46e80}, 0x37)
	/go/src/github.com/cilium/cilium/pkg/ipcache/cidr.go:99 +0x2f
github.com/cilium/cilium/daemon/cmd.cachingIdentityAllocator.AllocateCIDRsForIPs({0xc00041fc70}, {0xc00009bc20, 0xc00278f510, 0x3}, 0x40e3cb)
	/go/src/github.com/cilium/cilium/daemon/cmd/identity.go:113 +0x2a
github.com/cilium/cilium/pkg/policy.(*fqdnSelector).allocateIdentityMappings(0xc002698370, {0x7f1837c69138, 0xc000ac05a0}, 0x25)
	/go/src/github.com/cilium/cilium/pkg/policy/selectorcache.go:491 +0x258
github.com/cilium/cilium/pkg/policy.(*SelectorCache).AddFQDNSelector(0xc0004d13b0, {0x2bfdbc0, 0xc002851a00}, {{0x0, 0x0}, {0xc004c7ec60, 0xa}})
	/go/src/github.com/cilium/cilium/pkg/policy/selectorcache.go:820 +0x40b
github.com/cilium/cilium/pkg/policy.(*L4Filter).cacheFQDNSelector(0xc002851a00, {{0x0, 0xc00000c180}, {0xc004c7ec60, 0xc000e6eb10}}, 0x0, 0x0)
	/go/src/github.com/cilium/cilium/pkg/policy/l4.go:479 +0x65
github.com/cilium/cilium/pkg/policy.(*L4Filter).cacheFQDNSelectors(0xc0018ca280, {0xc000988380, 0xe, 0x2c732c0}, 0x0, 0x0)
	/go/src/github.com/cilium/cilium/pkg/policy/l4.go:474 +0x8f
github.com/cilium/cilium/pkg/policy.createL4Filter({0x2c732c0, 0xc0018ca060}, {0xc0018ca280, 0x1, 0x1}, {0x2c24098, 0xc0029a9740}, {{0x2bd17b2, 0x1}, {0x27d4b6a, ...}}, ...)
	/go/src/github.com/cilium/cilium/pkg/policy/l4.go:574 +0x398
github.com/cilium/cilium/pkg/policy.createL4EgressFilter(...)
	/go/src/github.com/cilium/cilium/pkg/policy/l4.go:697
github.com/cilium/cilium/pkg/policy.mergeEgressPortProto({0x2c732c0, 0xc0018ca060}, 0x0, {0xc0018ca280, 0xc0025cfe38, 0x44cd45}, {0x2c24098, 0xc0029a9740}, {{0x2bd17b2, 0x1}, ...}, ...)
	/go/src/github.com/cilium/cilium/pkg/policy/rule.go:773 +0x108
github.com/cilium/cilium/pkg/policy.mergeEgress({0x2c732c0, 0xc0018ca060}, 0xc001f0e3f0, {0xc0018ca280, 0x1, 0x1}, {0x2c2a268, 0x4875340}, {0x2c2a218, 0x4875340}, ...)
	/go/src/github.com/cilium/cilium/pkg/policy/rule.go:678 +0x35c
github.com/cilium/cilium/pkg/policy.(*rule).resolveEgressPolicy(0xc0023fb860, {0x2c732c0, 0xc0018ca060}, 0xc001f0e3f0, 0xc002790308, 0xc0029a9620, {0x0, 0x0, 0x0}, {0x0, ...})
	/go/src/github.com/cilium/cilium/pkg/policy/rule.go:809 +0x84f
github.com/cilium/cilium/pkg/policy.ruleSlice.resolveL4EgressPolicy({0xc00299af40, 0x6, 0xb7}, {0x2c732c0, 0xc0018ca060}, 0xc001f0e3f0)
	/go/src/github.com/cilium/cilium/pkg/policy/rules.go:102 +0x470
github.com/cilium/cilium/pkg/policy.(*Repository).resolvePolicyLocked(0xc0004d1490, 0xc001fcdbc0)
	/go/src/github.com/cilium/cilium/pkg/policy/repository.go:704 +0x531
github.com/cilium/cilium/pkg/policy.(*PolicyCache).updateSelectorPolicy(0xc000852a98, 0xc001fcdbc0)
	/go/src/github.com/cilium/cilium/pkg/policy/distillery.go:119 +0x14c
github.com/cilium/cilium/pkg/policy.(*PolicyCache).UpdatePolicy(...)
	/go/src/github.com/cilium/cilium/pkg/policy/distillery.go:153
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regeneratePolicy(0xc000ee3880)
	/go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:230 +0x22b
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).runPreCompilationSteps(0xc000ee3880, 0xc000bff400)
	/go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:815 +0x2dd
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF(0xc000ee3880, 0xc000bff400)
	/go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:584 +0x19d
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerate(0xc000ee3880, 0xc000bff400)
	/go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:405 +0x7b3
github.com/cilium/cilium/pkg/endpoint.(*EndpointRegenerationEvent).Handle(0xc003a950d0, 0xc001fcd620)
	/go/src/github.com/cilium/cilium/pkg/endpoint/events.go:53 +0x32c
github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run.func1()
	/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:245 +0x13b
sync.(*Once).doSlow(0xc000c25901, 0x43f325)
	/usr/local/go/src/sync/once.go:68 +0xd2
sync.(*Once).Do(...)
	/usr/local/go/src/sync/once.go:59
github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run(0xc00304ae40)
	/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:233 +0x45
created by github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).Run
	/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:229 +0x7b
```

The deadlock was discovered in a self-compiled version (branch v1.11) of cilium. I assume the fix needs to be at least backported into v.1.11, maybe also into v1.10.


```release-note
Fix deadlock with kube-apiserver policy matching feature
```