### PR TITLE
test: Flush CT tables after L7 proxy tests in K8sServices

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2823,6 +2823,18 @@ func (kub *Kubectl) CiliumExecMustSucceed(ctx context.Context, pod, cmd string, 
 	return res
 }
 
+// CiliumExecMustSucceedOnAll does the same as CiliumExecMustSucceed, just that
+// it execs cmd on all cilium-agent pods.
+func (kub *Kubectl) CiliumExecMustSucceedOnAll(ctx context.Context, cmd string, optionalDescription ...interface{}) {
+	pods, err := kub.GetCiliumPods()
+	gomega.Expect(err).Should(gomega.BeNil(), "failed to retrieve Cilium pods")
+
+	for _, pod := range pods {
+		kub.CiliumExecMustSucceed(ctx, pod, cmd, optionalDescription).
+			ExpectSuccess("failed to execute %q on Cilium pod %s", cmd, pod)
+	}
+}
+
 // CiliumExecUntilMatch executes the specified command repeatedly for the
 // specified Cilium pod until the given substring is present in stdout.
 // If the timeout is reached it will return an error.

--- a/test/k8sT/service_helpers.go
+++ b/test/k8sT/service_helpers.go
@@ -680,14 +680,9 @@ func testNodePortExternal(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, testS
 		testCurlFromOutside(kubectl, ni, httpURL, 10, checkTCP)
 		testCurlFromOutside(kubectl, ni, tftpURL, 10, checkUDP)
 
-		// Clear CT tables on both Cilium nodes
-		pod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
-		ExpectWithOffset(1, err).Should(BeNil(), "Cannot determine cilium pod name")
-		kubectl.CiliumExecMustSucceed(context.TODO(), pod, "cilium bpf ct flush global", "Unable to flush CT maps")
-
-		pod, err = kubectl.GetCiliumPodOnNode(helpers.K8s2)
-		ExpectWithOffset(1, err).Should(BeNil(), "Cannot determine cilium pod name")
-		kubectl.CiliumExecMustSucceed(context.TODO(), pod, "cilium bpf ct flush global", "Unable to flush CT maps")
+		// Clear CT tables on all Cilium nodes
+		kubectl.CiliumExecMustSucceedOnAll(context.TODO(),
+			"cilium bpf ct flush global", "Unable to flush CT maps")
 	}
 }
 


### PR DESCRIPTION
While debugging a CI flake in which pod2pod@same host via ClusterIP
done by bpf_lxc TCP SYN was not making into the dst pod, I've noticed
that the corresponding CT entry had ProxyRedirect flag set. The test
case in which the flag happened didn't have any L7 CNP, but some
previous test case had it. So it's very likely that the CT entry was
reused for by the connection which failed.

Paul Chaignon pointed to a very similar issue \[1\].

For now, to avoid such flakes, clear the CT tables to avoid stale CT
entries reuse.

\[1\]: https://github.com/cilium/cilium/issues/17459

---

The CI failure was the following:
```
/home/jenkins/workspace/Cilium-PR-K8s-1.23-kernel-net-next/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:527
Request from testclient-v4tq8 pod to service [http://10.102.56.251:80](http://10.102.56.251/) failed
Expected command: kubectl exec -n default testclient-v4tq8 -- /bin/bash -c 'fails=""; id=$RANDOM; for i in $(seq 1 10); do if curl --path-as-is -s -D /dev/stderr --fail --connect-timeout 5 --max-time 20 [http://10.102.56.251:80](http://10.102.56.251/) -H "User-Agent: cilium-test-$id/$i"; then echo "Test round $id/$i exit code: $?"; else fails=$fails:$id/$i=$?; fi; done; if [ -n "$fails" ]; then echo "failed: $fails"; fi; cnt="${fails//[^:]}"; if [ ${#cnt} -gt 0 ]; then exit 42; fi' 
To succeed, but it failed:
Exitcode: 42 
Err: exit status 42
Stdout:
```
https://jenkins.cilium.io/job/Cilium-PR-K8s-1.23-kernel-net-next/522/testReport/junit/Suite-k8s-1/23/K8sServicesTest_Checks_E_W_loadbalancing__ClusterIP__NodePort_from_inside_cluster__etc__Checks_connectivity_when_skipping_socket_lb_in_pod_ns_Checks_ClusterIP_connectivity/

This might explain more pod2pod flakes which we saw in the CI.
