### PR TITLE
vagrant: Generate kubeconfig correctly for netnext

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -613,8 +613,12 @@ function createVm(){
     else
         vagrant up $PROVISION_ARGS $1
         if [ "$?" -eq "0" -a -n "${K8S}" ]; then
-            host_port=$(vagrant port --guest 6443 k8s1)
-            vagrant ssh k8s1 -- cat /home/vagrant/.kube/config | sed "s;server:.*:6443;server: https://k8s1:$host_port;g" > vagrant.kubeconfig
+            hostname=k8s1
+            if [ ! -z "$NETNEXT" -a "$NETNEXT" = "true" -o "$NETNEXT" = "1" ]; then
+                hostname=k8s1+
+            fi
+            host_port=$(vagrant port --guest 6443 $hostname)
+            vagrant ssh $hostname -- cat /home/vagrant/.kube/config | sed "s;server:.*:6443;server: https://k8s1:$host_port;g" > vagrant.kubeconfig
             echo "Add '127.0.0.1 k8s1' to your /etc/hosts to use vagrant.kubeconfig file for kubectl"
         fi
     fi


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

When we start VMs with K8S=1 NETNEXT=1, vagrant.kubeconfig file is not
generated correctly because start.sh tries to `vagrant port` and
`vagrant ssh` with the host name k8s1 instead of k8s1+. Fix it to use
correct host name.

Bit tricky thing in here is we don't modify the host name inside the
kubeconfig from k8s1 to k8s1+. This is because the k8s1+ is the host
name on the Vagrant. Linux inside the VM still uses the host name k8s1.
Therefore we don't modify the "Add '127.0.0.1 k8s1' ~" instruction
sentence as well.
