### PR TITLE
v1.10 backports 2022-02-14

### DIFF
--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -303,6 +303,17 @@ restart:
 					}
 				}
 
+				peerIdentity := ipIDPair.ID
+				if option.Config.EnableRemoteNodeIdentity && peerIdentity == identity.ReservedIdentityHost {
+					// The only way we can discover IPs associated with the local host
+					// is directly via the NodeDiscovery package. If someone is informing
+					// this agent about IPs corresponding to the "host" via the kvstore,
+					// then they're sharing their own perspective on their own node IPs'
+					// identity. However, this node has remote-node enabled, so we should
+					// treat the peer as a "remote-node", not a "host".
+					peerIdentity = identity.ReservedIdentityRemoteNode
+				}
+
 				// There is no need to delete the "old" IP addresses from this
 				// ip ID pair. The only places where the ip ID pair are created
 				// is the clustermesh, where it sends a delete to the KVStore,
@@ -310,7 +321,7 @@ restart:
 				// lease and a controller which is stopped/removed when the
 				// endpoint is gone.
 				IPIdentityCache.Upsert(ip, ipIDPair.HostIP, ipIDPair.Key, k8sMeta, Identity{
-					ID:     ipIDPair.ID,
+					ID:     peerIdentity,
 					Source: source.KVStore,
 				})
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -357,7 +357,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 	remoteHostIdentity := identity.ReservedIdentityHost
 	if m.conf.RemoteNodeIdentitiesEnabled() {
 		nid := identity.NumericIdentity(n.NodeIdentity)
-		if nid != identity.IdentityUnknown {
+		if nid != identity.IdentityUnknown && nid != identity.ReservedIdentityHost {
 			remoteHostIdentity = nid
 		} else if n.Source != source.Local {
 			remoteHostIdentity = identity.ReservedIdentityRemoteNode


### PR DESCRIPTION
 * #18777 -- Fix bug where Cilium drops traffic from remote nodes in etcd mode, despite policy that allows the traffic (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18777; do contrib/backporting/set-labels.py $pr done 1.10; done
```
or with
```
$ make add-label branch=v1.10 issues=18777
```