### PR TITLE
Switch back to upstream 'helm-docs'.

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -75,7 +75,7 @@ HELM_DOCS := $(DOCKER_CTR) $(HELM_DOCS_IMAGE)
 
 M2R_VERSION := 0.2.1
 M2R_SHA := a3dc2c3fcdc31260dcb7cd42e39763281a6fdce4ca59b4c150fb3bfff5be9eb7
-M2R_IMAGE := docker.io/bmcustodio/m2r:$(M2R_VERSION)@sha256:$(M2R_SHA)
+M2R_IMAGE := quay.io/cilium/m2r:$(M2R_VERSION)@sha256:$(M2R_SHA)
 M2R := $(DOCKER_CTR) $(M2R_IMAGE) m2r
 
 .PHONY: update-helm-values FORCE

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -170,6 +170,6 @@ ifeq ($(BASE_IMAGE),)
     BASE_IMAGE=scratch
 endif
 
-HELM_DOCS_VERSION ?= "5ddabba"
-HELM_DOCS_SHA ?= "c4a91daac6bf9c181fac79e09712fcf1f9102fcab1bbacbc733883965f5fd244"
-HELM_DOCS_IMAGE ?= "docker.io/bmcustodio/helm-docs:$(HELM_DOCS_VERSION)@sha256:$(HELM_DOCS_SHA)"
+HELM_DOCS_VERSION ?= "v1.7.0"
+HELM_DOCS_SHA ?= "835200d7734899c7784419069be0a20a75b9bb381a790637ac911f26eb9d8c53"
+HELM_DOCS_IMAGE ?= "quay.io/cilium/helm-docs:$(HELM_DOCS_VERSION)@sha256:$(HELM_DOCS_SHA)"


### PR DESCRIPTION
https://github.com/norwoodj/helm-docs/pull/99 has been merged and v1.7.0 contains the required bits. It's time to move back to an upstream image.