### PR TITLE
ci: fix missing sysdump as separate workflow in L4LB tests for stable branches

### DIFF
--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -177,6 +177,7 @@ jobs:
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}
         run: |
+          ssh default "sudo /bin/sh -c 'cilium sysdump --output-filename cilium-sysdump-out; mv cilium-sysdump-out.zip /tmp'"
           scp default:/tmp/cilium-sysdump-out.zip .
 
       - name: Upload cilium-sysdump

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -177,6 +177,7 @@ jobs:
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}
         run: |
+          ssh default "sudo /bin/sh -c 'cilium sysdump --output-filename cilium-sysdump-out; mv cilium-sysdump-out.zip /tmp'"
           scp default:/tmp/cilium-sysdump-out.zip .
 
       - name: Upload cilium-sysdump


### PR DESCRIPTION
Follow up to https://github.com/cilium/cilium/pull/18380.

Signed-off-by: Ondrej Blazek <ondrej.blazek@firma.seznam.cz>