### PR TITLE
Skip host-networked pods in k8s-unmanaged script

### DIFF
--- a/contrib/k8s/k8s-unmanaged.sh
+++ b/contrib/k8s/k8s-unmanaged.sh
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 ALL_CEPS=$(kubectl get cep --all-namespaces -o json | jq -r '.items[].metadata | .namespace + "/" + .name')
-ALL_PODS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[].metadata | .namespace + "/" + .name')
+ALL_PODS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.spec.hostNetwork==true | not) | .metadata | .namespace + "/" + .name')
 
+echo "Skipping pods with host networking enabled..."
 for pod in $ALL_PODS; do
 	if ! echo "$ALL_CEPS" | grep -q "$pod"; then
 		echo $pod


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible. (no existing test to update, not clear whether it makes sense to add one here)
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

I'm running cilium on AKS where I'm unable to guarantee that system node pools are tainted with the cilium agent unready taint to ensure that cilium starts before other pods are able to come up. I used the k8s-unmanaged script as a way of identifying which pods needed to be restarted, but was surprised to find that it returned many pods that cilium won't manage (including the cilium agents theirselves), so it didn't provide a very useful list of pods as restart targets.

I found that if I excluded pods with host networking enabled, and restarted the remaining pods that were found in the diff, then the two lists converged after that and after those restarts, k8s-unmanaged.sh produced no outputs.

I think this edit makes the script's return value better align with what a user would expect it to return, but if there are any concerns about changing the behavior of the script I would be happy to just add a separate script with this new behavior and updating the docs to point to it.

Fixes: #issue-number

```release-note
Scripts: Update k8s-unmanaged script to only return pods where host networking is false
```
