### PR TITLE
install/kubernetes: expose DNS policy rule unload agent flag as helm value

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -814,6 +814,11 @@ data:
   enable-k8s-terminating-endpoint: {{ .Values.enableK8sTerminatingEndpoint | quote }}
 {{- end }}
 
+{{- if hasKey .Values "dnsPolicyUnloadOnShutdown" }}
+  # Unload DNS policy rules on graceful showdown
+  dns-policy-unload-on-shutdown: {{.Values.dnsPolicyUnloadOnShutdown | quote }}
+{{- end }}
+
 {{- if .Values.extraConfig }}
   {{ toYaml .Values.extraConfig | nindent 2 }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1898,3 +1898,6 @@ cgroup:
 # -- Configure whether to enable auto detect of terminating state for endpoints
 # in order to support graceful termination.
 enableK8sTerminatingEndpoint: true
+
+# -- Configure whether to unload DNS policy rules on graceful showdown
+# dnsPolicyUnloadOnShutdown: false


### PR DESCRIPTION
Expose the `dns-policy-unload-on-shutdown` agent flag introduced in
commit 708873d06934 ("daemon: allow unloading DNS policy rules on
graceful shutdown") as a helm value `dnsPolicyUnloadOnShutdown` which is
disabled by default.
