### PR TITLE
[SNAT] add "need to frag" ICMP support

### DIFF
--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -38,7 +38,7 @@ static __always_inline int ipv6_authlen(const struct ipv6_opt_hdr *opthdr)
 	return (opthdr->hdrlen + 2) << 2;
 }
 
-static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
+static __always_inline int ipv6_hdrlen_offset(struct __ctx_buff *ctx, __u8 *nexthdr, int l3_off)
 {
 	int i, len = sizeof(struct ipv6hdr);
 	struct ipv6_opt_hdr opthdr __align_stack_8;
@@ -57,7 +57,7 @@ static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
 		case NEXTHDR_ROUTING:
 		case NEXTHDR_AUTH:
 		case NEXTHDR_DEST:
-			if (ctx_load_bytes(ctx, ETH_HLEN + len, &opthdr, sizeof(opthdr)) < 0)
+			if (ctx_load_bytes(ctx, l3_off + len, &opthdr, sizeof(opthdr)) < 0)
 				return DROP_INVALID;
 
 			nh = opthdr.nexthdr;
@@ -75,6 +75,11 @@ static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
 
 	/* Reached limit of supported extension headers */
 	return DROP_INVALID_EXTHDR;
+}
+
+static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
+{
+	return ipv6_hdrlen_offset(ctx, nexthdr, ETH_HLEN);
 }
 
 static __always_inline void ipv6_addr_copy(union v6addr *dst,

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -379,7 +379,11 @@ static __always_inline int snat_v4_icmp_rewrite_embedded(struct __ctx_buff *ctx,
 
 		switch (tuple->nexthdr) {
 		case IPPROTO_TCP:
-		case IPPROTO_UDP: {
+		case IPPROTO_UDP:
+#ifdef ENABLE_SCTP
+		case IPPROTO_SCTP:
+#endif  /* ENABLE_SCTP */
+		{
 			/* In case that the destination port has been NATed from
 			 * target to dest. We want the embedded packet which
 			 * should refer to endpoint dest going back to original.
@@ -928,6 +932,9 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target)
 				switch (tuple.nexthdr) {
 				case IPPROTO_TCP:
 				case IPPROTO_UDP:
+#ifdef ENABLE_SCTP
+				case IPPROTO_SCTP:
+#endif  /* ENABLE_SCTP */
 					/* No reasons to handle IP fragmentation for this case
 					 * as it is expected that DF isn't set for this particular
 					 * context.
@@ -1679,6 +1686,9 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target)
 			switch (tuple.nexthdr) {
 			case IPPROTO_TCP:
 			case IPPROTO_UDP:
+#ifdef ENABLE_SCTP
+			case IPPROTO_SCTP:
+#endif  /* ENABLE_SCTP */
 				/* No reasons to handle IP fragmentation for this case
 				 * as it is expected that DF isn't set for this particular
 				 * context.

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -360,6 +360,73 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 		       NAT_PUNT_TO_STACK : DROP_NAT_NO_MAPPING;
 }
 
+static __always_inline int snat_v4_icmp_rewrite_embedded(struct __ctx_buff *ctx,
+							 struct ipv4_ct_tuple *tuple,
+							 struct ipv4_nat_entry *state,
+							 __u32 l4_off, __u32 inner_l4_off)
+{
+	struct csum_offset csum = {};
+	__be32 sum;
+
+	if (state->to_daddr == tuple->daddr &&
+	    state->to_dport == tuple->dport)
+		return 0;
+
+	sum = csum_diff(&tuple->daddr, 4, &state->to_daddr, 4, 0);
+	csum_l4_offset_and_flags(tuple->nexthdr, &csum);
+	if (state->to_dport != tuple->dport) {
+		__be32 suml4 = 0;
+
+		switch (tuple->nexthdr) {
+		case IPPROTO_TCP:
+		case IPPROTO_UDP: {
+			/* In case that the destination port has been NATed from
+			 * target to dest. We want the embedded packet which
+			 * should refer to endpoint dest going back to original.
+			 */
+			if (ctx_store_bytes(ctx, inner_l4_off +
+					    offsetof(struct tcphdr, source),
+					    &state->to_dport,
+					    sizeof(state->to_dport), 0) < 0)
+				return DROP_WRITE_ERROR;
+			break;
+		}
+		case IPPROTO_ICMP: {
+			/* In case that the ID has been used as source port during
+			 * NAT from target to dest. We want the embedded packet
+			 * which should refer to endpoint -> dest going back to
+			 * original.
+			 */
+			if (ctx_store_bytes(ctx, inner_l4_off +
+					    offsetof(struct icmphdr, un.echo.id),
+					    &state->to_dport,
+					    sizeof(state->to_dport), 0) < 0)
+				return DROP_WRITE_ERROR;
+			csum.offset = offsetof(struct icmphdr, checksum);
+			csum.flags = 0;
+			break;
+		}
+		default:
+			return DROP_UNKNOWN_L4;
+		}
+		/* By recomputing L4 checksum of inner packet we avoid having
+		 * to recompute L4 of the ICMP Error.
+		 */
+		suml4 = csum_diff(&tuple->dport, 4, &state->to_dport, 4, 0);
+		if (csum_l4_replace(ctx, inner_l4_off, &csum, 0, suml4, 0) < 0)
+			return DROP_CSUM_L4;
+	}
+	/* Change IP of source address of inner packet to refer the
+	 * endpoint and update csum accordinly.
+	 */
+	if (ctx_store_bytes(ctx, l4_off + sizeof(struct icmphdr) + offsetof(struct iphdr, saddr),
+			    &state->to_daddr, 4, 0) < 0)
+		return DROP_WRITE_ERROR;
+	if (ipv4_csum_update_by_diff(ctx, l4_off + sizeof(struct icmphdr), sum) < 0)
+		return DROP_CSUM_L3;
+	return 0;
+}
+
 static __always_inline int snat_v4_rewrite_egress(struct __ctx_buff *ctx,
 						  struct ipv4_ct_tuple *tuple,
 						  struct ipv4_nat_entry *state,
@@ -797,6 +864,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target)
 	} l4hdr;
 	__u64 off;
 	int ret;
+	__u8 nexthdr;
 
 	build_bug_on(sizeof(struct ipv4_nat_entry) > 64);
 
@@ -804,6 +872,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target)
 		return DROP_INVALID;
 
 	snat_v4_init_tuple(ip4, NAT_DIR_INGRESS, &tuple);
+	nexthdr = tuple.nexthdr;
 
 	off = ((void *)ip4 - data) + ipv4_hdrlen(ip4);
 	switch (tuple.nexthdr) {
@@ -829,6 +898,81 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target)
 			tuple.dport = icmphdr.un.echo.id;
 			tuple.sport = 0;
 			break;
+		case ICMP_DEST_UNREACH:
+			switch (icmphdr.code) {
+			case ICMP_FRAG_NEEDED: {
+				struct iphdr iphdr;
+				__be16 identifier;
+				__u8 type;
+				__u32 icmpoff = off + sizeof(icmphdr);
+
+				/* According to the RFC 5508, any networking
+				 * equipment that is responding with an ICMP Error
+				 * packet should embed the original packet in its
+				 * response.
+				 */
+
+				if (ctx_load_bytes(ctx, icmpoff, &iphdr,
+						   sizeof(iphdr)) < 0)
+					return DROP_INVALID;
+
+				/* From the embedded IP headers we should be able
+				 * to determine corresponding protocol, IP src/dst
+				 * of the packet sent to resolve the NAT session.
+				 */
+				tuple.nexthdr = iphdr.protocol;
+				tuple.saddr = iphdr.daddr;
+				tuple.daddr = iphdr.saddr;
+
+				icmpoff += ipv4_hdrlen(&iphdr);
+				switch (tuple.nexthdr) {
+				case IPPROTO_TCP:
+				case IPPROTO_UDP:
+					/* No reasons to handle IP fragmentation for this case
+					 * as it is expected that DF isn't set for this particular
+					 * context.
+					 */
+					if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+						return DROP_INVALID;
+					break;
+				case IPPROTO_ICMP:
+					/* No reasons to see a packet different than
+					 * ICMP_ECHO.
+					 */
+					if (ctx_load_bytes(ctx, icmpoff, &type, sizeof(type)) < 0 ||
+					    type != ICMP_ECHO)
+						return DROP_INVALID;
+					if (ctx_load_bytes(ctx, icmpoff +
+							   offsetof(struct icmphdr, un.echo.id),
+							   &identifier, sizeof(identifier)) < 0)
+						return DROP_INVALID;
+					tuple.sport = 0;
+					tuple.dport = identifier;
+					break;
+				default:
+					return DROP_INVALID;
+				}
+				state = snat_v4_lookup(&tuple);
+				if (!state)
+					return NAT_PUNT_TO_STACK;
+
+				/* We found SNAT entry to rev-NAT embedded packet. The source addr
+				 * should point to endpoint that initiated the packet, as-well if
+				 * dest port had been NATed.
+				 */
+				ret = snat_v4_icmp_rewrite_embedded(ctx, &tuple, state, off,
+								    icmpoff);
+				if (IS_ERR(ret))
+					return ret;
+
+				/* Switch back to the outer header. */
+				tuple.nexthdr = nexthdr;
+				goto rewrite_ingress;
+			}
+			default:
+				return DROP_UNKNOWN_ICMP_CODE;
+			}
+			break;
 		default:
 			return DROP_NAT_UNSUPP_PROTO;
 		}
@@ -845,6 +989,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target)
 	if (ret < 0)
 		return ret;
 
+rewrite_ingress:
 	return snat_v4_rewrite_ingress(ctx, &tuple, state, off);
 }
 #else

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#include <node_config.h>
+
+#undef EVENTS_MAP
+#define EVENTS_MAP test_events_map
+#define DEBUG
+
+#include <lib/dbg.h>
+#include <lib/eps.h>
+#include <lib/nat.h>
+#include <lib/time.h>
+
+#define IP_ENDPOINT 1
+#define IP_HOST     2
+#define IP_ROUTER   3
+#define IP_WORLD    4
+
+static char pkt[100];
+
+__always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
+{
+	void *orig = dst;
+
+	struct ethhdr l2 = {
+		.h_source = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
+		.h_dest = {0x12, 0x23, 0x34, 0x45, 0x56, 0x67},
+		.h_proto = bpf_htons(ETH_P_IP)
+	};
+	memcpy(dst, &l2, sizeof(struct ethhdr));
+	dst += sizeof(struct ethhdr);
+
+	/* Building an IP/ICMP Error Unreach need to fragment sent by
+	 * a networking equipment IP_ROUTER in response to a packet
+	 * that is exceeding the MTU.
+	 */
+	struct iphdr l3 = {
+		.version = 4,
+		.ihl = 5,
+		.protocol = IPPROTO_ICMP,
+		.saddr = bpf_htonl(IP_ROUTER),
+		.daddr = bpf_htonl(IP_HOST),
+	};
+	memcpy(dst, &l3, sizeof(struct iphdr));
+	dst += sizeof(struct iphdr);
+
+	struct icmphdr icmphdr = {
+		.type           = ICMP_DEST_UNREACH,
+		.code           = ICMP_FRAG_NEEDED,
+		.un = {
+			.frag = {
+				.mtu = bpf_htons(THIS_MTU),
+			},
+		},
+	};
+	memcpy(dst, &icmphdr, sizeof(struct icmphdr));
+	dst += sizeof(struct icmphdr);
+
+	/* Embedded packet is referring packet sent by Cilium to the
+	 * world using IP_HOST.
+	 */
+	struct iphdr inner_l3 = {
+		.version = 4,
+		.ihl = 5,
+		.protocol = error_hdr,
+		.saddr = bpf_htonl(IP_HOST),
+		.daddr = bpf_htonl(IP_WORLD),
+	};
+	memcpy(dst, &inner_l3, sizeof(struct iphdr));
+	dst += sizeof(struct iphdr);
+
+	switch (error_hdr) {
+	case IPPROTO_TCP: {
+		struct tcphdr inner_l4 = {
+			.source = bpf_htons(32768),
+			.dest = bpf_htons(80),
+		};
+		memcpy(dst, &inner_l4, sizeof(struct tcphdr));
+		dst += sizeof(struct tcphdr);
+	}
+		break;
+	case IPPROTO_UDP: {
+		struct udphdr inner_l4 = {
+			.source = bpf_htons(32768),
+			.dest = bpf_htons(333),
+		};
+		memcpy(dst, &inner_l4, sizeof(struct udphdr));
+		dst += sizeof(struct udphdr);
+	}
+		break;
+	case IPPROTO_ICMP: {
+		struct icmphdr inner_l4 = {
+			.type = ICMP_ECHO,
+			.un = {
+				.echo = {
+					.id = bpf_htons(32768)
+				},
+			},
+		};
+		memcpy(dst, &inner_l4, sizeof(struct icmphdr));
+		dst += sizeof(struct icmphdr);
+	}
+		break;
+	}
+	return dst - orig;
+}
+
+CHECK("tc", "nat4_icmp_error_tcp")
+int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
+{
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP);
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+
+		if (data + pkt_size > data_end)
+			return TEST_ERROR;
+
+		memcpy(data, pkt, pkt_size);
+	}
+
+	test_init();
+	/* The test is validating that the function snat_v4_rev_nat()
+	 * will rev-nat the ICMP Unreach error need to fragment to the
+	 * correct endpoint.  Also, to be valid, the embedded packet
+	 * should be NATed as-well, meaning that the source addr of
+	 * the original packet will be switched from IP_HOST to
+	 * IP_ENDPOINT, Also for TCP/UDP the dest port and ICMP the
+	 * identifier.
+	 *
+	 * This test is validating the TCP case.
+	 */
+
+	int ret;
+
+	/* As a pre-requist we intruct the NAT table
+	 * to simulate an ingress packet sent by
+	 * endpoint to the world.
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.nexthdr = IPPROTO_TCP,
+		.saddr = bpf_htonl(IP_ENDPOINT),
+		.daddr = bpf_htonl(IP_WORLD),
+		.sport = bpf_htons(3030),
+		.dport = bpf_htons(80),
+		.flags = 0,
+	};
+	struct ipv4_nat_target target = {
+		.addr = bpf_htonl(IP_HOST),
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MIN_NAT + 1,
+	};
+	struct ipv4_nat_entry state;
+
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	assert(ret == 0);
+
+	/* This is the entry-point of the test, calling
+	 * snat_v4_rev_nat().
+	 */
+	ret = snat_v4_rev_nat(ctx, &target);
+	assert(ret == 0);
+
+	__u16 proto;
+	void *data;
+	void *data_end;
+
+	int l3_off;
+	int l4_off;
+	struct iphdr *ip4;
+	struct icmphdr icmphdr __align_stack_8;
+
+	assert(validate_ethertype(ctx, &proto));
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	if (data + pkt_size > data_end)
+		test_fatal("packet shrank");
+
+	/* Validating outer headers */
+	assert(ip4->protocol == IPPROTO_ICMP);
+	assert(ip4->saddr == bpf_htonl(IP_ROUTER));
+	assert(ip4->daddr == bpf_htonl(IP_ENDPOINT));
+
+	l3_off = ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(ip4);
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		test_fatal("can't load icmp headers");
+	assert(icmphdr.type == ICMP_DEST_UNREACH);
+	assert(icmphdr.code == ICMP_FRAG_NEEDED);
+
+	/* Validating inner headers */
+	int in_l3_off;
+	int in_l4_off;
+	struct iphdr in_ip4;
+	struct {
+		__be16 sport;
+		__be16 dport;
+	} in_l4hdr;
+
+	in_l3_off = l4_off + sizeof(icmphdr);
+	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,
+			   sizeof(in_ip4)) < 0)
+		test_fatal("can't load embedded ip headers");
+	assert(in_ip4.protocol == IPPROTO_TCP);
+	assert(in_ip4.saddr == bpf_htonl(IP_ENDPOINT));
+	assert(in_ip4.daddr == bpf_htonl(IP_WORLD));
+
+	in_l4_off = in_l3_off + ipv4_hdrlen(&in_ip4);
+	if (ctx_load_bytes(ctx, in_l4_off, &in_l4hdr, sizeof(in_l4hdr)) < 0)
+		test_fatal("can't load embedded l4 headers");
+	assert(in_l4hdr.sport == bpf_htons(3030));
+	assert(in_l4hdr.dport == bpf_htons(80));
+
+	test_finish();
+}
+
+CHECK("tc", "nat4_icmp_error_udp")
+int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
+{
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_UDP);
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+
+		if (data + pkt_size > data_end)
+			return TEST_ERROR;
+
+		memcpy(data, pkt, pkt_size);
+	}
+
+	test_init();
+	/* The test is validating that the function snat_v4_rev_nat()
+	 * will rev-nat the ICMP Unreach error need to fragment to the
+	 * correct endpoint.  Also, to be valid, the embedded packet
+	 * should be NATed as-well, meaning that the source addr of
+	 * the original packet will be switched from IP_HOST to
+	 * IP_ENDPOINT, Also for TCP/UDP the dest port and ICMP the
+	 * identifier.
+	 *
+	 * This test is validating the UDP case.
+	 */
+
+	int ret;
+
+	/* As a pre-requist we intruct the NAT table
+	 * to simulate an ingress packet sent by
+	 * endpoint to the world.
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.nexthdr = IPPROTO_UDP,
+		.saddr = bpf_htonl(IP_ENDPOINT),
+		.daddr = bpf_htonl(IP_WORLD),
+		.sport = bpf_htons(9999),
+		.dport = bpf_htons(333),
+		.flags = 0,
+	};
+	struct ipv4_nat_target target = {
+		.addr = bpf_htonl(IP_HOST),
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MIN_NAT + 1,
+	};
+	struct ipv4_nat_entry state;
+
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	assert(ret == 0);
+
+	/* This is the entry-point of the test, calling
+	 * snat_v4_rev_nat().
+	 */
+	ret = snat_v4_rev_nat(ctx, &target);
+	assert(ret == 0);
+
+	__u16 proto;
+	void *data;
+	void *data_end;
+
+	int l3_off;
+	int l4_off;
+	struct iphdr *ip4;
+	struct icmphdr icmphdr __align_stack_8;
+
+	assert(validate_ethertype(ctx, &proto));
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	if (data + pkt_size > data_end)
+		test_fatal("packet shrank");
+
+	/* Validating outer headers */
+	assert(ip4->protocol == IPPROTO_ICMP);
+	assert(ip4->saddr == bpf_htonl(IP_ROUTER));
+	assert(ip4->daddr == bpf_htonl(IP_ENDPOINT));
+
+	l3_off = ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(ip4);
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		test_fatal("can't load icmp headers");
+	assert(icmphdr.type == ICMP_DEST_UNREACH);
+	assert(icmphdr.code == ICMP_FRAG_NEEDED);
+
+	/* Validating inner headers */
+	int in_l3_off;
+	int in_l4_off;
+	struct iphdr in_ip4;
+	struct {
+		__be16 sport;
+		__be16 dport;
+	} in_l4hdr;
+
+	in_l3_off = l4_off + sizeof(icmphdr);
+	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,
+			   sizeof(in_ip4)) < 0)
+		test_fatal("can't load embedded ip headers");
+	assert(in_ip4.protocol == IPPROTO_UDP);
+	assert(in_ip4.saddr == bpf_htonl(IP_ENDPOINT));
+	assert(in_ip4.daddr == bpf_htonl(IP_WORLD));
+
+	in_l4_off = in_l3_off + ipv4_hdrlen(&in_ip4);
+	if (ctx_load_bytes(ctx, in_l4_off, &in_l4hdr, sizeof(in_l4hdr)) < 0)
+		test_fatal("can't load embedded l4 headers");
+	assert(in_l4hdr.sport == bpf_htons(9999));
+	assert(in_l4hdr.dport == bpf_htons(333));
+
+	test_finish();
+}
+
+CHECK("tc", "nat4_icmp_error_icmp")
+int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
+{
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_ICMP);
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+
+		if (data + pkt_size > data_end)
+			return TEST_ERROR;
+
+		memcpy(data, pkt, pkt_size);
+	}
+
+	test_init();
+	/* The test is validating that the function snat_v4_rev_nat()
+	 * will rev-nat the ICMP Unreach error need to fragment to the
+	 * correct endpoint.  Also, to be valid, the embedded packet
+	 * should be NATed as-well, meaning that the source addr of
+	 * the original packet will be switched from IP_HOST to
+	 * IP_ENDPOINT, Also for TCP/UDP the dest port and ICMP the
+	 * identifier.
+	 *
+	 * This test is validating the ICMP case.
+	 */
+
+	int ret;
+
+	/* As a pre-requist we intruct the NAT table
+	 * to simulate an ingress packet sent by
+	 * endpoint to the world.
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.nexthdr = IPPROTO_ICMP,
+		.saddr = bpf_htonl(IP_ENDPOINT),
+		.daddr = bpf_htonl(IP_WORLD),
+		.sport = bpf_htons(123),
+		.flags = 0,
+	};
+	struct ipv4_nat_target target = {
+		.addr = bpf_htonl(IP_HOST),
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MIN_NAT + 1,
+	};
+	struct ipv4_nat_entry state;
+
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	assert(ret == 0);
+
+	/* This is the entry-point of the test, calling
+	 * snat_v4_rev_nat().
+	 */
+	ret = snat_v4_rev_nat(ctx, &target);
+	assert(ret == 0);
+
+	__u16 proto;
+	void *data;
+	void *data_end;
+
+	int l3_off;
+	int l4_off;
+	struct iphdr *ip4;
+	struct icmphdr icmphdr __align_stack_8;
+
+	assert(validate_ethertype(ctx, &proto));
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	if (data + pkt_size > data_end)
+		test_fatal("packet shrank");
+
+	/* Validating outer headers */
+	assert(ip4->protocol == IPPROTO_ICMP);
+	assert(ip4->saddr == bpf_htonl(IP_ROUTER));
+	assert(ip4->daddr == bpf_htonl(IP_ENDPOINT));
+
+	l3_off = ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(ip4);
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		test_fatal("can't load icmp headers");
+	assert(icmphdr.type == ICMP_DEST_UNREACH);
+	assert(icmphdr.code == ICMP_FRAG_NEEDED);
+
+	/* Validating inner headers */
+	int in_l3_off;
+	int in_l4_off;
+	struct iphdr in_ip4;
+	struct icmphdr in_l4hdr;
+
+	in_l3_off = l4_off + sizeof(icmphdr);
+	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,
+			   sizeof(in_ip4)) < 0)
+		test_fatal("can't load embedded ip headers");
+	assert(in_ip4.protocol == IPPROTO_ICMP);
+	assert(in_ip4.saddr == bpf_htonl(IP_ENDPOINT));
+	assert(in_ip4.daddr == bpf_htonl(IP_WORLD));
+
+	in_l4_off = in_l3_off + ipv4_hdrlen(&in_ip4);
+	if (ctx_load_bytes(ctx, in_l4_off, &in_l4hdr, sizeof(in_l4hdr)) < 0)
+		test_fatal("can't load embedded l4 headers");
+	assert(in_l4hdr.un.echo.id == bpf_htons(123));
+
+	test_finish();
+}
+
+BPF_LICENSE("Dual BSD/GPL");

--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -12,7 +12,8 @@ MAPTOOL=$(dirname $0)/../../tools/maptool/maptool
 ALL_TC_PROGS="bpf_lxc bpf_host bpf_network bpf_overlay"
 ALL_CG_PROGS="bpf_sock sockops/bpf_sockops sockops/bpf_redir"
 ALL_XDP_PROGS="bpf_xdp"
-IGNORED_PROGS="bpf_alignchecker tests/bpf_ct_tests custom/bpf_custom"
+IGNORED_PROGS="bpf_alignchecker tests/bpf_ct_tests tests/bpf_nat_tests \
+               custom/bpf_custom"
 ALL_PROGS="${IGNORED_PROGS} ${ALL_CG_PROGS} ${ALL_TC_PROGS} ${ALL_XDP_PROGS}"
 
 # if {TC,CG,XDP}_PROGS is set (even if empty) use the existing value.


### PR DESCRIPTION
Assuming that, for a given endpoint sending a packet to the world of a size bigger than the accepted MTU in the networking path.

A networking equipment in this networking path would return an ICMP Error Destination Unreachable with code `ICMP_FRAG_NEEDED`.

According to the RFE 5508 [0]. The networking equipment should embed the original packet in its response.

```
Destination Unreachable Message

    0                   1                   2                   3
    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |     Type      |     Code      |          Checksum             |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |                             unused                            |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |      Internet Header + 64 bits of Original Data Datagram      |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

Previously, because of the missing support of `ICMP_FRAG_NEEDED`, the NAT session to transfert the reply packet to the endpoint was never resolved since the source IP addr of the reply packet would be IP addr of the networking equipment.

```
Pod-X      : 10.244.0.236
Cilium-Nat : 192.168.49.2
Router-Y   : 192.168.49.1
Host-Y     : 10.1.0.100

                                         
                                  +------------+
                                  | Pod-X      |
                                  +------------+
            Cilium Host                  |
            --------------------+--------+-------------------
                                |  | ICMP Packet Pod-X to Host-y
                                |  |   10.244.0.256/10.1.0.100
                                |  v
                          +--------------+
                          | Cilium-Nat   |
                          +--------------+
                                |  | ICMP Packet Cilium-Nat to Host-y
                                |  |   192.168.49.2/10.1.0.100 
    World                       |  v
   ----------------+------------+----------------
                   |  ^
                   |  | ICMP Error Router-Y to Cilium-Nat
                   |  |   192.168.49.1/192.168.49.2
                   |  |      with in Payload ICMP 192.168.49.2/10.1.0.100
            +-------------+
            | Router-Y    |
            +-------------+
                   |
   ----------------+-------+--------
                           |
                         Host-Y
```

Mainly implementation consists:

- On adding to `snat_v{4,6}_rev_nat()` the support for reading the original packet that has been embedded in the ICMP Error to extract headers needed to resolve rev-NAT session. For `snat_v{4,6}_nat()` it is considered to drop the packet.
- It will be also mandatory to rewrite embedded packets to NAT original headers because the source IP addr of the original header is the backend node.

Finally reply packet received by endpoint will be:

```
                   |  | ICMP Error Router-Y to Pod-X
                   |  |   192.168.49.1/10.244.0.256
                   |  |      with in Payload ICMP 10.244.0.256/10.1.0.100
```

Fixes: #12968

[0] https://www.rfc-editor.org/rfc/rfc5508.html#section-7.1
