### PR TITLE
docs: Remove trailing step in AWS helm install

### DIFF
--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -191,8 +191,6 @@ Install Cilium
          If you use masquerading with the option ``egressMasqueradeInterfaces=eth0``,
          remember to replace ``eth0`` with the proper interface name.
 
-       Cilium is now deployed and you are ready to scale-up the cluster:
-
     .. group-tab:: OpenShift
 
        .. include:: requirements-openshift.rst


### PR DESCRIPTION
Commit 706c9009dc39 ("docs: re-write docs to create clusters with
tainted nodes") removed the command for this instruction step, so
there's no need to have the instruction any more. Remove it.
