### PR TITLE
ipsec: Generate from-stack trace for ipsec packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -860,11 +860,11 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	bpf_clear_meta(ctx);
 
 	if (from_host) {
+		__u32 magic;
 		enum trace_point trace = TRACE_FROM_HOST;
-		bool from_proxy;
 
-		from_proxy = inherit_identity_from_host(ctx, &identity);
-		if (from_proxy)
+		magic = inherit_identity_from_host(ctx, &identity);
+		if (magic == MARK_MAGIC_PROXY_INGRESS ||  magic == MARK_MAGIC_PROXY_EGRESS)
 			trace = TRACE_FROM_PROXY;
 		send_trace_notify(ctx, trace, identity, 0, 0,
 				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1769,7 +1769,7 @@ __section("to-container")
 int handle_to_container(struct __ctx_buff *ctx)
 {
 	enum trace_point trace = TRACE_FROM_STACK;
-	__u32 identity = 0;
+	__u32 magic, identity = 0;
 	__u16 proto;
 	int ret;
 
@@ -1780,7 +1780,8 @@ int handle_to_container(struct __ctx_buff *ctx)
 
 	bpf_clear_meta(ctx);
 
-	if (inherit_identity_from_host(ctx, &identity))
+	magic = inherit_identity_from_host(ctx, &identity);
+	if (magic == MARK_MAGIC_PROXY_INGRESS || magic == MARK_MAGIC_PROXY_EGRESS)
 		trace = TRACE_FROM_PROXY;
 
 	send_trace_notify(ctx, trace, identity, 0, 0,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -438,6 +438,9 @@ pass_to_stack:
 #  ifdef IP_POOLS
 		set_encrypt_dip(ctx, tunnel_endpoint);
 #  endif /* IP_POOLS */
+#  ifdef ENABLE_IDENTITY_MARK
+		set_identity_mark(ctx, SECLABEL);
+#  endif /* ENABLE_IDENTITY_MARK */
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* ENABLE_WIREGUARD */
@@ -908,6 +911,9 @@ pass_to_stack:
 #  ifdef IP_POOLS
 		set_encrypt_dip(ctx, tunnel_endpoint);
 #  endif /* IP_POOLS */
+#  ifdef ENABLE_IDENTITY_MARK
+		set_identity_mark(ctx, SECLABEL);
+#  endif
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* ENABLE_WIREGUARD */

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -81,6 +81,8 @@ static __always_inline bool inherit_identity_from_host(struct __ctx_buff *ctx,
 		*identity = get_identity(ctx);
 	} else if (magic == MARK_MAGIC_HOST) {
 		*identity = HOST_ID;
+	} else if (magic == MARK_MAGIC_ENCRYPT) {
+		*identity = get_identity(ctx);
 	} else {
 		*identity = WORLD_ID;
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

When ipsec packets comes from the host (xfrm) stack to from-host program
(bpf_host), it bypasses the send_trace_notify (<- stack). As a result, we
only see the trace for inner packet (ICMPRequest/Reply with <- endpoint
and -> stack). Fix bpf_host program not to bypass the trace.

Trace on source node before fix

```
<- endpoint ... EchoRequest
-> stack ... EchoRequest
```

Trace on the source node after fix

```
<- endpoint ... EchoRequest
-> stack ... EchoRequest
<- stack encrypted ...
```

This PR also contains some minor fixes related needed to achieving the main goal. Please see commit messages for more details.

Related #14625

```release-note
Fix the bug that ipsec packets bypass the <- stack trace after encryption
```
