### PR TITLE
Use direct routing device only when tunneling is disabled and BPF Host Routing or NodePort are enabled.

### DIFF
--- a/daemon/cmd/devices.go
+++ b/daemon/cmd/devices.go
@@ -97,8 +97,8 @@ func (dm *DeviceManager) Detect() error {
 		}
 	}
 
-	detectDirectRoutingDev := option.Config.EnableNodePort
-	if option.Config.DirectRoutingDevice != "" {
+	detectDirectRoutingDev := option.Config.DirectRoutingDeviceRequired()
+	if option.Config.DirectRoutingDeviceRequired() && option.Config.DirectRoutingDevice != "" {
 		dm.devices[option.Config.DirectRoutingDevice] = struct{}{}
 		detectDirectRoutingDev = false
 	}

--- a/daemon/cmd/devices_test.go
+++ b/daemon/cmd/devices_test.go
@@ -72,13 +72,13 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		c.Assert(dm.GetDevices(), checker.DeepEquals, []string{})
 		option.Config.Devices = []string{}
 
-		// 2. Node IP not set, can still detect.
+		// 2. Node IP not set, can still detect. Direct routing device shouldn't be detected.
 		option.Config.EnableNodePort = true
 		c.Assert(createDummy("dummy0", "192.168.0.1/24", false), IsNil)
 		node.SetK8sNodeIP(nil)
 		c.Assert(dm.Detect(), IsNil)
 		c.Assert(dm.GetDevices(), checker.DeepEquals, []string{"dummy0"})
-		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
+		c.Assert(option.Config.DirectRoutingDevice, Equals, "")
 		option.Config.Devices = []string{}
 
 		// 3. Manually specified devices, no detection is performed
@@ -88,6 +88,7 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		option.Config.Devices = []string{"dummy0"}
 		c.Assert(dm.Detect(), IsNil)
 		c.Assert(dm.GetDevices(), checker.DeepEquals, []string{"dummy0"})
+		c.Assert(option.Config.DirectRoutingDevice, Equals, "")
 		option.Config.Devices = []string{}
 		option.Config.DirectRoutingDevice = ""
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -419,7 +419,8 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	}
 	cDefinesMap["HASH_INIT4_SEED"] = fmt.Sprintf("%d", maglev.SeedJhash0)
 	cDefinesMap["HASH_INIT6_SEED"] = fmt.Sprintf("%d", maglev.SeedJhash1)
-	if option.Config.EnableNodePort {
+
+	if option.Config.DirectRoutingDeviceRequired() {
 		directRoutingIface := option.Config.DirectRoutingDevice
 		directRoutingIfIndex, err := link.GetIfIndex(directRoutingIface)
 		if err != nil {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1472,7 +1472,11 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 		switch {
 		case !option.Config.EnableL2NeighDiscovery:
 			n.enableNeighDiscovery = false
-		case option.Config.EnableNodePort:
+		case option.Config.DirectRoutingDeviceRequired():
+			if option.Config.DirectRoutingDevice == "" {
+				return fmt.Errorf("direct routing device is required, but not defined")
+			}
+
 			mac, err := link.GetHardwareAddr(option.Config.DirectRoutingDevice)
 			if err != nil {
 				return err

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1047,6 +1047,9 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		return nil
 	})
 
+	prevTunnel := option.Config.Tunnel
+	defer func() { option.Config.Tunnel = prevTunnel }()
+	option.Config.Tunnel = option.TunnelDisabled
 	prevDRDev := option.Config.DirectRoutingDevice
 	defer func() { option.Config.DirectRoutingDevice = prevDRDev }()
 	option.Config.DirectRoutingDevice = "veth0"
@@ -1840,6 +1843,9 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 		return nil
 	})
 
+	prevTunnel := option.Config.Tunnel
+	defer func() { option.Config.Tunnel = prevTunnel }()
+	option.Config.Tunnel = option.TunnelDisabled
 	prevDRDev := option.Config.DirectRoutingDevice
 	defer func() { option.Config.DirectRoutingDevice = prevDRDev }()
 	option.Config.DirectRoutingDevice = "veth0"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1230,7 +1230,7 @@ type DaemonConfig struct {
 	RunDir              string     // Cilium runtime directory
 	NAT46Prefix         *net.IPNet // NAT46 IPv6 Prefix
 	Devices             []string   // bpf_host device
-	DirectRoutingDevice string     // Direct routing device (used only by NodePort BPF)
+	DirectRoutingDevice string     // Direct routing device (used by BPF NodePort and BPF Host Routing)
 	LBDevInheritIPAddr  string     // Device which IP addr used by bpf_host devices
 	EnableXDPPrefilter  bool       // Enable XDP-based prefiltering
 	DevicePreFilter     string     // Prefilter device
@@ -2326,6 +2326,15 @@ func (c *DaemonConfig) K8sAPIDiscoveryEnabled() bool {
 // required groups.
 func (c *DaemonConfig) K8sLeasesFallbackDiscoveryEnabled() bool {
 	return c.K8sEnableAPIDiscovery
+}
+
+// DirectRoutingDeviceRequired return whether the Direct Routing Device is needed under
+// the current configuration.
+func (c *DaemonConfig) DirectRoutingDeviceRequired() bool {
+	// BPF NodePort and BPF Host Routing are using the direct routing device now.
+	// When tunneling is enabled, node-to-node redirection will be done by tunneling.
+	BPFHostRoutingEnabled := !c.EnableHostLegacyRouting
+	return (c.EnableNodePort || BPFHostRoutingEnabled) && !c.TunnelingEnabled()
 }
 
 // EnableK8sLeasesFallbackDiscovery enables using direct API probing as a fallback to check


### PR DESCRIPTION
Please see the commit for details.

Fixes: #17480

```release-note
Use direct routing device only when tunneling is disabled and BPF Host Routing or NodePort are enabled.
```
