### PR TITLE
bpf: Fix implicit cast for BPF TPROXY debug message

### DIFF
--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -17,7 +17,7 @@ assign_socket_tcp(struct __ctx_buff *ctx,
 {
 	int result = DROP_PROXY_LOOKUP_FAILED;
 	struct bpf_sock *sk;
-	__u16 dbg_ctx;
+	__u32 dbg_ctx;
 
 	sk = skc_lookup_tcp(ctx, tuple, len, BPF_F_CURRENT_NETNS, 0);
 	if (!sk)
@@ -48,7 +48,7 @@ assign_socket_udp(struct __ctx_buff *ctx,
 {
 	int result = DROP_PROXY_LOOKUP_FAILED;
 	struct bpf_sock *sk;
-	__u16 dbg_ctx;
+	__u32 dbg_ctx;
 
 	sk = sk_lookup_udp(ctx, tuple, len, BPF_F_CURRENT_NETNS, 0);
 	if (!sk)


### PR DESCRIPTION
Because `dbg_ctx` was declared 16-bit long, it would only hold the protocol and not the family (shifted to upper 16 bits). This incorrect implicit cast was discovered thanks to `-Wimplicit-int-conversion`, which I'm working on enabling.

Fixes: https://github.com/cilium/cilium/pull/11279.