### PR TITLE
v1.9 backports 2022-02-08

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -38,6 +38,10 @@ The documentation is divided into the following sections:
 * :ref:`dev_guide` : Gives background to those looking to develop and contribute
   modifications to the Cilium code or documentation.
 
+A `hands-on tutorial <https://play.instruqt.com/isovalent/invite/j4maqox5r1h5>`_ 
+in a live environment is also available for users looking for a way to quickly
+get started and experiment with Cilium.
+
 .. toctree::
    :maxdepth: 2
    :caption: Getting Started

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -193,19 +193,19 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 	}
 
 	expressions := []string{
-		reservedLabelsPattern,           // include all reserved labels
-		k8sConst.PodNamespaceLabel,      // include io.kubernetes.pod.namespace
-		k8sConst.PodNamespaceMetaLabels, // include all namespace labels
-		k8sConst.AppKubernetes,          // include app.kubernetes.io
-		"!io.kubernetes",                // ignore all other io.kubernetes labels
-		"!kubernetes.io",                // ignore all other kubernetes.io labels
-		"!.*beta.kubernetes.io",         // ignore all beta.kubernetes.io labels
-		"!k8s.io",                       // ignore all k8s.io labels
-		"!pod-template-generation",      // ignore pod-template-generation
-		"!pod-template-hash",            // ignore pod-template-hash
-		"!controller-revision-hash",     // ignore controller-revision-hash
-		"!annotation.*",                 // ignore all annotation labels
-		"!etcd_node",                    // ignore etcd_node label
+		reservedLabelsPattern,                             // include all reserved labels
+		regexp.QuoteMeta(k8sConst.PodNamespaceLabel),      // include io.kubernetes.pod.namespace
+		regexp.QuoteMeta(k8sConst.PodNamespaceMetaLabels), // include all namespace labels
+		regexp.QuoteMeta(k8sConst.AppKubernetes),          // include app.kubernetes.io
+		`!io\.kubernetes`,                                 // ignore all other io.kubernetes labels
+		`!kubernetes\.io`,                                 // ignore all other kubernetes.io labels
+		`!.*beta\.kubernetes\.io`,                         // ignore all beta.kubernetes.io labels
+		`!k8s\.io`,                                        // ignore all k8s.io labels
+		`!pod-template-generation`,                        // ignore pod-template-generation
+		`!pod-template-hash`,                              // ignore pod-template-hash
+		`!controller-revision-hash`,                       // ignore controller-revision-hash
+		`!annotation.*`,                                   // ignore all annotation labels
+		`!etcd_node`,                                      // ignore etcd_node label
 	}
 
 	for _, e := range expressions {

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -97,6 +97,7 @@ func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
 		"ignore":                      labels.NewLabel("ignore", "foo", labels.LabelSourceContainer),
 		"reserved:host":               labels.NewLabel("reserved:host", "", labels.LabelSourceAny),
 		"io.kubernetes.pod.namespace": labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceContainer),
+		"ioXkubernetes":               labels.NewLabel("ioXkubernetes", "foo", labels.LabelSourceContainer),
 	}
 
 	err := ParseLabelPrefixCfg([]string{}, "")
@@ -117,6 +118,7 @@ func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
 		"annotation." + k8sConst.CiliumIdentityAnnotationDeprecated: "12356",
 		"io.kubernetes.pod.terminationGracePeriod":                  "30",
 		"io.kubernetes.pod.uid":                                     "c2e22414-dfc3-11e5-9792-080027755f5a",
+		"ioXkubernetes":                                             "foo",
 		"ignore":                                                    "foo",
 		"ignorE":                                                    "foo",
 		"annotation.kubernetes.io/config.seen":                      "2017-05-30T14:22:17.691491034Z",
@@ -125,11 +127,10 @@ func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
 	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceContainer)
 	allLabels["reserved:host"] = labels.NewLabel("reserved:host", "", labels.LabelSourceAny)
 	filtered, _ := dlpcfg.filterLabels(allLabels)
-	c.Assert(len(filtered), Equals, 5)
+	c.Assert(len(filtered), Equals, len(wanted)-2) // -2 because we add two labels in the next lines
 	allLabels["id.lizards"] = labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer)
 	allLabels["id.lizards.k8s"] = labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
-	c.Assert(len(filtered), Equals, 7)
 	c.Assert(filtered, checker.DeepEquals, wanted)
 }
 


### PR DESCRIPTION
 * #18583 -- docs: add Hands-on tutorial (@vannyle)
 * #18693 -- labelfilter: Refine default label regexps (@twpayne)
 * #18707 -- ci: remove box download timeout in upstream tests (@nbusseneau)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18583 18693 18707; do contrib/backporting/set-labels.py $pr done 1.9; done
```
or with
```
$ make add-label branch=v1.9 issues=18583,18693,18707
```