### PR TITLE
Fix possible IP leak in case ENI's are not present in the CN yet

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -686,11 +686,16 @@ func (a *crdAllocator) Allocate(ip net.IP, owner string) (*AllocationResult, err
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 	// Update custom resource to reflect the newly allocated IP.
 	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("allocation of IP %s", ip.String()))
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // AllocateWithoutSyncUpstream will attempt to find the specified IP in the
@@ -710,9 +715,14 @@ func (a *crdAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string) (*Al
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // Release will release the specified IP or return an error if the IP has not
@@ -751,11 +761,16 @@ func (a *crdAllocator) AllocateNext(owner string) (*AllocationResult, error) {
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 	// Update custom resource to reflect the newly allocated IP.
 	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("allocation of IP %s", ip.String()))
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // AllocateNextWithoutSyncUpstream allocates the next available IP as offered
@@ -770,9 +785,14 @@ func (a *crdAllocator) AllocateNextWithoutSyncUpstream(owner string) (*Allocatio
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // totalPoolSize returns the total size of the allocation pool


### PR DESCRIPTION
buildAllocationResult may return an error in case of inconsistencies found
in the local CN's status. For example, there are situations where an IP
is already part of spec.ipam.pool (including the resource/ENI where the IP
comes from), while the corresponding ENI is not part of status.eni.enis
yet.

If that is the case, the IP would be allocated (e.g. by allocateNext)
and then marked as allocated (via a.markAllocated). Shortly after that,
a.buildAllocationResult() would fail and then NOT undo the changes done
by a.markAllocated(). This will then result in the IP never being freed up
again. At the same time, kubelet will keep scheduling PODs onto the same
node without knowing that IPs run out and thus causing new PODs to never
get an IP.

Why exactly this inconsistency between the spec and the status arise is
a different topic and should maybe be investigated further.

This commit/PR fixes this issue by simply moving a.markAllocated() after
the a.buildAllocationResult() result, so that the function is bailed out
early enough.

```release-note
Fix possible IP leak in case ENI's are not present in the CN yet
```
