### PR TITLE
test: Fix bpffs mount on kind

### DIFF
--- a/test/k8sT/Verifier.go
+++ b/test/k8sT/Verifier.go
@@ -124,7 +124,10 @@ var _ = Describe("K8sVerifier", func() {
 		err := kubectl.WaitForSinglePod(helpers.DefaultNamespace, podName, helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), fmt.Sprintf("%s pod not ready after timeout", podName))
 
-		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, podName, "mount | grep -q 'type bpf' || mount -t bpf bpf /sys/fs/bpf")
+		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, podName, "mount | grep -q 'type bpf'")
+		if !res.WasSuccessful() {
+			res = kubectl.ExecPodCmd(helpers.DefaultNamespace, podName, "mount -t bpf bpf /sys/fs/bpf")
+		}
 		res.ExpectSuccess("Failed to mount bpffs")
 
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, podName, "make -C bpf clean V=0")


### PR DESCRIPTION
When testing this command out, I tested it in a cluster where the BPFFS
was already mounted. As such, the grep command was successful and the
mount was never executed. However, upon testing this in a fresh kind
cluster,  Louis observes this failure in the test preparation:
    
    mount: /sys/fs/bpf: must be superuser to use mount.
    
This is because the kubectl.ExecPodCmd() helper doesn't actually run the
entire specified command inside the pod, it just appends it on the end
of a shell-out to "kubectl exec ... <argument>". As such, if you place
directives like || into the command, it will run the second commands on
the host instead of inside the pod (!).
    
Fix this for now by just doing the conditional check properly in Go
code.

Fixes: 0a7eddf8f5e9 ("test/K8sVerifier: Mount bpffs in BeforeAll")
Reported-by: Louis DeLosSantos <louis@isovalent.com>
