### PR TITLE
ci: fix QEMU image build following Google Cloud SDK updates

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -2,6 +2,7 @@ name: Image CI Build
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  pull_request: {} # DO NOT MERGE -- temp test
   pull_request_target:
     types:
       - opened
@@ -247,7 +248,6 @@ jobs:
   # which requires qemu setup in order to avoid x86/arm64 binaries mixups
   # note: we only build on pushes to master branch
   build-and-push-with-qemu:
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/images/cilium-test/install-deps.sh
+++ b/images/cilium-test/install-deps.sh
@@ -16,6 +16,7 @@ ubuntu_packages=(
   gnupg
   grep
   jq
+  python-is-python3
   sed
 )
 


### PR DESCRIPTION
Recent Google Cloud SDK updates broke our QEMU image build:

```
205.3 /usr/bin/gcloud: 190: exec: /usr/bin/../lib/google-cloud-sdk/platform/bundledpythonunix/bin/python3: not found
```

Google tracker link: https://issuetracker.google.com/issues/216325949

This has been reportedly fixed in version 371, however we still hit an
issue:

```
271.2 Setting up google-cloud-sdk (371.0.0-0) ...
271.9 /usr/bin/gcloud: 192: exec: python: not found
```

This is because the `python` dependency has been removed from
`google-cloud-sdk`:

```
23.07 The following NEW packages will be installed:
23.07   google-cloud-sdk kubectl
```

Previously, from a working run:

```
21.85 The following NEW packages will be installed:
21.85   google-cloud-sdk kubectl libexpat1 libmpdec2 libpython3-stdlib
21.85   libpython3.8-minimal libpython3.8-stdlib mime-support python3
21.85   python3-minimal python3.8 python3.8-minimal
```