### PR TITLE
Implement BPF-based masquerading for IPv6

### DIFF
--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -18,9 +18,6 @@ the network.
 .. image:: masquerade.png
     :align: center
 
-For IPv6 addresses masquerading is performed only when using iptables
-implementation mode.
-
 This behavior can be disabled with the option ``enable-ipv4-masquerade: false``
 for IPv4 and ``enable-ipv6-masquerade: false`` for IPv6 traffic leaving the host.
 
@@ -132,7 +129,7 @@ The example below shows how to configure the agent via :term:`ConfigMap` and to 
 
 .. note::
 
-    eBPF based masquerading is currently not supported for IPv6 traffic.
+    The eBPF-based ip-masq-agent is currently not supported for IPv6 traffic.
 
 iptables-based
 **************

--- a/bpf/include/bpf/ctx/common.h
+++ b/bpf/include/bpf/ctx/common.h
@@ -13,21 +13,6 @@
 #define __ctx_skb		1
 #define __ctx_xdp		2
 
-static __always_inline void *ctx_data(const struct __ctx_buff *ctx)
-{
-	return (void *)(unsigned long)ctx->data;
-}
-
-static __always_inline void *ctx_data_meta(const struct __ctx_buff *ctx)
-{
-	return (void *)(unsigned long)ctx->data_meta;
-}
-
-static __always_inline void *ctx_data_end(const struct __ctx_buff *ctx)
-{
-	return (void *)(unsigned long)ctx->data_end;
-}
-
 static __always_inline bool ctx_no_room(const void *needed, const void *limit)
 {
 	return unlikely(needed > limit);

--- a/bpf/include/bpf/ctx/skb.h
+++ b/bpf/include/bpf/ctx/skb.h
@@ -57,6 +57,28 @@
 #define get_hash(ctx)		ctx->hash
 #define get_hash_recalc(ctx)	get_hash(ctx)
 
+#define DEFINE_FUNC_CTX_POINTER(FIELD)						\
+static __always_inline void *							\
+ctx_ ## FIELD(const struct __sk_buff *ctx)					\
+{										\
+	void *ptr;								\
+										\
+	/* LLVM may generate u32 assignments of ctx->{data,data_end,data_meta}.	\
+	 * With this inline asm, LLVM loses track of the fact this field is on	\
+	 * 32 bits.								\
+	 */									\
+	asm volatile("%0 = *(u32 *)(%1 + %2)"					\
+		     : "=r"(ptr)						\
+		     : "r"(ctx), "i"(offsetof(struct __sk_buff, FIELD)));	\
+	return ptr;								\
+}
+/* This defines ctx_data(). */
+DEFINE_FUNC_CTX_POINTER(data)
+/* This defines ctx_data_end(). */
+DEFINE_FUNC_CTX_POINTER(data_end)
+/* This defines ctx_data_meta(). */
+DEFINE_FUNC_CTX_POINTER(data_meta)
+
 static __always_inline __maybe_unused int
 ctx_redirect(const struct __sk_buff *ctx __maybe_unused, int ifindex, __u32 flags)
 {

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -107,6 +107,28 @@ xdp_store_bytes(const struct xdp_md *ctx, __u64 off, const void *from,
 #define get_hash(ctx)			({ 0; })
 #define get_hash_recalc(ctx)		get_hash(ctx)
 
+#define DEFINE_FUNC_CTX_POINTER(FIELD)						\
+static __always_inline void *							\
+ctx_ ## FIELD(const struct xdp_md *ctx)						\
+{										\
+	void *ptr;								\
+										\
+	/* LLVM may generate u32 assignments of ctx->{data,data_end,data_meta}.	\
+	 * With this inline asm, LLVM loses track of the fact this field is on	\
+	 * 32 bits.								\
+	 */									\
+	asm volatile("%0 = *(u32 *)(%1 + %2)"					\
+		     : "=r"(ptr)						\
+		     : "r"(ctx), "i"(offsetof(struct xdp_md, FIELD)));		\
+	return ptr;								\
+}
+/* This defines ctx_data(). */
+DEFINE_FUNC_CTX_POINTER(data)
+/* This defines ctx_data_end(). */
+DEFINE_FUNC_CTX_POINTER(data_end)
+/* This defines ctx_data_meta(). */
+DEFINE_FUNC_CTX_POINTER(data_meta)
+
 static __always_inline __maybe_unused void
 __csum_replace_by_diff(__sum16 *sum, __wsum diff)
 {

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -272,6 +272,33 @@ ct_new: __maybe_unused
 	return CT_NEW;
 }
 
+/* The function determines whether an egress flow identified by the given
+ * tuple is a reply.
+ *
+ * The datapath creates a CT entry in a reverse order. E.g., if a pod sends a
+ * request to outside, the CT entry stored in the BPF map will be TUPLE_F_IN:
+ * pod => outside. So, we can leverage this fact to determine whether the given
+ * flow is a reply.
+ */
+#define DEFINE_FUNC_CT_IS_REPLY(FAMILY)						\
+static __always_inline int						\
+ct_is_reply ## FAMILY(const void *map, struct __ctx_buff *ctx, int off,	\
+		      struct ipv ## FAMILY ## _ct_tuple *tuple,		\
+		      bool *is_reply)					\
+{									\
+	int err = 0;							\
+									\
+	err = ct_extract_ports ## FAMILY(ctx, off, CT_EGRESS, tuple);	\
+	if (err < 0)							\
+		return err;						\
+									\
+	tuple->flags = TUPLE_F_IN;					\
+									\
+	*is_reply = map_lookup_elem(map, tuple) != NULL;		\
+									\
+	return 0;							\
+}
+
 static __always_inline int
 ipv6_extract_tuple(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 		   int *l4_off)
@@ -605,30 +632,8 @@ ct_extract_ports4(struct __ctx_buff *ctx, int off, enum ct_dir dir,
 	return 0;
 }
 
-/* The function determines whether an egress flow identified by the given
- * tuple is a reply.
- *
- * The datapath creates a CT entry in a reverse order. E.g., if a pod sends a
- * request to outside, the CT entry stored in the BPF map will be TUPLE_F_IN:
- * pod => outside. So, we can leverage this fact to determine whether the given
- * flow is a reply.
- */
-static __always_inline int
-ct_is_reply4(const void *map, struct __ctx_buff *ctx, int off,
-	     struct ipv4_ct_tuple *tuple, bool *is_reply)
-{
-	int err = 0;
-
-	err = ct_extract_ports4(ctx, off, CT_EGRESS, tuple);
-	if (err < 0)
-		return err;
-
-	tuple->flags = TUPLE_F_IN;
-
-	*is_reply = map_lookup_elem(map, tuple) != NULL;
-
-	return 0;
-}
+/* This defines the ct_is_reply4 function. */
+DEFINE_FUNC_CT_IS_REPLY(4)
 
 /* Offset must point to IPv4 header */
 static __always_inline int ct_lookup4(const void *map,

--- a/bpf/lib/stubs.h
+++ b/bpf/lib/stubs.h
@@ -19,6 +19,10 @@
 # ifndef IPV4_DIRECT_ROUTING
 #  define IPV4_DIRECT_ROUTING 0
 # endif
+# if defined(ENABLE_IPV6) && !defined(IPV6_MASQUERADE_V)
+DEFINE_IPV6(IPV6_MASQUERADE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+#  define IPV6_MASQUERADE_V
+# endif
 #endif
 
 #endif /* __STUBS_H_ */

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -86,6 +86,10 @@ DEFINE_U32(SECCTX_FROM_IPCACHE, 1);
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPV6
+# ifdef ENABLE_MASQUERADE
+#  define IPV6_SNAT_EXCLUSION_DST_CIDR      { .addr = { 0xfa, 0xce, 0xff, 0xff, 0xff, 0x0 } }
+#  define IPV6_SNAT_EXCLUSION_DST_CIDR_MASK { .addr = { 0xff, 0xff, 0xff, 0xff, 0xff, 0x0 } }
+# endif /* ENABLE_MASQUERADE */
 #ifdef ENABLE_NODEPORT
 #define SNAT_MAPPING_IPV6 test_cilium_snat_v6_external
 #define SNAT_MAPPING_IPV6_SIZE 524288

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -918,7 +918,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// BPF masquerade depends on BPF NodePort and require host-reachable svc to
 	// be fully enabled in the tunneling mode, so the following checks should
 	// happen after invoking initKubeProxyReplacementOptions().
-	if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade &&
+	if option.Config.MasqueradingEnabled() && option.Config.EnableBPFMasquerade &&
 		(!option.Config.EnableNodePort || option.Config.EgressMasqueradeInterfaces != "" || !option.Config.EnableRemoteNodeIdentity ||
 			(option.Config.TunnelingEnabled() && !hasFullHostReachableServices())) {
 
@@ -967,11 +967,11 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 					"if the same endpoint is selected both by an egress gateway and a L7 policy, endpoint traffic will not go through egress gateway.", option.EnableL7Proxy)
 		}
 	}
-	if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {
+	if option.Config.MasqueradingEnabled() && option.Config.EnableBPFMasquerade {
 		// TODO(brb) nodeport constraints will be lifted once the SNAT BPF code has been refactored
 		if err := node.InitBPFMasqueradeAddrs(option.Config.GetDevices()); err != nil {
-			log.WithError(err).Error("failed to determine BPF masquerade IPv4 addrs")
-			return nil, nil, fmt.Errorf("failed to determine BPF masquerade IPv4 addrs: %w", err)
+			log.WithError(err).Error("failed to determine BPF masquerade addrs")
+			return nil, nil, fmt.Errorf("failed to determine BPF masquerade addrs: %w", err)
 		}
 	} else if option.Config.EnableIPMasqAgent {
 		log.WithError(err).Errorf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
@@ -979,9 +979,9 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	} else if option.Config.EnableIPv4EgressGateway {
 		log.WithError(err).Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
 		return nil, nil, fmt.Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
-	} else if !option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {
+	} else if !option.Config.MasqueradingEnabled() && option.Config.EnableBPFMasquerade {
 		// There is not yet support for option.Config.EnableIPv6Masquerade
-		log.Infof("Auto-disabling %q feature since IPv4 masquerading was generally disabled",
+		log.Infof("Auto-disabling %q feature since IPv4 and IPv6 masquerading are disabled",
 			option.EnableBPFMasquerade)
 		option.Config.EnableBPFMasquerade = false
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1430,10 +1430,6 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.EnableBandwidthManager = false
 	}
 
-	if option.Config.EnableIPv6Masquerade && option.Config.EnableBPFMasquerade {
-		log.Fatal("BPF masquerade is not supported for IPv6.")
-	}
-
 	// If there is one device specified, use it to derive better default
 	// allocation prefixes
 	node.InitDefaultPrefix(option.Config.DirectRoutingDevice)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -533,18 +533,27 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			cDefinesMap["SNAT_MAPPING_IPV6_SIZE"] = fmt.Sprintf("%d", option.Config.NATMapEntriesGlobal)
 		}
 
-		if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {
+		if option.Config.EnableBPFMasquerade {
 			cDefinesMap["ENABLE_MASQUERADE"] = "1"
-			cidr := datapath.RemoteSNATDstAddrExclusionCIDRv4()
-			cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR"] =
-				fmt.Sprintf("%#x", byteorder.NetIPv4ToHost32(cidr.IP))
-			ones, _ := cidr.Mask.Size()
-			cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR_LEN"] = fmt.Sprintf("%d", ones)
+			if option.Config.EnableIPv4Masquerade {
+				cidr := datapath.RemoteSNATDstAddrExclusionCIDRv4()
+				cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR"] =
+					fmt.Sprintf("%#x", byteorder.NetIPv4ToHost32(cidr.IP))
+				ones, _ := cidr.Mask.Size()
+				cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR_LEN"] = fmt.Sprintf("%d", ones)
 
-			// ip-masq-agent depends on bpf-masq
-			if option.Config.EnableIPMasqAgent {
-				cDefinesMap["ENABLE_IP_MASQ_AGENT"] = "1"
-				cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapName
+				// ip-masq-agent depends on bpf-masq
+				if option.Config.EnableIPMasqAgent {
+					cDefinesMap["ENABLE_IP_MASQ_AGENT"] = "1"
+					cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapName
+				}
+			}
+			if option.Config.EnableIPv6Masquerade {
+				cidr := datapath.RemoteSNATDstAddrExclusionCIDRv6()
+				extraMacrosMap["IPV6_SNAT_EXCLUSION_DST_CIDR"] = cidr.IP.String()
+				fw.WriteString(FmtDefineAddress("IPV6_SNAT_EXCLUSION_DST_CIDR", cidr.IP))
+				extraMacrosMap["IPV6_SNAT_EXCLUSION_DST_CIDR_MASK"] = cidr.Mask.String()
+				fw.WriteString(FmtDefineAddress("IPV6_SNAT_EXCLUSION_DST_CIDR_MASK", cidr.Mask))
 			}
 		}
 
@@ -794,10 +803,17 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 			fmt.Fprint(fw, defineUint32("NATIVE_DEV_IFINDEX", 1))
 			fmt.Fprint(fw, "\n")
 		}
-		if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {
-			// NodePort comment above applies to IPV4_MASQUERADE too
-			placeholderIPv4 := []byte{1, 1, 1, 1}
-			fmt.Fprint(fw, defineIPv4("IPV4_MASQUERADE", placeholderIPv4))
+		if option.Config.EnableBPFMasquerade {
+			if option.Config.EnableIPv4Masquerade {
+				// NodePort comment above applies to IPV4_MASQUERADE too
+				placeholderIPv4 := []byte{1, 1, 1, 1}
+				fmt.Fprint(fw, defineIPv4("IPV4_MASQUERADE", placeholderIPv4))
+			}
+			if option.Config.EnableIPv6Masquerade {
+				// NodePort comment above applies to IPV6_MASQUERADE too
+				placeholderIPv6 := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+				fmt.Fprint(fw, defineIPv6("IPV6_MASQUERADE", placeholderIPv6))
+			}
 		}
 		// Dummy value to avoid being optimized when 0
 		fmt.Fprint(fw, defineUint32("SECCTX_FROM_IPCACHE", 1))

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -128,7 +128,7 @@ func nullifyStringSubstitutions(strings map[string]string) map[string]string {
 // Since the two object files should only differ by the values of their
 // NODE_MAC symbols, we can avoid a full compilation.
 func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName string,
-	bpfMasqIPv4Addrs map[string]net.IP) error {
+	bpfMasqIPv4Addrs, bpfMasqIPv6Addrs map[string]net.IP) error {
 
 	hostObj, err := elf.Open(objPath)
 	if err != nil {
@@ -165,10 +165,17 @@ func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName stri
 	if option.Config.EnableNodePort {
 		opts["NATIVE_DEV_IFINDEX"] = ifIndex
 	}
-	if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade && bpfMasqIPv4Addrs != nil {
-		if option.Config.EnableIPv4 {
+	if option.Config.EnableBPFMasquerade {
+		if option.Config.EnableIPv4Masquerade && bpfMasqIPv4Addrs != nil {
 			ipv4 := bpfMasqIPv4Addrs[ifName]
 			opts["IPV4_MASQUERADE"] = byteorder.NetIPv4ToHost32(ipv4)
+		}
+		if option.Config.EnableIPv6Masquerade && bpfMasqIPv6Addrs != nil {
+			ipv6 := bpfMasqIPv6Addrs[ifName]
+			opts["IPV6_MASQUERADE_1"] = sliceToBe32(ipv6[0:4])
+			opts["IPV6_MASQUERADE_2"] = sliceToBe32(ipv6[4:8])
+			opts["IPV6_MASQUERADE_3"] = sliceToBe32(ipv6[8:12])
+			opts["IPV6_MASQUERADE_4"] = sliceToBe32(ipv6[12:16])
 		}
 	}
 
@@ -212,13 +219,14 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 		symbols = append(symbols, symbolToHostEp)
 		directions = append(directions, dirIngress)
 		secondDevObjPath := path.Join(ep.StateDir(), hostEndpointPrefix+"_"+defaults.SecondHostDevice+".o")
-		if err := patchHostNetdevDatapath(ep, objPath, secondDevObjPath, defaults.SecondHostDevice, nil); err != nil {
+		if err := patchHostNetdevDatapath(ep, objPath, secondDevObjPath, defaults.SecondHostDevice, nil, nil); err != nil {
 			return err
 		}
 		objPaths = append(objPaths, secondDevObjPath)
 	}
 
 	bpfMasqIPv4Addrs := node.GetMasqIPv4AddrsWithDevices()
+	bpfMasqIPv6Addrs := node.GetMasqIPv6AddrsWithDevices()
 
 	for _, device := range option.Config.GetDevices() {
 		if _, err := netlink.LinkByName(device); err != nil {
@@ -227,7 +235,7 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 		}
 
 		netdevObjPath := path.Join(ep.StateDir(), hostEndpointNetdevPrefix+device+".o")
-		if err := patchHostNetdevDatapath(ep, objPath, netdevObjPath, device, bpfMasqIPv4Addrs); err != nil {
+		if err := patchHostNetdevDatapath(ep, objPath, netdevObjPath, device, bpfMasqIPv4Addrs, bpfMasqIPv6Addrs); err != nil {
 			return err
 		}
 		objPaths = append(objPaths, netdevObjPath)

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -233,9 +233,15 @@ func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
 		if option.Config.EnableNodePort {
 			result["NATIVE_DEV_IFINDEX"] = 0
 		}
-		if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {
-			if option.Config.EnableIPv4 {
+		if option.Config.EnableBPFMasquerade {
+			if option.Config.EnableIPv4Masquerade {
 				result["IPV4_MASQUERADE"] = 0
+			}
+			if option.Config.EnableIPv6Masquerade {
+				result["IPV6_MASQUERADE_1"] = 0
+				result["IPV6_MASQUERADE_2"] = 0
+				result["IPV6_MASQUERADE_3"] = 0
+				result["IPV6_MASQUERADE_4"] = 0
 			}
 		}
 		result["SECCTX_FROM_IPCACHE"] = uint32(SecctxFromIpcacheDisabled)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2447,7 +2447,6 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 
 		if RunsOn419OrLaterKernel() {
 			opts["bpf.masquerade"] = "true"
-			opts["enableIPv6Masquerade"] = "false"
 		}
 
 		for key, value := range opts {

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -214,7 +214,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 			if helpers.RunsOn419OrLaterKernel() {
 				By("Test BPF masquerade")
 				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, false)).
-					Should(BeTrue(), "Connectivity test to http://google.com failed")
+					Should(BeTrue(), "IPv4 connectivity test to http://google.com failed")
+				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, true)).
+					Should(BeTrue(), "IPv6 connectivity test to http://google.com failed")
 			}
 		})
 
@@ -290,7 +292,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 			if helpers.RunsOn419OrLaterKernel() {
 				By("Test BPF masquerade")
 				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, false)).
-					Should(BeTrue(), "Connectivity test to http://google.com failed")
+					Should(BeTrue(), "IPv4 connectivity test to http://google.com failed")
+				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, true)).
+					Should(BeTrue(), "IPv6 connectivity test to http://google.com failed")
 			}
 		})
 

--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -241,6 +241,12 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			"hubble.relay.image.repository":          "quay.io/cilium/hubble-relay-ci",
 			"clustermesh.apiserver.image.repository": "quay.io/cilium/clustermesh-apiserver-ci",
 		}
+		if helpers.RunsOn419OrLaterKernel() {
+			// Cilium v1.11 doesn't support IPv6 BPF masquerade.
+			// This can be removed once v1.12 is released.
+			Expect(oldHelmChartVersion).To(Equal("1.11"))
+			opts["enableIPv6Masquerade"] = "false"
+		}
 
 		// Eventually allows multiple return values, and performs the assertion
 		// on the first return value, and expects that all other return values


### PR DESCRIPTION
Summary of commits:
1. Preparatory: use a bit of inline BPF asm to avoid bad optimization from LLVM.
2. Preparatory: refactor `ct_is_reply4` as a macro to facilitate implem. of IPv6 counterpart.
3. Implement the datapath changes by following the IPv4 implementation.
4. Preparatory: refactor `InitBPFMasqueradeAddrs` to facilitate implem. of IPv6 counterpart.
5. Implement agent changes for the flags and macros.
6. Update documentation.
7. Extend the tests to cover IPv6 BPF masquerading.

See commits for details.

Fixes: https://github.com/cilium/cilium/issues/14350.