### PR TITLE
v1.11 backports 2022-01-14

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1219,8 +1219,6 @@ considered external to the cluster.
 Host Policies
 =============
 
-.. include:: ../beta.rst
-
 Host policies take the form of a `CiliumClusterwideNetworkPolicy` with a
 :ref:`NodeSelector` instead of an `EndpointSelector`. Host policies can have
 layer 3 and layer 4 rules on both ingress and egress. They cannot have layer

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1514,14 +1514,6 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	// This is necessary because the code inside pkg/k8s.NewService() for
-	// parsing services would not trigger unless NodePort is enabled. Without
-	// NodePort enabled, the external and LB IPs would not be parsed out.
-	if option.Config.BGPAnnounceLBIP {
-		option.Config.EnableNodePort = true
-		log.Infof("Auto-set BPF NodePort (%q) because LB IP announcements via BGP depend on it.", option.EnableNodePort)
-	}
-
 	if option.Config.BGPAnnouncePodCIDR &&
 		(option.Config.IPAM != ipamOption.IPAMClusterPool &&
 			option.Config.IPAM != ipamOption.IPAMKubernetes) {

--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -126,7 +126,7 @@ func (s *MetalLBSpeaker) OnUpdateService(svc *slim_corev1.Service) error {
 	}
 
 	l.Debug("adding event to queue")
-	s.queue.Add(epEvent{
+	s.queue.Add(svcEvent{
 		Meta: meta,
 		op:   Update,
 		id:   svcID,


### PR DESCRIPTION
 * #18358 -- bgp,bugfix: parse ips when converting from slim_core to k8s service (@ldelossa)
 * #18470 -- docs: Remove incorrect beta note for host policies (@pchaigno)
 ~* #17871 -- Skip node ipset updates if iptables masquerading is disabled (@pchaigno)~


Skipped due to conflicts - 

PR: 18431 -- Set debug.verbose to "flow" as a default for all CI runs (@christarazi) -- https://github.com/cilium/cilium/pull/18431
@christarazi Please check if the whitespace changes are intended.

PR: 17980 -- builder: Enable building images on arm64 (@jrajahalme) -- https://github.com/cilium/cilium/pull/17980
Non-trivial conflicts
@jrajahalme 

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18358 18470; do contrib/backporting/set-labels.py $pr done 1.11; done
```