### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -2130,7 +2130,7 @@ describe some of the differences for the BPF model:
         struct called_info called_info = {
                 .start = start_time,
                 .end = 0,
-                .bi_sector = 0
+                .sector = 0
         };
 
         bpf_map_update_elem(&called_info_map, &bio_ptr, &called_info, BPF_ANY);


### PR DESCRIPTION
This PR fixes a typo in [BPF guideline](https://docs.cilium.io/en/latest/bpf) which is I am digging now.

release-note-none.