### PR TITLE
contrib/backporting: Include golang in the image

### DIFF
--- a/contrib/backporting/Dockerfile
+++ b/contrib/backporting/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="maintainer@cilium.io"
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
 RUN apt-get install -y \
   git \
+  golang \
   jq \
   python3 \
   python3-pip \


### PR DESCRIPTION
Dev doctor is written with Go and is unable to be used in
the container right now:
```
❮ docker run -e GITHUB_TOKEN -v $(pwd):/cilium -v "$HOME/.ssh":/home/user/.ssh \
      -it cilium-backport /bin/bash
$ go run ./tools/dev-doctor --backporting
bash: go: command not found
```

Signed-off-by: Glib Smaga <code@gsmaga.com>
