### PR TITLE
test: Restructure k8sT/Services.go

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -529,7 +529,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						testExternalIPs(kubectl, ni)
 					})
 
-					SkipContextIf(helpers.RunsOnGKE, "With host policy", func() {
+					SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
 						var ccnpHostPolicy string
 
 						BeforeAll(func() {
@@ -660,7 +660,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						testExternalIPs(kubectl, ni)
 					})
 
-					SkipContextIf(helpers.RunsOnGKE, "With host policy", func() {
+					SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
 						var ccnpHostPolicy string
 
 						BeforeAll(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -283,14 +283,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		})
 	})
 
-	SkipContextIf(func() bool {
-		return helpers.SkipQuarantined() && helpers.RunsOnNetNextKernel()
-	}, "Checks service across nodes", func() {
-
+	Context("Checks N/S loadbalancing", func() {
 		var (
-			demoYAML   string
-			demoYAMLV6 string
-
+			demoYAML     string
+			demoYAMLV6   string
 			demoPolicyL7 string
 		)
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -53,7 +53,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		Expect(err).Should(BeNil(), "Cannot get nodes info")
 
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-		DeployCiliumAndDNS(kubectl, ciliumFilename)
 	})
 
 	AfterFailed(func() {
@@ -80,6 +79,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		)
 
 		BeforeAll(func() {
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+
 			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 			echoSVCYAML = helpers.ManifestGet(kubectl.BasePath(), "echo-svc.yaml")
 			echoPolicyYAML = helpers.ManifestGet(kubectl.BasePath(), "echo-policy.yaml")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -324,25 +324,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			ExpectAllPodsTerminated(kubectl)
 		})
 
-		SkipItIf(helpers.RunsWithKubeProxyReplacement, "Checks ClusterIP Connectivity", func() {
-			services := []string{testDSServiceIPv4}
-			if helpers.DualStackSupported() {
-				services = append(services, testDSServiceIPv6)
-			}
-
-			for _, svcName := range services {
-				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, svcName)
-				Expect(err).Should(BeNil(), "Cannot get service %s", svcName)
-				Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
-
-				url := fmt.Sprintf("http://%s", net.JoinHostPort(clusterIP, "80"))
-				testCurlFromPods(kubectl, testDSClient, url, 10, 0)
-
-				url = fmt.Sprintf("tftp://%s/hello", net.JoinHostPort(clusterIP, "69"))
-				testCurlFromPods(kubectl, testDSClient, url, 10, 0)
-			}
-		})
-
 		SkipContextIf(helpers.RunsWithKubeProxyReplacement, "Tests NodePort (kube-proxy)", func() {
 			SkipItIf(helpers.DoesNotRunOn419OrLaterKernel, "with IPSec and externalTrafficPolicy=Local", func() {
 				deploymentManager.SetKubectl(kubectl)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -188,7 +188,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 
 		SkipContextIf(helpers.DoesNotRunWithKubeProxyReplacement, "Checks in-cluster KPR", func() {
 			It("Tests NodePort", func() {
-				testNodePort(kubectl, ni, true, false, false, 0)
+				testNodePort(kubectl, ni, true, false, 0)
 			})
 
 			It("Tests NodePort with externalTrafficPolicy=Local", func() {
@@ -218,7 +218,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 
 				It("Tests NodePort with L7 Policy", func() {
 					applyPolicy(kubectl, demoPolicyL7)
-					testNodePort(kubectl, ni, false, false, false, 0)
+					testNodePort(kubectl, ni, false, false, 0)
 				})
 			})
 		})
@@ -347,7 +347,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			})
 
 			It("", func() {
-				testNodePort(kubectl, ni, false, false, false, 0)
+				testNodePort(kubectl, ni, false, false, 0)
 			})
 		})
 
@@ -459,7 +459,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				}()
 
 				applyPolicy(kubectl, demoPolicy)
-				testNodePort(kubectl, ni, false, false, false, 0)
+				testNodePort(kubectl, ni, false, false, 0)
 			})
 		})
 
@@ -489,7 +489,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				}()
 
 				applyPolicy(kubectl, demoPolicyL7)
-				testNodePort(kubectl, ni, false, false, false, 0)
+				testNodePort(kubectl, ni, false, false, 0)
 			})
 		})
 	})
@@ -565,18 +565,13 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			testCurlFromOutsideWithLocalPort(kubectl, ni, svc2URL, 1, false, 64002)
 		})
 
-		SkipItIf(func() bool {
-			// Quarantine when running with the third node as it's
-			// flaky. See GH-12511.
-			// It's also flaky for IPv6 traffic, see GH-18072
-			return helpers.SkipQuarantined()
-		}, "Tests with secondary NodePort device", func() {
+		It("Tests with secondary NodePort device", func() {
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 				"loadBalancer.mode": "snat",
 				"devices":           fmt.Sprintf(`'{%s,%s}'`, ni.PrivateIface, helpers.SecondaryIface),
 			})
 
-			testNodePort(kubectl, ni, true, true, true, 0)
+			testNodePortExternal(kubectl, ni, true, false, false)
 		})
 
 		It("Tests with direct routing and DSR", func() {
@@ -587,7 +582,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			})
 
 			testDSR(kubectl, ni, 64000)
-			testNodePort(kubectl, ni, true, false, false, 0)
+			testNodePortExternal(kubectl, ni, false, true, true)
 		})
 
 		It("Tests with XDP, direct routing, SNAT and Random", func() {
@@ -599,7 +594,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"autoDirectNodeRoutes":      "true",
 				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
 			})
-			testNodePortExternal(kubectl, ni, false, false)
+			testNodePortExternal(kubectl, ni, false, false, false)
 		})
 
 		It("Tests with XDP, direct routing, SNAT and Maglev", func() {
@@ -617,7 +612,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			})
 
 			testMaglev(kubectl, ni)
-			testNodePortExternal(kubectl, ni, false, false)
+			testNodePortExternal(kubectl, ni, false, false, false)
 		})
 
 		It("Tests with XDP, direct routing, Hybrid and Random", func() {
@@ -629,7 +624,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"autoDirectNodeRoutes":      "true",
 				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
 			})
-			testNodePortExternal(kubectl, ni, true, false)
+			testNodePortExternal(kubectl, ni, false, true, false)
 		})
 
 		It("Tests with XDP, direct routing, Hybrid and Maglev", func() {
@@ -645,7 +640,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				// see #14047 for details.
 				"hostFirewall.enabled": "false",
 			})
-			testNodePortExternal(kubectl, ni, true, false)
+			testNodePortExternal(kubectl, ni, false, true, false)
 		})
 
 		It("Tests with XDP, direct routing, DSR and Random", func() {
@@ -657,7 +652,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"autoDirectNodeRoutes":      "true",
 				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
 			})
-			testNodePortExternal(kubectl, ni, true, true)
+			testNodePortExternal(kubectl, ni, false, true, true)
 		})
 
 		It("Tests with XDP, direct routing, DSR and Maglev", func() {
@@ -673,7 +668,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				// see #14047 for details.
 				"hostFirewall.enabled": "false",
 			})
-			testNodePortExternal(kubectl, ni, true, true)
+			testNodePortExternal(kubectl, ni, false, true, true)
 		})
 
 		It("Tests with TC, direct routing and Hybrid", func() {
@@ -685,7 +680,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"autoDirectNodeRoutes":      "true",
 				"devices":                   fmt.Sprintf(`'{}'`), // Revert back to auto-detection after XDP.
 			})
-			testNodePortExternal(kubectl, ni, true, false)
+			testNodePortExternal(kubectl, ni, false, true, false)
 		})
 
 		// Run on net-next and 4.19 but not on old versions, because of
@@ -730,7 +725,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			})
 
 			It("Tests NodePort", func() {
-				testNodePort(kubectl, ni, true, false, true, 0)
+				testNodePort(kubectl, ni, true, true, 0)
 			})
 		})
 

--- a/test/k8sT/service_helpers.go
+++ b/test/k8sT/service_helpers.go
@@ -709,9 +709,6 @@ func testNodePortExternal(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, check
 		testCurlFromOutside(kubectl, ni, httpURL, 10, checkTCP)
 		testCurlFromOutside(kubectl, ni, tftpURL, 10, checkUDP)
 
-		// Make sure all the rest works as expected as well
-		testNodePort(kubectl, ni, true, false, false, 0)
-
 		// Clear CT tables on both Cilium nodes
 		pod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 		ExpectWithOffset(1, err).Should(BeNil(), "Cannot determine cilium pod name")


### PR DESCRIPTION
The high level changes:
- Structure tests into three categories: `E/W`, `N/S` and misc.
- Do not run `testNodePort()` when testing `N/S`. The former used to run tests from inside a cluster, so it definitely belongs to the `E/W` cat.
- Unquarantine tests from outside.

The refactoring significantly reduced the number of test cases (mostly thanks to the `testNodePort()` removal). Please see the individual commit msgs for more ctx.