### PR TITLE
docs: disable k3s network policy enforcement

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -57,7 +57,7 @@ Install Cilium by running:
 
 .. code-block:: shell-session
 
-    cilium install
+    KUBECONFIG=/etc/rancher/k3s/k3s.yaml cilium install
 
 Validate the Installation
 =========================

--- a/Documentation/gettingstarted/requirements-k3s.rst
+++ b/Documentation/gettingstarted/requirements-k3s.rst
@@ -11,9 +11,10 @@ Encapsulation   Cluster Pool    Kubernetes CRD
 
 **Requirements:**
 
-* Install your k3s cluster as you would normally would but pass in
-  ``--flannel-backend=none`` so you can install Cilium on top:
+* Install your k3s cluster as you normally would but making sure to disable
+  support for the default CNI plugin and the built-in network policy enforcer so
+  you can install Cilium on top:
 
 .. code-block:: shell-session
 
-   curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none' sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none --disable-network-policy' sh -


### PR DESCRIPTION
We already suggest to disable k3s network policy enforcement in the
quick start guide, see commit 1178b04de559 ("docs: disable k3s network
policy enforcement") and commit 7bd301bb5606 ("docs(k3s): add back the
flag to disable network policies").

Suggest doing so in the k3s-specific advanced installation guide as
well.