### PR TITLE
ipsec: set interface ID different from 0

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -33,6 +33,9 @@ const (
 	IPSecDirOut     IPSecDir = "IPSEC_OUT"
 	IPSecDirBoth    IPSecDir = "IPSEC_BOTH"
 	IPSecDirOutNode IPSecDir = "IPSEC_OUT_NODE"
+	// XfrmInterfaceID must be different from 0 to avoid
+	// error while constructing xfrm state or policy.
+	XfrmInterfaceID int = 1
 )
 
 type ipSecKey struct {
@@ -60,12 +63,15 @@ func ipSecNewState() *netlink.XfrmState {
 		Mode:  netlink.XFRM_MODE_TUNNEL,
 		Proto: netlink.XFRM_PROTO_ESP,
 		ESN:   false,
+		Ifid:  XfrmInterfaceID,
 	}
 	return &state
 }
 
 func ipSecNewPolicy() *netlink.XfrmPolicy {
-	policy := netlink.XfrmPolicy{}
+	policy := netlink.XfrmPolicy{
+		Ifid: XfrmInterfaceID,
+	}
 	return &policy
 }
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -171,6 +171,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 			Mask:  linux_defaults.IPsecMarkMaskIn,
 			Value: linux_defaults.RouteMarkToProxy,
 		},
+		Ifid: XfrmInterfaceID,
 	})
 	c.Assert(err, IsNil)
 	c.Assert(toProxyPolicy, Not(IsNil))


### PR DESCRIPTION
in this patch:
https://patchwork.kernel.org/project/netdevbpf/patch/20220106093606.3046771-6-steffen.klassert@secunet.com/
we see that `if_id` must be different from 0 for policy and
state construction.

With a 0 value, it makes the creation of the dummy interface fail with
the following error:
```
level=fatal msg="IPSec with tunneling requires support for xfrm state output masks (Linux 4.19 or later)." error="invalid argument" subsys=daemon
```

Related-To: https://github.com/flatcar-linux/Flatcar/issues/626
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
