### PR TITLE
watchers: Support hostPort for init containers

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -460,8 +460,13 @@ func (k *K8sWatcher) deleteK8sPodV1(pod *slim_corev1.Pod) error {
 }
 
 func (k *K8sWatcher) genServiceMappings(pod *slim_corev1.Pod, podIPs []string, logger *logrus.Entry) []loadbalancer.SVC {
-	var svcs []loadbalancer.SVC
-	for _, c := range pod.Spec.Containers {
+	var (
+		svcs       []loadbalancer.SVC
+		containers []slim_corev1.Container
+	)
+	containers = append(containers, pod.Spec.InitContainers...)
+	containers = append(containers, pod.Spec.Containers...)
+	for _, c := range containers {
 		for _, p := range c.Ports {
 			if p.HostPort <= 0 {
 				continue


### PR DESCRIPTION
The K8s watcher for HostPort services was only watching for containers and not init containers. This commit fixes it such that HostPorts assigned to init containers generate the proper service mapping in the datapath.

Fixes: https://github.com/cilium/cilium/issues/16191.

```release-note
Fix support of BPF-based HostPort on init containers.
```