### PR TITLE
api: API ratelimit logs are too noisy

### DIFF
--- a/daemon/cmd/api_limits.go
+++ b/daemon/cmd/api_limits.go
@@ -28,7 +28,7 @@ var apiRateLimitDefaults = map[string]rate.APILimiterParameters{
 		ParallelRequests:            4,
 		SkipInitial:                 4,
 		MaxWaitDuration:             15 * time.Second,
-		Log:                         true,
+		Log:                         false,
 	},
 	// DELETE /endpoint/{id}
 	//
@@ -43,7 +43,7 @@ var apiRateLimitDefaults = map[string]rate.APILimiterParameters{
 		AutoAdjust:                  true,
 		ParallelRequests:            4,
 		MinParallelRequests:         4,
-		Log:                         true,
+		Log:                         false,
 	},
 	// GET /endpoint/{id}/healthz
 	// GET /endpoint/{id}/log
@@ -78,7 +78,7 @@ var apiRateLimitDefaults = map[string]rate.APILimiterParameters{
 		ParallelRequests:            4,
 		SkipInitial:                 4,
 		MaxWaitDuration:             15 * time.Second,
-		Log:                         true,
+		Log:                         false,
 	},
 	// GET /endpoint
 	//


### PR DESCRIPTION
Description: Observed too many logs while creating and deletion of pods

Fix: By default, rate limited logs are disabled

Fixes: #13900

Signed-off-by: Mahadev Panchal <mahadev.panchal@benisontech.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!


```release-note
Make API ratelimit logs less noisy by default
```
