### PR TITLE
Revert "test: Add Error Log Exceptions"

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -241,16 +241,6 @@ const (
 	unstableStat        = "BUG: stat() has unstable behavior"                        // from https://github.com/cilium/cilium/pull/11028
 	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
 
-	// ...and their exceptions.
-	lrpExists                = "local-redirect service exists for frontend"                         // cf. https://github.com/cilium/cilium/issues/16400
-	opCantBeFulfilled        = "Operation cannot be fulfilled on leases.coordination.k8s.io"        // cf. https://github.com/cilium/cilium/issues/16402
-	initLeaderElection       = "error initially creating leader election record: leases."           // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-861544964
-	globalDataSupport        = "kernel doesn't support global data"                                 // cf. https://github.com/cilium/cilium/issues/16418
-	removeInexistentID       = "removing identity not added to the identity manager!"               // cf. https://github.com/cilium/cilium/issues/16419
-	failedToListCRDs         = "the server could not find the requested resource"                   // cf. https://github.com/cilium/cilium/issues/16425
-	retrieveResLock          = "retrieving resource lock kube-system/cilium-operator-resource-lock" // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-871155492
-	failedToRelLockEmptyName = "Failed to release lock: resource name may not be empty"             // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-985819560
-
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
 
@@ -315,9 +305,6 @@ var badLogMessages = map[string][]string{
 	unstableStat:        nil,
 	removeTransientRule: nil,
 	"DATA RACE":         nil,
-	// Exceptions for level=error should only be added as a last resort, if the
-	// error cannot be fixed in Cilium or in the test.
-	"level=error": {lrpExists, opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName},
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
This reverts commit b73c5b19cdf8583dfded17db75cad79c0e62c972.

Rationale:

- The reverted commit on v1.10[1] was a backport of a master commit[2], itself building upon another master commit[3], both adding `level=error` checking to the CI.
- [3] was not backported to v1.10, hence conflicts from backporting [2] to v1.10 were manually fixed, resulting in [1]'s description not matching its contents and also losing proper history tracing due to [3] not being present in the tree.
- [1] introduced issue #18285 in v1.10 CI tests.
- It also appears [2] was not intended for backport in the first place.
- Due to all of these, we revert [1] in v1.10.

[1] b73c5b19cdf8583dfded17db75cad79c0e62c972
[2] 82d44229e61d066b37d13ca34d0e30e5e2b0e9b0
[3] 11fb42adc2c53f38b66bc5f1271d370b6c1e8f9a

Note: a more thorough discussion can be found at https://github.com/cilium/cilium/issues/18285#issuecomment-1009970348