### PR TITLE
ci: Bump cyclonus to v0.4.7

### DIFF
--- a/test/k8s/manifests/netpol-cyclonus/install-cyclonus.yml
+++ b/test/k8s/manifests/netpol-cyclonus/install-cyclonus.yml
@@ -11,11 +11,15 @@ spec:
         - command:
             - ./cyclonus
             - generate
-            - --mode=upstream
+            - --exclude=
+            - --include=upstream-e2e
+            - --retries=3
             - --noisy=true
             - --ignore-loopback=true
             - --cleanup-namespaces=true
+            - --server-port=80
+            - --server-protocol=tcp
           name: cyclonus
           imagePullPolicy: IfNotPresent
-          image: mfenwick100/cyclonus:v0.2.0@sha256:e489de547399d248703623fb471c0d6221d3f479
+          image: mfenwick100/cyclonus:v0.4.7@sha256:20103a6c8ffae57864d3c665612e69708f3efe6566492776340bad9c4cd98116
       serviceAccount: cyclonus

--- a/test/k8s/manifests/netpol-cyclonus/test-cyclonus.sh
+++ b/test/k8s/manifests/netpol-cyclonus/test-cyclonus.sh
@@ -8,7 +8,11 @@ kubectl create clusterrolebinding cyclonus --clusterrole=cluster-admin --service
 kubectl create sa cyclonus -n kube-system
 kubectl create -f ./install-cyclonus.yml
 
-time kubectl wait --for=condition=complete --timeout=240m -n kube-system job.batch/cyclonus
+# don't fail on errors, so we can dump the logs.
+set +e
+
+time kubectl wait --for=condition=complete --timeout=60m -n kube-system job.batch/cyclonus
+rc=$?
 
 # grab the job logs
 LOG_FILE=$(mktemp)
@@ -16,8 +20,5 @@ kubectl logs -n kube-system job.batch/cyclonus > "$LOG_FILE"
 cat "$LOG_FILE"
 
 # if 'failure' is in the logs, fail; otherwise succeed
-rc=0
-cat "$LOG_FILE" | grep "failure" > /dev/null 2>&1 || rc=$?
-if [ $rc -eq 0 ]; then
-    exit 1
-fi
+cat "$LOG_FILE" | grep "failure" > /dev/null 2>&1 && rc=1
+exit $rc


### PR DESCRIPTION
We're observing periodic flakyness [1] with the Cyclonus tests.
As a first step on improving this, bump the test suite to
the latest version.

[1] https://github.com/cilium/cilium/actions/workflows/conformance-k8s-network-policies.yaml?query=event%3Aschedule

TODO:
- [ ] drop runs on `pull_request` 
- [x] figure out whether we need `include` or `exclude` flags since `mode` is now gone