### PR TITLE
byteorder: use native instructions in host/network order conversion

### DIFF
--- a/pkg/byteorder/byteorder_littleendian.go
+++ b/pkg/byteorder/byteorder_littleendian.go
@@ -6,19 +6,14 @@
 
 package byteorder
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"math/bits"
+)
 
 var Native binary.ByteOrder = binary.LittleEndian
 
-func HostToNetwork16(u uint16) uint16 { return swap16(u) }
-func HostToNetwork32(u uint32) uint32 { return swap32(u) }
-func NetworkToHost16(u uint16) uint16 { return swap16(u) }
-func NetworkToHost32(u uint32) uint32 { return swap32(u) }
-
-func swap16(u uint16) uint16 {
-	return (u&0xff00)>>8 | (u&0xff)<<8
-}
-
-func swap32(u uint32) uint32 {
-	return (u&0xff000000)>>24 | (u&0xff0000)>>8 | (u&0xff00)<<8 | (u&0xff)<<24
-}
+func HostToNetwork16(u uint16) uint16 { return bits.ReverseBytes16(u) }
+func HostToNetwork32(u uint32) uint32 { return bits.ReverseBytes32(u) }
+func NetworkToHost16(u uint16) uint16 { return bits.ReverseBytes16(u) }
+func NetworkToHost32(u uint32) uint32 { return bits.ReverseBytes32(u) }


### PR DESCRIPTION
In the current implementation of HostToNetwork{16,32} and
NetworkToHost{16,32} for big endian architectures the Go compiler isn't
able to convert these operations into native assembly instructions, e.g.
BSWAP on x86_64. These generally yields better performance.

Use ReverseBytes{16,32} from the math/bits stdlib package to implement
these functions which allows the Go compiler to emit the respective
assembly instructions. This is checked in the Go toolchain test suite:
https://github.com/golang/go/blob/16d6a5233a183be7264295c66167d35c689f9372/test/codegen/mathbits.go#L194-L208

Example output of `go tool compile -S byteorder_littleendian.go` on
x86_64 for the HostToNetwork{16,32} functions below.
NetworkToHost{16,32} look the same. Note the ROLW and BSWAPL
instructions emitted after this change.

<details>
<summary>Before:</summary>
<pre>
"".HostToNetwork16 STEXT nosplit size=20 args=0x8 locals=0x0 funcid=0x0
        0x0000 00000 (byteorder_littleendian.go:13)     TEXT    "".HostToNetwork16(SB), NOSPLIT|ABIInternal, $0-8
        0x0000 00000 (byteorder_littleendian.go:13)     FUNCDATA        $0, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
        0x0000 00000 (byteorder_littleendian.go:13)     FUNCDATA        $1, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
        0x0000 00000 (byteorder_littleendian.go:13)     FUNCDATA        $5, "".HostToNetwork16.arginfo1(SB)
        0x0000 00000 (<unknown line number>)    NOP
        0x0000 00000 (byteorder_littleendian.go:13)     MOVL    AX, CX
        0x0002 00002 (byteorder_littleendian.go:19)     ANDL    $-256, AX
        0x0007 00007 (byteorder_littleendian.go:19)     SHRW    $8, AX
        0x000b 00011 (byteorder_littleendian.go:19)     MOVBLZX CL, CX
        0x000e 00014 (byteorder_littleendian.go:19)     SHLL    $8, CX
        0x0011 00017 (byteorder_littleendian.go:19)     ORL     CX, AX
        0x0013 00019 (byteorder_littleendian.go:13)     RET
        0x0000 89 c1 25 00 ff ff ff 66 c1 e8 08 0f b6 c9 c1 e1  ..%....f........
        0x0010 08 09 c8 c3                                      ....
"".HostToNetwork32 STEXT nosplit size=45 args=0x8 locals=0x0 funcid=0x0
        0x0000 00000 (byteorder_littleendian.go:14)     TEXT    "".HostToNetwork32(SB), NOSPLIT|ABIInternal, $0-8
        0x0000 00000 (byteorder_littleendian.go:14)     FUNCDATA        $0, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
        0x0000 00000 (byteorder_littleendian.go:14)     FUNCDATA        $1, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
        0x0000 00000 (byteorder_littleendian.go:14)     FUNCDATA        $5, "".HostToNetwork32.arginfo1(SB)
        0x0000 00000 (<unknown line number>)    NOP
        0x0000 00000 (byteorder_littleendian.go:14)     MOVL    AX, CX
        0x0002 00002 (byteorder_littleendian.go:23)     ANDL    $-16777216, AX
        0x0007 00007 (byteorder_littleendian.go:23)     SHRL    $24, AX
        0x000a 00010 (byteorder_littleendian.go:23)     MOVL    CX, DX
        0x000c 00012 (byteorder_littleendian.go:23)     ANDL    $16711680, CX
        0x0012 00018 (byteorder_littleendian.go:23)     SHRL    $8, CX
        0x0015 00021 (byteorder_littleendian.go:23)     ORL     CX, AX
        0x0017 00023 (byteorder_littleendian.go:23)     MOVL    DX, CX
        0x0019 00025 (byteorder_littleendian.go:23)     ANDL    $65280, DX
        0x001f 00031 (byteorder_littleendian.go:23)     SHLL    $8, DX
        0x0022 00034 (byteorder_littleendian.go:23)     ORL     DX, AX
        0x0024 00036 (byteorder_littleendian.go:23)     MOVBLZX CL, CX
        0x0027 00039 (byteorder_littleendian.go:23)     SHLL    $24, CX
        0x002a 00042 (byteorder_littleendian.go:23)     ORL     CX, AX
        0x002c 00044 (byteorder_littleendian.go:14)     RET
        0x0000 89 c1 25 00 00 00 ff c1 e8 18 89 ca 81 e1 00 00  ..%.............
        0x0010 ff 00 c1 e9 08 09 c8 89 d1 81 e2 00 ff 00 00 c1  ................
        0x0020 e2 08 09 d0 0f b6 c9 c1 e1 18 09 c8 c3           .............
```
</pre>
</details>

<details>
<summary>After:</summary>
<pre>
"".HostToNetwork16 STEXT nosplit size=5 args=0x8 locals=0x0 funcid=0x0
        0x0000 00000 (byteorder_littleendian.go:16)     TEXT    "".HostToNetwork16(SB), NOSPLIT|ABIInternal, $0-8
        0x0000 00000 (byteorder_littleendian.go:16)     FUNCDATA        $0, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
        0x0000 00000 (byteorder_littleendian.go:16)     FUNCDATA        $1, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
        0x0000 00000 (byteorder_littleendian.go:16)     FUNCDATA        $5, "".HostToNetwork16.arginfo1(SB)
        0x0000 00000 (<unknown line number>)    NOP
        0x0000 00000 (byteorder_littleendian.go:16)     ROLW    $8, AX
        0x0004 00004 (byteorder_littleendian.go:16)     RET
        0x0000 66 c1 c0 08 c3                                   f....
"".HostToNetwork32 STEXT nosplit size=3 args=0x8 locals=0x0 funcid=0x0
        0x0000 00000 (byteorder_littleendian.go:17)     TEXT    "".HostToNetwork32(SB), NOSPLIT|ABIInternal, $0-8
        0x0000 00000 (byteorder_littleendian.go:17)     FUNCDATA        $0, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
        0x0000 00000 (byteorder_littleendian.go:17)     FUNCDATA        $1, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
        0x0000 00000 (byteorder_littleendian.go:17)     FUNCDATA        $5, "".HostToNetwork32.arginfo1(SB)
        0x0000 00000 (byteorder_littleendian.go:17)     BSWAPL  AX
        0x0002 00002 (byteorder_littleendian.go:17)     RET
        0x0000 0f c8 c3                                         ...
</pre>
</details>

Fixes: 332b16fcf3f2 ("byteorder: Simplify byte order functions")