### PR TITLE
v1.11 backports 2022-02-23

### DIFF
--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -191,8 +191,6 @@ Install Cilium
          If you use masquerading with the option ``egressMasqueradeInterfaces=eth0``,
          remember to replace ``eth0`` with the proper interface name.
 
-       Cilium is now deployed and you are ready to scale-up the cluster:
-
     .. group-tab:: OpenShift
 
        .. include:: requirements-openshift.rst

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -398,11 +398,17 @@ int from_overlay(struct __ctx_buff *ctx)
 #endif
 	{
 		__u32 identity = 0;
+		int obs_point = TRACE_FROM_OVERLAY;
 
-		if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT)
+		/* Non-ESP packet marked with MARK_MAGIC_DECRYPT is a packet
+		 * re-inserted from the stack.
+		 */
+		if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT) {
 			identity = get_identity(ctx);
+			obs_point = TRACE_FROM_STACK;
+		}
 
-		send_trace_notify(ctx, TRACE_FROM_OVERLAY, identity, 0, 0,
+		send_trace_notify(ctx, obs_point, identity, 0, 0,
 				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
 	}
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -116,6 +116,11 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		 * packet.
 		 */
 		ctx_change_type(ctx, PACKET_HOST);
+
+		send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0,
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
+				  TRACE_PAYLOAD_LEN);
+
 		return CTX_ACT_OK;
 	}
 	ctx->mark = 0;
@@ -255,6 +260,11 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 		 * packet.
 		 */
 		ctx_change_type(ctx, PACKET_HOST);
+
+		send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0,
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
+				  TRACE_PAYLOAD_LEN);
+
 		return CTX_ACT_OK;
 	}
 	ctx->mark = 0;

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1085,16 +1085,9 @@ func RemoveFromNodeIpset(nodeIP net.IP) {
 	}
 }
 
-// useNodeIpset returns true if the ipset for node IP addresses should be
-// used to skip masquerading.
-func useNodeIpset() bool {
-	return option.Config.Tunnel == option.TunnelDisabled &&
-		option.Config.IptablesMasqueradingEnabled()
-}
-
 func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName, localDeliveryInterface,
 	snatDstExclusionCIDR, allocRange, hostMasqueradeIP string) error {
-	if useNodeIpset() {
+	if option.Config.NodeIpsetNeeded() {
 		// Exclude traffic to nodes from masquerade.
 		if err := createIpset(prog.getIpset(), prog.getProg() == "ip6tables"); err != nil {
 			return err
@@ -1331,7 +1324,7 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 	// Note we don't need a backup system as for iptables rules because the
 	// contents of ipsets doesn't depend on configuration. Whether they are
 	// needed depends on the configuration, but the content doesn't.
-	if useNodeIpset() {
+	if option.Config.NodeIpsetNeeded() {
 		if option.Config.IptablesMasqueradingIPv4Enabled() {
 			if err = createIpset(ciliumNodeIpsetV4, false); err != nil {
 				return err

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1338,7 +1338,7 @@ func (n *linuxNodeHandler) replaceNodeIPSecOutRoute(ip *net.IPNet) {
 
 	_, err := route.Upsert(n.createNodeIPSecOutRoute(ip))
 	if err != nil {
-		log.WithError(err).Error("Unable to replace the IPSec route OUT the host routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to replace the IPSec route OUT the host routing table")
 	}
 }
 
@@ -1358,11 +1358,11 @@ func (n *linuxNodeHandler) replaceNodeExternalIPSecOutRoute(ip *net.IPNet) {
 
 	_, err := route.Upsert(n.createNodeExternalIPSecOutRoute(ip, true))
 	if err != nil {
-		log.WithError(err).Error("Unable to replace the IPSec route OUT the default routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to replace the IPSec route OUT the default routing table")
 	}
 	_, err = route.Upsert(n.createNodeExternalIPSecOutRoute(ip, false))
 	if err != nil {
-		log.WithError(err).Error("Unable to replace the IPSec route OUT the host routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to replace the IPSec route OUT the host routing table")
 	}
 }
 
@@ -1379,7 +1379,7 @@ func (n *linuxNodeHandler) deleteNodeIPSecOutRoute(ip *net.IPNet) {
 	}
 
 	if err := route.Delete(n.createNodeIPSecOutRoute(ip)); err != nil {
-		log.WithError(err).Error("Unable to delete the IPsec route OUT from the host routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to delete the IPsec route OUT from the host routing table")
 	}
 }
 
@@ -1396,11 +1396,11 @@ func (n *linuxNodeHandler) deleteNodeExternalIPSecOutRoute(ip *net.IPNet) {
 	}
 
 	if err := route.Delete(n.createNodeExternalIPSecOutRoute(ip, true)); err != nil {
-		log.WithError(err).Error("Unable to delete the IPsec route External OUT from the ipsec routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to delete the IPsec route External OUT from the ipsec routing table")
 	}
 
 	if err := route.Delete(n.createNodeExternalIPSecOutRoute(ip, false)); err != nil {
-		log.WithError(err).Error("Unable to delete the IPsec route External OUT from the host routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to delete the IPsec route External OUT from the host routing table")
 	}
 }
 
@@ -1420,7 +1420,7 @@ func (n *linuxNodeHandler) replaceNodeIPSecInRoute(ip *net.IPNet) {
 
 	_, err := route.Upsert(n.createNodeIPSecInRoute(ip))
 	if err != nil {
-		log.WithError(err).Error("Unable to replace the IPSec route IN the host routing table")
+		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to replace the IPSec route IN the host routing table")
 	}
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1170,7 +1170,9 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 	}
 
 	if n.nodeConfig.EnableIPSec {
-		n.deleteIPsec(oldNode)
+		if oldNode.IsLocal() || !n.subnetEncryption() {
+			n.deleteIPsec(oldNode)
+		}
 	}
 
 	if option.Config.EnableWireguard {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1322,13 +1322,10 @@ func (n *linuxNodeHandler) createNodeExternalIPSecOutRoute(ip *net.IPNet, dflt b
 	}
 }
 
-// replaceNodeIPSecOutRoute replace the out IPSec route in the host routing table
-// with the new route. If no route exists the route is installed on the host.
+// replaceNodeIPSecOutRoute replace the out IPSec route in the host routing
+// table with the new route. If no route exists the route is installed on the
+// host. The caller must ensure that the CIDR passed in must be non-nil.
 func (n *linuxNodeHandler) replaceNodeIPSecOutRoute(ip *net.IPNet) {
-	if ip == nil {
-		return
-	}
-
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
 			return
@@ -1345,13 +1342,10 @@ func (n *linuxNodeHandler) replaceNodeIPSecOutRoute(ip *net.IPNet) {
 	}
 }
 
-// replaceNodeExternalIPSecOutRoute replace the out IPSec route in the host routing table
-// with the new route. If no route exists the route is installed on the host.
+// replaceNodeExternalIPSecOutRoute replace the out IPSec route in the host
+// routing table with the new route. If no route exists the route is installed
+// on the host. The caller must ensure that the CIDR passed in must be non-nil.
 func (n *linuxNodeHandler) replaceNodeExternalIPSecOutRoute(ip *net.IPNet) {
-	if ip == nil {
-		return
-	}
-
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
 			return
@@ -1372,11 +1366,8 @@ func (n *linuxNodeHandler) replaceNodeExternalIPSecOutRoute(ip *net.IPNet) {
 	}
 }
 
+// The caller must ensure that the CIDR passed in must be non-nil.
 func (n *linuxNodeHandler) deleteNodeIPSecOutRoute(ip *net.IPNet) {
-	if ip == nil {
-		return
-	}
-
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
 			return
@@ -1392,11 +1383,8 @@ func (n *linuxNodeHandler) deleteNodeIPSecOutRoute(ip *net.IPNet) {
 	}
 }
 
+// The caller must ensure that the CIDR passed in must be non-nil.
 func (n *linuxNodeHandler) deleteNodeExternalIPSecOutRoute(ip *net.IPNet) {
-	if ip == nil {
-		return
-	}
-
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
 			return
@@ -1416,13 +1404,10 @@ func (n *linuxNodeHandler) deleteNodeExternalIPSecOutRoute(ip *net.IPNet) {
 	}
 }
 
-// replaceNodeIPSecoInRoute replace the in IPSec routes in the host routing table
-// with the new route. If no route exists the route is installed on the host.
+// replaceNodeIPSecoInRoute replace the in IPSec routes in the host routing
+// table with the new route. If no route exists the route is installed on the
+// host. The caller must ensure that the CIDR passed in must be non-nil.
 func (n *linuxNodeHandler) replaceNodeIPSecInRoute(ip *net.IPNet) {
-	if ip == nil {
-		return
-	}
-
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
 			return

--- a/pkg/datapath/node.go
+++ b/pkg/datapath/node.go
@@ -116,8 +116,9 @@ type NodeHandler interface {
 	// NodeDelete is called after a node has been deleted
 	NodeDelete(node nodeTypes.Node) error
 
-	// NodeValidateImplementation is called to validate the implementation
-	// of the node in the datapath
+	// NodeValidateImplementation is called to validate the implementation of
+	// the node in the datapath. This function is intended to be run on an
+	// interval to ensure that the datapath is consistently converged.
 	NodeValidateImplementation(node nodeTypes.Node) error
 
 	// NodeConfigurationChanged is called when the local node configuration

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -286,11 +286,9 @@ type Service struct {
 
 	// IncludeExternal is true when external endpoints from other clusters
 	// should be included
-	// +deepequal-gen=false
 	IncludeExternal bool
 
 	// Shared is true when the service should be exposed/shared to other clusters
-	// +deepequal-gen=false
 	Shared bool
 
 	// TrafficPolicy controls how backends are selected. If set to "Local", only
@@ -348,6 +346,10 @@ func (s *Service) DeepEqual(other *Service) bool {
 	}
 
 	if !ip.UnsortedIPListsAreEqual(s.FrontendIPs, other.FrontendIPs) {
+		return false
+	}
+
+	if s.Shared != other.Shared || s.IncludeExternal != other.IncludeExternal {
 		return false
 	}
 

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -495,7 +495,7 @@ func (s *ServiceCache) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 		}
 	}
 
-	if svcFound && svc.IncludeExternal {
+	if svcFound && svc.IncludeExternal && svc.Shared {
 		externalEndpoints, hasExternalEndpoints := s.externalEndpoints[id]
 		if hasExternalEndpoints {
 			// remote cluster endpoints already contain all Endpoints from all

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -281,6 +281,8 @@ func TestService_Equals(t *testing.T) {
 						Port:     1,
 					},
 				},
+				Shared:          true,
+				IncludeExternal: true,
 				NodePorts: map[loadbalancer.FEPortName]NodePortToFrontend{
 					loadbalancer.FEPortName("foo"): {
 						"0.0.0.0:31000": {
@@ -313,6 +315,8 @@ func TestService_Equals(t *testing.T) {
 							Port:     1,
 						},
 					},
+					Shared:          true,
+					IncludeExternal: true,
 					NodePorts: map[loadbalancer.FEPortName]NodePortToFrontend{
 						loadbalancer.FEPortName("foo"): {
 							"0.0.0.0:31000": {
@@ -367,6 +371,74 @@ func TestService_Equals(t *testing.T) {
 					Labels: map[string]string{
 						"foo": "bar",
 					},
+					Selector: map[string]string{
+						"baz": "foz",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different shared",
+			fields: &Service{
+				FrontendIPs: []net.IP{net.ParseIP("1.1.1.1")},
+				IsHeadless:  true,
+				Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+					loadbalancer.FEPortName("foo"): {
+						Protocol: loadbalancer.NONE,
+						Port:     1,
+					},
+				},
+				Shared:   true,
+				Labels:   map[string]string{},
+				Selector: map[string]string{},
+			},
+			args: args{
+				o: &Service{
+					FrontendIPs: []net.IP{net.ParseIP("1.1.1.1")},
+					IsHeadless:  true,
+					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+						loadbalancer.FEPortName("foo"): {
+							Protocol: loadbalancer.NONE,
+							Port:     1,
+						},
+					},
+					Shared: false,
+					Labels: map[string]string{},
+					Selector: map[string]string{
+						"baz": "foz",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different include external",
+			fields: &Service{
+				FrontendIPs: []net.IP{net.ParseIP("1.1.1.1")},
+				IsHeadless:  true,
+				Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+					loadbalancer.FEPortName("foo"): {
+						Protocol: loadbalancer.NONE,
+						Port:     1,
+					},
+				},
+				IncludeExternal: true,
+				Labels:          map[string]string{},
+				Selector:        map[string]string{},
+			},
+			args: args{
+				o: &Service{
+					FrontendIPs: []net.IP{net.ParseIP("1.1.1.1")},
+					IsHeadless:  true,
+					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+						loadbalancer.FEPortName("foo"): {
+							Protocol: loadbalancer.NONE,
+							Port:     1,
+						},
+					},
+					IncludeExternal: false,
+					Labels:          map[string]string{},
 					Selector: map[string]string{
 						"baz": "foz",
 					},

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -460,8 +460,13 @@ func (k *K8sWatcher) deleteK8sPodV1(pod *slim_corev1.Pod) error {
 }
 
 func (k *K8sWatcher) genServiceMappings(pod *slim_corev1.Pod, podIPs []string, logger *logrus.Entry) []loadbalancer.SVC {
-	var svcs []loadbalancer.SVC
-	for _, c := range pod.Spec.Containers {
+	var (
+		svcs       []loadbalancer.SVC
+		containers []slim_corev1.Container
+	)
+	containers = append(containers, pod.Spec.InitContainers...)
+	containers = append(containers, pod.Spec.Containers...)
+	for _, c := range containers {
 		for _, p := range c.Ports {
 			if p.HostPort <= 0 {
 				continue

--- a/pkg/k8s/zz_generated.deepequal.go
+++ b/pkg/k8s/zz_generated.deepequal.go
@@ -158,6 +158,12 @@ func (in *Service) deepEqual(other *Service) bool {
 	if in.IsHeadless != other.IsHeadless {
 		return false
 	}
+	if in.IncludeExternal != other.IncludeExternal {
+		return false
+	}
+	if in.Shared != other.Shared {
+		return false
+	}
 	if in.TrafficPolicy != other.TrafficPolicy {
 		return false
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -307,6 +307,8 @@ func (m *Manager) backgroundSyncInterval() time.Duration {
 	return m.ClusterSizeDependantInterval(baseBackgroundSyncInterval)
 }
 
+// backgroundSync ensures that local node has a valid datapath in-place for
+// each node in the cluster. See NodeValidateImplementation().
 func (m *Manager) backgroundSync() {
 	syncTimer, syncTimerDone := inctimer.New()
 	defer syncTimerDone()

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -411,8 +411,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			tunnelIP = nodeIP
 		}
 
-		if option.Config.IptablesMasqueradingEnabled() &&
-			address.Type != addressing.NodeInternalIP {
+		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			iptables.AddToNodeIpset(address.IP)
 		}
 
@@ -595,8 +594,7 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 	}
 
 	for _, address := range entry.node.IPAddresses {
-		if option.Config.IptablesMasqueradingEnabled() &&
-			address.Type != addressing.NodeInternalIP {
+		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			iptables.RemoveFromNodeIpset(address.IP)
 		}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2183,6 +2183,12 @@ func (c *DaemonConfig) IptablesMasqueradingEnabled() bool {
 	return c.IptablesMasqueradingIPv4Enabled() || c.IptablesMasqueradingIPv6Enabled()
 }
 
+// NodeIpsetNeeded returns true if a node ipsets should be used to skip
+// masquerading for traffic to cluster nodes.
+func (c *DaemonConfig) NodeIpsetNeeded() bool {
+	return c.Tunnel == TunnelDisabled && c.IptablesMasqueradingEnabled()
+}
+
 // RemoteNodeIdentitiesEnabled returns true if the remote-node identity feature
 // is enabled
 func (c *DaemonConfig) RemoteNodeIdentitiesEnabled() bool {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -720,6 +720,19 @@ func (kub *Kubectl) GetCiliumHostEndpointID(ciliumPod string) (int64, error) {
 	return hostEpID, nil
 }
 
+// GetCiliumHostEndpointState returns the state of the host endpoint on a given node.
+func (kub *Kubectl) GetCiliumHostEndpointState(ciliumPod string) (string, error) {
+	cmd := fmt.Sprintf("cilium endpoint list -o jsonpath='{[?(@.status.identity.id==%d)].status.state}'",
+		ReservedIdentityHost)
+	res := kub.CiliumExecContext(context.Background(), ciliumPod, cmd)
+	if !res.WasSuccessful() {
+		return "", fmt.Errorf("unable to run command '%s' to retrieve state of host endpoint from %s: %s",
+			cmd, ciliumPod, res.OutputPrettyPrint())
+	}
+
+	return strings.TrimSpace(res.Stdout()), nil
+}
+
 // GetNumCiliumNodes returns the number of Kubernetes nodes running cilium
 func (kub *Kubectl) GetNumCiliumNodes() int {
 	getNodesCmd := fmt.Sprintf("%s get nodes -o jsonpath='{.items.*.metadata.name}'", KubectlCmd)
@@ -3710,6 +3723,13 @@ func (kub *Kubectl) validateCilium() error {
 	})
 
 	g.Go(func() error {
+		if err := kub.ciliumHostEndpointRegenerated(); err != nil {
+			return fmt.Errorf("host EP is not ready: %s", err)
+		}
+		return nil
+	})
+
+	g.Go(func() error {
 		err := kub.fillServiceCache()
 		if err != nil {
 			return fmt.Errorf("unable to fill service cache: %s", err)
@@ -3860,6 +3880,24 @@ func (kub *Kubectl) ciliumHealthPreFlightCheck() error {
 			}
 		}
 
+	}
+	return nil
+}
+
+func (kub *Kubectl) ciliumHostEndpointRegenerated() error {
+	ginkgoext.By("Checking whether host EP regenerated")
+	ciliumPods, err := kub.GetCiliumPods()
+	if err != nil {
+		return fmt.Errorf("cannot retrieve cilium pods: %s", err)
+	}
+	for _, pod := range ciliumPods {
+		state, err := kub.GetCiliumHostEndpointState(pod)
+		if err != nil {
+			return err
+		}
+		if state != "ready" {
+			return fmt.Errorf("cilium-agent %q host EP is not in ready state: %q", pod, state)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
 * #18725 -- watchers: Support hostPort for init containers (@pchaigno)
 * #18788 -- iptables,option,node: Consistent condition for ipset usage (@pchaigno)
 * #18766 -- clustermesh: Modify shared-service annotation after creation (@sayboras)
 * #18827 -- pkg/datapath/linux: Fix asymmetric IPsec logic on delete (@christarazi)
 * excluded #18857 -- test: Flush CT tables after L7 proxy tests in K8sServices (@brb)
 * #18731 -- ipsec: Add/Fix packet tracing for overlay mode (@YutaroHayakawa)
 * #18859 -- test: Wait until host EP is ready (=regenerated) (@brb)
 * #18893 -- docs: Remove trailing step in AWS helm install (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18725 18788 18766 18827 18731 18859 18893; do contrib/backporting/set-labels.py $pr done 1.11; done
```
or with
```
$ make add-label branch=v1.11 issues=18725,18788,18766,18827,18731,18859,18893
```