### PR TITLE
loader: Fix egress attachment for bandwidth manager

### DIFF
--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -238,7 +238,8 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 		interfaceNames = append(interfaceNames, device)
 		symbols = append(symbols, symbolFromHostNetdevEp)
 		directions = append(directions, dirIngress)
-		if option.Config.EnableNodePort || option.Config.EnableHostFirewall {
+		if option.Config.EnableNodePort || option.Config.EnableHostFirewall ||
+			option.Config.EnableBandwidthManager {
 			interfaceNames = append(interfaceNames, device)
 			symbols = append(symbols, symbolToHostNetdevEp)
 			directions = append(directions, dirEgress)


### PR DESCRIPTION
The loader only attaches BPF programs to the egress of native devices if the host firewall or BPF NodePort are enabled. It is however also necessary to attach on egress if only the bandwidth manager is enabled.

Updates: https://github.com/cilium/cilium/issues/16790.

```release-note
Fix BPF attachment when bandwidth manager is enabled without host firewall or kube-proxy-replacement.
```
