### PR TITLE
docs: export KUBECONFIG for cilium-cli with k3s

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -48,6 +48,17 @@ Should you encounter any issues during the installation, please refer to the
 Please consult the Kubernetes :ref:`k8s_requirements` for information on  how
 you need to configure your Kubernetes cluster to operate with Cilium.
 
+Configure Cluster Access
+========================
+
+For the Cilium CLI to access the cluster in successive steps you will need to
+use the ``kubeconfig`` file stored at ``/etc/rancher/k3s/k3s.yaml`` by setting
+the ``KUBECONFIG`` environment variable:
+
+.. code-block:: shell-session
+
+    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
 Install Cilium
 ==============
 
@@ -57,7 +68,7 @@ Install Cilium by running:
 
 .. code-block:: shell-session
 
-    KUBECONFIG=/etc/rancher/k3s/k3s.yaml cilium install
+    cilium install
 
 Validate the Installation
 =========================

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -298,7 +298,7 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
        .. code-block:: shell-session
 
-           KUBECONFIG=/etc/rancher/k3s/k3s.yaml cilium install
+           cilium install
 
 
 If the installation fails for some reason, run ``cilium status`` to retrieve

--- a/Documentation/gettingstarted/requirements-k3s.rst
+++ b/Documentation/gettingstarted/requirements-k3s.rst
@@ -18,3 +18,11 @@ Encapsulation   Cluster Pool    Kubernetes CRD
 .. code-block:: shell-session
 
     curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none --disable-network-policy' sh -
+
+* For the Cilium CLI to access the cluster in successive steps you will need to
+  use the ``kubeconfig`` file stored at ``/etc/rancher/k3s/k3s.yaml`` by setting
+  the ``KUBECONFIG`` environment variable:
+
+.. code-block:: shell-session
+
+    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml


### PR DESCRIPTION
Previously, commit 606b5fe9f49f ("docs: KUBECONFIG for cilium-cli with
k3s") and commit 606b5fe9f49f ("docs: KUBECONFIG for cilium-cli with
k3s") changed `cilium install` commands to set KUBECONFIG explicitly.

However, successive cilium-cli commands (e.g. `cilium status` or
`cilium connectivity test` in the getting started guide) will need the
corresponding kubeconfig as well. Thus, suggest to `export KUBECONFIG`
at the top of the k3s specific guides.

For https://github.com/cilium/cilium-cli/issues/696
