### PR TITLE
v1.11 backports 2022-01-11

### DIFF
--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -47,7 +47,7 @@ eBPF-based
 
 The eBPF-based implementation is the most efficient
 implementation. It requires Linux kernel 4.19 and can be enabled with
-the ``bpf.masquerade=true`` helm option (enabled by default).
+the ``bpf.masquerade=true`` helm option.
 
 The current implementation depends on :ref:`the BPF NodePort feature <kubeproxy-free>`.
 The dependency will be removed in the future (:gh-issue:`13732`).

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -316,9 +316,9 @@ every week. The following steps describe how to perform those duties. Please
 submit changes to these steps if you have found a better way to perform each
 duty.
 
-* `People in a Janitor hat this week <https://github.com/orgs/cilium/teams/janitors/members>`_
-* `People in a Triage hat this week <https://github.com/orgs/cilium/teams/triage/members>`_
-* `People in a Backport hat this week <https://github.com/orgs/cilium/teams/backporter/members>`_
+* `People in a Janitor hat this week <https://github.com/orgs/cilium/teams/tophat/members>`_
+* `People in a Triage hat this week <https://github.com/orgs/cilium/teams/tophat/members>`_
+* `People in a Backport hat this week <https://github.com/orgs/cilium/teams/tophat/members>`_
 
 Pull request review process for Janitors team
 ---------------------------------------------
@@ -333,7 +333,7 @@ Pull request review process for Janitors team
 Dedicated expectation time for each member of Janitors team: Follow the next
 steps 1 to 2 times per day. Works best if done first thing in the working day.
 
-#. Review all PRs requesting for review in `for you <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+team-review-requested%3Acilium%2Fjanitors+sort%3Aupdated-asc>`_;
+#. Review all PRs requesting for review in `for you <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+team-review-requested%3Acilium%2Ftophat+sort%3Aupdated-asc>`_;
 
 #. If this PR was opened by a non-committer (e.g. external contributor) please
    assign yourself to that PR and make sure to keep track the PR gets reviewed

--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -31,7 +31,7 @@ On Freeze date
 
    ::
 
-        * @cilium/janitors
+        * @cilium/tophat
         .github/workflows/ @cilium/cilium-maintainers
         api/ @cilium/api
         pkg/apisocket/ @cilium/api

--- a/Documentation/internals/index.rst
+++ b/Documentation/internals/index.rst
@@ -14,3 +14,4 @@ Internals
 
    hubble
    cilium_operator
+   security-identities

--- a/Documentation/internals/security-identities.rst
+++ b/Documentation/internals/security-identities.rst
@@ -1,0 +1,59 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+*******************
+Security Identities
+*******************
+
+Security identities are generated from labels. They are stored as ``uint32``,
+which means the maximum limit for a security identity is ``2^32 - 1``. The
+minimum security identity is ``1``.
+
+.. note::
+
+   Identity 0 is not a valid value. If it shows up in Hubble output, this means
+   the identity was not found. In the eBPF datapath, it has a special role
+   where it denotes "any identity", i.e. as a wildcard allow in policy maps.
+
+Security identities span over several ranges, depending on the context:
+
+1) Cluster-local
+2) ClusterMesh
+3) Identities generated from CIDR-based policies
+
+Cluster-local identities (1) range from ``1`` to ``2^16 - 1``. The lowest
+values, from ``1`` to ``255``, correspond to the reserved identity range.  See
+the `internal code documentation
+<https://pkg.go.dev/github.com/cilium/cilium/pkg/identity#NumericIdentity>`__
+for details.
+
+For ClusterMesh (2), 8 bits are used as the ``cluster-id`` which identifies the
+cluster in the ClusterMesh, into the 3rd octet as shown by ``0x00FF0000``. The
+4th octet (uppermost bits) must be set to ``0`` as well. Neither of these
+constraints apply CIDR identities however, see (3).
+
+CIDR identities (3) are local to each node. CIDR identities begin from ``1``
+and end at ``16777215``, however since they're shifted by ``24``, this makes
+their effective range ``1 | (1 << 24)`` to ``16777215 | (1 << 24)`` or from
+``16777217`` to ``33554431``. When CIDR policies are applied, the identity
+generated is local to each node. In other words, the identity may not be the
+same for the same CIDR policy across two nodes.
+
+CIDR identities are never used for traffic between Cilium-managed nodes, so
+they do not need to fit inside of a VXLAN or Geneve virtual network field.
+Non-CIDR identities are limited to 24 bits so that they will fit in these
+fields on the wire, but since CIDR identities will not be encoded in these
+packets, they can start with a higher value. Hence, the minimum value for a
+CIDR identity is ``2^24 + 1``.
+
+Overall, the following represents the different ranges:
+
+::
+
+   0x00000001 - 0x0000FFFF (1           to 2^16 - 1)        => cluster-local identities
+   0x00010000 - 0x00FFFFFF (2^16        to 2^24 - 1)        => identities for remote clusters
+   0x01000000 - 0x0100FFFF (2^24        to 2^24 + 2^16 - 1) => identities for CIDRs (node-local)
+   0x01010000 - 0xFFFFFFFF (2^24 + 2^16 to 2^32 - 1)        => reserved for future use

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -320,6 +320,10 @@ remote-node
     Any node in any of the connected clusters other than the local host. This
     also includes all containers running in host-networking mode on remote
     nodes. (Requires the option ``enable-remote-node-identity`` to be enabled)
+kube-apiserver
+    The kube-apiserver entity represents the kube-apiserver in a Kubernetes
+    cluster. This entity represents both deployments of the kube-apiserver:
+    within the cluster and outside of the cluster.
 cluster
     Cluster is the logical group of all network endpoints inside of the local
     cluster. This includes all Cilium-managed endpoints of the local cluster,
@@ -350,6 +354,11 @@ all
 .. versionadded:: future
    Allowing users to define custom entities is on the roadmap but has not been
    implemented yet (see :gh-issue:`3553`).
+
+.. note::
+
+   A known issue with kube-apiserver entity matching is that the feature
+   doesn't work in tunneling mode (see :gh-issue:`18049`).
 
 Access to/from local host
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                     flags = env.ghprbCommentBody?.replace("\\", "")
                     env.K8S_VERSION = sh script: '''
                         if [ "${ghprbCommentBody}" != "" ]; then
-                            python ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="k8s_version" | \
+                            python3 ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="k8s_version" | \
                             sed "s/^$/${JobK8sVersion:-1.23}/" | \
                             sed 's/^"//' | sed 's/"$//' | \
                             xargs echo -n
@@ -68,7 +68,7 @@ pipeline {
                         fi''', returnStdout: true
                     env.KERNEL = sh script: '''
                         if [ "${ghprbCommentBody}" != "" ]; then
-                            python ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="kernel_version" | \
+                            python3 ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="kernel_version" | \
                             sed "s/^$/${JobKernelVersion:-419}/" | \
                             sed 's/^"//' | sed 's/"$//' | \
                             xargs echo -n
@@ -77,7 +77,7 @@ pipeline {
                         fi''', returnStdout: true
                     env.FOCUS = sh script: '''
                         if [ "${ghprbCommentBody}" != "" ]; then
-                            python ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="focus" | \
+                            python3 ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="focus" | \
                             sed "s/^$/K8s/" | \
                             sed "s/Runtime.*/NoTests/" | \
                             sed 's/^"//' | sed 's/"$//' | \

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
                         timeout(time: 30, unit: 'MINUTES'){
                             dir("${TESTDIR}") {
                                 sh 'vagrant destroy runtime --force'
-                                sh 'KERNEL=$(python get-gh-comment-info.py "${ghprbCommentBody}" --retrieve=kernel_version | sed "s/^$/${DEFAULT_KERNEL}/") vagrant up runtime --provision'
+                                sh 'KERNEL=$(python3 get-gh-comment-info.py "${ghprbCommentBody}" --retrieve=kernel_version | sed "s/^$/${DEFAULT_KERNEL}/") vagrant up runtime --provision'
                             }
                         }
                     }
@@ -138,7 +138,7 @@ pipeline {
                 TESTDIR="${GOPATH}/${PROJ_PATH}/test"
             }
             steps {
-                sh 'cd ${TESTDIR}; ginkgo --focus="$(python get-gh-comment-info.py "${ghprbCommentBody}" | sed "s/^$/Runtime/" | sed "s/K8s.*/NoTests/")" --tags=integration_tests -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED}'
+                sh 'cd ${TESTDIR}; ginkgo --focus="$(python3 get-gh-comment-info.py "${ghprbCommentBody}" | sed "s/^$/Runtime/" | sed "s/K8s.*/NoTests/")" --tags=integration_tests -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED}'
             }
             post {
                 always {


### PR DESCRIPTION
Only backporting simple changes that don't require end-to-end tests, mostly to pick #18443.

 * #18420 -- docs: Fix incorrect mention of `bpf.masquerade`'s default value (@pchaigno)
 * #18396 -- docs: Document the kube-apiserver entity (@christarazi)
 * #18430 -- docs: Replace janitors team with tophat team (@pchaigno)
     * Minor conflicts.
 * #16716 -- Clarify identity generated from CIDR-based policies and add security identity internal docs (@christarazi)
 * #18443 -- ci: use python3 instead of python (@nebril)

Skipped:

 * #18333 -- Add basic kube-apiserver policy matching e2e test  (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18420 18396 18430 16716 18443; do contrib/backporting/set-labels.py $pr done 1.11; done
```