### PR TITLE
hubble/filters: add a unit test for TCP flows without flags

### DIFF
--- a/pkg/hubble/filters/tcp_test.go
+++ b/pkg/hubble/filters/tcp_test.go
@@ -101,6 +101,13 @@ func TestFlowTCPFilter(t *testing.T) {
 			argsev: &flowpb.TCPFlags{PSH: true, ACK: true},
 			want:   true,
 		},
+		// regression test for GH-18830
+		{
+			name:   "TCP flow without flags",
+			argsf:  []*flowpb.TCPFlags{{SYN: true}},
+			argsev: nil,
+			want:   false,
+		},
 	}
 
 	for _, tt := range testflags {
@@ -110,9 +117,8 @@ func TestFlowTCPFilter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fl, err := BuildFilterList(context.Background(), argsfilter, []OnBuildFilter{&TCPFilter{}})
 			if err != nil {
-				return
-			}
-			if got := fl.MatchOne(argsevent); got != tt.want {
+				t.Errorf("unexpected filter build error: %s", err)
+			} else if got := fl.MatchOne(argsevent); got != tt.want {
 				t.Errorf("%s: got %v, want %v", tt.name, got, tt.want)
 			}
 		})


### PR DESCRIPTION
7e8b65187a4d37e0c41fd29c8d853ad44ecb5fd9 introduced a fix for L7 flows having L4/TCP info without TCP flags. This patch add a regression unit test to cover the fix.

cc @wazir-ahmed

checked that the test actually cover the fix by running:
```console
% git revert --no-commit 7e8b65187a4d37e0c41fd29c8d853ad44ecb5fd9
% go test -v ./pkg/hubble/filters/ -run TestFlowTCPFilter
…
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x29 pc=0xc0fdd5]

goroutine 61 [running]:
testing.tRunner.func1.2({0xce99e0, 0x1577980})
	/usr/lib/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/usr/lib/go/src/testing/testing.go:1212 +0x218
panic({0xce99e0, 0x1577980})
	/usr/lib/go/src/runtime/panic.go:1038 +0x215
github.com/cilium/cilium/pkg/hubble/filters.filterByTCPFlags.func1(0xf70f78)
	/home/alex/go/src/github.com/cilium/cilium/pkg/hubble/filters/tcp.go:27 +0x95
github.com/cilium/cilium/pkg/hubble/filters.FilterFuncs.MatchAll({0xc000010460, 0x1, 0x1}, 0x0)
	/home/alex/go/src/github.com/cilium/cilium/pkg/hubble/filters/filters.go:29 +0x56
github.com/cilium/cilium/pkg/hubble/filters.BuildFilterList.func1(0xc000010460)
	/home/alex/go/src/github.com/cilium/cilium/pkg/hubble/filters/filters.go:116 +0x2b
github.com/cilium/cilium/pkg/hubble/filters.FilterFuncs.MatchOne({0xc000010450, 0x1, 0xc000010440}, 0x1)
	/home/alex/go/src/github.com/cilium/cilium/pkg/hubble/filters/filters.go:44 +0x76
github.com/cilium/cilium/pkg/hubble/filters.TestFlowTCPFilter.func1(0xc000682820)
	/home/alex/go/src/github.com/cilium/cilium/pkg/hubble/filters/tcp_test.go:121 +0xe5
testing.tRunner(0xc000682820, 0xc00037eb40)
	/usr/lib/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/lib/go/src/testing/testing.go:1306 +0x35a
FAIL	github.com/cilium/cilium/pkg/hubble/filters	0.018s
FAIL
```
The trace match the one in https://github.com/cilium/cilium/issues/18830