### PR TITLE
contrib: Fix release script helm value generation

### DIFF
--- a/contrib/release/post-release.sh
+++ b/contrib/release/post-release.sh
@@ -65,7 +65,9 @@ main() {
 
     git checkout -b pr/$version-digests $version
     ${DIR}/pull-docker-manifests.sh "$@"
-    logrun make -C Documentation update-helm-values
+    if grep -q update-helm-values Documentation/Makefile; then
+        logrun make -C Documentation update-helm-values
+    fi
     logecho
     logecho "Check that the following changes look correct:"
     # TODO: Make this less interactive when we have used it enough

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -88,7 +88,9 @@ main() {
     echo $ersion > VERSION
     sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
     logrun make -C install/kubernetes all USE_DIGESTS=false
-    logrun make -C Documentation update-helm-values
+    if grep -q update-helm-values Documentation/Makefile; then
+        logrun make -C Documentation update-helm-values
+    fi
     logrun make update-authors
     if ! version_is_prerelease "$version"; then
         old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")


### PR DESCRIPTION
Commit 2bede0336208 ("release: Generate helm values docs") broke the
release scripts for branches v1.10 and earlier, as it introduced a
dependency on a new Makefile target that has not been backported.
Grep for the dependency and skip it silently if it's not available.

Fixes: 2bede0336208 ("release: Generate helm values docs")
