### PR TITLE
labelfilter: Refine default label regexps

### DIFF
--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -182,19 +182,19 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 	}
 
 	expressions := []string{
-		reservedLabelsPattern,           // include all reserved labels
-		k8sConst.PodNamespaceLabel,      // include io.kubernetes.pod.namespace
-		k8sConst.PodNamespaceMetaLabels, // include all namespace labels
-		k8sConst.AppKubernetes,          // include app.kubernetes.io
-		"!io.kubernetes",                // ignore all other io.kubernetes labels
-		"!kubernetes.io",                // ignore all other kubernetes.io labels
-		"!.*beta.kubernetes.io",         // ignore all beta.kubernetes.io labels
-		"!k8s.io",                       // ignore all k8s.io labels
-		"!pod-template-generation",      // ignore pod-template-generation
-		"!pod-template-hash",            // ignore pod-template-hash
-		"!controller-revision-hash",     // ignore controller-revision-hash
-		"!annotation.*",                 // ignore all annotation labels
-		"!etcd_node",                    // ignore etcd_node label
+		reservedLabelsPattern,                             // include all reserved labels
+		regexp.QuoteMeta(k8sConst.PodNamespaceLabel),      // include io.kubernetes.pod.namespace
+		regexp.QuoteMeta(k8sConst.PodNamespaceMetaLabels), // include all namespace labels
+		regexp.QuoteMeta(k8sConst.AppKubernetes),          // include app.kubernetes.io
+		`!io\.kubernetes`,                                 // ignore all other io.kubernetes labels
+		`!kubernetes\.io`,                                 // ignore all other kubernetes.io labels
+		`!.*beta\.kubernetes\.io`,                         // ignore all beta.kubernetes.io labels
+		`!k8s\.io`,                                        // ignore all k8s.io labels
+		`!pod-template-generation`,                        // ignore pod-template-generation
+		`!pod-template-hash`,                              // ignore pod-template-hash
+		`!controller-revision-hash`,                       // ignore controller-revision-hash
+		`!annotation.*`,                                   // ignore all annotation labels
+		`!etcd_node`,                                      // ignore etcd_node label
 	}
 
 	for _, e := range expressions {

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -87,6 +87,7 @@ func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
 		"ignore":                      labels.NewLabel("ignore", "foo", labels.LabelSourceContainer),
 		"host":                        labels.NewLabel("host", "", labels.LabelSourceReserved),
 		"io.kubernetes.pod.namespace": labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceContainer),
+		"ioXkubernetes":               labels.NewLabel("ioXkubernetes", "foo", labels.LabelSourceContainer),
 	}
 
 	err := ParseLabelPrefixCfg([]string{}, "")
@@ -107,6 +108,7 @@ func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
 		"annotation." + k8sConst.CiliumIdentityAnnotationDeprecated: "12356",
 		"io.kubernetes.pod.terminationGracePeriod":                  "30",
 		"io.kubernetes.pod.uid":                                     "c2e22414-dfc3-11e5-9792-080027755f5a",
+		"ioXkubernetes":                                             "foo",
 		"ignore":                                                    "foo",
 		"ignorE":                                                    "foo",
 		"annotation.kubernetes.io/config.seen":                      "2017-05-30T14:22:17.691491034Z",
@@ -115,11 +117,10 @@ func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
 	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceContainer)
 	allLabels["host"] = labels.NewLabel("host", "", labels.LabelSourceReserved)
 	filtered, _ := dlpcfg.filterLabels(allLabels)
-	c.Assert(len(filtered), Equals, 5)
+	c.Assert(len(filtered), Equals, len(wanted)-2) // -2 because we add two labels in the next lines
 	allLabels["id.lizards"] = labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer)
 	allLabels["id.lizards.k8s"] = labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
-	c.Assert(len(filtered), Equals, 7)
 	c.Assert(filtered, checker.DeepEquals, wanted)
 }
 


### PR DESCRIPTION
Cilium treats label patterns as regular expressions. The existing
default labels, e.g. "!k8s.io", used a '.', which matches any character.
This led to the default labels being too permissive in their matching
and consequently labels like "k8sXo" being excluded from the identity,
with consequent security implications.

This PR properly escapes the regular expressions used in the default
labels and updates the documentation to describe Cilium's actual behavior.