### PR TITLE
Revert "datapath: Remove !CONNTRACK"

### DIFF
--- a/bpf/ep_config.h
+++ b/bpf/ep_config.h
@@ -42,5 +42,6 @@ DEFINE_U32(POLICY_VERDICT_LOG_FILTER, 0xffff);
 #define CALLS_MAP test_cilium_calls_65535
 #define CUSTOM_CALLS_MAP test_cilium_calls_custom_65535
 #define LOCAL_DELIVERY_METRICS
+#define CONNTRACK
 #define CONNTRACK_ACCOUNTING
 #define DIRECT_ROUTING_DEV_IFINDEX 0

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -18,6 +18,7 @@
 #include "nat46.h"
 #include "signal.h"
 
+#ifdef CONNTRACK
 enum {
 	ACTION_UNSPEC,
 	ACTION_CREATE,
@@ -1071,4 +1072,99 @@ ct_update_nodeport(const void *map, const void *tuple, const bool node_port)
 
 	entry->node_port = node_port;
 }
+#else /* !CONNTRACK */
+static __always_inline int
+ct_lookup6(const void *map __maybe_unused,
+	   struct ipv6_ct_tuple *tuple __maybe_unused,
+	   struct __ctx_buff *ctx __maybe_unused, int off __maybe_unused,
+	   int dir __maybe_unused, struct ct_state *ct_state __maybe_unused,
+	   __u32 *monitor __maybe_unused)
+{
+	return 0;
+}
+
+static __always_inline int
+ct_is_reply4(const void *map __maybe_unused,
+	     struct __ctx_buff *ctx __maybe_unused, int off __maybe_unused,
+	     struct ipv4_ct_tuple *tuple __maybe_unused,
+	     bool *is_reply __maybe_unused)
+{
+	return 0;
+}
+
+static __always_inline int
+ct_lookup4(const void *map __maybe_unused,
+	   struct ipv4_ct_tuple *tuple __maybe_unused,
+	   struct __ctx_buff *ctx __maybe_unused, int off __maybe_unused,
+	   int dir __maybe_unused, struct ct_state *ct_state __maybe_unused,
+	   __u32 *monitor __maybe_unused)
+{
+	return 0;
+}
+
+static __always_inline void
+ct_update6_backend_id(const void *map __maybe_unused,
+		      const struct ipv6_ct_tuple *tuple __maybe_unused,
+		      const struct ct_state *state __maybe_unused)
+{
+}
+
+static __always_inline void
+ct_update6_rev_nat_index(const void *map __maybe_unused,
+			 const struct ipv6_ct_tuple *tuple __maybe_unused,
+			 const struct ct_state *state __maybe_unused)
+{
+}
+
+static __always_inline void
+ct_update6_dsr(const void *map __maybe_unused,
+	       const struct ipv6_ct_tuple *tuple __maybe_unused,
+	       const bool dsr __maybe_unused)
+{
+}
+
+static __always_inline int
+ct_create6(const void *map_main __maybe_unused,
+	   const void *map_related __maybe_unused,
+	   struct ipv6_ct_tuple *tuple __maybe_unused,
+	   struct __ctx_buff *ctx __maybe_unused, const int dir __maybe_unused,
+	   struct ct_state *ct_state __maybe_unused,
+	   bool from_proxy __maybe_unused)
+{
+	return 0;
+}
+
+static __always_inline void
+ct_update4_backend_id(const void *map __maybe_unused,
+		      const struct ipv4_ct_tuple *tuple __maybe_unused,
+		      const struct ct_state *state __maybe_unused)
+{
+}
+
+static __always_inline void
+ct_update4_rev_nat_index(const void *map __maybe_unused,
+			 const struct ipv4_ct_tuple *tuple __maybe_unused,
+			 const struct ct_state *state __maybe_unused)
+{
+}
+
+static __always_inline void
+ct_update4_dsr(const void *map __maybe_unused,
+	       const struct ipv4_ct_tuple *tuple __maybe_unused,
+	       const bool dsr __maybe_unused)
+{
+}
+
+static __always_inline int
+ct_create4(const void *map_main __maybe_unused,
+	   const void *map_related __maybe_unused,
+	   struct ipv4_ct_tuple *tuple __maybe_unused,
+	   struct __ctx_buff *ctx __maybe_unused, const int dir __maybe_unused,
+	   const struct ct_state *ct_state __maybe_unused,
+	   bool proxy_redirect __maybe_unused)
+{
+	return 0;
+}
+
+#endif /* CONNTRACK */
 #endif /* __LIB_CONNTRACK_H_ */

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1062,6 +1062,7 @@ void snat_v6_delete_tuples(struct ipv6_ct_tuple *tuple __maybe_unused)
 }
 #endif
 
+#ifdef CONNTRACK
 static __always_inline __maybe_unused void
 ct_delete4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ctx)
 {
@@ -1085,5 +1086,20 @@ ct_delete6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ctx)
 	else
 		snat_v6_delete_tuples(tuple);
 }
+#else
+static __always_inline __maybe_unused void
+ct_delete4(const void *map __maybe_unused,
+	   struct ipv4_ct_tuple *tuple __maybe_unused,
+	   struct __ctx_buff *ctx __maybe_unused)
+{
+}
+
+static __always_inline __maybe_unused void
+ct_delete6(const void *map __maybe_unused,
+	   struct ipv6_ct_tuple *tuple __maybe_unused,
+	   struct __ctx_buff *ctx __maybe_unused)
+{
+}
+#endif
 
 #endif /* __LIB_NAT__ */

--- a/bpf/lib/nat46.h
+++ b/bpf/lib/nat46.h
@@ -15,7 +15,7 @@
 
 #if defined(ENABLE_NAT46) && \
     (!defined(ENABLE_IPV4) || !defined(ENABLE_IPV6) || \
-     !defined(ENABLE_HOST_REDIRECT))
+     !defined(CONNTRACK) || !defined(ENABLE_HOST_REDIRECT))
 #error "ENABLE_NAT46 requisite options are not configured, see lib/nat46.h."
 #endif
 

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -133,6 +133,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define CT_MAP_ANY4 test_cilium_ct_any4_65535
 #define CT_MAP_SIZE_TCP 4096
 #define CT_MAP_SIZE_ANY 4096
+#define CONNTRACK
 #define CONNTRACK_ACCOUNTING
 #define LB4_HEALTH_MAP test_cilium_lb4_health
 #define LB6_HEALTH_MAP test_cilium_lb6_health

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -5,6 +5,7 @@
 #include <bpf/api.h>
 
 /* most values taken from node_config.h */
+#define CONNTRACK
 #define ENDPOINTS_MAP test_cilium_lxc
 #define POLICY_PROG_MAP_SIZE ENDPOINTS_MAP_SIZE
 #define METRICS_MAP test_cilium_metrics

--- a/pkg/option/daemon.go
+++ b/pkg/option/daemon.go
@@ -17,6 +17,7 @@ var (
 	DaemonMutableOptionLibrary = OptionLibrary{
 		ConntrackAccounting: &specConntrackAccounting,
 		ConntrackLocal:      &specConntrackLocal,
+		Conntrack:           &specConntrack,
 		Debug:               &specDebug,
 		DebugLB:             &specDebugLB,
 		DebugPolicy:         &specDebugPolicy,

--- a/pkg/option/endpoint.go
+++ b/pkg/option/endpoint.go
@@ -7,6 +7,7 @@ var (
 	endpointMutableOptionLibrary = OptionLibrary{
 		ConntrackAccounting: &specConntrackAccounting,
 		ConntrackLocal:      &specConntrackLocal,
+		Conntrack:           &specConntrack,
 		Debug:               &specDebug,
 		DebugLB:             &specDebugLB,
 		DebugPolicy:         &specDebugPolicy,

--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -47,6 +47,11 @@ var (
 		Requires:    []string{Conntrack},
 	}
 
+	specConntrack = Option{
+		Define:      "CONNTRACK",
+		Description: "Enable stateful connection tracking",
+	}
+
 	specDebug = Option{
 		Define:      "DEBUG",
 		Description: "Enable debugging trace statements",

--- a/test/bpf/unit-test.c
+++ b/test/bpf/unit-test.c
@@ -22,6 +22,8 @@
 
 #define HAVE_LARGE_INSN_LIMIT
 
+#define CONNTRACK
+
 #define htonl bpf_htonl
 #define ntohl bpf_ntohl
 


### PR DESCRIPTION
This reverts commit 21898cafc01cef5feb51c767e50d13339a7cac75.

Rationale:

- The change creates a consistent failure in test `RuntimeConntrackInVethModeTest Conntrack-related configuration options for endpoints` from the runtime pipeline.
- It is likely the test needs to be modified to remove now obsolete checks following the reverted changes.

[ revert note: manually resolved conflicts in `conntrack.h` due to
  e9b6d39e34c929f4e61f88ce9584b5f5e0a27077 being merged in `master` ]