### PR TITLE
CODEOWNERS: janitors renamed to tophat

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Code owners groups and a brief description of their areas:
-# @cilium/janitors           Catch-all for code not otherwise owned
+# @cilium/tophat             Catch-all for code not otherwise owned
 # @cilium/api                API stability guarantees
 # @cilium/agent              Cilium Agent
 # @cilium/alibabacloud       Integration with AlibabaCloud
@@ -30,7 +30,7 @@
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
-* @cilium/janitors
+* @cilium/tophat
 /CODEOWNERS @cilium/contributing
 /.github/ @cilium/contributing
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure


### PR DESCRIPTION
The janitors team was renamed to tophat so we need to update the code owners accordingly.