### PR TITLE
Revert "allocator: fix out-of-valid-range identities being allocated"

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -7,14 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/backoff"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -521,10 +519,6 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 	id, strID, unmaskedID := a.selectAvailableID()
 	if id == 0 {
 		return 0, false, false, fmt.Errorf("no more available IDs in configured space")
-	}
-
-	if id > math.MaxUint32 || !identity.IsInClusterIdentityRange(identity.NumericIdentity(id)) {
-		return 0, false, false, fmt.Errorf("allocated ID %v is out of cluster identity range", id)
 	}
 
 	kvstore.Trace("Selected available key ID", nil, logrus.Fields{fieldID: id})

--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -5,11 +5,9 @@ package allocator
 
 import (
 	"context"
-	"math"
 	"sync"
 	"time"
 
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
@@ -160,11 +158,7 @@ func (c *cache) OnDelete(id idpool.ID, key AllocatorKey) {
 	}
 
 	delete(c.nextCache, id)
-
-	// Only insert IDs that are in the valid identity range of this cluster
-	if id > math.MaxUint32 || identity.IsInClusterIdentityRange(identity.NumericIdentity(id)) {
-		a.idPool.Insert(id)
-	}
+	a.idPool.Insert(id)
 
 	c.sendEvent(kvstore.EventTypeDelete, id, key)
 }

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -371,16 +371,6 @@ func IsUserReservedIdentity(id NumericIdentity) bool {
 		id.Uint32() < MinimalNumericIdentity.Uint32()
 }
 
-// IsInClusterIdentityRange returns true if the given identity is in the
-// valid identity range of this cluster.
-func IsInClusterIdentityRange(id NumericIdentity) bool {
-	if id < MinimalAllocationIdentity || id > MaximumAllocationIdentity {
-		return false
-	}
-
-	return true
-}
-
 // AddUserDefinedNumericIdentity adds the given numeric identity and respective
 // label to the list of reservedIdentities. If the numeric identity is not
 // between UserReservedNumericIdentity and MinimalNumericIdentity it will return

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -17,7 +17,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/allocator"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/rand"
@@ -94,17 +93,16 @@ func randomTestName() string {
 
 func (s *AllocatorSuite) BenchmarkAllocate(c *C) {
 	allocatorName := randomTestName()
-	minID := idpool.ID(identity.MinimalAllocationIdentity)
-	maxID := minID + 256
+	maxID := idpool.ID(256 + c.N)
 	backend, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
 	c.Assert(err, IsNil)
-	a, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMin(minID), allocator.WithMax(maxID))
+	a, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(maxID))
 	c.Assert(err, IsNil)
 	c.Assert(a, Not(IsNil))
 	defer a.DeleteAllKeys()
 
 	c.ResetTimer()
-	for i := minID; i < maxID; i++ {
+	for i := 0; i < c.N; i++ {
 		_, _, _, err := a.Allocate(context.Background(), TestAllocatorKey(fmt.Sprintf("key%04d", i)))
 		c.Assert(err, IsNil)
 	}
@@ -114,14 +112,12 @@ func (s *AllocatorSuite) BenchmarkAllocate(c *C) {
 
 func (s *AllocatorSuite) TestRunLocksGC(c *C) {
 	allocatorName := randomTestName()
-	minID := idpool.ID(identity.MinimalAllocationIdentity)
-	maxID := minID + 256
+	maxID := idpool.ID(256 + c.N)
 	// FIXME: Did this previousy use allocatorName := randomTestName() ? so TestAllocatorKey(randomeTestName())
 	backend1, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
 	c.Assert(err, IsNil)
 	c.Assert(err, IsNil)
-	allocator, err := allocator.NewAllocator(TestAllocatorKey(""), backend1,
-		allocator.WithMin(minID), allocator.WithMax(maxID), allocator.WithoutGC())
+	allocator, err := allocator.NewAllocator(TestAllocatorKey(""), backend1, allocator.WithMax(maxID), allocator.WithoutGC())
 	c.Assert(err, IsNil)
 	shortKey := TestAllocatorKey("1;")
 
@@ -255,13 +251,11 @@ func (s *AllocatorSuite) TestRunLocksGC(c *C) {
 
 func (s *AllocatorSuite) TestGC(c *C) {
 	allocatorName := randomTestName()
-	minID := idpool.ID(identity.MinimalAllocationIdentity)
-	maxID := minID + 256
+	maxID := idpool.ID(256 + c.N)
 	// FIXME: Did this previousy use allocatorName := randomTestName() ? so TestAllocatorKey(randomeTestName())
 	backend, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
 	c.Assert(err, IsNil)
-	allocator, err := allocator.NewAllocator(TestAllocatorKey(""), backend,
-		allocator.WithMin(minID), allocator.WithMax(maxID), allocator.WithoutGC())
+	allocator, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(maxID), allocator.WithoutGC())
 	c.Assert(err, IsNil)
 	c.Assert(allocator, Not(IsNil))
 	defer allocator.DeleteAllKeys()
@@ -312,10 +306,8 @@ func (s *AllocatorSuite) TestGC_ShouldSkipOutOfRangeIdentites(c *C) {
 	backend, err := NewKVStoreBackend(randomTestName(), "a", TestAllocatorKey(""), kvstore.Client())
 	c.Assert(err, IsNil)
 
-	minID1 := idpool.ID(identity.MinimalAllocationIdentity)
-	maxID1 := minID1 + 4
-	allocator1, err := allocator.NewAllocator(TestAllocatorKey(""), backend,
-		allocator.WithMin(minID1), allocator.WithMax(maxID1), allocator.WithoutGC())
+	maxID1 := idpool.ID(4 + c.N)
+	allocator1, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(maxID1), allocator.WithoutGC())
 	c.Assert(err, IsNil)
 	c.Assert(allocator1, Not(IsNil))
 
@@ -384,11 +376,11 @@ func (s *AllocatorSuite) TestGC_ShouldSkipOutOfRangeIdentites(c *C) {
 	c.Assert(key2, Not(IsNil))
 }
 
-func testAllocator(c *C, minID, maxID idpool.ID, allocatorName string, suffix string) {
+func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 	backend, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
 	c.Assert(err, IsNil)
 	a, err := allocator.NewAllocator(TestAllocatorKey(""), backend,
-		allocator.WithMin(minID), allocator.WithMax(maxID), allocator.WithoutGC())
+		allocator.WithMax(maxID), allocator.WithoutGC())
 	c.Assert(err, IsNil)
 	c.Assert(a, Not(IsNil))
 
@@ -396,7 +388,7 @@ func testAllocator(c *C, minID, maxID idpool.ID, allocatorName string, suffix st
 	a.DeleteAllKeys()
 
 	// allocate all available IDs
-	for i := minID; i <= maxID; i++ {
+	for i := idpool.ID(1); i <= maxID; i++ {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
 		id, new, newLocally, err := a.Allocate(context.Background(), key)
 		c.Assert(err, IsNil)
@@ -406,7 +398,7 @@ func testAllocator(c *C, minID, maxID idpool.ID, allocatorName string, suffix st
 	}
 
 	// allocate all IDs again using the same set of keys, refcnt should go to 2
-	for i := minID; i <= maxID; i++ {
+	for i := idpool.ID(1); i <= maxID; i++ {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
 		id, new, newLocally, err := a.Allocate(context.Background(), key)
 		c.Assert(err, IsNil)
@@ -419,12 +411,12 @@ func testAllocator(c *C, minID, maxID idpool.ID, allocatorName string, suffix st
 	backend2, err := NewKVStoreBackend(allocatorName, "r", TestAllocatorKey(""), kvstore.Client())
 	c.Assert(err, IsNil)
 	a2, err := allocator.NewAllocator(TestAllocatorKey(""), backend2,
-		allocator.WithMin(minID), allocator.WithMax(maxID), allocator.WithoutGC())
+		allocator.WithMax(maxID), allocator.WithoutGC())
 	c.Assert(err, IsNil)
 	c.Assert(a2, Not(IsNil))
 
 	// allocate all IDs again using the same set of keys, refcnt should go to 2
-	for i := minID; i <= maxID; i++ {
+	for i := idpool.ID(1); i <= maxID; i++ {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
 		id, new, newLocally, err := a2.Allocate(context.Background(), key)
 		c.Assert(err, IsNil)
@@ -436,7 +428,7 @@ func testAllocator(c *C, minID, maxID idpool.ID, allocatorName string, suffix st
 	}
 
 	// release 2nd reference of all IDs
-	for i := minID; i <= maxID; i++ {
+	for i := idpool.ID(1); i <= maxID; i++ {
 		a.Release(context.Background(), TestAllocatorKey(fmt.Sprintf("key%04d", i)))
 	}
 
@@ -448,10 +440,10 @@ func testAllocator(c *C, minID, maxID idpool.ID, allocatorName string, suffix st
 
 	v, err := kvstore.Client().ListPrefix(context.TODO(), path.Join(allocatorName, "id"))
 	c.Assert(err, IsNil)
-	c.Assert(len(v), Equals, int(maxID-minID)+1)
+	c.Assert(len(v), Equals, int(maxID))
 
 	// release final reference of all IDs
-	for i := minID; i <= maxID; i++ {
+	for i := idpool.ID(1); i <= maxID; i++ {
 		a.Release(context.Background(), TestAllocatorKey(fmt.Sprintf("key%04d", i)))
 	}
 
@@ -471,9 +463,7 @@ func testAllocator(c *C, minID, maxID idpool.ID, allocatorName string, suffix st
 }
 
 func (s *AllocatorSuite) TestAllocateCached(c *C) {
-	minID := idpool.ID(identity.MinimalAllocationIdentity)
-	maxID := minID + 31
-	testAllocator(c, minID, maxID, randomTestName(), "a") // enable use of local cache
+	testAllocator(c, idpool.ID(32), randomTestName(), "a") // enable use of local cache
 }
 
 func (s *AllocatorSuite) TestKeyToID(c *C) {
@@ -501,12 +491,11 @@ func (s *AllocatorSuite) TestKeyToID(c *C) {
 	c.Assert(id, Equals, idpool.ID(10))
 }
 
-func testGetNoCache(c *C, minID, maxID idpool.ID, suffix string) {
+func testGetNoCache(c *C, maxID idpool.ID, suffix string) {
 	allocatorName := randomTestName()
 	backend, err := NewKVStoreBackend(allocatorName, "a", TestAllocatorKey(""), kvstore.Client())
 	c.Assert(err, IsNil)
-	allocator, err := allocator.NewAllocator(TestAllocatorKey(""), backend,
-		allocator.WithMin(minID), allocator.WithMax(maxID), allocator.WithoutGC())
+	allocator, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(maxID), allocator.WithoutGC())
 	c.Assert(err, IsNil)
 	c.Assert(allocator, Not(IsNil))
 
@@ -581,20 +570,14 @@ func (s *AllocatorSuite) TestprefixMatchesKey(c *C) {
 }
 
 func (s *AllocatorSuite) TestGetNoCache(c *C) {
-	minID := idpool.ID(identity.MinimalAllocationIdentity)
-	maxID := minID + 256
-	testGetNoCache(c, minID, maxID, "a") // enable use of local cache
+	testGetNoCache(c, idpool.ID(256), "a") // enable use of local cache
 }
 
 func (s *AllocatorSuite) TestRemoteCache(c *C) {
 	testName := randomTestName()
 	backend, err := NewKVStoreBackend(testName, "a", TestAllocatorKey(""), kvstore.Client())
 	c.Assert(err, IsNil)
-
-	minID := idpool.ID(identity.MinimalAllocationIdentity)
-	maxID := minID + 256
-	a, err := allocator.NewAllocator(TestAllocatorKey(""), backend,
-		allocator.WithMin(minID), allocator.WithMax(maxID))
+	a, err := allocator.NewAllocator(TestAllocatorKey(""), backend, allocator.WithMax(idpool.ID(256)))
 	c.Assert(err, IsNil)
 	c.Assert(a, Not(IsNil))
 
@@ -602,7 +585,7 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 	a.DeleteAllKeys()
 
 	// allocate all available IDs
-	for i := minID; i < minID+4; i++ {
+	for i := idpool.ID(1); i <= idpool.ID(4); i++ {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
 		_, _, _, err := a.Allocate(context.Background(), key)
 		c.Assert(err, IsNil)
@@ -632,8 +615,7 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 	// watch the prefix in the same kvstore via a 2nd watcher
 	backend2, err := NewKVStoreBackend(testName, "a", TestAllocatorKey(""), kvstore.Client())
 	c.Assert(err, IsNil)
-	a2, err := allocator.NewAllocator(TestAllocatorKey(""), backend2,
-		allocator.WithMin(minID), allocator.WithMax(maxID))
+	a2, err := allocator.NewAllocator(TestAllocatorKey(""), backend2, allocator.WithMax(idpool.ID(256)))
 	c.Assert(err, IsNil)
 	rc := a.WatchRemoteKVStore(a2)
 	c.Assert(rc, Not(IsNil))


### PR DESCRIPTION
This reverts pull request https://github.com/cilium/cilium/pull/18151.

This commit consistently broke the Multicluster workflow on master. We probably merged a bit quickly because the Multicluster workflow wasn't marked as Required and was very flaky until recently.

cc @ArthurChiao 