### PR TITLE
docs: Don't rely on `assignee` filter for reviews

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -283,10 +283,8 @@ Pull requests review process for committers
 #. Once a PR is open, GitHub will automatically pick which `teams <https://github.com/orgs/cilium/teams/team/teams>`_
    should review the PR using the ``CODEOWNERS`` file. Each committer can see
    the PRs they need to review by filtering by reviews requested.
-   A good filter is provided in this `link <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+assignee%3A%40me+sort%3Aupdated-asc>`_
-   so make sure to bookmark it. If a PR review is assigned to one or more
-   committers, they are expected to review that PR. Once they have performed
-   their review, they should remove themselves from the list of assignees.
+   A good filter is provided in this `link <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+user-review-requested%3A%40me+sort%3Aupdated-asc>`_
+   so make sure to bookmark it.
 
 #. Belonging to a team does not mean that a committer should know every single
    line of code the team is maintaining. For this reason it is recommended
@@ -338,7 +336,7 @@ Pull request review process for Janitors team
 Dedicated expectation time for each member of Janitors team: Follow the next
 steps 1 to 2 times per day. Works best if done first thing in the working day.
 
-#. Review all PRs requesting for review in `for you <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+team-review-requested%3Acilium%2Ftophat+sort%3Aupdated-asc>`_;
+#. Review all PRs needing a review `from you <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+team-review-requested%3Acilium%2Ftophat+sort%3Aupdated-asc>`_;
 
 #. If this PR was opened by a non-committer (e.g. external contributor) please
    assign yourself to that PR and make sure to keep track the PR gets reviewed


### PR DESCRIPTION
The `review-requested:@me` filter lists pull requests that expect a review from you or from any team you belong to. To allow everyone to see only pull requests assigned specifically to them, we had to teach MLH to assign individual reviewers to the pull request and then use `assignee:@me` instead of `review-requested:@me`.

Now that GitHub has a `user-review-requested` filter, we don't need to rely on the assignee filter anymore for reviews. To view pull requests assigned specifically to you (and not just to one of the teams you belong to), you can use `user-review-request:@me`.

There is one small difference in behavior between the two filters. `assignee:@me` would display pull requests you already reviewed but gave a `Request changes` or `Comment` review. Conversely, `user-review-requested:@me` will only display pull requests you haven't reviewed yet or for which the author re-requested a review from you.