### PR TITLE
v1.9 backports 2022-01-10

### DIFF
--- a/Documentation/gettingstarted/k8s-install-kubespray.rst
+++ b/Documentation/gettingstarted/k8s-install-kubespray.rst
@@ -141,14 +141,23 @@ Installing Kubernetes cluster with Cilium as CNI
 
 Kubespray uses Ansible as its substrate for provisioning and orchestration. Once the infrastructure is created, you can run the Ansible playbook to install Kubernetes and all the required dependencies. Execute the below command in the kubespray clone repo, providing the correct path of the AWS EC2 ssh private key in ``ansible_ssh_private_key_file=<path to EC2 SSH private key file>``
 
-We recommend using the `latest released Cilium version`_ by editing ``roles/download/defaults/main.yml``. Open the file, search for ``cilium_version``, and replace the version with the latest released. As an example, the updated version entry will look like: ``cilium_version: "v1.2.0"``.
-
+We recommend using the `latest released Cilium version`_ by passing the variable when running the ``ansible-playbook`` command.
+For example, you could add the following flag to the command below: ``-e cilium_version=v1.11.0``.
 
 .. code:: bash
 
   $ ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=core -e bootstrap_os=coreos -e kube_network_plugin=cilium -b --become-user=root --flush-cache  -e ansible_ssh_private_key_file=<path to EC2 SSH private key file>
 
 .. _latest released Cilium version: https://github.com/cilium/cilium/releases
+
+If you are interested in configuring your Kubernetes cluster setup, you should consider copying the sample inventory. Then, you can edit the variables in the relevant file in the ``group_vars`` directory.
+
+.. code-block:: shell-session
+
+  $ cp -r inventory/sample inventory/my-inventory
+  $ cp ./inventory/hosts ./inventory/my-inventory/hosts
+  $ echo 'cilium_version: "v1.11.0"' >> ./inventory/my-inventory/group_vars/k8s_cluster/k8s-net-cilium.yml
+  $ ansible-playbook -i ./inventory/my-inventory/hosts ./cluster.yml -e ansible_user=core -e bootstrap_os=coreos -e kube_network_plugin=cilium -b --become-user=root --flush-cache -e ansible_ssh_private_key_file=<path to EC2 SSH private key file>
 
 Validate Cluster
 ================

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -5,6 +5,7 @@ APIEndpoint
 AdapterLimitViaAPI
 Alemayhu
 Ansible
+Alibaba
 BPF
 Bertin
 Blanco
@@ -142,6 +143,7 @@ allocator
 allocators
 amd
 analytics
+ansible
 api
 apiKeys
 apiVersion

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -19,6 +19,7 @@
 #include "lib/maps.h"
 #include "lib/arp.h"
 #include "lib/edt.h"
+#include "lib/qm.h"
 #include "lib/ipv6.h"
 #include "lib/ipv4.h"
 #include "lib/icmp6.h"
@@ -844,6 +845,7 @@ int handle_xgress(struct __ctx_buff *ctx)
 	int ret;
 
 	bpf_clear_meta(ctx);
+	reset_queue_mapping(ctx);
 
 	send_trace_notify(ctx, TRACE_FROM_LXC, SECLABEL, 0, 0, 0, 0,
 			  TRACE_PAYLOAD_LEN);

--- a/bpf/lib/qm.h
+++ b/bpf/lib/qm.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2022 Authors of Cilium */
+
+#ifndef __QM_H_
+#define __QM_H_
+
+#include <bpf/ctx/ctx.h>
+
+static inline void reset_queue_mapping(struct __ctx_buff *ctx __maybe_unused)
+{
+#if defined(RESET_QUEUES) && __ctx_is == __ctx_skb
+	/* Workaround for GH-18311 where veth driver might have recorded
+	 * veth's RX queue mapping instead of leaving it at 0. This can
+	 * cause issues on the phys device where all traffic would only
+	 * hit a single TX queue (given veth device had a single one and
+	 * mapping was left at 1). Reset so that stack picks a fresh queue.
+	 * Kernel fix is at 710ad98c363a ("veth: Do not record rx queue
+	 * hint in veth_xmit").
+	 */
+	ctx->queue_mapping = 0;
+#endif
+}
+
+#endif /* __QM_H_ */

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -47,13 +47,7 @@ func GetBytesPerSec(bandwidth string) (uint64, error) {
 }
 
 func ProbeBandwidthManager() {
-	if option.Config.DryMode || !option.Config.EnableBandwidthManager {
-		return
-	}
-
-	if _, err := sysctl.Read("net.core.default_qdisc"); err != nil {
-		log.Warn("BPF bandwidth manager could not read procfs. Disabling the feature.")
-		option.Config.EnableBandwidthManager = false
+	if option.Config.DryMode {
 		return
 	}
 
@@ -65,6 +59,15 @@ func ProbeBandwidthManager() {
 		if _, ok := h["bpf_skb_ecn_set_ce"]; ok {
 			kernelGood = true
 		}
+	}
+	option.Config.ResetQueueMapping = kernelGood
+	if !option.Config.EnableBandwidthManager {
+		return
+	}
+	if _, err := sysctl.Read("net.core.default_qdisc"); err != nil {
+		log.Warn("BPF bandwidth manager could not read procfs. Disabling the feature.")
+		option.Config.EnableBandwidthManager = false
+		return
 	}
 	if !kernelGood {
 		log.Warn("BPF bandwidth manager needs kernel 5.1 or newer. Disabling the feature.")

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -350,6 +350,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 	}
 
+	if option.Config.ResetQueueMapping {
+		cDefinesMap["RESET_QUEUES"] = "1"
+	}
+
 	if option.Config.EnableBandwidthManager {
 		cDefinesMap["ENABLE_BANDWIDTH_MANAGER"] = "1"
 		cDefinesMap["THROTTLE_MAP"] = bwmap.MapName

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1882,6 +1882,9 @@ type DaemonConfig struct {
 	// EnableBandwidthManager enables EDT-based pacing
 	EnableBandwidthManager bool
 
+	// ResetQueueMapping resets the Pod's skb queue mapping
+	ResetQueueMapping bool
+
 	// KubeProxyReplacementHealthzBindAddr is the KubeProxyReplacement healthz server bind addr
 	KubeProxyReplacementHealthzBindAddr string
 


### PR DESCRIPTION
* #18342 -- Improve Kubespray installation guide (@necatican)
     * Trivial conflict in Documentation/spelling_wordlist.txt.
 * #18388 -- bpf: Reset Pod's queue mapping in host veth to fix phys dev mq selection (@borkmann)
     * Trivial conflict in pkg/option/config.go.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18342 18388; do contrib/backporting/set-labels.py $pr done 1.9; done
```