### PR TITLE
Add unreachable route for pod IP on deletion

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -118,6 +118,7 @@ cilium-agent [flags]
       --enable-session-affinity                              Enable support for service session affinity
       --enable-svc-source-range-check                        Enable check of service source ranges (currently, only for LoadBalancer) (default true)
       --enable-tracing                                       Enable tracing while determining policy (debugging)
+      --enable-unreachable-routes                            Add unreachable routes on pod deletion
       --enable-vtep                                          Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)
       --enable-well-known-identities                         Enable well-known identities for known Kubernetes components (default true)
       --enable-wireguard                                     Enable wireguard

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -397,6 +397,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableTracing, false, "Enable tracing while determining policy (debugging)")
 	option.BindEnv(option.EnableTracing)
 
+	flags.Bool(option.EnableUnreachableRoutes, false, "Add unreachable routes on pod deletion")
+	option.BindEnv(option.EnableUnreachableRoutes)
+
 	flags.Bool(option.EnableWellKnownIdentities, defaults.EnableWellKnownIdentities, "Enable well-known identities for known Kubernetes components")
 	option.BindEnv(option.EnableWellKnownIdentities)
 

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -209,6 +209,15 @@ func Delete(ip net.IP, compat bool) error {
 		scopedLog.WithField(logfields.Rule, egress).Debug("Deleted egress rule")
 	}
 
+	// Mark IP as unreachable to avoid triggering rp_filter after endpoint deletion for new packets to pod IP
+	if err := netlink.RouteReplace(&netlink.Route{
+		Dst:   &ipWithMask,
+		Table: route.MainTable,
+		Type:  unix.RTN_UNREACHABLE,
+	}); err != nil {
+		return fmt.Errorf("unable to add unreachable route for ip %s: %w", ipWithMask.String(), err)
+	}
+
 	return nil
 }
 

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -5,6 +5,7 @@ package ipam
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -13,6 +14,8 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -349,6 +352,25 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 				// Remove entry from release-ips only when it is removed from .spec.ipam.pool as well
 				delete(n.ownNode.Status.IPAM.ReleaseIPs, ip)
 				releaseUpstreamSyncNeeded = true
+
+				// Remove the unreachable route for this IP
+				parsedIP := net.ParseIP(ip)
+				if parsedIP == nil {
+					// Unable to parse IP, no point in trying to remove the route
+					log.Warningf("Unable to parse IP %s", ip)
+					continue
+				}
+
+				err := netlink.RouteDel(&netlink.Route{
+					Dst:   &net.IPNet{IP: parsedIP, Mask: net.CIDRMask(32, 32)},
+					Table: unix.RT_TABLE_MAIN,
+					Type:  unix.RTN_UNREACHABLE,
+				})
+				if err != nil && !errors.Is(err, unix.ESRCH) {
+					// We ignore ESRCH, as it means the entry was already deleted
+					log.WithError(err).Warningf("Unable to delete unreachable route for IP %s", ip)
+					continue
+				}
 			} else if status == ipamOption.IPAMMarkForRelease {
 				// NACK the IP, if this node doesn't own the IP
 				n.ownNode.Status.IPAM.ReleaseIPs[ip] = ipamOption.IPAMDoNotRelease

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -66,6 +66,7 @@ type testConfigurationCRD struct{}
 func (t *testConfigurationCRD) IPv4Enabled() bool                        { return true }
 func (t *testConfigurationCRD) IPv6Enabled() bool                        { return false }
 func (t *testConfigurationCRD) HealthCheckingEnabled() bool              { return true }
+func (t *testConfigurationCRD) UnreachableRoutesEnabled() bool           { return false }
 func (t *testConfigurationCRD) IPAMMode() string                         { return ipamOption.IPAMCRD }
 func (t *testConfigurationCRD) BlacklistConflictingRoutesEnabled() bool  { return false }
 func (t *testConfigurationCRD) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -53,6 +53,10 @@ type Configuration interface {
 	// enabled
 	HealthCheckingEnabled() bool
 
+	// UnreachableRoutesEnabled returns true when unreachable-routes is
+	// enabled
+	UnreachableRoutesEnabled() bool
+
 	// SetIPv4NativeRoutingCIDR is called by the IPAM module to announce
 	// the native IPv4 routing CIDR if it exists
 	SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR)

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -43,6 +43,7 @@ type testConfiguration struct{}
 func (t *testConfiguration) IPv4Enabled() bool                        { return true }
 func (t *testConfiguration) IPv6Enabled() bool                        { return true }
 func (t *testConfiguration) HealthCheckingEnabled() bool              { return true }
+func (t *testConfiguration) UnreachableRoutesEnabled() bool           { return false }
 func (t *testConfiguration) IPAMMode() string                         { return ipamOption.IPAMClusterPool }
 func (t *testConfiguration) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
 func (t *testConfiguration) GetIPv4NativeRoutingCIDR() *cidr.CIDR     { return nil }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -145,6 +145,9 @@ const (
 	// EnableTracing enables tracing mode in the agent.
 	EnableTracing = "enable-tracing"
 
+	// Add unreachable routes on pod deletion
+	EnableUnreachableRoutes = "enable-unreachable-routes"
+
 	// EncryptInterface enables encryption on specified interface
 	EncryptInterface = "encrypt-interface"
 
@@ -1488,6 +1491,7 @@ type DaemonConfig struct {
 	EnableHostServicesPeer        bool
 	EnablePolicy                  string
 	EnableTracing                 bool
+	EnableUnreachableRoutes       bool
 	EnvoyLog                      string
 	DisableEnvoyVersionCheck      bool
 	FixedIdentityMapping          map[string]string
@@ -2268,6 +2272,11 @@ func (c *DaemonConfig) TracingEnabled() bool {
 	return c.Opts.IsEnabled(PolicyTracing)
 }
 
+// UnreachableRoutesEnabled returns true if unreachable routes is enabled
+func (c *DaemonConfig) UnreachableRoutesEnabled() bool {
+	return c.EnableUnreachableRoutes
+}
+
 // EndpointStatusIsEnabled returns true if a particular EndpointStatus* feature
 // is enabled
 func (c *DaemonConfig) EndpointStatusIsEnabled(option string) bool {
@@ -2570,6 +2579,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableExternalIPs = viper.GetBool(EnableExternalIPs)
 	c.EnableL7Proxy = viper.GetBool(EnableL7Proxy)
 	c.EnableTracing = viper.GetBool(EnableTracing)
+	c.EnableUnreachableRoutes = viper.GetBool(EnableUnreachableRoutes)
 	c.EnableNodePort = viper.GetBool(EnableNodePort)
 	c.EnableSVCSourceRangeCheck = viper.GetBool(EnableSVCSourceRangeCheck)
 	c.EnableHostPort = viper.GetBool(EnableHostPort)


### PR DESCRIPTION
Addresses https://github.com/cilium/cilium/issues/13451
I tested this on 1.8 and things worked as expected as shown with route change monitoring, while deleting and adding a few pods:

```
$ ip monitor route
unreachable 10.132.6.42
10.132.11.107 dev lxc26596370b4a9 scope link
unreachable 10.132.7.37
10.132.7.37 dev lxcac1fafd305bc scope link
unreachable 10.132.7.37
unreachable 10.132.11.107
10.132.7.37 dev lxc5ba6f1edbb6d scope link
10.132.11.107 dev lxc630f0d9a19c4 scope link
```

When a pod is deleted, the route to its IP is replaced with an unreachable route
When a pod is created, the route is replaced with a route to the pod veth (so if an unreachable existed, it's replaced)

This is very simple and I'll let this run in a test cluster for a while

What's missing is the deletion of the unreachable route when release-excess-ips is enabled. We could maybe do it in [updateLocalNodeResource](https://github.com/cilium/cilium/blob/master/pkg/ipam/crd.go#L312) but this code currently does not interact with host routes/rules at all