### PR TITLE
datapath: Fix missing monitor events for NodePort BPF traffic when monitor-aggregation set to > none

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -281,6 +281,8 @@ ct_recreate6:
 # endif /* ENABLE_DSR */
 		/* See comment in handle_ipv4_from_lxc(). */
 		if (ct_state.node_port) {
+			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
+					  *dst_id, 0, 0, ret, monitor);
 			ctx->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
 			ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_REVNAT);
 			return DROP_MISSED_TAIL_CALL;
@@ -714,6 +716,8 @@ ct_recreate4:
 		 * the reverse DNAT.
 		 */
 		if (ct_state.node_port) {
+			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
+					  *dst_id, 0, 0, ct_ret, monitor);
 			ctx->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
 			ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_REVNAT);
 			return DROP_MISSED_TAIL_CALL;


### PR DESCRIPTION
Fixed together with @gandro. See commit msgs.

cc @mauilion 

For reviewers: please ignore the last commit which enables all relevant quarantined tests (we will drop it before the merge).