### PR TITLE
cli/metrics: Sort label in metrics list command

### DIFF
--- a/cilium/cmd/metrics_list.go
+++ b/cilium/cmd/metrics_list.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -54,8 +55,13 @@ var MetricsListCmd = &cobra.Command{
 			label := ""
 			if len(metric.Labels) > 0 {
 				labelArray := []string{}
-				for key, value := range metric.Labels {
-					labelArray = append(labelArray, fmt.Sprintf(`%s="%s"`, key, value))
+				keys := make([]string, 0, len(metric.Labels))
+				for k := range metric.Labels {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					labelArray = append(labelArray, fmt.Sprintf(`%s="%s"`, k, metric.Labels[k]))
 				}
 				label = strings.Join(labelArray, " ")
 			}


### PR DESCRIPTION
### Description

Please refer to commit message

### Testing

Testing was done locally as per below

<details>
<summary>before</summary>

```
root@kind-worker2:/home/cilium# cilium metrics list -p cilium_kubernetes_events_total
Metric                           Labels                                                    Value
cilium_kubernetes_events_total   scope="CiliumEndpoint" status="success" action="create"   3.000000
cilium_kubernetes_events_total   action="create" scope="CiliumNode" status="success"       2.000000
cilium_kubernetes_events_total   action="create" scope="EndpointSlice" status="success"    2.000000
cilium_kubernetes_events_total   action="create" scope="Node" status="success"             1.000000
cilium_kubernetes_events_total   action="create" scope="Pod" status="success"              5.000000
cilium_kubernetes_events_total   status="success" action="create" scope="Service"          2.000000 --> the labels here are out of order
cilium_kubernetes_events_total   action="update" scope="Pod" status="success"              1.000000


```

</details>


<details>
<summary>after</summary>

```
root@kind-worker:/home/cilium# cilium metrics list -p cilium_kubernetes_events_total
Metric                           Labels                                                    Value
cilium_kubernetes_events_total   action="create" scope="CiliumEndpoint" status="success"   3.000000
cilium_kubernetes_events_total   action="create" scope="CiliumNode" status="success"       2.000000
cilium_kubernetes_events_total   action="create" scope="EndpointSlice" status="success"    2.000000
cilium_kubernetes_events_total   action="create" scope="Node" status="success"             1.000000
cilium_kubernetes_events_total   action="create" scope="Pod" status="success"              3.000000
cilium_kubernetes_events_total   action="create" scope="Service" status="success"          2.000000
cilium_kubernetes_events_total   action="update" scope="CiliumNode" status="success"       1.000000
cilium_kubernetes_events_total   action="update" scope="Pod" status="success"              1.000000

```

</details>


```release-note
cli/metrics: Sort label in metrics list command
```
