### PR TITLE
[v1.11] Backport of #18431

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -80,33 +80,35 @@ var (
 	// below. These overrides represent a desire to set the default for all
 	// tests, instead of test-specific variations.
 	defaultHelmOptions = map[string]string{
-		"image.repository":              "k8s1:5000/cilium/cilium-dev",
-		"image.tag":                     "latest",
-		"image.useDigest":               "false",
-		"preflight.image.repository":    "k8s1:5000/cilium/cilium-dev", // Set again in init to match agent.image!
-		"preflight.image.tag":           "latest",
-		"preflight.image.useDigest":     "false",
-		"operator.image.repository":     "k8s1:5000/cilium/operator",
-		"operator.image.tag":            "latest",
-		"operator.image.suffix":         "",
-		"operator.image.useDigest":      "false",
+		"image.repository":           "k8s1:5000/cilium/cilium-dev",
+		"image.tag":                  "latest",
+		"image.useDigest":            "false",
+		"preflight.image.repository": "k8s1:5000/cilium/cilium-dev", // Set again in init to match agent.image!
+		"preflight.image.tag":        "latest",
+		"preflight.image.useDigest":  "false",
+		"operator.image.repository":  "k8s1:5000/cilium/operator",
+		"operator.image.tag":         "latest",
+		"operator.image.suffix":      "",
+		"operator.image.useDigest":   "false",
+
+		// Enable embedded Hubble, both on unix socket and TCP port 4244.
+		"hubble.enabled":                "true",
+		"hubble.listenAddress":          ":4244",
+		"hubble.eventBufferCapacity":    "65535",
 		"hubble.relay.image.repository": "k8s1:5000/cilium/hubble-relay",
 		"hubble.relay.image.tag":        "latest",
 		"hubble.relay.image.useDigest":  "false",
-		"debug.enabled":                 "true",
-		"k8s.requireIPv4PodCIDR":        "true",
-		"pprof.enabled":                 "true",
-		"logSystemLoad":                 "true",
-		"bpf.preallocateMaps":           "false",
-		"etcd.leaseTTL":                 "30s",
-		"ipv4.enabled":                  "true",
-		"ipv6.enabled":                  "true",
+
+		"debug.enabled":          "true",
+		"k8s.requireIPv4PodCIDR": "true",
+		"pprof.enabled":          "true",
+		"logSystemLoad":          "true",
+		"bpf.preallocateMaps":    "false",
+		"etcd.leaseTTL":          "30s",
+		"ipv4.enabled":           "true",
+		"ipv6.enabled":           "true",
 		// "extraEnv[0].name":              "KUBE_CACHE_MUTATION_DETECTOR",
 		// "extraEnv[0].value":             "true",
-
-		// Enable embedded Hubble, both on unix socket and TCP port 4244.
-		"hubble.enabled":       "true",
-		"hubble.listenAddress": ":4244",
 
 		// We need CNP node status to know when a policy is being enforced
 		"enableCnpStatusUpdates": "true",

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -99,7 +99,9 @@ var (
 		"hubble.relay.image.tag":        "latest",
 		"hubble.relay.image.useDigest":  "false",
 
-		"debug.enabled":          "true",
+		"debug.enabled": "true",
+		"debug.verbose": "flow",
+
 		"k8s.requireIPv4PodCIDR": "true",
 		"pprof.enabled":          "true",
 		"logSystemLoad":          "true",

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -104,8 +104,6 @@ var _ = SkipDescribeIf(func() bool {
 
 		daemonCfg = map[string]string{
 			"tls.secretsBackend": "k8s",
-			"debug.verbose":      "flow",
-			"hubble.enabled":     "true",
 		}
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
 		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, daemonCfg)
@@ -2359,8 +2357,6 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 			daemonCfg = map[string]string{
 				"tls.secretsBackend": "k8s",
-				"debug.verbose":      "flow",
-				"hubble.enabled":     "true",
 			}
 			ciliumFilename = helpers.TimestampFilename("cilium.yaml")
 		})

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -104,7 +104,7 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 
 // DeployCiliumAndDNS deploys DNS and cilium into the kubernetes cluster
 func DeployCiliumAndDNS(vm *helpers.Kubectl, ciliumFilename string) {
-	DeployCiliumOptionsAndDNS(vm, ciliumFilename, map[string]string{"debug.verbose": "flow"})
+	DeployCiliumOptionsAndDNS(vm, ciliumFilename, map[string]string{})
 }
 
 func redeployCilium(vm *helpers.Kubectl, ciliumFilename string, options map[string]string) {


### PR DESCRIPTION
* #18431 -- Set debug.verbose to "flow" as a default for all CI runs (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18431; do contrib/backporting/set-labels.py $pr done 1.11; done
```