### PR TITLE
Refactor pkg/mac with type Uint64MAC as uint64 for MAC address

### DIFF
--- a/pkg/mac/mac_test.go
+++ b/pkg/mac/mac_test.go
@@ -28,7 +28,7 @@ func (s *MACSuite) TestUint64(c *C) {
 	m := MAC([]byte{0x11, 0x12, 0x23, 0x34, 0x45, 0x56})
 	v, err := m.Uint64()
 	c.Assert(err, IsNil)
-	c.Assert(v, Equals, uint64(0x564534231211))
+	c.Assert(v, Equals, Uint64MAC(0x564534231211))
 }
 
 func (s *MACSuite) TestUnmarshalJSON(c *C) {

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -37,20 +37,6 @@ var (
 	).WithCache().WithPressureMetric()
 )
 
-// MAC is the __u64 representation of a MAC address.
-type MAC uint64
-
-func (m MAC) String() string {
-	return fmt.Sprintf("%02X:%02X:%02X:%02X:%02X:%02X",
-		uint64((m & 0x0000000000FF)),
-		uint64((m&0x00000000FF00)>>8),
-		uint64((m&0x000000FF0000)>>16),
-		uint64((m&0x0000FF000000)>>24),
-		uint64((m&0x00FF00000000)>>32),
-		uint64((m&0xFF0000000000)>>40),
-	)
-}
-
 const (
 	// EndpointFlagHost indicates that this endpoint represents the host
 	EndpointFlagHost = 1
@@ -102,8 +88,8 @@ func GetBPFValue(e EndpointFrontend) (*EndpointInfo, error) {
 		// written into the packet without an additional byte order
 		// conversion.
 		LxcID:   uint16(e.GetID()),
-		MAC:     MAC(mac),
-		NodeMAC: MAC(nodeMAC),
+		MAC:     mac,
+		NodeMAC: nodeMAC,
 	}
 
 	return info, nil
@@ -130,9 +116,9 @@ type EndpointInfo struct {
 	Flags   uint32 `align:"flags"`
 	// go alignment
 	_       uint32
-	MAC     MAC        `align:"mac"`
-	NodeMAC MAC        `align:"node_mac"`
-	Pad     pad4uint32 `align:"pad"`
+	MAC     mac.Uint64MAC `align:"mac"`
+	NodeMAC mac.Uint64MAC `align:"node_mac"`
+	Pad     pad4uint32    `align:"pad"`
 }
 
 // GetValuePtr returns the unsafe pointer to the BPF value


### PR DESCRIPTION
lxcmap and future VTEP map implementaiton will shares common code
for MAC address, this is to prepare pkg/mac for that to reduce code
duplication

Signed-off-by: Joe Stringer <joe@cilium.io>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
pkg/mac refactor for common code use
```
