### PR TITLE
CI: run K8sServices on KIND

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -8,6 +8,7 @@ default_controlplanes=1
 default_workers=1
 default_cluster_name=""
 default_image=""
+default_kubeproxy_mode="iptables"
 
 PROG=${0}
 CONTROLPLANES="${1:-${default_controlplanes}}"
@@ -15,10 +16,11 @@ WORKERS="${2:-${default_workers}}"
 CLUSTER_NAME="${3:-${default_cluster_name}}"
 # IMAGE controls the K8s version as well (e.g. kindest/node:v1.11.10)
 IMAGE="${4:-${default_image}}"
+KUBEPROXY_MODE="${5:-${default_kubeproxy_mode}}"
 CILIUM_ROOT="$(realpath $(dirname $(readlink -ne $BASH_SOURCE))/../..)"
 
 usage() {
-  echo "Usage: ${PROG} [control-plane node count] [worker node count] [cluster-name] [node image]"
+  echo "Usage: ${PROG} [control-plane node count] [worker node count] [cluster-name] [node image] [kube-proxy mode]"
 }
 
 have_kind() {
@@ -30,12 +32,12 @@ if ! have_kind; then
     echo "  https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
 fi
 
-if [[ "${#}" -gt 4 ]]; then
+if [[ "${#}" -gt 5 ]]; then
   usage
   exit 1
 fi
 
-if [[ "${#}" -gt 4 ]] ||
+if [[ "${#}" -gt 5 ]] ||
    [[ "${CONTROLPLANES}" == "-h" ||
       "${CONTROLPLANES}" == "--help" ]]; then
   usage
@@ -88,6 +90,7 @@ $(control_planes)
 $(workers)
 networking:
   disableDefaultCNI: true
+  kubeProxyMode: ${KUBEPROXY_MODE}
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,6 +12,10 @@ TEST_ARTIFACTS = ./tmp.yaml ./*_service_manifest.json ./*_manifest.yaml
 TEST_ARTIFACTS += ./*_policy.json ./k8s-*.xml ./runtime.xml ./test_results
 TEST_ARTIFACTS += ./test.test
 
+NETNEXT ?= false
+KUBEPROXY ?= 1
+NO_CILIUM_ON_NODES ?= ""
+
 GINKGO = $(QUIET) ginkgo
 
 REGISTRY_CREDENTIALS ?= "${DOCKER_LOGIN}:${DOCKER_PASSWORD}"
@@ -40,6 +44,9 @@ k8s-kind:
 	fi
 	@CNI_INTEGRATION=kind \
 		K8S_VERSION="$$(kubectl version -o json | jq -r '.serverVersion | "\(.major).\(.minor)"')" \
+		NETNEXT="$(NETNEXT)" \
+		KUBEPROXY="$(KUBEPROXY)" \
+		NO_CILIUM_ON_NODES="$(NO_CILIUM_ON_NODES)" \
 		ginkgo --focus "$(FOCUS)" --tags integration_tests -v -- \
 			-cilium.testScope=k8s \
 			-cilium.provision=false \

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -169,12 +169,8 @@ var (
 		"k8s.requireIPv4PodCIDR": "false",
 	}
 	kindHelmOverrides = map[string]string{
-		"ipv6.enabled":         "false",
-		"hostFirewall.enabled": "false",
-		"nodeinit.enabled":     "true",
-		"kubeProxyReplacement": "partial",
-		"externalIPs.enabled":  "true",
-		"ipam.mode":            "kubernetes",
+		// To mount the cgroupv2 sub-root
+		"nodeinit.enabled": "true",
 	}
 
 	// helmOverrides allows overriding of cilium-agent options for

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2392,7 +2392,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		}
 		for i, n := range noCiliumNodes {
 			key := fmt.Sprintf("affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[%d]", i)
-			opts[key] = n
+			opts[key] = kub.GetNodeCILabel(n)
 		}
 		for key, value := range opts {
 			options = addIfNotOverwritten(options, key, value)

--- a/test/helpers/nodes_info.go
+++ b/test/helpers/nodes_info.go
@@ -35,7 +35,7 @@ func GetNodesInfo(kubectl *Kubectl) (*NodesInfo, error) {
 	ni.K8s1NodeName, ni.K8s1IP = kubectl.GetNodeInfo(K8s1)
 	ni.K8s2NodeName, ni.K8s2IP = kubectl.GetNodeInfo(K8s2)
 	if ExistNodeWithoutCilium() {
-		ni.OutsideNodeName, ni.OutsideIP = kubectl.GetNodeInfo(GetFirstNodeWithoutCilium())
+		ni.OutsideNodeName, ni.OutsideIP = kubectl.GetNodeInfo(kubectl.GetFirstNodeWithoutCiliumLabel())
 	}
 
 	ni.PrivateIface, err = kubectl.GetPrivateIface()

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -661,6 +661,24 @@ func GetFirstNodeWithoutCilium() string {
 	return noCiliumNodes[0]
 }
 
+// GetFirstNodeWithoutCiliumLabel returns the ci-node label value of the first node
+// which is running without Cilium.
+func (kub *Kubectl) GetFirstNodeWithoutCiliumLabel() string {
+	nodeName := GetFirstNodeWithoutCilium()
+	return kub.GetNodeCILabel(nodeName)
+}
+
+// GetNodeCILabel returns the ci-node label value of the given node.
+func (kub *Kubectl) GetNodeCILabel(nodeName string) string {
+	cmd := fmt.Sprintf("%s get node %s -o jsonpath='{.metadata.labels.cilium\\.io/ci-node}'",
+		KubectlCmd, nodeName)
+	res := kub.ExecShort(cmd)
+	if !res.WasSuccessful() {
+		return ""
+	}
+	return res.SingleOut()
+}
+
 // IsNodeWithoutCilium returns true if node node doesn't run Cilium.
 func IsNodeWithoutCilium(node string) bool {
 	for _, n := range GetNodesWithoutCilium() {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -514,7 +514,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		testIPMasqAgent := func() {
 			// Check that requests to the echoserver from client pods are masqueraded.
-			nodeIP, err := kubectl.GetNodeIPByLabel(helpers.GetFirstNodeWithoutCilium(), false)
+			nodeIP, err := kubectl.GetNodeIPByLabel(kubectl.GetFirstNodeWithoutCiliumLabel(), false)
 			Expect(err).Should(BeNil())
 			Expect(testPodHTTPToOutside(kubectl,
 				fmt.Sprintf("http://%s:80", nodeIP), true, false, false)).Should(BeTrue(),

--- a/test/k8sT/Egress.go
+++ b/test/k8sT/Egress.go
@@ -89,7 +89,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		_, k8s1IP = kubectl.GetNodeInfo(helpers.K8s1)
 		_, k8s2IP = kubectl.GetNodeInfo(helpers.K8s2)
-		_, outsideIP = kubectl.GetNodeInfo(helpers.GetFirstNodeWithoutCilium())
+		_, outsideIP = kubectl.GetNodeInfo(kubectl.GetFirstNodeWithoutCiliumLabel())
 
 		egressIP = getEgressIP(k8s1IP)
 
@@ -172,7 +172,7 @@ var _ = SkipDescribeIf(func() bool {
 			fmt.Sprintf(`{"spec":{"externalIPs":["%s"],  "externalTrafficPolicy": "Local"}}`, hostIP))
 		ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "Error patching external IP service with node IP")
 
-		outsideNodeName, outsideNodeIP := kubectl.GetNodeInfo(helpers.GetFirstNodeWithoutCilium())
+		outsideNodeName, outsideNodeIP := kubectl.GetNodeInfo(kubectl.GetFirstNodeWithoutCiliumLabel())
 
 		res = kubectl.ExecInHostNetNS(context.TODO(), outsideNodeName,
 			helpers.CurlFail("http://%s:%d", hostIP, extIPsService.Spec.Ports[0].Port))

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1347,7 +1347,7 @@ var _ = SkipDescribeIf(func() bool {
 					})
 
 				By("Retrieving backend pod and outside node IP addresses")
-				outsideNodeName, outsideIP = kubectl.GetNodeInfo(helpers.GetFirstNodeWithoutCilium())
+				outsideNodeName, outsideIP = kubectl.GetNodeInfo(kubectl.GetFirstNodeWithoutCiliumLabel())
 
 				var demoPods v1.PodList
 				kubectl.GetPods(testNamespace, fmt.Sprintf("-l %s", testDS)).Unmarshal(&demoPods)
@@ -1602,7 +1602,7 @@ var _ = SkipDescribeIf(func() bool {
 				_, k8s2PodIP = kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s2, testDS, 0)
 
 				if helpers.ExistNodeWithoutCilium() {
-					outsideNodeName, _ = kubectl.GetNodeInfo(helpers.GetFirstNodeWithoutCilium())
+					outsideNodeName, _ = kubectl.GetNodeInfo(kubectl.GetFirstNodeWithoutCiliumLabel())
 				}
 
 				// Masquerade function should be disabled
@@ -2542,7 +2542,7 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 				k8s1PodName, k8s1PodIP = kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s1, testDS, 0)
 				k8s2PodName, k8s2PodIP = kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s2, testDS, 0)
 				if helpers.ExistNodeWithoutCilium() {
-					outsideNodeName, _ = kubectl.GetNodeInfo(helpers.GetFirstNodeWithoutCilium())
+					outsideNodeName, _ = kubectl.GetNodeInfo(kubectl.GetFirstNodeWithoutCiliumLabel())
 				}
 
 				var err error

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -565,7 +565,10 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			testCurlFromOutsideWithLocalPort(kubectl, ni, svc2URL, 1, false, 64002)
 		})
 
-		It("Tests with secondary NodePort device", func() {
+		SkipItIf(func() bool {
+			// Currently, KIND doesn't support multiple interfaces among nodes
+			return helpers.IsIntegration(helpers.CIIntegrationKind)
+		}, "Tests with secondary NodePort device", func() {
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 				"loadBalancer.mode": "snat",
 				"devices":           fmt.Sprintf(`'{%s,%s}'`, ni.PrivateIface, helpers.SecondaryIface),


### PR DESCRIPTION
This PR allows us to run the `K8sServices` suite (probably others as well; I haven't tested it) on KIND on a fairly recent kernel (with the Daniel's cgroup fix http://github.com/torvalds/linux/commit/8520e224f547cd070c7c8f97b1fc6d58cff7ccaa) or the one running with cgroupv1 disabled.

HOWTO:
```
./contrib/scripts/kind.sh "" 2 "" "" none
export DOCKER_REGISTRY=localhost:5000
make dev-docker-image
docker tag localhost:5000/cilium/cilium-dev:latest localhost:5000/cilium/cilium-dev:local
docker push localhost:5000/cilium/cilium-dev:local
cd test
FOCUS="K8sServices" NETNEXT=true KUBEPROXY=0 K8S_NODES=3 NO_CILIUM_ON_NODES=kind-worker2 make k8s-kind
```

Please see commit msgs for more details.