### PR TITLE
v1.11 backports 2022-02-14

### DIFF
--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -79,28 +79,28 @@ If you have not done so already, enable the Hubble UI by running the following c
                   server:
                     # set this to true if tls is enabled on Hubble relay server side
                     enabled: true
-            ui:
-              # enable Hubble UI
-              enabled: true
-              standalone:
-                # enable Hubble UI standalone deployment
+              ui:
+                # enable Hubble UI
                 enabled: true
-                # provide a volume containing Hubble relay client certificates to mount in Hubble UI pod
-                certsVolume:
-                  projected:
-                    defaultMode: 0400
-                    sources:
-                      - secret:
-                          name: my-hubble-ui-client-certs
-                          items:
-                            - key: tls.crt
-                              path: client.crt
-                            - key: tls.key
-                              path: client.key
-                            - key: ca.crt
-                              path: hubble-relay-ca.crt
+                standalone:
+                  # enable Hubble UI standalone deployment
+                  enabled: true
+                  # provide a volume containing Hubble relay client certificates to mount in Hubble UI pod
+                  tls:
+                    certsVolume:
+                      projected:
+                        defaultMode: 0400
+                        sources:
+                          - secret:
+                              name: my-hubble-ui-client-certs
+                              items:
+                                - key: tls.crt
+                                  path: client.crt
+                                - key: tls.key
+                                  path: client.key
+                                - key: ca.crt
+                                  path: hubble-relay-ca.crt
             EOF
-
 
         Please note that Hubble UI expects the certificate files to be available under the following paths:
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -665,14 +665,6 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		return nil, nil, fmt.Errorf("failed to finalise LB initialization: %w", err)
 	}
 
-	if k8s.IsEnabled() {
-		bootstrapStats.k8sInit.Start()
-		// Launch the K8s watchers in parallel as we continue to process other
-		// daemon options.
-		d.k8sCachesSynced = d.k8sWatcher.InitK8sSubsystem(d.ctx)
-		bootstrapStats.k8sInit.End(true)
-	}
-
 	// BPF masquerade depends on BPF NodePort and require host-reachable svc to
 	// be fully enabled in the tunneling mode, so the following checks should
 	// happen after invoking initKubeProxyReplacementOptions().
@@ -745,6 +737,17 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	if option.Config.EnableHostFirewall && len(option.Config.Devices) == 0 {
 		msg := "host firewall's external facing device could not be determined. Use --%s to specify."
 		return nil, nil, fmt.Errorf(msg, option.Devices)
+	}
+
+	// Some of the k8s watchers rely on option flags set above (specifically
+	// EnableBPFMasquerade), so we should only start them once the flag values
+	// are set.
+	if k8s.IsEnabled() {
+		bootstrapStats.k8sInit.Start()
+		// Launch the K8s watchers in parallel as we continue to process other
+		// daemon options.
+		d.k8sCachesSynced = d.k8sWatcher.InitK8sSubsystem(d.ctx)
+		bootstrapStats.k8sInit.End(true)
 	}
 
 	bootstrapStats.cleanup.Start()

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -548,8 +548,7 @@ func finishKubeProxyReplacementInit(isKubeProxyReplacementStrict bool) error {
 		case option.Config.EnableIPSec:
 			msg = fmt.Sprintf("BPF host routing is incompatible with %s.", option.EnableIPSecName)
 		// Non-BPF masquerade requires netfilter and hence CT.
-		case (option.Config.EnableIPv4Masquerade || option.Config.EnableIPv6Masquerade) &&
-			!option.Config.EnableBPFMasquerade:
+		case option.Config.IptablesMasqueradingEnabled():
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
 		// All cases below still need to be implemented ...
 		case option.Config.EnableEndpointRoutes:

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	oldCiliumPrefix       = "OLD_CILIUM_"
+	oldCiliumPrefix       = "OLD_"
 	ciliumInputChain      = "CILIUM_INPUT"
 	ciliumOutputChain     = "CILIUM_OUTPUT"
 	ciliumOutputRawChain  = "CILIUM_OUTPUT_raw"
@@ -497,19 +497,19 @@ func (m *IptablesManager) removeOldRules(quiet bool) {
 	// Set of tables that have had iptables rules in any Cilium version
 	tables := []string{"nat", "mangle", "raw", "filter"}
 	for _, t := range tables {
-		m.removeCiliumRules(t, ip4tables, oldCiliumPrefix)
+		m.removeCiliumRules(t, ip4tables, oldCiliumPrefix+"CILIUM_")
 	}
 
 	// Set of tables that have had ip6tables rules in any Cilium version
 	if m.haveIp6tables {
 		tables6 := []string{"nat", "mangle", "raw", "filter"}
 		for _, t := range tables6 {
-			m.removeCiliumRules(t, ip6tables, oldCiliumPrefix)
+			m.removeCiliumRules(t, ip6tables, oldCiliumPrefix+"CILIUM_")
 		}
 	}
 
 	for _, c := range ciliumChains {
-		c.name = "OLD_" + c.name
+		c.name = oldCiliumPrefix + c.name
 		c.remove(quiet)
 	}
 }
@@ -1283,7 +1283,7 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 
 	// Rename any old chains we may have
 	for _, c := range ciliumChains {
-		c.rename("OLD_"+c.name, quiet)
+		c.rename(oldCiliumPrefix+c.name, quiet)
 	}
 
 	// install rules if needed
@@ -1294,7 +1294,7 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 		if firstInitialization {
 			match = "cilium-dns-egress"
 		}
-		m.copyProxyRules("OLD_"+ciliumPreMangleChain, match)
+		m.copyProxyRules(oldCiliumPrefix+ciliumPreMangleChain, match)
 	}
 
 	// only remove old rules if new ones were successfully installed

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1074,9 +1074,16 @@ func RemoveFromNodeIpset(nodeIP net.IP) {
 	}
 }
 
+// useNodeIpset returns true if the ipset for node IP addresses should be
+// used to skip masquerading.
+func useNodeIpset() bool {
+	return option.Config.Tunnel == option.TunnelDisabled &&
+		option.Config.IptablesMasqueradingEnabled()
+}
+
 func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName, localDeliveryInterface,
 	snatDstExclusionCIDR, allocRange, hostMasqueradeIP string) error {
-	if option.Config.Tunnel == option.TunnelDisabled {
+	if useNodeIpset() {
 		// Exclude traffic to nodes from masquerade.
 		if err := createIpset(prog.getIpset(), prog.getProg() == "ip6tables"); err != nil {
 			return err

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1339,7 +1339,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 			return err
 		}
 
-		if option.Config.EnableIPv4Masquerade && !option.Config.EnableBPFMasquerade {
+		if option.Config.IptablesMasqueradingIPv4Enabled() {
 			if err := m.installMasqueradeRules(ip4tables, ifName, localDeliveryInterface,
 				datapath.RemoteSNATDstAddrExclusionCIDRv4().String(),
 				node.GetIPv4AllocRange().String(),
@@ -1355,7 +1355,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 			return err
 		}
 
-		if option.Config.EnableIPv6Masquerade && !option.Config.EnableBPFMasquerade {
+		if option.Config.IptablesMasqueradingIPv6Enabled() {
 			if err := m.installMasqueradeRules(ip6tables, ifName, localDeliveryInterface,
 				datapath.RemoteSNATDstAddrExclusionCIDRv6().String(),
 				node.GetIPv6AllocRange().String(),

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -475,7 +475,7 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv4(c *check.C) {
 	}
 
 	// Only removes Cilium chains with the OLD_ prefix
-	mockManager.removeCiliumRules("mangle", mockIp4tables, oldCiliumPrefix)
+	mockManager.removeCiliumRules("mangle", mockIp4tables, oldCiliumPrefix+"CILIUM_")
 	err := mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }
@@ -522,7 +522,7 @@ func (s *iptablesTestSuite) TestRemoveCiliumRulesv6(c *check.C) {
 	}
 
 	// Only removes Cilium chains with the OLD_ prefix
-	mockManager.removeCiliumRules("mangle", mockIp6tables, oldCiliumPrefix)
+	mockManager.removeCiliumRules("mangle", mockIp6tables, oldCiliumPrefix+"CILIUM_")
 	err := mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -256,7 +256,8 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 
 	for i, interfaceName := range interfaceNames {
 		symbol := symbols[i]
-		if err := replaceDatapath(ctx, interfaceName, objPaths[i], symbol, directions[i], false, ""); err != nil {
+		finalize, err := replaceDatapath(ctx, interfaceName, objPaths[i], symbol, directions[i], false, "")
+		if err != nil {
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
 				logfields.Veth: interfaceName,
@@ -269,6 +270,8 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 			}
 			return err
 		}
+		// Defer map removal until all interfaces' progs have been replaced.
+		defer finalize()
 	}
 
 	return nil
@@ -303,7 +306,8 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 			return err
 		}
 	} else {
-		if err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, ""); err != nil {
+		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+		if err != nil {
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
 				logfields.Veth: ep.InterfaceName(),
@@ -316,9 +320,11 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 			}
 			return err
 		}
+		defer finalize()
 
 		if ep.RequireEgressProg() {
-			if err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolToEndpoint, dirEgress, false, ""); err != nil {
+			finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolToEndpoint, dirEgress, false, "")
+			if err != nil {
 				scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 					logfields.Path: objPath,
 					logfields.Veth: ep.InterfaceName(),
@@ -331,6 +337,7 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 				}
 				return err
 			}
+			defer finalize()
 		} else {
 			err := RemoveTCFilters(ep.InterfaceName(), netlink.HANDLE_MIN_EGRESS)
 			if err != nil {
@@ -363,9 +370,12 @@ func (l *Loader) replaceNetworkDatapath(ctx context.Context, interfaces []string
 		log.WithError(err).Fatal("failed to compile encryption programs")
 	}
 	for _, iface := range option.Config.EncryptInterface {
-		if err := replaceDatapath(ctx, iface, networkObj, symbolFromNetwork, dirIngress, false, ""); err != nil {
+		finalize, err := replaceDatapath(ctx, iface, networkObj, symbolFromNetwork, dirIngress, false, "")
+		if err != nil {
 			log.WithField(logfields.Interface, iface).Fatal("Load encryption network failed")
 		}
+		// Defer map removal until all interfaces' progs have been replaced.
+		defer finalize()
 	}
 	return nil
 }

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -191,11 +191,13 @@ func (s *LoaderTestSuite) TestReload(c *C) {
 	c.Assert(err, IsNil)
 
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
-	err = replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
 	c.Assert(err, IsNil)
+	finalize()
 
-	err = replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+	finalize, err = replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
 	c.Assert(err, IsNil)
+	finalize()
 }
 
 func (s *LoaderTestSuite) testCompileFailure(c *C, ep *testutils.TestEndpoint) {
@@ -277,9 +279,11 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, ""); err != nil {
+		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+		if err != nil {
 			b.Fatal(err)
 		}
+		finalize()
 	}
 }
 

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -70,7 +70,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirectio
 
 	// Temporarily rename bpffs pins of maps whose definitions have changed in
 	// a new version of a datapath ELF.
-	if err := bpf.StartBPFFSMigration(bpf.GetMapRoot(), objPath); err != nil {
+	if err := bpf.StartBPFFSMigration(bpf.MapPrefixPath(), objPath); err != nil {
 		return fmt.Errorf("Failed to start bpffs map migration: %w", err)
 	}
 
@@ -79,7 +79,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirectio
 	// back to their initial paths.
 	var revert bool
 	defer func() {
-		if err := bpf.FinalizeBPFFSMigration(bpf.GetMapRoot(), objPath, revert); err != nil {
+		if err := bpf.FinalizeBPFFSMigration(bpf.MapPrefixPath(), objPath, revert); err != nil {
 			log.WithError(err).WithField("device", ifName).WithField("objPath", objPath).
 				Error("Could not finalize bpffs map migration")
 		}
@@ -110,13 +110,13 @@ func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirectio
 
 // graftDatapath replaces obj in tail call map
 func graftDatapath(ctx context.Context, mapPath, objPath, progSec string) error {
-	if err := bpf.StartBPFFSMigration(bpf.GetMapRoot(), objPath); err != nil {
+	if err := bpf.StartBPFFSMigration(bpf.MapPrefixPath(), objPath); err != nil {
 		return fmt.Errorf("Failed to start bpffs map migration: %w", err)
 	}
 
 	var revert bool
 	defer func() {
-		if err := bpf.FinalizeBPFFSMigration(bpf.GetMapRoot(), objPath, revert); err != nil {
+		if err := bpf.FinalizeBPFFSMigration(bpf.MapPrefixPath(), objPath, revert); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{logfields.BPFMapPath: mapPath, "objPath": objPath}).
 				Error("Could not finalize bpffs map migration")
 		}

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -118,5 +118,11 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev, xdpMode string, extraCAr
 	}
 
 	objPath := path.Join(dirs.Output, prog.Output)
-	return replaceDatapath(ctx, xdpDev, objPath, symbolFromHostNetdevEp, "", true, xdpMode)
+	finalize, err := replaceDatapath(ctx, xdpDev, objPath, symbolFromHostNetdevEp, "", true, xdpMode)
+	if err != nil {
+		return err
+	}
+	finalize()
+
+	return err
 }

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -384,7 +384,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 	remoteHostIdentity := identity.ReservedIdentityHost
 	if m.conf.RemoteNodeIdentitiesEnabled() {
 		nid := identity.NumericIdentity(n.NodeIdentity)
-		if nid != identity.IdentityUnknown {
+		if nid != identity.IdentityUnknown && nid != identity.ReservedIdentityHost {
 			remoteHostIdentity = nid
 		} else if !n.IsLocal() {
 			remoteHostIdentity = identity.ReservedIdentityRemoteNode

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -411,7 +411,8 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			tunnelIP = nodeIP
 		}
 
-		if address.Type == addressing.NodeInternalIP {
+		if option.Config.IptablesMasqueradingEnabled() &&
+			address.Type != addressing.NodeInternalIP {
 			iptables.AddToNodeIpset(address.IP)
 		}
 
@@ -594,7 +595,8 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 	}
 
 	for _, address := range entry.node.IPAddresses {
-		if address.Type == addressing.NodeInternalIP {
+		if option.Config.IptablesMasqueradingEnabled() &&
+			address.Type != addressing.NodeInternalIP {
 			iptables.RemoveFromNodeIpset(address.IP)
 		}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2165,6 +2165,24 @@ func (c *DaemonConfig) MasqueradingEnabled() bool {
 	return c.EnableIPv4Masquerade || c.EnableIPv6Masquerade
 }
 
+// IptablesMasqueradingIPv4Enabled returns true if iptables-based
+// masquerading is enabled for IPv4.
+func (c *DaemonConfig) IptablesMasqueradingIPv4Enabled() bool {
+	return !c.EnableBPFMasquerade && c.EnableIPv4Masquerade
+}
+
+// IptablesMasqueradingIPv6Enabled returns true if iptables-based
+// masquerading is enabled for IPv6.
+func (c *DaemonConfig) IptablesMasqueradingIPv6Enabled() bool {
+	return !c.EnableBPFMasquerade && c.EnableIPv6Masquerade
+}
+
+// IptablesMasqueradingEnabled returns true if iptables-based
+// masquerading is enabled.
+func (c *DaemonConfig) IptablesMasqueradingEnabled() bool {
+	return c.IptablesMasqueradingIPv4Enabled() || c.IptablesMasqueradingIPv6Enabled()
+}
+
 // RemoteNodeIdentitiesEnabled returns true if the remote-node identity feature
 // is enabled
 func (c *DaemonConfig) RemoteNodeIdentitiesEnabled() bool {


### PR DESCRIPTION
 * #17871 -- Skip node ipset updates if iptables masquerading is disabled (@pchaigno)
   * had to solve some minor conflicts (around the definition of `IptablesMasqueradingIPv4Enabled()` and in `pkg/node/manager/manager.go`), please double check
 * #18770 -- daemon: Init k8s watchers after setting agent flags (@pchaigno)
 * #17744 -- datapath: preserve tail call maps in between replacing interface program pairs (@ti-mo)
   * had to solve some minor conflicts (`log.WithField(logfields.Interface, iface).WithError(err).Fatal("Load encryption network failed")` -> `log.WithField(logfields.Interface, iface).Fatal("Load encryption network failed")`), please double check
 * #18777 -- Fix bug where Cilium drops traffic from remote nodes in etcd mode, despite policy that allows the traffic (@joestringer)
 * #18661 -- docs: Fix incorrect values for hubble-ui standalone install (@ysksuzuki)

PRs skipped due conflicts:

 * #18696 -- test: Restructure k8sT/Services.go (@brb)

edit:
I dropped also https://github.com/cilium/cilium/pull/18151 as that PR is being reverted

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17871 18770 17744 18777 18661; do contrib/backporting/set-labels.py $pr done 1.11; done
```
or with
```
$ make add-label branch=v1.11 issues=17871,18770,17744,18777,18661
```
