### PR TITLE
test: Fix pod cleanup after various tests

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2099,10 +2099,9 @@ func (kub *Kubectl) ScaleUpDNS() *CmdRes {
 	return res
 }
 
-// RedeployDNS deletes the kube-dns pods and does not wait for the deletion
-// to complete. Useful to ensure that the pods are recreated after datapath
-// configuration changes.
-func (kub *Kubectl) RedeployDNS() *CmdRes {
+// redeployDNS deletes the kube-dns pods and does not wait for the deletion
+// to complete.
+func (kub *Kubectl) redeployDNS() *CmdRes {
 	if res := kub.ScaleDownDNS(); !res.WasSuccessful() {
 		return res
 	}
@@ -2126,7 +2125,7 @@ func (kub *Kubectl) RedeployKubernetesDnsIfNecessary(force bool) {
 	}
 
 	ginkgoext.By("Restarting Kubernetes DNS (-l %s)", kubeDNSLabel)
-	res := kub.RedeployDNS()
+	res := kub.redeployDNS()
 	if !res.WasSuccessful() {
 		ginkgoext.Failf("Unable to delete DNS pods: %s", res.OutputPrettyPrint())
 	}

--- a/test/helpers/manifest.go
+++ b/test/helpers/manifest.go
@@ -280,6 +280,8 @@ func (m *DeploymentManager) DeleteAll() {
 // DeployCilium()
 func (m *DeploymentManager) DeleteCilium() {
 	if m.ciliumDeployed {
+		// Ensure any Cilium-managed pods are terminated first
+		m.kubectl.WaitTerminatingPods(2 * time.Minute)
 		ginkgoext.By("Deleting Cilium")
 		m.kubectl.DeleteAndWait(m.ciliumFilename, true)
 		m.kubectl.WaitTerminatingPods(2 * time.Minute)

--- a/test/k8sT/Bandwidth.go
+++ b/test/k8sT/Bandwidth.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cilium/cilium/test/helpers"
 )
 
-var _ = Describe("K8sBandwidthTest", func() {
+var _ = SkipDescribeIf(helpers.DoesNotRunOnNetNextKernel, "K8sBandwidthTest", func() {
 	var (
 		kubectl        *helpers.Kubectl
 		ciliumFilename string
@@ -39,7 +39,7 @@ var _ = Describe("K8sBandwidthTest", func() {
 		kubectl.CloseSSHClient()
 	})
 
-	SkipContextIf(helpers.DoesNotRunOnNetNextKernel, "Checks Bandwidth Rate-Limiting", func() {
+	Context("Checks Bandwidth Rate-Limiting", func() {
 		const (
 			testDS10       = "run=netperf-10"
 			testDS25       = "run=netperf-25"

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -189,6 +189,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sChaosTest", func() {
 
 		AfterAll(func() {
 			_ = kubectl.Delete(netperfManifest)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		AfterEach(func() {

--- a/test/k8sT/CustomCalls.go
+++ b/test/k8sT/CustomCalls.go
@@ -102,8 +102,10 @@ var _ = SkipDescribeIf(func() bool {
 
 		AfterAll(func() {
 			deploymentManager.DeleteAll()
+			kubectl.ScaleDownDNS()
+			ExpectAllPodsTerminated(kubectl)
 			deploymentManager.DeleteCilium()
-			kubectl.RedeployDNS()
+			kubectl.ScaleUpDNS()
 		})
 
 		installPods := func() {

--- a/test/k8sT/CustomCalls.go
+++ b/test/k8sT/CustomCalls.go
@@ -101,8 +101,8 @@ var _ = SkipDescribeIf(func() bool {
 		})
 
 		AfterAll(func() {
-			deploymentManager.DeleteCilium()
 			deploymentManager.DeleteAll()
+			deploymentManager.DeleteCilium()
 			kubectl.RedeployDNS()
 		})
 

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -44,8 +44,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	AfterAll(func() {
+		kubectl.ScaleDownDNS()
+		ExpectAllPodsTerminated(kubectl)
 		deploymentManager.DeleteCilium()
-		kubectl.RedeployDNS()
+		kubectl.ScaleUpDNS()
 		kubectl.CloseSSHClient()
 	})
 

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -36,6 +36,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	AfterEach(func() {
 		deploymentManager.DeleteAll()
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -110,6 +110,7 @@ var _ = SkipDescribeIf(func() bool {
 	AfterAll(func() {
 		_ = kubectl.Delete(echoPodYAML)
 		_ = kubectl.Delete(assignIPYAML)
+		ExpectAllPodsTerminated(kubectl)
 
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 	})

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -39,11 +39,8 @@ var _ = Describe("K8sHealthTest", func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		})
 
-		AfterEach(func() {
-			ExpectAllPodsTerminated(kubectl)
-		})
-
 		AfterAll(func() {
+			ExpectAllPodsTerminated(kubectl)
 			UninstallCiliumFromManifest(kubectl, ciliumFilename)
 			kubectl.CloseSSHClient()
 		})

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -109,10 +109,6 @@ var _ = SkipDescribeIf(func() bool {
 		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, daemonCfg)
 	})
 
-	AfterEach(func() {
-		ExpectAllPodsTerminated(kubectl)
-	})
-
 	AfterFailed(func() {
 		kubectl.CiliumReport("cilium service list", "cilium endpoint list")
 	})
@@ -218,6 +214,7 @@ var _ = SkipDescribeIf(func() bool {
 		AfterAll(func() {
 			kubectl.NamespaceDelete(namespaceForTest)
 			kubectl.Delete(demoPath)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		BeforeEach(func() {
@@ -1500,6 +1497,7 @@ var _ = SkipDescribeIf(func() bool {
 					// Remove echoserver pods from host namespace.
 					echoPodPath := helpers.ManifestGet(kubectl.BasePath(), "echoserver-cilium-hostnetns.yaml")
 					kubectl.Delete(echoPodPath).ExpectSuccess("Cannot remove echoserver application")
+					ExpectAllPodsTerminated(kubectl)
 				})
 
 				It("Connectivity to hostns is blocked after denying ingress", func() {
@@ -1759,6 +1757,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			AfterEach(func() {
 				kubectl.Delete(connectivityCheckYml)
+				ExpectAllPodsTerminated(kubectl)
 			})
 
 			It("using connectivity-check to check datapath", func() {
@@ -1969,6 +1968,7 @@ var _ = SkipDescribeIf(func() bool {
 			_ = kubectl.Delete(demoManifest)
 			_ = kubectl.Delete(cnpSecondNS)
 			_ = kubectl.NamespaceDelete(secondNS)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("Tests the same Policy in different namespaces", func() {
@@ -2179,6 +2179,7 @@ var _ = SkipDescribeIf(func() bool {
 			_ = kubectl.Delete(demoManifestNS2)
 			_ = kubectl.NamespaceDelete(firstNS)
 			_ = kubectl.NamespaceDelete(secondNS)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("Test clusterwide connectivity with policies", func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -134,10 +134,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
-	AfterEach(func() {
-		ExpectAllPodsTerminated(kubectl)
-	})
-
 	AfterAll(func() {
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
@@ -232,6 +228,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 					_ = kubectl.Delete(echoSVCYAMLDualStack)
 				}
 			}
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		SkipItIf(helpers.RunsWithKubeProxyReplacement, "Checks service on same node", func() {
@@ -1046,6 +1043,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 						AfterAll(func() {
 							kubectl.Delete(echoYAML)
+							ExpectAllPodsTerminated(kubectl)
 						})
 
 						It("Tests NodePort", func() {
@@ -1186,6 +1184,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 						AfterAll(func() {
 							_ = kubectl.Delete(echoYAML)
+							ExpectAllPodsTerminated(kubectl)
 						})
 
 						It("Tests NodePort", func() {
@@ -1369,6 +1368,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 							for _, node := range []string{ni.k8s1NodeName, ni.k8s2NodeName, ni.outsideNodeName} {
 								kubectl.ExecInHostNetNS(context.TODO(), node, "ip l del wg0")
 							}
+							ExpectAllPodsTerminated(kubectl)
 						})
 
 						It("Tests NodePort BPF", func() {
@@ -1659,6 +1659,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 		AfterEach(func() {
 			wg.Wait()
 			_ = kubectl.Delete(gracefulTermYAML)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("Checks client terminates gracefully on service endpoint deletion", func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1656,7 +1656,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			kubectl.LogsPreviousWithLabel(helpers.DefaultNamespace, clientPodLabel)
 		})
 
-		AfterAll(func() {
+		AfterEach(func() {
 			wg.Wait()
 			_ = kubectl.Delete(gracefulTermYAML)
 		})

--- a/test/k8sT/Verifier.go
+++ b/test/k8sT/Verifier.go
@@ -140,6 +140,7 @@ var _ = Describe("K8sVerifier", func() {
 
 	AfterAll(func() {
 		kubectl.DeleteResource("pod", podName)
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	It("Runs the kernel verifier against Cilium's BPF datapath", func() {

--- a/test/k8sT/bookinfo.go
+++ b/test/k8sT/bookinfo.go
@@ -34,10 +34,6 @@ var _ = SkipDescribeIf(func() bool {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
-	AfterEach(func() {
-		ExpectAllPodsTerminated(kubectl)
-	})
-
 	AfterAll(func() {
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
@@ -84,6 +80,7 @@ var _ = SkipDescribeIf(func() bool {
 				// Explicitly do not check result to avoid having assertions in AfterAll.
 				_ = kubectl.Delete(resourcePath)
 			}
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("Tests bookinfo demo", func() {

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -178,8 +178,10 @@ var _ = skipSuite("K8sKubeProxyFreeMatrix tests", func() {
 			return
 		}
 
-		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		_ = kubectl.NamespaceDelete(namespaceTest)
+		ExpectAllPodsTerminated(kubectl)
+
+		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
 	})
 

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -164,13 +164,10 @@ var _ = Describe("K8sHubbleTest", func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		})
 
-		AfterEach(func() {
-			ExpectAllPodsTerminated(kubectl)
-		})
-
 		AfterAll(func() {
 			kubectl.Delete(demoPath)
 			kubectl.NamespaceDelete(namespaceForTest)
+			ExpectAllPodsTerminated(kubectl)
 
 			kubectl.DeleteHubbleRelay(hubbleRelayNamespace)
 			UninstallCiliumFromManifest(kubectl, ciliumFilename)

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -129,6 +129,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 
 		By("Deleting the istio-system namespace")
 		_ = kubectl.NamespaceDelete(istioSystemNamespace)
+		ExpectAllPodsTerminated(kubectl)
 
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()

--- a/test/k8sT/lrp.go
+++ b/test/k8sT/lrp.go
@@ -33,10 +33,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
-	AfterEach(func() {
-		ExpectAllPodsTerminated(kubectl)
-	})
-
 	AfterAll(func() {
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
@@ -90,6 +86,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 
 		AfterAll(func() {
 			_ = kubectl.Delete(deploymentYAML)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("LRP connectivity", func() {


### PR DESCRIPTION
See individual commits for more details.

According to the [Cilium Ginkgo e2e test docs](https://docs.cilium.io/en/latest/contributing/testing/e2e/#example-test-layout), All `AfterEach` statements are executed before all `AfterAll` statements.

Previously, some of this code was assuming that `AfterAll` inside a context would run first (to delete pods) and then the `AfterEach` would run outside the context (to wait for the pods to terminate), then `AfterAll` outside the context to finally clean up the Cilium pods. The result was that in issue #18447, the next test to run could hit a race condition where pods were deleted but did not fully terminate before Cilium was removed. Cilium ends up getting deleted before all the pods, which means that there is no longer any way to execute the `CNI DEL` operation for those pods, so they get stuck in `Terminating` state.

Other parts of the code seemed to just omit the check for whether the pods were correctly terminated or not.

Fix these isseus by moving checks that the test pods are fully terminated into the statements where the pods are deleted.

Fixes: 412e299df74f ("test: Move LRP tests to a separate suite")
Fixes: #18447
Fixes: #18566

Note, I initially marked this for backport to v1.10 based on the first LRP test refactor commit, but left it like this since it seems like it should make the testsuite a bit more robust in general. I don't know if each of the changes will successfully backport to v1.10 or not. If not, we can maybe just drop those changes from the commit. Or we could just decide to avoid backporting the PR to v1.10 altogether.