### PR TITLE
hubble: Added nil check in filterByTCPFlags() to avoid segfault

### DIFF
--- a/pkg/hubble/filters/tcp.go
+++ b/pkg/hubble/filters/tcp.go
@@ -13,11 +13,10 @@ import (
 
 func filterByTCPFlags(flags []*flowpb.TCPFlags) (FilterFunc, error) {
 	return func(ev *v1.Event) bool {
-		l4tcp := ev.GetFlow().GetL4().GetTCP()
-		if l4tcp == nil {
+		flowFlags := ev.GetFlow().GetL4().GetTCP().GetFlags()
+		if flowFlags == nil {
 			return false
 		}
-		flowFlags := l4tcp.GetFlags()
 		// check if the TCP event has any of the flags mentioned in flowfilter
 		// example: if TCP event has flags SYN and ACK set and if the flowfilter
 		// only has SYN, then this event should be accepted by the filter.


### PR DESCRIPTION
Cilium agent crashes when an L7/HTTP flow is passed to TCP flag flow
filter (`filterByTCPFlags`). This is because HTTP flows will have
some L4/TCP info such as src/dst port in the flow struct, but will not
contain TCP flags.

Added `nil` check for TCP flag pointer to avoid the segfault.

Fixes: #18830

Signed-off-by: Wazir Ahmed <wazir@accuknox.com>