### PR TITLE
datapath: Fix IPv6 DSR

### DIFF
--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -235,7 +235,7 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 		case 48: /* struct {ipv6hdr + icmp6hdr} */
 			break;
 		case 40: /* struct ipv6hdr */
-		case 22: /* struct dsr_opt_v6 */
+		case 24: /* struct dsr_opt_v6 */
 			if (data + move_len_v6 + len_diff <= data_end)
 				__bpf_memmove_fwd(data, data + len_diff,
 						  move_len_v6);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -87,6 +87,7 @@ struct dsr_opt_v6 {
 	__u8 opt_len;
 	union v6addr addr;
 	__be16 port;
+	__u16 pad;
 };
 #endif /* ENABLE_IPV6 */
 
@@ -310,6 +311,9 @@ static __always_inline int dsr_set_ext6(struct __ctx_buff *ctx,
 {
 	struct dsr_opt_v6 opt __align_stack_8 = {};
 	__u16 payload_len = bpf_ntohs(ip6->payload_len) + sizeof(opt);
+
+	/* The IPv6 extension should be 8-bytes aligned */
+	build_bug_on((sizeof(struct dsr_opt_v6) % 8) != 0);
 
 	if (dsr_is_too_big(ctx, payload_len)) {
 		*ohead = sizeof(opt);


### PR DESCRIPTION
See commit msg. Tested by https://github.com/cilium/cilium/pull/18696. This is yet another example why we should not quarantine CI tests.