### PR TITLE
#18325 v1.10 backport

### DIFF
--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -62,15 +61,6 @@ type parsedEgressRule struct {
 
 type k8sCacheSyncedCheckerMock struct {
 	synced bool
-}
-
-func (k *k8sCacheSyncedCheckerMock) WaitUntilK8sCacheIsSynced() {
-	for {
-		if k.synced {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
 }
 
 func (k *k8sCacheSyncedCheckerMock) K8sCacheIsSynced() bool {


### PR DESCRIPTION
* https://github.com/cilium/cilium/pull/18325 -- egressgateway: fix initial reconciliation (@jibi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18325; do contrib/backporting/set-labels.py $pr done 1.10; done
```