### PR TITLE
iptables: Fatal when IPv6 is enabled but corresponding kernel modules are missing

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -428,8 +428,8 @@ func (m *IptablesManager) Init() {
 	if err := modulesManager.FindOrLoadModules(
 		"ip6_tables", "ip6table_mangle", "ip6table_raw", "ip6table_filter"); err != nil {
 		if option.Config.EnableIPv6 {
-			log.WithError(err).Warning(
-				"IPv6 is enabled and ip6tables modules could not be initialized (try loading ip6_tables, ip6table_mangle, ip6table_raw and ip6table_filter modules)")
+			log.WithError(err).Fatal(
+				"IPv6 is enabled and ip6tables modules could not be initialized (try disabling IPv6 in Cilium or loading ip6_tables, ip6table_mangle, ip6table_raw and ip6table_filter kernel modules)")
 		}
 		log.WithError(err).Debug(
 			"ip6tables kernel modules could not be loaded, so IPv6 cannot be used")


### PR DESCRIPTION
Before this change, when Cilium was running with --enable-ipv6 option,
we were only logging a warning, but then the rest of iptables.go module
was inserting ip6tables rules anyway. That resulted in errors, because
inserting such rules is impossible without IPv6 netfilter presence in
the kernel.

This change fixes that by a fatal error in situation when IPv6 is
enabled in Cilium, but not supported by the kernel. In such situations,
users should either disable IPv6 in Cilium or load the needed kernel
modules.

Fixes: #18904
Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>

```release-note
Fatal when IPv6 is enabled but corresponding kernel modules are missing
```
