### PR TITLE
ui: update envoy config to work with v1.18.4 envoy

### DIFF
--- a/install/kubernetes/cilium/files/envoy/envoy.yaml
+++ b/install/kubernetes/cilium/files/envoy/envoy.yaml
@@ -8,31 +8,34 @@ static_resources:
       filter_chains:
         - filters:
             - name: envoy.filters.network.http_connection_manager
-              config:
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                 codec_type: auto
                 stat_prefix: ingress_http
                 route_config:
                   name: local_route
                   virtual_hosts:
                     - name: local_service
-                      domains: ['*']
+                      domains: ["*"]
                       routes:
                         - match:
-                            prefix: '/api/'
+                            prefix: "/api/"
                           route:
                             cluster: backend
-                            max_grpc_timeout: 0s
-                            prefix_rewrite: '/'
+                            prefix_rewrite: "/"
+                            timeout: 0s
+                            max_stream_duration:
+                              grpc_timeout_header_max: 0s
                         - match:
-                            prefix: '/'
+                            prefix: "/"
                           route:
                             cluster: frontend
                       cors:
                         allow_origin_string_match:
-                          - prefix: '*'
+                          - prefix: "*"
                         allow_methods: GET, PUT, DELETE, POST, OPTIONS
                         allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
-                        max_age: '1728000'
+                        max_age: "1728000"
                         expose_headers: grpc-status,grpc-message
                 http_filters:
                   - name: envoy.filters.http.grpc_web
@@ -43,16 +46,26 @@ static_resources:
       connect_timeout: 0.25s
       type: strict_dns
       lb_policy: round_robin
-      hosts:
-        - socket_address:
-            address: 127.0.0.1
-            port_value: 8080
+      load_assignment:
+        cluster_name: frontend
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8080
     - name: backend
       connect_timeout: 0.25s
       type: logical_dns
       lb_policy: round_robin
       http2_protocol_options: {}
-      hosts:
-        - socket_address:
-            address: 127.0.0.1
-            port_value: 8090
+      load_assignment:
+        cluster_name: backend
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8090

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -223,31 +223,34 @@ data:
           filter_chains:
             - filters:
                 - name: envoy.filters.network.http_connection_manager
-                  config:
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     codec_type: auto
                     stat_prefix: ingress_http
                     route_config:
                       name: local_route
                       virtual_hosts:
                         - name: local_service
-                          domains: ['*']
+                          domains: ["*"]
                           routes:
                             - match:
-                                prefix: '/api/'
+                                prefix: "/api/"
                               route:
                                 cluster: backend
-                                max_grpc_timeout: 0s
-                                prefix_rewrite: '/'
+                                prefix_rewrite: "/"
+                                timeout: 0s
+                                max_stream_duration:
+                                  grpc_timeout_header_max: 0s
                             - match:
-                                prefix: '/'
+                                prefix: "/"
                               route:
                                 cluster: frontend
                           cors:
                             allow_origin_string_match:
-                              - prefix: '*'
+                              - prefix: "*"
                             allow_methods: GET, PUT, DELETE, POST, OPTIONS
                             allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
-                            max_age: '1728000'
+                            max_age: "1728000"
                             expose_headers: grpc-status,grpc-message
                     http_filters:
                       - name: envoy.filters.http.grpc_web
@@ -258,19 +261,29 @@ data:
           connect_timeout: 0.25s
           type: strict_dns
           lb_policy: round_robin
-          hosts:
-            - socket_address:
-                address: 127.0.0.1
-                port_value: 8080
+          load_assignment:
+            cluster_name: frontend
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 8080
         - name: backend
           connect_timeout: 0.25s
           type: logical_dns
           lb_policy: round_robin
           http2_protocol_options: {}
-          hosts:
-            - socket_address:
-                address: 127.0.0.1
-                port_value: 8090
+          load_assignment:
+            cluster_name: backend
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 8090
 ---
 # Source: cilium/templates/cilium-agent-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/kubernetes/quick-hubble-install.yaml
+++ b/install/kubernetes/quick-hubble-install.yaml
@@ -57,31 +57,34 @@ data:
           filter_chains:
             - filters:
                 - name: envoy.filters.network.http_connection_manager
-                  config:
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     codec_type: auto
                     stat_prefix: ingress_http
                     route_config:
                       name: local_route
                       virtual_hosts:
                         - name: local_service
-                          domains: ['*']
+                          domains: ["*"]
                           routes:
                             - match:
-                                prefix: '/api/'
+                                prefix: "/api/"
                               route:
                                 cluster: backend
-                                max_grpc_timeout: 0s
-                                prefix_rewrite: '/'
+                                prefix_rewrite: "/"
+                                timeout: 0s
+                                max_stream_duration:
+                                  grpc_timeout_header_max: 0s
                             - match:
-                                prefix: '/'
+                                prefix: "/"
                               route:
                                 cluster: frontend
                           cors:
                             allow_origin_string_match:
-                              - prefix: '*'
+                              - prefix: "*"
                             allow_methods: GET, PUT, DELETE, POST, OPTIONS
                             allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
-                            max_age: '1728000'
+                            max_age: "1728000"
                             expose_headers: grpc-status,grpc-message
                     http_filters:
                       - name: envoy.filters.http.grpc_web
@@ -92,19 +95,29 @@ data:
           connect_timeout: 0.25s
           type: strict_dns
           lb_policy: round_robin
-          hosts:
-            - socket_address:
-                address: 127.0.0.1
-                port_value: 8080
+          load_assignment:
+            cluster_name: frontend
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 8080
         - name: backend
           connect_timeout: 0.25s
           type: logical_dns
           lb_policy: round_robin
           http2_protocol_options: {}
-          hosts:
-            - socket_address:
-                address: 127.0.0.1
-                port_value: 8090
+          load_assignment:
+            cluster_name: backend
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 8090
 ---
 # Source: cilium/templates/hubble-generate-certs-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
current config is not compatible with 1.18.4 envoy version

Signed-off-by: Dmitry Kharitonov <dmitry@isovalent.com>

Fixes: https://github.com/cilium/hubble-ui/issues/196 https://github.com/cilium/cilium/issues/18734