### PR TITLE
v1.11 backports 2022-01-31

### DIFF
--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -21,9 +21,6 @@ Packets are not encrypted when they are destined to the same node from which
 they were sent. This behavior is intended. Encryption would provide no benefits
 in that case, given that the raw traffic can be observed on the node anyway.
 
-Transparent encryption is not currently supported when chaining Cilium on top
-of other CNI plugins. For more information, see :gh-issue:`15596`.
-
 Generate & Import the PSK
 =========================
 
@@ -355,3 +352,9 @@ Disabling Encryption
 
 To disable the encryption, regenerate the YAML with the option
 ``encryption.enabled=false``
+
+Limitations
+===========
+
+    * Transparent encryption is not currently supported when chaining Cilium on
+      top of other CNI plugins. For more information, see :gh-issue:`15596`.

--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -358,3 +358,4 @@ Limitations
 
     * Transparent encryption is not currently supported when chaining Cilium on
       top of other CNI plugins. For more information, see :gh-issue:`15596`.
+    * :ref:`HostPolicies` are not currently supported with IPsec encryption.

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -355,11 +355,6 @@ all
    Allowing users to define custom entities is on the roadmap but has not been
    implemented yet (see :gh-issue:`3553`).
 
-.. note::
-
-   A known issue with kube-apiserver entity matching is that the feature
-   doesn't work in tunneling mode (see :gh-issue:`18049`).
-
 Access to/from local host
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -860,11 +860,11 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	bpf_clear_meta(ctx);
 
 	if (from_host) {
+		__u32 magic;
 		int trace = TRACE_FROM_HOST;
-		bool from_proxy;
 
-		from_proxy = inherit_identity_from_host(ctx, &identity);
-		if (from_proxy)
+		magic = inherit_identity_from_host(ctx, &identity);
+		if (magic == MARK_MAGIC_PROXY_INGRESS ||  magic == MARK_MAGIC_PROXY_EGRESS)
 			trace = TRACE_FROM_PROXY;
 		send_trace_notify(ctx, trace, identity, 0, 0,
 				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -430,6 +430,9 @@ pass_to_stack:
 #  ifdef IP_POOLS
 		set_encrypt_dip(ctx, tunnel_endpoint);
 #  endif /* IP_POOLS */
+#  ifdef ENABLE_IDENTITY_MARK
+		set_identity_mark(ctx, SECLABEL);
+#  endif /* ENABLE_IDENTITY_MARK */
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* ENABLE_WIREGUARD */
@@ -891,6 +894,9 @@ pass_to_stack:
 #  ifdef IP_POOLS
 		set_encrypt_dip(ctx, tunnel_endpoint);
 #  endif /* IP_POOLS */
+#  ifdef ENABLE_IDENTITY_MARK
+		set_identity_mark(ctx, SECLABEL);
+#  endif
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* ENABLE_WIREGUARD */

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1726,7 +1726,7 @@ __section("to-container")
 int handle_to_container(struct __ctx_buff *ctx)
 {
 	int ret, trace = TRACE_FROM_STACK;
-	__u32 identity = 0;
+	__u32 magic, identity = 0;
 	__u16 proto;
 
 	if (!validate_ethertype(ctx, &proto)) {
@@ -1736,7 +1736,8 @@ int handle_to_container(struct __ctx_buff *ctx)
 
 	bpf_clear_meta(ctx);
 
-	if (inherit_identity_from_host(ctx, &identity))
+	magic = inherit_identity_from_host(ctx, &identity);
+	if (magic == MARK_MAGIC_PROXY_INGRESS || magic == MARK_MAGIC_PROXY_EGRESS)
 		trace = TRACE_FROM_PROXY;
 
 	send_trace_notify(ctx, trace, identity, 0, 0,

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -194,10 +194,6 @@ __revalidate_data_pull(struct __ctx_buff *ctx, void **data, void **data_end,
 #define revalidate_data(ctx, data, data_end, ip)			\
 	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), false)
 
-#define revalidate_data_with_eth_hlen(ctx, data, data_end, ip, eth_len)		\
-	____revalidate_data_pull(ctx, data, data_end, (void **)ip,	\
-				 sizeof(**ip), false, eth_len)
-
 /* Macros for working with L3 cilium defined IPV6 addresses */
 #define BPF_V6(dst, ...)	BPF_V6_1(dst, fetch_ipv6(__VA_ARGS__))
 #define BPF_V6_1(dst, ...)	BPF_V6_4(dst, __VA_ARGS__)

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -81,6 +81,8 @@ static __always_inline bool inherit_identity_from_host(struct __ctx_buff *ctx,
 		*identity = get_identity(ctx);
 	} else if (magic == MARK_MAGIC_HOST) {
 		*identity = HOST_ID;
+	} else if (magic == MARK_MAGIC_ENCRYPT) {
+		*identity = get_identity(ctx);
 	} else {
 		*identity = WORLD_ID;
 	}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -504,7 +504,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 	struct bpf_fib_lookup_padded fib_params = {
 		.l = {
 			.family		= AF_INET6,
-			.ifindex	= DIRECT_ROUTING_DEV_IFINDEX,
+			.ifindex	= ctx_get_ifindex(ctx),
 		},
 	};
 	void *data, *data_end;
@@ -542,27 +542,23 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	ret = maybe_add_l2_hdr(ctx, DIRECT_ROUTING_DEV_IFINDEX,
-			       &l2_hdr_required);
-	if (ret != 0)
-		goto drop_err;
-	if (!l2_hdr_required)
-		goto out_send;
-	else if (!revalidate_data_with_eth_hlen(ctx, &data, &data_end, &ip6,
-						__ETH_HLEN))
-		return DROP_INVALID;
-
 	ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_src,
 		       (union v6addr *)&ip6->saddr);
 	ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
 		       (union v6addr *)&ip6->daddr);
 
-	ret = fib_lookup(ctx, &fib_params.l, sizeof(fib_params),
-			 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
+	ret = fib_lookup(ctx, &fib_params.l, sizeof(fib_params), 0);
 	if (ret != 0) {
 		ret = DROP_NO_FIB;
 		goto drop_err;
 	}
+
+	ret = maybe_add_l2_hdr(ctx, fib_params.l.ifindex, &l2_hdr_required);
+	if (ret != 0)
+		goto drop_err;
+	if (!l2_hdr_required)
+		goto out_send;
+
 	if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0) {
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
@@ -587,7 +583,7 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 	struct bpf_fib_lookup_padded fib_params = {
 		.l = {
 			.family		= AF_INET6,
-			.ifindex	= DIRECT_ROUTING_DEV_IFINDEX,
+			.ifindex	= ctx_get_ifindex(ctx),
 		},
 	};
 	struct ipv6_nat_target target = {
@@ -666,27 +662,23 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	ret = maybe_add_l2_hdr(ctx, DIRECT_ROUTING_DEV_IFINDEX,
-			       &l2_hdr_required);
-	if (ret != 0)
-		goto drop_err;
-	if (!l2_hdr_required)
-		goto out_send;
-	else if (!revalidate_data_with_eth_hlen(ctx, &data, &data_end, &ip6,
-						__ETH_HLEN))
-		return DROP_INVALID;
-
 	ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_src,
 		       (union v6addr *)&ip6->saddr);
 	ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
 		       (union v6addr *)&ip6->daddr);
 
-	ret = fib_lookup(ctx, &fib_params.l, sizeof(fib_params),
-			 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
+	ret = fib_lookup(ctx, &fib_params.l, sizeof(fib_params), 0);
 	if (ret != 0) {
 		ret = DROP_NO_FIB;
 		goto drop_err;
 	}
+
+	ret = maybe_add_l2_hdr(ctx, fib_params.l.ifindex, &l2_hdr_required);
+	if (ret != 0)
+		goto drop_err;
+	if (!l2_hdr_required)
+		goto out_send;
+
 	if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0) {
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
@@ -873,7 +865,7 @@ redo_local:
 /* See comment in tail_rev_nodeport_lb4(). */
 static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex)
 {
-	int ret, ret2, l3_off = ETH_HLEN, l4_off, hdrlen;
+	int ret, fib_ret, ret2, l3_off = ETH_HLEN, l4_off, hdrlen;
 	struct ipv6_ct_tuple tuple = {};
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -937,29 +929,29 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex
 		}
 #endif
 
+		fib_params.family = AF_INET6;
+		fib_params.ifindex = ctx_get_ifindex(ctx);
+
+		ipv6_addr_copy((union v6addr *)&fib_params.ipv6_src, &tuple.saddr);
+		ipv6_addr_copy((union v6addr *)&fib_params.ipv6_dst, &tuple.daddr);
+
+		fib_ret = fib_lookup(ctx, &fib_params, sizeof(fib_params), 0);
+
+		if (fib_ret == 0)
+			*ifindex = fib_params.ifindex;
+
 		ret = maybe_add_l2_hdr(ctx, *ifindex, &l2_hdr_required);
 		if (ret != 0)
 			return ret;
 		if (!l2_hdr_required)
 			return CTX_ACT_OK;
-		else if (!revalidate_data_with_eth_hlen(ctx, &data, &data_end,
-							&ip6, __ETH_HLEN))
-			return DROP_INVALID;
 
-		fib_params.family = AF_INET6;
-		fib_params.ifindex = *ifindex;
-
-		ipv6_addr_copy((union v6addr *)&fib_params.ipv6_src, &tuple.saddr);
-		ipv6_addr_copy((union v6addr *)&fib_params.ipv6_dst, &tuple.daddr);
-
-		ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
-				 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
-		if (ret != 0) {
+		if (fib_ret != 0) {
 			union macaddr smac =
 				NATIVE_DEV_MAC_BY_IFINDEX(*ifindex);
 			union macaddr *dmac;
 
-			if (ret != BPF_FIB_LKUP_RET_NO_NEIGH)
+			if (fib_ret != BPF_FIB_LKUP_RET_NO_NEIGH)
 				return DROP_NO_FIB;
 
 			/* See comment in rev_nodeport_lb4(). */
@@ -1508,7 +1500,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 	struct bpf_fib_lookup_padded fib_params = {
 		.l = {
 			.family		= AF_INET,
-			.ifindex	= DIRECT_ROUTING_DEV_IFINDEX,
+			.ifindex	= ctx_get_ifindex(ctx),
 		},
 	};
 	void *data, *data_end;
@@ -1542,25 +1534,21 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	ret = maybe_add_l2_hdr(ctx, DIRECT_ROUTING_DEV_IFINDEX,
-			       &l2_hdr_required);
-	if (ret != 0)
-		goto drop_err;
-	if (!l2_hdr_required)
-		goto out_send;
-	else if (!revalidate_data_with_eth_hlen(ctx, &data, &data_end, &ip4,
-						__ETH_HLEN))
-		return DROP_INVALID;
-
 	fib_params.l.ipv4_src = ip4->saddr;
 	fib_params.l.ipv4_dst = ip4->daddr;
 
-	ret = fib_lookup(ctx, &fib_params.l, sizeof(fib_params),
-			 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
+	ret = fib_lookup(ctx, &fib_params.l, sizeof(fib_params), 0);
 	if (ret != 0) {
 		ret = DROP_NO_FIB;
 		goto drop_err;
 	}
+
+	ret = maybe_add_l2_hdr(ctx, fib_params.l.ifindex, &l2_hdr_required);
+	if (ret != 0)
+		goto drop_err;
+	if (!l2_hdr_required)
+		goto out_send;
+
 	if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0) {
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
@@ -1584,7 +1572,7 @@ int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 	struct bpf_fib_lookup_padded fib_params = {
 		.l = {
 			.family		= AF_INET,
-			.ifindex	= DIRECT_ROUTING_DEV_IFINDEX,
+			.ifindex	= ctx_get_ifindex(ctx),
 		},
 	};
 	struct ipv4_nat_target target = {
@@ -1596,6 +1584,11 @@ int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 	struct iphdr *ip4;
 	bool l2_hdr_required = true;
 
+	/* Unfortunately, the bpf_fib_lookup() is not able to set src IP addr.
+	 * So we need to assume that the direct routing device is going to be
+	 * used to fwd the NodePort request, thus SNAT-ing to its IP addr.
+	 * This will change once we have resolved GH#17158.
+	 */
 	target.addr = IPV4_DIRECT_ROUTING;
 #ifdef TUNNEL_MODE
 	if (dir == NAT_DIR_EGRESS) {
@@ -1665,25 +1658,21 @@ int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	ret = maybe_add_l2_hdr(ctx, DIRECT_ROUTING_DEV_IFINDEX,
-			       &l2_hdr_required);
-	if (ret != 0)
-		goto drop_err;
-	if (!l2_hdr_required)
-		goto out_send;
-	else if (!revalidate_data_with_eth_hlen(ctx, &data, &data_end, &ip4,
-						__ETH_HLEN))
-		return DROP_INVALID;
-
 	fib_params.l.ipv4_src = ip4->saddr;
 	fib_params.l.ipv4_dst = ip4->daddr;
 
-	ret = fib_lookup(ctx, &fib_params.l, sizeof(fib_params),
-			 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
+	ret = fib_lookup(ctx, &fib_params.l, sizeof(fib_params), 0);
 	if (ret != 0) {
 		ret = DROP_NO_FIB;
 		goto drop_err;
 	}
+
+	ret = maybe_add_l2_hdr(ctx, fib_params.l.ifindex, &l2_hdr_required);
+	if (ret != 0)
+		goto drop_err;
+	if (!l2_hdr_required)
+		goto out_send;
+
 	if (eth_store_daddr(ctx, fib_params.l.dmac, 0) < 0) {
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
@@ -1892,7 +1881,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 	void *data, *data_end;
 	struct iphdr *ip4;
 	struct csum_offset csum_off = {};
-	int ret, ret2, l3_off = ETH_HLEN, l4_off;
+	int ret, fib_ret, ret2, l3_off = ETH_HLEN, l4_off;
 	struct ct_state ct_state = {};
 	struct bpf_fib_lookup fib_params = {};
 	__u32 monitor = 0;
@@ -1962,30 +1951,36 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 		}
 #endif
 
+		fib_params.family = AF_INET;
+		fib_params.ifindex = ctx_get_ifindex(ctx);
+
+		fib_params.ipv4_src = ip4->saddr;
+		fib_params.ipv4_dst = ip4->daddr;
+
+		fib_ret = fib_lookup(ctx, &fib_params, sizeof(fib_params), 0);
+
+		if (fib_ret == 0)
+			/* If the FIB lookup was successful, use the outgoing
+			 * iface from its result. Otherwise, we will fallback
+			 * to CT's ifindex which was learned when the request
+			 * was sent. The latter assumes that the reply should
+			 * be sent over the same device which received the
+			 * request.
+			 */
+			*ifindex = fib_params.ifindex;
+
 		ret = maybe_add_l2_hdr(ctx, *ifindex, &l2_hdr_required);
 		if (ret != 0)
 			return ret;
 		if (!l2_hdr_required)
 			return CTX_ACT_OK;
-		else if (!revalidate_data_with_eth_hlen(ctx, &data, &data_end,
-							&ip4, __ETH_HLEN))
-			return DROP_INVALID;
 
-		fib_params.family = AF_INET;
-		fib_params.ifindex = *ifindex;
-
-		fib_params.ipv4_src = ip4->saddr;
-		fib_params.ipv4_dst = ip4->daddr;
-
-		ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
-				 BPF_FIB_LOOKUP_DIRECT |
-				 BPF_FIB_LOOKUP_OUTPUT);
-		if (ret != 0) {
+		if (fib_ret != 0) {
 			union macaddr smac =
 				NATIVE_DEV_MAC_BY_IFINDEX(*ifindex);
 			union macaddr *dmac;
 
-			if (ret != BPF_FIB_LKUP_RET_NO_NEIGH)
+			if (fib_ret != BPF_FIB_LKUP_RET_NO_NEIGH)
 				return DROP_NO_FIB;
 
 			/* For the case where a client from the same L2

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -39,7 +39,8 @@ func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode string) {
 	}
 
 	for _, link := range links {
-		if link.Attrs().Xdp == nil {
+		linkxdp := link.Attrs().Xdp
+		if linkxdp == nil || !linkxdp.Attached {
 			// No XDP program is attached
 			continue
 		}
@@ -51,7 +52,7 @@ func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode string) {
 		used := false
 		for _, xdpDev := range xdpDevs {
 			if link.Attrs().Name == xdpDev &&
-				link.Attrs().Xdp.Flags&xdpModeToFlag(xdpMode) != 0 {
+				linkxdp.Flags&xdpModeToFlag(xdpMode) != 0 {
 				// XDP mode matches; don't unload, otherwise we might introduce
 				// intermittent connectivity problems
 				used = true

--- a/pkg/hubble/recorder/service.go
+++ b/pkg/hubble/recorder/service.go
@@ -213,6 +213,8 @@ func (s *Service) Record(stream recorderpb.Recorder_RecordServer) error {
 
 const fileExistsRetries = 100
 
+var allowedFileChars = regexp.MustCompile("[^a-zA-Z0-9_.-]")
+
 func createPcapFile(basedir, prefix string) (f *os.File, filePath string, err error) {
 	try := 0
 	for {
@@ -220,7 +222,8 @@ func createPcapFile(basedir, prefix string) (f *os.File, filePath string, err er
 		random := rand.Uint32()
 		nodeName := nodeTypes.GetAbsoluteNodeName()
 		name := fmt.Sprintf("%s_%d_%d_%s.pcap", prefix, startTime, random, nodeName)
-		filePath = path.Join(basedir, name)
+		sanitizedName := allowedFileChars.ReplaceAllLiteralString(name, "_")
+		filePath = path.Join(basedir, sanitizedName)
 		f, err = os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 		if err != nil {
 			if os.IsExist(err) {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -314,6 +314,10 @@ type Kubectl struct {
 	// ciliumOptions is a cache of the most recent configuration options
 	// used to install Cilium via CiliumInstall().
 	ciliumOptions map[string]string
+
+	// nDNSReplicas is the number of replicas for DNS pods in the cluster.
+	// Stored via kub.ScaleDownDNS(), used by kub.ScaleUpDNS().
+	nDNSReplicas int
 }
 
 // CreateKubectl initializes a Kubectl helper with the provided vmName and log
@@ -2064,11 +2068,63 @@ iteratePods:
 	}
 }
 
+func (kub *Kubectl) setDNSReplicas(nReplicas int) *CmdRes {
+	res := kub.ExecShort(fmt.Sprintf("%s get deploy -n %s -l %s -o jsonpath='{.items[*].metadata.name}'", KubectlCmd, KubeSystemNamespace, kubeDNSLabel))
+	if !res.WasSuccessful() {
+		return res
+	}
+
+	// kubectl -n kube-system patch deploy coredns --patch '{"spec": { "replicas":1}}'
+	name := res.Stdout()
+	spec := fmt.Sprintf("{\"spec\": { \"replicas\":%d}}", nReplicas)
+	return kub.ExecShort(fmt.Sprintf("%s patch deploy -n %s %s --patch '%s'", KubectlCmd, KubeSystemNamespace, name, spec))
+}
+
+// ScaleDownDNS reduces the number of pods in the cluster performing kube-dns
+// duties down to zero. May be reverted by calling ScaleUpDNS().
+func (kub *Kubectl) ScaleDownDNS() *CmdRes {
+	cmd := fmt.Sprintf("%s get deploy -n %s -l %s -o jsonpath='{.items[*].status.replicas}'", KubectlCmd, KubeSystemNamespace, kubeDNSLabel)
+	res := kub.ExecShort(cmd)
+	if !res.WasSuccessful() {
+		ginkgoext.Failf("Unable to retrieve DNS pods to scale down, command '%s': %s", res.GetCmd(), res.OutputPrettyPrint())
+		return res
+	}
+
+	n, err := strconv.Atoi(res.Stdout())
+	if err != nil {
+		ginkgoext.Failf("Failed to retrieve DNS replicas via '%s': %s", res.GetCmd(), err)
+		res.success = false
+		res.err = err
+		return res
+	}
+	kub.nDNSReplicas = n
+
+	res = kub.setDNSReplicas(0)
+	if !res.WasSuccessful() {
+		ginkgoext.Failf("Unable to scale down DNS pods, command '%s': %s", res.GetCmd(), res.OutputPrettyPrint())
+	}
+	return res
+}
+
+// ScaleUpDNS restores the number of replicas for kube-dns to the number
+// prior to calling ScaleDownDNS(). Must be called after ScaleDownDNS().
+func (kub *Kubectl) ScaleUpDNS() *CmdRes {
+	res := kub.setDNSReplicas(kub.nDNSReplicas)
+	if !res.WasSuccessful() {
+		ginkgoext.Failf("Unable to scale down DNS pods, command '%s': %s", res.GetCmd(), res.OutputPrettyPrint())
+	}
+	return res
+}
+
 // RedeployDNS deletes the kube-dns pods and does not wait for the deletion
 // to complete. Useful to ensure that the pods are recreated after datapath
 // configuration changes.
 func (kub *Kubectl) RedeployDNS() *CmdRes {
-	return kub.DeleteResource("pod", "-n "+KubeSystemNamespace+" -l "+kubeDNSLabel)
+	if res := kub.ScaleDownDNS(); !res.WasSuccessful() {
+		return res
+	}
+
+	return kub.ScaleUpDNS()
 }
 
 // RedeployKubernetesDnsIfNecessary validates if the Kubernetes DNS is

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2116,10 +2116,9 @@ func (kub *Kubectl) ScaleUpDNS() *CmdRes {
 	return res
 }
 
-// RedeployDNS deletes the kube-dns pods and does not wait for the deletion
-// to complete. Useful to ensure that the pods are recreated after datapath
-// configuration changes.
-func (kub *Kubectl) RedeployDNS() *CmdRes {
+// redeployDNS deletes the kube-dns pods and does not wait for the deletion
+// to complete.
+func (kub *Kubectl) redeployDNS() *CmdRes {
 	if res := kub.ScaleDownDNS(); !res.WasSuccessful() {
 		return res
 	}
@@ -2143,7 +2142,7 @@ func (kub *Kubectl) RedeployKubernetesDnsIfNecessary(force bool) {
 	}
 
 	ginkgoext.By("Restarting Kubernetes DNS (-l %s)", kubeDNSLabel)
-	res := kub.RedeployDNS()
+	res := kub.redeployDNS()
 	if !res.WasSuccessful() {
 		ginkgoext.Failf("Unable to delete DNS pods: %s", res.OutputPrettyPrint())
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2215,6 +2215,8 @@ func (kub *Kubectl) WaitTerminatingPodsInNs(ns string, timeout time.Duration) er
 // state are deleted correctly in the platform. In case of excedding the
 // given timeout (in seconds) it returns an error.
 func (kub *Kubectl) WaitTerminatingPodsInNsWithFilter(ns, filter string, timeout time.Duration) error {
+	var innerErr error
+
 	body := func() bool {
 		where := ns
 		if where == "" {
@@ -2223,9 +2225,10 @@ func (kub *Kubectl) WaitTerminatingPodsInNsWithFilter(ns, filter string, timeout
 			where = "-n " + where
 		}
 		res := kub.ExecShort(fmt.Sprintf(
-			"%s get pods %s %s -o jsonpath='{.items[*].metadata.deletionTimestamp}'",
+			"%s get pods %s %s -o jsonpath='{.items[?(.metadata.deletionTimestamp!=\"\")].metadata.name}'",
 			KubectlCmd, filter, where))
 		if !res.WasSuccessful() {
+			innerErr = fmt.Errorf("Failed to connect to apiserver: %w", res.GetError())
 			return false
 		}
 
@@ -2234,9 +2237,11 @@ func (kub *Kubectl) WaitTerminatingPodsInNsWithFilter(ns, filter string, timeout
 			return true
 		}
 
-		podsTerminating := len(strings.Split(res.Stdout(), " "))
-		kub.Logger().WithField("Terminating pods", podsTerminating).Info("List of pods terminating")
-		if podsTerminating > 0 {
+		podsTerminating := strings.Split(res.Stdout(), " ")
+		nTerminating := len(podsTerminating)
+		kub.Logger().WithField("Terminating pods", nTerminating).Info("List of pods terminating")
+		if nTerminating > 0 {
+			innerErr = fmt.Errorf("Pods are still terminating: %s", podsTerminating)
 			return false
 		}
 		return true
@@ -2246,7 +2251,10 @@ func (kub *Kubectl) WaitTerminatingPodsInNsWithFilter(ns, filter string, timeout
 		body,
 		"Pods are still not deleted after a timeout",
 		&TimeoutConfig{Timeout: timeout})
-	return err
+	if err != nil {
+		return fmt.Errorf("%s: %w", err, innerErr)
+	}
+	return nil
 }
 
 // DeployPatchStdIn deploys the original kubernetes descriptor with the given patch.

--- a/test/helpers/manifest.go
+++ b/test/helpers/manifest.go
@@ -280,6 +280,8 @@ func (m *DeploymentManager) DeleteAll() {
 // DeployCilium()
 func (m *DeploymentManager) DeleteCilium() {
 	if m.ciliumDeployed {
+		// Ensure any Cilium-managed pods are terminated first
+		m.kubectl.WaitTerminatingPods(2 * time.Minute)
 		ginkgoext.By("Deleting Cilium")
 		m.kubectl.DeleteAndWait(m.ciliumFilename, true)
 		m.kubectl.WaitTerminatingPods(2 * time.Minute)

--- a/test/k8sT/Bandwidth.go
+++ b/test/k8sT/Bandwidth.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("K8sBandwidthTest", func() {
+var _ = SkipDescribeIf(helpers.DoesNotRunOnNetNextKernel, "K8sBandwidthTest", func() {
 	var (
 		kubectl        *helpers.Kubectl
 		ciliumFilename string
@@ -35,7 +35,7 @@ var _ = Describe("K8sBandwidthTest", func() {
 		kubectl.CloseSSHClient()
 	})
 
-	SkipContextIf(helpers.DoesNotRunOnNetNextKernel, "Checks Bandwidth Rate-Limiting", func() {
+	Context("Checks Bandwidth Rate-Limiting", func() {
 		const (
 			testDS10       = "run=netperf-10"
 			testDS25       = "run=netperf-25"

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -189,6 +189,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sChaosTest", func() {
 
 		AfterAll(func() {
 			_ = kubectl.Delete(netperfManifest)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		AfterEach(func() {

--- a/test/k8sT/CustomCalls.go
+++ b/test/k8sT/CustomCalls.go
@@ -100,8 +100,8 @@ var _ = SkipDescribeIf(func() bool {
 		})
 
 		AfterAll(func() {
-			deploymentManager.DeleteCilium()
 			deploymentManager.DeleteAll()
+			deploymentManager.DeleteCilium()
 			kubectl.RedeployDNS()
 		})
 

--- a/test/k8sT/CustomCalls.go
+++ b/test/k8sT/CustomCalls.go
@@ -16,7 +16,22 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("K8sCustomCalls", func() {
+var _ = SkipDescribeIf(func() bool {
+	// Believe it or not, bpftool internally attempts to retrieve
+	// map info before updating a map, but BPF_OBJ_GET_INFO_BY_FD
+	// is not supported on kernel 4.9 (it was introduced in Linux
+	// 4.13). Skip on 4.9 kernels.
+	//
+	// This leaves us with 4.19 and net-next. Coverage should be
+	// identical on the two versions, so just run on net-next.
+	//
+	// Also skip on GKE because we do not have the source of the
+	// custom program available on a node, for the compiler pod to
+	// pick up (although technically, skipping 4.19 kernels already
+	// skips GKE).
+	return helpers.DoesNotRunOnNetNextKernel() ||
+		helpers.RunsOnGKE()
+}, "K8sCustomCalls", func() {
 
 	var (
 		kubectl *helpers.Kubectl
@@ -53,22 +68,7 @@ var _ = Describe("K8sCustomCalls", func() {
 		kubectl.ValidateNoErrorsInLogs(duration)
 	})
 
-	SkipContextIf(func() bool {
-		// Believe it or not, bpftool internally attempts to retrieve
-		// map info before updating a map, but BPF_OBJ_GET_INFO_BY_FD
-		// is not supported on kernel 4.9 (it was introduced in Linux
-		// 4.13). Skip on 4.9 kernels.
-		//
-		// This leaves us with 4.19 and net-next. Coverage should be
-		// identical on the two versions, so just run on net-next.
-		//
-		// Also skip on GKE because we do not have the source of the
-		// custom program available on a node, for the compiler pod to
-		// pick up (although technically, skipping 4.19 kernels already
-		// skips GKE).
-		return helpers.DoesNotRunOnNetNextKernel() ||
-			helpers.RunsOnGKE()
-	}, "Basic test with byte-counter", func() {
+	Context("Basic test with byte-counter", func() {
 
 		var (
 			yaml string

--- a/test/k8sT/CustomCalls.go
+++ b/test/k8sT/CustomCalls.go
@@ -101,8 +101,10 @@ var _ = SkipDescribeIf(func() bool {
 
 		AfterAll(func() {
 			deploymentManager.DeleteAll()
+			kubectl.ScaleDownDNS()
+			ExpectAllPodsTerminated(kubectl)
 			deploymentManager.DeleteCilium()
-			kubectl.RedeployDNS()
+			kubectl.ScaleUpDNS()
 		})
 
 		installPods := func() {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -44,8 +44,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	AfterAll(func() {
+		kubectl.ScaleDownDNS()
+		ExpectAllPodsTerminated(kubectl)
 		deploymentManager.DeleteCilium()
-		kubectl.RedeployDNS()
+		kubectl.ScaleUpDNS()
 		kubectl.CloseSSHClient()
 	})
 

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -36,6 +36,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	AfterEach(func() {
 		deploymentManager.DeleteAll()
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -106,6 +106,7 @@ var _ = SkipDescribeIf(func() bool {
 	AfterAll(func() {
 		_ = kubectl.Delete(echoPodYAML)
 		_ = kubectl.Delete(assignIPYAML)
+		ExpectAllPodsTerminated(kubectl)
 
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 	})

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -39,11 +39,8 @@ var _ = Describe("K8sHealthTest", func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		})
 
-		AfterEach(func() {
-			ExpectAllPodsTerminated(kubectl)
-		})
-
 		AfterAll(func() {
+			ExpectAllPodsTerminated(kubectl)
 			UninstallCiliumFromManifest(kubectl, ciliumFilename)
 			kubectl.CloseSSHClient()
 		})

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -109,10 +109,6 @@ var _ = SkipDescribeIf(func() bool {
 		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, daemonCfg)
 	})
 
-	AfterEach(func() {
-		ExpectAllPodsTerminated(kubectl)
-	})
-
 	AfterFailed(func() {
 		kubectl.CiliumReport("cilium service list", "cilium endpoint list")
 	})
@@ -218,6 +214,7 @@ var _ = SkipDescribeIf(func() bool {
 		AfterAll(func() {
 			kubectl.NamespaceDelete(namespaceForTest)
 			kubectl.Delete(demoPath)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		BeforeEach(func() {
@@ -1500,6 +1497,7 @@ var _ = SkipDescribeIf(func() bool {
 					// Remove echoserver pods from host namespace.
 					echoPodPath := helpers.ManifestGet(kubectl.BasePath(), "echoserver-cilium-hostnetns.yaml")
 					kubectl.Delete(echoPodPath).ExpectSuccess("Cannot remove echoserver application")
+					ExpectAllPodsTerminated(kubectl)
 				})
 
 				It("Connectivity to hostns is blocked after denying ingress", func() {
@@ -1756,6 +1754,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			AfterEach(func() {
 				kubectl.Delete(connectivityCheckYml)
+				ExpectAllPodsTerminated(kubectl)
 			})
 
 			It("using connectivity-check to check datapath", func() {
@@ -1966,6 +1965,7 @@ var _ = SkipDescribeIf(func() bool {
 			_ = kubectl.Delete(demoManifest)
 			_ = kubectl.Delete(cnpSecondNS)
 			_ = kubectl.NamespaceDelete(secondNS)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("Tests the same Policy in different namespaces", func() {
@@ -2176,6 +2176,7 @@ var _ = SkipDescribeIf(func() bool {
 			_ = kubectl.Delete(demoManifestNS2)
 			_ = kubectl.NamespaceDelete(firstNS)
 			_ = kubectl.NamespaceDelete(secondNS)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("Test clusterwide connectivity with policies", func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -2590,6 +2590,60 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 				)
 			})
 
+			It("Still allows connection to KubeAPIServer with a duplicate policy", func() {
+				installDefaultDenyIngressPolicy(
+					kubectl,
+					testNamespace,
+					validateConnectivity,
+				)
+				installDefaultDenyEgressPolicy(
+					kubectl,
+					testNamespace,
+					validateConnectivity,
+				)
+				By("Installing toEntities KubeAPIServer")
+				importPolicy(
+					kubectl,
+					testNamespace,
+					cnpToEntitiesKubeAPIServer,
+					"to-entities-kube-apiserver",
+				)
+
+				By("Installing duplicate toEntities KubeAPIServer")
+				importPolicy(
+					kubectl,
+					testNamespace,
+					helpers.ManifestGet(
+						kubectl.BasePath(), "cnp-to-entities-kube-apiserver-2.yaml",
+					),
+					"to-entities-kube-apiserver-2",
+				)
+
+				By("Removing the previous toEntities KubeAPIServer policy")
+				_, err := kubectl.CiliumPolicyAction(
+					testNamespace, cnpToEntitiesKubeAPIServer, helpers.KubectlDelete, helpers.HelperTimeout,
+				)
+				Expect(err).Should(
+					BeNil(),
+					"policy %s cannot be deleted in %q namespace", cnpToEntitiesKubeAPIServer, testNamespace,
+				)
+
+				By("Verifying KubeAPIServer connectivity is still allowed")
+				// See previous It() about the assertion on 403 HTTP code.
+				Expect(
+					kubectl.ExecPodCmd(
+						testNamespace, k8s2PodName, helpers.CurlWithHTTPCode(
+							"https://%s %s",
+							kubeAPIServerService.Spec.ClusterIP,
+							"--insecure", // kube-apiserver needs cert, skip verification
+						),
+					).Stdout(),
+				).To(Equal("403"),
+					"HTTP egress connectivity to pod %q to kube-apiserver %q",
+					k8s2PodName, kubeAPIServerService.Spec.ClusterIP,
+				)
+			})
+
 			It("Denies connection to KubeAPIServer", func() {
 				By("Installing allow-all egress policy")
 				importPolicy(

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1617,7 +1617,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			kubectl.LogsPreviousWithLabel(helpers.DefaultNamespace, clientPodLabel)
 		})
 
-		AfterAll(func() {
+		AfterEach(func() {
 			wg.Wait()
 			_ = kubectl.Delete(gracefulTermYAML)
 		})

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -134,10 +134,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
-	AfterEach(func() {
-		ExpectAllPodsTerminated(kubectl)
-	})
-
 	AfterAll(func() {
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
@@ -232,6 +228,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 					_ = kubectl.Delete(echoSVCYAMLDualStack)
 				}
 			}
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		SkipItIf(helpers.RunsWithKubeProxyReplacement, "Checks service on same node", func() {
@@ -1011,6 +1008,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 						AfterAll(func() {
 							kubectl.Delete(echoYAML)
+							ExpectAllPodsTerminated(kubectl)
 						})
 
 						It("Tests NodePort", func() {
@@ -1148,6 +1146,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 						AfterAll(func() {
 							_ = kubectl.Delete(echoYAML)
+							ExpectAllPodsTerminated(kubectl)
 						})
 
 						It("Tests NodePort", func() {
@@ -1331,6 +1330,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 							for _, node := range []string{ni.k8s1NodeName, ni.k8s2NodeName, ni.outsideNodeName} {
 								kubectl.ExecInHostNetNS(context.TODO(), node, "ip l del wg0")
 							}
+							ExpectAllPodsTerminated(kubectl)
 						})
 
 						It("Tests NodePort BPF", func() {
@@ -1620,6 +1620,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 		AfterEach(func() {
 			wg.Wait()
 			_ = kubectl.Delete(gracefulTermYAML)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("Checks client terminates gracefully on service endpoint deletion", func() {

--- a/test/k8sT/Verifier.go
+++ b/test/k8sT/Verifier.go
@@ -140,6 +140,7 @@ var _ = Describe("K8sVerifier", func() {
 
 	AfterAll(func() {
 		kubectl.DeleteResource("pod", podName)
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	It("Runs the kernel verifier against Cilium's BPF datapath", func() {

--- a/test/k8sT/bookinfo.go
+++ b/test/k8sT/bookinfo.go
@@ -34,10 +34,6 @@ var _ = SkipDescribeIf(func() bool {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
-	AfterEach(func() {
-		ExpectAllPodsTerminated(kubectl)
-	})
-
 	AfterAll(func() {
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
@@ -84,6 +80,7 @@ var _ = SkipDescribeIf(func() bool {
 				// Explicitly do not check result to avoid having assertions in AfterAll.
 				_ = kubectl.Delete(resourcePath)
 			}
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("Tests bookinfo demo", func() {

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -178,8 +178,10 @@ var _ = skipSuite("K8sKubeProxyFreeMatrix tests", func() {
 			return
 		}
 
-		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		_ = kubectl.NamespaceDelete(namespaceTest)
+		ExpectAllPodsTerminated(kubectl)
+
+		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
 	})
 

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -164,13 +164,10 @@ var _ = Describe("K8sHubbleTest", func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		})
 
-		AfterEach(func() {
-			ExpectAllPodsTerminated(kubectl)
-		})
-
 		AfterAll(func() {
 			kubectl.Delete(demoPath)
 			kubectl.NamespaceDelete(namespaceForTest)
+			ExpectAllPodsTerminated(kubectl)
 
 			kubectl.DeleteHubbleRelay(hubbleRelayNamespace)
 			UninstallCiliumFromManifest(kubectl, ciliumFilename)

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -129,6 +129,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 
 		By("Deleting the istio-system namespace")
 		_ = kubectl.NamespaceDelete(istioSystemNamespace)
+		ExpectAllPodsTerminated(kubectl)
 
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()

--- a/test/k8sT/lrp.go
+++ b/test/k8sT/lrp.go
@@ -33,10 +33,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
-	AfterEach(func() {
-		ExpectAllPodsTerminated(kubectl)
-	})
-
 	AfterAll(func() {
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
@@ -90,6 +86,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
 
 		AfterAll(func() {
 			_ = kubectl.Delete(deploymentYAML)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("LRP connectivity", func() {

--- a/test/k8sT/manifests/cnp-to-entities-kube-apiserver-2.yaml
+++ b/test/k8sT/manifests/cnp-to-entities-kube-apiserver-2.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "to-entities-kube-apiserver-2"
+spec:
+  endpointSelector:
+    matchLabels:
+      {}
+  egress:
+  - toEntities:
+    - kube-apiserver

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1459,6 +1459,9 @@ var _ = Describe("RuntimePolicies", func() {
 			res := vm.ContainerCreate(initContainer, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l somelabel", cmdArgs...)
 			res.ExpectSuccess("Failed to create container")
 
+			By("Waiting for newly added endpoint to be ready")
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
+
 			endpoints, err := vm.GetAllEndpointsIds()
 			Expect(err).Should(BeNil(), "Unable to get IDs of endpoints")
 			var exists bool
@@ -1637,6 +1640,9 @@ var _ = Describe("RuntimePolicies", func() {
 			res := vm.ContainerCreate(initContainer, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l somelabel")
 			res.ExpectSuccess("Failed to create container")
 
+			By("Waiting for newly added endpoint to be ready")
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
+
 			endpoints, err := vm.GetAllEndpointsIds()
 			Expect(err).Should(BeNil(), "Unable to get IDs of endpoints")
 			endpointID, exists := endpoints[initContainer]
@@ -1678,6 +1684,9 @@ var _ = Describe("RuntimePolicies", func() {
 			By("Creating an endpoint")
 			res := vm.ContainerCreate(initContainer, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l somelabel", "ping", hostIP)
 			res.ExpectSuccess("Failed to create container")
+
+			By("Waiting for newly added endpoint to be ready")
+			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 
 			endpoints, err := vm.GetAllEndpointsIds()
 			Expect(err).To(BeNil(), "Unable to get IDs of endpoints")
@@ -1737,7 +1746,6 @@ var _ = Describe("RuntimePolicies", func() {
 				connectivityTest(pingRequests, app, newContainerName, false)
 				connectivityTest(httpRequests, app, newContainerName, true)
 			}
-
 		})
 	})
 })

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -43,6 +43,8 @@ const (
 	policiesL4Json                  = "Policies-l4-policy.json"
 	policiesL3DependentL7EgressJSON = "Policies-l3-dependent-l7-egress.json"
 	policiesReservedInitJSON        = "Policies-reserved-init.json"
+
+	initContainer = "initContainer"
 )
 
 var _ = Describe("RuntimePolicies", func() {
@@ -50,7 +52,6 @@ var _ = Describe("RuntimePolicies", func() {
 	var (
 		vm            *helpers.SSHMeta
 		monitorStop   = func() error { return nil }
-		initContainer string
 		testStartTime time.Time
 	)
 
@@ -72,8 +73,6 @@ var _ = Describe("RuntimePolicies", func() {
 		ExpectCiliumReady(vm)
 		vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		vm.PolicyDelAll()
-
-		initContainer = "initContainer"
 
 		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
 


### PR DESCRIPTION
* #18612 -- hubble/recorder: Sanitize pcap filename (@gandro)
 * #18527 -- Fix kube-apiserver policy matching feature with tunneling enabled (@christarazi)
 * #18627 -- test/runtime: fix flake on non-ready endpoints (@tklauser)
 * #18585 -- datapath: Change FIB lookups to enable NodePort multihoming (@brb)
 * #18448 -- test: Fix pod cleanup after various tests (@joestringer)
 * #18636 -- datapath: Only unload obsolete XDP when attached (@jaffcheng)
 * #18647 -- docs: Minor updates to IPsec limitations (@pchaigno)
 * #18608 -- ipsec: Generate from-stack trace for ipsec packets (@YutaroHayakawa)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18612 18527 18627 18585 18448 18636 18647 18608; do contrib/backporting/set-labels.py $pr done 1.11; done
```