### PR TITLE
v1.11 ci: set PR base for codeql workflow

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -1,7 +1,9 @@
 name: codeql
 
 on:
-  pull_request: {}
+  pull_request:
+    branches:
+      - v1.11
   push:
     branches:
       - v1.11

--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -15,7 +15,7 @@ permissions: read-all
 jobs:
   check_changes:
     name: Deduce required tests from code changes
-    if: github.repository == 'cilium/cilium'
+    if: ${{ github.repository == 'cilium/cilium' && github.event_name == 'pull_request' }}
     runs-on: ubuntu-18.04
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}
@@ -29,6 +29,8 @@ jobs:
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: go-changes
         with:
+          base: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           filters: |
             src:
               - .github/workflows/lint-codeql.yaml
@@ -38,7 +40,7 @@ jobs:
 
   analyze:
     needs: check_changes
-    if: github.repository == 'cilium/cilium' && needs.check_changes.outputs.go-changes == 'true'
+    if: ${{ github.repository == 'cilium/cilium' && (needs.check_changes.outputs.go-changes == 'true' || github.event_name != 'pull_request') }}
     runs-on: ubuntu-18.04
     permissions:
       security-events: write


### PR DESCRIPTION
Manual backport of  #18283 with adjusted branch name.

This makes sure only code changed by the CL is flagged by CodeQL,
but not existing issues in the repo.

Moreover, run the paths-filter action only on pull_request events. This
should fix scheduled run of the workflow.