### PR TITLE
.github: Fix 1.11.1 project link for MLH

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -3,13 +3,13 @@ column: "In progress"
 move-to-projects-for-labels-xored:
   v1.11:
     needs-backport/1.11:
-      project: "https://github.com/cilium/cilium/projects/155"
+      project: "https://github.com/cilium/cilium/projects/174"
       column: "Needs backport from master"
     backport-pending/1.11:
-      project: "https://github.com/cilium/cilium/projects/155"
+      project: "https://github.com/cilium/cilium/projects/174"
       column: "Backport pending to v1.10"
     backport-done/1.11:
-      project: "https://github.com/cilium/cilium/projects/155"
+      project: "https://github.com/cilium/cilium/projects/174"
       column: "Backport done to v1.11"
   v1.10:
     needs-backport/1.10:


### PR DESCRIPTION
The project was not updated when we did 1.11.0, so MLH wasn't managing
the projects correctly.

Fixes: 4b73684e08d7 ("docs: Update stable release versions")
CC: Daniel Borkmann <daniel@iogearbox.net>
