### PR TITLE
v1.10 backports 2022-01-03

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -641,12 +641,6 @@ func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) {
 			}
 		}
 	}
-
-	option.Config.NodePortHairpin = len(option.Config.Devices) == 1
-	if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled &&
-		len(option.Config.Devices) != 1 {
-		log.Fatalf("Cannot set NodePort acceleration due to multi-device setup (%q). Specify --%s with a single device to enable NodePort acceleration.", option.Config.Devices, option.Devices)
-	}
 }
 
 // disableNodePort disables BPF NodePort and friends who are dependent from


### PR DESCRIPTION
 * #18305 -- daemon: Fix multi-dev XDP check (@brb)

PRs skipped due conflicts:

 * #18279 -- docs: Replace 'micro version' with 'patch version' (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18305; do contrib/backporting/set-labels.py $pr done 1.10; done
```
or with
```
$ make add-label branch=v1.10 issues=18305
```