### PR TITLE
cmd: Fix issue reading string map type via config map

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -17,7 +17,7 @@ cilium-agent [flags]
       --allow-icmp-frag-needed                               Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
       --allow-localhost string                               Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
       --annotate-k8s-node                                    Annotate Kubernetes node (default true)
-      --api-rate-limit map                                   API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default map[])
+      --api-rate-limit map                                   API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --arping-refresh-period duration                       Period for remote node ARP entry refresh (set 0 to disable) (default 30s)
       --auto-create-cilium-node-resource                     Automatically create CiliumNode resource for own node on startup (default true)
       --auto-direct-node-routes                              Enable automatic L2 routing between nodes
@@ -131,7 +131,7 @@ cilium-agent [flags]
       --endpoint-status strings                              Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
       --envoy-log string                                     Path to a separate Envoy log file, if any
       --exclude-local-address strings                        Exclude CIDR from being recognized as local address
-      --fixed-identity-mapping map                           Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
+      --fixed-identity-mapping map                           Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns
       --force-local-policy-eval-at-source                    Force policy evaluation of all local communication at the source endpoint (default true)
       --gops-port int                                        Port for gops server to listen on (default 9890)
   -h, --help                                                 help for cilium-agent
@@ -196,7 +196,7 @@ cilium-agent [flags]
       --kvstore string                                       Key-value store type
       --kvstore-connectivity-timeout duration                Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
       --kvstore-max-consecutive-quorum-errors int            Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure (default 2)
-      --kvstore-opt map                                      Key-value store options (default map[])
+      --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
       --kvstore-periodic-sync duration                       Periodic KVstore synchronization interval (default 5m0s)
       --label-prefix-file string                             Valid label prefixes file path
       --labels strings                                       List of label prefixes used to determine identity of an endpoint
@@ -204,7 +204,7 @@ cilium-agent [flags]
       --local-router-ipv4 string                             Link-local IPv4 used for Cilium's router devices
       --local-router-ipv6 string                             Link-local IPv6 used for Cilium's router devices
       --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"} (default map[])
+      --log-opt map                                          Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
       --log-system-load                                      Enable periodic logging of system load
       --metrics strings                                      Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
       --monitor-aggregation string                           Level of monitor aggregation for traces from the datapath (default "None")

--- a/Documentation/cmdref/cilium-health.md
+++ b/Documentation/cmdref/cilium-health.md
@@ -19,7 +19,7 @@ cilium-health [flags]
   -h, --help                 help for cilium-health
   -H, --host string          URI to cilium-health server API
       --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health (default map[])
+      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_completion.md
+++ b/Documentation/cmdref/cilium-health_completion.md
@@ -22,7 +22,7 @@ See each sub-command's help for details on how to use the generated script.
   -D, --debug                Enable debug messages
   -H, --host string          URI to cilium-health server API
       --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health (default map[])
+      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_completion_bash.md
+++ b/Documentation/cmdref/cilium-health_completion_bash.md
@@ -45,7 +45,7 @@ cilium-health completion bash
   -D, --debug                Enable debug messages
   -H, --host string          URI to cilium-health server API
       --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health (default map[])
+      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_completion_fish.md
+++ b/Documentation/cmdref/cilium-health_completion_fish.md
@@ -36,7 +36,7 @@ cilium-health completion fish [flags]
   -D, --debug                Enable debug messages
   -H, --host string          URI to cilium-health server API
       --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health (default map[])
+      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_completion_powershell.md
+++ b/Documentation/cmdref/cilium-health_completion_powershell.md
@@ -33,7 +33,7 @@ cilium-health completion powershell [flags]
   -D, --debug                Enable debug messages
   -H, --host string          URI to cilium-health server API
       --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health (default map[])
+      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_completion_zsh.md
+++ b/Documentation/cmdref/cilium-health_completion_zsh.md
@@ -43,7 +43,7 @@ cilium-health completion zsh [flags]
   -D, --debug                Enable debug messages
   -H, --host string          URI to cilium-health server API
       --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health (default map[])
+      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_get.md
+++ b/Documentation/cmdref/cilium-health_get.md
@@ -21,7 +21,7 @@ cilium-health get [flags]
   -D, --debug                Enable debug messages
   -H, --host string          URI to cilium-health server API
       --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health (default map[])
+      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_ping.md
+++ b/Documentation/cmdref/cilium-health_ping.md
@@ -20,7 +20,7 @@ cilium-health ping [flags]
   -D, --debug                Enable debug messages
   -H, --host string          URI to cilium-health server API
       --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health (default map[])
+      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_status.md
+++ b/Documentation/cmdref/cilium-health_status.md
@@ -24,7 +24,7 @@ cilium-health status [flags]
   -D, --debug                Enable debug messages
   -H, --host string          URI to cilium-health server API
       --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health (default map[])
+      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -49,14 +49,14 @@ cilium-operator-alibabacloud [flags]
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
       --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
-      --kvstore-opt map                           Key-value store options (default map[])
+      --kvstore-opt map                           Key-value store options e.g. etcd.address=127.0.0.1:4001
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
-      --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"} (default map[])
+      --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -11,7 +11,7 @@ cilium-operator-aws [flags]
 ### Options
 
 ```
-      --aws-instance-limit-mapping map            Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
+      --aws-instance-limit-mapping map            Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"}
       --aws-release-excess-ips                    Enable releasing excess free IP addresses from AWS ENI.
       --bgp-announce-lb-ip                        Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                    Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
@@ -35,7 +35,7 @@ cilium-operator-aws [flags]
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
-      --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
+      --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
       --excess-ip-release-delay int               Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
       --gops-port int                             Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator-aws
@@ -53,14 +53,14 @@ cilium-operator-aws [flags]
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
       --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
-      --kvstore-opt map                           Key-value store options (default map[])
+      --kvstore-opt map                           Key-value store options e.g. etcd.address=127.0.0.1:4001
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
-      --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"} (default map[])
+      --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -52,14 +52,14 @@ cilium-operator-azure [flags]
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
       --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
-      --kvstore-opt map                           Key-value store options (default map[])
+      --kvstore-opt map                           Key-value store options e.g. etcd.address=127.0.0.1:4001
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
-      --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"} (default map[])
+      --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -48,14 +48,14 @@ cilium-operator-generic [flags]
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
       --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
-      --kvstore-opt map                           Key-value store options (default map[])
+      --kvstore-opt map                           Key-value store options e.g. etcd.address=127.0.0.1:4001
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
-      --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"} (default map[])
+      --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -12,7 +12,7 @@ cilium-operator [flags]
 
 ```
       --alibaba-cloud-vpc-id string               Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --aws-instance-limit-mapping map            Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
+      --aws-instance-limit-mapping map            Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"}
       --aws-release-excess-ips                    Enable releasing excess free IP addresses from AWS ENI.
       --azure-resource-group string               Resource group to use for Azure IPAM
       --azure-subscription-id string              Subscription ID to access Azure API
@@ -40,7 +40,7 @@ cilium-operator [flags]
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
-      --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
+      --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
       --excess-ip-release-delay int               Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
       --gops-port int                             Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator
@@ -58,14 +58,14 @@ cilium-operator [flags]
       --k8s-namespace string                      Name of the Kubernetes namespace in which Cilium Operator is deployed in
       --k8s-service-proxy-name string             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kvstore string                            Key-value store type
-      --kvstore-opt map                           Key-value store options (default map[])
+      --kvstore-opt map                           Key-value store options e.g. etcd.address=127.0.0.1:4001
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
-      --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"} (default map[])
+      --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium_kvstore.md
+++ b/Documentation/cmdref/cilium_kvstore.md
@@ -9,7 +9,7 @@ Direct access to the kvstore
 ```
   -h, --help              help for kvstore
       --kvstore string    kvstore type
-      --kvstore-opt map   kvstore options (default map[])
+      --kvstore-opt map   kvstore options
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium_kvstore_delete.md
+++ b/Documentation/cmdref/cilium_kvstore_delete.md
@@ -28,7 +28,7 @@ cilium kvstore delete --recursive foo
   -D, --debug             Enable debug messages
   -H, --host string       URI to server-side API
       --kvstore string    kvstore type
-      --kvstore-opt map   kvstore options (default map[])
+      --kvstore-opt map   kvstore options
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_kvstore_get.md
+++ b/Documentation/cmdref/cilium_kvstore_get.md
@@ -29,7 +29,7 @@ cilium kvstore get --recursive foo
   -D, --debug             Enable debug messages
   -H, --host string       URI to server-side API
       --kvstore string    kvstore type
-      --kvstore-opt map   kvstore options (default map[])
+      --kvstore-opt map   kvstore options
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_kvstore_set.md
+++ b/Documentation/cmdref/cilium_kvstore_set.md
@@ -29,7 +29,7 @@ cilium kvstore set foo=bar
   -D, --debug             Enable debug messages
   -H, --host string       URI to server-side API
       --kvstore string    kvstore type
-      --kvstore-opt map   kvstore options (default map[])
+      --kvstore-opt map   kvstore options
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_preflight_migrate-identity.md
+++ b/Documentation/cmdref/cilium_preflight_migrate-identity.md
@@ -26,7 +26,7 @@ cilium preflight migrate-identity [flags]
       --k8s-api-server string        Kubernetes api address server (for https use --k8s-kubeconfig-path instead)
       --k8s-kubeconfig-path string   Absolute path of the kubernetes kubeconfig file
       --kvstore string               Key-value store type
-      --kvstore-opt map              Key-value store options (default map[])
+      --kvstore-opt map              Key-value store options e.g. etcd.address=127.0.0.1:4001
 ```
 
 ### Options inherited from parent commands

--- a/Makefile
+++ b/Makefile
@@ -523,6 +523,8 @@ endif
 	$(QUIET) contrib/scripts/check-assert-deep-equals.sh
 	@$(ECHO_CHECK) contrib/scripts/lock-check.sh
 	$(QUIET) contrib/scripts/lock-check.sh
+	@$(ECHO_CHECK) contrib/scripts/check-viper-get-string-map-string.sh
+	$(QUIET) contrib/scripts/check-viper-get-string-map-string.sh
 ifeq ($(SKIP_CUSTOMVET_CHECK),"false")
 	@$(ECHO_CHECK) contrib/scripts/custom-vet-check.sh
 	$(QUIET) contrib/scripts/custom-vet-check.sh

--- a/cilium-health/cmd/root.go
+++ b/cilium-health/cmd/root.go
@@ -59,7 +59,7 @@ func init() {
 	flags.StringP("host", "H", "", "URI to cilium-health server API")
 	flags.StringSlice("log-driver", []string{}, "Logging endpoints to use for example syslog")
 	flags.Var(option.NewNamedMapOptions("log-opts", &logOpts, nil),
-		"log-opt", "Log driver options for cilium-health")
+		"log-opt", "Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent")
 	viper.BindPFlags(flags)
 
 	flags.StringVar(&cmdRefDir, "cmdref", "", "Path to cmdref output directory")

--- a/cilium/cmd/preflight.go
+++ b/cilium/cmd/preflight.go
@@ -63,7 +63,7 @@ func init() {
 	migrateIdentityCmd.Flags().StringVar(&k8sAPIServer, "k8s-api-server", "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")
 	migrateIdentityCmd.Flags().StringVar(&k8sKubeConfigPath, "k8s-kubeconfig-path", "", "Absolute path of the kubernetes kubeconfig file")
 	migrateIdentityCmd.Flags().StringVar(&kvStore, "kvstore", "", "Key-value store type")
-	migrateIdentityCmd.Flags().Var(option.NewNamedMapOptions("kvstore-opts", &kvStoreOpts, nil), "kvstore-opt", "Key-value store options")
+	migrateIdentityCmd.Flags().Var(option.NewNamedMapOptions("kvstore-opts", &kvStoreOpts, nil), "kvstore-opt", "Key-value store options e.g. etcd.address=127.0.0.1:4001")
 	preflightCmd.AddCommand(migrateIdentityCmd)
 
 	validateCNP.Flags().StringVar(&k8sAPIServer, "k8s-api-server", "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -211,7 +211,7 @@ func runApiserver() error {
 	option.BindEnv(option.KVstorePeriodicSync)
 
 	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &option.Config.KVStoreOpt, nil),
-		option.KVStoreOpt, "Key-value store options")
+		option.KVStoreOpt, "Key-value store options e.g. etcd.address=127.0.0.1:4001")
 	option.BindEnv(option.KVStoreOpt)
 
 	flags.StringVar(&cfg.serviceProxyName, option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")

--- a/contrib/scripts/check-viper-get-string-map-string.sh
+++ b/contrib/scripts/check-viper-get-string-map-string.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright 2022 Authors of Cilium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Simple script to make sure viper.GetStringMapString should not be used.
+# Related upstream issue https://github.com/spf13/viper/issues/911
+if grep -r --exclude-dir={.git,_build,vendor,contrib} -i --include \*.go "viper.GetStringMapString" .; then
+  echo "Found viper.GetStringMapString(key) usage. Please use command.GetStringMapString(viper.GetViper(), key) instead";
+  exit 1
+fi

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -449,7 +449,7 @@ func initializeFlags() {
 	option.BindEnvWithLegacyEnvFallback(option.DisableEnvoyVersionCheck, "CILIUM_DISABLE_ENVOY_BUILD")
 
 	flags.Var(option.NewNamedMapOptions(option.FixedIdentityMapping, &option.Config.FixedIdentityMapping, option.Config.FixedIdentityMappingValidator),
-		option.FixedIdentityMapping, "Key-value for the fixed identity mapping which allows to use reserved label for fixed identities")
+		option.FixedIdentityMapping, "Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns")
 	option.BindEnv(option.FixedIdentityMapping)
 
 	flags.Duration(option.IdentityChangeGracePeriod, defaults.IdentityChangeGracePeriod, "Time to wait before using new identity on endpoint identity change")
@@ -527,7 +527,7 @@ func initializeFlags() {
 	option.BindEnv(option.IPAllocationTimeout)
 
 	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &option.Config.KVStoreOpt, nil),
-		option.KVStoreOpt, "Key-value store options")
+		option.KVStoreOpt, "Key-value store options e.g. etcd.address=127.0.0.1:4001")
 	option.BindEnv(option.KVStoreOpt)
 
 	flags.Duration(option.K8sSyncTimeoutName, defaults.K8sSyncTimeout, "Timeout for synchronizing k8s resources before exiting")

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/servak/go-fastping v0.0.0-20160802140958-5718d12e20a0
 	github.com/shirou/gopsutil/v3 v3.21.12
 	github.com/sirupsen/logrus v1.8.1
+	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
@@ -194,7 +195,6 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
-	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -223,7 +223,7 @@ func init() {
 	option.BindEnv(option.KVStore)
 
 	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &option.Config.KVStoreOpt, nil),
-		option.KVStoreOpt, "Key-value store options")
+		option.KVStoreOpt, "Key-value store options e.g. etcd.address=127.0.0.1:4001")
 	option.BindEnv(option.KVStoreOpt)
 
 	flags.String(option.K8sAPIServer, "", "Kubernetes API server URL")

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -446,15 +447,21 @@ func (c *OperatorConfig) Populate() {
 		c.IPAMSubnetsIDs = m
 	}
 
-	if m := viper.GetStringMapString(IPAMSubnetsTags); len(m) != 0 {
+	if m, err := command.GetStringMapStringE(viper.GetViper(), IPAMSubnetsTags); err != nil {
+		log.Fatalf("unable to parse %s: %s", IPAMSubnetsTags, err)
+	} else if len(m) != 0 {
 		c.IPAMSubnetsTags = m
 	}
 
-	if m := viper.GetStringMapString(AWSInstanceLimitMapping); len(m) != 0 {
+	if m, err := command.GetStringMapStringE(viper.GetViper(), AWSInstanceLimitMapping); err != nil {
+		log.Fatalf("unable to parse %s: %s", AWSInstanceLimitMapping, err)
+	} else if len(m) != 0 {
 		c.AWSInstanceLimitMapping = m
 	}
 
-	if m := viper.GetStringMapString(ENITags); len(m) != 0 {
+	if m, err := command.GetStringMapStringE(viper.GetViper(), ENITags); err != nil {
+		log.Fatalf("unable to parse %s: %s", ENITags, err)
+	} else if len(m) != 0 {
 		c.ENITags = m
 	}
 }

--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Authors of Cilium
+
+package command
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/spf13/cast"
+	"github.com/spf13/viper"
+)
+
+var keyValueRegex = regexp.MustCompile(`([\w-:./]+=[\w-:./]+,)*([\w-:./]+=[\w-:./]+)$`)
+
+// GetStringMapString contains one enhancement to support k1=v2,k2=v2 compared to original
+// implementation of GetStringMapString function
+// Related upstream issue https://github.com/spf13/viper/issues/911
+func GetStringMapString(vp *viper.Viper, key string) map[string]string {
+	v, _ := GetStringMapStringE(vp, key)
+	return v
+}
+
+// GetStringMapStringE is same as GetStringMapString, but with error
+func GetStringMapStringE(vp *viper.Viper, key string) (map[string]string, error) {
+	data := vp.Get(key)
+	if data == nil {
+		return map[string]string{}, nil
+	}
+	v, err := cast.ToStringMapStringE(data)
+	if err != nil {
+		var syntaxErr *json.SyntaxError
+		if !errors.As(err, &syntaxErr) {
+			return v, err
+		}
+
+		switch s := data.(type) {
+		case string:
+			if len(s) == 0 {
+				return map[string]string{}, nil
+			}
+
+			// if the input is starting with either '{' or '[', just preserve original json parsing error.
+			firstIndex := strings.IndexFunc(s, func(r rune) bool {
+				return !unicode.IsSpace(r)
+			})
+			if firstIndex != -1 && (s[firstIndex] == '{' || s[firstIndex] == '[') {
+				return v, err
+			}
+
+			if !isValidKeyValuePair(s) {
+				return map[string]string{}, fmt.Errorf("'%s' is not formatted as key=value,key1=value1", s)
+			}
+
+			var v = map[string]string{}
+			kvs := strings.Split(s, ",")
+			for _, kv := range kvs {
+				temp := strings.Split(kv, "=")
+				if len(temp) != 2 {
+					return map[string]string{}, fmt.Errorf("'%s' is not formatted as key=value,key1=value1", s)
+				}
+				v[temp[0]] = temp[1]
+			}
+			return v, nil
+		}
+	}
+	return v, nil
+}
+
+// isValidKeyValuePair returns true if the input is following key1=value1,key2=value2,...,keyN=valueN format.
+func isValidKeyValuePair(str string) bool {
+	if len(str) == 0 {
+		return true
+	}
+	return len(keyValueRegex.ReplaceAllString(str, "")) == 0
+}

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Authors of Cilium
+
+//go:build !privileged_tests
+// +build !privileged_tests
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetStringMapString(t *testing.T) {
+	expectedResult := map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	}
+	type args struct {
+		key   string
+		value string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "valid json format",
+			args: args{
+				key:   "FOO_BAR",
+				value: `{"k1":"v1","k2":"v2"}`,
+			},
+			want:    expectedResult,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "invalid json format with extra comma at the end",
+			args: args{
+				key:   "FOO_BAR",
+				value: `{"k1":"v1","k2":"v2",}`,
+			},
+			want:    map[string]string{},
+			wantErr: assertErrorString("invalid character '}' looking for beginning of object key string"),
+		},
+		{
+			name: "valid single kv format",
+			args: args{
+				key:   "FOO_BAR",
+				value: "k1=v1",
+			},
+			want:    map[string]string{"k1": "v1"},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "valid kv format",
+			args: args{
+				key:   "FOO_BAR",
+				value: "k1=v1,k2=v2",
+			},
+			want:    expectedResult,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "valid kv format with forward slash",
+			args: args{
+				key:   "FOO_BAR",
+				value: "kubernetes.io/cluster/piano-eks-general-blue-01=owned,kubernetes.io/role/internal-elb=1",
+			},
+			want: map[string]string{
+				"kubernetes.io/cluster/piano-eks-general-blue-01": "owned",
+				"kubernetes.io/role/internal-elb":                 "1",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "valid kv format with hyphens",
+			args: args{
+				key:   "FOO_BAR",
+				value: "cluster=my-cluster",
+			},
+			want: map[string]string{
+				"cluster": "my-cluster",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "invalid kv format with extra comma",
+			args: args{
+				key:   "FOO_BAR",
+				value: "k1=v1,k2=v2,",
+			},
+			want:    map[string]string{},
+			wantErr: assertErrorString("'k1=v1,k2=v2,' is not formatted as key=value,key1=value1"),
+		},
+		{
+			name: "invalid kv format with extra equal",
+			args: args{
+				key:   "FOO_BAR",
+				value: "k1=v1,k2==v2",
+			},
+			want:    map[string]string{},
+			wantErr: assertErrorString("'k1=v1,k2==v2' is not formatted as key=value,key1=value1"),
+		},
+		{
+			name: "invalid kv format with wrong space in between",
+			args: args{
+				key:   "FOO_BAR",
+				value: "k1=v1, k2=v2",
+			},
+			want:    map[string]string{},
+			wantErr: assertErrorString("'k1=v1, k2=v2' is not formatted as key=value,key1=value1"),
+		},
+		{
+			name: "malformed json format",
+			args: args{
+				key:   "FOO_BAR",
+				value: `{"k1": "v1",=sdlkfj`,
+			},
+			want:    map[string]string{},
+			wantErr: assertErrorString("invalid character '=' looking for beginning of object key string"),
+		},
+		{
+			name: "staring with valid json beginning value e.g. t, f, n, 0, -, \"",
+			args: args{
+				key:   "FOO_BAR",
+				value: "this is a sentence used in test",
+			},
+			want:    map[string]string{},
+			wantErr: assertErrorString("'this is a sentence used in test' is not formatted as key=value,key1=value1"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			viper.AutomaticEnv()
+			t.Setenv(strings.ToUpper(tt.args.key), tt.args.value)
+			v, err := GetStringMapStringE(viper.GetViper(), strings.ToLower(tt.args.key))
+			tt.wantErr(t, err)
+			assert.Equal(t, tt.want, v)
+		})
+	}
+}
+
+func TestGetStringMapStringConversion(t *testing.T) {
+	viper.Reset()
+	viper.Set("foo_bar", struct{}{})
+	v, err := GetStringMapStringE(viper.GetViper(), "foo_bar")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to cast struct {}{} of type struct {} to map[string]string")
+	assert.Equal(t, map[string]string{}, v)
+}
+
+func Test_isValidKeyValuePair(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "valid format with one pair",
+			args: args{
+				str: "k1=v1",
+			},
+			want: true,
+		},
+		{
+			name: "valid format with hyphen in k and v",
+			args: args{
+				str: "k-1=v-1,k-2=v-2",
+			},
+			want: true,
+		},
+		{
+			name: "valid format with multiple hyphens",
+			args: args{
+				str: "Cluster=piano-eks-general-blue-01",
+			},
+			want: true,
+		},
+		{
+			name: "valid format with colon",
+			args: args{
+				str: "consul.address=127.0.0.1:8500",
+			},
+			want: true,
+		},
+		{
+			name: "valid format with forward slash",
+			args: args{
+				str: "kubernetes.io/cluster/piano-eks-general-blue-01=owned",
+			},
+			want: true,
+		},
+
+		{
+			name: "valid format with multiple pairs",
+			args: args{
+				str: "k1=v1,k2=v2,k3=v3,k4=v4,k4=v4,k4=v4",
+			},
+			want: true,
+		},
+		{
+			name: "empty value",
+			args: args{
+				str: "",
+			},
+			want: true,
+		},
+		{
+			name: "space in between",
+			args: args{
+				str: "k1=v1, k2=v2",
+			},
+			want: false,
+		},
+		{
+			name: "insufficient value",
+			args: args{
+				str: "k1=v1,k2,=v2",
+			},
+			want: false,
+		},
+		{
+			name: "no pair at all",
+			args: args{
+				str: "here is the test",
+			},
+			want: false,
+		},
+		{
+			name: "ending with command",
+			args: args{
+				str: "k1=v1,k2=v2,",
+			},
+			want: false,
+		},
+		{
+			name: "ending with equal",
+			args: args{
+				str: "k1=v1,k2=v2=",
+			},
+			want: false,
+		},
+		{
+			name: "kv separator as space",
+			args: args{
+				str: "k1=v1 k2=v2=",
+			},
+			want: false,
+		},
+		{
+			name: "space in key",
+			args: args{
+				str: "k1=v1, k2=v2",
+			},
+			want: false,
+		},
+		{
+			name: "space in value",
+			args: args{
+				str: "k1=v1,k2= v2",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, isValidKeyValuePair(tt.args.str), "isValidKeyValuePair(%v)", tt.args.str)
+		})
+	}
+}
+
+func assertErrorString(errString string) assert.ErrorAssertionFunc {
+	return func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+		return assert.EqualError(t, err, errString, msgAndArgs)
+	}
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/cidr"
 	clustermeshTypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ip"
@@ -2794,21 +2795,29 @@ func (c *DaemonConfig) Populate() {
 	c.MonitorAggregationFlags = ctMonitorReportFlags
 
 	// Map options
-	if m := viper.GetStringMapString(FixedIdentityMapping); len(m) != 0 {
+	if m := command.GetStringMapString(viper.GetViper(), FixedIdentityMapping); err != nil {
+		log.Fatalf("unable to parse %s: %s", FixedIdentityMapping, err)
+	} else if len(m) != 0 {
 		c.FixedIdentityMapping = m
 	}
 
 	c.ConntrackGCInterval = viper.GetDuration(ConntrackGCInterval)
 
-	if m := viper.GetStringMapString(KVStoreOpt); len(m) != 0 {
+	if m, err := command.GetStringMapStringE(viper.GetViper(), KVStoreOpt); err != nil {
+		log.Fatalf("unable to parse %s: %s", KVStoreOpt, err)
+	} else if len(m) != 0 {
 		c.KVStoreOpt = m
 	}
 
-	if m := viper.GetStringMapString(LogOpt); len(m) != 0 {
+	if m, err := command.GetStringMapStringE(viper.GetViper(), LogOpt); err != nil {
+		log.Fatalf("unable to parse %s: %s", LogOpt, err)
+	} else if len(m) != 0 {
 		c.LogOpt = m
 	}
 
-	if m := viper.GetStringMapString(APIRateLimitName); len(m) != 0 {
+	if m, err := command.GetStringMapStringE(viper.GetViper(), APIRateLimitName); err != nil {
+		log.Fatalf("unable to parse %s: %s", APIRateLimitName, err)
+	} else if len(m) != 0 {
 		c.APIRateLimit = m
 	}
 

--- a/pkg/option/map_options.go
+++ b/pkg/option/map_options.go
@@ -46,7 +46,11 @@ func NewMapOpts(values map[string]string, validator Validator) *MapOptions {
 }
 
 func (opts *MapOptions) String() string {
-	return fmt.Sprintf("%v", opts.vals)
+	var kvs []string
+	for k, v := range opts.vals {
+		kvs = append(kvs, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(kvs, ",")
 }
 
 // Type returns a string name for this Option type


### PR DESCRIPTION
### Description

As mentioned in below upstream issue, there is a discrepancy in viper
while reading string map string data type i.e. kv pair format was not
supported, only `{"k":"v"}` format is allowed. This commit is to wrap
GetStringMapString implementation to handle such case. This is backward
compatible change.

Relates https://github.com/spf13/viper/issues/911
Fixes https://github.com/cilium/cilium/issues/18328

Signed-off-by: Tam Mach <tam.mach@isovalent.com>

### Testing

Testing was done locally as per below

<details>
<summary>before</summary>

```
$ cat tmp/subnet-tags-filter
k1=v1,k2=v2% 

/usr/lib/go-1.17/bin/go build -o /tmp/GoLand/___2go_build_github_com_cilium_cilium_operator github.com/cilium/cilium/operator #gosetup
/tmp/GoLand/___2go_build_github_com_cilium_cilium_operator --config-dir tmp/
level=info msg="Started gops server" address="127.0.0.1:9891" subsys=___2go_build_github_com_cilium_cilium_operator
level=warning msg="Running Cilium with \"kvstore\"=\"\" requires identity allocation via CRDs. Changing identity-allocation-mode to \"crd\"" subsys=config
...
level=info msg="  --subnet-ids-filter=''" subsys=___2go_build_github_com_cilium_cilium_operator
level=info msg="  --subnet-ids-filter=''" subsys=___2go_build_github_com_cilium_cilium_operator --> THIS IS EMPTY
level=info msg="  --synchronize-k8s-nodes='true'" subsys=___2go_build_github_com_cilium_cilium_operator
...
level=info msg="Cilium Operator  go version go1.17 linux/amd64" subsys=___2go_build_github_com_cilium_cilium_operator
```

</details>


<details>
<summary>after</summary>

```
/usr/lib/go-1.17/bin/go build -o /tmp/GoLand/___2go_build_github_com_cilium_cilium_operator github.com/cilium/cilium/operator #gosetup
/tmp/GoLand/___2go_build_github_com_cilium_cilium_operator --config-dir tmp/
level=info msg="Started gops server" address="127.0.0.1:9891" subsys=___2go_build_github_com_cilium_cilium_operator
level=warning msg="Running Cilium with \"kvstore\"=\"\" requires identity allocation via CRDs. Changing identity-allocation-mode to \"crd\"" subsys=config

...
level=info msg="  --subnet-ids-filter=''" subsys=___2go_build_github_com_cilium_cilium_operator
level=info msg="  --subnet-tags-filter='k1=v1,k2=v2'" subsys=___2go_build_github_com_cilium_cilium_operator --> THIS HAS CORRECT VALUE
level=info msg="  --synchronize-k8s-nodes='true'" subsys=___2go_build_github_com_cilium_cilium_operator
...
level=info msg="Cilium Operator  go version go1.17 linux/amd64" subsys=___2go_build_github_com_cilium_cilium_operator
```

</details>


```release-note
cmd: Fix issue reading string map type via config map
```
