### PR TITLE
v1.10 backports 2022-01-14

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -19,6 +19,7 @@
 #include "lib/maps.h"
 #include "lib/arp.h"
 #include "lib/edt.h"
+#include "lib/qm.h"
 #include "lib/ipv6.h"
 #include "lib/ipv4.h"
 #include "lib/icmp6.h"
@@ -984,6 +985,7 @@ int handle_xgress(struct __ctx_buff *ctx)
 	int ret;
 
 	bpf_clear_meta(ctx);
+	reset_queue_mapping(ctx);
 
 	send_trace_notify(ctx, TRACE_FROM_LXC, SECLABEL, 0, 0, 0, 0,
 			  TRACE_PAYLOAD_LEN);

--- a/bpf/lib/qm.h
+++ b/bpf/lib/qm.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2022 Authors of Cilium */
+
+#ifndef __QM_H_
+#define __QM_H_
+
+#include <bpf/ctx/ctx.h>
+
+static inline void reset_queue_mapping(struct __ctx_buff *ctx __maybe_unused)
+{
+#if defined(RESET_QUEUES) && __ctx_is == __ctx_skb
+	/* Workaround for GH-18311 where veth driver might have recorded
+	 * veth's RX queue mapping instead of leaving it at 0. This can
+	 * cause issues on the phys device where all traffic would only
+	 * hit a single TX queue (given veth device had a single one and
+	 * mapping was left at 1). Reset so that stack picks a fresh queue.
+	 * Kernel fix is at 710ad98c363a ("veth: Do not record rx queue
+	 * hint in veth_xmit").
+	 */
+	ctx->queue_mapping = 0;
+#endif
+}
+
+#endif /* __QM_H_ */

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -47,13 +47,7 @@ func GetBytesPerSec(bandwidth string) (uint64, error) {
 }
 
 func ProbeBandwidthManager() {
-	if option.Config.DryMode || !option.Config.EnableBandwidthManager {
-		return
-	}
-
-	if _, err := sysctl.Read("net.core.default_qdisc"); err != nil {
-		log.Warn("BPF bandwidth manager could not read procfs. Disabling the feature.")
-		option.Config.EnableBandwidthManager = false
+	if option.Config.DryMode {
 		return
 	}
 
@@ -65,6 +59,15 @@ func ProbeBandwidthManager() {
 		if _, ok := h["bpf_skb_ecn_set_ce"]; ok {
 			kernelGood = true
 		}
+	}
+	option.Config.ResetQueueMapping = kernelGood
+	if !option.Config.EnableBandwidthManager {
+		return
+	}
+	if _, err := sysctl.Read("net.core.default_qdisc"); err != nil {
+		log.Warn("BPF bandwidth manager could not read procfs. Disabling the feature.")
+		option.Config.EnableBandwidthManager = false
+		return
 	}
 	if !kernelGood {
 		log.Warn("BPF bandwidth manager needs kernel 5.1 or newer. Disabling the feature.")

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -473,6 +473,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 	}
 
+	if option.Config.ResetQueueMapping {
+		cDefinesMap["RESET_QUEUES"] = "1"
+	}
+
 	if option.Config.EnableBandwidthManager {
 		cDefinesMap["ENABLE_BANDWIDTH_MANAGER"] = "1"
 		cDefinesMap["THROTTLE_MAP"] = bwmap.MapName

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -590,11 +590,16 @@ func (a *crdAllocator) Allocate(ip net.IP, owner string) (*AllocationResult, err
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 	// Update custom resource to reflect the newly allocated IP.
 	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("allocation of IP %s", ip.String()))
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // AllocateWithoutSyncUpstream will attempt to find the specified IP in the
@@ -614,9 +619,14 @@ func (a *crdAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string) (*Al
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // Release will release the specified IP or return an error if the IP has not
@@ -655,11 +665,16 @@ func (a *crdAllocator) AllocateNext(owner string) (*AllocationResult, error) {
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 	// Update custom resource to reflect the newly allocated IP.
 	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("allocation of IP %s", ip.String()))
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // AllocateNextWithoutSyncUpstream allocates the next available IP as offered
@@ -674,9 +689,14 @@ func (a *crdAllocator) AllocateNextWithoutSyncUpstream(owner string) (*Allocatio
 		return nil, err
 	}
 
+	result, err := a.buildAllocationResult(ip, ipInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+	}
+
 	a.markAllocated(ip, owner, *ipInfo)
 
-	return a.buildAllocationResult(ip, ipInfo)
+	return result, nil
 }
 
 // totalPoolSize returns the total size of the allocation pool

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1744,6 +1744,9 @@ type DaemonConfig struct {
 	// EnableBandwidthManager enables EDT-based pacing
 	EnableBandwidthManager bool
 
+	// ResetQueueMapping resets the Pod's skb queue mapping
+	ResetQueueMapping bool
+
 	// EnableRecorder enables the datapath pcap recorder
 	EnableRecorder bool
 

--- a/test/l4lb/Vagrantfile
+++ b/test/l4lb/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
     systemctl enable --now docker
 
     # cgroupv2 requires >= Kind 0.11.0
-    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.0/kind-linux-amd64
+    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
     chmod +x ./kind
     mv ./kind /usr/local/bin
 


### PR DESCRIPTION
* #18352 -- Fix possible IP leak in case ENI's are not present in the CN yet (@codablock)
 * #18370 -- test: bump l4lb Vagrantfile kind to 0.11.1 (@jibi)
 * #18388 -- bpf: Reset Pod's queue mapping in host veth to fix phys dev mq selection (@borkmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18352 18370 18388; do contrib/backporting/set-labels.py $pr done 1.10; done
```