### PR TITLE
ipsec: Fix incorrect trace in from-network

### DIFF
--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -14,19 +14,10 @@
 __section("from-network")
 int from_network(struct __ctx_buff *ctx)
 {
+	int ret;
 #ifdef ENABLE_IPSEC
 	__u16 proto;
-
-	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT) {
-		send_trace_notify(ctx, TRACE_FROM_NETWORK, get_identity(ctx), 0, 0,
-				  ctx->ingress_ifindex,
-				  TRACE_REASON_ENCRYPTED, TRACE_PAYLOAD_LEN);
-	} else
 #endif
-	{
-		send_trace_notify(ctx, TRACE_FROM_NETWORK, 0, 0, 0,
-				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
-	}
 
 	bpf_clear_meta(ctx);
 
@@ -35,11 +26,46 @@ int from_network(struct __ctx_buff *ctx)
 	if (!validate_ethertype(ctx, &proto))
 		return CTX_ACT_OK;
 
-	return do_decrypt(ctx, proto);
+	ret = do_decrypt(ctx, proto);
 #else
 	/* nop if IPSec is disabled */
-	return CTX_ACT_OK;
+	ret = CTX_ACT_OK;
 #endif
+
+/* We need to handle following possible packets come to this program
+ *
+ * 1. ESP packets coming from network (encrypted and not marked)
+ * 2. Non-ESP packets coming from network (plain and not marked)
+ * 3. Non-ESP packets coming from stack re-inserted by xfrm (plain
+ *    and marked with MARK_MAGIC_DECRYPT, IPSec mode only)
+ *
+ * 1. will be traced with TRACE_REASON_ENCRYPTED, because
+ * do_decrypt marks them with MARK_MAGIC_DECRYPT.
+ *
+ * 2. will be traced without TRACE_REASON_ENCRYPTED, because
+ * do_decrypt does't touch to mark.
+ *
+ * 3. will be traced without TRACE_REASON_ENCRYPTED, because
+ * do_decrypt clears the mark.
+ *
+ * Note that 1. contains the ESP packets someone else generated.
+ * In that case, we trace it as "encrypted", but it doesn't mean
+ * "encrypted by Cilium".
+ *
+ * We won't use TRACE_REASON_ENCRYPTED even if the packets are ESP,
+ * because it doesn't matter for the non-IPSec mode.
+ */
+#ifdef ENABLE_IPSEC
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT)
+		send_trace_notify(ctx, TRACE_FROM_NETWORK, get_identity(ctx), 0, 0,
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
+				  TRACE_PAYLOAD_LEN);
+	else
+#endif
+		send_trace_notify(ctx, TRACE_FROM_NETWORK, 0, 0, 0,
+				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
+
+	return ret;
 }
 
 BPF_LICENSE("GPL");


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

In from-network, there is a wrong send_trace_notify which sets
TRACE_REASON_ENCRYPTED for decrypted packets.

```release-note
Fix incorrect packet trace for encrypted packets received from the network
```
