### PR TITLE
bpf: Reset Pod's queue mapping in host veth to fix phys dev mq selection

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -19,6 +19,7 @@
 #include "lib/maps.h"
 #include "lib/arp.h"
 #include "lib/edt.h"
+#include "lib/qm.h"
 #include "lib/ipv6.h"
 #include "lib/ipv4.h"
 #include "lib/icmp6.h"
@@ -982,6 +983,7 @@ int handle_xgress(struct __ctx_buff *ctx)
 	int ret;
 
 	bpf_clear_meta(ctx);
+	reset_queue_mapping(ctx);
 
 	send_trace_notify(ctx, TRACE_FROM_LXC, SECLABEL, 0, 0, 0, 0,
 			  TRACE_PAYLOAD_LEN);

--- a/bpf/lib/qm.h
+++ b/bpf/lib/qm.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2022 Authors of Cilium */
+
+#ifndef __QM_H_
+#define __QM_H_
+
+#include <bpf/ctx/ctx.h>
+
+static inline void reset_queue_mapping(struct __ctx_buff *ctx __maybe_unused)
+{
+#if defined(RESET_QUEUES) && __ctx_is == __ctx_skb
+	/* Workaround for GH-18311 where veth driver might have recorded
+	 * veth's RX queue mapping instead of leaving it at 0. This can
+	 * cause issues on the phys device where all traffic would only
+	 * hit a single TX queue (given veth device had a single one and
+	 * mapping was left at 1). Reset so that stack picks a fresh queue.
+	 * Kernel fix is at 710ad98c363a ("veth: Do not record rx queue
+	 * hint in veth_xmit").
+	 */
+	ctx->queue_mapping = 0;
+#endif
+}
+
+#endif /* __QM_H_ */

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -460,6 +460,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 	}
 
+	if option.Config.ResetQueueMapping {
+		cDefinesMap["RESET_QUEUES"] = "1"
+	}
+
 	if option.Config.EnableBandwidthManager {
 		cDefinesMap["ENABLE_BANDWIDTH_MANAGER"] = "1"
 		cDefinesMap["THROTTLE_MAP"] = bwmap.MapName

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1763,6 +1763,9 @@ type DaemonConfig struct {
 	// EnableBandwidthManager enables EDT-based pacing
 	EnableBandwidthManager bool
 
+	// ResetQueueMapping resets the Pod's skb queue mapping
+	ResetQueueMapping bool
+
 	// EnableRecorder enables the datapath pcap recorder
 	EnableRecorder bool
 


### PR DESCRIPTION
Fix TX queue selection problem on the phys device as reported by Laurent.
At high throughput, they noticed a significant amount of TCP retransmissions
that they tracked back to qdic drops (fq_codel was used).

Suspicion is that kernel commit edbea9220251 ("veth: Store queue_mapping
independently of XDP prog presence") caused this due to its unconditional
skb_record_rx_queue() which sets queue mapping to 1, and thus this gets
propagated all the way to the physical device hitting only single queue
in a mq device.

Lets have bpf_lxc reset it as a workaround until we have a kernel fix.
Doing this unconditionally is good anyway in order to avoid Pods messing
with TX queue selection.

Related: #18311
Reported-by: Laurent Bernaille <laurent.bernaille@datadoghq.com>
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
Link: https://github.com/torvalds/linux/commit/edbea922025169c0e5cdca5ebf7bf5374cc5566c