### PR TITLE
Adding support for writing e2e tests exclusive to ENI mode

### DIFF
--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -79,6 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
+      eni_tested: ${{ steps.tested-tree.outputs.eni }}
     steps:
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
@@ -104,6 +105,11 @@ jobs:
           filters: |
             src:
               - '!(test|Documentation)/**'
+            eni:
+              - 'pkg/aws/**'
+              - 'pkg/ipam/**'
+              - 'pkg/policy/groups/aws/**'
+              - 'vendor/github.com/aws/**'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
@@ -117,8 +123,19 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
+      - name: Checkout code
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4
+        with:
+          go-version: 1.17.7
+      - name: Install ginkgo
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - name: Set up job variables
         id: vars
         run: |
@@ -239,6 +256,12 @@ jobs:
       - name: Run connectivity test
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+
+      - name: Run e2e tests
+        if: ${{ github.event.label.name == 'ci/eni-e2e' || needs.check_changes.outputs.eni_tested == 'true' }}
+        run: |
+          cd test
+          ginkgo --focus "Eni" --tags=integration_tests  -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.testScope=eni  -cilium.passCLIEnvironment=true
 
       # EKS testing with encryption is disabled due to https://github.com/cilium/cilium/issues/16938
       - name: Clean up Cilium

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -7,7 +7,7 @@ on:
       - created
   # Run every 6 hours
   schedule:
-    - cron:  '0 1/6 * * *'
+    - cron: '0 1/6 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `master`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:
@@ -82,6 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
+      eni_tested: ${{ steps.tested-tree.outputs.eni }}
     steps:
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
@@ -107,6 +108,11 @@ jobs:
           filters: |
             src:
               - '!(test|Documentation)/**'
+            eni:
+              - 'pkg/aws/**'
+              - 'pkg/ipam/**'
+              - 'pkg/policy/groups/aws/**'
+              - 'vendor/github.com/aws/**'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
@@ -120,8 +126,19 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
+      - name: Checkout code
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4
+        with:
+          go-version: 1.17.7
+      - name: Install ginkgo
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - name: Set up job variables
         id: vars
         run: |
@@ -238,6 +255,13 @@ jobs:
       - name: Run connectivity test
         run: |
           cilium connectivity test --flow-validation=disabled
+
+      - name: Run e2e tests
+        if: ${{ github.event.label.name == 'ci/eni-e2e' || needs.check_changes.outputs.eni_tested == 'true' }}
+        run: |
+          cd test
+          ginkgo --focus "Eni" --tags=integration_tests  -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.testScope=eni  -cilium.passCLIEnvironment=true
+
 
       # EKS testing with encryption is disabled due to https://github.com/cilium/cilium/issues/16938
       - name: Clean up Cilium

--- a/test/eni/IPRelease.go
+++ b/test/eni/IPRelease.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package eniTest
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/logging"
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+	"github.com/cilium/cilium/test/nodegroups"
+)
+
+func getAllocatedIPsOnNode(kubectl *helpers.Kubectl, nodeName string) (int, error) {
+	cn := kubectl.GetCiliumNode(nodeName)
+	if cn == nil {
+		return 0, fmt.Errorf("Unable to fetch cn %s", nodeName)
+	}
+	return len(cn.Spec.IPAM.Pool), nil
+}
+
+func hasRequiredIPsAllocated(kubectl *helpers.Kubectl, nodeName string, n int) func() bool {
+	return func() bool {
+		cn := kubectl.GetCiliumNode(nodeName)
+		if cn == nil {
+			return false
+		}
+		return len(cn.Spec.IPAM.Pool) == n
+	}
+}
+
+func hasRequiredIPBuffer(kubectl *helpers.Kubectl, nodeName string, n int) func() bool {
+	return func() bool {
+		cn := kubectl.GetCiliumNode(nodeName)
+		if cn == nil {
+			return false
+		}
+		return (len(cn.Spec.IPAM.Pool) - len(cn.Status.IPAM.Used)) == n
+	}
+}
+
+func hasNoIPsInHandshake(kubectl *helpers.Kubectl, nodeName string) func() bool {
+	return func() bool {
+		cn := kubectl.GetCiliumNode(nodeName)
+		if cn == nil {
+			return false
+		}
+		return len(cn.Status.IPAM.ReleaseIPs) == 0
+	}
+}
+
+var _ = Describe("EniIPReleaseHandshakeTest", func() {
+	var (
+		kubectl           *helpers.Kubectl
+		ciliumCli         *helpers.CiliumCli
+		deploymentManager *helpers.DeploymentManager
+		releaseTestNs     = "cilium-integration-tests"
+	)
+
+	BeforeAll(func() {
+		var log = logging.DefaultLogger
+		var logger = logrus.NewEntry(log)
+		kubectl = helpers.CreateKubectl("", logger)
+		ciliumCli = helpers.CreateCiliumCli(logger)
+		deploymentManager = helpers.NewDeploymentManager()
+		deploymentManager.SetKubectl(kubectl)
+	})
+
+	AfterAll(func() {
+		deploymentManager.DeleteAll()
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport("cilium status", "cilium endpoint list")
+	})
+
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	It("Test IP release abort", func() {
+		By("Enabling aws excess IP release feature and restarting cilium operator")
+		err := ciliumCli.UpdateCiliumConfig("aws-release-excess-ips", "true", false)
+		Expect(err).NotTo(HaveOccurred())
+		err = ciliumCli.UpdateCiliumConfig("excess-ip-release-delay", "30", false)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Workaround till cilium-cli supports restarting operator based on config change
+		err = kubectl.RestartOperator()
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Create nodegroup to deploy tests on")
+		ng := nodegroups.EksNodegroup{NodePool: nodegroups.NodePool{
+			Name:          "ip-release",
+			ClusterName:   os.Getenv("clusterName"),
+			InstanceTypes: []string{"t3.medium", "t3a.medium"},
+			Region:        os.Getenv("region"),
+			NumNodes:      1,
+			NodeTaint:     "ip-release",
+			Executor:      helpers.CreateLocalExecutor(os.Environ()),
+			Kubectl:       kubectl,
+		}}
+		err = ng.CreateNodePool()
+		Expect(err).NotTo(HaveOccurred(), "Error while creating nodegroup")
+
+		By("Creating a deployment to pick a node to test on")
+		configFile := "nginx-with-tolerations.yaml"
+		labelSelector := "zgroup=http-server"
+		tmpl := helpers.ManifestGet(kubectl.BasePath(), "http-deployment-node-toleration.yaml.tmpl")
+		helpers.RenderTemplateWithData(tmpl, configFile, struct{ NodeTaint string }{NodeTaint: "ip-release"})
+
+		_ = kubectl.Exec(fmt.Sprintf("kubectl create ns %s", releaseTestNs))
+		res := kubectl.Exec(fmt.Sprintf("kubectl -n %s apply -f %s", releaseTestNs, configFile))
+		res.ExpectSuccess("Error creating test workload: %s", res.OutputPrettyPrint())
+		kubectl.WaitforNPodsRunning(releaseTestNs, "-l "+labelSelector, 2, 10*time.Minute)
+
+		By("Fetching cilium node for test pods")
+		data, err := kubectl.GetPodsNodes(releaseTestNs, labelSelector)
+		Expect(err).To(BeNil(), "error getting pod->node mapping")
+		var nodeName string
+		for _, v := range data {
+			nodeName = v
+			break
+		}
+
+		cn := kubectl.GetCiliumNode(nodeName)
+		Expect(cn).NotTo(Equal(check.IsNil))
+		totalBuffer := cn.Spec.IPAM.PreAllocate + cn.Spec.IPAM.MaxAboveWatermark
+
+		By("Wait for new IPs to be allocated, IP Buffer : %v", totalBuffer)
+		err = helpers.WithTimeout(hasRequiredIPBuffer(kubectl, nodeName, totalBuffer), "Timeout while waiting for new IPs to be allocated",
+			&helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for new IPs to be allocated")
+
+		initialAllocCnt, err := getAllocatedIPsOnNode(kubectl, nodeName)
+		Expect(err).NotTo(Equal(check.IsNil))
+
+		By("Scaling replicas by 2")
+		res = kubectl.Exec(fmt.Sprintf("kubectl -n %s scale deploy %s --replicas=%v", releaseTestNs, "http-server", 4))
+		res.ExpectSuccess("Error while scaling replicas:  %s", res.OutputPrettyPrint())
+
+		By("Wait for new pods to start up")
+		kubectl.WaitforNPodsRunning(releaseTestNs, "-l "+labelSelector, 4, helpers.HelperTimeout)
+
+		By("Wait for new IPs to be allocated")
+		err = helpers.WithTimeout(hasRequiredIPBuffer(kubectl, nodeName, totalBuffer), "Timeout while waiting for new IPs to be allocated",
+			&helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for new IPs to be allocated")
+
+		By("Scale back by 2 to create excess")
+		res = kubectl.Exec(fmt.Sprintf("kubectl -n %s scale deploy %s --replicas=%v", releaseTestNs, "http-server", 2))
+		res.ExpectSuccess("Error while scaling replicas: %s", res.OutputPrettyPrint())
+
+		By("Wait for IPs to be released from the pool. Waiting for total IPs=%v", initialAllocCnt)
+		err = helpers.WithTimeout(hasRequiredIPsAllocated(kubectl, nodeName, initialAllocCnt), "Timeout while waiting for IPs to be released from pool",
+			&helpers.TimeoutConfig{Timeout: 10 * time.Minute})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for IPs to be released from pool")
+
+		By("Wait for entries to be cleared from release status")
+		err = helpers.WithTimeout(hasNoIPsInHandshake(kubectl, nodeName), "Timeout while waiting for entries to be cleared from release status",
+			&helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
+		ExpectWithOffset(1, err).To(BeNil(), "Timeout while waiting for entries to be cleared from release status")
+	})
+
+})

--- a/test/helpers/cilium-cli.go
+++ b/test/helpers/cilium-cli.go
@@ -1,0 +1,43 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/test/config"
+)
+
+const (
+	CiliumCliCmd = "cilium"
+)
+
+type CiliumCli struct {
+	executor Executor
+	log      *logrus.Entry
+}
+
+func CreateCiliumCli(log *logrus.Entry) (c *CiliumCli) {
+	var environ []string
+	if config.CiliumTestConfig.PassCLIEnvironment {
+		environ = append(environ, os.Environ()...)
+	}
+	environ = append(environ, "KUBECONFIG="+config.CiliumTestConfig.Kubeconfig)
+	environ = append(environ, fmt.Sprintf("PATH=%s:%s", GetKubectlPath(), os.Getenv("PATH")))
+
+	c = &CiliumCli{
+		executor: CreateLocalExecutor(environ),
+		log:      log,
+	}
+	return c
+}
+
+func (c *CiliumCli) UpdateCiliumConfig(key string, val string, restart bool) error {
+	res := c.executor.ExecShort(fmt.Sprintf("%s config set --restart=%v %s %s", CiliumCliCmd, restart, key, val))
+
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to update config with error %s", res.OutputPrettyPrint())
+	}
+	return nil
+}

--- a/test/helpers/scope.go
+++ b/test/helpers/scope.go
@@ -30,6 +30,8 @@ func GetScope() (string, error) {
 	case strings.Contains(focusString, "nightly"):
 		// Nightly tests run in a Kubernetes environment.
 		return K8s, nil
+	case strings.Contains(focusString, "eni"):
+		return "Eni", nil
 	default:
 		return "", errors.New("Scope cannot be set")
 	}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -85,6 +85,23 @@ func RenderTemplate(tmplt string) (*bytes.Buffer, error) {
 	return content, nil
 }
 
+func RenderTemplateWithData(sourcePath string, destPath string, data interface{}) error {
+	tmpl, err := template.ParseFiles(sourcePath)
+	if err != nil {
+		return fmt.Errorf("error while parsing template : %v", err.Error())
+	}
+	f, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("error while opening destination file : %v", err.Error())
+	}
+	defer f.Close()
+	err = tmpl.Execute(f, data)
+	if err != nil {
+		return fmt.Errorf("error while rendering template : %v", err.Error())
+	}
+	return nil
+}
+
 // TimeoutConfig represents the configuration for the timeout of a command.
 type TimeoutConfig struct {
 	Ticker  time.Duration // Check interval

--- a/test/k8s/manifests/eks-nodegroup.yaml.tmpl
+++ b/test/k8s/manifests/eks-nodegroup.yaml.tmpl
@@ -1,0 +1,24 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: {{ .ClusterName }}
+  region: {{ .Region }}
+managedNodeGroups:
+  - name: {{ .Name }}
+    labels: { role: {{ .NodeTaint }} }
+    instanceTypes:
+    {{range .InstanceTypes}}
+    - {{ . }}
+    {{end}}
+    desiredCapacity: {{ .NumNodes }}
+    spot: true
+    privateNetworking: true
+    volumeType: "gp3"
+    volumeSize: 10
+    taints:
+      - key: "node.cilium.io/agent-not-ready"
+        value: "true"
+        effect: "NoSchedule"
+      - key: {{ .NodeTaint }}
+        value: "true"
+        effect: "NoSchedule"

--- a/test/k8s/manifests/http-deployment-node-toleration.yaml.tmpl
+++ b/test/k8s/manifests/http-deployment-node-toleration.yaml.tmpl
@@ -1,0 +1,26 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: http-server
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+        zgroup: http-server
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/library/nginx:1.19.4
+          ports:
+            - containerPort: 80
+      tolerations:
+        - key: {{ .NodeTaint }}
+          operator: "Exists"
+          effect: "NoSchedule"
+      nodeSelector:
+        role: {{ .NodeTaint }}

--- a/test/nodegroups/nodegroups.go
+++ b/test/nodegroups/nodegroups.go
@@ -1,0 +1,68 @@
+package nodegroups
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/test/helpers"
+)
+
+const (
+	EksCliCmd = "eksctl"
+)
+
+type NodePool struct {
+	Name          string
+	ClusterName   string
+	InstanceTypes []string
+	Region        string
+	// Number of nodes for fixed size node pools
+	NumNodes int
+	// Min number of nodes in the nodepool
+	MinNodes int
+	// Taint to be added to the nodes created in this nodepool
+	NodeTaint string
+	Executor  *helpers.LocalExecutor
+	Kubectl   *helpers.Kubectl
+}
+
+type EksNodegroup struct {
+	NodePool
+}
+
+type NodePoolImpl interface {
+	CreateNodePool() error
+	DeleteNodePool() error
+	ScaleNodePool() error
+}
+
+func (e *EksNodegroup) CreateNodePool() error {
+	configFile := e.Name + ".yaml"
+	tmpl := helpers.ManifestGet(e.Kubectl.BasePath(), "eks-nodegroup.yaml.tmpl")
+	err := helpers.RenderTemplateWithData(tmpl, configFile, e.NodePool)
+	if err != nil {
+		return err
+	}
+	cmd := fmt.Sprintf("%s create nodegroup --config-file=%s", EksCliCmd, configFile)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	res := e.Executor.ExecContext(ctx, cmd)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to create eks nodegroup : %s", res.OutputPrettyPrint())
+	}
+	return nil
+}
+
+func (e *EksNodegroup) DeleteNodePool() error {
+	cmd := fmt.Sprintf("%s delete nodegroup --cluster=%s -n=%s", EksCliCmd, e.ClusterName, e.Name)
+	res := e.Executor.ExecMiddle(cmd)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to create eks nodegroup : %s", res.OutputPrettyPrint())
+	}
+	return nil
+}
+
+func (e *EksNodegroup) ScaleNodePool() error {
+	return fmt.Errorf("scaling nodegroup is not implemented yet")
+}

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -150,7 +150,11 @@ func reportCreateVMFailure(vm string, err error) {
 
 var _ = BeforeAll(func() {
 	helpers.Init()
-	By("Starting tests: command line parameters: %+v environment variables: %v", config.CiliumTestConfig, os.Environ())
+	var envToPrint []string
+	if os.Getenv("GITHUB_ACTIONS") != "true" {
+		envToPrint = os.Environ()
+	}
+	By("Starting tests: command line parameters: %+v environment variables: %v", config.CiliumTestConfig, envToPrint)
 	go func() {
 		defer GinkgoRecover()
 		time.Sleep(config.CiliumTestConfig.Timeout)

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -8,6 +8,7 @@ package ciliumTest
 
 import (
 	// test sources
+	_ "github.com/cilium/cilium/test/eni"
 	_ "github.com/cilium/cilium/test/k8s"
 	_ "github.com/cilium/cilium/test/runtime"
 )


### PR DESCRIPTION
Currently in CI only `cilium-cli` based connectivity tests are run for AWS ENI mode. AFAIK, There seems to be no easy way to write e2e tests exclusive to a cloud provider. This commit introduces a new ginkgo focus group for ENI, which can be used to house e2e tests for cloud provider specific features like AWS excess IP release, ENI prefix delegation, etc. There are more features that aren't currently tested e2e in CI and this focus group should make it easy to add them.

This could also be achieved with build tags maybe ? Please suggest if there's an easier / better way to achieve this.

This PR also adds an e2e test for changes added from https://github.com/cilium/cilium/pull/17939 and is needed to trigger the e2e test in https://github.com/cilium/cilium/pull/18463

Link to [successful workflow](https://github.com/DataDog/cilium/runs/5205944242?check_suite_focus=true) run with incoming changes.

Todo :

- [x] Github workflow changes to trigger new tests
- [x] Add support for managing cloud provider nodegroups from ginkgo
- [x] Support for using `cilium-cli` from ginkgo
