### PR TITLE
bpf: fix removal of stale bpf_netdev.o tc filters

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -497,7 +497,7 @@ for iface in $(ip -o -a l | awk '{print $2}' | cut -d: -f1 | cut -d@ -f1 | grep 
 	done
 	$found && continue
 	for where in ingress egress; do
-		if tc filter show dev "$iface" "$where" | grep -q "bpf_netdev[^\.]*.o"; then
+		if tc filter show dev "$iface" "$where" | grep -q "bpf_netdev.*[.]o"; then
 			echo "Removing bpf_netdev.o from $where of $iface"
 			tc filter del dev "$iface" "$where" || true
 		fi


### PR DESCRIPTION
<!-- Description of change -->
bpf_netdev filters are loaded with obj name `bpf_netdev_${iface}.o`, but init.sh was checking for stale filters with regex `bpf_netdev_[^\.]*.o`

Because of that stale tc filters were not removed from interfaces which had a dot in their name (for example, VLAN interfaces)

This PR updates expression in `bpf/init.sh` to match exact names as generated in `pkg/datapath/loader/loader.go` instead of the regex.

```release-note
Fixed removal of stale bpf_netdev tc filters for interfaces with a dot in the name
```
