### PR TITLE
docs: update Azure Service Principal / IPAM documentation

### DIFF
--- a/Documentation/concepts/networking/ipam/azure.rst
+++ b/Documentation/concepts/networking/ipam/azure.rst
@@ -194,17 +194,28 @@ When a node or instance terminates, the Kubernetes apiserver will send a node
 deletion event. This event will be picked up by the operator and the operator
 will delete the corresponding ``ciliumnodes.cilium.io`` custom resource.
 
+.. _ipam_azure_required_privileges:
+
 *******************
 Required Privileges
 *******************
 
 The following Azure API calls are being performed by the Cilium operator. The
-service principal provided must have privileges to perform these:
+Service Principal provided must have privileges to perform these within the
+scope of the AKS cluster node resource group:
 
  * `Network Interfaces - Create Or Update <https://docs.microsoft.com/en-us/rest/api/virtualnetwork/networkinterfaces/createorupdate>`__
  * `NetworkInterface In VMSS - List Virtual Machine Scale Set Network Interfaces <https://docs.microsoft.com/en-us/rest/api/virtualnetwork/networkinterface%20in%20vmss/listvirtualmachinescalesetnetworkinterfaces>`__
  * `Virtual Networks - List <https://docs.microsoft.com/en-us/rest/api/virtualnetwork/virtualnetworks/list>`__
  * `Virtual Machine Scale Sets - List All <https://docs.microsoft.com/en-us/rest/api/compute/virtualmachinescalesets/listall>`__
+
+.. note::
+
+   The node resource group is *not* the resource group of the AKS cluster. A
+   single resource group may hold multiple AKS clusters, but each AKS cluster
+   regroups all resources in an automatically managed secondary resource group.
+   See `Why are two resource groups created with AKS? <https://docs.microsoft.com/en-us/azure/aks/faq#why-are-two-resource-groups-created-with-aks>`__
+   for more details.
 
 *******
 Metrics

--- a/pkg/azure/api/api_interaction_test.go
+++ b/pkg/azure/api/api_interaction_test.go
@@ -18,21 +18,13 @@ import (
 // How to run these tests:
 //
 // 1. Modify testSubscription and testResourceGroup
-// 2. Create a service principal
-//      az ad sp create-for-rbac -n cilium-unit-test
-//      {
-//        "appId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-//        "displayName": "cilium-unit-test",
-//        "name": "http://cilium-unit-test",
-//        "password": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-//        "tenant": "cccccccc-cccc-cccc-cccc-cccccccccccc"
-//      }
-// 3. Set
-//      AZURE_SUBSCRIPTION_ID=$(az account show --query id | tr -d \")
-//      AZURE_CLIENT_ID=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
-//      AZURE_CLIENT_SECRET=bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
-//      AZURE_TENANT_ID=cccccccc-cccc-cccc-cccc-cccccccccccc
-//      AZURE_NODE_RESOURCE_GROUP=$(az aks show -n $CLUSTER_NAME -g $RESOURCE_GROUP | jq -r .nodeResourceGroup)
+// 2. Set
+//      AZURE_SUBSCRIPTION_ID=$(az account show --query "id" --output tsv)
+//      AZURE_NODE_RESOURCE_GROUP=$(az aks show --resource-group ${RESOURCE_GROUP} --name ${CLUSTER_NAME} --query "nodeResourceGroup" --output tsv)
+// 			AZURE_SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --scopes /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_NODE_RESOURCE_GROUP} --role Contributor --output json --only-show-errors)
+//      AZURE_TENANT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.tenant')
+//      AZURE_CLIENT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.appId')
+//      AZURE_CLIENT_SECRET=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.password')
 
 type ApiInteractionSuite struct{}
 


### PR DESCRIPTION
When installing Cilium in an AKS cluster, the Cilium Operator requires an Azure Service Principal with sufficient privileges to the Azure API for the IPAM allocator to be able to work.

Previously, the `az ad sp create-for-rbac` was assigning by default the `Contributor` role to new Service Principals when none was provided via the optional `--role` flag, whereas it now does not assign any role at all. This of course breaks IPAM allocation due to insufficient permissions, resulting in operator failures of this kind:

```
level=warning msg="Unable to synchronize Azure virtualnetworks list" error="network.VirtualNetworksClient#ListAll: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code=\"AuthorizationFailed\" Message=\"The client 'd09fb531-793a-40fc-b934-7af73ca60e32' with object id 'd09fb531-793a-40fc-b934-7af73ca60e32' does not have authorization to perform action 'Microsoft.Network/virtualNetworks/read' over scope '/subscriptions/22716d91-fb67-4a07-ac5f-d36ea49d6167' or the scope is invalid. If access was recently granted, please refresh your credentials.\"" subsys=azure
level=fatal msg="Unable to start azure allocator" error="Initial synchronization with instances API failed" subsys=cilium-operator-azure
```

We update the documentation guidelines for new installations to assign the `Contributor` role to new Service Principals used for Cilium.

We also take the opportunity to:

- Update Azure IPAM required privileges documentation.
- Make it so users can now set up all AKS-specific required variables for a Helm install in a single command block, rather than have it spread over several command blocks with intermediate steps and temporary files.
- Have the documentation recommend creating Service Principals with privileges over a restricted scope (AKS node resource group) for increased security.