### PR TITLE
bpf: Forbid implicit int conversions

### DIFF
--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -11,6 +11,7 @@ CLANG_FLAGS += -Wno-address-of-packed-member
 CLANG_FLAGS += -Wno-unknown-warning-option
 CLANG_FLAGS += -Wno-gnu-variable-sized-type-not-at-end
 CLANG_FLAGS += -Wdeclaration-after-statement
+CLANG_FLAGS += -Wimplicit-int-conversion -Wenum-conversion
 LLC_FLAGS := -march=bpf -mattr=dwarfris
 # Mimics the mcpu values set by cilium-agent. See GetBPFCPU().
 ifeq ("$(KERNEL)","49")

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -860,7 +860,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	bpf_clear_meta(ctx);
 
 	if (from_host) {
-		int trace = TRACE_FROM_HOST;
+		enum trace_point trace = TRACE_FROM_HOST;
 		bool from_proxy;
 
 		from_proxy = inherit_identity_from_host(ctx, &identity);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1752,9 +1752,10 @@ drop_err:
 __section("to-container")
 int handle_to_container(struct __ctx_buff *ctx)
 {
-	int ret, trace = TRACE_FROM_STACK;
+	enum trace_point trace = TRACE_FROM_STACK;
 	__u32 identity = 0;
 	__u16 proto;
+	int ret;
 
 	if (!validate_ethertype(ctx, &proto)) {
 		ret = DROP_UNSUPPORTED_L2;

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -73,7 +73,7 @@ ctx_dst_port(const struct bpf_sock_addr *ctx)
 static __always_inline __maybe_unused __be16
 ctx_src_port(const struct bpf_sock *ctx)
 {
-	volatile __u32 sport = ctx->src_port;
+	volatile __u16 sport = (__u16)ctx->src_port;
 
 	return (__be16)bpf_htons(sport);
 }
@@ -534,7 +534,7 @@ static __always_inline int __sock4_pre_bind(struct bpf_sock_addr *ctx,
 		.peer = {
 			.address	= ctx->user_ip4,
 			.port		= ctx_dst_port(ctx),
-			.proto		= ctx->protocol,
+			.proto		= (__u8)ctx->protocol,
 		},
 	};
 	int ret;
@@ -801,7 +801,7 @@ int sock6_xlate_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused,
 
 	build_v4_in_v6(&addr6, fake_ctx.user_ip4);
 	ctx_set_v6_address(ctx, &addr6);
-	ctx_set_port(ctx, fake_ctx.user_port);
+	ctx_set_port(ctx, (__u16)fake_ctx.user_port);
 
 	return 0;
 #endif /* ENABLE_IPV4 */
@@ -890,7 +890,7 @@ sock6_pre_bind_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused)
 
 	build_v4_in_v6(&addr6, fake_ctx.user_ip4);
 	ctx_set_v6_address(ctx, &addr6);
-	ctx_set_port(ctx, fake_ctx.user_port);
+	ctx_set_port(ctx, (__u16)fake_ctx.user_port);
 #endif /* ENABLE_IPV4 */
 	return 0;
 }
@@ -911,7 +911,7 @@ static __always_inline int __sock6_pre_bind(struct bpf_sock_addr *ctx)
 	struct lb6_health val = {
 		.peer = {
 			.port		= ctx_dst_port(ctx),
-			.proto		= ctx->protocol,
+			.proto		= (__u8)ctx->protocol,
 		},
 	};
 	int ret = 0;
@@ -1085,7 +1085,7 @@ sock6_xlate_rev_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused)
 
 	build_v4_in_v6(&addr6, fake_ctx.user_ip4);
 	ctx_set_v6_address(ctx, &addr6);
-	ctx_set_port(ctx, fake_ctx.user_port);
+	ctx_set_port(ctx, (__u16)fake_ctx.user_port);
 
 	return 0;
 #endif /* ENABLE_IPV4 */

--- a/bpf/ep_config.h
+++ b/bpf/ep_config.h
@@ -14,8 +14,8 @@ DEFINE_U32(LXC_IPV4, 0x10203040);
  * Both the LXC_ID and the HOST_EP_ID are defined here to ease compile testing,
  * but in the actual header files, only one of them will be present.
  */
-DEFINE_U32(LXC_ID, 0x2A);
-#define LXC_ID fetch_u32(LXC_ID)
+DEFINE_U16(LXC_ID, 0x2A);
+#define LXC_ID fetch_u16(LXC_ID)
 DEFINE_U32(SECLABEL, 0xfffff);
 #define SECLABEL fetch_u32(SECLABEL)
 DEFINE_U32(SECLABEL_NB, 0xfffff);

--- a/bpf/include/bpf/builtins.h
+++ b/bpf/include/bpf/builtins.h
@@ -141,7 +141,7 @@ static __always_inline __nobuiltin("memset") void memset(void *d, int c,
 	if (__builtin_constant_p(len) && __builtin_constant_p(c) && c == 0)
 		__bpf_memzero(d, len);
 	else
-		__bpf_memset_builtin(d, c, len);
+		__bpf_memset_builtin(d, (__u8)c, len);
 }
 
 static __always_inline __maybe_unused void

--- a/bpf/include/bpf/ctx/skb.h
+++ b/bpf/include/bpf/ctx/skb.h
@@ -98,10 +98,10 @@ ctx_load_meta(const struct __sk_buff *ctx, const __u32 off)
 	return ctx->cb[off];
 }
 
-static __always_inline __maybe_unused __u32
+static __always_inline __maybe_unused __u16
 ctx_get_protocol(const struct __sk_buff *ctx)
 {
-	return ctx->protocol;
+	return (__u16)ctx->protocol;
 }
 
 static __always_inline __maybe_unused __u32

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -235,7 +235,7 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 		case 48: /* struct {ipv6hdr + icmp6hdr} */
 			break;
 		case 40: /* struct ipv6hdr */
-		case 24: /* struct dsr_opt_v6 */
+		case 22: /* struct dsr_opt_v6 */
 			if (data + move_len_v6 + len_diff <= data_end)
 				__bpf_memmove_fwd(data, data + len_diff,
 						  move_len_v6);

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -309,7 +309,7 @@ ctx_load_meta(const struct xdp_md *ctx __maybe_unused, const __u64 off)
 	return 0;
 }
 
-static __always_inline __maybe_unused __u32
+static __always_inline __maybe_unused __u16
 ctx_get_protocol(const struct xdp_md *ctx)
 {
 	void *data_end = ctx_data_end(ctx);

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -224,6 +224,7 @@ function bpf_compile()
 	      -Wno-unknown-warning-option			\
 	      -Wno-gnu-variable-sized-type-not-at-end		\
 	      -Wdeclaration-after-statement			\
+	      -Wimplicit-int-conversion -Wenum-conversion	\
 	      -I. -I$DIR -I$LIB -I$LIB/include			\
 	      -D__NR_CPUS__=$NR_CPUS				\
 	      -DENABLE_ARP_RESPONDER=1				\

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -463,9 +463,11 @@ enum {
 #define LB_LOOKUP_SCOPE_INT	1
 
 /* Cilium metrics direction for dropping/forwarding packet */
-#define METRIC_INGRESS  1
-#define METRIC_EGRESS   2
-#define METRIC_SERVICE  3
+enum metric_dir {
+	METRIC_INGRESS = 1,
+	METRIC_EGRESS,
+	METRIC_SERVICE
+} __packed;
 
 /* Magic ctx->mark identifies packets origination and encryption status.
  *
@@ -612,9 +614,11 @@ enum {
 #define TUPLE_F_RELATED		2	/* Flow represents related packets */
 #define TUPLE_F_SERVICE		4	/* Flow represents packets to service */
 
-#define CT_EGRESS 0
-#define CT_INGRESS 1
-#define CT_SERVICE 2
+enum ct_dir {
+	CT_EGRESS,
+	CT_INGRESS,
+	CT_SERVICE,
+} __packed;
 
 #ifdef ENABLE_NODEPORT
 #define NAT_MIN_EGRESS		NODEPORT_PORT_MIN_NAT

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -626,13 +626,13 @@ enum ct_dir {
 #define NAT_MIN_EGRESS		EPHEMERAL_MIN
 #endif
 
-enum {
+enum ct_status {
 	CT_NEW,
 	CT_ESTABLISHED,
 	CT_REPLY,
 	CT_RELATED,
 	CT_REOPENED,
-};
+} __packed;
 
 /* Service flags (lb{4,6}_service->flags) */
 enum {

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -536,8 +536,8 @@ enum metric_dir {
  * [1]:  https://www.iana.org/assignments/ipv6-parameters/ipv6-parameters.xhtml#ipv6-parameters-2
  */
 #define DSR_IPV6_OPT_TYPE	0x1B
-#define DSR_IPV6_OPT_LEN	0x14	/* to store ipv6 addr + port */
-#define DSR_IPV6_EXT_LEN	0x2	/* = (sizeof(dsr_opt_v6) - 8) / 8 */
+#define DSR_IPV6_OPT_LEN	(sizeof(struct dsr_opt_v6) - 4)
+#define DSR_IPV6_EXT_LEN	((sizeof(struct dsr_opt_v6) - 8) / 8)
 
 /* We cap key index at 4 bits because mark value is used to map ctx to key */
 #define MAX_KEY_INDEX 15

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -515,7 +515,7 @@ ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
 
 static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 						    int off,
-						    int dir __maybe_unused,
+						    enum ct_dir dir __maybe_unused,
 						    struct ipv4_ct_tuple *tuple,
 						    bool *has_l4_header __maybe_unused)
 {
@@ -551,7 +551,7 @@ static __always_inline void ct4_cilium_dbg_tuple(struct __ctx_buff *ctx, __u8 ty
 }
 
 static __always_inline int
-ct_extract_ports4(struct __ctx_buff *ctx, int off, int dir,
+ct_extract_ports4(struct __ctx_buff *ctx, int off, enum ct_dir dir,
 		  struct ipv4_ct_tuple *tuple)
 {
 	int err;
@@ -641,7 +641,7 @@ ct_is_reply4(const void *map, struct __ctx_buff *ctx, int off,
 /* Offset must point to IPv4 header */
 static __always_inline int ct_lookup4(const void *map,
 				      struct ipv4_ct_tuple *tuple,
-				      struct __ctx_buff *ctx, int off, int dir,
+				      struct __ctx_buff *ctx, int off, enum ct_dir dir,
 				      struct ct_state *ct_state, __u32 *monitor)
 {
 	int err, ret = CT_NEW, action = ACTION_UNSPEC;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1031,7 +1031,7 @@ static __always_inline bool
 ct_has_nodeport_egress_entry4(const void *map,
 			      struct ipv4_ct_tuple *ingress_tuple)
 {
-	int prev_flags = ingress_tuple->flags;
+	__u8 prev_flags = ingress_tuple->flags;
 	struct ct_entry *entry;
 
 	ingress_tuple->flags = TUPLE_F_OUT;
@@ -1048,7 +1048,7 @@ static __always_inline bool
 ct_has_nodeport_egress_entry6(const void *map,
 			      struct ipv6_ct_tuple *ingress_tuple)
 {
-	int prev_flags = ingress_tuple->flags;
+	__u8 prev_flags = ingress_tuple->flags;
 	struct ct_entry *entry;
 
 	ingress_tuple->flags = TUPLE_F_OUT;

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -216,7 +216,7 @@ static __always_inline void cilium_dbg_capture2(struct __ctx_buff *ctx, __u8 typ
 	__u64 cap_len = min_t(__u64, TRACE_PAYLOAD_LEN, ctx_len);
 	struct debug_capture_msg msg = {
 		__notify_common_hdr(CILIUM_NOTIFY_DBG_CAPTURE, type),
-		__notify_pktcap_hdr(ctx_len, cap_len),
+		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
 		.arg1	= arg1,
 		.arg2	= arg2,
 	};

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -5,8 +5,8 @@
  * Drop & error notification via perf event ring buffer
  *
  * API:
- * int send_drop_notify(ctx, src, dst, dst_id, reason, exitcode, __u8 direction)
- * int send_drop_notify_error(ctx, error, exitcode, __u8 direction)
+ * int send_drop_notify(ctx, src, dst, dst_id, reason, exitcode, enum metric_dir direction)
+ * int send_drop_notify_error(ctx, error, exitcode, enum metric_dir direction)
  *
  * If DROP_NOTIFY is not defined, the API will be compiled in as a NOP.
  */
@@ -69,9 +69,9 @@ int __send_drop_notify(struct __ctx_buff *ctx)
  *
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
-static __always_inline int send_drop_notify(struct __ctx_buff *ctx, __u32 src,
-					    __u32 dst, __u32 dst_id, int reason,
-					    int exitcode, __u8 direction)
+static __always_inline int
+send_drop_notify(struct __ctx_buff *ctx, __u32 src, __u32 dst, __u32 dst_id,
+		 int reason, int exitcode, enum metric_dir direction)
 {
 	ctx_store_meta(ctx, 0, src);
 	ctx_store_meta(ctx, 1, dst);
@@ -88,16 +88,16 @@ static __always_inline int send_drop_notify(struct __ctx_buff *ctx, __u32 src,
 static __always_inline
 int send_drop_notify(struct __ctx_buff *ctx, __u32 src __maybe_unused,
 		     __u32 dst __maybe_unused, __u32 dst_id __maybe_unused,
-		     int reason, int exitcode, __u8 direction)
+		     int reason, int exitcode, enum metric_dir direction)
 {
-	update_metrics(ctx_full_len(ctx), direction, -reason);
+	update_metrics(ctx_full_len(ctx), direction, (__u8)-reason);
 	return exitcode;
 }
 #endif /* DROP_NOTIFY */
 
 static __always_inline int send_drop_notify_error(struct __ctx_buff *ctx, __u32 src,
 						  int error, int exitcode,
-						  __u8 direction)
+						  enum metric_dir direction)
 {
 	return send_drop_notify(ctx, src, 0, 0, error, exitcode, direction);
 }

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -42,8 +42,8 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 		error = -error;
 
 	msg = (typeof(msg)) {
-		__notify_common_hdr(CILIUM_NOTIFY_DROP, error),
-		__notify_pktcap_hdr(ctx_len, cap_len),
+		__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),
+		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
 		.src_label	= ctx_load_meta(ctx, 0),
 		.dst_label	= ctx_load_meta(ctx, 1),
 		.dst_id		= ctx_load_meta(ctx, 3),
@@ -79,7 +79,7 @@ send_drop_notify(struct __ctx_buff *ctx, __u32 src, __u32 dst, __u32 dst_id,
 	ctx_store_meta(ctx, 3, dst_id);
 	ctx_store_meta(ctx, 4, exitcode);
 
-	update_metrics(ctx_full_len(ctx), direction, -reason);
+	update_metrics(ctx_full_len(ctx), direction, (__u8)-reason);
 	ep_tail_call(ctx, CILIUM_CALL_DROP_NOTIFY);
 
 	return exitcode;

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -129,7 +129,7 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SEND_ICMP6_ECHO_REPLY)
 int tail_icmp6_send_echo_reply(struct __ctx_buff *ctx)
 {
 	int ret, nh_off = ctx_load_meta(ctx, 0);
-	__u8 direction  = ctx_load_meta(ctx, 1);
+	enum metric_dir direction  = (enum metric_dir)ctx_load_meta(ctx, 1);
 
 	ctx_store_meta(ctx, 0, 0);
 	ret = __icmp6_send_echo_reply(ctx, nh_off);
@@ -149,7 +149,7 @@ int tail_icmp6_send_echo_reply(struct __ctx_buff *ctx)
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
 static __always_inline int icmp6_send_echo_reply(struct __ctx_buff *ctx,
-						 int nh_off, __u8 direction)
+						 int nh_off, enum metric_dir direction)
 {
 	ctx_store_meta(ctx, 0, nh_off);
 	ctx_store_meta(ctx, 1, direction);
@@ -333,7 +333,7 @@ int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx __maybe_unused)
 {
 # ifdef BPF_HAVE_CHANGE_TAIL
 	int ret, nh_off = ctx_load_meta(ctx, 0);
-	__u8 direction  = ctx_load_meta(ctx, 1);
+	enum metric_dir direction  = (enum metric_dir)ctx_load_meta(ctx, 1);
 
 	ctx_store_meta(ctx, 0, 0);
 	ret = __icmp6_send_time_exceeded(ctx, nh_off);
@@ -357,7 +357,7 @@ int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx __maybe_unused)
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
 static __always_inline int icmp6_send_time_exceeded(struct __ctx_buff *ctx,
-						    int nh_off, __u8 direction)
+						    int nh_off, enum metric_dir direction)
 {
 	ctx_store_meta(ctx, 0, nh_off);
 	ctx_store_meta(ctx, 1, direction);
@@ -402,7 +402,7 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_HANDLE_ICMP6_NS)
 int tail_icmp6_handle_ns(struct __ctx_buff *ctx)
 {
 	int ret, nh_off = ctx_load_meta(ctx, 0);
-	__u8 direction  = ctx_load_meta(ctx, 1);
+	enum metric_dir direction  = (enum metric_dir)ctx_load_meta(ctx, 1);
 
 	ctx_store_meta(ctx, 0, 0);
 	ret = __icmp6_handle_ns(ctx, nh_off);
@@ -423,7 +423,7 @@ int tail_icmp6_handle_ns(struct __ctx_buff *ctx)
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
 static __always_inline int icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off,
-					   __u8 direction)
+					   enum metric_dir direction)
 {
 	ctx_store_meta(ctx, 0, nh_off);
 	ctx_store_meta(ctx, 1, direction);
@@ -434,7 +434,7 @@ static __always_inline int icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off,
 }
 
 static __always_inline int icmp6_handle(struct __ctx_buff *ctx, int nh_off,
-					struct ipv6hdr *ip6, __u8 direction)
+					struct ipv6hdr *ip6, enum metric_dir direction)
 {
 	union v6addr router_ip;
 	__u8 type = icmp6_load_type(ctx, nh_off);

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -109,12 +109,14 @@ ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 
 static __always_inline int
 ipv4_handle_fragmentation(struct __ctx_buff *ctx,
-			  const struct iphdr *ip4, int l4_off, int ct_dir,
+			  const struct iphdr *ip4, int l4_off,
+			  enum ct_dir ct_dir,
 			  struct ipv4_frag_l4ports *ports,
 			  bool *has_l4_header)
 {
-	int ret, dir;
 	bool is_fragment, not_first_fragment;
+	enum metric_dir dir;
+	int ret;
 
 	struct ipv4_frag_id frag_id = {
 		.daddr = ip4->daddr,

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -318,7 +318,7 @@ bool lb4_svc_is_localredirect(const struct lb4_service *svc __maybe_unused)
 
 static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 					   int l4_off,
-					   int dir __maybe_unused,
+					   enum ct_dir dir __maybe_unused,
 					   __be16 *port,
 					   __maybe_unused struct iphdr *ip4)
 {
@@ -481,7 +481,7 @@ static __always_inline int lb6_extract_key(struct __ctx_buff *ctx __maybe_unused
 					   int l4_off __maybe_unused,
 					   struct lb6_key *key,
 					   struct csum_offset *csum_off,
-					   int dir)
+					   enum ct_dir dir)
 {
 	union v6addr *addr;
 	/* FIXME(brb): set after adding support for different L4 protocols in LB */
@@ -1011,7 +1011,7 @@ static __always_inline int lb4_extract_key(struct __ctx_buff *ctx __maybe_unused
 					   int l4_off __maybe_unused,
 					   struct lb4_key *key,
 					   struct csum_offset *csum_off,
-					   int dir)
+					   enum ct_dir dir)
 {
 	/* FIXME: set after adding support for different L4 protocols in LB */
 	key->proto = 0;

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -588,7 +588,7 @@ lb6_select_backend_id(struct __ctx_buff *ctx,
 		      const struct ipv6_ct_tuple *tuple __maybe_unused,
 		      const struct lb6_service *svc)
 {
-	__u32 slot = (get_prandom_u32() % svc->count) + 1;
+	__u16 slot = (get_prandom_u32() % svc->count) + 1;
 	struct lb6_service *be = lb6_lookup_backend_slot(ctx, key, slot);
 
 	return be ? be->backend_id : 0;
@@ -1116,7 +1116,7 @@ lb4_select_backend_id(struct __ctx_buff *ctx,
 		      const struct ipv4_ct_tuple *tuple __maybe_unused,
 		      const struct lb4_service *svc)
 {
-	__u32 slot = (get_prandom_u32() % svc->count) + 1;
+	__u16 slot = (get_prandom_u32() % svc->count) + 1;
 	struct lb4_service *be = lb4_lookup_backend_slot(ctx, key, slot);
 
 	return be ? be->backend_id : 0;

--- a/bpf/lib/metrics.h
+++ b/bpf/lib/metrics.h
@@ -47,7 +47,7 @@ static __always_inline void update_metrics(__u64 bytes, __u8 direction,
  * @direction:	1: Ingress 2: Egress 3: Service
  * Convert a CT direction into the corresponding one for metrics.
  */
-static __always_inline __u8 ct_to_metrics_dir(__u8 ct_dir)
+static __always_inline enum metric_dir ct_to_metrics_dir(enum ct_dir ct_dir)
 {
 	switch (ct_dir) {
 	case CT_INGRESS:

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -57,7 +57,7 @@ static __always_inline __maybe_unused __be16
 __snat_try_keep_port(__u16 start, __u16 end, __u16 val)
 {
 	return val >= start && val <= end ? val :
-	       __snat_clamp_port_range(start, end, get_prandom_u32());
+	       __snat_clamp_port_range(start, end, (__u16)get_prandom_u32());
 }
 
 static __always_inline __maybe_unused void *
@@ -247,7 +247,7 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 		port = __snat_clamp_port_range(target->min_port,
 					       target->max_port,
 					       retries ? port + 1 :
-					       get_prandom_u32());
+					       (__u16)get_prandom_u32());
 		rtuple.dport = ostate->to_sport = bpf_htons(port);
 	}
 
@@ -734,7 +734,7 @@ static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 		port = __snat_clamp_port_range(target->min_port,
 					       target->max_port,
 					       retries ? port + 1 :
-					       get_prandom_u32());
+					       (__u16)get_prandom_u32());
 		rtuple.dport = ostate->to_sport = bpf_htons(port);
 	}
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -266,7 +266,8 @@ static __always_inline int snat_v4_track_local(struct __ctx_buff *ctx,
 	struct ipv4_ct_tuple tmp;
 	bool needs_ct = false;
 	__u32 monitor = 0;
-	int ret, where;
+	enum ct_dir where;
+	int ret;
 
 	if (state && state->common.host_local) {
 		needs_ct = true;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -19,10 +19,10 @@
 #include "conntrack_map.h"
 #include "icmp6.h"
 
-enum {
+enum  nat_dir {
 	NAT_DIR_EGRESS  = TUPLE_F_OUT,
 	NAT_DIR_INGRESS = TUPLE_F_IN,
-};
+} __packed;
 
 struct nat_entry {
 	__u64 created;
@@ -259,7 +259,7 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 static __always_inline int snat_v4_track_local(struct __ctx_buff *ctx,
 					       const struct ipv4_ct_tuple *tuple,
 					       const struct ipv4_nat_entry *state,
-					       int dir, __u32 off,
+					       enum nat_dir dir, __u32 off,
 					       const struct ipv4_nat_target *target)
 {
 	struct ct_state ct_state;
@@ -300,7 +300,7 @@ static __always_inline int snat_v4_handle_mapping(struct __ctx_buff *ctx,
 						  struct ipv4_ct_tuple *tuple,
 						  struct ipv4_nat_entry **state,
 						  struct ipv4_nat_entry *tmp,
-						  int dir, __u32 off,
+						  enum nat_dir dir, __u32 off,
 						  const struct ipv4_nat_target *target)
 {
 	int ret;
@@ -432,9 +432,10 @@ static __always_inline int snat_v4_rewrite_ingress(struct __ctx_buff *ctx,
 	return 0;
 }
 
-static __always_inline bool snat_v4_can_skip(const struct ipv4_nat_target *target,
-					     const struct ipv4_ct_tuple *tuple, int dir,
-					     bool from_endpoint, bool icmp_echoreply)
+static __always_inline bool
+snat_v4_can_skip(const struct ipv4_nat_target *target,
+		 const struct ipv4_ct_tuple *tuple, enum nat_dir dir,
+		 bool from_endpoint, bool icmp_echoreply)
 {
 	__u16 dport = bpf_ntohs(tuple->dport), sport = bpf_ntohs(tuple->sport);
 
@@ -501,9 +502,9 @@ static __always_inline __maybe_unused int snat_v4_create_dsr(struct __ctx_buff *
 	return CTX_ACT_OK;
 }
 
-static __always_inline __maybe_unused int snat_v4_process(struct __ctx_buff *ctx, int dir,
-						const struct ipv4_nat_target *target,
-						bool from_endpoint)
+static __always_inline __maybe_unused int
+snat_v4_process(struct __ctx_buff *ctx, enum nat_dir dir,
+		const struct ipv4_nat_target *target, bool from_endpoint)
 {
 	struct icmphdr icmphdr __align_stack_8;
 	struct ipv4_nat_entry *state, tmp;
@@ -570,7 +571,7 @@ static __always_inline __maybe_unused int snat_v4_process(struct __ctx_buff *ctx
 #else
 static __always_inline __maybe_unused
 int snat_v4_process(struct __ctx_buff *ctx __maybe_unused,
-		    int dir __maybe_unused,
+		    enum nat_dir dir __maybe_unused,
 		    const struct ipv4_nat_target *target __maybe_unused,
 		    bool from_endpoint __maybe_unused)
 {
@@ -744,7 +745,7 @@ static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 static __always_inline int snat_v6_track_local(struct __ctx_buff *ctx,
 					       struct ipv6_ct_tuple *tuple,
 					       const struct ipv6_nat_entry *state,
-					       int dir, __u32 off,
+					       enum nat_dir dir, __u32 off,
 					       const struct ipv6_nat_target *target)
 {
 	struct ct_state ct_state;
@@ -785,7 +786,7 @@ static __always_inline int snat_v6_handle_mapping(struct __ctx_buff *ctx,
 						  struct ipv6_ct_tuple *tuple,
 						  struct ipv6_nat_entry **state,
 						  struct ipv6_nat_entry *tmp,
-						  int dir, __u32 off,
+						  enum nat_dir dir, __u32 off,
 						  const struct ipv6_nat_target *target)
 {
 	int ret;
@@ -900,9 +901,10 @@ static __always_inline int snat_v6_rewrite_ingress(struct __ctx_buff *ctx,
 	return 0;
 }
 
-static __always_inline bool snat_v6_can_skip(const struct ipv6_nat_target *target,
-					     const struct ipv6_ct_tuple *tuple, int dir,
-						 bool icmp_echoreply)
+static __always_inline bool
+snat_v6_can_skip(const struct ipv6_nat_target *target,
+		 const struct ipv6_ct_tuple *tuple, enum nat_dir dir,
+		 bool icmp_echoreply)
 {
 	__u16 dport = bpf_ntohs(tuple->dport), sport = bpf_ntohs(tuple->sport);
 
@@ -972,8 +974,9 @@ static __always_inline __maybe_unused int snat_v6_create_dsr(struct __ctx_buff *
 	return CTX_ACT_OK;
 }
 
-static __always_inline __maybe_unused int snat_v6_process(struct __ctx_buff *ctx, int dir,
-					   const struct ipv6_nat_target *target)
+static __always_inline __maybe_unused int
+snat_v6_process(struct __ctx_buff *ctx, enum nat_dir dir,
+		const struct ipv6_nat_target *target)
 {
 	struct icmp6hdr icmp6hdr __align_stack_8;
 	struct ipv6_nat_entry *state, tmp;
@@ -1050,7 +1053,7 @@ static __always_inline __maybe_unused int snat_v6_process(struct __ctx_buff *ctx
 #else
 static __always_inline __maybe_unused
 int snat_v6_process(struct __ctx_buff *ctx __maybe_unused,
-		    int dir __maybe_unused,
+		    enum nat_dir dir __maybe_unused,
 		    const struct ipv6_nat_target *target __maybe_unused)
 {
 	return CTX_ACT_OK;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -582,7 +582,7 @@ drop_err:
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT)
 int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 {
-	int ret, dir = ctx_load_meta(ctx, CB_NAT);
+	enum nat_dir dir = (enum nat_dir)ctx_load_meta(ctx, CB_NAT);
 	union v6addr tmp = IPV6_DIRECT_ROUTING;
 	struct bpf_fib_lookup_padded fib_params = {
 		.l = {
@@ -598,6 +598,7 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	bool l2_hdr_required = true;
+	int ret;
 
 	target.addr = tmp;
 #ifdef TUNNEL_MODE
@@ -1560,7 +1561,7 @@ drop_err:
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_NAT)
 int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 {
-	int ret, dir = ctx_load_meta(ctx, CB_NAT);
+	enum nat_dir dir = (enum nat_dir)ctx_load_meta(ctx, CB_NAT);
 	struct bpf_fib_lookup_padded fib_params = {
 		.l = {
 			.family		= AF_INET,
@@ -1575,6 +1576,7 @@ int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 	void *data, *data_end;
 	struct iphdr *ip4;
 	bool l2_hdr_required = true;
+	int ret;
 
 	target.addr = IPV4_DIRECT_ROUTING;
 #ifdef TUNNEL_MODE

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -306,7 +306,7 @@ static __always_inline int dsr_set_ipip6(struct __ctx_buff *ctx,
 static __always_inline int dsr_set_ext6(struct __ctx_buff *ctx,
 					struct ipv6hdr *ip6,
 					union v6addr *svc_addr,
-					__be32 svc_port, int *ohead)
+					__be16 svc_port, int *ohead)
 {
 	struct dsr_opt_v6 opt __align_stack_8 = {};
 	__u16 payload_len = bpf_ntohs(ip6->payload_len) + sizeof(opt);
@@ -438,12 +438,14 @@ static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
 	__u64 len_old = ctx_full_len(ctx);
 	void *data_end = ctx_data_end(ctx);
 	void *data = ctx_data(ctx);
+	__u8 reason = (__u8)-code;
 	__wsum wsum;
 	union macaddr smac, dmac;
 	struct icmp6hdr icmp __align_stack_8 = {
 		.icmp6_type	= ICMPV6_PKT_TOOBIG,
 		.icmp6_mtu	= bpf_htonl(THIS_MTU - ohead),
 	};
+	__u64 payload_len = sizeof(*ip6) + sizeof(icmp) + orig_dgram;
 	struct ipv6hdr ip __align_stack_8 = {
 		.version	= 6,
 		.priority	= ip6->priority,
@@ -454,10 +456,10 @@ static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
 		.hop_limit	= IPDEFTTL,
 		.saddr		= ip6->daddr,
 		.daddr		= ip6->saddr,
-		.payload_len	= bpf_htons(sizeof(icmp) + len_new - off),
+		.payload_len	= bpf_htons((__u16)payload_len),
 	};
 
-	update_metrics(ctx_full_len(ctx), METRIC_EGRESS, -code);
+	update_metrics(ctx_full_len(ctx), METRIC_EGRESS, reason);
 
 	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
 		goto drop_err;
@@ -507,6 +509,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 			.ifindex	= DIRECT_ROUTING_DEV_IFINDEX,
 		},
 	};
+	__u16 port __maybe_unused;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	union v6addr addr;
@@ -527,8 +530,8 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 	ret = dsr_set_ipip6(ctx, ip6, &addr,
 			    ctx_load_meta(ctx, CB_HINT), &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
-	ret = dsr_set_ext6(ctx, ip6, &addr,
-			   ctx_load_meta(ctx, CB_PORT), &ohead);
+	port = (__u16)ctx_load_meta(ctx, CB_PORT);
+	ret = dsr_set_ext6(ctx, ip6, &addr, port, &ohead);
 #else
 # error "Invalid load balancer DSR encapsulation mode!"
 #endif
@@ -790,7 +793,7 @@ skip_service_lookup:
 redo:
 			ct_state_new.src_sec_id = SECLABEL;
 			ct_state_new.node_port = 1;
-			ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
+			ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 			ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
 					 CT_EGRESS, &ct_state_new, false);
 			if (IS_ERR(ret))
@@ -1235,7 +1238,7 @@ static __always_inline __be32 rss_gen_src4(__be32 client, __be32 l4_hint)
 static __always_inline int dsr_set_ipip4(struct __ctx_buff *ctx,
 					 const struct iphdr *ip4,
 					 __be32 backend_addr,
-					 __be32 l4_hint, int *ohead)
+					 __be32 l4_hint, __be16 *ohead)
 {
 	__u16 tot_len = bpf_ntohs(ip4->tot_len) + sizeof(*ip4);
 	const int l3_off = ETH_HLEN;
@@ -1288,7 +1291,7 @@ static __always_inline int dsr_set_ipip4(struct __ctx_buff *ctx,
 #elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
 static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 					struct iphdr *ip4, __be32 svc_addr,
-					__be32 svc_port, int *ohead)
+					__be32 svc_port, __be16 *ohead)
 {
 	__u32 iph_old, iph_new, opt[2];
 	__u16 tot_len = bpf_ntohs(ip4->tot_len) + sizeof(opt);
@@ -1354,7 +1357,8 @@ static __always_inline int handle_dsr_v4(struct __ctx_buff *ctx, bool *dsr)
 	 */
 	if (ip4->ihl == 0x7) {
 		__u32 opt1 = 0, opt2 = 0;
-		__be32 address, dport;
+		__be32 address;
+		__be16 dport;
 
 		if (ctx_load_bytes(ctx, ETH_HLEN + sizeof(struct iphdr),
 				   &opt1, sizeof(opt1)) < 0)
@@ -1401,7 +1405,7 @@ static __always_inline int xlate_dsr_v4(struct __ctx_buff *ctx,
 
 static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
 					   struct iphdr *ip4 __maybe_unused,
-					   int code, int ohead __maybe_unused)
+					   int code, __be16 ohead __maybe_unused)
 {
 #ifdef ENABLE_DSR_ICMP_ERRORS
 	const __s32 orig_dgram = 8, off = ETH_HLEN;
@@ -1409,6 +1413,7 @@ static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
 	__be16 type = bpf_htons(ETH_P_IP);
 	__s32 len_new = off + ipv4_hdrlen(ip4) + orig_dgram;
 	__s32 len_old = ctx_full_len(ctx);
+	__u8 reason = (__u8)-code;
 	__u8 tmp[l3_max];
 	union macaddr smac, dmac;
 	struct icmphdr icmp __align_stack_8 = {
@@ -1420,6 +1425,7 @@ static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
 			},
 		},
 	};
+	__u64 tot_len = sizeof(struct iphdr) + ipv4_hdrlen(ip4) + sizeof(icmp) + orig_dgram;
 	struct iphdr ip __align_stack_8 = {
 		.ihl		= sizeof(ip) >> 2,
 		.version	= IPVERSION,
@@ -1430,11 +1436,10 @@ static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
 		.saddr		= ip4->daddr,
 		.daddr		= ip4->saddr,
 		.frag_off	= bpf_htons(IP_DF),
-		.tot_len	= bpf_htons(sizeof(ip) + sizeof(icmp) +
-					    len_new - off),
+		.tot_len	= bpf_htons((__u16)tot_len),
 	};
 
-	update_metrics(ctx_full_len(ctx), METRIC_EGRESS, -code);
+	update_metrics(ctx_full_len(ctx), METRIC_EGRESS, reason);
 
 	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
 		goto drop_err;
@@ -1492,10 +1497,11 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 			.ifindex	= DIRECT_ROUTING_DEV_IFINDEX,
 		},
 	};
-	void *data, *data_end;
-	int ret, ohead = 0;
-	struct iphdr *ip4;
 	bool l2_hdr_required = true;
+	void *data, *data_end;
+	struct iphdr *ip4;
+	__be16 ohead = 0;
+	int ret;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
 		ret = DROP_INVALID;
@@ -1777,7 +1783,7 @@ skip_service_lookup:
 redo:
 			ct_state_new.src_sec_id = SECLABEL;
 			ct_state_new.node_port = 1;
-			ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
+			ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 			ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
 					 CT_EGRESS, &ct_state_new, false);
 			if (IS_ERR(ret))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -86,7 +86,7 @@ struct dsr_opt_v6 {
 	__u8 opt_type;
 	__u8 opt_len;
 	union v6addr addr;
-	__be32 port;
+	__be16 port;
 };
 #endif /* ENABLE_IPV6 */
 

--- a/bpf/lib/pcap.h
+++ b/bpf/lib/pcap.h
@@ -410,7 +410,7 @@ cilium_capture_classify_wcard(struct __ctx_buff *ctx)
 static __always_inline bool
 cilium_capture_candidate(struct __ctx_buff *ctx __maybe_unused,
 			 __u16 *rule_id __maybe_unused,
-			 __u32 *cap_len __maybe_unused)
+			 __u16 *cap_len __maybe_unused)
 {
 	if (capture_enabled) {
 		struct capture_cache *c;
@@ -422,7 +422,7 @@ cilium_capture_candidate(struct __ctx_buff *ctx __maybe_unused,
 			r = cilium_capture_classify_wcard(ctx);
 			c->rule_seen = r;
 			if (r) {
-				c->cap_len = *cap_len = r->cap_len;
+				c->cap_len = *cap_len = (__u16)r->cap_len;
 				c->rule_id = *rule_id = r->rule_id;
 				return true;
 			}
@@ -457,7 +457,7 @@ cilium_capture_cached(struct __ctx_buff *ctx __maybe_unused,
 static __always_inline void
 cilium_capture_in(struct __ctx_buff *ctx __maybe_unused)
 {
-	__u32 cap_len;
+	__u16 cap_len;
 	__u16 rule_id;
 
 	if (cilium_capture_candidate(ctx, &rule_id, &cap_len))

--- a/bpf/lib/policy_log.h
+++ b/bpf/lib/policy_log.h
@@ -60,7 +60,7 @@ send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_POLICY_VERDICT, 0),
-		__notify_pktcap_hdr(ctx_len, cap_len),
+		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
 		.remote_label	= remote_label,
 		.verdict	= verdict,
 		.dst_port	= bpf_ntohs(dst_port),

--- a/bpf/lib/static_data.h
+++ b/bpf/lib/static_data.h
@@ -10,12 +10,14 @@
 #include "endian.h"
 
 /* fetch_* macros assist in fetching variously sized static data */
+#define fetch_u16(x) (__u16)__fetch(x)
 #define fetch_u32(x) __fetch(x)
 #define fetch_u32_i(x, i) __fetch(x ## _ ## i)
 #define fetch_ipv6(x) fetch_u32_i(x, 1), fetch_u32_i(x, 2), fetch_u32_i(x, 3), fetch_u32_i(x, 4)
 #define fetch_mac(x) { { fetch_u32_i(x, 1), (__u16)fetch_u32_i(x, 2) } }
 
 /* DEFINE_* macros help to declare static data. */
+#define DEFINE_U16(NAME, value) volatile __u16 NAME = value
 #define DEFINE_U32(NAME, value) volatile __u32 NAME = value
 #define DEFINE_U32_I(NAME, i) volatile __u32 NAME ## _ ## i
 #define DEFINE_IPV6(NAME,									\

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -187,7 +187,7 @@ send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr(ctx_len, cap_len),
+		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
@@ -218,7 +218,7 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr(ctx_len, cap_len),
+		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
@@ -250,7 +250,7 @@ send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr(ctx_len, cap_len),
+		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -100,6 +100,8 @@ update_trace_metrics(struct __ctx_buff *ctx, __u8 obs_point, enum trace_reason r
 		update_metrics(ctx_full_len(ctx), METRIC_EGRESS,
 			       REASON_FORWARDED);
 		break;
+	case TRACE_FROM_HOST:
+	case TRACE_FROM_STACK:
 	case TRACE_FROM_OVERLAY:
 	case TRACE_FROM_NETWORK:
 		encrypted = reason & TRACE_REASON_ENCRYPTED;

--- a/bpf/sockops/bpf_redir.c
+++ b/bpf/sockops/bpf_redir.c
@@ -60,7 +60,7 @@ int bpf_redir_proxy(struct sk_msg_md *msg)
 	else
 		dst_id = WORLD_ID;
 
-	verdict = policy_sk_egress(dst_id, key.sip4, key.dport);
+	verdict = policy_sk_egress(dst_id, key.sip4, (__u16)key.dport);
 	if (verdict >= 0)
 		msg_redirect_hash(msg, &SOCK_OPS_MAP, &key, flags);
 	return SK_PASS;

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -44,7 +44,7 @@ static __always_inline void sk_lb4_key(struct lb4_key *lb4,
 {
 	/* SK MSG is always egress, so use daddr */
 	lb4->address = key->dip4;
-	lb4->dport = key->dport;
+	lb4->dport = (__u16)key->dport;
 }
 
 static __always_inline bool redirect_to_proxy(int verdict)
@@ -82,7 +82,7 @@ static inline void bpf_sock_ops_ipv4(struct bpf_sock_ops *skops)
 			dst_id = WORLD_ID;
 	}
 
-	verdict = policy_sk_egress(dst_id, key.sip4, key.dport);
+	verdict = policy_sk_egress(dst_id, key.sip4, (__u16)key.dport);
 	if (redirect_to_proxy(verdict)) {
 		__be32 host_ip = IPV4_GATEWAY;
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -782,7 +782,7 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 		}
 
 		fmt.Fprint(fw, defineIPv4("LXC_IPV4", e.IPv4Address()))
-		fmt.Fprint(fw, defineUint32("LXC_ID", uint32(e.GetID())))
+		fmt.Fprint(fw, defineUint16("LXC_ID", uint16(e.GetID())))
 	}
 
 	fmt.Fprint(fw, defineMAC("NODE_MAC", e.GetNodeMAC()))

--- a/pkg/datapath/linux/config/utils.go
+++ b/pkg/datapath/linux/config/utils.go
@@ -18,6 +18,12 @@ func FmtDefineAddress(name string, addr []byte) string {
 	return fmt.Sprintf("#define %s { .addr = { %s } }\n", name, common.GoArray2C(addr))
 }
 
+// defineUint16 writes the C definition for an unsigned 16-bit value.
+func defineUint16(name string, value uint16) string {
+	return fmt.Sprintf("DEFINE_U16(%s, %#04x);\t/* %d */\n#define %s fetch_u16(%s)\n",
+		name, value, value, name, name)
+}
+
 // defineUint32 writes the C definition for an unsigned 32-bit value.
 func defineUint32(name string, value uint32) string {
 	return fmt.Sprintf("DEFINE_U32(%s, %#08x);\t/* %d */\n#define %s fetch_u32(%s)\n",

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -93,7 +93,9 @@ var (
 		"-Wno-address-of-packed-member",
 		"-Wno-unknown-warning-option",
 		"-Wno-gnu-variable-sized-type-not-at-end",
-		"-Wdeclaration-after-statement"}
+		"-Wdeclaration-after-statement",
+		"-Wimplicit-int-conversion",
+		"-Wenum-conversion"}
 	standardLDFlags = []string{"-march=bpf"}
 
 	// testIncludes allows the unit tests to inject additional include

--- a/pkg/elf/elf.go
+++ b/pkg/elf/elf.go
@@ -139,10 +139,13 @@ processSymbols:
 		var value []byte
 		switch symbol.kind {
 		case symbolData:
-			if symbol.size == uint64(unsafe.Sizeof(uint32(0))) {
-				if v, exists := intOptions[symbol.name]; exists {
-					value = make([]byte, symbol.size)
+			if v, exists := intOptions[symbol.name]; exists {
+				value = make([]byte, symbol.size)
+				switch uintptr(symbol.size) {
+				case unsafe.Sizeof(uint32(0)):
 					elf.metadata.ByteOrder.PutUint32(value, v)
+				case unsafe.Sizeof(uint16(0)):
+					elf.metadata.ByteOrder.PutUint16(value, uint16(v))
 				}
 			}
 

--- a/pkg/elf/elf.go
+++ b/pkg/elf/elf.go
@@ -138,7 +138,7 @@ processSymbols:
 		// Figure out the value to substitute
 		var value []byte
 		switch symbol.kind {
-		case symbolUint32:
+		case symbolData:
 			if symbol.size == uint64(unsafe.Sizeof(uint32(0))) {
 				if v, exists := intOptions[symbol.name]; exists {
 					value = make([]byte, symbol.size)

--- a/pkg/elf/elf_test.go
+++ b/pkg/elf/elf_test.go
@@ -96,7 +96,7 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 		{
 			description:  "test constant substitution 1",
 			key:          "FOO",
-			kind:         symbolUint32,
+			kind:         symbolData,
 			intValue:     42,
 			elfValid:     validOptions,
 			elfChangeErr: errDifferentFiles,
@@ -104,7 +104,7 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 		{
 			description:  "test constant substitution 2",
 			key:          "BAR",
-			kind:         symbolUint32,
+			kind:         symbolData,
 			intValue:     42,
 			elfValid:     validOptions,
 			elfChangeErr: errDifferentFiles,
@@ -130,7 +130,7 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 		testOptions = append(testOptions, testOption{
 			description:  fmt.Sprintf("test ipv6 substitution %d", i),
 			key:          fmt.Sprintf("GLOBAL_IPV6_%d", i),
-			kind:         symbolUint32,
+			kind:         symbolData,
 			intValue:     42,
 			elfValid:     validOptions,
 			elfChangeErr: errDifferentFiles,
@@ -141,7 +141,7 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 		testOptions = append(testOptions, testOption{
 			description:  fmt.Sprintf("test mac substitution %d", i),
 			key:          fmt.Sprintf("LOCAL_MAC_%d", i),
-			kind:         symbolUint32,
+			kind:         symbolData,
 			intValue:     42,
 			elfValid:     validOptions,
 			elfChangeErr: errDifferentFiles,
@@ -155,7 +155,7 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 		intOptions := make(map[string]uint32)
 		strOptions := make(map[string]string)
 		switch test.kind {
-		case symbolUint32:
+		case symbolData:
 			intOptions[test.key] = test.intValue
 		case symbolString:
 			strOptions[test.key] = test.strValue
@@ -180,7 +180,7 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 		defer modifiedElf.Close()
 
 		switch test.kind {
-		case symbolUint32:
+		case symbolData:
 			value, err := modifiedElf.readOption(test.key)
 			c.Assert(err, IsNil)
 			c.Assert(value, Equals, test.intValue)

--- a/pkg/elf/symbols.go
+++ b/pkg/elf/symbols.go
@@ -34,14 +34,14 @@ const (
 type symbolKind uint32
 
 const (
-	symbolUint32 = symbolKind(1)
+	symbolData   = symbolKind(1)
 	symbolString = symbolKind(2)
 )
 
 func (k symbolKind) String() string {
 	switch k {
-	case symbolUint32:
-		return "uint32"
+	case symbolData:
+		return "data"
 	case symbolString:
 		return "string"
 	}
@@ -67,7 +67,7 @@ func newSymbol(name string, kind symbolKind, offset, size uint64) symbol {
 }
 
 func newVariable(name string, offset, size uint64) symbol {
-	return newSymbol(name, symbolUint32, offset, size)
+	return newSymbol(name, symbolData, offset, size)
 }
 
 func newString(name string, offset uint64) symbol {


### PR DESCRIPTION
This pull request enables flag `-Wimplicit-int-conversion` in Clang to forbid implicit integer conversions. Enforcing this restriction at the compiler would have allowed us to avoid 1cf3ef3 ("bpf: Fix invalid trace reason in bpf_host") if done earlier. It also allowed us to detect and fix another minor incorrect cast, fixed at https://github.com/cilium/cilium/pull/18429.

To help avoid implicit integer conversions, several lists of constants are converted to enumerations. Flag `-Wenum-conversion` is therefore also enabled. Using enumerations whenever possible also uncovered a bug, fixed in the first commit.

See commits for details.