### PR TITLE
datapath: Only unload obsolete XDP when attached

### DIFF
--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -39,7 +39,8 @@ func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode string) {
 	}
 
 	for _, link := range links {
-		if link.Attrs().Xdp == nil {
+		linkxdp := link.Attrs().Xdp
+		if linkxdp == nil || !linkxdp.Attached {
 			// No XDP program is attached
 			continue
 		}
@@ -51,7 +52,7 @@ func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode string) {
 		used := false
 		for _, xdpDev := range xdpDevs {
 			if link.Attrs().Name == xdpDev &&
-				link.Attrs().Xdp.Flags&xdpModeToFlag(xdpMode) != 0 {
+				linkxdp.Flags&xdpModeToFlag(xdpMode) != 0 {
 				// XDP mode matches; don't unload, otherwise we might introduce
 				// intermittent connectivity problems
 				used = true


### PR DESCRIPTION
Currently, we determine whether a device is attached with an XDP
program by checking if `link.Attrs().Xdp == nil`. We need to check
for `Xdp.Attached` as well, otherwise, the XDP unloading will be
executed on innocent devices every time the agent restarts, which
might further cause network interruption for some NIC drivers,
e.g. Mellanox mlx5.

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

```release-note
datapath: Only unload obsolete XDP when attached
```
