### PR TITLE
v1.10 backports 2022-01-11

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -187,11 +187,11 @@ allocation:
 
 ``spec.eni.first-interface-index``
   The index of the first ENI to use for IP allocation, e.g. if the node has
-  ``eth0``, ``eth1``, ``eth2`` and FirstInterfaceIndex is set to 0, then only
+  ``eth0``, ``eth1``, ``eth2`` and FirstInterfaceIndex is set to 1, then only
   ``eth1`` and ``eth2`` will be used for IP allocation, ``eth0`` will be
   ignored for PodIP allocation.
 
-  If unspecified, this value defaults to 1 which means that ``eth0`` will not
+  If unspecified, this value defaults to 0 which means that ``eth0`` will
   be used for pod IPs.
 
 ``spec.eni.security-group-tags``

--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -47,7 +47,7 @@ eBPF-based
 
 The eBPF-based implementation is the most efficient
 implementation. It requires Linux kernel 4.19 and can be enabled with
-the ``bpf.masquerade=true`` helm option (enabled by default).
+the ``bpf.masquerade=true`` helm option.
 
 The current implementation depends on :ref:`the BPF NodePort feature <kubeproxy-free>`.
 The dependency will be removed in the future (:gh-issue:`13732`).

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -314,9 +314,9 @@ every week. The following steps describe how to perform those duties. Please
 submit changes to these steps if you have found a better way to perform each
 duty.
 
-* `People on Janitor hat this week <https://github.com/orgs/cilium/teams/janitors/members>`_
-* `People on Triage hat this week <https://github.com/orgs/cilium/teams/triage/members>`_
-* `People on Backport hat this week <https://github.com/orgs/cilium/teams/backporter/members>`_
+* `People on Janitor hat this week <https://github.com/orgs/cilium/teams/tophat/members>`_
+* `People on Triage hat this week <https://github.com/orgs/cilium/teams/tophat/members>`_
+* `People on Backport hat this week <https://github.com/orgs/cilium/teams/tophat/members>`_
 
 Pull request review process for Janitors team
 ---------------------------------------------

--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -31,7 +31,7 @@ On Freeze date
 
    ::
 
-        * @cilium/janitors
+        * @cilium/tophat
         api/ @cilium/api
         pkg/apisocket/ @cilium/api
         pkg/monitor/payload @cilium/api

--- a/Documentation/contributing/release/organization.rst
+++ b/Documentation/contributing/release/organization.rst
@@ -25,10 +25,10 @@ by incrementing the ``Y`` in the version format ``X.Y.Z``.
 Three stable branches are maintained at a time: One for the most recent minor
 release, and two for the prior two minor releases. For each minor release that
 is currently maintained, the stable branch ``vX.Y`` on github contains the code
-for the next stable release. New micro releases for an existing stable version
+for the next stable release. New patch releases for an existing stable version
 ``X.Y.Z`` are published incrementing the ``Z`` in the version format.
 
-New micro releases for stable branches are made periodically to provide
+New patch releases for stable branches are made periodically to provide
 security and bug fixes, based upon community demand and bugfix severity.
 Potential fixes for an upcoming release are first merged into the ``master``
 branch, then backported to the relevant stable branches using the following

--- a/Documentation/gettingstarted/k8s-install-kubespray.rst
+++ b/Documentation/gettingstarted/k8s-install-kubespray.rst
@@ -141,14 +141,23 @@ Installing Kubernetes cluster with Cilium as CNI
 
 Kubespray uses Ansible as its substrate for provisioning and orchestration. Once the infrastructure is created, you can run the Ansible playbook to install Kubernetes and all the required dependencies. Execute the below command in the kubespray clone repo, providing the correct path of the AWS EC2 ssh private key in ``ansible_ssh_private_key_file=<path to EC2 SSH private key file>``
 
-We recommend using the `latest released Cilium version`_ by editing ``roles/download/defaults/main.yml``. Open the file, search for ``cilium_version``, and replace the version with the latest released. As an example, the updated version entry will look like: ``cilium_version: "v1.2.0"``.
-
+We recommend using the `latest released Cilium version`_ by passing the variable when running the ``ansible-playbook`` command.
+For example, you could add the following flag to the command below: ``-e cilium_version=v1.11.0``.
 
 .. code-block:: shell-session
 
   $ ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=core -e bootstrap_os=coreos -e kube_network_plugin=cilium -b --become-user=root --flush-cache  -e ansible_ssh_private_key_file=<path to EC2 SSH private key file>
 
 .. _latest released Cilium version: https://github.com/cilium/cilium/releases
+
+If you are interested in configuring your Kubernetes cluster setup, you should consider copying the sample inventory. Then, you can edit the variables in the relevant file in the ``group_vars`` directory.
+
+.. code-block:: shell-session
+
+  $ cp -r inventory/sample inventory/my-inventory
+  $ cp ./inventory/hosts ./inventory/my-inventory/hosts
+  $ echo 'cilium_version: "v1.11.0"' >> ./inventory/my-inventory/group_vars/k8s_cluster/k8s-net-cilium.yml
+  $ ansible-playbook -i ./inventory/my-inventory/hosts ./cluster.yml -e ansible_user=core -e bootstrap_os=coreos -e kube_network_plugin=cilium -b --become-user=root --flush-cache -e ansible_ssh_private_key_file=<path to EC2 SSH private key file>
 
 Validate Cluster
 ================

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -136,14 +136,14 @@ one stable release to a later stable release.
 
 .. include:: upgrade-warning.rst
 
-Step 1: Upgrade to latest micro version (Recommended)
+Step 1: Upgrade to latest patch version (Recommended)
 -----------------------------------------------------
 
 When upgrading from one minor release to another minor release, for example
-1.x to 1.y, it is recommended to upgrade to the latest micro release for a
-Cilium release series first. The latest micro releases for each supported
+1.x to 1.y, it is recommended to upgrade to the latest patch release for a
+Cilium release series first. The latest patch releases for each supported
 version of Cilium are `here <https://github.com/cilium/cilium#stable-releases>`_.
-Upgrading to the latest micro release ensures the most seamless experience if a
+Upgrading to the latest patch release ensures the most seamless experience if a
 rollback is required following the minor release upgrade.
 
 Step 2: Use Helm to Upgrade your Cilium deployment

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -4,7 +4,6 @@ APIEndpoint
 AdapterLimitViaAPI
 Alemayhu
 Alibaba
-Ansible
 BPF
 Bertin
 Blanco
@@ -145,6 +144,7 @@ allocator
 allocators
 amd
 analytics
+ansible
 api
 apiKeys
 apiVersion

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                     flags = env.ghprbCommentBody?.replace("\\", "")
                     env.K8S_VERSION = sh script: '''
                         if [ "${ghprbCommentBody}" != "" ]; then
-                            python ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="k8s_version" | \
+                            python3 ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="k8s_version" | \
                             sed "s/^$/${JobK8sVersion:-1.20}/" | \
                             sed 's/^"//' | sed 's/"$//' | \
                             xargs echo -n
@@ -68,7 +68,7 @@ pipeline {
                         fi''', returnStdout: true
                     env.KERNEL = sh script: '''
                         if [ "${ghprbCommentBody}" != "" ]; then
-                            python ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="kernel_version" | \
+                            python3 ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="kernel_version" | \
                             sed "s/^$/${JobKernelVersion:-419}/" | \
                             sed 's/^"//' | sed 's/"$//' | \
                             xargs echo -n
@@ -77,7 +77,7 @@ pipeline {
                         fi''', returnStdout: true
                     env.FOCUS = sh script: '''
                         if [ "${ghprbCommentBody}" != "" ]; then
-                            python ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="focus" | \
+                            python3 ${TESTDIR}/get-gh-comment-info.py ''' + flags + ''' --retrieve="focus" | \
                             sed "s/^$/K8s/" | \
                             sed "s/Runtime.*/NoTests/" | \
                             sed 's/^"//' | sed 's/"$//' | \

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
                         timeout(time: 30, unit: 'MINUTES'){
                             dir("${TESTDIR}") {
                                 sh 'vagrant destroy runtime --force'
-                                sh 'KERNEL=$(python get-gh-comment-info.py "${ghprbCommentBody}" --retrieve=kernel_version | sed "s/^$/${DEFAULT_KERNEL}/") vagrant up runtime --provision'
+                                sh 'KERNEL=$(python3 get-gh-comment-info.py "${ghprbCommentBody}" --retrieve=kernel_version | sed "s/^$/${DEFAULT_KERNEL}/") vagrant up runtime --provision'
                             }
                         }
                     }
@@ -138,7 +138,7 @@ pipeline {
                 TESTDIR="${GOPATH}/${PROJ_PATH}/test"
             }
             steps {
-                sh 'cd ${TESTDIR}; ginkgo --focus="$(python get-gh-comment-info.py "${ghprbCommentBody}" | sed "s/^$/Runtime/" | sed "s/K8s.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED}'
+                sh 'cd ${TESTDIR}; ginkgo --focus="$(python3 get-gh-comment-info.py "${ghprbCommentBody}" | sed "s/^$/Runtime/" | sed "s/K8s.*/NoTests/")" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.runQuarantined=${RUN_QUARANTINED}'
             }
             post {
                 always {


### PR DESCRIPTION
Only backporting simple changes that don't require end-to-end tests, mostly to pick #18443.

 * #18279 -- docs: Replace 'micro version' with 'patch version' (@pchaigno)
     * Minor conflicts.
 * #18327 -- docs: Fix `first-interface-index` documentation (@gandro)
 * #18342 -- Improve Kubespray installation guide (@necatican)
 * #18420 -- docs: Fix incorrect mention of `bpf.masquerade`'s default value (@pchaigno)
 * #18430 -- docs: Replace janitors team with tophat team (@pchaigno)
     * Minor conflicts.
 * #18443 -- ci: use python3 instead of python (@nebril)
     * Minor conflicts in both files.

Skipped:

 * #18352 -- Fix possible IP leak in case ENI's are not present in the CN yet (@codablock)
 * #18370 -- test: bump l4lb Vagrantfile kind to 0.11.1 (@jibi)
 * #18325 -- egressgateway: fix initial reconciliation (@jibi)
 * #18388 -- bpf: Reset Pod's queue mapping in host veth to fix phys dev mq selection (@borkmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18279 18327 18342 18420 18430 18443; do contrib/backporting/set-labels.py $pr done 1.10; done
```