### PR TITLE
bpf/test: Fix incorrect macro definition

### DIFF
--- a/bpf/tests/drop_notify_test.h
+++ b/bpf/tests/drop_notify_test.h
@@ -32,7 +32,7 @@
 // Define macros like the followings to make sure the original tailcall is redirected
 // to the mock tailcall function, the last 0 does not matter because we do not
 // actually use the arguments.
-#define ep_tail_call(a, b) tail_call(a, b, 0)
+#define ep_tail_call(a, b) tail_call(a, NULL, 0)
 
 // The file containing the functions to be tested must be included after
 // defining the above macros.

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -11,7 +11,7 @@ DOCKER_CTR := $(CONTAINER_ENGINE) container run --rm \
 		--user "$(shell id -u):$(shell id -g)"
 DOCKER_RUN := $(DOCKER_CTR) cilium/bpf-mock
 
-FLAGS := -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc --all) -O2
+FLAGS := -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc --all) -O2 -Werror
 FLAGS_CLANG := -Wall -Wextra -Werror -Wshadow -Wno-unused-parameter
 FLAGS_CLANG += -Wno-address-of-packed-member
 FLAGS_CLANG += -Wno-unknown-warning-option


### PR DESCRIPTION
The first commit fixes an incorrect macro definition which leads to a compilation warning. The second commit ensures that doesn't sneak in again, by turning all compilation warnings into errors.

Fixes: https://github.com/cilium/cilium/pull/17114.