### PR TITLE
accesslog: Pass destination identity from L7 proxies to access logs

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -467,7 +467,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		}
 	}
 	ep.UpdateProxyStatistics(strings.ToUpper(protocol), serverPort, false, !msg.Response, verdict)
-	record := logger.NewLogRecord(proxy.DefaultEndpointInfoRegistry, flowType, false,
+	record := logger.NewLogRecord(flowType, false,
 		func(lr *logger.LogRecord) { lr.LogRecord.TransportProtocol = accesslog.TransportProtocol(protoID) },
 		logger.LogTags.Verdict(verdict, reason),
 		logger.LogTags.Addressing(logger.AddressingInfo{

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -467,7 +467,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		}
 	}
 	ep.UpdateProxyStatistics(strings.ToUpper(protocol), serverPort, false, !msg.Response, verdict)
-	record := logger.NewLogRecord(proxy.DefaultEndpointInfoRegistry, ep, flowType, false,
+	record := logger.NewLogRecord(proxy.DefaultEndpointInfoRegistry, flowType, false,
 		func(lr *logger.LogRecord) { lr.LogRecord.TransportProtocol = accesslog.TransportProtocol(protoID) },
 		logger.LogTags.Verdict(verdict, reason),
 		logger.LogTags.Addressing(logger.AddressingInfo{

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2252,21 +2252,6 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 	return errs
 }
 
-// GetProxyInfoByFields returns the ID, IPv4 address, IPv6 address, labels,
-// SHA of labels, and identity of the endpoint. Returns an error if the endpoint
-// is in the process of being deleted / has been deleted.
-func (e *Endpoint) GetProxyInfoByFields() (uint64, string, string, []string, string, uint64, error) {
-	// We use unconditional locking here because we explicitly handle state
-	// in which the endpoint is being deleted.
-	e.unconditionalRLock()
-	defer e.runlock()
-	var err error
-	if e.IsDisconnecting() {
-		err = fmt.Errorf("endpoint is in the process of being deleted")
-	}
-	return e.GetID(), e.GetIPv4Address(), e.GetIPv6Address(), e.GetLabels(), e.GetLabelsSHA(), uint64(e.getIdentity()), err
-}
-
 // WaitForFirstRegeneration waits for specific conditions before returning:
 // * if the endpoint has a sidecar proxy, it waits for the endpoint's BPF
 // program to be generated for the first time.

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -54,7 +54,6 @@ type EndpointInfoSource interface {
 	HasSidecarProxy() bool
 	ConntrackName() string
 	ConntrackNameLocked() string
-	GetProxyInfoByFields() (uint64, string, string, []string, string, uint64, error)
 }
 
 // EndpointUpdater returns information about an endpoint being proxied and

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/flowdebug"
+	"github.com/cilium/cilium/pkg/identity"
 	kafka_api "github.com/cilium/cilium/pkg/policy/api/kafka"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -169,7 +170,8 @@ func logRecord(endpointInfoRegistry logger.EndpointInfoRegistry, localEndpoint l
 		logger.LogTags.Addressing(logger.AddressingInfo{
 			SrcIPPort:   pblog.SourceAddress,
 			DstIPPort:   pblog.DestinationAddress,
-			SrcIdentity: pblog.SourceSecurityId,
+			SrcIdentity: identity.NumericIdentity(pblog.SourceSecurityId),
+			DstIdentity: identity.NumericIdentity(pblog.DestinationSecurityId),
 		}), l7tags)
 
 	r.Log()

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -164,7 +164,7 @@ func logRecord(endpointInfoRegistry logger.EndpointInfoRegistry, localEndpoint l
 		})
 	}
 
-	r := logger.NewLogRecord(endpointInfoRegistry, localEndpoint, GetFlowType(pblog), pblog.IsIngress,
+	r := logger.NewLogRecord(endpointInfoRegistry, GetFlowType(pblog), pblog.IsIngress,
 		logger.LogTags.Timestamp(time.Unix(int64(pblog.Timestamp/1000000000), int64(pblog.Timestamp%1000000000))),
 		logger.LogTags.Verdict(GetVerdict(pblog), pblog.CiliumRuleRef),
 		logger.LogTags.Addressing(logger.AddressingInfo{

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -105,19 +105,24 @@ func (s *accessLogServer) accessLogger(conn *net.UnixConn) {
 		flowdebug.Log(log.WithFields(logrus.Fields{}),
 			fmt.Sprintf("%s: Access log message: %s", pblog.PolicyName, pblog.String()))
 
-		// Correlate the log entry's network policy name with a local endpoint info source.
-		localEndpoint := s.xdsServer.getLocalEndpoint(pblog.PolicyName)
-		if localEndpoint == nil {
-			log.Warnf("Envoy: Discarded access log message for non-existent network policy %s",
-				pblog.PolicyName)
-			continue
-		}
+		r := logRecord(&pblog)
 
-		logRecord(localEndpoint, &pblog)
+		// Update proxy stats for the endpoint if it still exists
+		localEndpoint := s.xdsServer.getLocalEndpoint(pblog.PolicyName)
+		if localEndpoint != nil {
+			// Update stats for the endpoint.
+			ingress := r.ObservationPoint == accesslog.Ingress
+			request := r.Type == accesslog.TypeRequest
+			port := r.DestinationEndpoint.Port
+			if !request {
+				port = r.SourceEndpoint.Port
+			}
+			localEndpoint.UpdateProxyStatistics("TCP", port, ingress, request, r.Verdict)
+		}
 	}
 }
 
-func logRecord(localEndpoint logger.EndpointUpdater, pblog *cilium.LogEntry) {
+func logRecord(pblog *cilium.LogEntry) *logger.LogRecord {
 	var kafkaRecord *accesslog.LogRecordKafka
 	var kafkaTopics []string
 
@@ -191,12 +196,5 @@ func logRecord(localEndpoint logger.EndpointUpdater, pblog *cilium.LogEntry) {
 		r.Log()
 	}
 
-	// Update stats for the endpoint.
-	ingress := r.ObservationPoint == accesslog.Ingress
-	request := r.Type == accesslog.TypeRequest
-	port := r.DestinationEndpoint.Port
-	if !request {
-		port = r.SourceEndpoint.Port
-	}
-	localEndpoint.UpdateProxyStatistics("TCP", port, ingress, request, r.Verdict)
+	return r
 }

--- a/pkg/envoy/accesslog_server_test.go
+++ b/pkg/envoy/accesslog_server_test.go
@@ -13,7 +13,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/proxy/logger"
-	logger_test "github.com/cilium/cilium/pkg/proxy/logger/test"
 )
 
 type AccessLogServerSuite struct{}
@@ -60,7 +59,7 @@ func (n *testNotifier) NewProxyLogRecord(l *logger.LogRecord) error {
 func (k *AccessLogServerSuite) TestKafkaLogNoTopic(c *C) {
 	notifier := &testNotifier{}
 	logger.SetNotifier(notifier)
-	logRecord(&logger_test.ProxyUpdaterMock{}, &cilium.LogEntry{
+	logRecord(&cilium.LogEntry{
 		L7: &cilium.LogEntry_Kafka{Kafka: &cilium.KafkaLogEntry{
 			CorrelationId: 76541,
 			ErrorCode:     42,
@@ -76,7 +75,7 @@ func (k *AccessLogServerSuite) TestKafkaLogNoTopic(c *C) {
 func (k *AccessLogServerSuite) TestKafkaLogSingleTopic(c *C) {
 	notifier := &testNotifier{}
 	logger.SetNotifier(notifier)
-	logRecord(&logger_test.ProxyUpdaterMock{}, &cilium.LogEntry{
+	logRecord(&cilium.LogEntry{
 		L7: &cilium.LogEntry_Kafka{Kafka: &cilium.KafkaLogEntry{
 			CorrelationId: 76541,
 			ErrorCode:     42,
@@ -95,7 +94,7 @@ func (k *AccessLogServerSuite) TestKafkaLogSingleTopic(c *C) {
 func (k *AccessLogServerSuite) TestKafkaLogMultipleTopics(c *C) {
 	notifier := &testNotifier{}
 	logger.SetNotifier(notifier)
-	logRecord(&logger_test.ProxyUpdaterMock{}, &cilium.LogEntry{
+	logRecord(&cilium.LogEntry{
 		L7: &cilium.LogEntry_Kafka{Kafka: &cilium.KafkaLogEntry{
 			CorrelationId: 76541,
 			ErrorCode:     42,

--- a/pkg/envoy/accesslog_server_test.go
+++ b/pkg/envoy/accesslog_server_test.go
@@ -60,7 +60,7 @@ func (n *testNotifier) NewProxyLogRecord(l *logger.LogRecord) error {
 func (k *AccessLogServerSuite) TestKafkaLogNoTopic(c *C) {
 	notifier := &testNotifier{}
 	logger.SetNotifier(notifier)
-	logRecord(&dummyEndpointInfoRegistry{}, &logger_test.ProxyUpdaterMock{}, &cilium.LogEntry{
+	logRecord(&logger_test.ProxyUpdaterMock{}, &cilium.LogEntry{
 		L7: &cilium.LogEntry_Kafka{Kafka: &cilium.KafkaLogEntry{
 			CorrelationId: 76541,
 			ErrorCode:     42,
@@ -76,7 +76,7 @@ func (k *AccessLogServerSuite) TestKafkaLogNoTopic(c *C) {
 func (k *AccessLogServerSuite) TestKafkaLogSingleTopic(c *C) {
 	notifier := &testNotifier{}
 	logger.SetNotifier(notifier)
-	logRecord(&dummyEndpointInfoRegistry{}, &logger_test.ProxyUpdaterMock{}, &cilium.LogEntry{
+	logRecord(&logger_test.ProxyUpdaterMock{}, &cilium.LogEntry{
 		L7: &cilium.LogEntry_Kafka{Kafka: &cilium.KafkaLogEntry{
 			CorrelationId: 76541,
 			ErrorCode:     42,
@@ -95,7 +95,7 @@ func (k *AccessLogServerSuite) TestKafkaLogSingleTopic(c *C) {
 func (k *AccessLogServerSuite) TestKafkaLogMultipleTopics(c *C) {
 	notifier := &testNotifier{}
 	logger.SetNotifier(notifier)
-	logRecord(&dummyEndpointInfoRegistry{}, &logger_test.ProxyUpdaterMock{}, &cilium.LogEntry{
+	logRecord(&logger_test.ProxyUpdaterMock{}, &cilium.LogEntry{
 		L7: &cilium.LogEntry_Kafka{Kafka: &cilium.KafkaLogEntry{
 			CorrelationId: 76541,
 			ErrorCode:     42,

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -8,7 +8,6 @@ package envoy
 
 import (
 	"context"
-	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,11 +19,9 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/flowdebug"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -42,11 +39,6 @@ func (s *EnvoySuite) waitForProxyCompletion() error {
 	err := s.waitGroup.Wait()
 	log.Debug("Wait time for proxy updates: ", time.Since(start))
 	return err
-}
-
-type dummyEndpointInfoRegistry struct{}
-
-func (r *dummyEndpointInfoRegistry) FillEndpointInfo(*accesslog.EndpointInfo, net.IP, identity.NumericIdentity) {
 }
 
 func (s *EnvoySuite) TestEnvoy(c *C) {
@@ -72,7 +64,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 
 	xdsServer := StartXDSServer(stateLogDir)
 	defer xdsServer.stop()
-	StartAccessLogServer(stateLogDir, xdsServer, &dummyEndpointInfoRegistry{})
+	StartAccessLogServer(stateLogDir, xdsServer)
 
 	// launch debug variant of the Envoy proxy
 	envoyProxy := StartEnvoy(stateLogDir, filepath.Join(stateLogDir, "cilium-envoy.log"), 0)
@@ -152,7 +144,7 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 
 	xdsServer := StartXDSServer(stateLogDir)
 	defer xdsServer.stop()
-	StartAccessLogServer(stateLogDir, xdsServer, &dummyEndpointInfoRegistry{})
+	StartAccessLogServer(stateLogDir, xdsServer)
 
 	// launch debug variant of the Envoy proxy
 	envoyProxy := StartEnvoy(stateLogDir, filepath.Join(stateLogDir, "cilium-envoy.log"), 42)

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -46,12 +46,7 @@ func (s *EnvoySuite) waitForProxyCompletion() error {
 
 type dummyEndpointInfoRegistry struct{}
 
-func (r *dummyEndpointInfoRegistry) FillEndpointIdentityByID(id identity.NumericIdentity, info *accesslog.EndpointInfo) bool {
-	return false
-}
-
-func (r *dummyEndpointInfoRegistry) FillEndpointIdentityByIP(ip net.IP, info *accesslog.EndpointInfo) bool {
-	return false
+func (r *dummyEndpointInfoRegistry) FillEndpointInfo(*accesslog.EndpointInfo, net.IP, identity.NumericIdentity) {
 }
 
 func (s *EnvoySuite) TestEnvoy(c *C) {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -336,7 +336,7 @@ type LookupIPsBySecIDFunc func(nid identity.NumericIdentity) []string
 
 // NotifyOnDNSMsgFunc handles propagating DNS response data
 // See DNSProxy.LookupEndpointIDByIP for usage.
-type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error
+type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error
 
 // ProxyRequestContext proxy dns request context struct to send in the callback
 type ProxyRequestContext struct {
@@ -538,7 +538,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.WithError(err).Error("cannot extract endpoint IP from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract endpoint IP from DNS request: %s", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, "", request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, "", request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -547,7 +547,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.WithError(err).Error("cannot extract endpoint ID from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %s", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, "", request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, "", request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -559,7 +559,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		log.WithError(err).Error("cannot extract destination IP:port from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract destination IP:port from DNS request: %s", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, 0, targetServerAddr, request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -583,7 +583,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.WithError(err).Error("Rejecting DNS query from endpoint due to error")
 		stat.Err = fmt.Errorf("Rejecting DNS query from endpoint due to error: %s", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 
@@ -591,12 +591,12 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Debug("Rejecting DNS query from endpoint due to policy")
 		stat.Err = p.sendRefused(scopedLog, w, request)
 		stat.ProcessingTime.End(true)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, request, protocol, false, &stat)
 		return
 	}
 
 	scopedLog.Debug("Forwarding DNS request for a name that is allowed")
-	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, true, &stat)
+	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, request, protocol, true, &stat)
 
 	// Keep the same L4 protocol. This handles DNS re-requests over TCP, for
 	// requests that were too large for UDP.
@@ -610,7 +610,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Error("Cannot parse DNS proxy client network to select forward client")
 		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %s", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -629,7 +629,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 			p.sendRefused(scopedLog, w, request)
 			stat.Err = fmt.Errorf("Cannot forward proxied DNS lookup: %s", err)
 		}
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, request, protocol, false, &stat)
 		return
 	}
 
@@ -637,7 +637,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	stat.Success = true
 
 	scopedLog.Debug("Notifying with DNS response to original DNS query")
-	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, response, protocol, true, &stat)
+	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, response, protocol, true, &stat)
 
 	scopedLog.Debug("Responding to original DNS query")
 	// restore the ID to the one in the initial request so it matches what the requester expects.
@@ -647,7 +647,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	if err != nil {
 		scopedLog.WithError(err).Error("Cannot forward proxied DNS response")
 		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %s", err)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, response, protocol, true, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, response, protocol, true, &stat)
 	} else {
 		p.Lock()
 		// Add the server to the set of used DNS servers. This set is never GCd, but is limited by set

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -225,7 +225,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 			}
 		},
 		// NotifyOnDNSMsg
-		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error {
+		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error {
 			return nil
 		})
 	c.Assert(err, IsNil, Commentf("error starting DNS Proxy"))

--- a/pkg/monitor/logrecord.go
+++ b/pkg/monitor/logrecord.go
@@ -61,8 +61,8 @@ func (l *LogRecordNotify) DumpInfo() {
 
 	case accesslog.TypeResponse:
 		fmt.Printf("%s %s %s to %d (%s) from %d (%s), identity %d->%d, verdict %s",
-			l.direction(), l.Type, l.l7Proto(), l.SourceEndpoint.ID, l.SourceEndpoint.Labels,
-			l.DestinationEndpoint.ID, l.DestinationEndpoint.Labels,
+			l.direction(), l.Type, l.l7Proto(), l.DestinationEndpoint.ID, l.DestinationEndpoint.Labels,
+			l.SourceEndpoint.ID, l.SourceEndpoint.Labels,
 			l.SourceEndpoint.Identity, l.DestinationEndpoint.Identity,
 			l.Verdict)
 	}

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -537,16 +537,6 @@ func GetK8sExternalIPv6() net.IP {
 	return ipv6ExternalAddress
 }
 
-// IsHostIPv4 returns true if the IP specified is a host IP
-func IsHostIPv4(ip net.IP) bool {
-	return ip.Equal(GetInternalIPv4Router()) || ip.Equal(GetIPv4())
-}
-
-// IsHostIPv6 returns true if the IP specified is a host IP
-func IsHostIPv6(ip net.IP) bool {
-	return ip.Equal(GetIPv6()) || ip.Equal(GetIPv6Router())
-}
-
 // GetNodeAddressing returns the NodeAddressing model for the local IPs.
 func GetNodeAddressing() *models.NodeAddressing {
 	a := &models.NodeAddressing{}

--- a/pkg/node/address_test.go
+++ b/pkg/node/address_test.go
@@ -33,17 +33,6 @@ func (s *NodeSuite) TearDownTest(c *C) {
 	Uninitialize()
 }
 
-func (s *NodeSuite) TestMaskCheck(c *C) {
-	InitDefaultPrefix("")
-
-	allocCIDR := cidr.MustParseCIDR("1.1.1.1/16")
-	SetIPv4AllocRange(allocCIDR)
-	SetInternalIPv4Router(allocCIDR.IP)
-	c.Assert(IsHostIPv4(GetInternalIPv4Router()), Equals, true)
-	c.Assert(IsHostIPv4(GetIPv4()), Equals, true)
-	c.Assert(IsHostIPv6(GetIPv6()), Equals, true)
-}
-
 // This also provides cover for RestoreHostIPs.
 func (s *NodeSuite) Test_chooseHostIPsToRestore(c *C) {
 	tests := []struct {

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -29,22 +29,6 @@ type EndpointInfoSource interface {
 	ConntrackName() string
 	ConntrackNameLocked() string
 	GetNamedPortLocked(ingress bool, name string, proto uint8) uint16
-	GetProxyInfoByFields() (uint64, string, string, []string, string, uint64, error)
-}
-
-// getEndpointInfo returns a consistent snapshot of the given source.
-// The source's read lock must not be held.
-func getEndpointInfo(source EndpointInfoSource) *accesslog.EndpointInfo {
-
-	id, ipv4, ipv6, labels, labelsSHA256, identity, _ := source.GetProxyInfoByFields()
-	return &accesslog.EndpointInfo{
-		ID:           id,
-		IPv4:         ipv4,
-		IPv6:         ipv6,
-		Labels:       labels,
-		LabelsSHA256: labelsSHA256,
-		Identity:     identity,
-	}
 }
 
 // EndpointUpdater returns information about an endpoint being proxied and

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -69,21 +69,13 @@ type EndpointUpdater interface {
 // EndpointInfoRegistry provides endpoint information lookup by endpoint IP
 // address.
 type EndpointInfoRegistry interface {
-	// FillEndpointIdentityByID resolves the labels of the specified identity
-	// if known locally and fills in the following info member fields:
-	//  - info.Identity
-	//  - info.Labels
-	//  - info.LabelsSHA256
-	// Returns true if found, false if not found.
-	FillEndpointIdentityByID(id identity.NumericIdentity, info *accesslog.EndpointInfo) bool
-
-	// FillEndpointIdentityByIP resolves the labels of the endpoint with the
-	// specified IP if known locally and fills in the following info member
-	// fields:
-	//  - info.ID
-	//  - info.Identity
-	//  - info.Labels
-	//  - info.LabelsSHA256
-	// Returns true if found, false if not found.
-	FillEndpointIdentityByIP(ip net.IP, info *accesslog.EndpointInfo) bool
+	// FillEndpointInfo resolves the labels of the specified identity if known locally.
+	// If 'id' is passed as zero, will locate the EP by 'ip', and also fill info.ID, if found.
+	// Fills in the following info member fields:
+	//  - info.IPv4           (if 'ip' is IPv4)
+	//  - info.IPv6           (if 'ip' is not IPv4)
+	//  - info.Identity       (defaults to WORLD if not known)
+	//  - info.Labels         (only if identity is found)
+	//  - info.LabelsSHA256   (only if identity is found)
+	FillEndpointInfo(info *accesslog.EndpointInfo, ip net.IP, id identity.NumericIdentity)
 }

--- a/pkg/proxy/logger/test/epinfo.go
+++ b/pkg/proxy/logger/test/epinfo.go
@@ -24,10 +24,6 @@ type ProxyUpdaterMock struct {
 	SidecarProxy bool
 }
 
-func (m *ProxyUpdaterMock) GetProxyInfoByFields() (uint64, string, string, []string, string, uint64, error) {
-	return m.GetID(), m.GetIPv4Address(), m.GetIPv6Address(), m.GetLabels(), m.GetLabelsSHA(), uint64(m.GetIdentityLocked()), nil
-}
-
 func (m *ProxyUpdaterMock) UnconditionalRLock() { m.RWMutex.RLock() }
 func (m *ProxyUpdaterMock) RUnlock()            { m.RWMutex.RUnlock() }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -104,6 +104,7 @@ func StartProxySupport(minPort uint16, maxPort uint16, stateDir string,
 	accessLogNotifier logger.LogRecordNotifier, accessLogMetadata []string,
 	datapathUpdater DatapathUpdater, mgr EndpointLookup) *Proxy {
 	endpointManager = mgr
+	logger.SetEndpointInfoRegistry(DefaultEndpointInfoRegistry)
 	xdsServer := envoy.StartXDSServer(stateDir)
 
 	if accessLogNotifier != nil {
@@ -114,7 +115,7 @@ func StartProxySupport(minPort uint16, maxPort uint16, stateDir string,
 		logger.SetMetadata(accessLogMetadata)
 	}
 
-	envoy.StartAccessLogServer(stateDir, xdsServer, DefaultEndpointInfoRegistry)
+	envoy.StartAccessLogServer(stateDir, xdsServer)
 
 	return &Proxy{
 		XDSServer:       xdsServer,


### PR DESCRIPTION
Always pass both the source and destination security identities that were used
in L7 proxy policy enforcement to access logs and make sure that also
destination security identity is access logged in L7 messages in all cases. This
fixes cases where destination security identity may have been access logged
as 'WORLD' even though the destination is a pod in the cluster.

This also makes sure that the correct security identities are access logged,
even in cases where endpoint's security identity may have changed between
the time of the proxy event and log handling in the Cilium agent.

4th commit fixes an old discrepancy by passing source and destination
addressing info in access logs correctly instead of relying Hubble to swap
them around for responses. This has the benefit that also cilium monitor
output has correct security identity for L7 responses.

Note that this changes cilium proxy output that used to incorrectly show
security identities as "A->B" for both requests and responses. Now these
are formatted as "A->B" and "B->A" for requests and responses,
respectively.

Final commit avoids losing Envoy access log messages in the case the
local endpoint can not be found (any more).

This is a prerequisite for #18894

Fixes: #9558
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
Cilium monitor now correctly reports security identities for L7 flows.
```
