### PR TITLE
node: Fix bug where node ipsets are never cleaned

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -596,7 +596,7 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 
 	for _, address := range entry.node.IPAddresses {
 		if option.Config.IptablesMasqueradingEnabled() &&
-			address.Type != addressing.NodeInternalIP {
+			address.Type == addressing.NodeInternalIP {
 			iptables.RemoveFromNodeIpset(address.IP)
 		}
 


### PR DESCRIPTION
Due to a typo in the condition for the removal of IP addresses from the node ipset in commit 9708e5d21 ("node: Don't skip masquerading for External node IPs"), the ipsets would have never been cleaned up. This commit fixes it.

Not flagging as bug since it didn't made it into any release yet.

Fixes: https://github.com/cilium/cilium/pull/18483.