### PR TITLE
docs: Fix incorrect values for hubble-ui standalone install

### DIFF
--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -79,28 +79,28 @@ If you have not done so already, enable the Hubble UI by running the following c
                   server:
                     # set this to true if tls is enabled on Hubble relay server side
                     enabled: true
-            ui:
-              # enable Hubble UI
-              enabled: true
-              standalone:
-                # enable Hubble UI standalone deployment
+              ui:
+                # enable Hubble UI
                 enabled: true
-                # provide a volume containing Hubble relay client certificates to mount in Hubble UI pod
-                certsVolume:
-                  projected:
-                    defaultMode: 0400
-                    sources:
-                      - secret:
-                          name: my-hubble-ui-client-certs
-                          items:
-                            - key: tls.crt
-                              path: client.crt
-                            - key: tls.key
-                              path: client.key
-                            - key: ca.crt
-                              path: hubble-relay-ca.crt
+                standalone:
+                  # enable Hubble UI standalone deployment
+                  enabled: true
+                  # provide a volume containing Hubble relay client certificates to mount in Hubble UI pod
+                  tls:
+                    certsVolume:
+                      projected:
+                        defaultMode: 0400
+                        sources:
+                          - secret:
+                              name: my-hubble-ui-client-certs
+                              items:
+                                - key: tls.crt
+                                  path: client.crt
+                                - key: tls.key
+                                  path: client.key
+                                - key: ca.crt
+                                  path: hubble-relay-ca.crt
             EOF
-
 
         Please note that Hubble UI expects the certificate files to be available under the following paths:
 


### PR DESCRIPTION
This PR fixes incorrect values given in the document for hubble-ui standalone install.

Fixes: #18650

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
