### PR TITLE
monitor: Output non-trace messages to stderr

### DIFF
--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -85,7 +85,7 @@ func setupSigHandler() {
 	signal.Notify(signalChan, os.Interrupt)
 	go func() {
 		for range signalChan {
-			fmt.Printf("\nReceived an interrupt, disconnecting from monitor...\n\n")
+			fmt.Fprintf(os.Stderr, "\nReceived an interrupt, disconnecting from monitor...\n\n")
 			os.Exit(0)
 		}
 	}()
@@ -226,7 +226,7 @@ func validateEndpointsFilters() {
 
 func runMonitor(args []string) {
 	if len(args) > 0 {
-		fmt.Println("Error: arguments not recognized")
+		fmt.Fprintln(os.Stderr, "Error: arguments not recognized")
 		os.Exit(1)
 	}
 
@@ -235,11 +235,11 @@ func runMonitor(args []string) {
 	setupSigHandler()
 	if resp, err := client.Daemon.GetHealthz(nil); err == nil {
 		if nm := resp.Payload.NodeMonitor; nm != nil {
-			fmt.Printf("Listening for events on %d CPUs with %dx%d of shared memory\n",
+			fmt.Fprintf(os.Stderr, "Listening for events on %d CPUs with %dx%d of shared memory\n",
 				nm.Cpus, nm.Npages, nm.Pagesize)
 		}
 	}
-	fmt.Printf("Press Ctrl-C to quit\n")
+	fmt.Fprintf(os.Stderr, "Press Ctrl-C to quit\n")
 
 	// On EOF, retry
 	// On other errors, exit


### PR DESCRIPTION
When we use JSON output of cilium monitor, it would be useful if we
could filter the output by the tools like JQ. However, since some of the
non-JSON messages are generated through stdout, it ends up to the JSON
parse error. Fix `cilium monitor` command to generate non-JSON messages
to stderr.

Signed-off-by: Yutaro Hayakawa <yutaro.hayakawa@isovalent.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!