### PR TITLE
While recovering services, don't skip if one of the service recovery fails.

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -568,4 +568,16 @@ const (
 
 	// GatewayIP is the gateway IP used in a given egress policy
 	GatewayIP = "gatewayIP"
+
+	// Number of Backends failed while restoration.
+	RestoredBackends = "restoredBackends"
+
+	// Number of Backends failed while restoration.
+	FailedBackends = "failedBackends"
+
+	// Number of Services failed while restoration.
+	RestoredSVCs = "restoredServices"
+
+	// Number of Services failed while restoration.
+	FailedSVCs = "failedServices"
 )

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -840,6 +840,7 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, onlyLocalBackends bool,
 }
 
 func (s *Service) restoreBackendsLocked() error {
+	failed, restored := 0, 0
 	backends, err := s.lbmap.DumpBackendMaps()
 	if err != nil {
 		return fmt.Errorf("Unable to dump backend maps: %s", err)
@@ -851,13 +852,22 @@ func (s *Service) restoreBackendsLocked() error {
 			logfields.L3n4Addr:  b.L3n4Addr.String(),
 		}).Debug("Restoring backend")
 		if err := RestoreBackendID(b.L3n4Addr, b.ID); err != nil {
-			return fmt.Errorf("Unable to restore backend ID %d for %q: %s",
-				b.ID, b.L3n4Addr, err)
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.BackendID: b.ID,
+				logfields.L3n4Addr:  b.L3n4Addr,
+			}).Warning("Unable to restore backend")
+			failed++
+			continue
 		}
-
+		restored++
 		hash := b.L3n4Addr.Hash()
 		s.backendByHash[hash] = b
 	}
+
+	log.WithFields(logrus.Fields{
+		logfields.RestoredBackends: restored,
+		logfields.FailedBackends:   failed,
+	}).Info("Restored backends from maps")
 
 	return nil
 }
@@ -935,7 +945,8 @@ func (s *Service) restoreServicesLocked() error {
 				backends[b.String()] = b.ID
 			}
 			if err := s.lbmap.UpsertMaglevLookupTable(uint16(newSVC.frontend.ID), backends, ipv6); err != nil {
-				return err
+				scopedLog.WithError(err).Warning("Unable to upsert into the Maglev BPF map.")
+				continue
 			}
 		}
 
@@ -945,8 +956,8 @@ func (s *Service) restoreServicesLocked() error {
 	}
 
 	log.WithFields(logrus.Fields{
-		"restored": restored,
-		"failed":   failed,
+		logfields.RestoredSVCs: restored,
+		logfields.FailedSVCs:   failed,
 	}).Info("Restored services from maps")
 
 	return nil


### PR DESCRIPTION
While recovering a service doesn't return an error instead try to recover the remaining service. 
Fixes: [#18371](https://github.com/cilium/cilium/issues/18371)

```release-note
In the case of recovering the services, cilium will not fail directly on the first service recovery error but will try to recover other services. 
```
