### PR TITLE
helm: check for contents of bootstartFile

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -372,7 +372,7 @@ spec:
         - sh
         - -c
         - |
-          until test -f {{ .Values.nodeinit.bootstrapFile | quote }}; do
+          until test -s {{ .Values.nodeinit.bootstrapFile | quote }}; do
             echo "Waiting on node-init to run...";
             sleep 1;
           done


### PR DESCRIPTION
Checking for the existence of the .Values.nodeinit.bootstrapFile
file will be a no-op because the file is created by kubelet if
it does not exist. Instead, we should check if the file has some
contents inside of it which is when we can be sure the node-init
DaemonSet has started.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix concurrency issue while waiting for node-init DaemonSet to be ready
```
