### PR TITLE
bpf: Cover native routing CIDR check in compile tests

### DIFF
--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -58,6 +58,10 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define IPV4_MASK 0xffff
 #define IPV4_GATEWAY 0xfffff50a
 #define IPV4_LOOPBACK 0x1ffff50a
+# ifdef ENABLE_MASQUERADE
+#  define IPV4_SNAT_EXCLUSION_DST_CIDR 0xffff0000
+#  define IPV4_SNAT_EXCLUSION_DST_CIDR_LEN 16
+# endif /* ENABLE_MASQUERADE */
 #ifdef ENABLE_NODEPORT
 #define SNAT_MAPPING_IPV4 test_cilium_snat_v4_external
 #define SNAT_MAPPING_IPV4_SIZE 524288


### PR DESCRIPTION
This small pull request defines the `IPV4_SNAT_EXCLUSION_DST_CIDR{,_LEN}` macros in `node_config.h` such that [the related code (guarded by that macro)](https://github.com/cilium/cilium/blob/96152dcbd59da5f1c0be27f2b3e7a0a91eddad8b/bpf/lib/nodeport.h#L1136-L1146) is compiled during compile tests (`build_all` make target).