### PR TITLE
treewide: Sort imports according to Go conventions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -51,6 +51,8 @@ linters-settings:
   govet:
     enable:
       - nilness
+  goimports:
+    local-prefixes: github.com/cilium/cilium
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.
@@ -79,11 +81,16 @@ issues:
     - path: test/
       linters:
         - unused
+    # Skip goimports check on generated files
+    - path: \\.(generated\\.deepcopy|pb)\\.go$
+      linters:
+        - goimports
 linters:
   disable-all: true
   enable:
     - goerr113
     - gofmt
+    - goimports
     - govet
     - ineffassign
     - misspell

--- a/bpf/tests/prog_test/prog_test.go
+++ b/bpf/tests/prog_test/prog_test.go
@@ -17,19 +17,19 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/perf"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/monitor"
 	"github.com/cilium/cilium/pkg/tuple"
 	"github.com/cilium/cilium/pkg/types"
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/perf"
-
-	"github.com/google/gopacket"
-	"github.com/google/gopacket/layers"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 type ct4GlobalMap map[ctmap.CtKey4Global]ctmap.CtEntry

--- a/cilium/cmd/bpf_ct.go
+++ b/cilium/cmd/bpf_ct.go
@@ -4,9 +4,10 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/spf13/cobra"
 )
 
 // bpfCtCmd represents the bpf_ct command

--- a/cilium/cmd/bpf_ipcache_get.go
+++ b/cilium/cmd/bpf_ipcache_get.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/maps/ipcache"
 
-	"github.com/hashicorp/go-immutable-radix"
+	iradix "github.com/hashicorp/go-immutable-radix"
 	"github.com/spf13/cobra"
 )
 

--- a/cilium/cmd/encrypt_flush.go
+++ b/cilium/cmd/encrypt_flush.go
@@ -4,11 +4,11 @@
 package cmd
 
 import (
-	"github.com/cilium/cilium/pkg/command"
-	"github.com/cilium/cilium/pkg/common"
+	"github.com/spf13/cobra"
 	"github.com/vishvananda/netlink"
 
-	"github.com/spf13/cobra"
+	"github.com/cilium/cilium/pkg/command"
+	"github.com/cilium/cilium/pkg/common"
 )
 
 var encryptFlushCmd = &cobra.Command{

--- a/cilium/cmd/encrypt_status.go
+++ b/cilium/cmd/encrypt_status.go
@@ -10,14 +10,14 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/prometheus/procfs"
+	"github.com/spf13/cobra"
+	"github.com/vishvananda/netlink"
+
 	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/prometheus/procfs"
-	"github.com/vishvananda/netlink"
-
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cilium/cmd/encrypt_status_test.go
+++ b/cilium/cmd/encrypt_status_test.go
@@ -8,12 +8,13 @@ package cmd
 
 import (
 	"encoding/hex"
-	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netns"
-	. "gopkg.in/check.v1"
 	"net"
 	"runtime"
 	"testing"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/cilium/cmd/identity_list.go
+++ b/cilium/cmd/identity_list.go
@@ -9,6 +9,9 @@ import (
 	"sort"
 	"text/tabwriter"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	identityApi "github.com/cilium/cilium/api/v1/client/policy"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/api"
@@ -17,9 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/spf13/viper"
-
-	"github.com/spf13/cobra"
 )
 
 // identityListCmd represents the identity_list command

--- a/cilium/cmd/metrics_list.go
+++ b/cilium/cmd/metrics_list.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/command"
-	"github.com/spf13/cobra"
 )
 
 var matchPattern string

--- a/daemon/cmd/cleanup.go
+++ b/daemon/cmd/cleanup.go
@@ -9,11 +9,11 @@ import (
 	"os/signal"
 	"sync"
 
+	gops "github.com/google/gops/agent"
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/pidfile"
-	gops "github.com/google/gops/agent"
-
-	"golang.org/x/sys/unix"
 )
 
 var cleaner = &daemonCleanup{

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/go-openapi/runtime/middleware"
+
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/api"
@@ -16,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/go-openapi/runtime/middleware"
 )
 
 // ConfigModifyEvent is a wrapper around the parameters for configModify.

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -8,13 +8,16 @@ package cmd
 
 import (
 	"context"
-	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
-	"github.com/cilium/cilium/pkg/proxy"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
+
+	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
+	"github.com/cilium/cilium/pkg/proxy"
+	"github.com/prometheus/client_golang/prometheus"
+	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/controller"
@@ -31,9 +34,6 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-
-	"github.com/prometheus/client_golang/prometheus"
-	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/daemon/cmd/devices.go
+++ b/daemon/cmd/devices.go
@@ -11,6 +11,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/lock"
@@ -18,8 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 )
 
 var (

--- a/daemon/cmd/devices_test.go
+++ b/daemon/cmd/devices_test.go
@@ -10,14 +10,14 @@ import (
 	"net"
 	"runtime"
 
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
-	"golang.org/x/sys/unix"
-
-	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netns"
-	. "gopkg.in/check.v1"
 )
 
 type DevicesSuite struct {

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -15,6 +15,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/api"
@@ -35,11 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/u8proto"
-	"github.com/go-openapi/runtime/middleware"
-	"github.com/go-openapi/strfmt"
-	"github.com/sirupsen/logrus"
-
-	"github.com/miekg/dns"
 )
 
 const (

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -16,6 +16,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/datapath/loader"
@@ -28,8 +31,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/probe"
 	"github.com/cilium/cilium/pkg/sysctl"
-	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 )
 
 // initKubeProxyReplacementOptions will grok the global config and determine

--- a/daemon/cmd/prefilter.go
+++ b/daemon/cmd/prefilter.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/go-openapi/runtime/middleware"
+
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/prefilter"
 	"github.com/cilium/cilium/pkg/api"
-	"github.com/go-openapi/runtime/middleware"
 )
 
 type getPrefilter struct {

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -9,6 +9,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus"
+	versionapi "k8s.io/apimachinery/pkg/version"
+
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/backoff"
@@ -36,11 +41,6 @@ import (
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/status"
 	"github.com/cilium/cilium/pkg/version"
-	"github.com/sirupsen/logrus"
-
-	"github.com/go-openapi/runtime/middleware"
-	"github.com/go-openapi/strfmt"
-	versionapi "k8s.io/apimachinery/pkg/version"
 )
 
 const (

--- a/operator/api/health.go
+++ b/operator/api/health.go
@@ -4,8 +4,9 @@
 package api
 
 import (
-	"github.com/cilium/cilium/api/v1/operator/server/restapi/operator"
 	"github.com/go-openapi/runtime/middleware"
+
+	"github.com/cilium/cilium/api/v1/operator/server/restapi/operator"
 )
 
 type getHealthz struct {

--- a/operator/api/server.go
+++ b/operator/api/server.go
@@ -10,14 +10,15 @@ import (
 	"net/http"
 	"syscall"
 
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/runtime"
+	"golang.org/x/sys/unix"
+
 	operatorApi "github.com/cilium/cilium/api/v1/operator/server"
 	"github.com/cilium/cilium/api/v1/operator/server/restapi"
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/operator"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/go-openapi/loads"
-	"github.com/go-openapi/runtime"
-	"golang.org/x/sys/unix"
 )
 
 var (

--- a/operator/provider_aws_flags.go
+++ b/operator/provider_aws_flags.go
@@ -7,9 +7,9 @@
 package main
 
 import (
-	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/spf13/viper"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/option"
 )
 

--- a/operator/provider_azure_flags.go
+++ b/operator/provider_azure_flags.go
@@ -7,9 +7,9 @@
 package main
 
 import (
-	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/spf13/viper"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/option"
 )
 

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 
 	"github.com/aws/smithy-go"
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/aws/eni/limits"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
@@ -22,8 +24,6 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/math"
-
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/azure/ipam/node_test.go
+++ b/pkg/azure/ipam/node_test.go
@@ -7,8 +7,9 @@
 package ipam
 
 import (
-	"github.com/cilium/cilium/pkg/azure/types"
 	"gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/azure/types"
 )
 
 func (e *IPAMSuite) TestGetMaximumAllocatableIPv4(c *check.C) {

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -4,16 +4,16 @@
 package bandwidth
 
 import (
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
-	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netlink"
-
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (

--- a/pkg/bgp/k8s/client.go
+++ b/pkg/bgp/k8s/client.go
@@ -8,11 +8,11 @@ package k8s
 import (
 	"context"
 
-	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/sirupsen/logrus"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/pkg/k8s"
 )
 
 func New(l *logrus.Logger) *Client {

--- a/pkg/bgp/manager/metallb.go
+++ b/pkg/bgp/manager/metallb.go
@@ -9,17 +9,17 @@ import (
 	"context"
 	"os"
 
-	bgpconfig "github.com/cilium/cilium/pkg/bgp/config"
-	bgpk8s "github.com/cilium/cilium/pkg/bgp/k8s"
-	bgplog "github.com/cilium/cilium/pkg/bgp/log"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/sirupsen/logrus"
-
 	metallballoc "go.universe.tf/metallb/pkg/allocator"
 	metallbctl "go.universe.tf/metallb/pkg/controller"
 	"go.universe.tf/metallb/pkg/k8s"
 	"go.universe.tf/metallb/pkg/k8s/types"
 	v1 "k8s.io/api/core/v1"
+
+	bgpconfig "github.com/cilium/cilium/pkg/bgp/config"
+	bgpk8s "github.com/cilium/cilium/pkg/bgp/k8s"
+	bgplog "github.com/cilium/cilium/pkg/bgp/log"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // Controller provides a method set for interfacing with a BGP Controller.

--- a/pkg/bgp/speaker/pod_cidr.go
+++ b/pkg/bgp/speaker/pod_cidr.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/sirupsen/logrus"
-
 	metallbbgp "go.universe.tf/metallb/pkg/bgp"
 	metallbspr "go.universe.tf/metallb/pkg/speaker"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/cilium/cilium/pkg/cidr"
 )
 
 var (

--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -10,6 +10,12 @@ import (
 	"errors"
 	"sync/atomic"
 
+	"github.com/sirupsen/logrus"
+	metallbspr "go.universe.tf/metallb/pkg/speaker"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+
 	"github.com/cilium/cilium/pkg/bgp/fence"
 	"github.com/cilium/cilium/pkg/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -19,12 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
 	"github.com/cilium/cilium/pkg/lock"
 	nodetypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/sirupsen/logrus"
-
-	metallbspr "go.universe.tf/metallb/pkg/speaker"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/workqueue"
 )
 
 var (

--- a/pkg/bpf/bpffs_migrate.go
+++ b/pkg/bpf/bpffs_migrate.go
@@ -1,18 +1,17 @@
 package bpf
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
 
-	"encoding/binary"
-
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/ebpf"
-
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const bpffsPending = ":pending"

--- a/pkg/byteorder/byteorder_bigendian.go
+++ b/pkg/byteorder/byteorder_bigendian.go
@@ -6,6 +6,8 @@
 
 package byteorder
 
+import "encoding/binary"
+
 var Native binary.ByteOrder = binary.BigEndian
 
 func HostToNetwork16(u uint16) uint16 { return u }

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -22,9 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/testutils"
-	"github.com/cilium/cilium/pkg/testutils/identity"
-
-	. "gopkg.in/check.v1"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
 func Test(t *testing.T) {

--- a/pkg/clustermesh/config_test.go
+++ b/pkg/clustermesh/config_test.go
@@ -11,11 +11,11 @@ import (
 	"path"
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/testutils"
-	"github.com/cilium/cilium/pkg/testutils/identity"
-
-	. "gopkg.in/check.v1"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
 func createFile(c *C, name string) {

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -13,6 +13,8 @@ import (
 	"path"
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
@@ -26,9 +28,7 @@ import (
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/testutils"
-	"github.com/cilium/cilium/pkg/testutils/identity"
-
-	. "gopkg.in/check.v1"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
 var etcdConfig = []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))

--- a/pkg/completion/completion_test.go
+++ b/pkg/completion/completion_test.go
@@ -7,11 +7,11 @@
 package completion
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
-	"context"
 	. "gopkg.in/check.v1"
 )
 

--- a/pkg/datapath/connector/ipvlan.go
+++ b/pkg/datapath/connector/ipvlan.go
@@ -6,17 +6,16 @@ package connector
 import (
 	"fmt"
 
-	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/datapath/link"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
-
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
-
 	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/datapath/link"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 func getEntryProgInstructions(fd int) asm.Instructions {

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -16,12 +16,13 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
-	"golang.org/x/sys/unix"
 )
 
 var (

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -11,13 +11,13 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/mac"
-	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netns"
-
-	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -12,6 +12,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/command/exec"
@@ -31,8 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
-	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netlink"
 )
 
 const (

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sLabels "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
@@ -25,9 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/sirupsen/logrus"
-
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // PolicyConfig is the internal representation of Cilium Egress NAT Policy.

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -12,9 +12,10 @@ import (
 	"os"
 	"testing"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/datapath/linux"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
-	. "gopkg.in/check.v1"
 )
 
 func (s *EndpointSuite) TestWriteInformationalComments(c *C) {

--- a/pkg/endpoint/directory_test.go
+++ b/pkg/endpoint/directory_test.go
@@ -10,8 +10,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/checker"
 )
 
 func (s *EndpointSuite) TestMoveNewFilesTo(c *check.C) {

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -9,6 +9,8 @@ package endpoint
 import (
 	"context"
 
+	"gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -25,7 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/u8proto"
-	"gopkg.in/check.v1"
 )
 
 type RedirectSuite struct{}

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"sort"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/cilium/cilium/pkg/checker"
 	linuxDatapath "github.com/cilium/cilium/pkg/datapath/linux"
@@ -23,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
-	. "gopkg.in/check.v1"
 )
 
 func (ds *EndpointSuite) createEndpoints() ([]*Endpoint, map[uint16]*Endpoint) {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -11,6 +11,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
@@ -28,9 +31,6 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/envoy/accesslog.go
+++ b/pkg/envoy/accesslog.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 )
 
 // ParseURL returns the URL as *net.url.URL

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -12,15 +12,15 @@ import (
 	"syscall"
 	"time"
 
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	"github.com/golang/protobuf/proto"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/flowdebug"
 	kafka_api "github.com/cilium/cilium/pkg/policy/api/kafka"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
-
-	"github.com/cilium/proxy/go/cilium/api"
-	"github.com/golang/protobuf/proto"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 func getAccessLogPath(stateDir string) string {

--- a/pkg/envoy/accesslog_server_test.go
+++ b/pkg/envoy/accesslog_server_test.go
@@ -9,12 +9,11 @@ package envoy
 import (
 	"encoding/json"
 
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	logger_test "github.com/cilium/cilium/pkg/proxy/logger/test"
-
-	"github.com/cilium/proxy/go/cilium/api"
-
-	. "gopkg.in/check.v1"
 )
 
 type AccessLogServerSuite struct{}

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -9,13 +9,13 @@ import (
 	"net"
 	"time"
 
-	"github.com/cilium/cilium/pkg/envoy/xds"
-
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_service_discovery "github.com/cilium/proxy/go/envoy/service/discovery/v3"
 	envoy_service_listener "github.com/cilium/proxy/go/envoy/service/listener/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+
+	"github.com/cilium/cilium/pkg/envoy/xds"
 )
 
 var (

--- a/pkg/envoy/sort.go
+++ b/pkg/envoy/sort.go
@@ -6,7 +6,7 @@ package envoy
 import (
 	"sort"
 
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
 )
 

--- a/pkg/envoy/sort_test.go
+++ b/pkg/envoy/sort_test.go
@@ -9,12 +9,12 @@ package envoy
 import (
 	"github.com/cilium/cilium/pkg/checker"
 
-	"github.com/cilium/proxy/go/cilium/api"
+	. "gopkg.in/check.v1"
+
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
 	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
 	envoy_type_matcher "github.com/cilium/proxy/go/envoy/type/matcher/v3"
-
-	. "gopkg.in/check.v1"
 )
 
 type SortSuite struct{}

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -15,16 +15,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/completion"
 	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
 	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
 	envoy_service_disacovery "github.com/cilium/proxy/go/envoy/service/discovery/v3"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/completion"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -15,9 +15,10 @@ import (
 	"sort"
 	"time"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/defaults"
-	. "gopkg.in/check.v1"
 )
 
 type DNSCacheTestSuite struct{}

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -7,12 +7,14 @@
 package dnsproxy
 
 import (
+	"testing"
+
+	"github.com/golang/groupcache/lru"
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/golang/groupcache/lru"
-	. "gopkg.in/check.v1"
-	"testing"
 )
 
 type DNSProxyHelperTestSuite struct{}

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -7,11 +7,12 @@ import (
 	"net"
 	"regexp"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/sirupsen/logrus"
 )
 
 // MapSelectorsToIPsLocked iterates through a set of FQDNSelectors and evalutes

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -12,10 +12,11 @@ import (
 	"net"
 	"time"
 
-	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/policy/api"
 )
 
 var (

--- a/pkg/hubble/exporter/exporter_test.go
+++ b/pkg/hubble/exporter/exporter_test.go
@@ -13,14 +13,14 @@ import (
 	"io"
 	"testing"
 
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/golang/protobuf/ptypes/timestamp"
-
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestExporter(t *testing.T) {

--- a/pkg/hubble/filters/filters_test.go
+++ b/pkg/hubble/filters/filters_test.go
@@ -10,9 +10,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestApply(t *testing.T) {

--- a/pkg/hubble/filters/reply_test.go
+++ b/pkg/hubble/filters/reply_test.go
@@ -10,10 +10,11 @@ import (
 	"context"
 	"testing"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func Test_filterByReplyField(t *testing.T) {

--- a/pkg/identity/identitymanager/manager_test.go
+++ b/pkg/identity/identitymanager/manager_test.go
@@ -9,10 +9,11 @@ package identitymanager
 import (
 	"testing"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
-	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/pkg/ipam/crd_eni.go
+++ b/pkg/ipam/crd_eni.go
@@ -9,14 +9,14 @@ import (
 	"net"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/backoff"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/sirupsen/logrus"
-
-	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 )
 
 type eniDeviceConfig struct {

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -7,19 +7,19 @@ package ipam
 import (
 	"context"
 	"fmt"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/math"
 	"github.com/cilium/cilium/pkg/trigger"
-
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -6,6 +6,8 @@ package ipcache
 import (
 	"net"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
@@ -13,7 +15,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/source"
-	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/k8s/apis/cilium.io/client/v1beta1.go
+++ b/pkg/k8s/apis/cilium.io/client/v1beta1.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"time"
 
-	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/versioncheck"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -18,6 +16,9 @@ import (
 	v1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 func createUpdateV1beta1CRD(

--- a/pkg/k8s/apis/cilium.io/v2alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/types.go
@@ -4,9 +4,10 @@
 package v2alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/cilium/cilium/api/v1/models"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -10,10 +10,16 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/idpool"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -21,12 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/rate"
-
-	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/client-go/tools/cache"
 )
 
 var (

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -14,18 +14,18 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/cilium/cilium/pkg/annotation"
-	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/k8s/informer"
-
 	. "gopkg.in/check.v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/informer"
 )
 
 func Test(t *testing.T) {

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -6,6 +6,10 @@ package k8s
 import (
 	"net"
 
+	"github.com/davecgh/go-spew/spew"
+	"github.com/sirupsen/logrus"
+	core_v1 "k8s.io/api/core/v1"
+
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/ip"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -16,10 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
-	core_v1 "k8s.io/api/core/v1"
-
-	"github.com/davecgh/go-spew/spew"
-	"github.com/sirupsen/logrus"
 )
 
 // CacheAction is the type of action that was performed on the cache

--- a/pkg/k8s/slim/k8s/apis/meta/v1/helpers.go
+++ b/pkg/k8s/slim/k8s/apis/meta/v1/helpers.go
@@ -7,10 +7,11 @@ package v1
 import (
 	"fmt"
 
-	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
-	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/selection"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/selection"
 )
 
 // LabelSelectorAsSelector converts the LabelSelector api type into a struct that implements

--- a/pkg/k8s/types/types.go
+++ b/pkg/k8s/types/types.go
@@ -5,7 +5,7 @@ package types
 
 import (
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 

--- a/pkg/kafka/response.go
+++ b/pkg/kafka/response.go
@@ -7,9 +7,9 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/optiopay/kafka/proto"
-	"io"
 )
 
 // ResponseMessage represents a Kafka response message.

--- a/pkg/labels/arraylist_test.go
+++ b/pkg/labels/arraylist_test.go
@@ -7,8 +7,9 @@
 package labels
 
 import (
-	"github.com/cilium/cilium/pkg/checker"
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/checker"
 )
 
 func (s *LabelsSuite) TestLabelArrayListEquals(c *C) {

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -13,9 +13,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/stretchr/testify/assert"
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/checker"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/pkg/maglev/maglev.go
+++ b/pkg/maglev/maglev.go
@@ -9,8 +9,9 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/cilium/cilium/pkg/murmur3"
 	"github.com/shirou/gopsutil/v3/mem"
+
+	"github.com/cilium/cilium/pkg/murmur3"
 )
 
 const (

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/inctimer"
@@ -17,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/signal"
-	"github.com/sirupsen/logrus"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ct-gc")

--- a/pkg/mcastmanager/mcastmanager.go
+++ b/pkg/mcastmanager/mcastmanager.go
@@ -4,12 +4,13 @@
 package mcastmanager
 
 import (
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/multicast"
-	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/mcastmanager/mcastmanager_test.go
+++ b/pkg/mcastmanager/mcastmanager_test.go
@@ -9,9 +9,10 @@ package mcastmanager
 import (
 	"testing"
 
-	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/vishvananda/netlink"
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/addressing"
 )
 
 func Test(t *testing.T) { TestingT(t) }

--- a/pkg/monitor/agent/agent.go
+++ b/pkg/monitor/agent/agent.go
@@ -12,6 +12,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/perf"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/api/v1/models"
 	oldBPF "github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/lock"
@@ -20,11 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/monitor/agent/listener"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/monitor/payload"
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/perf"
-
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 const eventsMapName = "cilium_events"

--- a/pkg/monitor/logrecord.go
+++ b/pkg/monitor/logrecord.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/miekg/dns"
+
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
 // LogRecordNotify is a proxy access log notification

--- a/pkg/multicast/multicast.go
+++ b/pkg/multicast/multicast.go
@@ -6,12 +6,13 @@ package multicast
 import (
 	"net"
 
+	"github.com/vishvananda/netlink"
+	"golang.org/x/net/ipv6"
+
 	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/vishvananda/netlink"
-	"golang.org/x/net/ipv6"
 )
 
 var (

--- a/pkg/multicast/multicast_test.go
+++ b/pkg/multicast/multicast_test.go
@@ -11,9 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/vishvananda/netlink"
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/addressing"
 )
 
 func Test(t *testing.T) { TestingT(t) }

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -14,13 +14,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cilium/cilium/pkg/cidr"
-	"github.com/cilium/cilium/pkg/defaults"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/google/go-cmp/cmp"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/defaults"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 )
 
 func (s *OptionSuite) TestValidateIPv6ClusterAllocCIDR(c *C) {

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -9,11 +9,12 @@ package api
 import (
 	"fmt"
 
+	. "gopkg.in/check.v1"
+
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api/kafka"
-	. "gopkg.in/check.v1"
 )
 
 // This test ensures that only PortRules which have L7Rules associated with them

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -13,6 +13,9 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/iana"
 	"github.com/cilium/cilium/pkg/identity"
@@ -23,9 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
-	cilium "github.com/cilium/proxy/go/cilium/api"
-
-	"github.com/sirupsen/logrus"
 )
 
 // __canSkipArgs is a wrapper structure to store all boolean conditions for the

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -11,6 +11,9 @@ import (
 	"fmt"
 	stdlog "log"
 
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
@@ -18,9 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/api/kafka"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
-	"github.com/cilium/proxy/go/cilium/api"
-
-	. "gopkg.in/check.v1"
 )
 
 var (

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -9,13 +9,13 @@ package policy
 import (
 	"sort"
 
+	"github.com/kr/pretty"
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/kr/pretty"
-
-	. "gopkg.in/check.v1"
 )
 
 func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	cilium "github.com/cilium/proxy/go/cilium/api"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/identity"
@@ -21,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/proxy/go/cilium/api"
 )
 
 type CertificateManager interface {

--- a/pkg/policy/visibility_test.go
+++ b/pkg/policy/visibility_test.go
@@ -7,10 +7,11 @@
 package policy
 
 import (
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/u8proto"
-	. "gopkg.in/check.v1"
 )
 
 func (ds *PolicyTestSuite) TestGenerateL7RulesByParser(c *C) {

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -4,13 +4,14 @@
 package proxy
 
 import (
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/revert"
-	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/version/version_unix.go
+++ b/pkg/version/version_unix.go
@@ -12,8 +12,9 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/cilium/cilium/pkg/versioncheck"
 	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 func parseKernelVersion(ver string) (semver.Version, error) {

--- a/plugins/cilium-cni/chaining/awscni/aws-cni.go
+++ b/plugins/cilium-cni/chaining/awscni/aws-cni.go
@@ -5,7 +5,7 @@ package awscni
 
 import (
 	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
-	"github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
+	genericveth "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 )
 
 func init() {

--- a/plugins/cilium-cni/chaining/azure/azure-cni.go
+++ b/plugins/cilium-cni/chaining/azure/azure-cni.go
@@ -5,7 +5,7 @@ package azure
 
 import (
 	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
-	"github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
+	genericveth "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 )
 
 func init() {

--- a/plugins/cilium-cni/chaining/flannel/flannel.go
+++ b/plugins/cilium-cni/chaining/flannel/flannel.go
@@ -5,7 +5,7 @@ package flannel
 
 import (
 	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
-	"github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
+	genericveth "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 )
 
 func init() {

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -16,6 +16,18 @@ import (
 	"runtime"
 	"sort"
 
+	"github.com/cilium/ebpf"
+	"github.com/containernetworking/cni/pkg/skel"
+	cniTypes "github.com/containernetworking/cni/pkg/types"
+	cniTypesVer "github.com/containernetworking/cni/pkg/types/040"
+	cniVersion "github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
+	gops "github.com/google/gops/agent"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/cilium/cilium/pkg/client"
@@ -37,18 +49,6 @@ import (
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/portmap"
 	"github.com/cilium/cilium/plugins/cilium-cni/types"
-	"github.com/cilium/ebpf"
-
-	"github.com/containernetworking/cni/pkg/skel"
-	cniTypes "github.com/containernetworking/cni/pkg/types"
-	cniTypesVer "github.com/containernetworking/cni/pkg/types/040"
-	cniVersion "github.com/containernetworking/cni/pkg/version"
-	"github.com/containernetworking/plugins/pkg/ns"
-	gops "github.com/google/gops/agent"
-	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 )
 
 var (

--- a/proxylib/accesslog/client.go
+++ b/proxylib/accesslog/client.go
@@ -8,12 +8,12 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/proxylib/proxylib"
-
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/proxylib/proxylib"
 )
 
 type Client struct {

--- a/proxylib/cassandra/cassandraparser.go
+++ b/proxylib/cassandra/cassandraparser.go
@@ -10,10 +10,10 @@ import (
 	"regexp"
 	"strings"
 
-	. "github.com/cilium/cilium/proxylib/proxylib"
-
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	log "github.com/sirupsen/logrus"
+
+	. "github.com/cilium/cilium/proxylib/proxylib"
 )
 
 //

--- a/proxylib/cassandra/cassandraparser_test.go
+++ b/proxylib/cassandra/cassandraparser_test.go
@@ -10,13 +10,11 @@ import (
 	"encoding/hex"
 	"testing"
 
-	// "github.com/cilium/cilium/pkg/logging"
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/proxylib/accesslog"
 	"github.com/cilium/cilium/proxylib/proxylib"
 	"github.com/cilium/cilium/proxylib/test"
-
-	// log "github.com/sirupsen/logrus"
-	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/proxylib/kafka/parser.go
+++ b/proxylib/kafka/parser.go
@@ -6,13 +6,12 @@ package kafka
 import (
 	"encoding/binary"
 
-	. "github.com/cilium/cilium/proxylib/proxylib"
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/kafka"
-	cilium "github.com/cilium/proxy/go/cilium/api"
-
-	log "github.com/sirupsen/logrus"
+	. "github.com/cilium/cilium/proxylib/proxylib"
 )
 
 const (

--- a/proxylib/kafka/parser_test.go
+++ b/proxylib/kafka/parser_test.go
@@ -10,13 +10,12 @@ import (
 	"encoding/hex"
 	"testing"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/pkg/logging"
-	// "github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/proxylib/accesslog"
 	"github.com/cilium/cilium/proxylib/proxylib"
 	"github.com/cilium/cilium/proxylib/test"
-
-	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/proxylib/memcached/binary/parser.go
+++ b/proxylib/memcached/binary/parser.go
@@ -8,11 +8,11 @@ import (
 	"encoding/binary"
 	"strconv"
 
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/proxylib/memcached/meta"
 	"github.com/cilium/cilium/proxylib/proxylib"
-
-	"github.com/cilium/proxy/go/cilium/api"
-	log "github.com/sirupsen/logrus"
 )
 
 // ParserFactory implements proxylib.ParserFactory

--- a/proxylib/memcached/parser.go
+++ b/proxylib/memcached/parser.go
@@ -10,14 +10,13 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/cilium/cilium/proxylib/proxylib"
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/proxylib/memcached/binary"
 	"github.com/cilium/cilium/proxylib/memcached/meta"
 	"github.com/cilium/cilium/proxylib/memcached/text"
-
-	"github.com/cilium/proxy/go/cilium/api"
-	log "github.com/sirupsen/logrus"
+	"github.com/cilium/cilium/proxylib/proxylib"
 )
 
 // Rule matches against memcached requests

--- a/proxylib/memcached/text/parser.go
+++ b/proxylib/memcached/text/parser.go
@@ -9,11 +9,11 @@ import (
 	"bytes"
 	"strconv"
 
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/proxylib/memcached/meta"
 	"github.com/cilium/cilium/proxylib/proxylib"
-
-	"github.com/cilium/proxy/go/cilium/api"
-	log "github.com/sirupsen/logrus"
 )
 
 // ParserFactory implements proxylib.ParserFactory

--- a/proxylib/npds/client.go
+++ b/proxylib/npds/client.go
@@ -10,16 +10,16 @@ import (
 	"io"
 	"time"
 
-	"github.com/cilium/cilium/pkg/backoff"
-	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/proxylib/proxylib"
-
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
 	envoy_service_disacovery "github.com/cilium/proxy/go/envoy/service/discovery/v3"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
+
+	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/proxylib/proxylib"
 )
 
 const (

--- a/proxylib/npds/client_test.go
+++ b/proxylib/npds/client_test.go
@@ -13,14 +13,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cilium/cilium/pkg/completion"
-	"github.com/cilium/cilium/pkg/envoy"
-	"github.com/cilium/cilium/proxylib/test"
-
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_service_disacovery "github.com/cilium/proxy/go/envoy/service/discovery/v3"
 	log "github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/proxylib/test"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/proxylib/proxylib.go
+++ b/proxylib/proxylib.go
@@ -9,6 +9,10 @@ package main
 import "C"
 
 import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/flowdebug"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/proxylib/accesslog"
 	_ "github.com/cilium/cilium/proxylib/cassandra"
 	_ "github.com/cilium/cilium/proxylib/kafka"
@@ -17,10 +21,6 @@ import (
 	. "github.com/cilium/cilium/proxylib/proxylib"
 	_ "github.com/cilium/cilium/proxylib/r2d2"
 	_ "github.com/cilium/cilium/proxylib/testparsers"
-
-	"github.com/cilium/cilium/pkg/flowdebug"
-	"github.com/cilium/cilium/pkg/lock"
-	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/proxylib/proxylib/connection.go
+++ b/proxylib/proxylib/connection.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/proxylib/proxylib/instance.go
+++ b/proxylib/proxylib/instance.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"github.com/cilium/cilium/pkg/lock"
-
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_service_disacovery "github.com/cilium/proxy/go/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/lock"
 )
 
 type PolicyClient interface {

--- a/proxylib/proxylib/policymap.go
+++ b/proxylib/proxylib/policymap.go
@@ -8,11 +8,11 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/cilium/cilium/pkg/flowdebug"
-
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	core "github.com/cilium/proxy/go/envoy/config/core/v3"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/flowdebug"
 )
 
 // Each L7 rule implements this interface

--- a/proxylib/proxylib/test_util.go
+++ b/proxylib/proxylib/test_util.go
@@ -4,7 +4,7 @@
 package proxylib
 
 import (
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_service_disacovery "github.com/cilium/proxy/go/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"

--- a/proxylib/proxylib_memcached_test.go
+++ b/proxylib/proxylib_memcached_test.go
@@ -10,13 +10,13 @@ import (
 	"fmt"
 	"testing"
 
+	_ "gopkg.in/check.v1"
+
 	_ "github.com/cilium/cilium/proxylib/memcached"
 	binarymemcache "github.com/cilium/cilium/proxylib/memcached/binary"
 	textmemcache "github.com/cilium/cilium/proxylib/memcached/text"
 	"github.com/cilium/cilium/proxylib/proxylib"
 	"github.com/cilium/cilium/proxylib/test"
-
-	_ "gopkg.in/check.v1"
 )
 
 var setHelloText = []byte("set key 0 0 5\r\nhello\r\n")

--- a/proxylib/proxylib_test.go
+++ b/proxylib/proxylib_test.go
@@ -11,15 +11,13 @@ import (
 	"testing"
 	"time"
 
-	_ "gopkg.in/check.v1"
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/proxylib/proxylib"
 	"github.com/cilium/cilium/proxylib/test"
 	_ "github.com/cilium/cilium/proxylib/testparsers"
-
-	cilium "github.com/cilium/proxy/go/cilium/api"
-	log "github.com/sirupsen/logrus"
 )
 
 const debug = false

--- a/proxylib/r2d2/r2d2parser.go
+++ b/proxylib/r2d2/r2d2parser.go
@@ -9,10 +9,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cilium/cilium/proxylib/proxylib"
-
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/proxylib/proxylib"
 )
 
 //

--- a/proxylib/r2d2/r2d2parser_test.go
+++ b/proxylib/r2d2/r2d2parser_test.go
@@ -9,12 +9,11 @@ package r2d2
 import (
 	"testing"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/cilium/cilium/proxylib/accesslog"
 	"github.com/cilium/cilium/proxylib/proxylib"
 	"github.com/cilium/cilium/proxylib/test"
-
-	// log "github.com/sirupsen/logrus"
-	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/proxylib/test/accesslog_server.go
+++ b/proxylib/test/accesslog_server.go
@@ -12,13 +12,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cilium/cilium/pkg/inctimer"
-	"github.com/cilium/cilium/pkg/lock"
 	cilium "github.com/cilium/proxy/go/cilium/api"
-
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/lock"
 )
 
 type AccessLogServer struct {

--- a/proxylib/testparsers/blockparser.go
+++ b/proxylib/testparsers/blockparser.go
@@ -9,10 +9,10 @@ import (
 	"math"
 	"strconv"
 
-	. "github.com/cilium/cilium/proxylib/proxylib"
-
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	log "github.com/sirupsen/logrus"
+
+	. "github.com/cilium/cilium/proxylib/proxylib"
 )
 
 //

--- a/proxylib/testparsers/headerparser.go
+++ b/proxylib/testparsers/headerparser.go
@@ -13,10 +13,10 @@ import (
 	"bytes"
 	"fmt"
 
-	. "github.com/cilium/cilium/proxylib/proxylib"
-
-	"github.com/cilium/proxy/go/cilium/api"
+	cilium "github.com/cilium/proxy/go/cilium/api"
 	log "github.com/sirupsen/logrus"
+
+	. "github.com/cilium/cilium/proxylib/proxylib"
 )
 
 //

--- a/proxylib/testparsers/lineparser.go
+++ b/proxylib/testparsers/lineparser.go
@@ -6,9 +6,9 @@ package testparsers
 import (
 	"bytes"
 
-	. "github.com/cilium/cilium/proxylib/proxylib"
-
 	log "github.com/sirupsen/logrus"
+
+	. "github.com/cilium/cilium/proxylib/proxylib"
 )
 
 //

--- a/proxylib/testparsers/passer.go
+++ b/proxylib/testparsers/passer.go
@@ -4,9 +4,9 @@
 package testparsers
 
 import (
-	. "github.com/cilium/cilium/proxylib/proxylib"
-
 	log "github.com/sirupsen/logrus"
+
+	. "github.com/cilium/cilium/proxylib/proxylib"
 )
 
 type PasserParserFactory struct{}

--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cilium/cilium/test/helpers/constants"
 	"github.com/onsi/ginkgo"
+
+	"github.com/cilium/cilium/test/helpers/constants"
 )
 
 // ContainerExec executes cmd in the container with the provided name along with

--- a/test/k8sT/CustomCalls.go
+++ b/test/k8sT/CustomCalls.go
@@ -9,11 +9,12 @@ import (
 	"strconv"
 	"strings"
 
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/cilium/cilium/pkg/defaults"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
-	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("K8sCustomCalls", func() {

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -20,10 +20,11 @@ import (
 	"net"
 	"strings"
 
-	. "github.com/cilium/cilium/test/ginkgo-ext"
-	"github.com/cilium/cilium/test/helpers"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
 )
 
 var _ = SkipDescribeIf(func() bool {

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/cilium/cilium/test/config"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
-	. "github.com/onsi/gomega"
 )
 
 var longTimeout = 10 * time.Minute

--- a/test/k8sT/log.go
+++ b/test/k8sT/log.go
@@ -4,8 +4,9 @@
 package k8sTest
 
 import (
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/logging"
 )
 
 var log = logging.DefaultLogger

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -10,14 +10,15 @@ import (
 	"sync"
 	"time"
 
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/policy/api"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 	"github.com/cilium/cilium/test/helpers/constants"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/test/runtime/log.go
+++ b/test/runtime/log.go
@@ -4,8 +4,9 @@
 package RuntimeTest
 
 import (
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/logging"
 )
 
 var log = logging.DefaultLogger

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -12,17 +12,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/test/config"
-	. "github.com/cilium/cilium/test/ginkgo-ext"
-	"github.com/cilium/cilium/test/helpers"
-	"github.com/cilium/cilium/test/logger"
 	gops "github.com/google/gops/agent"
 	"github.com/onsi/ginkgo"
 	ginkgoconfig "github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/test/config"
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+	"github.com/cilium/cilium/test/logger"
 )
 
 var (


### PR DESCRIPTION
Conventional Go imports are divided into three ordered blocks:

```
import (
    // standard library packages

    // third-party packages

    // local packages
)
```

This commit re-orders imports to match these conventions and configures
golangci-lint to enforce them with the goimports linter.

Signed-off-by: Tom Payne <tom@isovalent.com>
