### PR TITLE
v1.10 backports 2022-02-22

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:e47ae96532b0fd14dbaf593f6
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:9b1701da9cc035a1696f3e492ee2526101262e56@sha256:c0e0586bf97e69b9c16c95eff707a264c1c00bb89371205e88f6849d12ed2de2 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:28b3c32edfeeaef9e20104368680d8148a4da841@sha256:7cb1033da6a183e5a18599649dac5ef31a5983f7f4af2ff53d63c5050d595b67 as cilium-envoy
 
 #
 # Hubble CLI

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:e47ae96532b0fd14dbaf593f6
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:28b3c32edfeeaef9e20104368680d8148a4da841@sha256:7cb1033da6a183e5a18599649dac5ef31a5983f7f4af2ff53d63c5050d595b67 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:9c0d933166ba192713f9e2fc3901f788557286ee@sha256:943f1f522bdfcb1ca3fe951bd8186c41b970afa254096513ae6e0e0efda1a10d as cilium-envoy
 
 #
 # Hubble CLI

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1044,6 +1044,14 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 		},
 	}
 
+	if option.Config.EnableBPFTProxy {
+		// Envoy since 1.20.0 uses SO_REUSEPORT on listeners by default.
+		// BPF TPROXY is currently not compatible with SO_REUSEPORT, so disable it.
+		// Note that this may degrade Envoy performance.
+		bs.LayeredRuntime.Layers[0].GetStaticLayer().Fields["envoy.reloadable_features.listener_reuse_port_default_enabled"] =
+			&structpb.Value{Kind: &structpb.Value_BoolValue{BoolValue: false}}
+	}
+
 	log.Debugf("Envoy: Bootstrap: %s", bs)
 	data, err := proto.Marshal(bs)
 	if err != nil {


### PR DESCRIPTION
 * #18748 -- envoy: Update to release 1.21.0 (@jrajahalme)
 * #18899 -- envoy: Update to 1.21.1 (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18748 18899; do contrib/backporting/set-labels.py $pr done 1.10; done
```
