### PR TITLE
pkg/endpoint: fix data race in endpoint logger

### DIFF
--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -96,13 +96,12 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 		return
 	}
 
-	// default to using the log var set above
-	baseLogger := log.Logger
+	// default to a new default logger
+	baseLogger := logging.InitializeDefaultLogger()
 
 	// If this endpoint is set to debug ensure it will print debug by giving it
 	// an independent logger
 	if e.Options != nil && e.Options.IsEnabled(option.Debug) {
-		baseLogger = logging.InitializeDefaultLogger()
 		baseLogger.SetLevel(logrus.DebugLevel)
 	} else {
 		// Debug mode takes priority; if not in debug, check what log level user


### PR DESCRIPTION
The endpoint logger was concurrently setting the log level of the global
logger. By initializing a new logger we avoid that concurrency problem.

More info in https://github.com/cilium/cilium/issues/18728

Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/18728