### PR TITLE
test: Don't redeploy in AfterAll of K8sServices test case

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -769,7 +769,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			AfterAll(func() {
 				res := kubectl.DelIPRoute(ni.OutsideNodeName, svcIP, ni.K8s1IP)
 				Expect(res).Should(helpers.CMDSuccess(), "Error removing IP route for %s via %s", svcIP, ni.K8s1IP)
-				DeployCiliumAndDNS(kubectl, ciliumFilename)
 			})
 
 			It("ClusterIP can be accessed when external access is enabled", func() {


### PR DESCRIPTION
There is no need to redeploy Cilium in AfterAll of the "With ClusterIP
external access" test suite, as the next test case will deploy it
anyway.

It should improve the K8sServices test suite run time by a bit.