### PR TITLE
examples/kubernetes: allow node-local DNS cache in connectivity-check

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -1738,6 +1738,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -1778,6 +1791,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -1819,6 +1845,25 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -1863,6 +1908,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -1907,6 +1965,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -1951,6 +2022,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -1995,6 +2079,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -841,6 +841,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -881,6 +894,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -694,6 +694,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -738,6 +751,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -782,6 +808,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -826,6 +865,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -512,6 +512,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -553,6 +566,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -594,6 +620,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -635,6 +674,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -621,6 +621,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -661,6 +674,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -702,6 +728,25 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -953,6 +953,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -993,6 +1006,19 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 ---
@@ -1034,6 +1060,25 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 

--- a/examples/kubernetes/connectivity-check/connectivity-debug-tools.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-debug-tools.yaml
@@ -79,6 +79,25 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: openshift-dns
         k8s:dns.operator.openshift.io/daemonset-dns: default
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+    toCIDR:
+    - 169.254.0.0/16
+    - fd00::/8
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+    toEntities:
+    - host
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 

--- a/examples/kubernetes/connectivity-check/resources.cue
+++ b/examples/kubernetes/connectivity-check/resources.cue
@@ -253,6 +253,35 @@ egressCNP: [ID=_]: _cnp & {
 					}
 				}]
 			},
+			// Allow node-local-dns bound on a link-local address
+			{
+				toCIDR: [
+					"169.254.0.0/16",
+					"fd00::/8",
+				]
+				toPorts: [{
+					ports: [{
+						port:     "53"
+						protocol: "ANY"
+					}]
+					if _enableDNSVisibility {
+						rules: dns: [{matchPattern: "*"}]
+					}
+				}]
+			},
+			// Allow node-local-dns in host network namespace
+			{
+				toEntities: ["host"]
+				toPorts: [{
+					ports: [{
+						port:     "53"
+						protocol: "ANY"
+					}]
+					if _enableDNSVisibility {
+						rules: dns: [{matchPattern: "*"}]
+					}
+				}]
+			},
 		]
 	}
 }


### PR DESCRIPTION
This PR allows running connectivity-check on clusters with [Nodelocal DNS Cache](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns/nodelocaldns) running in `hostNetwork=true` pods bound to a link-local IP (standard node-local DNS cache deployment, not using [Cilium LRP](https://docs.cilium.io/en/latest/gettingstarted/local-redirect-policy/#node-local-dns-cache)). For cases when cluster DNS communication should be allowed, it allows DNS requests to the link-local subnets recommended by the [node-local-dns configuration documentation](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/#configuration).

Due to https://github.com/cilium/cilium/issues/18644, it also allows DNS requests to the `host` entity.

Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>