### PR TITLE
vagrant, test: Enable IPv6 connectivity to the outside world

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -57,6 +57,16 @@ class VagrantPlugins::ProviderVirtualBox::Action::Network
   end
 end
 
+$cleanup = <<SCRIPT
+i=1
+res=0
+while [ "$res" == "0" ]; do
+    VBoxManage natnetwork remove --netname natnet$i
+    res=$?
+    i=$((i+1))
+done 2>/dev/null
+SCRIPT
+
 $bootstrap = <<SCRIPT
 set -o errexit
 set -o nounset
@@ -81,6 +91,10 @@ Vagrant.configure("2") do |config|
     elsif ENV["SHARE_PARENT"] then
         cilium_dir = '../..'
         cilium_path = '/home/vagrant/go/src/github.com/cilium'
+    end
+
+    config.trigger.before :up, :provision do |trigger|
+        trigger.run = {inline: "bash -c '#{$cleanup}'"}
     end
 
     config.vm.define "runtime" do |server|
@@ -196,6 +210,22 @@ Vagrant.configure("2") do |config|
             else
                 server.vm.synced_folder cilium_dir, cilium_path
             end
+
+            # Interface for the IPv6 NAT Service. The IP address doesn't matter
+            # as it won't be used. We use an IPv6 address as newer versions of
+            # VBox reject all IPv6 addresses.
+            server.vm.network "private_network",
+                ip: "192.168.59.15"
+            server.vm.provider "virtualbox" do |vb|
+                vb.customize ["natnetwork", "add", "--netname", "natnet#{i}", "--network", "fd08::/64", "--ipv6", "on", "--enable"]
+                vb.customize ["modifyvm", :id, "--nic5", "natnetwork"]
+                vb.customize ["modifyvm", :id, "--nat-network5", "natnet#{i}"]
+            end
+            server.vm.provision "ipv6-nat-config",
+                type: "shell",
+                run: "always",
+                inline: "ip -6 r a default via fd17:625c:f037:2::1 dev enp0s16 || true"
+
             # Provision section
             server.vm.provision "bootstrap", type: "shell", inline: $bootstrap
             server.vm.provision :shell,

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -258,36 +258,42 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 			if helpers.RunsOn419OrLaterKernel() {
 				By("Test BPF masquerade")
-				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).
+				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, false)).
 					Should(BeTrue(), "Connectivity test to http://google.com failed")
 			}
 		})
 
 		It("Check iptables masquerading with random-fully", func() {
 			options := map[string]string{
-				"bpf.masquerade":      "false",
-				"iptablesRandomFully": "true",
+				"bpf.masquerade":       "false",
+				"enableIPv6Masquerade": "true",
+				"iptablesRandomFully":  "true",
 			}
 			enableVXLANTunneling(options)
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 
 			By("Test iptables masquerading")
-			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).
-				Should(BeTrue(), "Connectivity test to http://google.com failed")
+			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, false)).
+				Should(BeTrue(), "IPv4 connectivity test to http://google.com failed")
+			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, true)).
+				Should(BeTrue(), "IPv6 connectivity test to http://google.com failed")
 		})
 
 		It("Check iptables masquerading without random-fully", func() {
 			options := map[string]string{
-				"bpf.masquerade": "false",
+				"bpf.masquerade":       "false",
+				"enableIPv6Masquerade": "true",
 			}
 			enableVXLANTunneling(options)
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 
 			By("Test iptables masquerading")
-			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).
-				Should(BeTrue(), "Connectivity test to http://google.com failed")
+			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, false)).
+				Should(BeTrue(), "IPv4 connectivity test to http://google.com failed")
+			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, true)).
+				Should(BeTrue(), "IPv6 connectivity test to http://google.com failed")
 		})
 	})
 
@@ -333,7 +339,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 			if helpers.RunsOn419OrLaterKernel() {
 				By("Test BPF masquerade")
-				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).
+				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, false)).
 					Should(BeTrue(), "Connectivity test to http://google.com failed")
 			}
 		})
@@ -521,7 +527,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			nodeIP, err := kubectl.GetNodeIPByLabel(helpers.GetFirstNodeWithoutCilium(), false)
 			Expect(err).Should(BeNil())
 			Expect(testPodHTTPToOutside(kubectl,
-				fmt.Sprintf("http://%s:80", nodeIP), true, false)).Should(BeTrue(),
+				fmt.Sprintf("http://%s:80", nodeIP), true, false, false)).Should(BeTrue(),
 				"Connectivity test to http://%s failed", nodeIP)
 
 			// Update ip-masq-agent config to prevent masquerading to the node IP
@@ -533,7 +539,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 			// Check that connections from the client pods are not masqueraded
 			Expect(testPodHTTPToOutside(kubectl,
-				fmt.Sprintf("http://%s:80", nodeIP), false, true)).Should(BeTrue(),
+				fmt.Sprintf("http://%s:80", nodeIP), false, true, false)).Should(BeTrue(),
 				"Connectivity test to http://%s failed", nodeIP)
 		}
 
@@ -1163,9 +1169,16 @@ func testPodHTTP(kubectl *helpers.Kubectl, namespace string, requireMultiNode bo
 
 }
 
-func testPodHTTPToOutside(kubectl *helpers.Kubectl, outsideURL string, expectNodeIP, expectPodIP bool) bool {
+func testPodHTTPToOutside(kubectl *helpers.Kubectl, outsideURL string, expectNodeIP, expectPodIP, ipv6 bool) bool {
 	var hostIPs map[string]string
 	var podIPs map[string]string
+
+	// IPv6 is not supported when the source IP should be checked. It could be
+	// supported with more work, but it doesn't make sense as in those cases,
+	// we can simply pass the IPv6 target address as outsideURL.
+	if ipv6 && expectPodIP {
+		panic("IPv6 not supported with source IP checking.")
+	}
 
 	namespace := deploymentManager.DeployRandomNamespaceShared(DemoDaemonSet)
 	applyL3Policy(kubectl, namespace)
@@ -1175,7 +1188,12 @@ func testPodHTTPToOutside(kubectl *helpers.Kubectl, outsideURL string, expectNod
 	pods, err := kubectl.GetPodNames(namespace, label)
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot retrieve pod names by label %s", label)
 
-	cmd := helpers.CurlWithRetries(outsideURL, 10, true)
+	cmd := outsideURL
+	if ipv6 {
+		cmd = fmt.Sprintf("-6 %s", cmd)
+	}
+	cmd = helpers.CurlWithRetries(cmd, 10, true)
+
 	if expectNodeIP || expectPodIP {
 		cmd += " | grep client_address="
 		hostIPs, err = kubectl.GetPodsHostIPs(namespace, label)

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -791,7 +791,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 		SkipItIf(helpers.RunsWithoutKubeProxy, "Check connectivity with transparent encryption and direct routing with bpf_host", func() {
 			privateIface, err := kubectl.GetPrivateIface()
 			Expect(err).Should(BeNil(), "Unable to determine the private interface")
-			defaultIface, err := kubectl.GetDefaultIface()
+			defaultIface, err := kubectl.GetDefaultIface(false)
 			Expect(err).Should(BeNil(), "Unable to determine the default interface")
 			devices := fmt.Sprintf(`'{%s,%s}'`, privateIface, defaultIface)
 

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -89,11 +89,6 @@ ff02::2 ip6-allrouters
 192.168.56.16 k8s6
 EOF
 
-# Configure default IPv6 route without this connectivity from host to
-# services is not possible as there is no default route. enp0s8 is the primary
-# interface for test environment.
-sudo ip -6 route add default dev enp0s8
-
 cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF


### PR DESCRIPTION
See commits for details.

Tested on the following setups:
- [x] With IPv6 connectivity on the host.
    - Test passes.
- [x] Without IPv6 connectivity on the host.
    - VM provisioned without issues.
- [x] With IPv6 disabled on the host.
    - VM provisioned without issues.
- [x] With IPv6 not compiled in the host kernel.
    - VM provisioned without issues.
- [x] On macOS.
    - VM provisioned without issues.
- [x] On Linux.
    - VM provisioned without issues.

If you test this, you can simply use the following commands (you can use any value you prefer for `KERNEL`):
```
git fetch origin pull/18714/head:pr/18714
git checkout pr/18714
cd test
KERNEL=49 ginkgo -v --focus="K8sDatapathConfig .* Check iptables masquerading with" --tags=integration_tests -- --cilium.provision=true --cilium.holdEnvironment=true -cilium.testScope="k8s" -cilium.runQuarantined=true
```
I'm interested to know if (1) the VM provisioning succeeds and (2) if the test passes.