### PR TITLE
daemon: Removed unused method

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1106,9 +1106,3 @@ func (d *Daemon) K8sCacheIsSynced() bool {
 		return false
 	}
 }
-
-// WaitUntilK8sCacheIsSynced waits until the agent has fully synced its k8s cache with the API
-// server
-func (d *Daemon) WaitUntilK8sCacheIsSynced() {
-	_, _ = <-d.k8sCachesSynced
-}


### PR DESCRIPTION
There are no callers of the method `WaitUntilK8sCacheIsSynced`.

Fixes: https://github.com/cilium/cilium/commit/560c85fa550c5cedb18897577d3a08063f83516f
Signed-off-by: Aditi Ghag <aditi@cilium.io>