### PR TITLE
Allow `install-no-conntrack-iptables-rules` when masquerading is disabled

### DIFF
--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -51,7 +51,7 @@ bypassing the iptables connection tracker.
 * Kernel >= 4.19.57, >= 5.1.16, >= 5.2
 * Direct-routing configuration
 * eBPF-based kube-proxy replacement
-* eBPF masquerading
+* eBPF-based masquerading or no masquerading
 
 To enable the iptables connection-tracking bypass:
 

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -194,7 +194,7 @@ func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
 			OperationMode:     option.Config.Ipvlan.OperationMode,
 		},
 		IpamMode:   option.Config.IPAM,
-		Masquerade: option.Config.EnableIPv4Masquerade || option.Config.EnableIPv6Masquerade,
+		Masquerade: option.Config.MasqueradingEnabled(),
 		MasqueradeProtocols: &models.DaemonConfigurationStatusMasqueradeProtocols{
 			IPV4: option.Config.EnableIPv4Masquerade,
 			IPV6: option.Config.EnableIPv6Masquerade,

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -401,7 +401,7 @@ func initKubeProxyReplacementOptions() (bool, error) {
 				option.InstallNoConntrackIptRules, option.KubeProxyReplacement, option.KubeProxyReplacementStrict)
 		}
 
-		if !option.Config.EnableBPFMasquerade {
+		if option.Config.MasqueradingEnabled() && !option.Config.EnableBPFMasquerade {
 			return false, fmt.Errorf("%s requires the agent to run with %s.",
 				option.InstallNoConntrackIptRules, option.EnableBPFMasquerade)
 		}

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -115,14 +115,14 @@ func (d *Daemon) getK8sStatus() *models.K8sStatus {
 
 func (d *Daemon) getMasqueradingStatus() *models.Masquerading {
 	s := &models.Masquerading{
-		Enabled: option.Config.EnableIPv4Masquerade || option.Config.EnableIPv6Masquerade,
+		Enabled: option.Config.MasqueradingEnabled(),
 		EnabledProtocols: &models.MasqueradingEnabledProtocols{
 			IPV4: option.Config.EnableIPv4Masquerade,
 			IPV6: option.Config.EnableIPv6Masquerade,
 		},
 	}
 
-	if !option.Config.EnableIPv4Masquerade && !option.Config.EnableIPv6Masquerade {
+	if !option.Config.MasqueradingEnabled() {
 		return s
 	}
 

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -77,8 +77,7 @@ func (ms *MapSweeper) deleteMapIfStale(path string, filename string, endpointID 
 
 func (ms *MapSweeper) checkStaleGlobalMap(path string, filename string) {
 	globalCTinUse := ms.HasGlobalCT() || option.Config.EnableNodePort ||
-		!option.Config.InstallIptRules && (option.Config.EnableIPv4Masquerade ||
-			option.Config.EnableIPv6Masquerade)
+		!option.Config.InstallIptRules && option.Config.MasqueradingEnabled()
 
 	if !globalCTinUse && ctmap.NameIsGlobal(filename) {
 		ms.RemoveMapPath(path)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2180,6 +2180,11 @@ func (c *DaemonConfig) TunnelingEnabled() bool {
 	return c.Tunnel != TunnelDisabled
 }
 
+// MasqueradingEnabled returns true if either IPv4 or IPv6 masquerading is enabled.
+func (c *DaemonConfig) MasqueradingEnabled() bool {
+	return c.EnableIPv4Masquerade || c.EnableIPv6Masquerade
+}
+
 // IptablesMasqueradingIPv4Enabled returns true if iptables-based
 // masquerading is enabled for IPv4.
 func (c *DaemonConfig) IptablesMasqueradingIPv4Enabled() bool {


### PR DESCRIPTION
The first commit introduces a helper function used by the second commit. The second commit allows `install-no-conntrack-iptables-rules` to be used if (1) BPF masquerading is used or if (2) all masquerading is disabled. Until now, it was only allowed for the first condition.

```release-note
Allow using install-no-conntrack-iptables-rules when all masquerading is disabled.
```