### PR TITLE
pkg/datapath/linux: Fix asymmetric IPsec logic on delete

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1171,7 +1171,9 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 	}
 
 	if n.nodeConfig.EnableIPSec {
-		n.deleteIPsec(oldNode)
+		if oldNode.IsLocal() || !n.subnetEncryption() {
+			n.deleteIPsec(oldNode)
+		}
 	}
 
 	if option.Config.EnableWireguard {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1339,7 +1339,7 @@ func (n *linuxNodeHandler) replaceNodeIPSecOutRoute(ip *net.IPNet) {
 
 	_, err := route.Upsert(n.createNodeIPSecOutRoute(ip))
 	if err != nil {
-		log.WithError(err).Error("Unable to replace the IPSec route OUT the host routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to replace the IPSec route OUT the host routing table")
 	}
 }
 
@@ -1359,11 +1359,11 @@ func (n *linuxNodeHandler) replaceNodeExternalIPSecOutRoute(ip *net.IPNet) {
 
 	_, err := route.Upsert(n.createNodeExternalIPSecOutRoute(ip, true))
 	if err != nil {
-		log.WithError(err).Error("Unable to replace the IPSec route OUT the default routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to replace the IPSec route OUT the default routing table")
 	}
 	_, err = route.Upsert(n.createNodeExternalIPSecOutRoute(ip, false))
 	if err != nil {
-		log.WithError(err).Error("Unable to replace the IPSec route OUT the host routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to replace the IPSec route OUT the host routing table")
 	}
 }
 
@@ -1380,7 +1380,7 @@ func (n *linuxNodeHandler) deleteNodeIPSecOutRoute(ip *net.IPNet) {
 	}
 
 	if err := route.Delete(n.createNodeIPSecOutRoute(ip)); err != nil {
-		log.WithError(err).Error("Unable to delete the IPsec route OUT from the host routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to delete the IPsec route OUT from the host routing table")
 	}
 }
 
@@ -1397,11 +1397,11 @@ func (n *linuxNodeHandler) deleteNodeExternalIPSecOutRoute(ip *net.IPNet) {
 	}
 
 	if err := route.Delete(n.createNodeExternalIPSecOutRoute(ip, true)); err != nil {
-		log.WithError(err).Error("Unable to delete the IPsec route External OUT from the ipsec routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to delete the IPsec route External OUT from the ipsec routing table")
 	}
 
 	if err := route.Delete(n.createNodeExternalIPSecOutRoute(ip, false)); err != nil {
-		log.WithError(err).Error("Unable to delete the IPsec route External OUT from the host routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to delete the IPsec route External OUT from the host routing table")
 	}
 }
 
@@ -1421,7 +1421,7 @@ func (n *linuxNodeHandler) replaceNodeIPSecInRoute(ip *net.IPNet) {
 
 	_, err := route.Upsert(n.createNodeIPSecInRoute(ip))
 	if err != nil {
-		log.WithError(err).Error("Unable to replace the IPSec route IN the host routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to replace the IPSec route IN the host routing table")
 	}
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1323,13 +1323,10 @@ func (n *linuxNodeHandler) createNodeExternalIPSecOutRoute(ip *net.IPNet, dflt b
 	}
 }
 
-// replaceNodeIPSecOutRoute replace the out IPSec route in the host routing table
-// with the new route. If no route exists the route is installed on the host.
+// replaceNodeIPSecOutRoute replace the out IPSec route in the host routing
+// table with the new route. If no route exists the route is installed on the
+// host. The caller must ensure that the CIDR passed in must be non-nil.
 func (n *linuxNodeHandler) replaceNodeIPSecOutRoute(ip *net.IPNet) {
-	if ip == nil {
-		return
-	}
-
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
 			return
@@ -1346,13 +1343,10 @@ func (n *linuxNodeHandler) replaceNodeIPSecOutRoute(ip *net.IPNet) {
 	}
 }
 
-// replaceNodeExternalIPSecOutRoute replace the out IPSec route in the host routing table
-// with the new route. If no route exists the route is installed on the host.
+// replaceNodeExternalIPSecOutRoute replace the out IPSec route in the host
+// routing table with the new route. If no route exists the route is installed
+// on the host. The caller must ensure that the CIDR passed in must be non-nil.
 func (n *linuxNodeHandler) replaceNodeExternalIPSecOutRoute(ip *net.IPNet) {
-	if ip == nil {
-		return
-	}
-
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
 			return
@@ -1373,11 +1367,8 @@ func (n *linuxNodeHandler) replaceNodeExternalIPSecOutRoute(ip *net.IPNet) {
 	}
 }
 
+// The caller must ensure that the CIDR passed in must be non-nil.
 func (n *linuxNodeHandler) deleteNodeIPSecOutRoute(ip *net.IPNet) {
-	if ip == nil {
-		return
-	}
-
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
 			return
@@ -1393,11 +1384,8 @@ func (n *linuxNodeHandler) deleteNodeIPSecOutRoute(ip *net.IPNet) {
 	}
 }
 
+// The caller must ensure that the CIDR passed in must be non-nil.
 func (n *linuxNodeHandler) deleteNodeExternalIPSecOutRoute(ip *net.IPNet) {
-	if ip == nil {
-		return
-	}
-
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
 			return
@@ -1417,13 +1405,10 @@ func (n *linuxNodeHandler) deleteNodeExternalIPSecOutRoute(ip *net.IPNet) {
 	}
 }
 
-// replaceNodeIPSecoInRoute replace the in IPSec routes in the host routing table
-// with the new route. If no route exists the route is installed on the host.
+// replaceNodeIPSecoInRoute replace the in IPSec routes in the host routing
+// table with the new route. If no route exists the route is installed on the
+// host. The caller must ensure that the CIDR passed in must be non-nil.
 func (n *linuxNodeHandler) replaceNodeIPSecInRoute(ip *net.IPNet) {
-	if ip == nil {
-		return
-	}
-
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
 			return

--- a/pkg/datapath/node.go
+++ b/pkg/datapath/node.go
@@ -116,8 +116,9 @@ type NodeHandler interface {
 	// NodeDelete is called after a node has been deleted
 	NodeDelete(node nodeTypes.Node) error
 
-	// NodeValidateImplementation is called to validate the implementation
-	// of the node in the datapath
+	// NodeValidateImplementation is called to validate the implementation of
+	// the node in the datapath. This function is intended to be run on an
+	// interval to ensure that the datapath is consistently converged.
 	NodeValidateImplementation(node nodeTypes.Node) error
 
 	// NodeConfigurationChanged is called when the local node configuration

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -307,6 +307,8 @@ func (m *Manager) backgroundSyncInterval() time.Duration {
 	return m.ClusterSizeDependantInterval(baseBackgroundSyncInterval)
 }
 
+// backgroundSync ensures that local node has a valid datapath in-place for
+// each node in the cluster. See NodeValidateImplementation().
 func (m *Manager) backgroundSync() {
 	syncTimer, syncTimerDone := inctimer.New()
 	defer syncTimerDone()


### PR DESCRIPTION
First 3 commits are cleanups, the last commit is the main fix.

-  pkg/datapath, pkg/node/manager: Clarify NodeValidateImplementation godoc
- pkg/datapath/linux: Remove unnecessary branch in IPsec route functions
- pkg/datapath/linux: Add CIDR logfield to IPsec route logs
- pkg/datapath/linux: Fix asymmetric IPsec logic on delete

```release-note
Fix connectivity outage periods with ENI IPAM mode and IPsec enabled when nodes are deleted from the cluster
```