### PR TITLE
docs: Update contributing guide pages

### DIFF
--- a/Documentation/contributing/development/codeoverview.rst
+++ b/Documentation/contributing/development/codeoverview.rst
@@ -150,7 +150,7 @@ pkg/controller
 pkg/datapath
   Abstraction layer for datapath interaction
 
-pkg/default
+pkg/defaults
   All default values
 
 pkg/elf

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -215,8 +215,11 @@ Getting a pull request merged
    ``/test`` as described in :ref:`trigger_phrases`. If you are a core team
    member, you may trigger the CI run yourself.
 
-   #. Hound: basic ``golang/lint`` static code analyzer. You need to make the
-      puppy happy.
+   #. Basic static code analyzer by Github Action and Travis CI. Golang linter
+      suggestions are added in-line on PRs. For other failed jobs, please refer
+      to build log for required action (e.g. Please run ``go mod tidy && go mod
+      vendor`` and submit your changes, etc).
+
    #. :ref:`ci_jenkins`: Will run a series of tests:
 
       #. Unit tests

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -293,7 +293,7 @@ Pull requests review process for committers
    example below, the committer belonging to the CI team is re-requesting a
    review for other team members to review the PR. This allows other team
    members belonging to the CI team to see the PR as part of the PRs that
-   require review in the `filter provided above <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+review-requested%3A%40me+sort%3Aupdated-asc>`_
+   require review in the `filter <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+review-requested%3A%40me+sort%3Aupdated-asc>`_
 
    .. image:: ../../images/re-request-review.png
       :align: center

--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -87,7 +87,7 @@ build your own cilium-runtime and cilium-builder images:
 
 .. code-block:: shell-session
 
-    make docker-image-runtime
+    make -C images runtime-image
 
 After the build finishes update the runtime image references in other
 Dockerfiles (``docker buildx imagetools inspect`` is useful for finding
@@ -95,7 +95,7 @@ image information). Then proceed to build the cilium-builder:
 
 .. code-block:: shell-session
 
-    make docker-image-builder
+    make -C images builder-image
 
 After the build finishes update the main Cilium Dockerfile with the
 new builder reference, then proceed to build Hubble from

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -553,6 +553,7 @@ libnetwork
 libvirt
 lifecycle
 linearize
+linter
 linux
 linuxconf
 listenAddress

--- a/Makefile
+++ b/Makefile
@@ -617,7 +617,7 @@ help: Makefile ## Display help for the Makefile, from https://www.thapaliya.com/
 	$(call print_help_line,"docker-hubble-relay-image","Build hubble-relay docker image")
 	$(call print_help_line,"docker-clustermesh-apiserver-image","Build docker image for Cilium clustermesh APIServer")
 	$(call print_help_line,"docker-operator-image","Build cilium-operator docker image")
-	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(aws, azure, generic)")
+	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(alibabacloud, aws, azure, generic)")
 	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
 
 .PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-hubble-api install licenses-all veryclean


### PR DESCRIPTION
### Description

I am refreshing [contributing guide](https://docs.cilium.io/en/latest/contributing/development/), and realise that 
there are some simple discrepancies, hence just make some small changes.

Please refer to individual commits for details.

```release-note
docs: Update contributing guide pages
```
