### PR TITLE
helm: add ability to create ipsec secret

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -140,7 +140,9 @@ contributors across the globe, there is almost always someone available to help.
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: http://docs.cilium.io/en/stable/install/system_requirements/#admin-kernel-version. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
 | encryption.interface | string | `""` | Deprecated in favor of encryption.ipsec.interface. The interface to use for encrypted traffic. This option is only effective when encryption.type is set to ipsec. |
+| encryption.ipsec.createSecret | bool | `false` | Whether to create the secret. |
 | encryption.ipsec.interface | string | `""` | The interface to use for encrypted traffic. |
+| encryption.ipsec.keyData | string | `""` | Secret key data to use when creating the secret. e.g., "3 rfc4106(gcm(aes)) c971f5e7a633b2e5ff248b53995784026fd48873 128". |
 | encryption.ipsec.keyFile | string | `""` | Name of the key file inside the Kubernetes secret configured via secretName. |
 | encryption.ipsec.mountPath | string | `""` | Path to mount the secret inside the Cilium pod. |
 | encryption.ipsec.secretName | string | `""` | Name of the Kubernetes secret containing the encryption keys. |

--- a/install/kubernetes/cilium/templates/cilium-agent/ipsec-secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/ipsec-secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.encryption.enabled (eq .Values.encryption.type "ipsec") }}
+{{- if .Values.encryption.ipsec.createSecret }}
+{{- $keys := .Values.encryption.ipsec.keyData | required "must set encryption.ipsec.keyData when creating secret" | quote }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.encryption.ipsec.secretName | default .Values.encryption.secretName }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+  {{- if and .Values.encryption.ipsec.mountPath .Values.encryption.ipsec.keyFile }}
+  {{ .Values.encryption.ipsec.keyFile }}: {{ $keys }}
+  {{- else }}
+  {{ .Values.encryption.keyFile }}: {{ $keys }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -443,6 +443,12 @@ encryption:
     # -- The interface to use for encrypted traffic.
     interface: ""
 
+    # -- Whether to create the secret.
+    createSecret: false
+
+    # -- Secret key data to use when creating the secret. e.g., "3 rfc4106(gcm(aes)) c971f5e7a633b2e5ff248b53995784026fd48873 128".
+    keyData: ""
+
   wireguard:
     # -- Enables the fallback to the user-space implementation.
     userspaceFallback: false
@@ -643,7 +649,7 @@ hubble:
       # Defaults to midnight of the first day of every fourth month. For syntax, see
       # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
       schedule: "0 0 1 */4 *"
-      
+
       # [Example]
       # certManagerIssuerRef:
       #   group: cert-manager.io
@@ -1772,7 +1778,7 @@ clustermesh:
         # fourth month. For syntax, see
         # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
         # schedule: "0 0 1 */4 *"
-        
+
         # [Example]
         # certManagerIssuerRef:
         #   group: cert-manager.io


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
  - Are there tests for helm somewhere?  –> It looks like I could add an end-to-end test here, but that feels a bit overboard.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Adds the following value options:
* `encryption.ipsec.createSecret`
* `encryption.ipsec.keyData`

If `createSecret` is set, try to create
a secret using the `keyData`. `keyData`
is required if `createSecret` is true.

Also supports the existing
`mountPath` and `keyFile` options,
both deprecated versions and not.

Signed-off-by: austin ce <austin.cawley@gmail.com>

Fixes: #18084

```release-note
helm: add option for creating ipsec Secret resource
```


Here are the test cases I've tried:

```yaml
# fail, keyData required
encryption:
  enabled: true
  ipsec:
    createSecret: true
```

```yaml
# success, happy path
encryption:
  enabled: true
  ipsec:
    createSecret: true
    keyData: "3 rfc4106(gcm(aes)) c971f5e7a633b2e5ff248b53995784026fd48873 128"
```

```yaml
# success, non-default mountpath + keyFIle
encryption:
  enabled: true
  ipsec:
    createSecret: true
    keyData: "3 rfc4106(gcm(aes)) c971f5e7a633b2e5ff248b53995784026fd48873 128"
    mountPath: "/tmp"
    keyFile: "abc"
```

```yaml
# success, non-default mountpath + keyFile using deprecated values
encryption:
  enabled: true
  mountPath: "/tmp"
  keyFile: "abc"
  ipsec:
    createSecret: true
    keyData: "3 rfc4106(gcm(aes)) c971f5e7a633b2e5ff248b53995784026fd48873 128"
```

```yaml
# success, wireguard no-op
encryption:
  enabled: true
  type: "wireguard"
  ipsec:
    createSecret: true
    keyData: "3 rfc4106(gcm(aes)) c971f5e7a633b2e5ff248b53995784026fd48873 128"
```
