### PR TITLE
ci: remove box download timeout in upstream tests

### DIFF
--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -64,10 +64,6 @@ pipeline {
             }
         }
         stage('Preload vagrant boxes'){
-            options {
-                timeout(time: 20, unit: 'MINUTES')
-            }
-
             steps {
                 sh '/usr/local/bin/add_vagrant_box ${WORKSPACE}/${PROJ_PATH}/vagrant_box_defaults.rb'
             }


### PR DESCRIPTION
This timeout can be too small when the host has to download all boxes due to not having any of the boxes required for the SHA to be tested.

In particular this is prone to happen on backport PRs, since it's more likely for the job to be scheduled on a node that primarily run `master` pipelines up to that point.