### PR TITLE
API and implementation to quarantine service backends

### DIFF
--- a/Documentation/cmdref/cilium_service_update.md
+++ b/Documentation/cmdref/cilium_service_update.md
@@ -22,6 +22,7 @@ cilium service update [flags]
       --k8s-node-port               Set service as a k8s NodePort
       --k8s-traffic-policy string   Set service with k8s externalTrafficPolicy as {Local,Cluster} (default "Cluster")
       --local-redirect              Set service as Local Redirect
+      --states strings              Backend state(s) as {active(default),terminating,quarantined,maintenance}
 ```
 
 ### Options inherited from parent commands

--- a/api/v1/client/service/put_service_id_responses.go
+++ b/api/v1/client/service/put_service_id_responses.go
@@ -56,6 +56,12 @@ func (o *PutServiceIDReader) ReadResponse(response runtime.ClientResponse, consu
 			return nil, err
 		}
 		return nil, result
+	case 501:
+		result := NewPutServiceIDUpdateBackendFailure()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
@@ -188,6 +194,37 @@ func (o *PutServiceIDFailure) GetPayload() models.Error {
 }
 
 func (o *PutServiceIDFailure) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewPutServiceIDUpdateBackendFailure creates a PutServiceIDUpdateBackendFailure with default headers values
+func NewPutServiceIDUpdateBackendFailure() *PutServiceIDUpdateBackendFailure {
+	return &PutServiceIDUpdateBackendFailure{}
+}
+
+/*PutServiceIDUpdateBackendFailure handles this case with default header values.
+
+Error while updating backend states
+*/
+type PutServiceIDUpdateBackendFailure struct {
+	Payload models.Error
+}
+
+func (o *PutServiceIDUpdateBackendFailure) Error() string {
+	return fmt.Sprintf("[PUT /service/{id}][%d] putServiceIdUpdateBackendFailure  %+v", 501, o.Payload)
+}
+
+func (o *PutServiceIDUpdateBackendFailure) GetPayload() models.Error {
+	return o.Payload
+}
+
+func (o *PutServiceIDUpdateBackendFailure) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {

--- a/api/v1/models/backend_address.go
+++ b/api/v1/models/backend_address.go
@@ -9,6 +9,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -29,6 +31,10 @@ type BackendAddress struct {
 
 	// Layer 4 port number
 	Port uint16 `json:"port,omitempty"`
+
+	// State of the backend for load-balancing service traffic
+	// Enum: [active terminating quarantined maintenance]
+	State string `json:"state,omitempty"`
 }
 
 // Validate validates this backend address
@@ -36,6 +42,10 @@ func (m *BackendAddress) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateIP(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -48,6 +58,55 @@ func (m *BackendAddress) Validate(formats strfmt.Registry) error {
 func (m *BackendAddress) validateIP(formats strfmt.Registry) error {
 
 	if err := validate.Required("ip", "body", m.IP); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var backendAddressTypeStatePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["active","terminating","quarantined","maintenance"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		backendAddressTypeStatePropEnum = append(backendAddressTypeStatePropEnum, v)
+	}
+}
+
+const (
+
+	// BackendAddressStateActive captures enum value "active"
+	BackendAddressStateActive string = "active"
+
+	// BackendAddressStateTerminating captures enum value "terminating"
+	BackendAddressStateTerminating string = "terminating"
+
+	// BackendAddressStateQuarantined captures enum value "quarantined"
+	BackendAddressStateQuarantined string = "quarantined"
+
+	// BackendAddressStateMaintenance captures enum value "maintenance"
+	BackendAddressStateMaintenance string = "maintenance"
+)
+
+// prop value enum
+func (m *BackendAddress) validateStateEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, backendAddressTypeStatePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *BackendAddress) validateState(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.State) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateStateEnum("state", "body", m.State); err != nil {
 		return err
 	}
 

--- a/api/v1/models/service_spec.go
+++ b/api/v1/models/service_spec.go
@@ -35,6 +35,11 @@ type ServiceSpec struct {
 
 	// Unique identification
 	ID int64 `json:"id,omitempty"`
+
+	// Update all services selecting the backends with their given states
+	// (id and frontend are ignored)
+	//
+	UpdateServices bool `json:"updateServices,omitempty"`
 }
 
 // Validate validates this service spec

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2478,6 +2478,14 @@ definitions:
       nodeName:
         description: Optional name of the node on which this backend runs
         type: string
+      state:
+        description: State of the backend for load-balancing service traffic
+        type: string
+        enum:
+          - active
+          - terminating
+          - quarantined
+          - maintenance
   LRPBackend:
     description: Pod backend of an LRP
     type: object

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -643,6 +643,11 @@ paths:
           x-go-name: Failure
           schema:
             "$ref": "#/definitions/Error"
+        '501':
+          description: Error while updating backend states
+          x-go-name: UpdateBackendFailure
+          schema:
+            "$ref": "#/definitions/Error"
     delete:
       summary: Delete a service
       tags:
@@ -2595,6 +2600,12 @@ definitions:
           namespace:
             description: Service namespace  (e.g. Kubernetes namespace)
             type: string
+      updateServices:
+        description: |
+          Update all services selecting the backends with their given states
+          (id and frontend are ignored)
+        type: boolean
+
   ServiceStatus:
     description: Configuration of a service
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1426,6 +1426,13 @@ func init() {
               "$ref": "#/definitions/Error"
             },
             "x-go-name": "Failure"
+          },
+          "501": {
+            "description": "Error while updating backend states",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "x-go-name": "UpdateBackendFailure"
           }
         }
       },
@@ -3882,6 +3889,10 @@ func init() {
         "id": {
           "description": "Unique identification",
           "type": "integer"
+        },
+        "updateServices": {
+          "description": "Update all services selecting the backends with their given states\n(id and frontend are ignored)\n",
+          "type": "boolean"
         }
       }
     },
@@ -5862,6 +5873,13 @@ func init() {
               "$ref": "#/definitions/Error"
             },
             "x-go-name": "Failure"
+          },
+          "501": {
+            "description": "Error while updating backend states",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "x-go-name": "UpdateBackendFailure"
           }
         }
       },
@@ -8661,6 +8679,10 @@ func init() {
         "id": {
           "description": "Unique identification",
           "type": "integer"
+        },
+        "updateServices": {
+          "description": "Update all services selecting the backends with their given states\n(id and frontend are ignored)\n",
+          "type": "boolean"
         }
       }
     },

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1598,6 +1598,16 @@ func init() {
           "description": "Layer 4 port number",
           "type": "integer",
           "format": "uint16"
+        },
+        "state": {
+          "description": "State of the backend for load-balancing service traffic",
+          "type": "string",
+          "enum": [
+            "active",
+            "terminating",
+            "quarantined",
+            "maintenance"
+          ]
         }
       }
     },
@@ -6028,6 +6038,16 @@ func init() {
           "description": "Layer 4 port number",
           "type": "integer",
           "format": "uint16"
+        },
+        "state": {
+          "description": "State of the backend for load-balancing service traffic",
+          "type": "string",
+          "enum": [
+            "active",
+            "terminating",
+            "quarantined",
+            "maintenance"
+          ]
         }
       }
     },

--- a/api/v1/server/restapi/service/put_service_id_responses.go
+++ b/api/v1/server/restapi/service/put_service_id_responses.go
@@ -189,3 +189,45 @@ func (o *PutServiceIDFailure) WriteResponse(rw http.ResponseWriter, producer run
 		panic(err) // let the recovery middleware deal with this
 	}
 }
+
+// PutServiceIDUpdateBackendFailureCode is the HTTP code returned for type PutServiceIDUpdateBackendFailure
+const PutServiceIDUpdateBackendFailureCode int = 501
+
+/*PutServiceIDUpdateBackendFailure Error while updating backend states
+
+swagger:response putServiceIdUpdateBackendFailure
+*/
+type PutServiceIDUpdateBackendFailure struct {
+
+	/*
+	  In: Body
+	*/
+	Payload models.Error `json:"body,omitempty"`
+}
+
+// NewPutServiceIDUpdateBackendFailure creates PutServiceIDUpdateBackendFailure with default headers values
+func NewPutServiceIDUpdateBackendFailure() *PutServiceIDUpdateBackendFailure {
+
+	return &PutServiceIDUpdateBackendFailure{}
+}
+
+// WithPayload adds the payload to the put service Id update backend failure response
+func (o *PutServiceIDUpdateBackendFailure) WithPayload(payload models.Error) *PutServiceIDUpdateBackendFailure {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the put service Id update backend failure response
+func (o *PutServiceIDUpdateBackendFailure) SetPayload(payload models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *PutServiceIDUpdateBackendFailure) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(501)
+	payload := o.Payload
+	if err := producer.Produce(rw, payload); err != nil {
+		panic(err) // let the recovery middleware deal with this
+	}
+}

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -768,7 +768,7 @@ struct lb6_backend {
 	union v6addr address;
 	__be16 port;
 	__u8 proto;
-	__u8 pad;
+	__u8 flags;
 };
 
 struct lb6_health {
@@ -822,7 +822,7 @@ struct lb4_backend {
 	__be32 address;		/* Service endpoint IPv4 address */
 	__be16 port;		/* L4 port filter */
 	__u8 proto;		/* L4 protocol, currently not used (set to 0) */
-	__u8 pad;
+	__u8 flags;
 };
 
 struct lb4_health {

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -18,8 +18,8 @@ import (
 const (
 	idTitle             = "ID"
 	serviceAddressTitle = "SERVICE ADDRESS"
-	backendAddressTitle = "BACKEND ADDRESS"
 	backendIdTitle      = "BACKEND ID"
+	backendAddressTitle = "BACKEND ADDRESS (REVNAT_ID) (SLOT)"
 )
 
 var (
@@ -76,25 +76,26 @@ func dumpSVC(serviceList map[string][]string) {
 		svcVal := value.(lbmap.ServiceValue).ToHost()
 		svc := svcKey.String()
 		svcKey = svcKey.ToHost()
+		backendSlot := svcKey.GetBackendSlot()
 		revNATID := svcVal.GetRevNat()
 		backendID := svcVal.GetBackendID()
 		flags := loadbalancer.ServiceFlags(svcVal.GetFlags())
 
-		if svcKey.GetBackendSlot() == 0 {
+		if backendSlot == 0 {
 			ip := "0.0.0.0"
 			if svcKey.IsIPv6() {
 				ip = "[::]"
 			}
-			entry = fmt.Sprintf("%s:%d (%d) [%s]", ip, 0, revNATID, flags)
+			entry = fmt.Sprintf("%s:%d (%d) (%d) [%s]", ip, 0, revNATID, backendSlot, flags)
 		} else if backend, found := backendMap[backendID]; !found {
 			entry = fmt.Sprintf("backend %d not found", backendID)
 		} else {
-			fmtStr := "%s:%d (%d)"
+			fmtStr := "%s:%d (%d) (%d)"
 			if svcKey.IsIPv6() {
-				fmtStr = "[%s]:%d (%d)"
+				fmtStr = "[%s]:%d (%d) (%d)"
 			}
 			entry = fmt.Sprintf(fmtStr, backend.GetAddress(),
-				backend.GetPort(), revNATID)
+				backend.GetPort(), revNATID, backendSlot)
 		}
 
 		serviceList[svc] = append(serviceList[svc], entry)

--- a/cilium/cmd/service_list.go
+++ b/cilium/cmd/service_list.go
@@ -78,7 +78,7 @@ func printServiceList(w *tabwriter.Writer, list []*models.Service) {
 				fmt.Fprintf(os.Stderr, "error parsing backend %+v", be)
 				continue
 			}
-			str := fmt.Sprintf("%d => %s", i+1, beA.String())
+			str := fmt.Sprintf("%d => %s (%s)", i+1, beA.String(), be.State)
 			backendAddresses = append(backendAddresses, str)
 		}
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -683,13 +683,17 @@ func genCartesianProduct(
 			parsedIP := net.ParseIP(netIP)
 
 			if backendPort := backend.Ports[string(fePortName)]; backendPort != nil && feFamilyIPv6 == ip.IsIPv6(parsedIP) {
+				backendState := loadbalancer.BackendStateActive
+				if backend.Terminating {
+					backendState = loadbalancer.BackendStateTerminating
+				}
 				besValues = append(besValues, loadbalancer.Backend{
 					NodeName: backend.NodeName,
 					L3n4Addr: loadbalancer.L3n4Addr{
 						IP:     parsedIP,
 						L4Addr: *backendPort,
 					},
-					Terminating: backend.Terminating,
+					State: backendState,
 				})
 			}
 		}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -398,6 +398,12 @@ func (state BackendState) String() (string, error) {
 	}
 }
 
+func IsValidBackendState(state string) bool {
+	_, err := GetBackendState(state)
+
+	return err == nil
+}
+
 func NewL4Type(name string) (L4Type, error) {
 	switch strings.ToLower(name) {
 	case "tcp":

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -345,6 +345,32 @@ func (s *SVC) GetModel() *models.Service {
 	}
 }
 
+func IsValidStateTransition(old, new BackendState) bool {
+	if old == new {
+		return true
+	}
+	if new == BackendStateInvalid {
+		return false
+	}
+
+	switch old {
+	case BackendStateActive:
+	case BackendStateTerminating:
+		return false
+	case BackendStateQuarantined:
+		if new == BackendStateMaintenance {
+			return false
+		}
+	case BackendStateMaintenance:
+		if new != BackendStateActive {
+			return false
+		}
+	default:
+		return false
+	}
+	return true
+}
+
 func NewL4Type(name string) (L4Type, error) {
 	switch strings.ToLower(name) {
 	case "tcp":

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -270,9 +270,6 @@ type Backend struct {
 	// a node.
 	NodeName string
 	L3n4Addr
-	// State indicating whether backend is terminating so that it can be
-	// gracefully removed
-	Terminating bool
 	// State of the backend for load-balancing service traffic
 	State BackendState
 }

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -313,6 +313,8 @@ type Backend struct {
 	L3n4Addr
 	// State of the backend for load-balancing service traffic
 	State BackendState
+	// RestoredFromDatapath indicates whether the backend was restored from BPF maps
+	RestoredFromDatapath bool
 }
 
 func (b *Backend) String() string {
@@ -559,13 +561,16 @@ func NewBackend(id BackendID, protocol L4Type, ip net.IP, portNumber uint16) *Ba
 	return &b
 }
 
-// NewBackendWithState creates the Backend struct instance from given params.
-func NewBackendWithState(id BackendID, protocol L4Type, ip net.IP, portNumber uint16, state BackendState) *Backend {
+// NewBackendWithState creates the Backend struct instance from given params,
+// and sets the restore state for the Backend.
+func NewBackendWithState(id BackendID, protocol L4Type, ip net.IP, portNumber uint16,
+	state BackendState, restored bool) *Backend {
 	lbport := NewL4Addr(protocol, portNumber)
 	b := Backend{
-		ID:       id,
-		L3n4Addr: L3n4Addr{IP: ip, L4Addr: *lbport},
-		State:    state,
+		ID:                   id,
+		L3n4Addr:             L3n4Addr{IP: ip, L4Addr: *lbport},
+		State:                state,
+		RestoredFromDatapath: restored,
 	}
 
 	return &b

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -274,6 +274,9 @@ const (
 	// L7LBProxyPort is the port number of the Envoy listener a L7 LB service redirects traffic to for load balancing.
 	L7LBProxyPort = "l7LBProxyPort"
 
+	// BackendState is the state of the backend
+	BackendState = "backendState"
+
 	// CiliumNetworkPolicy is a cilium specific NetworkPolicy
 	CiliumNetworkPolicy = "ciliumNetworkPolicy"
 

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -393,7 +393,7 @@ type Backend4Value struct {
 	Address types.IPv4      `align:"address"`
 	Port    uint16          `align:"port"`
 	Proto   u8proto.U8proto `align:"proto"`
-	Pad     uint8           `align:"pad"`
+	Flags   uint8           `align:"flags"`
 }
 
 func NewBackend4Value(ip net.IP, port uint16, proto u8proto.U8proto) (*Backend4Value, error) {
@@ -420,6 +420,7 @@ func (v *Backend4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) 
 
 func (b *Backend4Value) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend4Value) GetPort() uint16    { return b.Port }
+func (b *Backend4Value) GetFlags() uint8    { return b.Flags }
 
 func (v *Backend4Value) ToNetwork() BackendValue {
 	n := *v

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -396,15 +396,17 @@ type Backend4Value struct {
 	Flags   uint8           `align:"flags"`
 }
 
-func NewBackend4Value(ip net.IP, port uint16, proto u8proto.U8proto) (*Backend4Value, error) {
+func NewBackend4Value(ip net.IP, port uint16, proto u8proto.U8proto, state loadbalancer.BackendState) (*Backend4Value, error) {
 	ip4 := ip.To4()
 	if ip4 == nil {
 		return nil, fmt.Errorf("Not an IPv4 address")
 	}
+	flags := loadbalancer.NewBackendFlags(state)
 
 	val := Backend4Value{
 		Port:  port,
 		Proto: proto,
+		Flags: flags,
 	}
 	copy(val.Address[:], ip.To4())
 
@@ -440,8 +442,9 @@ type Backend4V2 struct {
 	Value *Backend4Value
 }
 
-func NewBackend4V2(id loadbalancer.BackendID, ip net.IP, port uint16, proto u8proto.U8proto) (*Backend4V2, error) {
-	val, err := NewBackend4Value(ip, port, proto)
+func NewBackend4V2(id loadbalancer.BackendID, ip net.IP, port uint16, proto u8proto.U8proto,
+	state loadbalancer.BackendState) (*Backend4V2, error) {
+	val, err := NewBackend4Value(ip, port, proto, state)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -290,15 +290,17 @@ type Backend6Value struct {
 	Flags   uint8           `align:"flags"`
 }
 
-func NewBackend6Value(ip net.IP, port uint16, proto u8proto.U8proto) (*Backend6Value, error) {
+func NewBackend6Value(ip net.IP, port uint16, proto u8proto.U8proto, state loadbalancer.BackendState) (*Backend6Value, error) {
 	ip6 := ip.To16()
 	if ip6 == nil {
 		return nil, fmt.Errorf("Not an IPv6 address")
 	}
+	flags := loadbalancer.NewBackendFlags(state)
 
 	val := Backend6Value{
 		Port:  port,
 		Proto: proto,
+		Flags: flags,
 	}
 	copy(val.Address[:], ip.To16())
 
@@ -334,8 +336,9 @@ type Backend6V2 struct {
 	Value *Backend6Value
 }
 
-func NewBackend6V2(id loadbalancer.BackendID, ip net.IP, port uint16, proto u8proto.U8proto) (*Backend6V2, error) {
-	val, err := NewBackend6Value(ip, port, proto)
+func NewBackend6V2(id loadbalancer.BackendID, ip net.IP, port uint16, proto u8proto.U8proto,
+	state loadbalancer.BackendState) (*Backend6V2, error) {
+	val, err := NewBackend6Value(ip, port, proto, state)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -287,7 +287,7 @@ type Backend6Value struct {
 	Address types.IPv6      `align:"address"`
 	Port    uint16          `align:"port"`
 	Proto   u8proto.U8proto `align:"proto"`
-	Pad     uint8           `align:"pad"`
+	Flags   uint8           `align:"flags"`
 }
 
 func NewBackend6Value(ip net.IP, port uint16, proto u8proto.U8proto) (*Backend6Value, error) {
@@ -314,6 +314,7 @@ func (v *Backend6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) 
 
 func (b *Backend6Value) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend6Value) GetPort() uint16    { return b.Port }
+func (b *Backend6Value) GetFlags() uint8    { return b.Flags }
 
 func (v *Backend6Value) ToNetwork() BackendValue {
 	n := *v

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -577,7 +577,7 @@ func (*LBBPFMap) DumpBackendMaps() ([]*loadbalancer.Backend, error) {
 		port := backendVal.GetPort()
 		proto := loadbalancer.NONE
 		state := loadbalancer.GetBackendStateFromFlags(backendVal.GetFlags())
-		lbBackend := loadbalancer.NewBackendWithState(backendID, proto, ip, port, state)
+		lbBackend := loadbalancer.NewBackendWithState(backendID, proto, ip, port, state, true)
 		lbBackends = append(lbBackends, lbBackend)
 	}
 

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -297,9 +297,9 @@ func (*LBBPFMap) AddBackend(id loadbalancer.BackendID, ip net.IP, port uint16, i
 	}
 
 	if ipv6 {
-		backend, err = NewBackend6V2(loadbalancer.BackendID(id), ip, port, u8proto.ANY)
+		backend, err = NewBackend6V2(id, ip, port, u8proto.ANY)
 	} else {
-		backend, err = NewBackend4V2(loadbalancer.BackendID(id), ip, port, u8proto.ANY)
+		backend, err = NewBackend4V2(id, ip, port, u8proto.ANY)
 	}
 	if err != nil {
 		return fmt.Errorf("Unable to create backend (%d, %s, %d, %t): %s",
@@ -568,6 +568,7 @@ func (*LBBPFMap) DumpBackendMaps() ([]*loadbalancer.Backend, error) {
 		port := backendVal.GetPort()
 		proto := loadbalancer.NONE
 		lbBackend := loadbalancer.NewBackend(backendID, proto, ip, port)
+		lbBackend.State = loadbalancer.BackendState(backendVal.GetFlags())
 		lbBackends = append(lbBackends, lbBackend)
 	}
 

--- a/pkg/maps/lbmap/maglev_test.go
+++ b/pkg/maps/lbmap/maglev_test.go
@@ -86,12 +86,12 @@ func (s *MaglevSuite) TestInitMaps(c *C) {
 	c.Assert(err, IsNil)
 	lbm := New(true, option.Config.MaglevTableSize)
 	params := &UpsertServiceParams{
-		ID:        1,
-		IP:        net.ParseIP("1.1.1.1"),
-		Port:      8080,
-		Backends:  map[string]loadbalancer.BackendID{"backend-1": 1},
-		Type:      loadbalancer.SVCTypeNodePort,
-		UseMaglev: true,
+		ID:             1,
+		IP:             net.ParseIP("1.1.1.1"),
+		Port:           8080,
+		ActiveBackends: map[string]loadbalancer.BackendID{"backend-1": 1},
+		Type:           loadbalancer.SVCTypeNodePort,
+		UseMaglev:      true,
 	}
 	err = lbm.UpsertService(params)
 	c.Assert(err, IsNil)

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -190,7 +190,7 @@ func svcBackend(backendID loadbalancer.BackendID, backend BackendValue) *loadbal
 	beIP := backend.GetAddress()
 	bePort := backend.GetPort()
 	beProto := loadbalancer.NONE
-	beBackend := loadbalancer.NewBackend(backendID, beProto, beIP, bePort)
-	beBackend.State = loadbalancer.BackendState(backend.GetFlags())
+	beState := loadbalancer.GetBackendStateFromFlags(backend.GetFlags())
+	beBackend := loadbalancer.NewBackendWithState(backendID, beProto, beIP, bePort, beState, true)
 	return beBackend
 }

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -123,6 +123,9 @@ type BackendValue interface {
 	// Get backend port
 	GetPort() uint16
 
+	// Get backend flags
+	GetFlags() uint8
+
 	// Convert fields to network byte order.
 	ToNetwork() BackendValue
 
@@ -188,5 +191,6 @@ func svcBackend(backendID loadbalancer.BackendID, backend BackendValue) *loadbal
 	bePort := backend.GetPort()
 	beProto := loadbalancer.NONE
 	beBackend := loadbalancer.NewBackend(backendID, beProto, beIP, bePort)
+	beBackend.State = loadbalancer.BackendState(backend.GetFlags())
 	return beBackend
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1032,14 +1032,12 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, onlyLocalBackends bool,
 				natPolicy = lb.SVCNatPolicyNat46
 			}
 		}
-		// Skip adding the terminating backend to the service map so that it
-		// won't be selected to serve new requests. However, the backend is still
-		// kept in the affinity and backend maps so that existing connections
-		// are able to terminate gracefully. The final clean-up for the backend
-		// will happen once the agent receives a delete event for the service
-		// endpoint as it'll be part of obsoleteBackendIDs/obsoleteSVCBackendIDs
-		// list passed to this function.
-		if !b.Terminating {
+		// Skip adding backends that are not active to the service map so that they
+		// won't be selected to serve new requests. However, non-active backends
+		// are still kept in the affinity and backend maps so that existing connections
+		// are able to terminate gracefully. Such backends would either be cleaned-up
+		// when the backends are deleted, or they would transition to active state.
+		if b.State == lb.BackendStateActive {
 			backends[b.String()] = b.ID
 			activeBackendsCount++
 		}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1316,6 +1316,13 @@ func (s *Service) updateBackendsCacheLocked(svc *svcInfo, backends []lb.Backend)
 			svc.backendByHash[hash] = &backends[i]
 		} else {
 			backends[i].ID = b.ID
+			if b.State != backends[i].State {
+				if !lb.IsValidStateTransition(b.State, backends[i].State) {
+					return nil, nil, nil,
+						fmt.Errorf("invalid state transition [%d] -> [%d]", b.State, backends[i].State)
+
+				}
+			}
 		}
 	}
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -818,7 +818,7 @@ func (m *ManagerTestSuite) TestLocalRedirectServiceOverride(c *C) {
 func (m *ManagerTestSuite) TestUpsertServiceWithTerminatingBackends(c *C) {
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	backends := append(backends1, backends4...)
-	backends[2].Terminating = true
+	backends[2].State = lb.BackendStateTerminating
 	p := &lb.SVC{
 		Frontend:                  frontend1,
 		Backends:                  backends,
@@ -915,7 +915,7 @@ func (m *ManagerTestSuite) TestUpsertServiceWithOutExternalClusterIP(c *C) {
 func (m *ManagerTestSuite) TestRestoreServiceWithTerminatingBackends(c *C) {
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	backends := append(backends1, backends4...)
-	backends[2].Terminating = true
+	backends[2].State = lb.BackendStateTerminating
 	p1 := &lb.SVC{
 		Frontend:                  frontend1,
 		Backends:                  backends,

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1099,6 +1099,9 @@ func (m *ManagerTestSuite) TestUpdateBackendsState(c *C) {
 	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, len(backends))
 	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id2)], Equals, len(backends))
 	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends))
+	// Backend states are persisted in the map.
+	c.Assert(m.lbmap.BackendByID[1].State, Equals, lb.BackendStateActive)
+	c.Assert(m.lbmap.BackendByID[2].State, Equals, lb.BackendStateActive)
 
 	// Update the state for one of the backends.
 	updated := []lb.Backend{backends[0]}
@@ -1117,6 +1120,9 @@ func (m *ManagerTestSuite) TestUpdateBackendsState(c *C) {
 	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, 1)
 	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id2)], Equals, 1)
 	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends))
+	// Updated backend states are persisted in the map.
+	c.Assert(m.lbmap.BackendByID[1].State, Equals, lb.BackendStateQuarantined)
+	c.Assert(m.lbmap.BackendByID[2].State, Equals, lb.BackendStateActive)
 
 	// Update the state again.
 	updated = []lb.Backend{backends[0]}
@@ -1135,4 +1141,7 @@ func (m *ManagerTestSuite) TestUpdateBackendsState(c *C) {
 	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, len(backends))
 	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id2)], Equals, len(backends))
 	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends))
+	// Updated backend states are persisted in the map.
+	c.Assert(m.lbmap.BackendByID[1].State, Equals, lb.BackendStateActive)
+	c.Assert(m.lbmap.BackendByID[2].State, Equals, lb.BackendStateActive)
 }

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -817,8 +817,8 @@ func (m *ManagerTestSuite) TestLocalRedirectServiceOverride(c *C) {
 // affinity maps.
 func (m *ManagerTestSuite) TestUpsertServiceWithTerminatingBackends(c *C) {
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
-	backends := append(backends1, backends4...)
-	backends[2].State = lb.BackendStateTerminating
+	backends := append(backends4, backends1...)
+	backends[0].State = lb.BackendStateTerminating
 	p := &lb.SVC{
 		Frontend:                  frontend1,
 		Backends:                  backends,
@@ -835,7 +835,12 @@ func (m *ManagerTestSuite) TestUpsertServiceWithTerminatingBackends(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, true)
 	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 2)
+	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
+	c.Assert(m.lbmap.SvcActiveBackendsCount[uint16(id1)], Equals, len(backends1))
+	// Sorted active backends by ID first followed by non-active
+	c.Assert(m.lbmap.ServiceByID[uint16(id1)].Backends[0].ID, Equals, lb.BackendID(2))
+	c.Assert(m.lbmap.ServiceByID[uint16(id1)].Backends[1].ID, Equals, lb.BackendID(3))
+	c.Assert(m.lbmap.ServiceByID[uint16(id1)].Backends[2].ID, Equals, lb.BackendID(1))
 	c.Assert(len(m.lbmap.BackendByID), Equals, 3)
 	c.Assert(m.svc.svcByID[id1].svcName, Equals, "svc1")
 	c.Assert(m.svc.svcByID[id1].svcNamespace, Equals, "ns1")

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -102,7 +102,7 @@ func (m *LBMockMap) AddBackend(b lb.Backend, ipv6 bool) error {
 		return fmt.Errorf("Backend %d already exists", id)
 	}
 
-	be := lb.NewBackendWithState(id, b.Protocol, ip, port, b.State)
+	be := lb.NewBackendWithState(id, b.Protocol, ip, port, b.State, false)
 	m.BackendByID[id] = be
 
 	return nil
@@ -145,6 +145,7 @@ func (m *LBMockMap) DumpServiceMaps() ([]*lb.SVC, []error) {
 func (m *LBMockMap) DumpBackendMaps() ([]*lb.Backend, error) {
 	list := make([]*lb.Backend, 0, len(m.BackendByID))
 	for _, backend := range m.BackendByID {
+		backend.RestoredFromDatapath = true
 		list = append(list, backend)
 	}
 	return list, nil

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -895,7 +895,7 @@ func (s *SSHMeta) ServiceIsSynced(id int) (bool, error) {
 		target := fmt.Sprintf("%s (%d)", backendSVC, id)
 
 		for _, addr := range lb {
-			if addr == target {
+			if strings.Contains(addr, target) {
 				result = true
 			}
 		}


### PR DESCRIPTION
The API will allow users to set backend states. The primary motivation is to quarantine unreachable backends so that such
backends won't be selected for load-balancing service traffic.
The backend states can be set in response to various events like Kubernetes events (e.g., terminating endpoints), or service APIs (e.g., quarantine unreachable backends). Backend states are persisted across cilium agent restart.

```
$ cilium service list
ID   Frontend          Service Type   Backend
4    10.96.95.246:80   ClusterIP      1 => 10.244.0.58:80 (active)
                                      2 => 10.244.1.59:80 (active)
                                      3 => 10.244.1.8:80 (active)

$ cilium service update --backends 10.244.0.58:80 --states quarantined
Updating backend states
Updated service with 1 backends

$ cilium service list
ID   Frontend          Service Type   Backend
4    10.96.95.246:80   ClusterIP      1 => 10.244.0.58:80 (quarantined)
                                      2 => 10.244.1.59:80 (active)
                                      3 => 10.244.1.8:80 (active)

$ cilium service update --backends 10.244.0.58:80 --states active
Updating backend states
Updated service with 1 backends

$ cilium service list
ID   Frontend          Service Type   Backend
4    10.96.95.246:80   ClusterIP      1 => 10.244.0.58:80 (active)
                                      2 => 10.244.1.59:80 (active)
                                      3 => 10.244.1.8:80 (active)

```
See commits description for more details.


```release-note
Support setting service backend states such as quarantine, maintenance so that these backends are not selected for load-balancing service traffic. 

```