### PR TITLE
git: Ignore local emacs config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ GIT_VERSION
 
 # Generated dockerignore files
 images/*/Dockerfile.dockerignore
+
+# Local Emacs files
+.dir-locals.el


### PR DESCRIPTION
Local emacs config is useful in many ways, but should not be pushed to
the repo.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
