### PR TITLE
node: Fix incorrect comment for S/GetRouterInfo

### DIFF
--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -282,14 +282,14 @@ func GetK8sExternalIPv4() net.IP {
 	return ipv4ExternalAddress
 }
 
-// GetRouterEniInfo returns additional information for the router. It is applicable
-// only in the ENI IPAM mode.
+// GetRouterInfo returns additional information for the router. It is applicable
+// only in the ENI & Alibaba IPAM modes.
 func GetRouterInfo() RouterInfo {
 	return routerInfo
 }
 
-// SetRouterEniInfo sets additional information for the router. It is applicable
-// only in the ENI IPAM mode.
+// SetRouterInfo sets additional information for the router. It is applicable
+// only in the ENI & Alibaba IPAM modes.
 func SetRouterInfo(info RouterInfo) {
 	routerInfo = info
 }


### PR DESCRIPTION
This function is not specific to ENI IPAM mode anymore since Alibaba IPAM mode is also using it.