### PR TITLE
elf: Don't assume data symbols are 4-bytes long

### DIFF
--- a/pkg/elf/elf.go
+++ b/pkg/elf/elf.go
@@ -139,10 +139,11 @@ processSymbols:
 		var value []byte
 		switch symbol.kind {
 		case symbolUint32:
-			v, exists := intOptions[symbol.name]
-			if exists {
-				value = make([]byte, unsafe.Sizeof(v))
-				elf.metadata.ByteOrder.PutUint32(value, v)
+			if symbol.size == uint64(unsafe.Sizeof(uint32(0))) {
+				if v, exists := intOptions[symbol.name]; exists {
+					value = make([]byte, symbol.size)
+					elf.metadata.ByteOrder.PutUint32(value, v)
+				}
 			}
 
 		case symbolString:

--- a/pkg/elf/symbols.go
+++ b/pkg/elf/symbols.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"sort"
 	"strings"
-	"unsafe"
 )
 
 const (
@@ -67,8 +66,7 @@ func newSymbol(name string, kind symbolKind, offset, size uint64) symbol {
 	}
 }
 
-func newVariable(name string, offset uint64) symbol {
-	size := uint64(unsafe.Sizeof(symbolUint32))
+func newVariable(name string, offset, size uint64) symbol {
 	return newSymbol(name, symbolUint32, offset, size)
 }
 
@@ -179,7 +177,7 @@ func (s *symbols) extractFrom(e *elf.File) error {
 		case section.Name == dataSection:
 			// Offset from start of binary to variable inside .data
 			offset := section.Offset + sym.Value
-			dataOffsets[sym.Name] = newVariable(sym.Name, offset)
+			dataOffsets[sym.Name] = newVariable(sym.Name, offset, sym.Size)
 			log.WithField(fieldSymbol, sym.Name).Debugf("Found variable with offset %d", offset)
 
 		// Find the absolute offset to the map's entry in .strtab.


### PR DESCRIPTION
The size of data symbols is currently hardcoded to 4 bytes when we parse them in `elf.extractFrom()`. Instead, we should retrieve the actual size from the object file and skip any symbol that doesn't have the expected size (our symbol substitution logic currently assumes 4-bytes long symbols for data).

Fixes: https://github.com/cilium/cilium/pull/7196.