### PR TITLE
test: Fix make target for e2e tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -25,7 +25,7 @@ build:
 test: run k8s
 
 run:
-	ginkgo --focus "Runtime" --tags integration_tests -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
+	KERNEL=net-next ginkgo --focus "Runtime" --tags integration_tests -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
 
 k8s:
 	ginkgo --focus "K8s" --tags integration_tests -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)


### PR DESCRIPTION
The privileged unit test `TestArpPingHandling` requires support for neighbor flags `NTF_EXT_LEARNED` and `NTF_EXT_MANAGED` in the kernel. Kernel v4.9 doesn't support those flags so we need to run the Runtime tests on our net-next image instead.

That's what the CI has been doing for a while, but we didn't update the make target for end-to-end tests at the same time.

This Makefile isn't used anywhere in CI, so no need to trigger end-to-end tests.