### PR TITLE
Support running K8sVerifier tests on kind

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -15,6 +15,7 @@ WORKERS="${2:-${default_workers}}"
 CLUSTER_NAME="${3:-${default_cluster_name}}"
 # IMAGE controls the K8s version as well (e.g. kindest/node:v1.11.10)
 IMAGE="${4:-${default_image}}"
+CILIUM_ROOT="$(realpath $(dirname $(readlink -ne $BASH_SOURCE))/../..)"
 
 usage() {
   echo "Usage: ${PROG} [control-plane node count] [worker node count] [cluster-name] [node image]"
@@ -61,18 +62,20 @@ if [[ -n "${IMAGE}" ]]; then
 fi
 
 control_planes() {
-  line="- role: control-plane"
-
   for _ in $(seq 1 "${CONTROLPLANES}"); do
-    echo "$line"
+    echo "- role: control-plane"
+    echo "  extraMounts:"
+    echo "  - hostPath: $CILIUM_ROOT"
+    echo "    containerPath: /home/vagrant/go/src/github.com/cilium/cilium"
   done
 }
 
 workers() {
-  line="- role: worker"
-
   for _ in $(seq 1 "${WORKERS}"); do
-    echo "$line"
+    echo "- role: worker"
+    echo "  extraMounts:"
+    echo "  - hostPath: $CILIUM_ROOT"
+    echo "    containerPath: /home/vagrant/go/src/github.com/cilium/cilium"
   done
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,6 +6,7 @@ include ../Makefile.defs
 PROVISION ?= true
 # If you set provision to false the test will run without bootstrapping the
 # cluster again.
+HOLD_ENVIRONMENT ?= true
 
 TEST_ARTIFACTS = ./tmp.yaml ./*_service_manifest.json ./*_manifest.yaml
 TEST_ARTIFACTS += ./*_policy.json ./k8s-*.xml ./runtime.xml ./test_results
@@ -29,6 +30,26 @@ run:
 
 k8s:
 	ginkgo --focus "K8s" --tags integration_tests -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
+
+# Match kind-image target in parent directory
+k8s-kind: export DOCKER_REGISTRY=localhost:5000
+k8s-kind:
+	@if [ -z $(FOCUS) ]; then \
+		>&2 echo "usage: FOCUS=K8sFoo make k8s-kind"; \
+		exit 1; \
+	fi
+	@CNI_INTEGRATION=kind \
+		K8S_VERSION="$$(kubectl version -o json | jq -r '.serverVersion | "\(.major).\(.minor)"')" \
+		ginkgo --focus "$(FOCUS)" --tags integration_tests -v -- \
+			-cilium.testScope=k8s \
+			-cilium.provision=false \
+			-cilium.kubeconfig=$$(echo ~/.kube/config) \
+			-cilium.passCLIEnvironment=true \
+			-cilium.image="$(DOCKER_REGISTRY)/cilium/cilium-dev" \
+			-cilium.tag="local" \
+			-cilium.operator-image="quay.io/cilium/operator" \
+			-cilium.operator-suffix="-ci" \
+			-cilium.holdEnvironment=$(HOLD_ENVIRONMENT)
 
 nightly:
 	ginkgo --focus "Nightly" -v --tags integration_tests -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)

--- a/test/k8sT/Verifier.go
+++ b/test/k8sT/Verifier.go
@@ -124,6 +124,9 @@ var _ = Describe("K8sVerifier", func() {
 		err := kubectl.WaitForSinglePod(helpers.DefaultNamespace, podName, helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), fmt.Sprintf("%s pod not ready after timeout", podName))
 
+		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, podName, "mount | grep -q 'type bpf' || mount -t bpf bpf /sys/fs/bpf")
+		res.ExpectSuccess("Failed to mount bpffs")
+
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, podName, "make -C bpf clean V=0")
 		res.ExpectSuccess("Failed to clean up bpf/ tree")
 	})

--- a/test/k8sT/manifests/test-verifier.yaml
+++ b/test/k8sT/manifests/test-verifier.yaml
@@ -15,6 +15,7 @@ spec:
     volumeMounts:
       - mountPath: /sys/fs/bpf
         name: bpf-maps
+        mountPropagation: Bidirectional
       - mountPath: /cilium
         name: cilium-src
   volumes:


### PR DESCRIPTION
After applying these changes, it's possible to run the K8sVerifier tests by:

```
make kind
make kind-image
cd test
FOCUS=K8sVerifier make k8s-kind
```
