### PR TITLE
tooling: add kind-down script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -498,6 +498,9 @@ microk8s: check-microk8s ## Build cilium-dev docker image and import to microk8s
 kind: ## Create a kind cluster for Cilium development.
 	$(QUIET)./contrib/scripts/kind.sh
 
+kind-down: ## Destroy a kind cluster for Cilium development.
+	$(QUIET)./contrib/scripts/kind-down.sh
+
 kind-image: export DOCKER_REGISTRY=localhost:5000
 kind-image: export LOCAL_IMAGE=$(DOCKER_REGISTRY)/$(DOCKER_DEV_ACCOUNT)/cilium-dev:$(LOCAL_IMAGE_TAG)
 kind-image:

--- a/contrib/scripts/kind-down.sh
+++ b/contrib/scripts/kind-down.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+have_kind() {
+    [[ -n "$(command -v kind)" ]]
+}
+
+if ! have_kind; then
+    echo "Please install kind first:"
+    echo "  https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
+fi
+
+kind delete clusters kind && \
+docker kill kind-registry && \
+docker rm kind-registry


### PR DESCRIPTION
Add a `kind-down` make target to compliment the `kind` target.

This target makes sure to clean up the registry container which remains
present when a user only issues the destruction of a kind cluster.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>

