### PR TITLE
cni: Add log file for CNI executions

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -281,6 +281,10 @@
      - Install the CNI configuration and binary files into the filesystem.
      - bool
      - ``true``
+   * - cni.logFile
+     - Configure the log file for CNI logging with retention policy of 7 days. Disable CNI file logging by setting this field to empty explicitly.
+     - string
+     - ``"/var/run/cilium/cilium-cni.log"``
    * - containerRuntime
      - Configure container runtime specific integration.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -572,6 +572,7 @@ loadbalancing
 localRedirectPolicy
 localhost
 lockless
+logFile
 logSystemLoad
 logfile
 login

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -121,6 +121,7 @@ contributors across the globe, there is almost always someone available to help.
 | cni.exclusive | bool | `true` | Make Cilium take ownership over the `/etc/cni/net.d` directory on the node, renaming all non-Cilium CNI configurations to `*.cilium_bak`. This ensures no Pods can be scheduled using other CNI plugins during Cilium agent downtime. |
 | cni.hostConfDirMountPath | string | `"/host/etc/cni/net.d"` | Configure the path to where the CNI configuration directory is mounted inside the agent pod. |
 | cni.install | bool | `true` | Install the CNI configuration and binary files into the filesystem. |
+| cni.logFile | string | `"/var/run/cilium/cilium-cni.log"` | Configure the log file for CNI logging with retention policy of 7 days. Disable CNI file logging by setting this field to empty explicitly. |
 | containerRuntime | object | `{"integration":"none"}` | Configure container runtime specific integration. |
 | containerRuntime.integration | string | `"none"` | Enables specific integrations for container runtimes. Supported values: - containerd - crio - docker - none - auto (automatically detect the container runtime) |
 | customCalls | object | `{"enabled":false}` | Tail call hooks for custom eBPF programs. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -210,6 +210,7 @@ spec:
               - "/cni-install.sh"
               - "--enable-debug={{ .Values.debug.enabled }}"
               - "--cni-exclusive={{ .Values.cni.exclusive }}"
+              - "--log-file={{ .Values.cni.logFile }}"
           preStop:
             exec:
               command:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -321,6 +321,10 @@ cni:
   # agent downtime.
   exclusive: true
 
+  # -- Configure the log file for CNI logging with retention policy of 7 days.
+  # Disable CNI file logging by setting this field to empty explicitly.
+  logFile: /var/run/cilium/cilium-cni.log
+
   # -- Skip writing of the CNI configuration. This can be used if
   # writing of the CNI configuration is performed by external automation.
   customConf: false

--- a/pkg/logging/hooks/file_rotation.go
+++ b/pkg/logging/hooks/file_rotation.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Authors of Cilium
+
+package hooks
+
+import (
+	"github.com/sirupsen/logrus"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// FileRotationOption provides all parameters for file rotation
+type FileRotationOption struct {
+	FileName   string
+	MaxSize    int
+	MaxAge     int
+	MaxBackups int
+	LocalTime  bool
+	Compress   bool
+}
+
+type Option func(*FileRotationOption)
+
+// WithMaxSize provides way to adjust maxSize (in MBs). Defaults to
+// 100 MBs.
+func WithMaxSize(maxSize int) Option {
+	return func(option *FileRotationOption) {
+		option.MaxSize = maxSize
+	}
+}
+
+// WithMaxAge provides way to adjust max age (in days). The default is
+// not to remove old log files based on age.
+func WithMaxAge(maxAge int) Option {
+	return func(option *FileRotationOption) {
+		option.MaxAge = maxAge
+	}
+}
+
+// WithMaxBackups provides way to adjust max number of backups. Defaults
+// to retain all old log files though MaxAge may still cause them to get
+// deleted.
+func WithMaxBackups(MaxBackups int) Option {
+	return func(option *FileRotationOption) {
+		option.MaxBackups = MaxBackups
+	}
+}
+
+// EnableLocalTime is to determine if the time used for formatting the
+// timestamps in backup files is the computer's local time.  The default
+// is to use UTC time.
+func EnableLocalTime() Option {
+	return func(option *FileRotationOption) {
+		option.LocalTime = true
+	}
+}
+
+// EnableCompression is to enable old log file gzip compression. Defaults
+// to false.
+func EnableCompression() Option {
+	return func(option *FileRotationOption) {
+		option.Compress = true
+	}
+}
+
+// FileRotationLogHook stores the configuration of the hook
+type FileRotationLogHook struct {
+	logger *lumberjack.Logger
+}
+
+// NewFileRotationLogHook creates a new FileRotationLogHook*/
+func NewFileRotationLogHook(fileName string, opts ...Option) *FileRotationLogHook {
+	options := &FileRotationOption{
+		FileName:  fileName,
+		MaxSize:   100,   // MBs
+		LocalTime: false, // UTC
+		Compress:  false, // no compression with gzip
+	}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	logger := &lumberjack.Logger{
+		Filename:   options.FileName,
+		MaxSize:    options.MaxSize,
+		MaxAge:     options.MaxAge,
+		MaxBackups: options.MaxBackups,
+		LocalTime:  options.LocalTime,
+		Compress:   options.Compress,
+	}
+
+	return &FileRotationLogHook{
+		logger: logger,
+	}
+}
+
+// Fire is called when a log event is fired.
+func (hook *FileRotationLogHook) Fire(entry *logrus.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		return err
+	}
+
+	_, err = hook.logger.Write([]byte(line))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Levels returns the available logging levels
+func (hook *FileRotationLogHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -136,9 +136,16 @@ func SetLogFormat(logFormat LogFormat) {
 	DefaultLogger.SetFormatter(GetFormatter(logFormat))
 }
 
-// SetLogLevel updates the DefaultLogger with the DefaultLogFormat
+// SetDefaultLogFormat updates the DefaultLogger with the DefaultLogFormat
 func SetDefaultLogFormat() {
 	DefaultLogger.SetFormatter(GetFormatter(DefaultLogFormat))
+}
+
+// AddHooks adds additional logrus hook to default logger
+func AddHooks(hooks ...logrus.Hook) {
+	for _, hook := range hooks {
+		DefaultLogger.AddHook(hook)
+	}
 }
 
 // SetupLogging sets up each logging service provided in loggers and configures

--- a/plugins/cilium-cni/05-cilium-cni.conf
+++ b/plugins/cilium-cni/05-cilium-cni.conf
@@ -2,5 +2,6 @@
     "cniVersion": "0.3.1",
     "name": "cilium",
     "type": "cilium-cni",
-    "enable-debug": true
+    "enable-debug": true,
+    "log-file": "/var/run/cilium/cilium-cni.log"
 }

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -24,16 +24,26 @@ esac
 
 ENABLE_DEBUG=false
 CNI_EXCLUSIVE=true
+LOG_FILE="/var/run/cilium/cilium-cni.log"
+
 while test $# -gt 0; do
   case "$1" in
     --enable-debug*)
       # shellcheck disable=SC2001
+      # the below sed is to support both formats "--flag value" and "--flag=value"
       ENABLE_DEBUG=$(echo "$1" | sed -e 's/^[^=]*=//g')
       shift
       ;;
     --cni-exclusive*)
       # shellcheck disable=SC2001
+      # the below sed is to support both formats "--flag value" and "--flag=value"
       CNI_EXCLUSIVE=$(echo "$1" | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --log-file*)
+      # shellcheck disable=SC2001
+      # the below sed is to support both formats "--flag value" and "--flag=value"
+      LOG_FILE=$(echo "$1" | sed -e 's/^[^=]*=//g')
       shift
       ;;
     *)
@@ -134,7 +144,8 @@ case "$CILIUM_CNI_CHAINING_MODE" in
     {
        "name": "cilium",
        "type": "cilium-cni",
-       "enable-debug": ${ENABLE_DEBUG}
+       "enable-debug": ${ENABLE_DEBUG},
+       "log-file": "${LOG_FILE}"
     }
   ]
 }
@@ -150,7 +161,8 @@ EOF
     {
        "name": "cilium",
        "type": "cilium-cni",
-       "enable-debug": ${ENABLE_DEBUG}
+       "enable-debug": ${ENABLE_DEBUG},
+       "log-file": "${LOG_FILE}"
     },
     {
       "type": "portmap",
@@ -183,7 +195,8 @@ EOF
     {
        "name": "cilium",
        "type": "cilium-cni",
-       "enable-debug": ${ENABLE_DEBUG}
+       "enable-debug": ${ENABLE_DEBUG},
+       "log-file": "${LOG_FILE}"
     }
   ]
 }
@@ -196,7 +209,8 @@ EOF
   "cniVersion": "0.3.1",
   "name": "cilium",
   "type": "cilium-cni",
-  "enable-debug": ${ENABLE_DEBUG}
+  "enable-debug": ${ENABLE_DEBUG},
+  "log-file": "${LOG_FILE}"
 }
 EOF
 	;;

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -30,6 +30,7 @@ type NetConf struct {
 	AlibabaCloud alibabaCloudTypes.Spec `json:"alibaba-cloud,omitempty"`
 	EnableDebug  bool                   `json:"enable-debug"`
 	LogFormat    string                 `json:"log-format"`
+	LogFile      string                 `json:"log-file"`
 }
 
 // NetConfList is a CNI chaining configuration


### PR DESCRIPTION
### Description

This commit is to add logging configuration, in which existing log entry
should be written to both stdout and file system. Logrus hook approach
is taken to avoid major refactoring on existing SetupLogging function.

Fixes: #16798

Signed-off-by: Tam Mach <sayboras@yahoo.com>

### Testing

Testing was done locally with kind cluster, and with --enable-debug true (otherwise, by default, CNI log contains only error).


<details>
<summary>CNI config and logs</summary>

```
root@kind-control-plane:~# cat  /host/etc/cni/net.d/05-cilium.conf
{
  "cniVersion": "0.3.1",
  "name": "cilium",
  "type": "cilium-cni",
  "enable-debug": true,
  "log-file": "/var/run/cilium/cilium-cni.log"
}

root@kind-control-plane:~# ls -lrt /var/run/cilium/cilium-cni.log
-rw-r--r-- 1 root root 11117 Jan  6 07:12 /var/run/cilium/cilium-cni.log

root@kind-control-plane:~# head -1 /var/run/cilium/cilium-cni.log
level=debug msg="Processing CNI ADD request &skel.CmdArgs{ContainerID:\"4ef09eda8633d7c85f64eda031823cd3c66c5db37642593373813e73fa5ca4ce\", Netns:\"/var/run/netns/cni-e7c5b205-8cc0-4e0e-0080-2e8b478786ff\", IfName:\"eth0\", Args:\"IgnoreUnknown=1;K8S_POD_NAMESPACE=cilium-test;K8S_POD_NAME=client2-5998d566b4-jf7c5;K8S_POD_INFRA_CONTAINER_ID=4ef09eda8633d7c85f64eda031823cd3c66c5db37642593373813e73fa5ca4ce\", Path:\"/opt/cni/bin\", StdinData:[]uint8{0x7b, 0x22, 0x63, 0x6e, 0x69, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x3a, 0x22, 0x30, 0x2e, 0x33, 0x2e, 0x31, 0x22, 0x2c, 0x22, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x2d, 0x64, 0x65, 0x62, 0x75, 0x67, 0x22, 0x3a, 0x74, 0x72, 0x75, 0x65, 0x2c, 0x22, 0x6c, 0x6f, 0x67, 0x2d, 0x66, 0x69, 0x6c, 0x65, 0x22, 0x3a, 0x22, 0x2f, 0x76, 0x61, 0x72, 0x2f, 0x72, 0x75, 0x6e, 0x2f, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x2f, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x2d, 0x63, 0x6e, 0x69, 0x2e, 0x6c, 0x6f, 0x67, 0x22, 0x2c, 0x22, 0x6e, 0x61, 0x6d, 0x65, 0x22, 0x3a, 0x22, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x22, 0x2c, 0x22, 0x74, 0x79, 0x70, 0x65, 0x22, 0x3a, 0x22, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x2d, 0x63, 0x6e, 0x69, 0x22, 0x7d}}" eventUUID=2d7e0ed1-f4ba-4d56-bf94-b608fe2db8a5 subsys=cilium-cni
```

</details>

<details>
<summary>Running /cni-install.sh directly with different options</summary>

```
root@kind-control-plane:/# /cni-install.sh --enable-debug=true --cni-exclusive=false --log-file=/var/run/cilium/cilium-cni2.log
Installing cilium-cni to /host/opt/cni/bin/ ...
Removing active Cilium CNI configurations from /host/etc/cni/net.d})...
Installing new /host/etc/cni/net.d/05-cilium.conf...
root@kind-control-plane:/# cat /host/etc/cni/net.d/05-cilium.conf
{
  "cniVersion": "0.3.1",
  "name": "cilium",
  "type": "cilium-cni",
  "enable-debug": false,
  "log-file": "/var/run/cilium/cilium-cni2.log"
}

root@kind-control-plane:/var/run/cilium# ls -lrt /var/run/cilium/cilium-cni2.log
-rw-r--r-- 1 root root 58711 Jan  6 07:20 /var/run/cilium/cilium-cni2.log


root@kind-control-plane:/# cni-install.sh --enable-debug=true --cni-exclusive=false --log-file=''
Installing cilium-cni to /host/opt/cni/bin/ ...
Removing active Cilium CNI configurations from /host/etc/cni/net.d})...
Installing new /host/etc/cni/net.d/05-cilium.conf...
root@kind-control-plane:/var/run/cilium# cat /host/etc/cni/net.d/05-cilium.conf
{
  "cniVersion": "0.3.1",
  "name": "cilium",
  "type": "cilium-cni",
  "enable-debug": true,
  "log-file": ""
}
```

</details>

```release-note
cni: Add log file for CNI executions
```
