### PR TITLE
Fix IPsec in Azure's IPAM mode

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -226,7 +226,9 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerI
 		}
 		routerIP = result.IP
 	}
-	if (option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAlibabaCloud) && result != nil {
+	if (option.Config.IPAM == ipamOption.IPAMENI ||
+		option.Config.IPAM == ipamOption.IPAMAlibabaCloud ||
+		option.Config.IPAM == ipamOption.IPAMAzure) && result != nil {
 		var routingInfo *linuxrouting.RoutingInfo
 		routingInfo, err = linuxrouting.NewRoutingInfo(result.GatewayIP, result.CIDRs,
 			result.PrimaryMAC, result.InterfaceNumber, option.Config.EnableIPv4Masquerade)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -486,9 +486,11 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
 			}
 		}
-		// If we are using IPAMENI always use IP_POOLS datapath, the pod subnets
-		// will be auto-discovered later at runtime.
-		if (option.Config.IPAM == ipamOption.IPAMENI) ||
+		// If we are using EKS or AKS IPAM modes, we should use IP_POOLS
+		// datapath as the pod subnets will be auto-discovered later at
+		// runtime.
+		if option.Config.IPAM == ipamOption.IPAMENI ||
+			option.Config.IPAM == ipamOption.IPAMAzure ||
 			option.Config.IsPodSubnetsDefined() {
 			cDefinesMap["IP_POOLS"] = "1"
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1524,7 +1524,8 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 	if newConfig.EnableIPSec {
 		// For the ENI ipam mode on EKS, this will be the interface that
 		// the router (cilium_host) IP is associated to.
-		if option.Config.IPAM == ipamOption.IPAMENI && len(option.Config.IPv4PodSubnets) == 0 {
+		if (option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) &&
+			len(option.Config.IPv4PodSubnets) == 0 {
 			if info := node.GetRouterInfo(); info != nil {
 				var ipv4PodSubnets []*net.IPNet
 				for _, c := range info.GetIPv4CIDRs() {

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -282,14 +282,12 @@ func GetK8sExternalIPv4() net.IP {
 	return ipv4ExternalAddress
 }
 
-// GetRouterEniInfo returns additional information for the router. It is applicable
-// only in the ENI IPAM mode.
+// GetRouterInfo returns additional information for the router, the cilium_host interface.
 func GetRouterInfo() RouterInfo {
 	return routerInfo
 }
 
-// SetRouterEniInfo sets additional information for the router. It is applicable
-// only in the ENI IPAM mode.
+// SetRouterInfo sets additional information for the router, the cilium_host interface.
 func SetRouterInfo(info RouterInfo) {
 	routerInfo = info
 }


### PR DESCRIPTION
When using Azure's IPAM mode, we don't have non-overlapping pod CIDRs for each node, so we can't rely on the default IPsec mode where we use the destination CIDRs to match the xfrm policies.

Instead, we need to enable subnet IPsec as in EKS. In that case, the dir=out xfrm policy and state look like:

    src 0.0.0.0/0 dst 10.240.0.0/16
        dir out priority 0
        mark 0x3e00/0xff00
        tmpl src 0.0.0.0 dst 10.240.0.0
             proto esp spi 0x00000003 reqid 1 mode tunnel

    src 0.0.0.0 dst 10.240.0.0
        proto esp spi 0x00000003 reqid 1 mode tunnel
        replay-window 0
        mark 0x3e00/0xff00 output-mark 0xe00/0xf00
        aead rfc4106(gcm(aes)) 0x567a47ff70a43a3914719a593d5b12edce25a971 128
        anti-replay context: seq 0x0, oseq 0x105, bitmap 0x00000000
        sel src 0.0.0.0/0 dst 0.0.0.0/0

As can be seen the xfrm policy matches on a broad /16 encompassing all endpoints in the cluster. The xfrm state then matches the policy's template. Finally, to write the proper outer destination IP, we need to define the `IP_POOLS` macro in our datapath. That way, our BPF programs will determine the outer IP from the ipcache lookup.