### PR TITLE
clustermesh: added new command-line options k8s-kubeconfig-path and clustermesh-health-port

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -205,6 +205,12 @@ func runApiserver() error {
 	flags.StringVar(&cfg.clusterName, option.ClusterName, "default", "Cluster name")
 	option.BindEnv(option.ClusterName)
 
+	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
+	option.BindEnv(option.K8sKubeConfigPath)
+
+	flags.Int(option.ClusterMeshHealthPort, defaults.ClusterMeshHealthPort, "TCP port for ClusterMesh apiserver health API")
+	option.BindEnv(option.ClusterMeshHealthPort)
+
 	flags.StringVar(&mockFile, "mock-file", "", "Read from mock file")
 
 	flags.Duration(option.KVstoreConnectivityTimeout, defaults.KVstoreConnectivityTimeout, "Time after which an incomplete kvstore operation  is considered failed")
@@ -260,7 +266,7 @@ func startApi() {
 		}
 	})
 
-	srv := &http.Server{}
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", option.Config.ClusterMeshHealthPort)}
 
 	go func() {
 		if err := srv.ListenAndServe(); err != nil {
@@ -564,7 +570,7 @@ func runServer(cmd *cobra.Command) {
 	}).Info("Starting clustermesh-apiserver...")
 
 	if mockFile == "" {
-		k8s.Configure("", "", 0.0, 0)
+		k8s.Configure("", option.Config.K8sKubeConfigPath, 0.0, 0)
 		if err := k8s.Init(k8sconfig.NewDefaultConfiguration()); err != nil {
 			log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 		}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -14,6 +14,9 @@ const (
 	// ClusterHealthPort is the default value for option.ClusterHealthPort
 	ClusterHealthPort = 4240
 
+	// ClusterMeshHealthPort is the default value for option.ClusterMeshHealthPort
+	ClusterMeshHealthPort = 80
+
 	// GopsPortAgent is the default value for option.GopsPort in the agent
 	GopsPortAgent = 9890
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -50,6 +50,9 @@ const (
 	// ClusterHealthPort is the TCP port for cluster-wide network connectivity health API
 	ClusterHealthPort = "cluster-health-port"
 
+	// ClusterMeshHealthPort is the TCP port for ClusterMesh apiserver health API
+	ClusterMeshHealthPort = "clustermesh-health-port"
+
 	// AgentLabels are additional labels to identify this agent
 	AgentLabels = "agent-labels"
 
@@ -1279,6 +1282,9 @@ type DaemonConfig struct {
 
 	// ClusterHealthPort is the TCP port for cluster-wide network connectivity health API
 	ClusterHealthPort int
+
+	// ClusterMeshHealthPort is the TCP port for ClusterMesh apiserver health API
+	ClusterMeshHealthPort int
 
 	// AgentLabels contains additional labels to identify this agent in monitor events.
 	AgentLabels []string
@@ -2555,6 +2561,7 @@ func (c *DaemonConfig) Populate() {
 
 	c.AgentHealthPort = viper.GetInt(AgentHealthPort)
 	c.ClusterHealthPort = viper.GetInt(ClusterHealthPort)
+	c.ClusterMeshHealthPort = viper.GetInt(ClusterMeshHealthPort)
 	c.AgentLabels = viper.GetStringSlice(AgentLabels)
 	c.AllowICMPFragNeeded = viper.GetBool(AllowICMPFragNeeded)
 	c.AllowLocalhost = viper.GetString(AllowLocalhost)


### PR DESCRIPTION
The PR adds some new command-line options of clustermesh-apiserver

### Added new command-line options
In our usecase we have separate k8s where Cilium components are running (including clustermesh-apiserver) and k3s where CEWs are deployed into. So configurable k8s linkage is needed. 

--k8s-kubeconfig-path
For possibility to connect clustermesh-apiserver to user-defined kubernetes api.
 
--clustermesh-health-port
For enforcing user-defined TCP port of clustermesh-apiserver health API instead of default :80 

Signed-off-by: Adam Bocim <adam.bocim@seznam.cz>