### PR TITLE
hubble: read proxy port from trace event

### DIFF
--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -207,7 +207,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	decoded.PolicyMatchType = decodePolicyMatchType(pvn)
 	decoded.DebugCapturePoint = decodeDebugCapturePoint(dbg)
 	decoded.Interface = p.decodeNetworkInterface(tn, dbg)
-	decoded.ProxyPort = decodeProxyPort(dbg)
+	decoded.ProxyPort = decodeProxyPort(dbg, tn)
 	decoded.Summary = summary
 
 	return nil
@@ -687,8 +687,10 @@ func (p *Parser) decodeNetworkInterface(tn *monitor.TraceNotify, dbg *monitor.De
 	}
 }
 
-func decodeProxyPort(dbg *monitor.DebugCapture) uint32 {
-	if dbg != nil {
+func decodeProxyPort(dbg *monitor.DebugCapture, tn *monitor.TraceNotify) uint32 {
+	if tn != nil && tn.ObsPoint == monitorAPI.TraceToProxy {
+		return uint32(tn.DstID)
+	} else if dbg != nil {
 		switch dbg.SubType {
 		case monitor.DbgCaptureProxyPre,
 			monitor.DbgCaptureProxyPost:


### PR DESCRIPTION
Commit 5e00eaa exposed the proxy port via the DstId flag, so add code read proxy port from trace event.
Fixes  #18417

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!
