### PR TITLE
docs: remove gobpf, mention cilium/ebpf

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -4581,12 +4581,22 @@ legacy cBPF:
 
 ..
 
-* **gobpf**
+* **cilium/ebpf**
 
-  gobpf provides go bindings for the bcc framework as well as low-level routines in
-  order to load and use BPF programs from ELF files.
+  ``cilium/ebpf`` (ebpf-go) is a pure Go library that provides utilities for
+  loading, compiling, and debugging eBPF programs. It has minimal external
+  dependencies and is intended to be used in long-running processes.
 
-  https://github.com/iovisor/gobpf
+  Its ``bpf2go`` utility automates away compiling eBPF C programs and embedding
+  them into Go binaries.
+
+  It implements attaching programs to various kernel hooks, as well as kprobes
+  and uprobes for tracing arbitrary kernel and user space functions. It also
+  features a complete assembler that allows constructing eBPF programs at
+  runtime using Go, or modifying them after they've been loaded from an ELF
+  object.
+
+  https://github.com/cilium/ebpf
 
 ..
 


### PR DESCRIPTION
As it's been unmaintained for a while, and there are [talks](https://github.com/iovisor/gobpf/issues/304) of officially deprecating gobpf, I guess it's time to remove it here.

I was hinted by a fellow community member that this list might need a bit of work (or we could just redirect to ebpf.io instead), but cilium/ebpf should at least be mentioned here for now.