### PR TITLE
monitor: Improve NodePort tracepoint reliability

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -281,8 +281,6 @@ ct_recreate6:
 # endif /* ENABLE_DSR */
 		/* See comment in handle_ipv4_from_lxc(). */
 		if (ct_state.node_port) {
-			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
-					  *dst_id, 0, 0, ret, monitor);
 			ctx->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
 			ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_REVNAT);
 			return DROP_MISSED_TAIL_CALL;
@@ -716,8 +714,6 @@ ct_recreate4:
 		 * the reverse DNAT.
 		 */
 		if (ct_state.node_port) {
-			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
-					  *dst_id, 0, 0, ct_ret, monitor);
 			ctx->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
 			ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_REVNAT);
 			return DROP_MISSED_TAIL_CALL;


### PR DESCRIPTION
This commit improves the reliability of the `TRACE_TO_NETWORK` monitor
trace point for NodePort reply traffic by moving it to after the tail
call.  This addresses a concern was raised during code review [1].
Namely, before this commit, the datapath would emit the
`TRACE_TO_NETWORK` event for NodePort reply traffic before it performed
a tail call to `tail_rev_nodeport_lb[46]()`. If that tail call failed
for any reason, the trace event would still be emitted, even though the
packet was dropped without a notification. This is not desirable as it
looks like the packet was forwarded, when in fact it was dropped.

We originally deemed it to complicated to move the trace event to after
the tail call, as it would have required us to pass the conntrack state
(`ct_ret` and `monitor`) through the tail call to the receiver. However,
it turns out that `rev_nodeport_lb[46]()` also performs a conntrack
lookup, and thus allowing us to use the state retrieved from the
conntrack lookup performed there.

It should be noted that the conntrack entry used in this commit is
different from the entry used previously. Previously, we used the same
`ENTRY_INGRESS` conntrack entry for monitor aggregation in both
directions (ingress and egress), while this patch switches the reply
trace event to contain the status of the `ENTRY_EGRESS` entry (see
example below). Using a different entry for the egress path than for the
ingress should be okay as monitor aggregation uses separate fields in
the entry (`{rx,tx}_seen_flags`) depending on the direction. The
approach of using two entries also seems consistent with pod-to-pod
traffic, where we also seem to be populating `send_trace_notify` from
two different entries (one for ingress and one for egress)

By moving the trace point to after the tail call, we loose access to the
destination security identity (the `dst_id` value passed to
`send_trace_notify`), but we gain access to the index of the interface
(`ifindex`) on which the reply packet is being sent. This is consistent
with other `TRACE_TO_STACK`/`TRACE_TO_NETWORK` trace points. If the
destination security identity is missing, Hubble will fall back on a
user-space IPCache lookup when populating the flow metadata.

Overview of connection tracking entries involved:

<details>

```
ct_lookup4(.., CT_SERVICE):
    1. tuple = (saddr=client,daddr=svc,flags=TUPLE_F_SERVICE,dport=client_port,sport=svc_port)
       nothing found
ct_create4(.., CT_SERVICE)

ct_lookup4(.., CT_EGRESS):
    1. tuple = (saddr=client,daddr=pod,flags=TUPLE_F_IN,dport=client_port,sport=80)
       nothing found
    2. tuple = (saddr=pod,daddr=client,flags=TUPLE_F_OUT,dport=80,sport=client_port)
       nothing found

ct_create4(..., CT_EGRESS):
    key = tuple=(saddr=pod,daddr=client,flags=TUPLE_F_OUT,dport=80,sport=client_port) <-- ENTRY_EGRESS
    val = entry=(rev_nat_id=$SVC_ID,node_port=1,ifindex=FOO)

ct_lookup4(.., CT_INGRESS):
    1. tuple = (saddr=client,daddr=pod,flags=TUPLE_F_OUT,dport=client_port,sport=80)
       nothing found
    2. tuple = (saddr=pod,daddr=client,flags=TUPLE_F_IN,dport=80,sport=client_port)
       nothing found

ct_create4(..., CT_INGRESS):
    key = tuple=(saddr=pod,daddr=client,flags=TUPLE_F_IN,dport=80,sport=client_port) <-- ENTRY_INGRESS
    val = entry=(rev_nat_id=0,node_port=1)

ct_lookup4(.., CT_EGRESS)
    1. tuple = (saddr=pod,daddr=client,flags=TUPLE_F_IN,dport=80,sport=client_port)
       finds ENTRY_INGRESS
             ^-- before this patch, this entry is used to determine the `monitor` value on the reply path

-send_trace_notify(TRACE_TO_NETWORK, ...) <-- removed by this patch

ct_lookup4(.., CT_INGRESS)
    1. tuple = (saddr=pod,daddr=client,flags=TUPLE_F_OUT,dport=80,sport=client_port)
       finds ENTRY_EGRESS
             ^-- after this patch, this entry is now used to determine the `monitor` value on the reply path

+send_trace_notify(TRACE_TO_NETWORK, ...) <-- added by this patch

ct_lookup4(.., CT_EGRESS)
    1. tuple = (saddr=client,daddr=pod,flags=TUPLE_F_IN,dport=client_port,sport=80)
       nothing found
    2. tuple = (saddr=pod,daddr=client,flags=TUPLE_F_OUT,dport=80,sport=client_port)
       finds ENTRY_EGRESS

ct_entry_keep_alive(ENTRY_INGRESS)

ct_lookup4(.., CT_INGRESS):
    1. tuple = (saddr=client,daddr=pod,flags=TUPLE_F_OUT,dport=client_port,sport=80)
       nothing found
    2. tuple = (saddr=pod,daddr=client,flags=TUPLE_F_IN,dport=80,sport=client_port)
       finds ENTRY_INGRESS
```

</details>

[1] https://github.com/cilium/cilium/pull/18454#discussion_r786959078

Co-authored-by: Martynas Pumputis <m@lambda.lt>
Signed-off-by: Martynas Pumputis <m@lambda.lt>
Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>

/cc @joestringer who initially raised the concern addressed by this PR
