### PR TITLE
install: add mountPropagation directive to bpf-maps volume in cilium DS

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -274,6 +274,7 @@ spec:
 {{- /* CRI-O already mounts the BPF filesystem */ -}}
 {{- if not (eq .Values.containerRuntime.integration "crio") }}
         - mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
           name: bpf-maps
 {{- end }}
 {{- if not (contains "/run/cilium/cgroupv2" .Values.cgroup.hostRoot) }}


### PR DESCRIPTION
The original backport was missing the "mountPropagation: Bidirectional"
directive for the bpf-maps volume, causing the bpffs to not get mounted
in the host.

Fixes: d2217045cb ("install/kubernetes: use bidirectional mounts to mount bpf fs")