### PR TITLE
ipsec: Add/Fix packet tracing for overlay mode

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -413,11 +413,17 @@ int from_overlay(struct __ctx_buff *ctx)
 #endif
 	{
 		__u32 identity = 0;
+		enum trace_point obs_point = TRACE_FROM_OVERLAY;
 
-		if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT)
+		/* Non-ESP packet marked with MARK_MAGIC_DECRYPT is a packet
+		 * re-inserted from the stack.
+		 */
+		if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT) {
 			identity = get_identity(ctx);
+			obs_point = TRACE_FROM_STACK;
+		}
 
-		send_trace_notify(ctx, TRACE_FROM_OVERLAY, identity, 0, 0,
+		send_trace_notify(ctx, obs_point, identity, 0, 0,
 				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
 	}
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -116,6 +116,11 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		 * packet.
 		 */
 		ctx_change_type(ctx, PACKET_HOST);
+
+		send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0,
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
+				  TRACE_PAYLOAD_LEN);
+
 		return CTX_ACT_OK;
 	}
 	ctx->mark = 0;
@@ -270,6 +275,11 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 		 * packet.
 		 */
 		ctx_change_type(ctx, PACKET_HOST);
+
+		send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0,
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
+				  TRACE_PAYLOAD_LEN);
+
 		return CTX_ACT_OK;
 	}
 	ctx->mark = 0;


### PR DESCRIPTION
Please see the commit messages for more details.

```release-note
Add missing & fix wrong traces for IPSec + overlay receive path
```
