### PR TITLE
test/Runtime: Skip pre/post-checks during build

### DIFF
--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -113,7 +113,7 @@ then
     fi
 else
     echo "compiling cilium..."
-    sudo -u vagrant -H -E make SKIP_CUSTOMVET_CHECK=true LOCKDEBUG=1 SKIP_K8S_CODE_GEN_CHECK=false
+    sudo -u vagrant -H -E make build LOCKDEBUG=1
     echo "installing cilium..."
     make install
     mkdir -p /etc/sysconfig/


### PR DESCRIPTION
When building images for the K8s CI jobs, we don't run the pre and post checks. We do however for the Runtime CI job. That is unnecessary because we already have other CI checks for this (Smoke tests and Travis CI). This pull request changes the Runtime job to be consistent with the K8s jobs.