### PR TITLE
test: Remove workaround for old issue #12141

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -320,15 +320,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 
 		It("Check connectivity with automatic direct nodes routes", func() {
-			options := map[string]string{
+			deploymentManager.DeployCilium(map[string]string{
 				"tunnel":               "disabled",
 				"autoDirectNodeRoutes": "true",
-			}
-			// Needed to bypass bug with masquerading when devices are set. See #12141.
-			if helpers.DoesNotRunWithKubeProxyReplacement() {
-				options["masquerade"] = "false"
-			}
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
+			}, DeployCiliumOptionsAndDNS)
 
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 			if helpers.RunsOn419OrLaterKernel() {
@@ -339,17 +334,12 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 
 		It("Check direct connectivity with per endpoint routes", func() {
-			options := map[string]string{
+			deploymentManager.DeployCilium(map[string]string{
 				"tunnel":                 "disabled",
 				"autoDirectNodeRoutes":   "true",
 				"endpointRoutes.enabled": "true",
 				"ipv6.enabled":           "false",
-			}
-			// Needed to bypass bug with masquerading when devices are set. See #12141.
-			if helpers.DoesNotRunWithKubeProxyReplacement() {
-				options["masquerade"] = "false"
-			}
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
+			}, DeployCiliumOptionsAndDNS)
 
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})


### PR DESCRIPTION
This reverts commit c4936c7e1abb2b8b99b4ed57fba91bf974c2d5eb.

I am now unable to reproduce the issue described in https://github.com/cilium/cilium/issues/12141. It was probably fixed a while ago, when we fixed several issues related to setting devices (before making the host firewall stable).

Fixes: https://github.com/cilium/cilium/pull/18722.