### PR TITLE
daemon: Remove defunct `--single-cluster-route` flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -228,7 +228,6 @@ cilium-agent [flags]
       --restore                                              Restores state, if possible, from previous daemon (default true)
       --route-metric int                                     Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
       --sidecar-istio-proxy-image string                     Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
-      --single-cluster-route                                 Use a single cluster route instead of per node routes
       --socket-path string                                   Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
       --sockops-enable                                       Enable sockops when kernel supported
       --state-dir string                                     Directory path to store runtime state (default "/var/run/cilium")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -752,10 +752,6 @@ func initializeFlags() {
 		"Regular expression matching compatible Istio sidecar istio-proxy container image names")
 	option.BindEnv(option.SidecarIstioProxyImage)
 
-	flags.Bool(option.SingleClusterRouteName, false,
-		"Use a single cluster route instead of per node routes")
-	option.BindEnv(option.SingleClusterRouteName)
-
 	flags.String(option.SocketPath, defaults.SockPath, "Sets daemon's socket path to listen for connections")
 	option.BindEnv(option.SocketPath)
 

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -232,70 +232,6 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 	}
 }
 
-func (s *linuxPrivilegedBaseTestSuite) TestSingleClusterPrefix(c *check.C) {
-	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
-	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
-
-	// enable as per test definition
-	err := linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
-		UseSingleClusterRoute: true,
-		EnableIPv4:            s.enableIPv4,
-		EnableIPv6:            s.enableIPv6,
-	})
-	c.Assert(err, check.IsNil)
-
-	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR(), false)
-		c.Assert(err, check.IsNil)
-		c.Assert(foundRoute, check.Not(check.IsNil))
-	}
-
-	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR(), false)
-		c.Assert(err, check.IsNil)
-		c.Assert(foundRoute, check.Not(check.IsNil))
-	}
-
-	// disable ipv4, enable ipv6. addressing may not be available for IPv6
-	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
-		UseSingleClusterRoute: true,
-		EnableIPv6:            true,
-	})
-	c.Assert(err, check.IsNil)
-
-	foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR(), false)
-	c.Assert(err, check.IsNil)
-	c.Assert(foundRoute, check.IsNil)
-
-	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR(), false)
-		c.Assert(err, check.IsNil)
-		c.Assert(foundRoute, check.Not(check.IsNil))
-	}
-
-	// enable ipv4, enable ipv6, addressing may not be available
-	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
-		UseSingleClusterRoute: true,
-		EnableIPv6:            true,
-		EnableIPv4:            true,
-	})
-	c.Assert(err, check.IsNil)
-
-	if s.enableIPv4 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv4().AllocationCIDR(), false)
-		c.Assert(err, check.IsNil)
-		c.Assert(foundRoute, check.Not(check.IsNil))
-	}
-
-	if s.enableIPv6 {
-		foundRoute, err := linuxNodeHandler.lookupNodeRoute(s.nodeAddressing.IPv6().AllocationCIDR(), false)
-		c.Assert(err, check.IsNil)
-		c.Assert(foundRoute, check.Not(check.IsNil))
-	}
-}
-
 func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	net1 := cidr.MustParseCIDR("30.30.0.0/24")
 	net2 := cidr.MustParseCIDR("cafe:f00d::/112")
@@ -2647,15 +2583,6 @@ func (s *linuxPrivilegedBaseTestSuite) BenchmarkNodeUpdateEncap(c *check.C) {
 	})
 }
 
-func (s *linuxPrivilegedBaseTestSuite) BenchmarkNodeUpdateEncapSingleClusterRoute(c *check.C) {
-	s.benchmarkNodeUpdate(c, datapath.LocalNodeConfiguration{
-		EnableIPv4:            s.enableIPv4,
-		EnableIPv6:            s.enableIPv6,
-		EnableEncapsulation:   true,
-		UseSingleClusterRoute: true,
-	})
-}
-
 func (s *linuxPrivilegedBaseTestSuite) BenchmarkNodeUpdateDirectRoute(c *check.C) {
 	s.benchmarkNodeUpdate(c, datapath.LocalNodeConfiguration{
 		EnableIPv4:              s.enableIPv4,
@@ -2791,15 +2718,6 @@ func (s *linuxPrivilegedBaseTestSuite) BenchmarkNodeValidateImplementationEncap(
 		EnableIPv4:          s.enableIPv4,
 		EnableIPv6:          s.enableIPv6,
 		EnableEncapsulation: true,
-	})
-}
-
-func (s *linuxPrivilegedBaseTestSuite) BenchmarkNodeValidateImplementationEncapSingleCluster(c *check.C) {
-	s.benchmarkNodeValidateImplementation(c, datapath.LocalNodeConfiguration{
-		EnableIPv4:            s.enableIPv4,
-		EnableIPv6:            s.enableIPv6,
-		EnableEncapsulation:   true,
-		UseSingleClusterRoute: true,
 	})
 }
 

--- a/pkg/datapath/node.go
+++ b/pkg/datapath/node.go
@@ -41,21 +41,6 @@ type LocalNodeConfiguration struct {
 	// subsequent calls to NodeConfigurationChanged().
 	EnableIPv6 bool
 
-	// UseSingleClusterRoute enables the use of a single cluster-wide route
-	// to direct traffic from the host into the Cilium datapath.  This
-	// avoids the requirement to install a separate route for each node
-	// CIDR and can thus improve the overhead when operating large clusters
-	// with significant node event churn due to auto-scaling.
-	//
-	// Use of UseSingleClusterRoute must be compatible with
-	// EnableAutoDirectRouting. When both are enabled, any direct node
-	// route must take precedence over the cluster-wide route as per LPM
-	// routing definition.
-	//
-	// This field is mutable. The implementation of
-	// NodeConfigurationChanged() must adjust the routes accordingly.
-	UseSingleClusterRoute bool
-
 	// EnableEncapsulation enables use of encapsulation in communication
 	// between nodes.
 	//

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -102,7 +102,6 @@ func NewNodeDiscovery(manager *nodemanager.Manager, mtuConfig mtu.Configuration,
 		Manager: manager,
 		LocalConfig: datapath.LocalNodeConfiguration{
 			MtuConfig:               mtuConfig,
-			UseSingleClusterRoute:   option.Config.UseSingleClusterRoute,
 			EnableIPv4:              option.Config.EnableIPv4,
 			EnableIPv6:              option.Config.EnableIPv6,
 			EnableEncapsulation:     option.Config.Tunnel != option.TunnelDisabled,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -476,14 +476,6 @@ const (
 	// TunnelPortName is the name of the TunnelPort option
 	TunnelPortName = "tunnel-port"
 
-	// SingleClusterRouteName is the name of the SingleClusterRoute option
-	//
-	// SingleClusterRoute enables use of a single route covering the entire
-	// cluster CIDR to point to the cilium_host interface instead of using
-	// a separate route for each cluster node CIDR. This option is not
-	// compatible with Tunnel=TunnelDisabled
-	SingleClusterRouteName = "single-cluster-route"
-
 	// MonitorAggregationName specifies the MonitorAggregationLevel on the
 	// comandline.
 	MonitorAggregationName = "monitor-aggregation"
@@ -1356,10 +1348,6 @@ type DaemonConfig struct {
 	// MaxControllerInterval is the maximum value for a controller's
 	// RunInterval. Zero means unlimited.
 	MaxControllerInterval int
-
-	// UseSingleClusterRoute specifies whether to use a single cluster route
-	// instead of per-node routes.
-	UseSingleClusterRoute bool
 
 	// HTTPNormalizePath switches on Envoy HTTP path normalization options, which currently
 	// includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and
@@ -2319,12 +2307,7 @@ func (c *DaemonConfig) Validate() error {
 	}
 
 	switch c.Tunnel {
-	case TunnelVXLAN, TunnelGeneve, "":
-	case TunnelDisabled:
-		if c.UseSingleClusterRoute {
-			return fmt.Errorf("option --%s cannot be used in combination with --%s=%s",
-				SingleClusterRouteName, TunnelName, TunnelDisabled)
-		}
+	case TunnelVXLAN, TunnelGeneve, TunnelDisabled, "":
 	default:
 		return fmt.Errorf("invalid tunnel mode '%s', valid modes = {%s}", c.Tunnel, GetTunnelModes())
 	}
@@ -2617,7 +2600,6 @@ func (c *DaemonConfig) Populate() {
 	c.RouteMetric = viper.GetInt(RouteMetric)
 	c.RunDir = viper.GetString(StateDir)
 	c.SidecarIstioProxyImage = viper.GetString(SidecarIstioProxyImage)
-	c.UseSingleClusterRoute = viper.GetBool(SingleClusterRouteName)
 	c.SocketPath = viper.GetString(SocketPath)
 	c.SockopsEnable = viper.GetBool(SockopsEnableName)
 	c.TracePayloadlen = viper.GetInt(TracePayloadlen)


### PR DESCRIPTION
The `single-cluster-route` flag was intended to instruct Cilium to use a
single route covering the entire cluster CIDR to point to the
`cilium_host` interface in tunnel mode, instead of per-host or
per-endpoint routes.

However, the underlying concept of a cluster prefix used for routing was
removed in PR #10194. It seems the `single-cluster-route`
flag was likely even broken prior to that and accidentally used the
per-node mask instead of the per-cluster mask for the route. In summary,
this flag has not been functional for almost two years. As no one seems
to have noticed, it should be safe to remove this defunct flag without a
deprecation period.