### PR TITLE
 docs: Update clustermesh example verification steps

### DIFF
--- a/Documentation/gettingstarted/clustermesh/services.rst
+++ b/Documentation/gettingstarted/clustermesh/services.rst
@@ -73,6 +73,6 @@ Deploying a Simple Example Service
 
    .. code-block:: shell-session
 
-      kubectl exec -ti xwing-xxx -- curl rebel-base
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
 
    You will see replies from pods in both clusters.


### PR DESCRIPTION
This commit is to update verification command to avoid the need
of passing pod name explicitly, so that it's easier for users to
just copy and paste.

Signed-off-by: Tam Mach <tam.mach@isovalent.com>

