### PR TITLE
ci: disable failing test on net-next (#18520)

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1732,7 +1732,10 @@ var _ = SkipDescribeIf(func() bool {
 				validateConnectivity(HostConnectivityAllow, RemoteNodeConnectivityAllow, PodConnectivityAllow, WorldConnectivityDeny)
 			})
 
-			It("Validates fromEntities all policy", func() {
+			// Quarantined on net-next until #18520 is fixed
+			SkipItIf(func() bool {
+				return helpers.RunsOnNetNextKernel() && helpers.SkipQuarantined()
+			}, "Validates fromEntities all policy", func() {
 				installDefaultDenyIngressPolicy(kubectl, testNamespace, validateConnectivity)
 
 				By("Installing fromEntities all policy")


### PR DESCRIPTION
`K8sPolicyTest Multi-node policy test validates fromEntities policies Validates fromEntities all policy` has been failing consistently on net-next testing pipelines after we upgraded the net-next Vagrant VM in 8bf4e228693c87ab50227245c403d179f418de56.

We disable the test until it is fixed (tracked in #18520).