### PR TITLE
Revert "nodediscovery: Fix local host identity propagation"

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -176,7 +176,7 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.LocalNode.EncryptionKey = node.GetIPsecKeyIdentity()
 	n.LocalNode.WireguardPubKey = node.GetWireguardPubKey()
 	n.LocalNode.Labels = node.GetLabels()
-	n.LocalNode.NodeIdentity = uint32(identity.ReservedIdentityHost)
+	n.LocalNode.NodeIdentity = identity.GetLocalNodeID().Uint32()
 
 	if node.GetK8sExternalIPv4() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, nodeTypes.Address{


### PR DESCRIPTION
This reverts commit 7bf60a59f0720e5546c68dccf4e4fa133407355f.

Setting the local node's identity to `identity.ReservedIdentityHost`
will make this identity to be part of the node which will be propagated
to the KVStore. If `--enable-remote-node-identity` is set to `true`, all
other Cilium agents, that receive the node update event from the
KVStore, will use that `identity.ReservedIdentityHost` and all remote
nodes will not have `identity.ReservedIdentityRemoteNode` as they should
have.

The logic for the events received from KVStore is currently the
following, which can be found in pkg/node/manager/manager.go#L385-L392

```
	if m.conf.RemoteNodeIdentitiesEnabled() {
		nid := identity.NumericIdentity(n.NodeIdentity)
		if nid != identity.IdentityUnknown {
			remoteHostIdentity = nid
		} else if !n.IsLocal() {
			remoteHostIdentity = identity.ReservedIdentityRemoteNode
		}
	}
```

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix regression that causes traffic from remote nodes to be considered as "world" traffic in environments with KVStore enabled
```
