### PR TITLE
Fix local redirect policies selecting host networked pods

### DIFF
--- a/Documentation/gettingstarted/local-redirect-policy.rst
+++ b/Documentation/gettingstarted/local-redirect-policy.rst
@@ -419,7 +419,7 @@ security credentials for pods.
 
       $ helm repo add uswitch https://uswitch.github.io/kiam-helm-charts/charts/
       $ helm repo update
-      $ helm install --set agent.host.iptables=false --set agent.extraArgs.whitelist-route-regexp=meta-data kiam uswitch/kiam
+      $ helm install --set agent.host.iptables=false --set agent.whitelist-route-regexp=meta-data kiam uswitch/kiam
 
   - The above command may provide instructions to prepare kiam in the cluster.
     Follow the instructions before continuing.

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -355,6 +355,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium-health status --verbose",
 		"cilium policy selectors -o json",
 		"cilium node list",
+		"cilium lrp list",
 	}
 	var commands []string
 

--- a/test/k8sT/lrp.go
+++ b/test/k8sT/lrp.go
@@ -49,6 +49,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 			be2Name        = "k8s2-backend"
 			feFilter       = "role=frontend"
 			beFilter       = "role=backend"
+			beFilter2      = "role=lrpAddrBackend"
+			lrpAddrIP      = "169.254.169.254"
 		)
 
 		var (
@@ -59,6 +61,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 			curl4UDP       string
 			curl4in6TCP    string
 			curl4in6UDP    string
+			curlTCPAddr    string
+			curlUDPAddr    string
+			be3Name        string
+			be4Name        string
 		)
 
 		BeforeAll(func() {
@@ -69,7 +75,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 			lrpSvcYAML = helpers.ManifestGet(kubectl.BasePath(), "lrp-svc.yaml")
 			res := kubectl.ApplyDefault(deploymentYAML)
 			res.ExpectSuccess("Unable to apply %s", deploymentYAML)
-			for _, pod := range []string{feFilter, beFilter} {
+			for _, pod := range []string{feFilter, beFilter, beFilter2} {
 				err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", pod), helpers.HelperTimeout)
 				Expect(err).Should(BeNil())
 			}
@@ -86,6 +92,12 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 			curl4UDP = helpers.CurlFailNoStats(tftp4SVCURL)
 			curl4in6TCP = helpers.CurlFailNoStats(http4in6SVCURL)
 			curl4in6UDP = helpers.CurlFailNoStats(tftp4in6SVCURL)
+			curlTCPAddr = helpers.CurlFailNoStats(getHTTPLink(lrpAddrIP, 80))
+			curlUDPAddr = helpers.CurlFailNoStats(getTFTPLink(lrpAddrIP, 69))
+
+			// Hostnames for host networked pods
+			be3Name, _ = kubectl.GetNodeInfo(helpers.K8s1)
+			be4Name, _ = kubectl.GetNodeInfo(helpers.K8s2)
 		})
 
 		AfterAll(func() {
@@ -106,6 +118,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 			for _, pod := range ciliumPods {
 				service := kubectl.CiliumExecMustSucceed(context.TODO(), pod, fmt.Sprintf("cilium service list | grep \" %s:\"", svcIP), "Cannot retrieve services on cilium pod")
 				service.ExpectContains("LocalRedirect", "LocalRedirect is not present in the cilium service list")
+				service2 := kubectl.CiliumExecMustSucceed(context.TODO(), pod, fmt.Sprintf("cilium service list | grep \" %s:\"", lrpAddrIP), "Cannot retrieve services on cilium pod")
+				service2.ExpectContains("LocalRedirect", "LocalRedirect is not present in the cilium service list for [%s]", lrpAddrIP)
 			}
 
 			By("Checking traffic goes to local backend")
@@ -159,6 +173,19 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 					cmd:      curl4in6UDP,
 					want:     be2Name,
 					notWant:  be1Name,
+				},
+				// Address matcher test cases.
+				{
+					selector: "id=app1",
+					cmd:      curlTCPAddr,
+					want:     be3Name,
+					notWant:  be4Name,
+				},
+				{
+					selector: "id=app2",
+					cmd:      curlUDPAddr,
+					want:     be4Name,
+					notWant:  be3Name,
 				},
 			}
 

--- a/test/k8sT/lrp.go
+++ b/test/k8sT/lrp.go
@@ -42,6 +42,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 		kubectl.CloseSSHClient()
 	})
 
+	AfterFailed(func() {
+		kubectl.CiliumReport("cilium lrp list", "cilium service list")
+	})
+
 	SkipContextIf(func() bool { return !helpers.RunsOn419OrLaterKernel() }, "Checks local redirect policy", func() {
 		const (
 			lrpServiceName = "lrp-demo-service"
@@ -117,7 +121,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 			Expect(err).To(BeNil(), "Cannot get cilium pods")
 			for _, pod := range ciliumPods {
 				service := kubectl.CiliumExecMustSucceed(context.TODO(), pod, fmt.Sprintf("cilium service list | grep \" %s:\"", svcIP), "Cannot retrieve services on cilium pod")
-				service.ExpectContains("LocalRedirect", "LocalRedirect is not present in the cilium service list")
+				service.ExpectContains("LocalRedirect", "LocalRedirect is not present in the cilium service list for [%s]", svcIP)
 				service2 := kubectl.CiliumExecMustSucceed(context.TODO(), pod, fmt.Sprintf("cilium service list | grep \" %s:\"", lrpAddrIP), "Cannot retrieve services on cilium pod")
 				service2.ExpectContains("LocalRedirect", "LocalRedirect is not present in the cilium service list for [%s]", lrpAddrIP)
 			}

--- a/test/k8sT/manifests/lrp-test.yaml
+++ b/test/k8sT/manifests/lrp-test.yaml
@@ -142,3 +142,95 @@ spec:
       - name: tftp
         port: "69"
         protocol: UDP
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: k8s1-backend2
+  labels:
+    id: be3
+    role: lrpAddrBackend
+spec:
+  # Host networked backends test kiam like use cases.
+  hostNetwork: true
+  containers:
+    - name: web
+      image: docker.io/cilium/echoserver:1.10.1
+      imagePullPolicy: IfNotPresent
+      ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 80
+    - name: udp
+      image: docker.io/cilium/echoserver-udp:v2020.01.30
+      imagePullPolicy: IfNotPresent
+      ports:
+        - name: tftp
+          containerPort: 69
+          protocol: UDP
+  terminationGracePeriodSeconds: 0
+  nodeSelector:
+    "cilium.io/ci-node": k8s1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: k8s2-backend2
+  labels:
+    id: be4
+    role: lrpAddrBackend
+spec:
+  hostNetwork: true
+  containers:
+    - name: web
+      image: docker.io/cilium/echoserver:1.10.1
+      imagePullPolicy: IfNotPresent
+      ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 80
+    - name: udp
+      image: docker.io/cilium/echoserver-udp:v2020.01.30
+      imagePullPolicy: IfNotPresent
+      ports:
+        - name: tftp
+          containerPort: 69
+          protocol: UDP
+  terminationGracePeriodSeconds: 0
+  nodeSelector:
+    "cilium.io/ci-node": k8s2
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-test-addr"
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.169.254"
+      toPorts:
+        - name: http
+          port: "80"
+          protocol: TCP
+        - name: tftp
+          port: "69"
+          protocol: UDP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        role: lrpAddrBackend
+    toPorts:
+      - name: http
+        port: "80"
+        protocol: TCP
+      - name: tftp
+        port: "69"
+        protocol: UDP


### PR DESCRIPTION
See commit messages.

Fixes: da35c88eb9f8 ("k8s/watchers: don't silently ignore (*K8sWatcher).updatePodHostData error")
Fixes: 0ab4fa184d3a ("pkg/k8s: ignore certain ipcache errors")
Related: #16920

**Release note**
```release-note
Fix a bug with local redirect policies selecting host networked pods as local endpoints not taking effect.
```