### PR TITLE
iptables,option,node: Consistent condition for ipset usage

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1085,16 +1085,9 @@ func RemoveFromNodeIpset(nodeIP net.IP) {
 	}
 }
 
-// useNodeIpset returns true if the ipset for node IP addresses should be
-// used to skip masquerading.
-func useNodeIpset() bool {
-	return option.Config.Tunnel == option.TunnelDisabled &&
-		option.Config.IptablesMasqueradingEnabled()
-}
-
 func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName, localDeliveryInterface,
 	snatDstExclusionCIDR, allocRange, hostMasqueradeIP string) error {
-	if useNodeIpset() {
+	if option.Config.NodeIpsetNeeded() {
 		// Exclude traffic to nodes from masquerade.
 		if err := createIpset(prog.getIpset(), prog.getProg() == "ip6tables"); err != nil {
 			return err
@@ -1331,7 +1324,7 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 	// Note we don't need a backup system as for iptables rules because the
 	// contents of ipsets doesn't depend on configuration. Whether they are
 	// needed depends on the configuration, but the content doesn't.
-	if useNodeIpset() {
+	if option.Config.NodeIpsetNeeded() {
 		if option.Config.IptablesMasqueradingIPv4Enabled() {
 			if err = createIpset(ciliumNodeIpsetV4, false); err != nil {
 				return err

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -411,8 +411,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			tunnelIP = nodeIP
 		}
 
-		if option.Config.IptablesMasqueradingEnabled() &&
-			address.Type == addressing.NodeInternalIP {
+		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			iptables.AddToNodeIpset(address.IP)
 		}
 
@@ -595,8 +594,7 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 	}
 
 	for _, address := range entry.node.IPAddresses {
-		if option.Config.IptablesMasqueradingEnabled() &&
-			address.Type == addressing.NodeInternalIP {
+		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			iptables.RemoveFromNodeIpset(address.IP)
 		}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2232,6 +2232,12 @@ func (c *DaemonConfig) IptablesMasqueradingEnabled() bool {
 	return c.IptablesMasqueradingIPv4Enabled() || c.IptablesMasqueradingIPv6Enabled()
 }
 
+// NodeIpsetNeeded returns true if a node ipsets should be used to skip
+// masquerading for traffic to cluster nodes.
+func (c *DaemonConfig) NodeIpsetNeeded() bool {
+	return c.Tunnel == TunnelDisabled && c.IptablesMasqueradingEnabled()
+}
+
 // RemoteNodeIdentitiesEnabled returns true if the remote-node identity feature
 // is enabled
 func (c *DaemonConfig) RemoteNodeIdentitiesEnabled() bool {


### PR DESCRIPTION
This pull request fixes a bug where we would create ipsets and fill them with IP addresses even though they would never be used by our iptables rules.

To fix this, we introduce a new `NodeIpsetNeeded` helper function, such that there is a single place where we define whether node ipsets should be used. This helper function is then used both to create ipset iptables rules and add IP addresses to ipsets.

Fixes: https://github.com/cilium/cilium/pull/16603.
Related: https://github.com/cilium/cilium/issues/18787.

```release-note
Fix bug where unnecessary ipset was created and populated in tunneling mode with iptables masquerading.
```