### PR TITLE
v1.11 backport: manual backport of "test: Restructure k8sT/Services.go"

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4321,7 +4321,17 @@ func validateCiliumSvc(cSvc models.Service, k8sSvcs []v1.Service, k8sEps []v1.En
 			k8sService = &k8sSvc
 			break
 		}
+		for _, clusterIP := range k8sSvc.Spec.ClusterIPs {
+			if clusterIP == cSvc.Status.Realized.FrontendAddress.IP {
+				k8sService = &k8sSvc
+				break
+			}
+		}
+		if k8sService != nil {
+			break
+		}
 	}
+
 	if k8sService == nil {
 		return fmt.Errorf("Could not find Cilium service with ip %s in k8s", cSvc.Spec.FrontendAddress.IP)
 	}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -686,6 +686,8 @@ func SkipK8sVersions(k8sVersions string) bool {
 // enabled or not for the cluster.
 func DualStackSupported() bool {
 	supportedVersions := versioncheck.MustCompile(">=1.18.0")
+	kubeProxyOnlySupportedVersions := versioncheck.MustCompile(">=1.20.0")
+
 	k8sVersion, err := versioncheck.Version(GetCurrentK8SEnv())
 	if err != nil {
 		// If we cannot conclude the k8s version we assume that dual stack is not
@@ -693,8 +695,15 @@ func DualStackSupported() bool {
 		return false
 	}
 
+	// When running with kube-proxy only, some IPv6 family services are not
+	// provisioned in ip6tables on k8s < 1.20. Therefore, skip any DualStack
+	// tests on those versions/configurations.
+	if DoesNotRunWithKubeProxyReplacement() && !kubeProxyOnlySupportedVersions(k8sVersion) {
+		return false
+	}
+
 	// We only have DualStack enabled in Vagrant test env.
-	return GetCurrentIntegration() == "" && supportedVersions(k8sVersion)
+	return (GetCurrentIntegration() == "" && supportedVersions(k8sVersion))
 }
 
 // DualStackSupportBeta returns true if the environment has a Kubernetes version that

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -53,7 +53,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		Expect(err).Should(BeNil(), "Cannot get nodes info")
 
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-		DeployCiliumAndDNS(kubectl, ciliumFilename)
 	})
 
 	AfterFailed(func() {
@@ -80,6 +79,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		)
 
 		BeforeAll(func() {
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+
 			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 			echoSVCYAML = helpers.ManifestGet(kubectl.BasePath(), "echo-svc.yaml")
 			echoPolicyYAML = helpers.ManifestGet(kubectl.BasePath(), "echo-policy.yaml")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -493,24 +493,19 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 	})
 
 	Context("Checks N/S loadbalancing", func() {
-		var (
-			demoYAML   string
-			demoYAMLV6 string
-		)
+		var yamls []string
 
 		BeforeAll(func() {
-			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
-
 			DeployCiliumAndDNS(kubectl, ciliumFilename)
 
-			res := kubectl.ApplyDefault(demoYAML)
-			Expect(res).Should(helpers.CMDSuccess(), "Unable to apply %s", demoYAML)
-
+			toApply := []string{"demo.yaml", "demo_ds.yaml", "echo-svc.yaml"}
 			if helpers.DualStackSupported() {
-				demoYAMLV6 = helpers.ManifestGet(kubectl.BasePath(), "demo_ds_v6.yaml")
-
-				res = kubectl.ApplyDefault(demoYAMLV6)
-				Expect(res).Should(helpers.CMDSuccess(), "Unable to apply %s", demoYAMLV6)
+				toApply = append(toApply, "demo_ds_v6.yaml")
+			}
+			for _, fn := range toApply {
+				path := helpers.ManifestGet(kubectl.BasePath(), fn)
+				kubectl.ApplyDefault(path).ExpectSuccess("Unable to apply %s", path)
+				yamls = append(yamls, path)
 			}
 
 			By(`Connectivity config:: helpers.DualStackSupported(): %v
@@ -518,13 +513,14 @@ Primary Interface %s   :: IPv4: (%s, %s), IPv6: (%s, %s)
 Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupported(), ni.PrivateIface, ni.K8s1IP, ni.K8s2IP, ni.PrimaryK8s1IPv6, ni.PrimaryK8s2IPv6,
 				helpers.SecondaryIface, ni.SecondaryK8s1IPv4, ni.SecondaryK8s2IPv4, ni.SecondaryK8s1IPv6, ni.SecondaryK8s2IPv6)
 
-			waitPodsDs(kubectl, []string{testDS, testDSClient, testDSK8s2})
+			// Wait for all pods to be in ready state.
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
+			Expect(err).Should(BeNil())
 		})
 
 		AfterAll(func() {
-			kubectl.Delete(demoYAML)
-			if helpers.DualStackSupported() {
-				kubectl.Delete(demoYAMLV6)
+			for _, yaml := range yamls {
+				kubectl.Delete(yaml)
 			}
 			ExpectAllPodsTerminated(kubectl)
 		})
@@ -567,43 +563,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						It("Tests NodePort", func() {
 							testNodePort(kubectl, ni, true, false, helpers.ExistNodeWithoutCilium(), 0)
 						})
-					})
-
-					// TODO(brb) use one of the maglev test cases below to run testMaglev()
-					Context("Tests NodePort with Maglev", func() {
-						var echoYAML string
-
-						BeforeAll(func() {
-							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-								"loadBalancer.algorithm": "maglev",
-								// The echo svc has two backends. the closest supported
-								// prime number which is greater than 100 * |backends_count|
-								// is 251.
-								"maglev.tableSize": "251",
-								// Support for host firewall + Maglev is currently broken,
-								// see #14047 for details.
-								"hostFirewall.enabled": "false",
-							})
-
-							echoYAML = helpers.ManifestGet(kubectl.BasePath(), "echo-svc.yaml")
-							kubectl.ApplyDefault(echoYAML).ExpectSuccess("unable to apply %s", echoYAML)
-							err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l name=echo", helpers.HelperTimeout)
-							Expect(err).Should(BeNil())
-						})
-
-						AfterAll(func() {
-							kubectl.Delete(echoYAML)
-							ExpectAllPodsTerminated(kubectl)
-						})
-
-						It("Tests NodePort", func() {
-							testNodePort(kubectl, ni, true, false, helpers.ExistNodeWithoutCilium(), 0)
-						})
-
-						SkipItIf(helpers.DoesNotExistNodeWithoutCilium,
-							"Tests Maglev backend selection", func() {
-								testMaglev(kubectl, ni)
-							})
 					})
 
 					SkipItIf(func() bool {
@@ -668,44 +627,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						It("Tests NodePort", func() {
 							testNodePort(kubectl, ni, true, false, helpers.ExistNodeWithoutCilium(), 0)
 						})
-					})
-
-					Context("Tests NodePort with Maglev", func() {
-						var echoYAML string
-
-						BeforeAll(func() {
-							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-								"tunnel":                 "disabled",
-								"autoDirectNodeRoutes":   "true",
-								"loadBalancer.algorithm": "maglev",
-								// The echo svc has two backends. the closest supported
-								// prime number which is greater than 100 * |backends_count|
-								// is 251.
-								"maglev.tableSize": "251",
-								// Support for host firewall + Maglev is currently broken,
-								// see #14047 for details.
-								"hostFirewall.enabled": "false",
-							})
-
-							echoYAML = helpers.ManifestGet(kubectl.BasePath(), "echo-svc.yaml")
-							kubectl.ApplyDefault(echoYAML).ExpectSuccess("unable to apply %s", echoYAML)
-							err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l name=echo", helpers.HelperTimeout)
-							Expect(err).Should(BeNil())
-						})
-
-						AfterAll(func() {
-							kubectl.Delete(echoYAML)
-							ExpectAllPodsTerminated(kubectl)
-						})
-
-						It("Tests NodePort", func() {
-							testNodePort(kubectl, ni, true, false, helpers.ExistNodeWithoutCilium(), 0)
-						})
-
-						SkipItIf(helpers.DoesNotExistNodeWithoutCilium,
-							"Tests Maglev backend selection", func() {
-								testMaglev(kubectl, ni)
-							})
 					})
 
 					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests GH#10983", func() {
@@ -786,6 +707,8 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						// see #14047 for details.
 						"hostFirewall.enabled": "false",
 					})
+
+					testMaglev(kubectl, ni)
 					testNodePortExternal(kubectl, ni, false, false)
 				})
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -70,13 +70,14 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 
 	Context("Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc)", func() {
 		var yamls []string
+		var demoPolicyL7 string
 
 		BeforeAll(func() {
 			DeployCiliumAndDNS(kubectl, ciliumFilename)
 
 			toApply := []string{"demo.yaml", "demo_ds.yaml", "echo-svc.yaml", "echo-policy.yaml"}
 			if helpers.DualStackSupported() {
-				toApply = append(toApply, "demo_v6.yaml", "echo-svc_v6.yaml")
+				toApply = append(toApply, "demo_v6.yaml", "demo_ds_v6.yaml", "echo-svc_v6.yaml")
 				if helpers.DualStackSupportBeta() {
 					toApply = append(toApply, "echo_svc_dualstack.yaml")
 				}
@@ -90,6 +91,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			// Wait for all pods to be in ready state.
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
+
+			demoPolicyL7 = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-demo.yaml")
 		})
 
 		AfterAll(func() {
@@ -181,6 +184,43 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				url = fmt.Sprintf("tftp://%s/hello", net.JoinHostPort(clusterIP, "69"))
 				testCurlFromPods(kubectl, app2PodLabel, url, 10, 0)
 			}
+		})
+
+		SkipContextIf(helpers.DoesNotRunWithKubeProxyReplacement, "Checks in-cluster KPR", func() {
+			It("Tests NodePort", func() {
+				testNodePort(kubectl, ni, true, false, false, 0)
+			})
+
+			It("Tests NodePort with externalTrafficPolicy=Local", func() {
+				// TODO(brb) split testExternalTrafficPolicyLocal into two functions -
+				// one for in-cluster, one for outside cluster
+				testExternalTrafficPolicyLocal(kubectl, ni)
+			})
+
+			It("Tests NodePort with sessionAffinity", func() {
+				testSessionAffinity(kubectl, ni, false, true)
+			})
+
+			It("Tests HealthCheckNodePort", func() {
+				testHealthCheckNodePort(kubectl, ni)
+			})
+
+			It("Tests that binding to NodePort port fails", func() {
+				testFailBind(kubectl, ni)
+			})
+
+			It("Tests HostPort", func() {
+				testHostPort(kubectl, ni)
+			})
+
+			Context("with L7 policy", func() {
+				AfterAll(func() { kubectl.Delete(demoPolicyL7) })
+
+				It("Tests NodePort with L7 Policy", func() {
+					applyPolicy(kubectl, demoPolicyL7)
+					testNodePort(kubectl, ni, false, false, false, 0)
+				})
+			})
 		})
 
 		// The test is relevant only for bpf_lxc LB, while bpf_sock (KPR enabled)
@@ -454,9 +494,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 
 	Context("Checks N/S loadbalancing", func() {
 		var (
-			demoYAML     string
-			demoYAMLV6   string
-			demoPolicyL7 string
+			demoYAML   string
+			demoYAMLV6 string
 		)
 
 		BeforeAll(func() {
@@ -479,7 +518,6 @@ Primary Interface %s   :: IPv4: (%s, %s), IPv6: (%s, %s)
 Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupported(), ni.PrivateIface, ni.K8s1IP, ni.K8s2IP, ni.PrimaryK8s1IPv6, ni.PrimaryK8s2IPv6,
 				helpers.SecondaryIface, ni.SecondaryK8s1IPv4, ni.SecondaryK8s2IPv4, ni.SecondaryK8s1IPv6, ni.SecondaryK8s2IPv6)
 
-			demoPolicyL7 = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-demo.yaml")
 			waitPodsDs(kubectl, []string{testDS, testDSClient, testDSK8s2})
 		})
 
@@ -494,32 +532,8 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 		SkipContextIf(helpers.DoesNotRunWithKubeProxyReplacement, "Tests NodePort BPF",
 			func() {
 				Context("Tests with vxlan", func() {
-					It("Tests NodePort", func() {
-						testNodePort(kubectl, ni, true, false, helpers.ExistNodeWithoutCilium(), 0)
-					})
-
-					It("Tests NodePort with externalTrafficPolicy=Local", func() {
-						testExternalTrafficPolicyLocal(kubectl, ni)
-					})
-
-					It("Tests NodePort with sessionAffinity", func() {
-						testSessionAffinity(kubectl, ni, false, true)
-					})
-
 					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests NodePort with sessionAffinity from outside", func() {
 						testSessionAffinity(kubectl, ni, true, true)
-					})
-
-					It("Tests HealthCheckNodePort", func() {
-						testHealthCheckNodePort(kubectl, ni)
-					})
-
-					It("Tests that binding to NodePort port fails", func() {
-						testFailBind(kubectl, ni)
-					})
-
-					It("Tests HostPort", func() {
-						testHostPort(kubectl, ni)
 					})
 
 					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests externalIPs", func() {
@@ -555,15 +569,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						})
 					})
 
-					Context("with L7 policy", func() {
-						AfterAll(func() { kubectl.Delete(demoPolicyL7) })
-
-						It("Tests NodePort with L7 Policy", func() {
-							applyPolicy(kubectl, demoPolicyL7)
-							testNodePort(kubectl, ni, false, false, false, 0)
-						})
-					})
-
+					// TODO(brb) use one of the maglev test cases below to run testMaglev()
 					Context("Tests NodePort with Maglev", func() {
 						var echoYAML string
 
@@ -622,32 +628,8 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						})
 					})
 
-					It("Tests NodePort", func() {
-						testNodePort(kubectl, ni, true, false, helpers.ExistNodeWithoutCilium(), 0)
-					})
-
-					It("Tests NodePort with externalTrafficPolicy=Local", func() {
-						testExternalTrafficPolicyLocal(kubectl, ni)
-					})
-
-					It("Tests NodePort with sessionAffinity", func() {
-						testSessionAffinity(kubectl, ni, false, false)
-					})
-
 					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests NodePort with sessionAffinity from outside", func() {
 						testSessionAffinity(kubectl, ni, true, false)
-					})
-
-					It("Tests HealthCheckNodePort", func() {
-						testHealthCheckNodePort(kubectl, ni)
-					})
-
-					It("Tests that binding to NodePort port fails", func() {
-						testFailBind(kubectl, ni)
-					})
-
-					It("Tests HostPort", func() {
-						testHostPort(kubectl, ni)
 					})
 
 					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests externalIPs", func() {
@@ -685,15 +667,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 						It("Tests NodePort", func() {
 							testNodePort(kubectl, ni, true, false, helpers.ExistNodeWithoutCilium(), 0)
-						})
-					})
-
-					Context("with L7 policy", func() {
-						AfterAll(func() { kubectl.Delete(demoPolicyL7) })
-
-						It("Tests NodePort with L7 Policy", func() {
-							applyPolicy(kubectl, demoPolicyL7)
-							testNodePort(kubectl, ni, false, false, false, 0)
 						})
 					})
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -280,14 +280,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		})
 	})
 
-	SkipContextIf(func() bool {
-		return helpers.SkipQuarantined() && helpers.RunsOnNetNextKernel()
-	}, "Checks service across nodes", func() {
-
+	Context("Checks N/S loadbalancing", func() {
 		var (
-			demoYAML   string
-			demoYAMLV6 string
-
+			demoYAML     string
+			demoYAMLV6   string
 			demoPolicyL7 string
 		)
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -205,78 +205,78 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			}
 
 		}, 600)
-	})
 
-	SkipContextIf(func() bool {
-		return helpers.DoesNotRunWithKubeProxyReplacement() || helpers.DoesNotRunOnNetNextKernel()
-	}, "Checks connectivity when skipping socket lb in pod ns", func() {
-		var yamls []string
+		SkipContextIf(func() bool {
+			return helpers.DoesNotRunWithKubeProxyReplacement() || helpers.DoesNotRunOnNetNextKernel()
+		}, "Checks connectivity when skipping socket lb in pod ns", func() {
+			var yamls []string
 
-		BeforeAll(func() {
-			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-				"hostServices.hostNamespaceOnly": "true",
+			BeforeAll(func() {
+				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+					"hostServices.hostNamespaceOnly": "true",
+				})
+
+				yamls = []string{"demo_ds.yaml"}
+				if helpers.DualStackSupported() {
+					yamls = append(yamls, "demo_ds_v6.yaml")
+				}
+
+				for _, yaml := range yamls {
+					path := helpers.ManifestGet(kubectl.BasePath(), yaml)
+					kubectl.ApplyDefault(path).
+						ExpectSuccess("Unable to apply %s", path)
+				}
+				waitPodsDs(kubectl, []string{testDS, testDSClient, testDSK8s2})
 			})
 
-			yamls = []string{"demo_ds.yaml"}
-			if helpers.DualStackSupported() {
-				yamls = append(yamls, "demo_ds_v6.yaml")
-			}
+			AfterAll(func() {
+				for _, yaml := range yamls {
+					path := helpers.ManifestGet(kubectl.BasePath(), yaml)
+					kubectl.Delete(path)
+				}
+				ExpectAllPodsTerminated(kubectl)
+			})
 
-			for _, yaml := range yamls {
-				path := helpers.ManifestGet(kubectl.BasePath(), yaml)
-				kubectl.ApplyDefault(path).
-					ExpectSuccess("Unable to apply %s", path)
-			}
-			waitPodsDs(kubectl, []string{testDS, testDSClient, testDSK8s2})
-		})
+			// In adition to the bpf_sock bypass, this test is testing whether bpf_lxc
+			// ClusterIP for IPv6 is working
+			It("Checks ClusterIP connectivity", func() {
+				services := []string{testDSServiceIPv4}
+				if helpers.DualStackSupported() {
+					services = append(services, testDSServiceIPv6)
+				}
 
-		AfterAll(func() {
-			for _, yaml := range yamls {
-				path := helpers.ManifestGet(kubectl.BasePath(), yaml)
-				kubectl.Delete(path)
-			}
-			ExpectAllPodsTerminated(kubectl)
-		})
+				// Test that socket lb doesn't kick in, aka we see service VIP in monitor output.
+				// Note that cilium monitor won't capture service VIP if run with Istio.
+				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
+				Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
+				monitorRes, monitorCancel := kubectl.MonitorStart(ciliumPodK8s1)
+				defer func() {
+					monitorCancel()
+					helpers.WriteToReportFile(monitorRes.CombineOutput().Bytes(), "skip-socket-lb-connectivity-across-nodes.log")
+				}()
 
-		// In adition to the bpf_sock bypass, this test is testing whether bpf_lxc
-		// ClusterIP for IPv6 is working
-		It("Checks ClusterIP connectivity", func() {
-			services := []string{testDSServiceIPv4}
-			if helpers.DualStackSupported() {
-				services = append(services, testDSServiceIPv6)
-			}
+				for _, service := range services {
+					clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, service)
+					Expect(err).Should(BeNil(), "Cannot get services %s", service)
+					Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
+					httpURL := fmt.Sprintf("http://%s", net.JoinHostPort(clusterIP, "80"))
+					tftpURL := fmt.Sprintf("tftp://%s/hello", net.JoinHostPort(clusterIP, "69"))
 
-			// Test that socket lb doesn't kick in, aka we see service VIP in monitor output.
-			// Note that cilium monitor won't capture service VIP if run with Istio.
-			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
-			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
-			monitorRes, monitorCancel := kubectl.MonitorStart(ciliumPodK8s1)
-			defer func() {
-				monitorCancel()
-				helpers.WriteToReportFile(monitorRes.CombineOutput().Bytes(), "skip-socket-lb-connectivity-across-nodes.log")
-			}()
+					// Test connectivity from root ns (bpf_sock)
+					kubectl.ExecInHostNetNS(context.TODO(), ni.K8s1NodeName,
+						helpers.CurlFail(httpURL)).
+						ExpectSuccess("cannot curl to service IP from host")
+					kubectl.ExecInHostNetNS(context.TODO(), ni.K8s1NodeName,
+						helpers.CurlFail(tftpURL)).
+						ExpectSuccess("cannot curl to service IP from host")
 
-			for _, service := range services {
-				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, service)
-				Expect(err).Should(BeNil(), "Cannot get services %s", service)
-				Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
-				httpURL := fmt.Sprintf("http://%s", net.JoinHostPort(clusterIP, "80"))
-				tftpURL := fmt.Sprintf("tftp://%s/hello", net.JoinHostPort(clusterIP, "69"))
+					// Test connectivity from pod netns (bpf_lxc)
+					testCurlFromPods(kubectl, testDSClient, httpURL, 10, 0)
+					testCurlFromPods(kubectl, testDSClient, tftpURL, 10, 0)
 
-				// Test connectivity from root ns (bpf_sock)
-				kubectl.ExecInHostNetNS(context.TODO(), ni.K8s1NodeName,
-					helpers.CurlFail(httpURL)).
-					ExpectSuccess("cannot curl to service IP from host")
-				kubectl.ExecInHostNetNS(context.TODO(), ni.K8s1NodeName,
-					helpers.CurlFail(tftpURL)).
-					ExpectSuccess("cannot curl to service IP from host")
-
-				// Test connectivity from pod netns (bpf_lxc)
-				testCurlFromPods(kubectl, testDSClient, httpURL, 10, 0)
-				testCurlFromPods(kubectl, testDSClient, tftpURL, 10, 0)
-
-				monitorRes.ExpectContains(clusterIP, "Service VIP not seen in monitor trace, indicating socket lb still in effect")
-			}
+					monitorRes.ExpectContains(clusterIP, "Service VIP not seen in monitor trace, indicating socket lb still in effect")
+				}
+			})
 		})
 	})
 
@@ -941,9 +941,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			BeforeAll(func() {
 				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 					"bpf.lbExternalClusterIP": "true",
-					// Enable Maglev to check if the Maglev LUT for ClusterIP is properly populated,
-					// and external clients can access ClusterIP with it.
-					"loadBalancer.algorithm": "maglev",
 				})
 				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, appServiceName)
 				svcIP = clusterIP

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -321,25 +321,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			ExpectAllPodsTerminated(kubectl)
 		})
 
-		SkipItIf(helpers.RunsWithKubeProxyReplacement, "Checks ClusterIP Connectivity", func() {
-			services := []string{testDSServiceIPv4}
-			if helpers.DualStackSupported() {
-				services = append(services, testDSServiceIPv6)
-			}
-
-			for _, svcName := range services {
-				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, svcName)
-				Expect(err).Should(BeNil(), "Cannot get service %s", svcName)
-				Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
-
-				url := fmt.Sprintf("http://%s", net.JoinHostPort(clusterIP, "80"))
-				testCurlFromPods(kubectl, testDSClient, url, 10, 0)
-
-				url = fmt.Sprintf("tftp://%s/hello", net.JoinHostPort(clusterIP, "69"))
-				testCurlFromPods(kubectl, testDSClient, url, 10, 0)
-			}
-		})
-
 		SkipContextIf(helpers.RunsWithKubeProxyReplacement, "Tests NodePort (kube-proxy)", func() {
 			SkipItIf(helpers.DoesNotRunOn419OrLaterKernel, "with IPSec and externalTrafficPolicy=Local", func() {
 				deploymentManager.SetKubectl(kubectl)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -489,10 +489,12 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				testNodePort(kubectl, ni, false, false, false, 0)
 			})
 		})
-
 	})
 
-	Context("Checks N/S loadbalancing", func() {
+	SkipContextIf(func() bool {
+		return helpers.DoesNotRunWithKubeProxyReplacement() ||
+			helpers.DoesNotExistNodeWithoutCilium()
+	}, "Checks N/S loadbalancing", func() {
 		var yamls []string
 
 		BeforeAll(func() {
@@ -510,8 +512,11 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 
 			By(`Connectivity config:: helpers.DualStackSupported(): %v
 Primary Interface %s   :: IPv4: (%s, %s), IPv6: (%s, %s)
-Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupported(), ni.PrivateIface, ni.K8s1IP, ni.K8s2IP, ni.PrimaryK8s1IPv6, ni.PrimaryK8s2IPv6,
-				helpers.SecondaryIface, ni.SecondaryK8s1IPv4, ni.SecondaryK8s2IPv4, ni.SecondaryK8s1IPv6, ni.SecondaryK8s2IPv6)
+Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
+				helpers.DualStackSupported(), ni.PrivateIface,
+				ni.K8s1IP, ni.K8s2IP, ni.PrimaryK8s1IPv6, ni.PrimaryK8s2IPv6,
+				helpers.SecondaryIface, ni.SecondaryK8s1IPv4, ni.SecondaryK8s2IPv4,
+				ni.SecondaryK8s1IPv6, ni.SecondaryK8s2IPv6)
 
 			// Wait for all pods to be in ready state.
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
@@ -525,261 +530,160 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			ExpectAllPodsTerminated(kubectl)
 		})
 
-		SkipContextIf(helpers.DoesNotRunWithKubeProxyReplacement, "Tests NodePort BPF",
-			func() {
-				Context("Tests with vxlan", func() {
-					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests NodePort with sessionAffinity from outside", func() {
-						testSessionAffinity(kubectl, ni, true, true)
-					})
+		It("Tests NodePort with sessionAffinity from outside", func() {
+			testSessionAffinity(kubectl, ni, true, true)
+		})
 
-					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests externalIPs", func() {
-						testExternalIPs(kubectl, ni)
-					})
+		It("Tests externalIPs", func() {
+			testExternalIPs(kubectl, ni)
+		})
 
-					SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
-						var ccnpHostPolicy string
+		It("Tests GH#10983", func() {
+			var data v1.Service
 
-						BeforeAll(func() {
-							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-								"hostFirewall.enabled": "true",
-							})
+			// We need two NodePort services with the same single endpoint,
+			// so thus we choose the "test-nodeport{-local,}-k8s2" svc.
+			// Both svcs will be accessed via the k8s2 node, because
+			// "test-nodeport-local-k8s2" has the local external traffic
+			// policy.
+			err := kubectl.Get(helpers.DefaultNamespace, "svc test-nodeport-local-k8s2").Unmarshal(&data)
+			Expect(err).Should(BeNil(), "Can not retrieve service")
+			svc1URL := getHTTPLink(ni.K8s2IP, data.Spec.Ports[0].NodePort)
+			err = kubectl.Get(helpers.DefaultNamespace, "svc test-nodeport-k8s2").Unmarshal(&data)
+			Expect(err).Should(BeNil(), "Can not retrieve service")
+			svc2URL := getHTTPLink(ni.K8s2IP, data.Spec.Ports[0].NodePort)
 
-							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
-							_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
-								helpers.KubectlApply, helpers.HelperTimeout)
-							Expect(err).Should(BeNil(),
-								"Policy %s cannot be applied", ccnpHostPolicy)
-						})
+			// Send two requests from the same src IP and port to the endpoint
+			// via two different NodePort svc to trigger the stale conntrack
+			// entry issue. Once it's fixed, the second request should not
+			// fail.
+			testCurlFromOutsideWithLocalPort(kubectl, ni, svc1URL, 1, false, 64002)
+			time.Sleep(120 * time.Second) // to reuse the source port
+			testCurlFromOutsideWithLocalPort(kubectl, ni, svc2URL, 1, false, 64002)
+		})
 
-						AfterAll(func() {
-							_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
-								helpers.KubectlDelete, helpers.HelperTimeout)
-							Expect(err).Should(BeNil(),
-								"Policy %s cannot be deleted", ccnpHostPolicy)
-
-							DeployCiliumAndDNS(kubectl, ciliumFilename)
-						})
-
-						It("Tests NodePort", func() {
-							testNodePort(kubectl, ni, true, false, helpers.ExistNodeWithoutCilium(), 0)
-						})
-					})
-
-					SkipItIf(func() bool {
-						// Quarantine when running with the third node as it's
-						// flaky. See #12511.
-						return helpers.GetCurrentIntegration() != "" ||
-							(helpers.SkipQuarantined() && helpers.ExistNodeWithoutCilium())
-					}, "Tests with secondary NodePort device", func() {
-						DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-							"devices": fmt.Sprintf(`'{%s,%s}'`, ni.PrivateIface, helpers.SecondaryIface),
-						})
-
-						testNodePort(kubectl, ni, true, true, helpers.ExistNodeWithoutCilium(), 0)
-					})
-				})
-
-				SkipContextIf(helpers.SkipQuarantined, "Tests with direct routing", func() {
-					BeforeAll(func() {
-						DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-							"tunnel":               "disabled",
-							"autoDirectNodeRoutes": "true",
-						})
-					})
-
-					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests NodePort with sessionAffinity from outside", func() {
-						testSessionAffinity(kubectl, ni, true, false)
-					})
-
-					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests externalIPs", func() {
-						testExternalIPs(kubectl, ni)
-					})
-
-					SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
-						var ccnpHostPolicy string
-
-						BeforeAll(func() {
-							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-								"tunnel":               "disabled",
-								"autoDirectNodeRoutes": "true",
-								"hostFirewall.enabled": "true",
-							})
-
-							ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
-							_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
-								helpers.KubectlApply, helpers.HelperTimeout)
-							Expect(err).Should(BeNil(),
-								"Policy %s cannot be applied", ccnpHostPolicy)
-						})
-
-						AfterAll(func() {
-							_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
-								helpers.KubectlDelete, helpers.HelperTimeout)
-							Expect(err).Should(BeNil(),
-								"Policy %s cannot be deleted", ccnpHostPolicy)
-
-							DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-								"tunnel":               "disabled",
-								"autoDirectNodeRoutes": "true",
-							})
-						})
-
-						It("Tests NodePort", func() {
-							testNodePort(kubectl, ni, true, false, helpers.ExistNodeWithoutCilium(), 0)
-						})
-					})
-
-					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests GH#10983", func() {
-						var data v1.Service
-
-						// We need two NodePort services with the same single endpoint,
-						// so thus we choose the "test-nodeport{-local,}-k8s2" svc.
-						// Both svcs will be accessed via the k8s2 node, because
-						// "test-nodeport-local-k8s2" has the local external traffic
-						// policy.
-						err := kubectl.Get(helpers.DefaultNamespace, "svc test-nodeport-local-k8s2").Unmarshal(&data)
-						Expect(err).Should(BeNil(), "Can not retrieve service")
-						svc1URL := getHTTPLink(ni.K8s2IP, data.Spec.Ports[0].NodePort)
-						err = kubectl.Get(helpers.DefaultNamespace, "svc test-nodeport-k8s2").Unmarshal(&data)
-						Expect(err).Should(BeNil(), "Can not retrieve service")
-						svc2URL := getHTTPLink(ni.K8s2IP, data.Spec.Ports[0].NodePort)
-
-						// Send two requests from the same src IP and port to the endpoint
-						// via two different NodePort svc to trigger the stale conntrack
-						// entry issue. Once it's fixed, the second request should not
-						// fail.
-						testCurlFromOutsideWithLocalPort(kubectl, ni, svc1URL, 1, false, 64002)
-						time.Sleep(120 * time.Second) // to reuse the source port
-						testCurlFromOutsideWithLocalPort(kubectl, ni, svc2URL, 1, false, 64002)
-					})
-
-				})
-
-				SkipItIf(func() bool {
-					// Quarantine when running with the third node as it's
-					// flaky. See GH-12511.
-					// It's also flaky for IPv6 traffic, see GH-18072
-					return helpers.SkipQuarantined()
-				}, "Tests with secondary NodePort device", func() {
-					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"tunnel":               "disabled",
-						"autoDirectNodeRoutes": "true",
-						"loadBalancer.mode":    "snat",
-						"devices":              fmt.Sprintf(`'{%s,%s}'`, ni.PrivateIface, helpers.SecondaryIface),
-					})
-
-					testNodePort(kubectl, ni, true, true, helpers.ExistNodeWithoutCilium(), 0)
-				})
-
-				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with direct routing and DSR", func() {
-					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"loadBalancer.mode":    "dsr",
-						"tunnel":               "disabled",
-						"autoDirectNodeRoutes": "true",
-					})
-
-					testDSR(kubectl, ni, 64000)
-					testNodePort(kubectl, ni, true, false, false, 0)
-				})
-
-				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with XDP, direct routing, SNAT and Random", func() {
-					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"loadBalancer.acceleration": "testing-only",
-						"loadBalancer.mode":         "snat",
-						"loadBalancer.algorithm":    "random",
-						"tunnel":                    "disabled",
-						"autoDirectNodeRoutes":      "true",
-						"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
-					})
-					testNodePortExternal(kubectl, ni, false, false)
-				})
-
-				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with XDP, direct routing, SNAT and Maglev", func() {
-					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"loadBalancer.acceleration": "testing-only",
-						"loadBalancer.mode":         "snat",
-						"loadBalancer.algorithm":    "maglev",
-						"maglev.tableSize":          "251",
-						"tunnel":                    "disabled",
-						"autoDirectNodeRoutes":      "true",
-						"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
-						// Support for host firewall + Maglev is currently broken,
-						// see #14047 for details.
-						"hostFirewall.enabled": "false",
-					})
-
-					testMaglev(kubectl, ni)
-					testNodePortExternal(kubectl, ni, false, false)
-				})
-
-				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with XDP, direct routing, Hybrid and Random", func() {
-					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"loadBalancer.acceleration": "testing-only",
-						"loadBalancer.mode":         "hybrid",
-						"loadBalancer.algorithm":    "random",
-						"tunnel":                    "disabled",
-						"autoDirectNodeRoutes":      "true",
-						"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
-					})
-					testNodePortExternal(kubectl, ni, true, false)
-				})
-
-				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with XDP, direct routing, Hybrid and Maglev", func() {
-					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"loadBalancer.acceleration": "testing-only",
-						"loadBalancer.mode":         "hybrid",
-						"loadBalancer.algorithm":    "maglev",
-						"maglev.tableSize":          "251",
-						"tunnel":                    "disabled",
-						"autoDirectNodeRoutes":      "true",
-						"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
-						// Support for host firewall + Maglev is currently broken,
-						// see #14047 for details.
-						"hostFirewall.enabled": "false",
-					})
-					testNodePortExternal(kubectl, ni, true, false)
-				})
-
-				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with XDP, direct routing, DSR and Random", func() {
-					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"loadBalancer.acceleration": "testing-only",
-						"loadBalancer.mode":         "dsr",
-						"loadBalancer.algorithm":    "random",
-						"tunnel":                    "disabled",
-						"autoDirectNodeRoutes":      "true",
-						"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
-					})
-					testNodePortExternal(kubectl, ni, true, true)
-				})
-
-				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with XDP, direct routing, DSR and Maglev", func() {
-					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"loadBalancer.acceleration": "testing-only",
-						"loadBalancer.mode":         "dsr",
-						"loadBalancer.algorithm":    "maglev",
-						"maglev.tableSize":          "251",
-						"tunnel":                    "disabled",
-						"autoDirectNodeRoutes":      "true",
-						"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
-						// Support for host firewall + Maglev is currently broken,
-						// see #14047 for details.
-						"hostFirewall.enabled": "false",
-					})
-					testNodePortExternal(kubectl, ni, true, true)
-				})
-
-				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with TC, direct routing and Hybrid", func() {
-					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"loadBalancer.acceleration": "disabled",
-						"loadBalancer.mode":         "hybrid",
-						"loadBalancer.algorithm":    "random",
-						"tunnel":                    "disabled",
-						"autoDirectNodeRoutes":      "true",
-						"devices":                   fmt.Sprintf(`'{}'`), // Revert back to auto-detection after XDP.
-					})
-					testNodePortExternal(kubectl, ni, true, false)
-				})
+		SkipItIf(func() bool {
+			// Quarantine when running with the third node as it's
+			// flaky. See GH-12511.
+			// It's also flaky for IPv6 traffic, see GH-18072
+			return helpers.SkipQuarantined()
+		}, "Tests with secondary NodePort device", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.mode": "snat",
+				"devices":           fmt.Sprintf(`'{%s,%s}'`, ni.PrivateIface, helpers.SecondaryIface),
 			})
+
+			testNodePort(kubectl, ni, true, true, true, 0)
+		})
+
+		It("Tests with direct routing and DSR", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.mode":    "dsr",
+				"tunnel":               "disabled",
+				"autoDirectNodeRoutes": "true",
+			})
+
+			testDSR(kubectl, ni, 64000)
+			testNodePort(kubectl, ni, true, false, false, 0)
+		})
+
+		It("Tests with XDP, direct routing, SNAT and Random", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.acceleration": "testing-only",
+				"loadBalancer.mode":         "snat",
+				"loadBalancer.algorithm":    "random",
+				"tunnel":                    "disabled",
+				"autoDirectNodeRoutes":      "true",
+				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
+			})
+			testNodePortExternal(kubectl, ni, false, false)
+		})
+
+		It("Tests with XDP, direct routing, SNAT and Maglev", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.acceleration": "testing-only",
+				"loadBalancer.mode":         "snat",
+				"loadBalancer.algorithm":    "maglev",
+				"maglev.tableSize":          "251",
+				"tunnel":                    "disabled",
+				"autoDirectNodeRoutes":      "true",
+				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
+				// Support for host firewall + Maglev is currently broken,
+				// see #14047 for details.
+				"hostFirewall.enabled": "false",
+			})
+
+			testMaglev(kubectl, ni)
+			testNodePortExternal(kubectl, ni, false, false)
+		})
+
+		It("Tests with XDP, direct routing, Hybrid and Random", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.acceleration": "testing-only",
+				"loadBalancer.mode":         "hybrid",
+				"loadBalancer.algorithm":    "random",
+				"tunnel":                    "disabled",
+				"autoDirectNodeRoutes":      "true",
+				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
+			})
+			testNodePortExternal(kubectl, ni, true, false)
+		})
+
+		It("Tests with XDP, direct routing, Hybrid and Maglev", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.acceleration": "testing-only",
+				"loadBalancer.mode":         "hybrid",
+				"loadBalancer.algorithm":    "maglev",
+				"maglev.tableSize":          "251",
+				"tunnel":                    "disabled",
+				"autoDirectNodeRoutes":      "true",
+				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
+				// Support for host firewall + Maglev is currently broken,
+				// see #14047 for details.
+				"hostFirewall.enabled": "false",
+			})
+			testNodePortExternal(kubectl, ni, true, false)
+		})
+
+		It("Tests with XDP, direct routing, DSR and Random", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.acceleration": "testing-only",
+				"loadBalancer.mode":         "dsr",
+				"loadBalancer.algorithm":    "random",
+				"tunnel":                    "disabled",
+				"autoDirectNodeRoutes":      "true",
+				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
+			})
+			testNodePortExternal(kubectl, ni, true, true)
+		})
+
+		It("Tests with XDP, direct routing, DSR and Maglev", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.acceleration": "testing-only",
+				"loadBalancer.mode":         "dsr",
+				"loadBalancer.algorithm":    "maglev",
+				"maglev.tableSize":          "251",
+				"tunnel":                    "disabled",
+				"autoDirectNodeRoutes":      "true",
+				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
+				// Support for host firewall + Maglev is currently broken,
+				// see #14047 for details.
+				"hostFirewall.enabled": "false",
+			})
+			testNodePortExternal(kubectl, ni, true, true)
+		})
+
+		It("Tests with TC, direct routing and Hybrid", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.acceleration": "disabled",
+				"loadBalancer.mode":         "hybrid",
+				"loadBalancer.algorithm":    "random",
+				"tunnel":                    "disabled",
+				"autoDirectNodeRoutes":      "true",
+				"devices":                   fmt.Sprintf(`'{}'`), // Revert back to auto-detection after XDP.
+			})
+			testNodePortExternal(kubectl, ni, true, false)
+		})
 
 		// Run on net-next and 4.19 but not on old versions, because of
 		// LRU requirement.
@@ -798,15 +702,43 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			testIPv4FragmentSupport(kubectl, ni)
 		})
 
-		SkipItIf(helpers.DoesNotExistNodeWithoutCilium,
-			"ClusterIP cannot be accessed externally when access is disabled",
+		SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
+			var ccnpHostPolicy string
+
+			BeforeAll(func() {
+				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+					"hostFirewall.enabled": "true",
+				})
+
+				ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
+				_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
+					helpers.KubectlApply, helpers.HelperTimeout)
+				Expect(err).Should(BeNil(),
+					"Policy %s cannot be applied", ccnpHostPolicy)
+			})
+
+			AfterAll(func() {
+				_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
+					helpers.KubectlDelete, helpers.HelperTimeout)
+				Expect(err).Should(BeNil(),
+					"Policy %s cannot be deleted", ccnpHostPolicy)
+
+				DeployCiliumAndDNS(kubectl, ciliumFilename)
+			})
+
+			It("Tests NodePort", func() {
+				testNodePort(kubectl, ni, true, false, true, 0)
+			})
+		})
+
+		It("ClusterIP cannot be accessed externally when access is disabled",
 			func() {
 				Expect(curlClusterIPFromExternalHost(kubectl, ni)).
 					ShouldNot(helpers.CMDSuccess(),
 						"External host %s unexpectedly connected to ClusterIP when lbExternalClusterIP was unset", ni.OutsideNodeName)
 			})
 
-		SkipContextIf(helpers.DoesNotExistNodeWithoutCilium, "With ClusterIP external access", func() {
+		Context("With ClusterIP external access", func() {
 			var (
 				svcIP string
 			)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -526,7 +526,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						testExternalIPs(kubectl, ni)
 					})
 
-					SkipContextIf(helpers.RunsOnGKE, "With host policy", func() {
+					SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
 						var ccnpHostPolicy string
 
 						BeforeAll(func() {
@@ -654,7 +654,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						testExternalIPs(kubectl, ni)
 					})
 
-					SkipContextIf(helpers.RunsOnGKE, "With host policy", func() {
+					SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
 						var ccnpHostPolicy string
 
 						BeforeAll(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -278,50 +278,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				}
 			})
 		})
-	})
 
-	Context("Checks N/S loadbalancing", func() {
-		var (
-			demoYAML     string
-			demoYAMLV6   string
-			demoPolicyL7 string
-		)
-
-		BeforeAll(func() {
-			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
-
-			DeployCiliumAndDNS(kubectl, ciliumFilename)
-
-			res := kubectl.ApplyDefault(demoYAML)
-			Expect(res).Should(helpers.CMDSuccess(), "Unable to apply %s", demoYAML)
-
-			if helpers.DualStackSupported() {
-				demoYAMLV6 = helpers.ManifestGet(kubectl.BasePath(), "demo_ds_v6.yaml")
-
-				res = kubectl.ApplyDefault(demoYAMLV6)
-				Expect(res).Should(helpers.CMDSuccess(), "Unable to apply %s", demoYAMLV6)
-			}
-
-			By(`Connectivity config:: helpers.DualStackSupported(): %v
-Primary Interface %s   :: IPv4: (%s, %s), IPv6: (%s, %s)
-Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupported(), ni.PrivateIface, ni.K8s1IP, ni.K8s2IP, ni.PrimaryK8s1IPv6, ni.PrimaryK8s2IPv6,
-				helpers.SecondaryIface, ni.SecondaryK8s1IPv4, ni.SecondaryK8s2IPv4, ni.SecondaryK8s1IPv6, ni.SecondaryK8s2IPv6)
-
-			demoPolicyL7 = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-demo.yaml")
-			waitPodsDs(kubectl, []string{testDS, testDSClient, testDSK8s2})
-		})
-
-		AfterAll(func() {
-			// Explicitly ignore result of deletion of resources to avoid incomplete
-			// teardown if any step fails.
-			_ = kubectl.Delete(demoYAML)
-			if helpers.DualStackSupported() {
-				_ = kubectl.Delete(demoYAMLV6)
-			}
-			ExpectAllPodsTerminated(kubectl)
-		})
-
-		SkipContextIf(helpers.RunsWithKubeProxyReplacement, "Tests NodePort (kube-proxy)", func() {
+		SkipContextIf(helpers.RunsWithKubeProxyReplacement, "Tests NodePort inside cluster (kube-proxy)", func() {
 			SkipItIf(helpers.DoesNotRunOn419OrLaterKernel, "with IPSec and externalTrafficPolicy=Local", func() {
 				deploymentManager.SetKubectl(kubectl)
 				deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
@@ -350,7 +308,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			})
 		})
 
-		Context("TFTP with DNS Proxy port collision", func() {
+		SkipContextIf(helpers.RunsWithKubeProxyReplacement, "TFTP with DNS Proxy port collision", func() {
 			var (
 				demoPolicy    string
 				ciliumPodK8s1 string
@@ -376,9 +334,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			})
 
 			AfterAll(func() {
-				// Explicitly ignore result of deletion of resources to avoid incomplete
-				// teardown if any step fails.
-				_ = kubectl.Delete(demoPolicy)
+				kubectl.Delete(demoPolicy)
 			})
 
 			It("Tests TFTP from DNS Proxy Port", func() {
@@ -432,7 +388,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			})
 		})
 
-		Context("with L4 policy", func() {
+		SkipContextIf(helpers.RunsWithKubeProxyReplacement, "with L4 policy", func() {
 			var (
 				demoPolicy string
 			)
@@ -442,9 +398,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			})
 
 			AfterAll(func() {
-				// Explicitly ignore result of deletion of resources to avoid incomplete
-				// teardown if any step fails.
-				_ = kubectl.Delete(demoPolicy)
+				kubectl.Delete(demoPolicy)
 			})
 
 			It("Tests NodePort with L4 Policy", func() {
@@ -467,10 +421,14 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 		})
 
 		SkipContextIf(helpers.RunsWithKubeProxyReplacement, "with L7 policy", func() {
+			var demoPolicyL7 string
+
+			BeforeAll(func() {
+				demoPolicyL7 = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-demo.yaml")
+			})
+
 			AfterAll(func() {
-				// Explicitly ignore result of deletion of resources to avoid incomplete
-				// teardown if any step fails.
-				_ = kubectl.Delete(demoPolicyL7)
+				kubectl.Delete(demoPolicyL7)
 			})
 
 			It("Tests NodePort with L7 Policy", func() {
@@ -490,6 +448,47 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 				applyPolicy(kubectl, demoPolicyL7)
 				testNodePort(kubectl, ni, false, false, false, 0)
 			})
+		})
+
+	})
+
+	Context("Checks N/S loadbalancing", func() {
+		var (
+			demoYAML     string
+			demoYAMLV6   string
+			demoPolicyL7 string
+		)
+
+		BeforeAll(func() {
+			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
+
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
+
+			res := kubectl.ApplyDefault(demoYAML)
+			Expect(res).Should(helpers.CMDSuccess(), "Unable to apply %s", demoYAML)
+
+			if helpers.DualStackSupported() {
+				demoYAMLV6 = helpers.ManifestGet(kubectl.BasePath(), "demo_ds_v6.yaml")
+
+				res = kubectl.ApplyDefault(demoYAMLV6)
+				Expect(res).Should(helpers.CMDSuccess(), "Unable to apply %s", demoYAMLV6)
+			}
+
+			By(`Connectivity config:: helpers.DualStackSupported(): %v
+Primary Interface %s   :: IPv4: (%s, %s), IPv6: (%s, %s)
+Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupported(), ni.PrivateIface, ni.K8s1IP, ni.K8s2IP, ni.PrimaryK8s1IPv6, ni.PrimaryK8s2IPv6,
+				helpers.SecondaryIface, ni.SecondaryK8s1IPv4, ni.SecondaryK8s2IPv4, ni.SecondaryK8s1IPv6, ni.SecondaryK8s2IPv6)
+
+			demoPolicyL7 = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-demo.yaml")
+			waitPodsDs(kubectl, []string{testDS, testDSClient, testDSK8s2})
+		})
+
+		AfterAll(func() {
+			kubectl.Delete(demoYAML)
+			if helpers.DualStackSupported() {
+				kubectl.Delete(demoYAMLV6)
+			}
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		SkipContextIf(helpers.DoesNotRunWithKubeProxyReplacement, "Tests NodePort BPF",
@@ -722,7 +721,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 						})
 
 						AfterAll(func() {
-							_ = kubectl.Delete(echoYAML)
+							kubectl.Delete(echoYAML)
 							ExpectAllPodsTerminated(kubectl)
 						})
 
@@ -1009,7 +1008,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 
 		AfterEach(func() {
 			wg.Wait()
-			_ = kubectl.Delete(gracefulTermYAML)
+			kubectl.Delete(gracefulTermYAML)
 			ExpectAllPodsTerminated(kubectl)
 		})
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -188,7 +188,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 
 		SkipContextIf(helpers.DoesNotRunWithKubeProxyReplacement, "Checks in-cluster KPR", func() {
 			It("Tests NodePort", func() {
-				testNodePort(kubectl, ni, true, false, false, 0)
+				testNodePort(kubectl, ni, true, false, 0)
 			})
 
 			It("Tests NodePort with externalTrafficPolicy=Local", func() {
@@ -218,7 +218,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 
 				It("Tests NodePort with L7 Policy", func() {
 					applyPolicy(kubectl, demoPolicyL7)
-					testNodePort(kubectl, ni, false, false, false, 0)
+					testNodePort(kubectl, ni, false, false, 0)
 				})
 			})
 		})
@@ -344,7 +344,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			})
 
 			It("", func() {
-				testNodePort(kubectl, ni, false, false, false, 0)
+				testNodePort(kubectl, ni, false, false, 0)
 			})
 		})
 
@@ -456,7 +456,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				}()
 
 				applyPolicy(kubectl, demoPolicy)
-				testNodePort(kubectl, ni, false, false, false, 0)
+				testNodePort(kubectl, ni, false, false, 0)
 			})
 		})
 
@@ -486,7 +486,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				}()
 
 				applyPolicy(kubectl, demoPolicyL7)
-				testNodePort(kubectl, ni, false, false, false, 0)
+				testNodePort(kubectl, ni, false, false, 0)
 			})
 		})
 	})
@@ -562,18 +562,13 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			testCurlFromOutsideWithLocalPort(kubectl, ni, svc2URL, 1, false, 64002)
 		})
 
-		SkipItIf(func() bool {
-			// Quarantine when running with the third node as it's
-			// flaky. See GH-12511.
-			// It's also flaky for IPv6 traffic, see GH-18072
-			return helpers.SkipQuarantined()
-		}, "Tests with secondary NodePort device", func() {
+		It("Tests with secondary NodePort device", func() {
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 				"loadBalancer.mode": "snat",
 				"devices":           fmt.Sprintf(`'{%s,%s}'`, ni.PrivateIface, helpers.SecondaryIface),
 			})
 
-			testNodePort(kubectl, ni, true, true, true, 0)
+			testNodePortExternal(kubectl, ni, true, false, false)
 		})
 
 		It("Tests with direct routing and DSR", func() {
@@ -584,7 +579,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			})
 
 			testDSR(kubectl, ni, 64000)
-			testNodePort(kubectl, ni, true, false, false, 0)
+			testNodePortExternal(kubectl, ni, false, true, true)
 		})
 
 		It("Tests with XDP, direct routing, SNAT and Random", func() {
@@ -596,7 +591,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"autoDirectNodeRoutes":      "true",
 				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
 			})
-			testNodePortExternal(kubectl, ni, false, false)
+			testNodePortExternal(kubectl, ni, false, false, false)
 		})
 
 		It("Tests with XDP, direct routing, SNAT and Maglev", func() {
@@ -614,7 +609,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			})
 
 			testMaglev(kubectl, ni)
-			testNodePortExternal(kubectl, ni, false, false)
+			testNodePortExternal(kubectl, ni, false, false, false)
 		})
 
 		It("Tests with XDP, direct routing, Hybrid and Random", func() {
@@ -626,7 +621,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"autoDirectNodeRoutes":      "true",
 				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
 			})
-			testNodePortExternal(kubectl, ni, true, false)
+			testNodePortExternal(kubectl, ni, false, true, false)
 		})
 
 		It("Tests with XDP, direct routing, Hybrid and Maglev", func() {
@@ -642,7 +637,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				// see #14047 for details.
 				"hostFirewall.enabled": "false",
 			})
-			testNodePortExternal(kubectl, ni, true, false)
+			testNodePortExternal(kubectl, ni, false, true, false)
 		})
 
 		It("Tests with XDP, direct routing, DSR and Random", func() {
@@ -654,7 +649,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"autoDirectNodeRoutes":      "true",
 				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
 			})
-			testNodePortExternal(kubectl, ni, true, true)
+			testNodePortExternal(kubectl, ni, false, true, true)
 		})
 
 		It("Tests with XDP, direct routing, DSR and Maglev", func() {
@@ -670,7 +665,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				// see #14047 for details.
 				"hostFirewall.enabled": "false",
 			})
-			testNodePortExternal(kubectl, ni, true, true)
+			testNodePortExternal(kubectl, ni, false, true, true)
 		})
 
 		It("Tests with TC, direct routing and Hybrid", func() {
@@ -682,7 +677,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"autoDirectNodeRoutes":      "true",
 				"devices":                   fmt.Sprintf(`'{}'`), // Revert back to auto-detection after XDP.
 			})
-			testNodePortExternal(kubectl, ni, true, false)
+			testNodePortExternal(kubectl, ni, false, true, false)
 		})
 
 		// Run on net-next and 4.19 but not on old versions, because of
@@ -727,7 +722,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			})
 
 			It("Tests NodePort", func() {
-				testNodePort(kubectl, ni, true, false, true, 0)
+				testNodePort(kubectl, ni, true, true, 0)
 			})
 		})
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -205,41 +205,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			}
 
 		}, 600)
-
-		SkipItIf(func() bool { return helpers.DoesNotExistNodeWithoutCilium() },
-			"ClusterIP cannot be accessed externally when access is disabled",
-			func() {
-				Expect(curlClusterIPFromExternalHost(kubectl, ni)).
-					ShouldNot(helpers.CMDSuccess(),
-						"External host %s unexpectedly connected to ClusterIP when lbExternalClusterIP was unset", ni.OutsideNodeName)
-			})
-
-		SkipContextIf(func() bool { return helpers.DoesNotExistNodeWithoutCilium() }, "With ClusterIP external access", func() {
-			var (
-				svcIP string
-			)
-			BeforeAll(func() {
-				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-					"bpf.lbExternalClusterIP": "true",
-				})
-				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, appServiceName)
-				svcIP = clusterIP
-				Expect(err).Should(BeNil(), "Cannot get service %s", appServiceName)
-				res := kubectl.AddIPRoute(ni.OutsideNodeName, svcIP, ni.K8s1IP, false)
-				Expect(res).Should(helpers.CMDSuccess(), "Error adding IP route for %s via %s", svcIP, ni.K8s1IP)
-			})
-
-			AfterAll(func() {
-				res := kubectl.DelIPRoute(ni.OutsideNodeName, svcIP, ni.K8s1IP)
-				Expect(res).Should(helpers.CMDSuccess(), "Error removing IP route for %s via %s", svcIP, ni.K8s1IP)
-				DeployCiliumAndDNS(kubectl, ciliumFilename)
-			})
-
-			It("ClusterIP can be accessed when external access is enabled", func() {
-				Expect(curlClusterIPFromExternalHost(kubectl, ni)).
-					Should(helpers.CMDSuccess(), "Could not curl ClusterIP %s from external host", svcIP)
-			})
-		})
 	})
 
 	SkipContextIf(func() bool {
@@ -959,6 +924,44 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`, helpers.DualStackSupp
 			}
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 			testIPv4FragmentSupport(kubectl, ni)
+		})
+
+		SkipItIf(helpers.DoesNotExistNodeWithoutCilium,
+			"ClusterIP cannot be accessed externally when access is disabled",
+			func() {
+				Expect(curlClusterIPFromExternalHost(kubectl, ni)).
+					ShouldNot(helpers.CMDSuccess(),
+						"External host %s unexpectedly connected to ClusterIP when lbExternalClusterIP was unset", ni.OutsideNodeName)
+			})
+
+		SkipContextIf(helpers.DoesNotExistNodeWithoutCilium, "With ClusterIP external access", func() {
+			var (
+				svcIP string
+			)
+			BeforeAll(func() {
+				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+					"bpf.lbExternalClusterIP": "true",
+					// Enable Maglev to check if the Maglev LUT for ClusterIP is properly populated,
+					// and external clients can access ClusterIP with it.
+					"loadBalancer.algorithm": "maglev",
+				})
+				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, appServiceName)
+				svcIP = clusterIP
+				Expect(err).Should(BeNil(), "Cannot get service %s", appServiceName)
+				res := kubectl.AddIPRoute(ni.OutsideNodeName, svcIP, ni.K8s1IP, false)
+				Expect(res).Should(helpers.CMDSuccess(), "Error adding IP route for %s via %s", svcIP, ni.K8s1IP)
+			})
+
+			AfterAll(func() {
+				res := kubectl.DelIPRoute(ni.OutsideNodeName, svcIP, ni.K8s1IP)
+				Expect(res).Should(helpers.CMDSuccess(), "Error removing IP route for %s via %s", svcIP, ni.K8s1IP)
+				DeployCiliumAndDNS(kubectl, ciliumFilename)
+			})
+
+			It("ClusterIP can be accessed when external access is enabled", func() {
+				Expect(curlClusterIPFromExternalHost(kubectl, ni)).
+					Should(helpers.CMDSuccess(), "Could not curl ClusterIP %s from external host", svcIP)
+			})
 		})
 	})
 

--- a/test/k8sT/service_helpers.go
+++ b/test/k8sT/service_helpers.go
@@ -709,9 +709,6 @@ func testNodePortExternal(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, check
 		testCurlFromOutside(kubectl, ni, httpURL, 10, checkTCP)
 		testCurlFromOutside(kubectl, ni, tftpURL, 10, checkUDP)
 
-		// Make sure all the rest works as expected as well
-		testNodePort(kubectl, ni, true, false, false, 0)
-
 		// Clear CT tables on both Cilium nodes
 		pod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 		ExpectWithOffset(1, err).Should(BeNil(), "Cannot determine cilium pod name")


### PR DESCRIPTION
This is a manual backport of https://github.com/cilium/cilium/pull/18696 and https://github.com/cilium/cilium/pull/18831. Once it's merged, please change the label of #18696 and #18831 to indicate that the backport is done.

UPDATE: also, https://github.com/cilium/cilium/pull/18184/commits/cc10609d8c1b824479d26a7dbad17069ad64bec3 was backported too.

Blocked by https://github.com/cilium/cilium/pull/19135.

