### PR TITLE
ipsec: Feed src_id to traces in do_netdev_encrypt for native routing

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -860,11 +860,11 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	bpf_clear_meta(ctx);
 
 	if (from_host) {
+		__u32 magic;
 		enum trace_point trace = TRACE_FROM_HOST;
-		bool from_proxy;
 
-		from_proxy = inherit_identity_from_host(ctx, &identity);
-		if (from_proxy)
+		magic = inherit_identity_from_host(ctx, &identity);
+		if (magic == MARK_MAGIC_PROXY_INGRESS ||  magic == MARK_MAGIC_PROXY_EGRESS)
 			trace = TRACE_FROM_PROXY;
 		send_trace_notify(ctx, trace, identity, 0, 0,
 				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -789,7 +789,7 @@ drop_err_fib:
 }
 
 static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto,
-					     __u32 src_id __maybe_unused)
+					     __u32 src_id)
 {
 	int encrypt_iface = 0;
 	int ret = 0;
@@ -798,11 +798,11 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 #endif
 	ret = do_netdev_encrypt_pools(ctx);
 	if (ret)
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
+		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	ret = do_netdev_encrypt_fib(ctx, proto, &encrypt_iface);
 	if (ret)
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
+		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	bpf_clear_meta(ctx);
 #ifdef BPF_HAVE_FIB_LOOKUP

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -788,7 +788,8 @@ drop_err_fib:
 	return ret;
 }
 
-static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto)
+static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto,
+					     __u32 src_id __maybe_unused)
 {
 	int encrypt_iface = 0;
 	int ret = 0;
@@ -818,21 +819,21 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 }
 
 #else /* TUNNEL_MODE */
-static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx)
+static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32 src_id)
 {
-	__u32 seclabel, tunnel_endpoint = 0;
+	__u32 tunnel_endpoint = 0;
 
-	seclabel = get_identity(ctx);
 	tunnel_endpoint = ctx_load_meta(ctx, 4);
 	ctx->mark = 0;
 
 	bpf_clear_meta(ctx);
-	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, TRACE_PAYLOAD_LEN);
+	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, src_id, TRACE_PAYLOAD_LEN);
 }
 
-static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto __maybe_unused)
+static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto __maybe_unused,
+					     __u32 src_id)
 {
-	return do_netdev_encrypt_encap(ctx);
+	return do_netdev_encrypt_encap(ctx, src_id);
 }
 #endif /* TUNNEL_MODE */
 #endif /* ENABLE_IPSEC */
@@ -845,18 +846,14 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	int ret;
 
 #ifdef ENABLE_IPSEC
-	if (from_host) {
-		__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
-
-		if (magic == MARK_MAGIC_ENCRYPT)
-			return do_netdev_encrypt(ctx, proto);
-	} else {
-		int done = do_decrypt(ctx, proto);
-
-		if (!done)
-			return CTX_ACT_OK;
-	}
+	if (!from_host && !do_decrypt(ctx, proto))
+		/* Don't have to do send_trace_notify in here, because
+		 * the packet will be hooked into the to-host program
+		 * soon and trace is there.
+		 */
+		return CTX_ACT_OK;
 #endif
+
 	bpf_clear_meta(ctx);
 
 	if (from_host) {
@@ -866,6 +863,15 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 		magic = inherit_identity_from_host(ctx, &identity);
 		if (magic == MARK_MAGIC_PROXY_INGRESS ||  magic == MARK_MAGIC_PROXY_EGRESS)
 			trace = TRACE_FROM_PROXY;
+
+#ifdef ENABLE_IPSEC
+		if (magic == MARK_MAGIC_ENCRYPT) {
+			send_trace_notify(ctx, trace, identity, 0, 0, ctx->ingress_ifindex,
+					  TRACE_REASON_ENCRYPTED, TRACE_PAYLOAD_LEN);
+			return do_netdev_encrypt(ctx, proto, identity);
+		}
+#endif
+
 		send_trace_notify(ctx, trace, identity, 0, 0,
 				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
 	} else {

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1769,7 +1769,7 @@ __section("to-container")
 int handle_to_container(struct __ctx_buff *ctx)
 {
 	enum trace_point trace = TRACE_FROM_STACK;
-	__u32 identity = 0;
+	__u32 magic, identity = 0;
 	__u16 proto;
 	int ret;
 
@@ -1780,7 +1780,8 @@ int handle_to_container(struct __ctx_buff *ctx)
 
 	bpf_clear_meta(ctx);
 
-	if (inherit_identity_from_host(ctx, &identity))
+	magic = inherit_identity_from_host(ctx, &identity);
+	if (magic == MARK_MAGIC_PROXY_INGRESS || magic == MARK_MAGIC_PROXY_EGRESS)
 		trace = TRACE_FROM_PROXY;
 
 	send_trace_notify(ctx, trace, identity, 0, 0,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -438,6 +438,9 @@ pass_to_stack:
 #  ifdef IP_POOLS
 		set_encrypt_dip(ctx, tunnel_endpoint);
 #  endif /* IP_POOLS */
+#  ifdef ENABLE_IDENTITY_MARK
+		set_identity_mark(ctx, SECLABEL);
+#  endif /* ENABLE_IDENTITY_MARK */
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* ENABLE_WIREGUARD */
@@ -908,6 +911,9 @@ pass_to_stack:
 #  ifdef IP_POOLS
 		set_encrypt_dip(ctx, tunnel_endpoint);
 #  endif /* IP_POOLS */
+#  ifdef ENABLE_IDENTITY_MARK
+		set_identity_mark(ctx, SECLABEL);
+#  endif
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* ENABLE_WIREGUARD */

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -76,11 +76,12 @@ static __always_inline bool inherit_identity_from_host(struct __ctx_buff *ctx,
 	} else if (magic == MARK_MAGIC_PROXY_EGRESS) {
 		*identity = get_identity(ctx);
 		ctx->tc_index |= TC_INDEX_F_SKIP_EGRESS_PROXY;
-		from_proxy = true;
 	} else if (magic == MARK_MAGIC_IDENTITY) {
 		*identity = get_identity(ctx);
 	} else if (magic == MARK_MAGIC_HOST) {
 		*identity = HOST_ID;
+	} else if (magic == MARK_MAGIC_ENCRYPT) {
+		*identity = get_identity(ctx);
 	} else {
 		*identity = WORLD_ID;
 	}

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -55,11 +55,9 @@ static __always_inline bool identity_is_reserved(__u32 identity)
 }
 
 #if __ctx_is == __ctx_skb
-static __always_inline bool inherit_identity_from_host(struct __ctx_buff *ctx,
-						       __u32 *identity)
+static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, __u32 *identity)
 {
 	__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
-	bool from_proxy = false;
 
 	/* Packets from the ingress proxy must skip the proxy when the
 	 * destination endpoint evaluates the policy. As the packet would loop
@@ -68,7 +66,6 @@ static __always_inline bool inherit_identity_from_host(struct __ctx_buff *ctx,
 	if (magic == MARK_MAGIC_PROXY_INGRESS) {
 		*identity = get_identity(ctx);
 		ctx->tc_index |= TC_INDEX_F_SKIP_INGRESS_PROXY;
-		from_proxy = true;
 	/* (Return) packets from the egress proxy must skip the redirection to
 	 * the proxy, as the packet would loop and/or the connection be reset
 	 * otherwise.
@@ -90,7 +87,7 @@ static __always_inline bool inherit_identity_from_host(struct __ctx_buff *ctx,
 	ctx->mark = 0;
 	cilium_dbg(ctx, DBG_INHERIT_IDENTITY, *identity, 0);
 
-	return from_proxy;
+	return magic;
 }
 #endif /* __ctx_is == __ctx_skb */
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

In do_netdev_encrypt for native routing mode, there are some drop notifications available. However, they are missing source identity currently. With the change in ae6868c, we can pass inherited source identity from mark to do_netdev_encrypt, so use that.

```release-note
Add src_id information to drop trace inside the do_netdev_encrypt for native routing mode
```
