### PR TITLE
hubble/recorder: Sanitize pcap filename

### DIFF
--- a/pkg/hubble/recorder/service.go
+++ b/pkg/hubble/recorder/service.go
@@ -213,6 +213,8 @@ func (s *Service) Record(stream recorderpb.Recorder_RecordServer) error {
 
 const fileExistsRetries = 100
 
+var allowedFileChars = regexp.MustCompile("[^a-zA-Z0-9_.-]")
+
 func createPcapFile(basedir, prefix string) (f *os.File, filePath string, err error) {
 	try := 0
 	for {
@@ -220,7 +222,8 @@ func createPcapFile(basedir, prefix string) (f *os.File, filePath string, err er
 		random := rand.Uint32()
 		nodeName := nodeTypes.GetAbsoluteNodeName()
 		name := fmt.Sprintf("%s_%d_%d_%s.pcap", prefix, startTime, random, nodeName)
-		filePath = path.Join(basedir, name)
+		sanitizedName := allowedFileChars.ReplaceAllLiteralString(name, "_")
+		filePath = path.Join(basedir, sanitizedName)
 		f, err = os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 		if err != nil {
 			if os.IsExist(err) {


### PR DESCRIPTION
This removes any special characters from the generated pcap filename.

This fixes a bug where we accidentally added a slash to the filename
when we added support for the clustername. This broke file creation, as
file names cannot contain slashes.

Fixes: 3203df90821f ("hubble: Hubble node_name field should contain cluster name")

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
