### PR TITLE
fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,6 +27,7 @@
 # @cilium/operator           Cilium operator
 # @cilium/policy             Policy behaviour
 # @cilium/proxy              L7 proxy, Envoy
+# @cilium/sig-clustermesh    All code related with clustermesh
 # @cilium/vendor             Vendoring, dependency management
 # @cilium/wireguard          Wireguard integration
 


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/18972 introduced changes that broke the CODEOWNERS linter.