### PR TITLE
docs: Use `kubectl exec daemonset/cilium` where possible

### DIFF
--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -62,7 +62,7 @@ to determine which devices the program is running on:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep Masquerading
+    $ kubectl -n kube-system exec ds/cilium -- cilium status | grep Masquerading
     Masquerading:   BPF (ip-masq-agent)   [eth0, eth1]  10.0.0.0/16
 
 From the output above, the program is running on the ``eth0`` and ``eth1`` devices.
@@ -129,7 +129,7 @@ The example below shows how to configure the agent via `ConfigMap` and to verify
 
     $ # Wait ~60s until the ConfigMap is mounted into a cilium pod
 
-    $ kubectl -n kube-system exec -ti cilium-xxxxx -- cilium bpf ipmasq list
+    $ kubectl -n kube-system exec ds/cilium -- cilium bpf ipmasq list
     IP PREFIX/ADDRESS
     10.0.0.0/8
     169.254.0.0/16

--- a/Documentation/gettingstarted/kube-router.rst
+++ b/Documentation/gettingstarted/kube-router.rst
@@ -117,7 +117,7 @@ Verify that kube-router has installed routes:
 
 .. code-block:: shell-session
 
-    $ kubectl -n kube-system exec -ti cilium-fhpk2 -- ip route list scope global
+    $ kubectl -n kube-system exec ds/cilium -- ip route list scope global
     default via 172.0.32.1 dev eth0 proto dhcp src 172.0.50.227 metric 1024
     10.2.0.0/24 via 10.2.0.172 dev cilium_host src 10.2.0.172
     10.2.1.0/24 via 172.0.51.175 dev eth0 proto 17

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -145,14 +145,14 @@ the Cilium agent is running in the desired mode:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n kube-system cilium-fmh8d -- cilium status | grep KubeProxyReplacement
+    $ kubectl -n kube-system exec ds/cilium -- cilium status | grep KubeProxyReplacement
     KubeProxyReplacement:   Strict	[eth0 (Direct Routing), eth1]
 
 Use ``--verbose`` for full details:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n kube-system cilium-fmh8d -- cilium status --verbose
+    $ kubectl -n kube-system exec ds/cilium -- cilium status --verbose
     [...]
     KubeProxyReplacement Details:
       Status:                Strict
@@ -228,7 +228,7 @@ port ``31940`` (one for each of devices ``eth0`` and ``eth1``):
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n kube-system cilium-fmh8d -- cilium service list
+    $ kubectl -n kube-system exec ds/cilium -- cilium service list
     ID   Frontend               Service Type   Backend
     [...]
     4    10.104.239.135:80      ClusterIP      1 => 10.217.0.107:80
@@ -623,7 +623,7 @@ is shown:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium status --verbose | grep XDP
+    $ kubectl -n kube-system exec ds/cilium -- cilium status --verbose | grep XDP
       XDP Acceleration:    Native
 
 Note that packets which have been pushed back out of the device for NodePort handling
@@ -977,7 +977,7 @@ for example:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium status --verbose | grep HostPort
+    $ kubectl -n kube-system exec ds/cilium -- cilium status --verbose | grep HostPort
       - HostPort:       Enabled
 
 The following modified example yaml from the setup validation with an additional
@@ -1160,7 +1160,7 @@ The current Cilium kube-proxy replacement mode can also be introspected through 
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n kube-system cilium-xxxxx -- cilium status | grep KubeProxyReplacement
+    $ kubectl -n kube-system exec ds/cilium -- cilium status | grep KubeProxyReplacement
     KubeProxyReplacement:   Strict	[eth0 (DR)]
 
 Graceful Termination
@@ -1176,7 +1176,7 @@ The cilium agent feature flag can be probed by running ``cilium status`` command
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n kube-system cilium-fmh8d -- cilium status --verbose
+    $ kubectl -n kube-system exec ds/cilium -- cilium status --verbose
     [...]
     KubeProxyReplacement Details:
      [...]


### PR DESCRIPTION
This pull request changes a couple documentation pages to use `kubectl exec ds/cilium` where possible instead of `kubectl exec cilium-xxxx` which requires retrieving a pod name first. The new command is only used when the specific Cilium agent being queried doesn't matter (e.g., when checking if a Cilium feature is enabled in `cilium status`). It should simplify copy-pasting of GSG commands.