### PR TITLE
datapath: make tc filter priority configurable

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1073,6 +1073,10 @@ func initializeFlags() {
 	flags.StringSlice(option.VtepMAC, []string{}, "List of VTEP MAC addresses for forwarding traffic outside the cluster")
 	option.BindEnv(option.VtepMAC)
 
+	flags.Int(option.TCFilterPriority, 1, "Priority of TC BPF filter")
+	flags.MarkHidden(option.TCFilterPriority)
+	option.BindEnv(option.TCFilterPriority)
+
 	viper.BindPFlags(flags)
 }
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -646,7 +646,7 @@ hubble:
       # Defaults to midnight of the first day of every fourth month. For syntax, see
       # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
       schedule: "0 0 1 */4 *"
-      
+
       # [Example]
       # certManagerIssuerRef:
       #   group: cert-manager.io
@@ -1485,7 +1485,7 @@ operator:
 
   # -- Additional cilium-operator volumes.
   extraVolumes: []
-  
+
   # -- Additional cilium-operator volumeMounts.
   extraVolumeMounts: []
 
@@ -1727,12 +1727,12 @@ clustermesh:
     domain: mesh.cilium.io
     # -- List of clusters to be peered in the mesh.
     clusters: []
-    # clusters: 
+    # clusters:
     # # -- Name of the cluster
     # - name: cluster1
     # # -- Address of the cluster, use this if you created DNS records for
     # # the cluster Clustermesh API server.
-    #   address: cluster1.mesh.cilium.io 
+    #   address: cluster1.mesh.cilium.io
     # # -- Port of the cluster Clustermesh API server.
     #   port: 2379
     # # -- IPs of the cluster Clustermesh API server, use multiple ones when
@@ -1743,7 +1743,7 @@ clustermesh:
     #   tls:
     #     cert: ""
     #     key: ""
-  
+
   apiserver:
     # -- Clustermesh API server image.
     image:
@@ -1874,7 +1874,7 @@ clustermesh:
         # fourth month. For syntax, see
         # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
         # schedule: "0 0 1 */4 *"
-        
+
         # [Example]
         # certManagerIssuerRef:
         #   group: cert-manager.io

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -60,6 +61,7 @@ const (
 	initArgNrCPUs
 	initArgEndpointRoutes
 	initArgProxyRule
+	initTCFilterPriority
 	initArgMax
 )
 
@@ -415,6 +417,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	} else {
 		args[initArgProxyRule] = "false"
 	}
+
+	args[initTCFilterPriority] = strconv.Itoa(option.Config.TCFilterPriority)
 
 	// "Legacy" datapath inizialization with the init.sh script
 	// TODO(mrostecki): Rewrite the whole init.sh in Go, step by step.

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -93,8 +94,11 @@ func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirectio
 			"obj", objPath, "sec", progSec}
 	} else {
 		loaderProg = "tc"
+
+		tcPrio := strconv.Itoa(option.Config.TCFilterPriority)
+		log.Debugf("tc filter using priority %s for interface %s", tcPrio, ifName)
 		args = []string{"filter", "replace", "dev", ifName, progDirection,
-			"prio", "1", "handle", "1", "bpf", "da", "obj", objPath,
+			"prio", tcPrio, "handle", "1", "bpf", "da", "obj", objPath,
 			"sec", progSec,
 		}
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1017,6 +1017,10 @@ const (
 
 	// VTEP MACs
 	VtepMAC = "vtep-mac"
+
+	// TCFilterPriority sets the priority of the cilium tc filter, enabling other
+	// filters to be inserted prior to the cilium filter.
+	TCFilterPriority = "bpf-filter-priority"
 )
 
 // Default string arguments
@@ -2079,6 +2083,10 @@ type DaemonConfig struct {
 
 	// VtepMACs VTEP MACs
 	VtepMACs []mac.MAC
+
+	// TCFilterPriority sets the priority of the cilium tc filter, enabling other
+	// filters to be inserted prior to the cilium filter.
+	TCFilterPriority int
 }
 
 var (
@@ -2725,6 +2733,7 @@ func (c *DaemonConfig) Populate() {
 	c.BGPAnnouncePodCIDR = viper.GetBool(BGPAnnouncePodCIDR)
 	c.BGPConfigPath = viper.GetString(BGPConfigPath)
 	c.ExternalClusterIP = viper.GetBool(ExternalClusterIPName)
+	c.TCFilterPriority = viper.GetInt(TCFilterPriority)
 
 	c.EnableIPv4Masquerade = viper.GetBool(EnableIPv4Masquerade) && c.EnableIPv4
 	c.EnableIPv6Masquerade = viper.GetBool(EnableIPv6Masquerade) && c.EnableIPv6


### PR DESCRIPTION
Previously, during initialization, cilium installed bpf filters via the tc
command using a hardcoded priority of 1. This patch adds the hidden tc-filter-priority
option for specifying a priority of the cilium bpf filters enabling other
filters to be inserted prior to cilium's filters. The default is 1, for
backward compatibility. Use Helm's extraArgs to pass this option to cilium-agent
when using Helm to install cilium.

Fixes: #17193

Signed-off-by: Anderson, David L <david.l.anderson@intel.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #17193 
