### PR TITLE
Allow unloading DNS policy rules on graceful shutdown

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -71,6 +71,7 @@ cilium-agent [flags]
       --disable-endpoint-crd                                 Disable use of CiliumEndpoint CRD
       --disable-iptables-feeder-rules strings                Chains to ignore when installing feeder rules.
       --dns-max-ips-per-restored-rule int                    Maximum number of IPs to maintain for each restored DNS rule (default 1000)
+      --dns-policy-unload-on-shutdown                        Unload DNS policy rules on graceful showdown
       --egress-masquerade-interfaces string                  Limit egress masquerading to interface selector
       --egress-multi-home-ip-rule-compat                     Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
       --enable-auto-protect-node-port-range                  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -725,6 +725,10 @@
      - Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100).
      - string
      - ``nil``
+   * - hubble.relay.terminationGracePeriodSeconds
+     - Configure termination grace period for hubble relay Deployment.
+     - int
+     - ``1``
    * - hubble.relay.tls
      - TLS configuration for Hubble Relay
      - object
@@ -1305,6 +1309,10 @@
      - Security context to be added to preflight pods
      - object
      - ``{}``
+   * - preflight.terminationGracePeriodSeconds
+     - Configure termination grace period for preflight Deployment and DaemonSet.
+     - int
+     - ``1``
    * - preflight.tofqdnsPreCache
      - Path to write the ``--tofqdns-pre-cache`` file to.
      - string
@@ -1413,6 +1421,10 @@
      - interval between checks of the startup probe
      - int
      - ``2``
+   * - terminationGracePeriodSeconds
+     - Configure termination grace period for cilium-agent DaemonSet.
+     - int
+     - ``1``
    * - tls
      - Configure TLS configuration in the agent.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -861,6 +861,8 @@ tcptop
 tcptracer
 templating
 terminatingTLS
+terminationGracePeriodSeconds
+terminationGracePeriods
 testsuite
 th
 thunderx
@@ -927,8 +929,8 @@ virtualbox
 virtualization
 vlan
 vmlinux
-vtep
 volumeMounts
+vtep
 vxlan
 waitForMount
 waker

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -71,7 +71,7 @@ import (
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-	policyApi "github.com/cilium/cilium/pkg/policy/api"
+	policyAPI "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/probe"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
@@ -582,8 +582,78 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	debug.RegisterStatusObject("ongoing-endpoint-creations", d.endpointCreations)
 
 	d.k8sWatcher.RunK8sServiceHandler()
+
+	if option.Config.DNSPolicyUnloadOnShutdown {
+		log.Debugf("Registering cleanup function to unload DNS policies due to --%s", option.DNSPolicyUnloadOnShutdown)
+
+		// add to pre-cleanup funcs because this needs to run on graceful shutdown, but
+		// before the relevant subystems are being shut down.
+		cleaner.preCleanupFuncs.Add(func() {
+			// Stop k8s watchers
+			log.Info("Stopping k8s service handler")
+			d.k8sWatcher.StopK8sServiceHandler()
+
+			// Iterate over the policy repository and remove L7 DNS part
+			needsPolicyRegen := false
+			removeL7DNSRules := func(pr policyAPI.Ports) error {
+				portProtocols := pr.GetPortProtocols()
+				if len(portProtocols) == 0 {
+					return nil
+				}
+				portRule := pr.GetPortRule()
+				if portRule == nil || portRule.Rules == nil {
+					return nil
+				}
+				dnsRules := portRule.Rules.DNS
+				log.Debugf("Found egress L7 DNS rules (portProtocol %#v): %#v", portProtocols[0], dnsRules)
+
+				// For security reasons, the L7 DNS policy must be a
+				// wildcard in order to trigger this logic.
+				// Otherwise we could invalidate the L7 security
+				// rules. This means if any of the DNS L7 rules
+				// have a matchPattern of * then it is OK to delete
+				// the L7 portion of those rules.
+				hasWildcard := false
+				for _, dns := range dnsRules {
+					if dns.MatchPattern == "*" {
+						hasWildcard = true
+						break
+					}
+				}
+				if hasWildcard {
+					portRule.Rules = nil
+					needsPolicyRegen = true
+				}
+				return nil
+			}
+
+			policyRepo := d.GetPolicyRepository()
+			policyRepo.Iterate(func(rule *policyAPI.Rule) {
+				for _, er := range rule.Egress {
+					_ = er.ToPorts.Iterate(removeL7DNSRules)
+				}
+			})
+
+			if !needsPolicyRegen {
+				log.Infof("No policy recalculation needed to remove DNS rules due to --%s", option.DNSPolicyUnloadOnShutdown)
+				return
+			}
+
+			// Bump revision to trigger policy recalculation
+			log.Infof("Triggering policy recalculation to remove DNS rules due to --%s", option.DNSPolicyUnloadOnShutdown)
+			policyRepo.BumpRevision()
+			regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
+				Reason:            "unloading DNS rules on graceful shutdown",
+				RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+			}
+			wg := d.endpointManager.RegenerateAllEndpoints(regenerationMetadata)
+			wg.Wait()
+			log.Info("All endpoints regenerated after unloading DNS rules on graceful shutdown")
+		})
+	}
+
 	treatRemoteNodeAsHost := option.Config.AlwaysAllowLocalhost() && !option.Config.EnableRemoteNodeIdentity
-	policyApi.InitEntities(option.Config.ClusterName, treatRemoteNodeAsHost)
+	policyAPI.InitEntities(option.Config.ClusterName, treatRemoteNodeAsHost)
 
 	// Start the proxy before we restore endpoints so that we can inject the
 	// daemon's proxy into each endpoint.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -893,6 +893,9 @@ func initializeFlags() {
 	flags.Int(option.DNSMaxIPsPerRestoredRule, defaults.DNSMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored DNS rule")
 	option.BindEnv(option.DNSMaxIPsPerRestoredRule)
 
+	flags.Bool(option.DNSPolicyUnloadOnShutdown, false, "Unload DNS policy rules on graceful showdown")
+	option.BindEnv(option.DNSPolicyUnloadOnShutdown)
+
 	flags.Int(option.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxDeferredConnectionDeletes, "Maximum number of IPs to retain for expired DNS lookups with still-active connections")
 	option.BindEnv(option.ToFQDNsMaxDeferredConnectionDeletes)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -232,6 +232,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.securityContext | object | `{}` | hubble-relay security context |
 | hubble.relay.sortBufferDrainTimeout | string | `nil` | When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s"). |
 | hubble.relay.sortBufferLenMax | string | `nil` | Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100). |
+| hubble.relay.terminationGracePeriodSeconds | int | `1` | Configure termination grace period for hubble relay Deployment. |
 | hubble.relay.tls | object | `{"client":{"cert":"","key":""},"server":{"cert":"","enabled":false,"extraDnsNames":[],"extraIpAddresses":[],"key":""}}` | TLS configuration for Hubble Relay |
 | hubble.relay.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values for the hubble-relay client certificate and private key This keypair is presented to Hubble server instances for mTLS authentication and is required when hubble.tls.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false. |
 | hubble.relay.tls.server | object | `{"cert":"","enabled":false,"extraDnsNames":[],"extraIpAddresses":[],"key":""}` | base64 encoded PEM values for the hubble-relay server certificate and private key |
@@ -377,6 +378,7 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.priorityClassName | string | `""` | The priority class to use for the preflight pod. |
 | preflight.resources | object | `{}` | preflight resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | preflight.securityContext | object | `{}` | Security context to be added to preflight pods |
+| preflight.terminationGracePeriodSeconds | int | `1` | Configure termination grace period for preflight Deployment and DaemonSet. |
 | preflight.tofqdnsPreCache | string | `""` | Path to write the `--tofqdns-pre-cache` file to. |
 | preflight.tolerations | list | `[{"effect":"NoSchedule","key":"node.kubernetes.io/not-ready"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"},{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized","value":"true"},{"key":"CriticalAddonsOnly","operator":"Exists"}]` | Node tolerations for preflight scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | preflight.updateStrategy | object | `{"type":"RollingUpdate"}` | preflight update strategy |
@@ -404,6 +406,7 @@ contributors across the globe, there is almost always someone available to help.
 | sockops | object | `{"enabled":false}` | Configure BPF socket operations configuration |
 | startupProbe.failureThreshold | int | `105` | failure threshold of startup probe. 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s) |
 | startupProbe.periodSeconds | int | `2` | interval between checks of the startup probe |
+| terminationGracePeriodSeconds | int | `1` | Configure termination grace period for cilium-agent DaemonSet. |
 | tls | object | `{"ca":{"cert":"","certValidityDuration":1095,"key":""},"secretsBackend":"local"}` | Configure TLS configuration in the agent. |
 | tls.ca | object | `{"cert":"","certValidityDuration":1095,"key":""}` | Base64 encoded PEM values for the CA certificate and private key. This can be used as common CA to generate certificates used by hubble and clustermesh components |
 | tls.ca.cert | string | `""` | Optional CA cert. If it is provided, it will be used by cilium to generate all other certificates. Otherwise, an ephemeral CA is generated. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -436,7 +436,7 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.cilium.name | quote }}
-      terminationGracePeriodSeconds: 1
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       hostNetwork: true
       {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -150,7 +150,7 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.preflight.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.preflight.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
-      terminationGracePeriodSeconds: 1
+      terminationGracePeriodSeconds: {{ .Values.preflight.terminationGracePeriodSeconds }}
       {{- with .Values.preflight.tolerations }}
       tolerations:
         {{- toYaml . | trim | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -72,7 +72,7 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.preflight.priorityClassName "system-cluster-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.preflight.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
-      terminationGracePeriodSeconds: 1
+      terminationGracePeriodSeconds: {{ .Values.preflight.terminationGracePeriodSeconds }}
       {{- with .Values.preflight.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -84,7 +84,7 @@ spec:
       serviceAccount: {{ .Values.serviceAccounts.relay.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.relay.name | quote }}
       automountServiceAccountToken: false
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: {{ .Values.hubble.relay.terminationGracePeriodSeconds }}
       {{- with .Values.hubble.relay.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -70,6 +70,9 @@ serviceAccounts:
     name: hubble-generate-certs
     annotations: {}
 
+# -- Configure termination grace period for cilium-agent DaemonSet.
+terminationGracePeriodSeconds: 1
+
 # -- Install the cilium agent resources.
 agent: true
 
@@ -732,6 +735,9 @@ hubble:
 
     # -- The priority class to use for hubble-relay
     priorityClassName: ""
+
+    # -- Configure termination grace period for hubble relay Deployment.
+    terminationGracePeriodSeconds: 1
 
     # -- hubble-relay update strategy
     updateStrategy:
@@ -1677,6 +1683,10 @@ preflight:
 
   # -- Path to write the `--tofqdns-pre-cache` file to.
   tofqdnsPreCache: ""
+
+  # -- Configure termination grace period for preflight Deployment and DaemonSet.
+  terminationGracePeriodSeconds: 1
+
   # -- By default we should always validate the installed CNPs before upgrading
   # Cilium. This will make sure the user will have the policies deployed in the
   # cluster with the right schema.

--- a/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
@@ -6,7 +6,6 @@ package watchers
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/k8s"
@@ -84,12 +83,12 @@ func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient *k8s.K8
 	)
 
 	k.blockWaitGroupToSyncResources(
-		wait.NeverStop,
+		k.stop,
 		nil,
 		ciliumV2ClusterwidePolicyController.HasSynced,
 		k8sAPIGroupCiliumClusterwideNetworkPolicyV2,
 	)
 
-	go ciliumV2ClusterwidePolicyController.Run(wait.NeverStop)
+	go ciliumV2ClusterwidePolicyController.Run(k.stop)
 	k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumClusterwideNetworkPolicyV2)
 }

--- a/pkg/k8s/watchers/cilium_egress_gateway_policy.go
+++ b/pkg/k8s/watchers/cilium_egress_gateway_policy.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/egressgateway"
@@ -72,13 +71,13 @@ func (k *K8sWatcher) ciliumEgressNATPolicyInit(ciliumNPClient *k8s.K8sCiliumClie
 	)
 
 	k.blockWaitGroupToSyncResources(
-		wait.NeverStop,
+		k.stop,
 		nil,
 		egpController.HasSynced,
 		k8sAPIGroupCiliumEgressNATPolicyV2,
 	)
 
-	go egpController.Run(wait.NeverStop)
+	go egpController.Run(k.stop)
 	k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumEgressNATPolicyV2)
 }
 

--- a/pkg/k8s/watchers/cilium_local_redirect_policy.go
+++ b/pkg/k8s/watchers/cilium_local_redirect_policy.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/k8s"
@@ -66,13 +65,13 @@ func (k *K8sWatcher) ciliumLocalRedirectPolicyInit(ciliumLRPClient *k8s.K8sCiliu
 	)
 
 	k.blockWaitGroupToSyncResources(
-		wait.NeverStop,
+		k.stop,
 		nil,
 		lrpController.HasSynced,
 		k8sAPIGroupCiliumLocalRedirectPolicyV2,
 	)
 
-	go lrpController.Run(wait.NeverStop)
+	go lrpController.Run(k.stop)
 	k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumLocalRedirectPolicyV2)
 }
 

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/controller"
@@ -150,8 +149,8 @@ func (k *K8sWatcher) ciliumNetworkPoliciesInit(ciliumNPClient *k8s.K8sCiliumClie
 		cnpStore,
 	)
 
-	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, ciliumV2Controller.HasSynced, k8sAPIGroupCiliumNetworkPolicyV2)
-	go ciliumV2Controller.Run(wait.NeverStop)
+	k.blockWaitGroupToSyncResources(k.stop, nil, ciliumV2Controller.HasSynced, k8sAPIGroupCiliumNetworkPolicyV2)
+	go ciliumV2Controller.Run(k.stop)
 	k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumNetworkPolicyV2)
 }
 

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -7,7 +7,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
@@ -74,8 +73,8 @@ func (k *K8sWatcher) endpointsInit(k8sClient kubernetes.Interface, swgEps *lock.
 		},
 		nil,
 	)
-	k.blockWaitGroupToSyncResources(wait.NeverStop, swgEps, endpointController.HasSynced, K8sAPIGroupEndpointV1Core)
-	go endpointController.Run(wait.NeverStop)
+	k.blockWaitGroupToSyncResources(k.stop, swgEps, endpointController.HasSynced, K8sAPIGroupEndpointV1Core)
+	go endpointController.Run(k.stop)
 	k.k8sAPIGroups.AddAPI(K8sAPIGroupEndpointV1Core)
 }
 

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -11,7 +11,6 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
@@ -58,10 +57,10 @@ func (k *K8sWatcher) namespacesInit(k8sClient kubernetes.Interface, asyncControl
 	)
 
 	k.namespaceStore = namespaceStore
-	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, namespaceController.HasSynced, k8sAPIGroupNamespaceV1Core)
+	k.blockWaitGroupToSyncResources(k.stop, nil, namespaceController.HasSynced, k8sAPIGroupNamespaceV1Core)
 	k.k8sAPIGroups.AddAPI(k8sAPIGroupNamespaceV1Core)
 	asyncControllers.Done()
-	namespaceController.Run(wait.NeverStop)
+	namespaceController.Run(k.stop)
 }
 
 func (k *K8sWatcher) updateK8sV1Namespace(oldNS, newNS *slim_corev1.Namespace) error {

--- a/pkg/k8s/watchers/network_policy.go
+++ b/pkg/k8s/watchers/network_policy.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
@@ -69,8 +68,8 @@ func (k *K8sWatcher) networkPoliciesInit(k8sClient kubernetes.Interface, swgKNPs
 		nil,
 	)
 	k.networkpolicyStore = store
-	k.blockWaitGroupToSyncResources(wait.NeverStop, swgKNPs, policyController.HasSynced, k8sAPIGroupNetworkingV1Core)
-	go policyController.Run(wait.NeverStop)
+	k.blockWaitGroupToSyncResources(k.stop, swgKNPs, policyController.HasSynced, k8sAPIGroupNetworkingV1Core)
+	go policyController.Run(k.stop)
 
 	k.k8sAPIGroups.AddAPI(k8sAPIGroupNetworkingV1Core)
 }

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -81,7 +81,7 @@ func (k *K8sWatcher) NodesInit(k8sClient *k8s.K8sClient) {
 		k.nodeStore = nodeStore
 
 		k.blockWaitGroupToSyncResources(wait.NeverStop, swg, nodeController.HasSynced, k8sAPIGroupNodeV1Core)
-		go nodeController.Run(wait.NeverStop)
+		go nodeController.Run(k.stop)
 		k.k8sAPIGroups.AddAPI(k8sAPIGroupNodeV1Core)
 	})
 }

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -6,7 +6,6 @@ package watchers
 import (
 	v1 "k8s.io/api/core/v1"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
@@ -64,8 +63,8 @@ func (k *K8sWatcher) servicesInit(k8sClient kubernetes.Interface, swgSvcs *lock.
 		},
 		nil,
 	)
-	k.blockWaitGroupToSyncResources(wait.NeverStop, swgSvcs, svcController.HasSynced, K8sAPIGroupServiceV1Core)
-	go svcController.Run(wait.NeverStop)
+	k.blockWaitGroupToSyncResources(k.stop, swgSvcs, svcController.HasSynced, K8sAPIGroupServiceV1Core)
+	go svcController.Run(k.stop)
 	k.k8sAPIGroups.AddAPI(K8sAPIGroupServiceV1Core)
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -422,6 +422,9 @@ const (
 	// for each FQDN selector in endpoint's restored DNS rules
 	DNSMaxIPsPerRestoredRule = "dns-max-ips-per-restored-rule"
 
+	// DNSPolicyUnloadOnShutdown is the name of the dns-policy-unload-on-shutdown option.
+	DNSPolicyUnloadOnShutdown = "dns-policy-unload-on-shutdown"
+
 	// ToFQDNsMinTTL is the minimum time, in seconds, to use DNS data for toFQDNs policies.
 	ToFQDNsMinTTL = "tofqdns-min-ttl"
 
@@ -1545,6 +1548,10 @@ type DaemonConfig struct {
 	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
 	// for each FQDN selector in endpoint's restored DNS rules
 	DNSMaxIPsPerRestoredRule int
+
+	// DNSPolicyUnloadOnShutdown defines whether DNS policy rules should be unloaded on
+	// graceful shutdown.
+	DNSPolicyUnloadOnShutdown bool
 
 	// ToFQDNsProxyPort is the user-configured global, shared, DNS listen port used
 	// by the DNS Proxy. Both UDP and TCP are handled on the same port. When it
@@ -2777,6 +2784,7 @@ func (c *DaemonConfig) Populate() {
 
 	// toFQDNs options
 	c.DNSMaxIPsPerRestoredRule = viper.GetInt(DNSMaxIPsPerRestoredRule)
+	c.DNSPolicyUnloadOnShutdown = viper.GetBool(DNSPolicyUnloadOnShutdown)
 	c.ToFQDNsMaxIPsPerHost = viper.GetInt(ToFQDNsMaxIPsPerHost)
 	if maxZombies := viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes); maxZombies >= 0 {
 		c.ToFQDNsMaxDeferredConnectionDeletes = viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -420,6 +420,16 @@ func (p *Repository) AddList(rules api.Rules) (ruleSlice, uint64) {
 	return p.AddListLocked(rules)
 }
 
+// Iterate iterates the policy repository, calling f for each rule. It is safe
+// to execute Iterate concurrently.
+func (p *Repository) Iterate(f func(rule *api.Rule)) {
+	p.Mutex.RWMutex.Lock()
+	defer p.Mutex.RWMutex.Unlock()
+	for _, r := range p.rules {
+		f(&r.Rule)
+	}
+}
+
 // UpdateRulesEndpointsCaches updates the caches within each rule in r that
 // specify whether the rule selects the endpoints in eps. If any rule matches
 // the endpoints, it is added to the provided IDSet, and removed from the

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2118,3 +2118,78 @@ func (ds *PolicyTestSuite) TestremoveIdentityFromRuleCaches(c *C) {
 
 	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{})
 }
+
+func (ds *PolicyTestSuite) TestIterate(c *C) {
+	repo := NewPolicyRepository(nil, nil, nil)
+	repo.selectorCache = testSelectorCache
+
+	numWithEgress := 0
+	countEgressRules := func(r *api.Rule) {
+		if len(r.Egress) > 0 {
+			numWithEgress++
+		}
+	}
+	repo.Iterate(countEgressRules)
+
+	c.Assert(numWithEgress, Equals, 0)
+
+	numRules := 10
+	lbls := make([]labels.Label, 10)
+	for i := 0; i < numRules; i++ {
+		it := fmt.Sprintf("baz%d", i)
+		epSelector := api.NewESFromLabels(
+			labels.NewLabel(
+				"foo",
+				it,
+				labels.LabelSourceK8s,
+			),
+		)
+		lbls[i] = labels.NewLabel("tag3", it, labels.LabelSourceK8s)
+		_, _, err := repo.Add(api.Rule{
+			EndpointSelector: epSelector,
+			Labels:           labels.LabelArray{lbls[i]},
+			Egress: []api.EgressRule{
+				{
+					EgressCommonRule: api.EgressCommonRule{
+						ToEndpoints: []api.EndpointSelector{
+							epSelector,
+						},
+					},
+				},
+			},
+		}, []Endpoint{})
+		c.Assert(err, IsNil)
+	}
+
+	numWithEgress = 0
+	repo.Iterate(countEgressRules)
+
+	c.Assert(numWithEgress, Equals, numRules)
+
+	numModified := 0
+	modifyRules := func(r *api.Rule) {
+		if r.Labels.Contains(labels.LabelArray{lbls[1]}) || r.Labels.Contains(labels.LabelArray{lbls[3]}) {
+			r.Egress = nil
+			numModified++
+		}
+	}
+
+	repo.Iterate(modifyRules)
+
+	c.Assert(numModified, Equals, 2)
+
+	numWithEgress = 0
+	repo.Iterate(countEgressRules)
+
+	c.Assert(numWithEgress, Equals, numRules-numModified)
+
+	repo.Mutex.Lock()
+	_, _, numDeleted := repo.DeleteByLabelsLocked(labels.LabelArray{lbls[0]})
+	repo.Mutex.Unlock()
+	c.Assert(numDeleted, Equals, 1)
+
+	numWithEgress = 0
+	repo.Iterate(countEgressRules)
+
+	c.Assert(numWithEgress, Equals, numRules-numModified-numDeleted)
+}


### PR DESCRIPTION
Introduce the `--dns-policy-unload-on-shutdown` option which will cause
DNS policy rules to be unloaded on graceful agent shutdown.
    
This leads to DNS queries no longer being redirected to the L7 DNS proxy
by the BPF datapath and allows endpoints on a node where the agent is
not running to continue being able to resolve DNS queries.
    
By default the option is disabled as it would result in a default allow
posture during agent downtime.
    
Also, only "match all" wildcard rules (i.e. `matchPattern = "*"`) are
unloaded for security reasons. Otherwise we could invalidate the L7
security rules.