### PR TITLE
daemon, option: consistently hard-code host device

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1600,7 +1600,7 @@ func (d *Daemon) initKVStore() {
 
 func runDaemon() {
 	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice: option.Config.HostDevice,
+		HostDevice: defaults.HostDevice,
 	}
 
 	log.Info("Initializing daemon")

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -19,6 +19,7 @@ import (
 	datapathIpcache "github.com/cilium/cilium/pkg/datapath/ipcache"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -66,14 +67,14 @@ func (d *Daemon) createNodeConfigHeaderfile() error {
 }
 
 func deleteHostDevice() {
-	link, err := netlink.LinkByName(option.Config.HostDevice)
+	link, err := netlink.LinkByName(defaults.HostDevice)
 	if err != nil {
-		log.WithError(err).Warningf("Unable to lookup host device %s. No old cilium_host interface exists", option.Config.HostDevice)
+		log.WithError(err).Warningf("Unable to lookup host device %s. No old cilium_host interface exists", defaults.HostDevice)
 		return
 	}
 
 	if err := netlink.LinkDel(link); err != nil {
-		log.WithError(err).Errorf("Unable to delete host device %s to change allocation CIDR", option.Config.HostDevice)
+		log.WithError(err).Errorf("Unable to delete host device %s to change allocation CIDR", defaults.HostDevice)
 	}
 }
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -455,7 +455,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return err
 	}
 
-	if err := iptMgr.InstallRules(option.Config.HostDevice, firstInitialization, option.Config.InstallIptRules); err != nil {
+	if err := iptMgr.InstallRules(defaults.HostDevice, firstInitialization, option.Config.InstallIptRules); err != nil {
 		return err
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/fqdn"
@@ -482,14 +483,12 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, pro
 
 // CreateHostEndpoint creates the endpoint corresponding to the host.
 func CreateHostEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, proxy EndpointProxy, allocator cache.IdentityAllocator) (*Endpoint, error) {
-	ifName := option.Config.HostDevice
-
-	mac, err := link.GetHardwareAddr(ifName)
+	mac, err := link.GetHardwareAddr(defaults.HostDevice)
 	if err != nil {
 		return nil, err
 	}
 
-	ep := createEndpoint(owner, policyGetter, proxy, allocator, 0, ifName)
+	ep := createEndpoint(owner, policyGetter, proxy, allocator, 0, defaults.HostDevice)
 	ep.isHost = true
 	ep.mac = mac
 	ep.nodeMAC = mac

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -656,7 +656,7 @@ func getCiliumHostIPs() (ipv4GW, ipv6Router net.IP) {
 		}).Info("Restored router address from node_config")
 		return ipv4GW, ipv6Router
 	}
-	return getCiliumHostIPsFromNetDev(option.Config.HostDevice)
+	return getCiliumHostIPsFromNetDev(defaults.HostDevice)
 }
 
 // SetIPsecKeyIdentity sets the IPsec key identity an opaque value used to

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1563,9 +1563,6 @@ type DaemonConfig struct {
 	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
 	ToFQDNsEnableDNSCompression bool
 
-	// HostDevice will be device used by Cilium to connect to the outside world.
-	HostDevice string
-
 	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
 	// sysctl option if `xt_socket` kernel module is not available.
 	EnableXTSocketFallback bool
@@ -2559,7 +2556,6 @@ func (c *DaemonConfig) Populate() {
 	c.EncryptNode = viper.GetBool(EncryptNode)
 	c.EnvoyLogPath = viper.GetString(EnvoyLog)
 	c.ForceLocalPolicyEvalAtSource = viper.GetBool(ForceLocalPolicyEvalAtSource)
-	c.HostDevice = defaults.HostDevice
 	c.HTTPNormalizePath = viper.GetBool(HTTPNormalizePath)
 	c.HTTPIdleTimeout = viper.GetInt(HTTPIdleTimeout)
 	c.HTTPMaxGRPCTimeout = viper.GetInt(HTTPMaxGRPCTimeout)


### PR DESCRIPTION
The host device name is currently stored in option.Config.HostDevice
which is always initialized to defaults.HostDevice and there is no
command line option or other method to change it. Remove the option var
and always consistently hard-code the host device name using
defaults.HostDevice, like already done in several other places in the
code base.
