### PR TITLE
docs: Add limitation document for bandwidth-manager + nested network namespace

### DIFF
--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -174,6 +174,6 @@ Limitations
     * Bandwidth enforcement currently does not work in combination with L7 Cilium Network Policies.
       In case they select the Pod at egress, then the bandwidth enforcement will be disabled for
       those Pods.
-    * Bandwidth enforcement doesn't work with nested network namespace environments like Kind. Because
+    * Bandwidth enforcement doesn't work with nested network namespace environments like Kind. This is because
       they typically don't have access to the global sysctl under ``/proc/sys/net/core`` and the
       bandwidth enforcement depends on them.

--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -174,3 +174,6 @@ Limitations
     * Bandwidth enforcement currently does not work in combination with L7 Cilium Network Policies.
       In case they select the Pod at egress, then the bandwidth enforcement will be disabled for
       those Pods.
+    * Bandwidth enforcement doesn't work with nested network namespace environments like Kind. Because
+      they typically don't have access to the global sysctl under ``/proc/sys/net/core`` and the
+      bandwidth enforcement depends on them.


### PR DESCRIPTION
In the current bandwidth manager implemetation, it reads/writes some sysctl
parameters under net.core such as default_qdisc (read) or
netdev_max_backlog (write). In the typical nested namespace environment like
Kind, nodes (container) doesn't have access to these parameters. Thus,
bandwidth manager doesn't work. This commit documents it.

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!