### PR TITLE
v1.11 backports 2022-02-17

### DIFF
--- a/pkg/ipam/allocator/alibabacloud/alibabacloud.go
+++ b/pkg/ipam/allocator/alibabacloud/alibabacloud.go
@@ -37,7 +37,7 @@ func (a *AllocatorAlibabaCloud) Init(ctx context.Context) error {
 	var aMetrics openapi.MetricsAPI
 
 	if operatorOption.Config.EnableMetrics {
-		aMetrics = apiMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, "alibaba-cloud", operatorMetrics.Registry)
+		aMetrics = apiMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, "alibabacloud", operatorMetrics.Registry)
 	} else {
 		aMetrics = &apiMetrics.NoOpMetrics{}
 	}

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -603,6 +603,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 			if len(c.AlibabaCloud.SecurityGroupTags) > 0 {
 				nodeResource.Spec.AlibabaCloud.SecurityGroupTags = c.AlibabaCloud.SecurityGroupTags
 			}
+
+			if c.IPAM.PreAllocate != 0 {
+				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
+			}
 		}
 	}
 


### PR DESCRIPTION
 * not included due to conflicts #18696 -- test: Restructure k8sT/Services.go (@brb)
 * #18762 -- Alibabacloud fixes (@jaffcheng)
 * #18790 -- iptables: Fix race condition on ipset removal (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18762 18790; do contrib/backporting/set-labels.py $pr done 1.11; done
```
or with
```
$ make add-label branch=v1.11 issues=18762,18790
```