### PR TITLE
CODEOWNERS: Do not assign reviewers for Documentation/helm-values.rst

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -127,6 +127,7 @@ Makefile* @cilium/build
 /Documentation/gettingstarted/kubeproxy-free.rst @cilium/loadbalancer @cilium/docs-structure
 /Documentation/gettingstarted/policy-creation.rst @cilium/policy @cilium/docs-structure
 /Documentation/glossary.rst @cilium/docs-structure
+/Documentation/helm-values.rst @cilium/nonexistantteam
 /Documentation/images/re-request-review.png @cilium/contributing @cilium/docs-structure
 /Documentation/index.rst @cilium/docs-structure
 /Documentation/internals/index.rst @cilium/docs-structure


### PR DESCRIPTION
Similarly to the files under `Documentation/cmdref/`, the reference at `Documentation/helm-values.rst` is automatically generated during the build process, and needs no manual edit. As a consequence, it is generally useless to ask for reviews from the `cilium/docs-structure` team when this file is the only piece of documentation that changes. Let's assign it to the non-existent team placeholder.
