### PR TITLE
Prevent unmanaged pods in GKE's containerd flavors

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -213,14 +213,14 @@ jobs:
             ${{ env.cost_reduction }} \
             --no-wait
 
-          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoSchedule`
+          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoExecute`
           az aks nodepool add \
             --resource-group ${{ env.name }} \
             --cluster-name ${{ env.name }} \
             --name userpool \
             --mode user \
             --node-count 2 \
-            --node-taints "node.cilium.io/agent-not-ready=true:NoSchedule" \
+            --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
             ${{ env.cost_reduction }} \
             --no-wait
 

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -213,14 +213,14 @@ jobs:
             ${{ env.cost_reduction }} \
             --no-wait
 
-          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoSchedule`
+          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoExecute`
           az aks nodepool add \
             --resource-group ${{ env.name }} \
             --cluster-name ${{ env.name }} \
             --name userpool \
             --mode user \
             --node-count 2 \
-            --node-taints "node.cilium.io/agent-not-ready=true:NoSchedule" \
+            --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
             ${{ env.cost_reduction }} \
             --no-wait
 

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -215,14 +215,14 @@ jobs:
             ${{ env.cost_reduction }} \
             --no-wait
 
-          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoSchedule`
+          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoExecute`
           az aks nodepool add \
             --resource-group ${{ env.name }} \
             --cluster-name ${{ env.name }} \
             --name userpool \
             --mode user \
             --node-count 2 \
-            --node-taints "node.cilium.io/agent-not-ready=true:NoSchedule" \
+            --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
             ${{ env.cost_reduction }} \
             --no-wait
 

--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -194,7 +194,7 @@ jobs:
               taints:
                - key: "node.cilium.io/agent-not-ready"
                  value: "true"
-                 effect: "NoSchedule"
+                 effect: "NoExecute"
           EOF
 
           eksctl create cluster -f ./eks-config.yaml

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -194,7 +194,7 @@ jobs:
               taints:
                - key: "node.cilium.io/agent-not-ready"
                  value: "true"
-                 effect: "NoSchedule"
+                 effect: "NoExecute"
           EOF
 
           eksctl create cluster -f ./eks-config.yaml

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -197,7 +197,7 @@ jobs:
               taints:
                - key: "node.cilium.io/agent-not-ready"
                  value: "true"
-                 effect: "NoSchedule"
+                 effect: "NoExecute"
           EOF
 
           eksctl create cluster -f ./eks-config.yaml

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -206,7 +206,7 @@ jobs:
             taints:
              - key: "node.cilium.io/agent-not-ready"
                value: "true"
-               effect: "NoSchedule"
+               effect: "NoExecute"
           EOF
 
           eksctl create cluster -f ./eks-config.yaml

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -206,7 +206,7 @@ jobs:
             taints:
              - key: "node.cilium.io/agent-not-ready"
                value: "true"
-               effect: "NoSchedule"
+               effect: "NoExecute"
           EOF
 
           eksctl create cluster -f ./eks-config.yaml

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -208,7 +208,7 @@ jobs:
             taints:
              - key: "node.cilium.io/agent-not-ready"
                value: "true"
-               effect: "NoSchedule"
+               effect: "NoExecute"
           EOF
 
           eksctl create cluster -f ./eks-config.yaml

--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -214,7 +214,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-externalworkloads-v1.11.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yml
@@ -214,7 +214,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -216,7 +216,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -188,7 +188,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible
 
       - name: Get cluster credentials

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -188,7 +188,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible
 
       - name: Get cluster credentials

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -190,7 +190,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible
 
       - name: Get cluster credentials

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -192,7 +192,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible \
             --enable-ip-alias
 
@@ -206,7 +206,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible \
             --enable-ip-alias
 

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -192,7 +192,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible \
             --enable-ip-alias
 
@@ -206,7 +206,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible \
             --enable-ip-alias
 

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -194,7 +194,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible \
             --enable-ip-alias
 
@@ -208,7 +208,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --preemptible \
             --enable-ip-alias
 

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -45,9 +45,9 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
            export NAME="$(whoami)-$RANDOM"
            # Create the node pool with the following taint to guarantee that
-           # Pods are only scheduled in the node when Cilium is ready.
+           # Pods are only scheduled/executed in the node when Cilium is ready.
            gcloud container clusters create "${NAME}" \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --zone us-west2-a
            gcloud container clusters get-credentials "${NAME}" --zone us-west2-a
 
@@ -91,14 +91,14 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
              --node-taints "CriticalAddonsOnly=true:NoSchedule" \
              --no-wait
 
-           # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoSchedule`
+           # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoExecute`
            az aks nodepool add \
              --resource-group "${AZURE_RESOURCE_GROUP}" \
              --cluster-name "${NAME}" \
              --name userpool \
              --mode user \
              --node-count 2 \
-             --node-taints "node.cilium.io/agent-not-ready=true:NoSchedule" \
+             --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
              --no-wait
 
            # Delete the initial system node pool
@@ -120,14 +120,14 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
        .. note::
 
           `Node pools <https://aka.ms/aks/nodepools>`_ must be tainted with
-          ``node.cilium.io/agent-not-ready=true:NoSchedule`` to ensure that
-          applications pods will only be scheduled once Cilium is ready to
-          manage them, however on AKS:
+          ``node.cilium.io/agent-not-ready=true:NoExecute`` to ensure that
+          applications pods will only be scheduled/executed once Cilium is ready
+          to manage them, however on AKS:
 
           * It is not possible to assign taints to the initial node pool at this
             time, cf. `Azure/AKS#1402 <https://github.com/Azure/AKS/issues/1402>`_.
 
-          * It is not possible to assign custom node taints such as ``node.cilium.io/agent-not-ready=true:NoSchedule``
+          * It is not possible to assign custom node taints such as ``node.cilium.io/agent-not-ready=true:NoExecute``
             to system node pools, cf. `Azure/AKS#2578 <https://github.com/Azure/AKS/issues/2578>`_.
 
           In order to have Cilium properly manage application pods on AKS with
@@ -137,8 +137,8 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
             with ``CriticalAddonsOnly=true:NoSchedule``, preventing application
             pods from being scheduled on it.
 
-          * Create a secondary user node pool tainted with ``node.cilium.io/agent-not-ready=true:NoSchedule``,
-            preventing application pods from being scheduled on it until Cilium
+          * Create a secondary user node pool tainted with ``node.cilium.io/agent-not-ready=true:NoExecute``,
+            preventing application pods from being scheduled/executed on it until Cilium
             is ready to manage them.
 
     .. group-tab:: EKS
@@ -169,7 +169,7 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
              taints:
               - key: "node.cilium.io/agent-not-ready"
                 value: "true"
-                effect: "NoSchedule"
+                effect: "NoExecute"
            EOF
            eksctl create cluster -f ./eks-config.yaml
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -659,11 +659,11 @@ As an instance example, ``m5n.xlarge`` is used in the config ``nodegroup-config.
       ssh:
         allow: true
       ## taint nodes so that application pods are
-      ## not scheduled until Cilium is deployed.
+      ## not scheduled/executed until Cilium is deployed.
       taints:
         - key: "node.cilium.io/agent-not-ready"
           value: "true"
-          effect: "NoSchedule"
+          effect: "NoExecute"
 
 The nodegroup is created with:
 

--- a/Documentation/gettingstarted/requirements-aks.rst
+++ b/Documentation/gettingstarted/requirements-aks.rst
@@ -23,13 +23,13 @@ Direct Routing  Azure IPAM          Kubernetes CRD
 * Node pools must be properly tainted to ensure applications pods are properly
   managed by Cilium:
 
-  * User node pools must be tainted with ``node.cilium.io/agent-not-ready=true:NoSchedule``
-    to ensure application pods will only be scheduled once Cilium is ready to
+  * User node pools must be tainted with ``node.cilium.io/agent-not-ready=true:NoExecute``
+    to ensure application pods will only be scheduled/executed once Cilium is ready to
     manage them.
 
   * System node pools must be tainted with ``CriticalAddonsOnly=true:NoSchedule``,
     preventing application pods from being scheduled on them. This is necessary
-    because it is not possible to assign custom node taints such as ``node.cilium.io/agent-not-ready=true:NoSchedule``
+    because it is not possible to assign custom node taints such as ``node.cilium.io/agent-not-ready=true:NoExecute``
     to system node pools, cf. `Azure/AKS#2578 <https://github.com/Azure/AKS/issues/2578>`_.
     
     * The initial node pool must be replaced with a new system node pool since

--- a/Documentation/gettingstarted/requirements-eks.rst
+++ b/Documentation/gettingstarted/requirements-eks.rst
@@ -23,7 +23,7 @@ For more information on AWS ENI mode, see :ref:`ipam_eni`.
   Cilium:
 
   * ``managedNodeGroups`` must be tainted with
-    ``node.cilium.io/agent-not-ready=true:NoSchedule`` to ensure application
+    ``node.cilium.io/agent-not-ready=true:NoExecute`` to ensure application
     pods will only be scheduled once Cilium is ready to manage them. For
     example, when using a `ClusterConfig <https://eksctl.io/usage/creating-and-managing-clusters/#using-config-files>`_
     file to create the cluster:
@@ -37,11 +37,11 @@ For more information on AWS ENI mode, see :ref:`ipam_eni`.
         - name: ng-1
           ...
           # taint nodes so that application pods are
-          # not scheduled until Cilium is deployed.
+          # not scheduled/executed until Cilium is deployed.
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"
-             effect: "NoSchedule"
+             effect: "NoExecute"
 
 **Limitations:**
 

--- a/Documentation/gettingstarted/requirements-gke.rst
+++ b/Documentation/gettingstarted/requirements-gke.rst
@@ -11,5 +11,5 @@ Direct Routing  Kubernetes PodCIDR  Kubernetes CRD
 
 **Requirements:**
 
-* The cluster must  be created with the taint ``node.cilium.io/agent-not-ready=true:NoSchedule``
+* The cluster must  be created with the taint ``node.cilium.io/agent-not-ready=true:NoExecute``
   using ``--node-taints`` option.

--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -22,11 +22,85 @@ fi
 {{- end }}
 
 {{- if .Values.nodeinit.reconfigureKubelet }}
-# GKE: Alter the kubelet configuration to run in CNI mode
-echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir={{ .Values.cni.binPath }}"
-mkdir -p {{ .Values.cni.binPath }}
-sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir={{ .Values.cni.binPath }}:g" /etc/default/kubelet
-echo "Restarting kubelet..."
+# Check if we're running on a GKE containerd flavor.
+GKE_KUBERNETES_BIN_DIR="/home/kubernetes/bin"
+if [[ -f "${GKE_KUBERNETES_BIN_DIR}/gke" ]] && command -v containerd &>/dev/null; then
+  echo "GKE *_containerd flavor detected..."
+
+  # (GKE *_containerd) Upon node restarts, GKE's containerd images seem to reset
+  # the /etc directory and our changes to the kubelet and Cilium's CNI
+  # configuration are removed. This leaves room for containerd and its CNI to
+  # take over pods previously managed by Cilium, causing Cilium to lose
+  # ownership over these pods. We rely on the empirical observation that
+  # /home/kubernetes/bin/kubelet is not changed across node reboots, and replace
+  # it with a wrapper script that performs some initialization steps when
+  # required and then hands over control to the real kubelet.
+
+  # Only create the kubelet wrapper if we haven't previously done so.
+  if [[ ! -f "${GKE_KUBERNETES_BIN_DIR}/the-kubelet" ]];
+  then
+    echo "Installing the kubelet wrapper..."
+
+    # Rename the real kubelet.
+    mv "${GKE_KUBERNETES_BIN_DIR}/kubelet" "${GKE_KUBERNETES_BIN_DIR}/the-kubelet"
+
+    # Initialize the kubelet wrapper which lives in the place of the real kubelet.
+    touch "${GKE_KUBERNETES_BIN_DIR}/kubelet"
+    chmod a+x "${GKE_KUBERNETES_BIN_DIR}/kubelet"
+
+    # Populate the kubelet wrapper. It will perform the initialization steps we
+    # need and then become the kubelet.
+    cat <<'EOF' | tee "${GKE_KUBERNETES_BIN_DIR}/kubelet"
+#!/bin/bash
+
+set -euo pipefail
+
+CNI_CONF_DIR="/etc/cni/net.d"
+CONTAINERD_CONFIG="/etc/containerd/config.toml"
+
+# Only stop and start containerd if the Cilium CNI configuration does not exist,
+# or if the 'conf_template' property is present in the containerd config file,
+# in order to avoid unnecessarily restarting containerd.
+if [[ -z "$(find "${CNI_CONF_DIR}" -type f -name '*cilium*')" || \
+      "$(grep -cE '^\s+conf_template' "${CONTAINERD_CONFIG}")" != "0" ]];
+then
+  # Stop containerd as it starts by creating a CNI configuration from a template
+  # causing pods to start with IPs assigned by GKE's CNI.
+  # 'disable --now' is used instead of stop as this script runs concurrently
+  # with containerd on node startup, and hence containerd might not have been
+  # started yet, in which case 'disable' prevents it from starting.
+  echo "Disabling and stopping containerd"
+  systemctl disable --now containerd
+
+  # Remove any pre-existing files in the CNI configuration directory. We skip
+  # any possibly existing Cilium configuration file for the obvious reasons.
+  echo "Removing undesired CNI configuration files"
+  find "${CNI_CONF_DIR}" -type f -not -name '*cilium*' -exec rm {} \;
+
+  # As mentioned above, the containerd configuration needs a little tweak in
+  # order not to create the default CNI configuration, so we update its config.
+  echo "Fixing containerd configuration"
+  sed -Ei 's/^(\s+conf_template)/\#\1/g' "${CONTAINERD_CONFIG}"
+
+  # Start containerd. It won't create it's CNI configuration file anymore.
+  echo "Enabling and starting containerd"
+  systemctl enable --now containerd
+fi
+
+# Become the real kubelet, and pass it some additionally required flags (and
+# place these last so they have precedence).
+exec /home/kubernetes/bin/the-kubelet "${@}" --network-plugin=cni --cni-bin-dir={{ .Values.cni.binPath }}
+EOF
+  else
+    echo "Kubelet wrapper already exists, skipping..."
+  fi
+else
+  # (Generic) Alter the kubelet configuration to run in CNI mode
+  echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir={{ .Values.cni.binPath }}"
+  mkdir -p {{ .Values.cni.binPath }}
+  sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir={{ .Values.cni.binPath }}:g" /etc/default/kubelet
+fi
+echo "Restarting the kubelet..."
 systemctl restart kubelet
 {{- end }}
 


### PR DESCRIPTION
The changes that we have been doing to `/etc/defaults/kubelet` are reset on node reboots, as is apparently the whole `/etc` directory — which also means that `/etc/cni/net.d/05-cilium.conf` is removed.

This would not be a problem if the assumption we made that the node taint we recommend placing on the nodes would come back upon reboots held true, but in practice it doesn't.

Besides this, it seems that containerd will re-instante its CNI configuration file, and it will do so way before Cilium has had the chance to re-run on the node and re-create its CNI configuration, causing pods to be assigned IPs by the default CNI rather than by Cilium in the meantime.

This commit attempts at preventing that from happening by observing that `/home/kubernetes/bin/kubelet` (i.e. the actual kubelet binary) is kept between reboots and executed concurrently with containerd by systemd. We leverage on this empirical observation to replace this file kubelet with a wrapper script that, under the required conditions, disables containerd, patches its configuration, removes undesired CNI configuration files, re-enables containerd and becomes the kubelet.

Additionally, to prevent situations in which the GKE node is forcibly stopped and re-created from causing unmanaged pods, and building on the observation that the node comes back with the same name and pods are already scheduled there, we change the recommended taint effect from `NoSchedule` to `NoExecute`, to cause any previously scheduled pods to be evicted, preventing them from getting IPs assigned by the default CNI.This should not impact other environments due to the nature of `NoExecute`, so we recommend it everywhere.

```release-note
Prevent unmanaged pods in GKE's containerd flavors.
*Important:* Users should update their node taints from `node.cilium.io/agent-not-ready=true:NoSchedule` to `node.cilium.io/agent-not-ready=true:NoExecute`.
*Important:* During the first node reboot after the fix is applied pods may still get IPs from the default CNI as cilium-node-init is only run later in the node startup process. The fix will then be in place for all subsequent reboots.
```