### PR TITLE
Add missing error reporting in replaceNetworkDatapath

### DIFF
--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -363,7 +363,7 @@ func (l *Loader) replaceNetworkDatapath(ctx context.Context, interfaces []string
 	}
 	for _, iface := range option.Config.EncryptInterface {
 		if err := replaceDatapath(ctx, iface, networkObj, symbolFromNetwork, dirIngress, false, ""); err != nil {
-			log.WithField(logfields.Interface, iface).Fatal("Load encryption network failed")
+			log.WithField(logfields.Interface, iface).WithError(err).Fatal("Load encryption network failed")
 		}
 	}
 	return nil


### PR DESCRIPTION
Just a trivial one-line change.

```release-note
Add missing error reporting in replaceNetworkDatapath
```