### PR TITLE
docs: add Hands-on tutorial

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -38,6 +38,10 @@ The documentation is divided into the following sections:
 * :ref:`dev_guide` : Gives background to those looking to develop and contribute
   modifications to the Cilium code or documentation.
 
+A `hands-on tutorial <https://play.instruqt.com/isovalent/invite/j4maqox5r1h5>`_ 
+in a live environment is also available for users looking for a way to quickly
+get started and experiment with Cilium.
+
 .. toctree::
    :maxdepth: 2
    :caption: Getting Started


### PR DESCRIPTION
This pull request adds the following text to documentation after the line Getting Started Guides:

"[Hands-on tutorial](https://play.instruqt.com/isovalent/invite/j4maqox5r1h5) in a live environment to quickly get started with Cilium."

![image](https://user-images.githubusercontent.com/48465000/150569802-77623cfb-53b5-4cfc-873a-1050d2927c2a.png)


<!-- Description of change -->

Signed-off-by: Van Le <vannnyle@gmail.com>
