### PR TITLE
bpf: Simplify `ipv6_hdrlen`'s prototype

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -192,7 +192,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx, const bool from_host)
 		return DROP_INVALID;
 
 	nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen(ctx, ETH_HLEN, &nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
@@ -370,7 +370,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, __u32 *monitor)
 		return DROP_INVALID;
 
 	nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen(ctx, ETH_HLEN, &nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -88,15 +88,14 @@ encode_custom_prog_meta(struct __ctx_buff *ctx, int ret, __u32 identity)
 #endif
 
 #ifdef ENABLE_IPV6
-static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
-					    struct ipv6_ct_tuple *tuple,
-					    int l3_off, struct ipv6hdr *ip6,
-					    __u32 *dst_id)
+static __always_inline int
+ipv6_l3_from_lxc(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
+		 struct ipv6hdr *ip6, __u32 *dst_id)
 {
 #ifdef ENABLE_ROUTING
 	union macaddr router_mac = NODE_MAC;
 #endif
-	int ret, verdict = 0, l4_off, hdrlen;
+	int ret, verdict = 0, l4_off, hdrlen, l3_off = ETH_HLEN;
 	struct csum_offset csum_off = {};
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
@@ -119,7 +118,7 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 	ipv6_addr_copy(&tuple->daddr, (union v6addr *) &ip6->daddr);
 	ipv6_addr_copy(&tuple->saddr, (union v6addr *) &ip6->saddr);
 
-	hdrlen = ipv6_hdrlen(ctx, l3_off, &tuple->nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &tuple->nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
@@ -492,7 +491,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx, __u32 *dst_id)
 
 	/* Perform L3 action on the frame */
 	tuple.nexthdr = ip6->nexthdr;
-	return ipv6_l3_from_lxc(ctx, &tuple, ETH_HLEN, ip6, dst_id);
+	return ipv6_l3_from_lxc(ctx, &tuple, ip6, dst_id);
 }
 
 declare_tailcall_if(__or3(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6),
@@ -1089,7 +1088,7 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 	 */
 	skip_ingress_proxy = tc_index_skip_ingress_proxy(ctx);
 
-	hdrlen = ipv6_hdrlen(ctx, ETH_HLEN, &tuple.nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
@@ -1720,7 +1719,7 @@ int tail_ipv6_to_ipv4(struct __ctx_buff *ctx)
 {
 	int ret;
 
-	ret = ipv6_to_ipv4(ctx, 14, LXC_IPV4);
+	ret = ipv6_to_ipv4(ctx, LXC_IPV4);
 	if (IS_ERR(ret))
 		goto drop_err;
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -134,7 +134,7 @@ not_esp:
 			goto to_host;
 
 		nexthdr = ip6->nexthdr;
-		hdrlen = ipv6_hdrlen(ctx, l3_off, &nexthdr);
+		hdrlen = ipv6_hdrlen(ctx, &nexthdr);
 		if (hdrlen < 0)
 			return hdrlen;
 

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -282,7 +282,7 @@ ipv6_extract_tuple(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	ipv6_addr_copy(&tuple->daddr, (union v6addr *)&ip6->daddr);
 	ipv6_addr_copy(&tuple->saddr, (union v6addr *)&ip6->saddr);
 
-	ret = ipv6_hdrlen(ctx, l3_off, &tuple->nexthdr);
+	ret = ipv6_hdrlen(ctx, &tuple->nexthdr);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -90,7 +90,7 @@ encap_remap_v6_host_address(struct __ctx_buff *ctx __maybe_unused,
 	if (ipv6_addrcmp(which, &host_ip))
 		return 0;
 	nexthdr = ip6->nexthdr;
-	ret = ipv6_hdrlen(ctx, ETH_HLEN, &nexthdr);
+	ret = ipv6_hdrlen(ctx, &nexthdr);
 	if (ret < 0)
 		return ret;
 	off = ((void *)ip6 - data) + ret;

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -39,7 +39,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 *monitor)
 	ipv6_addr_copy(&tuple.saddr, (union v6addr *)&ip6->saddr);
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *)&ip6->daddr);
 	ipv6_addr_copy(&orig_dip, (union v6addr *)&ip6->daddr);
-	hdrlen = ipv6_hdrlen(ctx, ETH_HLEN, &tuple.nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 	l4_off = l3_off + hdrlen;
@@ -128,7 +128,7 @@ ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id)
 	tuple.nexthdr = ip6->nexthdr;
 	ipv6_addr_copy(&tuple.saddr, (union v6addr *)&ip6->saddr);
 	ipv6_addr_copy(&orig_sip, (union v6addr *)&ip6->saddr);
-	hdrlen = ipv6_hdrlen(ctx, ETH_HLEN, &tuple.nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 	l4_off = ETH_HLEN + hdrlen;

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -45,8 +45,7 @@ static __always_inline int ipv6_authlen(const struct ipv6_opt_hdr *opthdr)
 	return (opthdr->hdrlen + 2) << 2;
 }
 
-static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, int l3_off,
-				       __u8 *nexthdr)
+static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
 {
 	int i, len = sizeof(struct ipv6hdr);
 	struct ipv6_opt_hdr opthdr __align_stack_8;
@@ -65,7 +64,7 @@ static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, int l3_off,
 		case NEXTHDR_ROUTING:
 		case NEXTHDR_AUTH:
 		case NEXTHDR_DEST:
-			if (ctx_load_bytes(ctx, l3_off + len, &opthdr, sizeof(opthdr)) < 0)
+			if (ctx_load_bytes(ctx, ETH_HLEN + len, &opthdr, sizeof(opthdr)) < 0)
 				return DROP_INVALID;
 
 			nh = opthdr.nexthdr;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -939,7 +939,7 @@ static __always_inline __maybe_unused int snat_v6_create_dsr(struct __ctx_buff *
 		return DROP_INVALID;
 
 	tuple.nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen(ctx, ETH_HLEN, &tuple.nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
@@ -999,7 +999,7 @@ snat_v6_process(struct __ctx_buff *ctx, enum nat_dir dir,
 		return DROP_INVALID;
 
 	nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen(ctx, ETH_HLEN, &nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 

--- a/bpf/lib/nat46.h
+++ b/bpf/lib/nat46.h
@@ -320,21 +320,20 @@ static __always_inline int ipv4_to_ipv6(struct __ctx_buff *ctx, struct iphdr *ip
  * s4 = <ipv4-range>.<lxc-id>
  * d4 = d6[96 .. 127]
  */
-static __always_inline int ipv6_to_ipv4(struct __ctx_buff *ctx, int nh_off,
-					__be32 saddr)
+static __always_inline int ipv6_to_ipv4(struct __ctx_buff *ctx, __be32 saddr)
 {
 	struct ipv6hdr v6;
 	struct iphdr v4 = {};
-	int csum_off;
 	__be32 csum = 0;
 	__be16 protocol = bpf_htons(ETH_P_IP);
 	__u64 csum_flags = BPF_F_PSEUDO_HDR;
+	int csum_off, nh_off = ETH_HLEN;
 
 	if (ctx_load_bytes(ctx, nh_off, &v6, sizeof(v6)) < 0)
 		return DROP_INVALID;
 
 	/* Drop frames which carry extensions headers */
-	if (ipv6_hdrlen(ctx, nh_off, &v6.nexthdr) != sizeof(v6))
+	if (ipv6_hdrlen(ctx, &v6.nexthdr) != sizeof(v6))
 		return DROP_INVALID_EXTHDR;
 
 	/* build v4 header */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -203,7 +203,7 @@ static __always_inline bool snat_v6_needed(struct __ctx_buff *ctx,
 		__u8 nexthdr = ip6->nexthdr;
 		int ret;
 
-		ret = ipv6_hdrlen(ctx, ETH_HLEN, &nexthdr);
+		ret = ipv6_hdrlen(ctx, &nexthdr);
 		if (ret > 0) {
 			if (nodeport_uses_dsr(nexthdr))
 				return false;
@@ -725,7 +725,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *) &ip6->daddr);
 	ipv6_addr_copy(&tuple.saddr, (union v6addr *) &ip6->saddr);
 
-	hdrlen = ipv6_hdrlen(ctx, l3_off, &tuple.nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
@@ -866,7 +866,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *) &ip6->daddr);
 	ipv6_addr_copy(&tuple.saddr, (union v6addr *) &ip6->saddr);
 
-	hdrlen = ipv6_hdrlen(ctx, l3_off, &tuple.nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 

--- a/bpf/lib/pcap.h
+++ b/bpf/lib/pcap.h
@@ -357,7 +357,7 @@ cilium_capture6_classify_wcard(struct __ctx_buff *ctx)
 	okey.smask = 128;
 	okey.nexthdr = ip6->nexthdr;
 
-	ret = ipv6_hdrlen(ctx, l3_off, &okey.nexthdr);
+	ret = ipv6_hdrlen(ctx, &okey.nexthdr);
 	if (ret < 0)
 		return NULL;
 	if (okey.nexthdr != IPPROTO_TCP &&

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -149,7 +149,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
-		off = ((void *)ip6 - data) + ipv6_hdrlen(ctx, ETH_HLEN, &ip6->nexthdr);
+		off = ((void *)ip6 - data) + ipv6_hdrlen(ctx, &ip6->nexthdr);
 		if (ctx_load_bytes(ctx, off, &icmp_type, sizeof(icmp_type)) < 0)
 			return DROP_INVALID;
 


### PR DESCRIPTION
`l3_off`'s value is the same everywhere in our datapath, so we don't really need to pass it as an argument to `ipv6_hdrlen`. That also matches how [the IPv4 counterpart of this function](https://github.com/cilium/cilium/blob/ce6f2c7729df96f31a0637c6a24f24add3a65fa6/bpf/lib/ipv4.h#L57-L60) works.

If a function was taking `l3_off` as an argument and passing it to `ipv6_hdrlen`, then the argument is removed from the function's prototype, to not give the wrong impression that different L3 offsets are supported.