### PR TITLE
test: Bump upgrade for v1.12 development

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -176,9 +176,9 @@ const (
 
 	// CiliumStableHelmChartVersion should be the chart version that points
 	// to the v1.X branch
-	CiliumStableHelmChartVersion = "1.10"
+	CiliumStableHelmChartVersion = "1.11"
 	CiliumStableVersion          = "v" + CiliumStableHelmChartVersion
-	CiliumLatestHelmChartVersion = "1.10.90"
+	CiliumLatestHelmChartVersion = "1.11.90"
 
 	MonitorLogFileName = "monitor.log"
 


### PR DESCRIPTION
Test upgrade from the latest v1.11 development chart up until the master
branch for all new pull requests.
