### PR TITLE
daemon: Allow to enable PCAP recorder in non-lb mode

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -360,9 +360,6 @@ func initKubeProxyReplacementOptions() (bool, error) {
 		}
 
 		if option.Config.EnableRecorder {
-			if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
-				return false, fmt.Errorf("pcap recorder --%s currently only supported for --%s=%s", option.EnableRecorder, option.DatapathMode, datapathOption.DatapathModeLBOnly)
-			}
 			found := false
 			if h := probesManager.GetHelpers("xdp"); h != nil {
 				if _, ok := h["bpf_ktime_get_boot_ns"]; ok {


### PR DESCRIPTION
Previously, the PCAP recorder \[1\] was enabled only when running the
lb-only mode. However, there was an ask from users, who are running KPR
in the XDP mode, to have means to observe the LB traffic (tcpdump
cannot be used for XDP progs).

Why we didn't allow it before? Our main concern was potential verifier
complexity issues. But considering that the opt is disabled by default,
it's up to a user to take the potential risk.

Tested manually on the 5.16 kernel with the following cmds:

    ./daemon/cilium-agent  --debug=true --enable-ipv4=true
    --enable-ipv6=false --disable-envoy-version-check=true
    --tunnel=disabled --k8s-kubeconfig-path=/home/vagrant/.kube/config
    --kube-proxy-replacement=strict --native-routing-cidr=10.154.0.0/16
    --enable-ipv4-masquerade=true --auto-direct-node-routes=true
    --enable-hubble=true --enable-recorder=true --bpf-lb-acceleration=native
    --bpf-lb-acceleration=testing-only

    # create nginx pod and expose it via NodePort service

    hubble record --server=unix:///var/run/cilium/hubble.sock "0.0.0.0/0
    0 192.168.34.11/32 31894 TCP"

    # access the svc from outside

    2022-01-24T10:25:03Z Status: 14 packets (1106 bytes) written


\[1\]: https://cilium.io/blog/2021/05/20/cilium-110#pcap