### PR TITLE
pkg/daemon: Log error when node port init fails

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -507,9 +507,9 @@ func probeCgroupSupportUDP(strict, ipv4 bool) error {
 func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) error {
 	if option.Config.EnableNodePort {
 		if err := node.InitNodePortAddrs(option.Config.Devices, option.Config.LBDevInheritIPAddr); err != nil {
-			msg := "Failed to initialize NodePort addrs."
+			msg := "failed to initialize NodePort addrs."
 			if isKubeProxyReplacementStrict {
-				return fmt.Errorf(msg)
+				return fmt.Errorf(msg+" : %w", err)
 			} else {
 				disableNodePort()
 				log.WithError(err).Warn(msg + " Disabling BPF NodePort.")


### PR DESCRIPTION
Related to the current CI failures on the master branch.

Log the error returned by `InitNodePortAddrs` to get more
information about the failures -

```
2022-01-13T11:47:40.666004653Z level=fatal msg="Error while creating daemon" error="failed to finalise LB initialization: Failed to initialize NodePort addrs." subsys=daemon
```

Signed-off-by: Aditi Ghag <aditi@cilium.io>