### PR TITLE
hubble/relay: Make Peer Service a K8s Service

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -689,6 +689,18 @@
      - Labels to add to ServiceMonitor hubble
      - object
      - ``{}``
+   * - hubble.peerService.clusterDomain
+     - The cluster domain to use to query the Hubble Peer service. It should be the local cluster.
+     - string
+     - ``"cluster.local"``
+   * - hubble.peerService.enabled
+     - Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client
+     - bool
+     - ``true``
+   * - hubble.peerService.servicePort
+     - Service Port for the Peer service.
+     - int
+     - ``4254``
    * - hubble.relay.affinity
      - Affinity for hubble-replay
      - object

--- a/Documentation/internals/hubble.rst
+++ b/Documentation/internals/hubble.rst
@@ -46,8 +46,8 @@ Hubble server
 
 The Hubble server component implements two gRPC services. The **Observer
 service** which may optionally be exposed via a TCP socket in addition to a
-local Unix domain socket and the  **Peer service**, which is only served on a
-local Unix domain socket.
+local Unix domain socket and the  **Peer service**, which is served on both
+as well as a Kubernetes Service.
 
 The Observer service
 ^^^^^^^^^^^^^^^^^^^^
@@ -95,9 +95,9 @@ the peers in the cluster and subsequently sends information about peers that
 are updated, added or removed from the cluster. Thus, it allows the caller to
 keep track of all Hubble instances and query their respective gRPC services.
 
-This service is typically only exposed on a local Unix domain socket and is
-primarily used by Hubble Relay in order to have a cluster-wide view of all
-Hubble instances.
+This service is typically only exposed on a local Unix domain socket and a
+Kubernetes Service and is primarily used by Hubble Relay in order to have
+a cluster-wide view of all Hubble instances.
 
 The Peer service obtains peer change notifications by subscribing to Cilium's
 node manager. To this end, it internally defines a handler that implements

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -701,6 +701,7 @@ parsers
 passthrough
 pc
 pcap
+peerService
 perf
 periodSeconds
 pipelining

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	keyClusterName            = "cluster-name"
 	keyPprof                  = "pprof"
 	keyPprofPort              = "pprof-port"
 	keyGops                   = "gops"
@@ -52,6 +53,10 @@ func New(vp *viper.Viper) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
+	flags.String(
+		keyClusterName,
+		defaults.ClusterName,
+		"Name of the current cluster")
 	flags.Bool(
 		keyPprof, false, "Enable serving the pprof debugging API",
 	)
@@ -79,7 +84,7 @@ func New(vp *viper.Viper) *cobra.Command {
 		"Address on which to listen")
 	flags.String(
 		keyPeerService,
-		defaults.HubbleTarget,
+		defaults.PeerTarget,
 		"Address of the server that implements the peer gRPC service")
 	flags.Int(
 		keySortBufferMaxLen,
@@ -136,8 +141,9 @@ func runServe(vp *viper.Viper) error {
 	logger := logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay")
 
 	opts := []server.Option{
+		server.WithLocalClusterName(vp.GetString(keyClusterName)),
 		server.WithDialTimeout(vp.GetDuration(keyDialTimeout)),
-		server.WithHubbleTarget(vp.GetString(keyPeerService)),
+		server.WithPeerTarget(vp.GetString(keyPeerService)),
 		server.WithListenAddress(vp.GetString(keyListenAddress)),
 		server.WithRetryTimeout(vp.GetDuration(keyRetryTimeout)),
 		server.WithSortBufferMaxLen(vp.GetInt(keySortBufferMaxLen)),

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -223,6 +223,9 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble |
 | hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | hubble.metrics.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor hubble |
+| hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
+| hubble.peerService.enabled | bool | `true` | Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client |
+| hubble.peerService.servicePort | int | `4254` | Service Port for the Peer service. |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -1,4 +1,8 @@
 {{- if and .Values.hubble.enabled .Values.hubble.relay.enabled }}
+{{- $peerSvcPort := .Values.hubble.peerService.servicePort -}}
+{{- if not .Values.hubble.peerService.servicePort }}
+{{- $peerSvcPort = (.Values.hubble.tls.enabled | ternary 443 80) -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -7,7 +11,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |
+    cluster-name: {{ .Values.cluster.name }}
+    {{- if and .Values.hubble.enabled .Values.hubble.peerService.enabled }}
+    peer-service: "hubble-peer.{{ .Release.Namespace }}.svc.{{ .Values.hubble.peerService.clusterDomain }}:{{ $peerSvcPort }}"
+    {{- else }}
     peer-service: unix://{{ .Values.hubble.socketPath }}
+    {{- end }}
     listen-address: {{ .Values.hubble.relay.listenHost }}:{{ .Values.hubble.relay.listenPort }}
     dial-timeout: {{ .Values.hubble.relay.dialTimeout }}
     retry-timeout: {{ .Values.hubble.relay.retryTimeout }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.hubble.enabled .Values.hubble.relay.enabled }}
+{{- $mountSocket := not .Values.hubble.peerService.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -68,9 +69,11 @@ spec:
             {{- toYaml . | trim | nindent 12 }}
           {{- end }}
           volumeMounts:
+          {{- if $mountSocket }}
           - name: hubble-sock-dir
             mountPath: {{ dir .Values.hubble.socketPath }}
             readOnly: true
+          {{- end }}
           - name: config
             mountPath: /etc/hubble-relay
             readOnly: true
@@ -104,10 +107,12 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+      {{- if $mountSocket }}
       - name: hubble-sock-dir
         hostPath:
           path: {{ dir .Values.hubble.socketPath }}
           type: Directory
+      {{- end }}
       {{- if .Values.hubble.tls.enabled }}
       - name: tls
         projected:

--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.hubble.enabled .Values.hubble.listenAddress .Values.hubble.peerService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-peer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: cilium
+spec:
+  selector:
+    k8s-app: cilium
+  ports:
+  - name: peer-service
+    {{- if .Values.hubble.peerService.servicePort }}
+    port: {{ .Values.hubble.peerService.servicePort }}
+    {{- else }}
+    port: {{ .Values.hubble.tls.enabled | ternary 443 80 }}
+    {{- end }}
+    protocol: TCP
+    targetPort: {{ splitList ":" .Values.hubble.listenAddress | last }}
+{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
+  internalTrafficPolicy: Local
+{{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -672,7 +672,15 @@ hubble:
   # Set this field ":4244" if you are enabling Hubble Relay, as it assumes that
   # Hubble is listening on port 4244.
   listenAddress: ":4244"
-
+  peerService:
+    # -- Enable a K8s Service for the Peer service, so that it can be accessed
+    # by a non-local client
+    enabled: true
+    # -- Service Port for the Peer service.
+    servicePort: 4254
+    # -- The cluster domain to use to query the Hubble Peer service. It should
+    # be the local cluster.
+    clusterDomain: cluster.local
   # -- TLS configuration for Hubble
   tls:
     # -- Enable mutual TLS for listenAddress. Setting this value to false is

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -136,7 +136,7 @@ func newChangeNotification(n types.Node, t peerpb.ChangeNotificationType, withTL
 	var tls *peerpb.TLS
 	if withTLS {
 		tls = &peerpb.TLS{
-			ServerName: tlsServerName(n.Name, n.Cluster),
+			ServerName: TLSServerName(n.Name, n.Cluster),
 		}
 	}
 	return &peerpb.ChangeNotification{
@@ -161,7 +161,7 @@ func nodeAddress(n types.Node) string {
 	return addr.String()
 }
 
-// tlsServerName constructs a server name to be used as the TLS server name.
+// TLSServerName constructs a server name to be used as the TLS server name.
 // The server name is of the following form:
 //
 //     <nodeName>.<clusterName>.<hubble-grpc-svc-name>.<domain>
@@ -175,7 +175,7 @@ func nodeAddress(n types.Node) string {
 // nodeName are replaced by Hyphen (-). When clusterName is not provided, it
 // defaults to the default cluster name. All Dot (.) in clusterName are
 // replaced by Hypen (-).
-func tlsServerName(nodeName, clusterName string) string {
+func TLSServerName(nodeName, clusterName string) string {
 	if nodeName == "" {
 		return ""
 	}

--- a/pkg/hubble/peer/types/client.go
+++ b/pkg/hubble/peer/types/client.go
@@ -5,12 +5,17 @@ package types
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	peerpb "github.com/cilium/cilium/api/v1/peer"
+	"github.com/cilium/cilium/pkg/crypto/certloader"
+	hubbleopts "github.com/cilium/cilium/pkg/hubble/server/serveroption"
 )
 
 // Client defines an interface that Peer service client should implement.
@@ -49,6 +54,35 @@ func (b LocalClientBuilder) Client(target string) (Client, error) {
 	defer cancel()
 	// the connection is local so we assume WithInsecure() is safe in this context
 	conn, err := grpc.DialContext(ctx, target, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return nil, err
+	}
+	return &client{conn, peerpb.NewPeerClient(conn)}, nil
+}
+
+// RemoteClientBuilder is a ClientBuilder that is suitable when the gRPC
+// connection to the Peer service is remote (typically a K8s Service).
+type RemoteClientBuilder struct {
+	DialTimeout   time.Duration
+	TLSConfig     certloader.ClientConfigBuilder
+	TLSServerName string
+}
+
+// Client implements ClientBuilder.Client.
+func (b RemoteClientBuilder) Client(target string) (Client, error) {
+	opts := []grpc.DialOption{grpc.WithBlock()}
+	if b.TLSConfig == nil {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	} else {
+		tlsConfig := b.TLSConfig.ClientConfig(&tls.Config{
+			ServerName: b.TLSServerName,
+			MinVersion: hubbleopts.MinTLSVersion,
+		})
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), b.DialTimeout)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, target, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -12,6 +12,8 @@ import (
 )
 
 const (
+	// ClusterName is the default cluster name
+	ClusterName = ciliumDefaults.ClusterName
 	// DialTimeout is the timeout that is used when establishing a new
 	// connection.
 	DialTimeout = 5 * time.Second
@@ -21,8 +23,10 @@ const (
 	PprofPort = 6062
 	// RetryTimeout is the duration to wait between reconnection attempts.
 	RetryTimeout = 30 * time.Second
-	// HubbleTarget is the address of the local Hubble instance.
-	HubbleTarget = "unix://" + ciliumDefaults.HubbleSockPath
+	// PeerTarget is the address of the peer service.
+	PeerTarget = "unix://" + ciliumDefaults.HubbleSockPath
+	// PeerServiceName is the name of the peer service, should it exist.
+	PeerServiceName = "hubble-peer"
 
 	// SortBufferMaxLen is the max number of flows that can be buffered for
 	// sorting before being sen to the client.

--- a/pkg/hubble/relay/pool/option.go
+++ b/pkg/hubble/relay/pool/option.go
@@ -19,7 +19,7 @@ import (
 
 // defaultOptions is the reference point for default values.
 var defaultOptions = options{
-	peerServiceAddress: defaults.HubbleTarget,
+	peerServiceAddress: defaults.PeerTarget,
 	peerClientBuilder: peerTypes.LocalClientBuilder{
 		DialTimeout: defaults.DialTimeout,
 	},


### PR DESCRIPTION
Currently, Hubble-Relay builds its client list by querying
the Peer Service over the local Hubble Unix domain socket.
This goes against best security practices (sharing files
across pods) and is not allowed on platforms that strictly
enforce SELinux policies (e.g. OpenShift).

This PR enables, by default, the creation of a Kubernetes Service
that proxies the Hubble Peer Service so that Hubble-Relay
can use it to build its client list, eliminating the need
for a shared Unix domain socket completely.
    
Helm values and configurations have been added to enable
the service in a cilium deployment.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>


```release-note
hubble/relay: Make the Hubble Peer service available by making it a Kubernetes service to eliminate the need to share a local Unix domain socket between a privileged pod (cilium daemon) and an unprivileged one (hubble-relay).
```
