### PR TITLE
Fix the typo in Fatalf message of printConfigurations

### DIFF
--- a/cilium/cmd/config.go
+++ b/cilium/cmd/config.go
@@ -111,15 +111,15 @@ func printConfigurations(cfgStatus *models.DaemonConfigurationStatus) {
 	if command.OutputJSON() {
 		if listReadOnlyConfigurations {
 			if err := command.PrintOutput(cfgStatus.DaemonConfigurationMap); err != nil {
-				Fatalf("Cannot show configuratons: %v", err)
+				Fatalf("Cannot show configurations: %v", err)
 			}
 		} else if listAllConfigurations {
 			if err := command.PrintOutputWithPatch(cfgStatus.DaemonConfigurationMap, cfgStatus.Realized); err != nil {
-				Fatalf("Cannot show configuratons: %v", err)
+				Fatalf("Cannot show configurations: %v", err)
 			}
 		} else {
 			if err := command.PrintOutput(cfgStatus.Realized.Options); err != nil {
-				Fatalf("Cannot show configuratons: %v", err)
+				Fatalf("Cannot show configurations: %v", err)
 			}
 		}
 		return


### PR DESCRIPTION
Signed-off-by: Wongyu Lee <kyu21@outlook.com>

I fixed Fatalf msg's typo in printConfigurations() method.
configuratons -> configurations

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!
