### PR TITLE
bgp,testing: fix race condition in checking fencer map

### DIFF
--- a/pkg/bgp/speaker/speaker_test.go
+++ b/pkg/bgp/speaker/speaker_test.go
@@ -201,15 +201,10 @@ func TestSpeakerOnDeleteService(t *testing.T) {
 		t.Fatalf("got: %v, want: nil", rr.eps)
 	}
 
-	// confirm spkr appended service to map
+	// confirm spkr removed service to map
 	_, ok := spkr.services[serviceID]
 	if ok {
 		t.Fatalf("speaker did not delete slim_corev1.Service object to its services map.")
-	}
-
-	// confirm fence is empty
-	if len(spkr.Fencer) != 0 {
-		t.Fatalf("expected fence to be empty. got: %v", spkr.Fencer)
 	}
 }
 


### PR DESCRIPTION
this commit removes a racy portion of the BGP speaker test.

prior to this commit the fence was checked for deletion however this
deletion happens in a separate go routine and timing cannot be
guaratneed.

the removal of this line is acceptable since the method it indirectly is
testing is tested in `fence_test.go`

closes: #18300

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>
