### PR TITLE
bpf: use bounded loops in pcap recorder and nat engine

### DIFF
--- a/bpf/lib/loop.h
+++ b/bpf/lib/loop.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2022 Authors of Cilium */
+
+#ifndef __LIB_LOOP_H_
+#define __LIB_LOOP_H_
+
+#include <bpf/ctx/ctx.h>
+#include <bpf/api.h>
+
+#ifdef HAVE_BOUNDED_LOOPS
+# define __bounded_loop		/* no unroll */
+#else /* !HAVE_BOUNDED_LOOPS */
+# define __bounded_loop		_Pragma("unroll")
+#endif
+
+#endif /* __LIB_LOOP_H_ */

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -13,6 +13,7 @@
 #include <linux/ipv6.h>
 
 #include "common.h"
+#include "loop.h"
 #include "drop.h"
 #include "signal.h"
 #include "conntrack.h"
@@ -233,7 +234,7 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 		rstate.common.host_local = ostate->common.host_local;
 	}
 
-#pragma unroll
+__bounded_loop
 	for (retries = 0; retries < SNAT_COLLISION_RETRIES; retries++) {
 		if (!snat_v4_lookup(&rtuple)) {
 			ostate->common.created = bpf_mono_now();
@@ -720,7 +721,7 @@ static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 		rstate.common.host_local = ostate->common.host_local;
 	}
 
-#pragma unroll
+__bounded_loop
 	for (retries = 0; retries < SNAT_COLLISION_RETRIES; retries++) {
 		if (!snat_v6_lookup(&rtuple)) {
 			ostate->common.created = bpf_mono_now();

--- a/bpf/lib/pcap.h
+++ b/bpf/lib/pcap.h
@@ -10,6 +10,7 @@
 #ifdef ENABLE_CAPTURE
 #include "common.h"
 #include "time_cache.h"
+#include "loop.h"
 #include "lb.h"
 
 struct pcap_timeval {
@@ -245,7 +246,7 @@ cilium_capture4_classify_wcard(struct __ctx_buff *ctx)
 	okey.flags = 0;
 	lkey.flags = 0;
 
-_Pragma("unroll")
+__bounded_loop
 	for (i = 0; i < size; i++) {
 		cilium_capture4_masked_key(&okey, &prefix_masks[i], &lkey);
 		match = map_lookup_elem(&CAPTURE4_RULES, &lkey);
@@ -370,7 +371,7 @@ cilium_capture6_classify_wcard(struct __ctx_buff *ctx)
 	okey.flags = 0;
 	lkey.flags = 0;
 
-_Pragma("unroll")
+__bounded_loop
 	for (i = 0; i < size; i++) {
 		cilium_capture6_masked_key(&okey, &prefix_masks[i], &lkey);
 		match = map_lookup_elem(&CAPTURE6_RULES, &lkey);


### PR DESCRIPTION
See commit msgs. Follow-up to https://github.com/cilium/cilium/pull/18592. (dep: https://github.com/cilium/cilium/pull/18597)