### PR TITLE
Fix kube-apiserver policy matching feature with tunneling enabled

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -355,11 +355,6 @@ all
    Allowing users to define custom entities is on the roadmap but has not been
    implemented yet (see :gh-issue:`3553`).
 
-.. note::
-
-   A known issue with kube-apiserver entity matching is that the feature
-   doesn't work in tunneling mode (see :gh-issue:`18049`).
-
 Access to/from local host
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -2590,6 +2590,60 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 				)
 			})
 
+			It("Still allows connection to KubeAPIServer with a duplicate policy", func() {
+				installDefaultDenyIngressPolicy(
+					kubectl,
+					testNamespace,
+					validateConnectivity,
+				)
+				installDefaultDenyEgressPolicy(
+					kubectl,
+					testNamespace,
+					validateConnectivity,
+				)
+				By("Installing toEntities KubeAPIServer")
+				importPolicy(
+					kubectl,
+					testNamespace,
+					cnpToEntitiesKubeAPIServer,
+					"to-entities-kube-apiserver",
+				)
+
+				By("Installing duplicate toEntities KubeAPIServer")
+				importPolicy(
+					kubectl,
+					testNamespace,
+					helpers.ManifestGet(
+						kubectl.BasePath(), "cnp-to-entities-kube-apiserver-2.yaml",
+					),
+					"to-entities-kube-apiserver-2",
+				)
+
+				By("Removing the previous toEntities KubeAPIServer policy")
+				_, err := kubectl.CiliumPolicyAction(
+					testNamespace, cnpToEntitiesKubeAPIServer, helpers.KubectlDelete, helpers.HelperTimeout,
+				)
+				Expect(err).Should(
+					BeNil(),
+					"policy %s cannot be deleted in %q namespace", cnpToEntitiesKubeAPIServer, testNamespace,
+				)
+
+				By("Verifying KubeAPIServer connectivity is still allowed")
+				// See previous It() about the assertion on 403 HTTP code.
+				Expect(
+					kubectl.ExecPodCmd(
+						testNamespace, k8s2PodName, helpers.CurlWithHTTPCode(
+							"https://%s %s",
+							kubeAPIServerService.Spec.ClusterIP,
+							"--insecure", // kube-apiserver needs cert, skip verification
+						),
+					).Stdout(),
+				).To(Equal("403"),
+					"HTTP egress connectivity to pod %q to kube-apiserver %q",
+					k8s2PodName, kubeAPIServerService.Spec.ClusterIP,
+				)
+			})
+
 			It("Denies connection to KubeAPIServer", func() {
 				By("Installing allow-all egress policy")
 				importPolicy(

--- a/test/k8sT/manifests/cnp-to-entities-kube-apiserver-2.yaml
+++ b/test/k8sT/manifests/cnp-to-entities-kube-apiserver-2.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "to-entities-kube-apiserver-2"
+spec:
+  endpointSelector:
+    matchLabels:
+      {}
+  egress:
+  - toEntities:
+    - kube-apiserver


### PR DESCRIPTION
- bpf: Fix kube-apiserver policy drop in tunneling
- test/K8sT: Add case for duplicate kube-apiserver policy
- docs: Remove kube-apiserver policy feature limitation

See commit msgs.

Fixes: https://github.com/cilium/cilium/issues/18049
Updates: https://github.com/cilium/cilium/issues/17962
Updates: https://github.com/cilium/cilium/issues/17829
