### PR TITLE
contrib: Improve version matching in readme bump

### DIFF
--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -41,7 +41,7 @@ for release in $(grep "General Announcement" README.rst \
     echo "  $current on $old_date with project $old_proj to"
     echo "  $latest on $new_date with project $new_proj"
     sed -i 's/\('$release'.*\)'$old_date'/\1'$new_date'/g' README.rst
-    sed -i 's/'$current'/'$latest'/g' README.rst
+    sed -i 's/v'$current'/v'$latest'/g' README.rst
     sed -i 's/\(projects\/\)'$old_proj'/\1'$new_proj'/g' $ACTS_YAML
 done
 


### PR DESCRIPTION
The previous version didn't prepend `v` to the version numbers, which
meant that it could end up unintentionally matching other text that
isn't version numbers, since the period characters in the versions are
not escaped (and are hence treated as wildcards by sed). Implement the
simple fix and just prepend the 'v' before the version so that the
substitutions are implemented correctly.
