### PR TITLE
fix: allow recreate update strategy for operator

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -18,7 +18,12 @@ spec:
       name: cilium-operator
   {{- with .Values.operator.updateStrategy }}
   strategy:
-    {{- toYaml . | trim | nindent 4 }}
+    type: {{ .type }}
+    {{- if eq .type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .rollingUpdate.maxUnavailable }}
+    {{- end }}
   {{- end }}
   template:
     metadata:


### PR DESCRIPTION
At the moment, it is not possible to use Recreate strategy since Helm is merging the whole structure together.
Hence it generates invalid configuration like

```yaml
  strategy:
    type: Recreate
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
```

An alternative approach would be deleting the `rollingUpdate` key from the default values. 

----

Fixes: n/a


