### PR TITLE
clustermesh: Modify shared-service annotation after creation

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -286,11 +286,9 @@ type Service struct {
 
 	// IncludeExternal is true when external endpoints from other clusters
 	// should be included
-	// +deepequal-gen=false
 	IncludeExternal bool
 
 	// Shared is true when the service should be exposed/shared to other clusters
-	// +deepequal-gen=false
 	Shared bool
 
 	// TrafficPolicy controls how backends are selected. If set to "Local", only
@@ -348,6 +346,10 @@ func (s *Service) DeepEqual(other *Service) bool {
 	}
 
 	if !ip.UnsortedIPListsAreEqual(s.FrontendIPs, other.FrontendIPs) {
+		return false
+	}
+
+	if s.Shared != other.Shared || s.IncludeExternal != other.IncludeExternal {
 		return false
 	}
 

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -495,7 +495,7 @@ func (s *ServiceCache) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 		}
 	}
 
-	if svcFound && svc.IncludeExternal {
+	if svcFound && svc.IncludeExternal && svc.Shared {
 		externalEndpoints, hasExternalEndpoints := s.externalEndpoints[id]
 		if hasExternalEndpoints {
 			// remote cluster endpoints already contain all Endpoints from all

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -281,6 +281,8 @@ func TestService_Equals(t *testing.T) {
 						Port:     1,
 					},
 				},
+				Shared:          true,
+				IncludeExternal: true,
 				NodePorts: map[loadbalancer.FEPortName]NodePortToFrontend{
 					loadbalancer.FEPortName("foo"): {
 						"0.0.0.0:31000": {
@@ -313,6 +315,8 @@ func TestService_Equals(t *testing.T) {
 							Port:     1,
 						},
 					},
+					Shared:          true,
+					IncludeExternal: true,
 					NodePorts: map[loadbalancer.FEPortName]NodePortToFrontend{
 						loadbalancer.FEPortName("foo"): {
 							"0.0.0.0:31000": {
@@ -367,6 +371,74 @@ func TestService_Equals(t *testing.T) {
 					Labels: map[string]string{
 						"foo": "bar",
 					},
+					Selector: map[string]string{
+						"baz": "foz",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different shared",
+			fields: &Service{
+				FrontendIPs: []net.IP{net.ParseIP("1.1.1.1")},
+				IsHeadless:  true,
+				Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+					loadbalancer.FEPortName("foo"): {
+						Protocol: loadbalancer.NONE,
+						Port:     1,
+					},
+				},
+				Shared:   true,
+				Labels:   map[string]string{},
+				Selector: map[string]string{},
+			},
+			args: args{
+				o: &Service{
+					FrontendIPs: []net.IP{net.ParseIP("1.1.1.1")},
+					IsHeadless:  true,
+					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+						loadbalancer.FEPortName("foo"): {
+							Protocol: loadbalancer.NONE,
+							Port:     1,
+						},
+					},
+					Shared: false,
+					Labels: map[string]string{},
+					Selector: map[string]string{
+						"baz": "foz",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different include external",
+			fields: &Service{
+				FrontendIPs: []net.IP{net.ParseIP("1.1.1.1")},
+				IsHeadless:  true,
+				Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+					loadbalancer.FEPortName("foo"): {
+						Protocol: loadbalancer.NONE,
+						Port:     1,
+					},
+				},
+				IncludeExternal: true,
+				Labels:          map[string]string{},
+				Selector:        map[string]string{},
+			},
+			args: args{
+				o: &Service{
+					FrontendIPs: []net.IP{net.ParseIP("1.1.1.1")},
+					IsHeadless:  true,
+					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+						loadbalancer.FEPortName("foo"): {
+							Protocol: loadbalancer.NONE,
+							Port:     1,
+						},
+					},
+					IncludeExternal: false,
+					Labels:          map[string]string{},
 					Selector: map[string]string{
 						"baz": "foz",
 					},

--- a/pkg/k8s/zz_generated.deepequal.go
+++ b/pkg/k8s/zz_generated.deepequal.go
@@ -158,6 +158,12 @@ func (in *Service) deepEqual(other *Service) bool {
 	if in.IsHeadless != other.IsHeadless {
 		return false
 	}
+	if in.IncludeExternal != other.IncludeExternal {
+		return false
+	}
+	if in.Shared != other.Shared {
+		return false
+	}
 	if in.TrafficPolicy != other.TrafficPolicy {
 		return false
 	}


### PR DESCRIPTION
### Description

Changing global service annotation shared-service to false is not
getting reflected, traffic from local cluster is still routing to remote
endpoints.

This commit is to make sure that any change in service attribute (e.g.
shared, include external) should trigger update event in clustermesh api
server, and also to correlate remote endpoints if and only if the service
from underlying event is shared.

Signed-off-by: Tam Mach <tam.mach@isovalent.com>

### Testing

Testing was done locally with 2 kind clusters with sample services mentioned
in [docs](https://docs.cilium.io/en/latest/gettingstarted/clustermesh/services/#load-balancing-with-global-services)

<details>
<summary>After provision global service</summary>

```
$ kg services rebel-base 
NAME         TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
rebel-base   ClusterIP   10.96.164.22   <none>        80/TCP    14m

$ ksysex --context kind-kind-2 ds/cilium -- cilium bpf lb list
Defaulted container "cilium-agent" out of: cilium-agent, ebpf-mount (init), clean-cilium-state (init)
SERVICE ADDRESS    BACKEND ADDRESS
...                     
10.96.164.22:80    10.244.1.228:80 (14)                       (2 local endpoints, and 2 remote endpoints)
                   10.244.1.221:80 (14)                       
                   10.244.1.184:80 (14)                       
                   10.244.1.84:80 (14)                        
                   0.0.0.0:0 (14) [ClusterIP, non-routable]   
...

$ cat temp_check.sh      
#!/usr/bin/env bash

echo 'Checking in cluster 1'
for i in $(seq 1 10); do kubectl exec -ti --context kind-kind-1 deployment/x-wing -- curl rebel-base; done

echo 'Checking in cluster 2'
for i in $(seq 1 10); do kubectl exec -ti --context kind-kind-2 deployment/x-wing -- curl rebel-base; done

$ ./temp_check.sh
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
```

</details>

<details>
<summary>Annotate cluster 2 service with io.cilium/shared-service="false"</summary>

```
$ k annotate service rebel-base io.cilium/shared-service="false"
service/rebel-base annotated

$ ksysex --context kind-kind-2 ds/cilium -- cilium bpf lb list  
Defaulted container "cilium-agent" out of: cilium-agent, ebpf-mount (init), clean-cilium-state (init)
SERVICE ADDRESS    BACKEND ADDRESS
...
10.96.164.22:80    10.244.1.221:80 (14)                       (only local endpoints)
                   10.244.1.84:80 (14)                        
                   0.0.0.0:0 (14) [ClusterIP, non-routable]   
...

$ ./temp_check.sh
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}

```

</details>

<details>

<summary> Remove io.cilium/shared-service annotation to make service shared again </summary>

```
$ k annotate service rebel-base io.cilium/shared-service-     
service/rebel-base annotated

$ ksysex --context kind-kind-2 ds/cilium -- cilium bpf lb list  
Defaulted container "cilium-agent" out of: cilium-agent, ebpf-mount (init), clean-cilium-state (init)
SERVICE ADDRESS    BACKEND ADDRESS
10.96.164.22:80    10.244.1.184:80 (14)                       
                   10.244.1.228:80 (14)                       
                   10.244.1.221:80 (14)                       
                   10.244.1.84:80 (14)                        
                   0.0.0.0:0 (14) [ClusterIP, non-routable] 
                   
$ ./temp_check.sh
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
```

</details>