### PR TITLE
build: format go code correctly by don't depend on go version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,7 @@ release: ## Perform a Git release for Cilium.
 	git archive --format tar $(BRANCH) | gzip > ../cilium_$(VERSION).orig.tar.gz
 
 gofmt: ## Run gofmt on Go source files in the repository.
-	$(QUIET)for pkg in $(GOFILES); do $(GO) fmt $$pkg; done
+	$(QUIET)for pkg in $(GOFILES); do $(GOFMT) $$pkg; done
 
 govet: ## Run govet on Go source files in the repository.
 	@$(ECHO_CHECK) vetting all GOFILES...

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -47,7 +47,7 @@ endif
 CONSUL_IMAGE=consul:1.7.2
 
 GO ?= go
-
+GOFMT ?= gofmt -l -w
 # go build/test/clean flags
 # these are declared here so they are treated explicitly
 # as non-immediate variables


### PR DESCRIPTION
in our Makefile, `gofmt` target receipe execute `go fmt $$pkg`,but it depend `go` cmd param `-mod` , because our project use `vendor` directory, for `vendor` mode, `make gofmt` will report following line:
`cannot find package "." in: /home/zhanghe/cilium/cilium/vendor/api/v1/client`

Signed-off-by: zhang he <zhanghe9702@163.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #18511


