### PR TITLE
[v1.11] Backport #18150

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -392,9 +392,9 @@ func RemoveLabels(prefix string, lbls labels.Labels, src source.Source) labels.L
 // The following diagram describes the relationship between the label injector
 // triggered here and the callers/callees.
 //
-//       +------------+  (1)        (1)  +------------+
-//      | EP Watcher +-----+      +-----+ CN Watcher |
-//      +-----+------+   W |      | W   +------+-----+
+//      +------------+  (1)        (1)  +-----------------------------+
+//      | EP Watcher +-----+      +-----+ CN Watcher / Node Discovery |
+//      +-----+------+   W |      | W   +------+----------------------+
 //            |            |      |            |
 //            |            v      v            |
 //            |            +------+            |
@@ -404,7 +404,7 @@ func RemoveLabels(prefix string, lbls labels.Labels, src source.Source) labels.L
 //            |               |                |
 //            |           (3) |R               |
 //            | (2)    +------+--------+   (2) |
-//            +------> |Label Injector |<------+
+//            +------->|Label Injector |<------+
 //           Trigger   +-------+-------+ Trigger
 //                         (4) |W
 //                             |

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -311,7 +311,7 @@ func RemoveLabelsFromIPs(
 			la = l.LabelArray()
 		}
 		idsToDelete[id.ID] = la
-		if len(lbls) > 0 {
+		if len(la) > 0 {
 			// If for example kube-apiserver label is removed from
 			// a remote-node, then RemoveLabels() will return a
 			// non-empty set representing the new full set of

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -52,8 +52,8 @@ func TestFilterMetadataByLabels(t *testing.T) {
 	UpsertMetadata("2.1.1.1", labels.LabelWorld)
 	UpsertMetadata("3.1.1.1", labels.LabelWorld)
 
-	assert.Len(t, FilterMetadataByLabels(labels.LabelKubeAPIServer), 1)
-	assert.Len(t, FilterMetadataByLabels(labels.LabelWorld), 2)
+	assert.Len(t, filterMetadataByLabels(labels.LabelKubeAPIServer), 1)
+	assert.Len(t, filterMetadataByLabels(labels.LabelWorld), 2)
 }
 
 func TestRemoveLabelsFromIPs(t *testing.T) {
@@ -63,7 +63,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.NoError(t, InjectLabels(source.Local, &mockUpdater{}, &mockTriggerer{}))
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
-	RemoveLabelsFromIPs(map[string]labels.Labels{
+	removeLabelsFromIPs(map[string]labels.Labels{
 		"1.1.1.1": labels.LabelKubeAPIServer,
 	}, source.Local, &mockUpdater{}, &mockTriggerer{})
 	assert.Len(t, identityMetadata, 1)
@@ -90,7 +90,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, ids, 1)
 	assert.Equal(t, 2, id.ReferenceCount)
-	RemoveLabelsFromIPs(map[string]labels.Labels{ // remove kube-apiserver policy
+	removeLabelsFromIPs(map[string]labels.Labels{ // remove kube-apiserver policy
 		"1.1.1.1": labels.LabelKubeAPIServer,
 	}, source.Local, &mockUpdater{}, &mockTriggerer{})
 	assert.NotContains(t, identityMetadata["1.1.1.1"], labels.LabelKubeAPIServer)

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -131,15 +131,9 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 	//     an update event.
 	//   * if the entire object is deleted, then it will quickly be recreated
 	//     and this will be in the form of an add event.
-	oldAPIServerIPs := ipcache.FilterMetadataByLabels(labels.LabelKubeAPIServer)
-	toRemove := make(map[string]labels.Labels)
-	for _, ip := range oldAPIServerIPs {
-		if _, ok := desiredIPs[ip]; !ok {
-			toRemove[ip] = labels.LabelKubeAPIServer
-		}
-	}
-	ipcache.RemoveLabelsFromIPs(
-		toRemove,
+	ipcache.RemoveLabelsExcluded(
+		labels.LabelKubeAPIServer,
+		desiredIPs,
 		src,
 		k.policyRepository.GetSelectorCache(),
 		k.policyManager,


### PR DESCRIPTION
* #18150 -- Various improvements and bugfixes for kube-apiserver policy matching (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18150; do contrib/backporting/set-labels.py $pr done 1.11; done
```