### PR TITLE
bpf: Move to-stack trace after host firewall

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1141,11 +1141,6 @@ int to_host(struct __ctx_buff *ctx)
 	 */
 	ctx_change_type(ctx, PACKET_HOST);
 #endif
-
-	if (!traced)
-		send_trace_notify(ctx, TRACE_TO_STACK, src_id, 0, 0,
-				  CILIUM_IFINDEX, 0, 0);
-
 #ifdef ENABLE_HOST_FIREWALL
 	if (!validate_ethertype(ctx, &proto)) {
 		ret = DROP_UNSUPPORTED_L2;
@@ -1182,6 +1177,10 @@ out:
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
 					      METRIC_INGRESS);
+
+	if (!traced)
+		send_trace_notify(ctx, TRACE_TO_STACK, src_id, 0, 0,
+				  CILIUM_IFINDEX, 0, 0);
 
 	return ret;
 }


### PR DESCRIPTION
When host firewall feature is enable, to-stack trace can be generated
even if the packets are rejected by host firewall policies. Generate trace
only when the packets are actually delivered to the stack.

Fixes: #12562
Signed-off-by: Yutaro Hayakawa <yutaro.hayakawa@isovalent.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

```release-note
Fix bug where Hubble flows report that a packet is both forwarded and dropped by host firewall. It will now only report the drop.
```