### PR TITLE
reduce GC load

### DIFF
--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -297,7 +297,7 @@ func (s *SharedStore) syncLocalKeys(ctx context.Context) error {
 	// Create a copy of all local keys so we can unlock and sync to kvstore
 	// without holding the lock
 	s.mutex.RLock()
-	keys := []LocalKey{}
+	keys := make([]LocalKey, 0, len(s.localKeys))
 	for _, key := range s.localKeys {
 		keys = append(keys, key)
 	}

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -326,7 +326,7 @@ func (o *IntOptions) GetFmtList() string {
 	txt := ""
 
 	o.optsMU.RLock()
-	opts := []string{}
+	opts := make([]string, 0, len(o.Opts))
 	for k := range o.Opts {
 		opts = append(opts, k)
 	}
@@ -349,7 +349,7 @@ func (o *IntOptions) Dump() {
 	}
 
 	o.optsMU.RLock()
-	opts := []string{}
+	opts := make([]string, 0, len(o.Opts))
 	for k := range o.Opts {
 		opts = append(opts, k)
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Looping over an array to append something can put high preasure on the garbage collector and cause memory relocations. If the destination is properly allocated in advance, it reduces the work that is needed to be done by GC.

This is not a enduser visible change so I did not add something for the release notes.