### PR TITLE
docs: Don't mark pre-upgrade step as "recommended"

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -136,8 +136,8 @@ one stable release to a later stable release.
 
 .. include:: upgrade-warning.rst
 
-Step 1: Upgrade to latest patch version (Recommended)
------------------------------------------------------
+Step 1: Upgrade to latest patch version
+---------------------------------------
 
 When upgrading from one minor release to another minor release, for example
 1.x to 1.y, it is recommended to upgrade to the latest patch release for a


### PR DESCRIPTION
In the upgrade guide, we recommend to first upgrade to the latest patch release before upgrading to a new minor release, to ensure downgrade will work if ever needed. This commit removes the "Recommended" tag on the step title. The worry is that a user who goes a bit too quickly through the guide may skip that step just because it's marked "recommended". Instead the user should read the short text to make an informed decision.

(Discussed before the holidays with Joe and Martynas.)