### PR TITLE
Revert "iptables: Don't use `ip{,6}tables` if unavailable"

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -494,21 +494,17 @@ func (m *IptablesManager) SupportsOriginalSourceAddr() bool {
 
 // removeRulesAndIpsets removes iptables rules and ipsets installed by Cilium.
 func (m *IptablesManager) removeRulesAndIpsets(prefix string, quiet bool) {
-	if option.Config.EnableIPv4 {
-		// Set of tables that have had iptables rules in any Cilium version
-		tables := []string{"nat", "mangle", "raw", "filter"}
-		for _, t := range tables {
-			m.removeCiliumRules(t, ip4tables, prefix+"CILIUM_")
-		}
+	// Set of tables that have had iptables rules in any Cilium version
+	tables := []string{"nat", "mangle", "raw", "filter"}
+	for _, t := range tables {
+		m.removeCiliumRules(t, ip4tables, prefix+"CILIUM_")
 	}
 
-	if option.Config.EnableIPv6 {
-		// Set of tables that have had ip6tables rules in any Cilium version
-		if m.haveIp6tables {
-			tables6 := []string{"nat", "mangle", "raw", "filter"}
-			for _, t := range tables6 {
-				m.removeCiliumRules(t, ip6tables, prefix+"CILIUM_")
-			}
+	// Set of tables that have had ip6tables rules in any Cilium version
+	if m.haveIp6tables {
+		tables6 := []string{"nat", "mangle", "raw", "filter"}
+		for _, t := range tables6 {
+			m.removeCiliumRules(t, ip6tables, prefix+"CILIUM_")
 		}
 	}
 


### PR DESCRIPTION
This pull request reverts https://github.com/cilium/cilium/pull/18716.

We don't want to condition the removal of IPv6 rules on IPv6 being enabled because it might cause us to leave stale IPv6 rules around after IPv6 is disabled. This should also not be necessary to fix the original bug report since we already check the iptables IPv6 modules are loaded before attempting to remove IPv6 iptables rules.