### PR TITLE
v1.11 backports 2022-01-10

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -187,11 +187,11 @@ allocation:
 
 ``spec.eni.first-interface-index``
   The index of the first ENI to use for IP allocation, e.g. if the node has
-  ``eth0``, ``eth1``, ``eth2`` and FirstInterfaceIndex is set to 0, then only
+  ``eth0``, ``eth1``, ``eth2`` and FirstInterfaceIndex is set to 1, then only
   ``eth1`` and ``eth2`` will be used for IP allocation, ``eth0`` will be
   ignored for PodIP allocation.
 
-  If unspecified, this value defaults to 1 which means that ``eth0`` will not
+  If unspecified, this value defaults to 0 which means that ``eth0`` will
   be used for pod IPs.
 
 ``spec.eni.security-group-tags``

--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -76,7 +76,7 @@ The eBPF-based masquerading can masquerade packets of the following IPv4 L4 prot
 
 By default, any packet from a pod destined to an IP address outside of the
 ``ipv4-native-routing-cidr`` range is masqueraded. The exclusion CIDR is shown
-in the above output of ``cilium status`` (``10.0.0.0.16``).  To allow more
+in the above output of ``cilium status`` (``10.0.0.0/16``).  To allow more
 fine-grained control, Cilium implements `ip-masq-agent
 <https://github.com/kubernetes-sigs/ip-masq-agent>`_ in eBPF which can be
 enabled with the ``ipMasqAgent.enabled=true`` helm option.

--- a/Documentation/gettingstarted/k8s-install-kubespray.rst
+++ b/Documentation/gettingstarted/k8s-install-kubespray.rst
@@ -141,14 +141,23 @@ Installing Kubernetes cluster with Cilium as CNI
 
 Kubespray uses Ansible as its substrate for provisioning and orchestration. Once the infrastructure is created, you can run the Ansible playbook to install Kubernetes and all the required dependencies. Execute the below command in the kubespray clone repo, providing the correct path of the AWS EC2 ssh private key in ``ansible_ssh_private_key_file=<path to EC2 SSH private key file>``
 
-We recommend using the `latest released Cilium version`_ by editing ``roles/download/defaults/main.yml``. Open the file, search for ``cilium_version``, and replace the version with the latest released. As an example, the updated version entry will look like: ``cilium_version: "v1.2.0"``.
-
+We recommend using the `latest released Cilium version`_ by passing the variable when running the ``ansible-playbook`` command.
+For example, you could add the following flag to the command below: ``-e cilium_version=v1.11.0``.
 
 .. code-block:: shell-session
 
   $ ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=core -e bootstrap_os=coreos -e kube_network_plugin=cilium -b --become-user=root --flush-cache  -e ansible_ssh_private_key_file=<path to EC2 SSH private key file>
 
 .. _latest released Cilium version: https://github.com/cilium/cilium/releases
+
+If you are interested in configuring your Kubernetes cluster setup, you should consider copying the sample inventory. Then, you can edit the variables in the relevant file in the ``group_vars`` directory.
+
+.. code-block:: shell-session
+
+  $ cp -r inventory/sample inventory/my-inventory
+  $ cp ./inventory/hosts ./inventory/my-inventory/hosts
+  $ echo 'cilium_version: "v1.11.0"' >> ./inventory/my-inventory/group_vars/k8s_cluster/k8s-net-cilium.yml
+  $ ansible-playbook -i ./inventory/my-inventory/hosts ./cluster.yml -e ansible_user=core -e bootstrap_os=coreos -e kube_network_plugin=cilium -b --become-user=root --flush-cache -e ansible_ssh_private_key_file=<path to EC2 SSH private key file>
 
 Validate Cluster
 ================

--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -54,9 +54,20 @@ Then, install Cilium release via Helm:
 
 .. note::
 
-   To fully enable Cilium's kube-proxy replacement (:ref:`kubeproxy-free`), cgroup v1
-   controllers ``net_cls`` and ``net_prio`` have to be disabled, or cgroup v1 has
-   to be disabled (e.g. by setting the kernel ``cgroup_no_v1="all"`` parameter).
+   To fully enable Cilium's kube-proxy replacement (:ref:`kubeproxy-free`), cgroup v2
+   needs to be enabled by setting the kernel ``systemd.unified_cgroup_hierarchy=1`` parameter.
+   Also, cgroup v1 controllers ``net_cls`` and ``net_prio`` have to be disabled, or
+   cgroup v1 has to be disabled (e.g. by setting the kernel ``cgroup_no_v1="all"`` parameter).
+   This ensures that Kind nodes have their own cgroup namespace, and Cilium can
+   attach BPF programs at the right cgroup hierarchy. To verify this, run the
+   following commands on the host, and check that the output values are different.
+
+   .. code-block:: shell-session
+
+      $ sudo ls -al /proc/$(docker inspect -f '{{.State.Pid}}' kind-control-plane)/ns/cgroup
+      $ sudo ls -al /proc/self/ns/cgroup
+
+   See the `Pull Request <https://github.com/cilium/cilium/pull/16259>`__ for more details.
 
 .. include:: k8s-install-validate.rst
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -4,7 +4,6 @@ APIEndpoint
 AdapterLimitViaAPI
 Alemayhu
 Alibaba
-Ansible
 BPF
 Bertin
 Blanco
@@ -149,6 +148,7 @@ allocator
 allocators
 amd
 analytics
+ansible
 api
 apiKeys
 apiVersion

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -794,6 +794,11 @@ ct_recreate4:
 		struct egress_gw_policy_entry *egress_gw_policy;
 		struct endpoint_key key = {};
 
+		/* If the packet is destined to an entity inside the cluster,
+		 * either EP or node, it should not be forwarded to an egress
+		 * gateway since only traffic leaving the cluster is supposed to
+		 * be masqueraded with an egress IP.
+		 */
 		if (is_cluster_destination(ip4, *dst_id, tunnel_endpoint))
 			goto skip_egress_gateway;
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -19,6 +19,7 @@
 #include "lib/maps.h"
 #include "lib/arp.h"
 #include "lib/edt.h"
+#include "lib/qm.h"
 #include "lib/ipv6.h"
 #include "lib/ipv4.h"
 #include "lib/icmp6.h"
@@ -982,6 +983,7 @@ int handle_xgress(struct __ctx_buff *ctx)
 	int ret;
 
 	bpf_clear_meta(ctx);
+	reset_queue_mapping(ctx);
 
 	send_trace_notify(ctx, TRACE_FROM_LXC, SECLABEL, 0, 0, 0, 0,
 			  TRACE_PAYLOAD_LEN);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1135,9 +1135,8 @@ static __always_inline bool snat_v4_needed(struct __ctx_buff *ctx, __be32 *addr,
 	 * or node, skip SNAT since only traffic leaving the cluster is supposed
 	 * to be masqueraded with an egress IP.
 	 */
-	if (!local_ep || (remote_ep &&
-			  is_cluster_destination(ip4, remote_ep->sec_label,
-						 remote_ep->tunnel_endpoint)))
+	if (remote_ep &&
+	    is_cluster_destination(ip4, remote_ep->sec_label, remote_ep->tunnel_endpoint))
 		goto skip_egress_gateway;
 
 	/* If the packet is a reply it means that outside has initiated the

--- a/bpf/lib/qm.h
+++ b/bpf/lib/qm.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2022 Authors of Cilium */
+
+#ifndef __QM_H_
+#define __QM_H_
+
+#include <bpf/ctx/ctx.h>
+
+static inline void reset_queue_mapping(struct __ctx_buff *ctx __maybe_unused)
+{
+#if defined(RESET_QUEUES) && __ctx_is == __ctx_skb
+	/* Workaround for GH-18311 where veth driver might have recorded
+	 * veth's RX queue mapping instead of leaving it at 0. This can
+	 * cause issues on the phys device where all traffic would only
+	 * hit a single TX queue (given veth device had a single one and
+	 * mapping was left at 1). Reset so that stack picks a fresh queue.
+	 * Kernel fix is at 710ad98c363a ("veth: Do not record rx queue
+	 * hint in veth_xmit").
+	 */
+	ctx->queue_mapping = 0;
+#endif
+}
+
+#endif /* __QM_H_ */

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -661,7 +661,9 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		log.WithError(err).Warn("failed to detect devices, disabling BPF NodePort")
 		disableNodePort()
 	}
-	finishKubeProxyReplacementInit(isKubeProxyReplacementStrict)
+	if err := finishKubeProxyReplacementInit(isKubeProxyReplacementStrict); err != nil {
+		return nil, nil, fmt.Errorf("failed to finalise LB initialization: %w", err)
+	}
 
 	if k8s.IsEnabled() {
 		bootstrapStats.k8sInit.Start()

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -460,6 +460,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 	}
 
+	if option.Config.ResetQueueMapping {
+		cDefinesMap["RESET_QUEUES"] = "1"
+	}
+
 	if option.Config.EnableBandwidthManager {
 		cDefinesMap["ENABLE_BANDWIDTH_MANAGER"] = "1"
 		cDefinesMap["THROTTLE_MAP"] = bwmap.MapName

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -62,15 +61,6 @@ type parsedEgressRule struct {
 
 type k8sCacheSyncedCheckerMock struct {
 	synced bool
-}
-
-func (k *k8sCacheSyncedCheckerMock) WaitUntilK8sCacheIsSynced() {
-	for {
-		if k.synced {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
 }
 
 func (k *k8sCacheSyncedCheckerMock) K8sCacheIsSynced() bool {

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -686,11 +686,16 @@ func (a *crdAllocator) Allocate(ip net.IP, owner string) (*AllocationResult, err
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 	// Update custom resource to reflect the newly allocated IP.
 	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("allocation of IP %s", ip.String()))
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // AllocateWithoutSyncUpstream will attempt to find the specified IP in the
@@ -710,9 +715,14 @@ func (a *crdAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string) (*Al
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // Release will release the specified IP or return an error if the IP has not
@@ -751,11 +761,16 @@ func (a *crdAllocator) AllocateNext(owner string) (*AllocationResult, error) {
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 	// Update custom resource to reflect the newly allocated IP.
 	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("allocation of IP %s", ip.String()))
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // AllocateNextWithoutSyncUpstream allocates the next available IP as offered
@@ -770,9 +785,14 @@ func (a *crdAllocator) AllocateNextWithoutSyncUpstream(owner string) (*Allocatio
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // totalPoolSize returns the total size of the allocation pool

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -41,6 +41,9 @@ var (
 	// policy and propagated in monitor output.
 	identityMetadata = make(map[string]labels.Labels)
 
+	// applyIDMDChangesMutex protects InjectLabels and RemoveLabelsExcluded from being run in parallel
+	applyIDMDChangesMutex lock.Mutex
+
 	// ErrLocalIdentityAllocatorUninitialized is an error that's returned when
 	// the local identity allocator is uninitialized.
 	ErrLocalIdentityAllocatorUninitialized = errors.New("local identity allocator uninitialized")
@@ -101,6 +104,9 @@ func InjectLabels(src source.Source, updater identityUpdater, triggerer policyTr
 		// selector cache.
 		idsToPropagate = make(map[identity.NumericIdentity]labels.LabelArray)
 	)
+
+	applyIDMDChangesMutex.Lock()
+	defer applyIDMDChangesMutex.Unlock()
 
 	idMDMU.Lock()
 
@@ -280,6 +286,9 @@ func RemoveLabelsExcluded(
 	updater identityUpdater,
 	triggerer policyTriggerer,
 ) {
+	applyIDMDChangesMutex.Lock()
+	defer applyIDMDChangesMutex.Unlock()
+
 	idMDMU.Lock()
 	defer idMDMU.Unlock()
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1760,6 +1760,9 @@ type DaemonConfig struct {
 	// EnableBandwidthManager enables EDT-based pacing
 	EnableBandwidthManager bool
 
+	// ResetQueueMapping resets the Pod's skb queue mapping
+	ResetQueueMapping bool
+
 	// EnableRecorder enables the datapath pcap recorder
 	EnableRecorder bool
 

--- a/test/l4lb/Vagrantfile
+++ b/test/l4lb/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
     systemctl enable --now docker
 
     # cgroupv2 requires >= Kind 0.11.0
-    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.0/kind-linux-amd64
+    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
     chmod +x ./kind
     mv ./kind /usr/local/bin
 


### PR DESCRIPTION
* #18304 -- daemon: Fix KPR init finalisation (@brb)
 * #18327 -- docs: Fix `first-interface-index` documentation (@gandro)
 * #18352 -- Fix possible IP leak in case ENI's are not present in the CN yet (@codablock)
 * #18338 -- docs: fix small spelling mistakes in masquerading pages (@yanhongchang)
 * #18269 -- docs: Update the kind documentation with cgroup requirements (@aditighag)
 * #18246 -- bpf: egressgw: sync logic to determine if destination is outside cluster  (@jibi)
 * #18370 -- test: bump l4lb Vagrantfile kind to 0.11.1 (@jibi)
 * #18342 -- Improve Kubespray installation guide (@necatican)
 * #18325 -- egressgateway: fix initial reconciliation (@jibi)
 * #18055 -- Adds missing lock for cesTracker operation (@Weil0ng)
 * #18330 -- MaintainIPPool refactor and support for aborting release handshake (@hemanthmalla)
 * #18343 -- Don't hold idMDMU lock while calling UpdateIdentities from InjectLabels (@codablock)
 * #18388 -- bpf: Reset Pod's queue mapping in host veth to fix phys dev mq selection (@borkmann)

None of the PRs are conflicts!

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18304 18327 18352 18338 18269 18246 18370 18342 18325 18055 18330 18343 18388; do contrib/backporting/set-labels.py $pr done 1.11; done
```