### PR TITLE
bgp,bugfix: parse ips when converting from slim_core to k8s service

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1517,14 +1517,6 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	// This is necessary because the code inside pkg/k8s.NewService() for
-	// parsing services would not trigger unless NodePort is enabled. Without
-	// NodePort enabled, the external and LB IPs would not be parsed out.
-	if option.Config.BGPAnnounceLBIP {
-		option.Config.EnableNodePort = true
-		log.Infof("Auto-set BPF NodePort (%q) because LB IP announcements via BGP depend on it.", option.EnableNodePort)
-	}
-
 	if option.Config.BGPAnnouncePodCIDR &&
 		(option.Config.IPAM != ipamOption.IPAMClusterPool &&
 			option.Config.IPAM != ipamOption.IPAMKubernetes) {

--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -128,7 +128,7 @@ func (s *MetalLBSpeaker) OnUpdateService(svc *slim_corev1.Service) error {
 	}
 
 	l.Debug("adding event to queue")
-	s.queue.Add(epEvent{
+	s.queue.Add(svcEvent{
 		Meta: meta,
 		op:   Update,
 		id:   svcID,


### PR DESCRIPTION
this fixes #16967.

previous to this commit, when converting from a slim_core Service to our
k8s Service abstraction the parsed out loadBalancersIP were not
converted to the appropriate map of net.IP objects.

they were not converted because of a guard which only does this for when
"NodePort" configuration is set to true.

with the introduction of the BGP load balancer announcement feature, we
also need to parse IPs coming from the ServiceStatus field in a
slim_core Service.

If this change is not made, both the old and new services look exactly
the same to the k8sWatcher infrastructure and when the Service gets its
load balancer IP the entire event is thrown away.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>