### PR TITLE
test: bump l4lb Vagrantfile kind to 0.11.1

### DIFF
--- a/test/l4lb/Vagrantfile
+++ b/test/l4lb/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
     systemctl enable --now docker
 
     # cgroupv2 requires >= Kind 0.11.0
-    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.0/kind-linux-amd64
+    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
     chmod +x ./kind
     mv ./kind /usr/local/bin
 


### PR DESCRIPTION
The 0.11.1 release bumps the base ubuntu image to 21.04 [1], which should
fix the issue we are seeing with the current test:

    ++ docker exec -i kind-control-plane /bin/sh -c 'echo $(( $(ip -o l show eth0 | awk "{print $1}" | cut -d: -f1) ))'
    [..]
    Reading package lists...
    E: The repository 'http://security.ubuntu.com/ubuntu groovy-security Release' does not have a Release file.
    E: The repository 'http://archive.ubuntu.com/ubuntu groovy Release' does not have a Release file.
    E: The repository 'http://archive.ubuntu.com/ubuntu groovy-updates Release' does not have a Release file.
    E: The repository 'http://archive.ubuntu.com/ubuntu groovy-backports Release' does not have a Release file.
    Error: Process completed with exit code 100.

[1] https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1