### PR TITLE
.github: fix conditions for running CODEOWNERS checks

### DIFF
--- a/.github/workflows/lint-codeowners.yaml
+++ b/.github/workflows/lint-codeowners.yaml
@@ -110,12 +110,13 @@ jobs:
         run: |
           EXIT_STATUS=0
           # List all teams used in CODEOWNERS rules: discard comments and empty
-          # lines, discard the first field (pattern to match) for the remaining
+          # lines, discard lines with no team assigned (with no space in it),
+          # then discard the first field (pattern to match) for the remaining
           # rules, split the list of teams by replacing spaces with line
           # breaks, sort the results. Then grep for each team name among
           # CODEOWNERS's comments.
           cd src/github.com/cilium/cilium
-          for team in $(sed -e '/^\(#\|$\)/d' -e 's/^[^ #]\+ //' -e 's/ /\n/g' CODEOWNERS | sort -u); do
+          for team in $(sed -e '/^\(#\|$\)/d' -e '/^[^ ]*$/d' -e 's/^[^ #]\+ //' -e 's/ /\n/g' CODEOWNERS | sort -u); do
               if ! grep -q "^# ${team} " CODEOWNERS; then
                   echo "${team}";
                   EXIT_STATUS=1

--- a/.github/workflows/lint-codeowners.yaml
+++ b/.github/workflows/lint-codeowners.yaml
@@ -33,10 +33,11 @@ jobs:
               - deleted: '**'
             codeowners-changed:
               - 'CODEOWNERS'
+              - '.github/workflows/lint-codeowners.yaml'
 
   codeowners:
     needs: check_changes
-    if: ${{ needs.check_changes.outputs.added-files == 'true' || needs.check_changes.outputs.deleted-files == 'true' }}
+    if: ${{ needs.check_changes.outputs.codeowners-changed == 'true' || needs.check_changes.outputs.added-files == 'true' || needs.check_changes.outputs.deleted-files == 'true' }}
     name: Check CODEOWNERS consistency
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +49,7 @@ jobs:
           path: src/github.com/cilium/cilium
 
       - name: Check if all files have attributed code owners
-        if: ${{ needs.check_changes.outputs.added-files == 'true' }}
+        if: ${{ needs.check_changes.outputs.codeowners-changed == 'true' || needs.check_changes.outputs.added-files == 'true' }}
         run: |
           # CODEOWNERS patterns follows nearly the same syntax as a .gitignore.
           # To check if all files are covered by patterns other than the
@@ -69,7 +70,7 @@ jobs:
           fi
 
       - name: Check if CODEOWNERS has stale entries
-        if: ${{ needs.check_changes.outputs.deleted-files == 'true' }}
+        if: ${{ needs.check_changes.outputs.codeowners-changed == 'true' || needs.check_changes.outputs.deleted-files == 'true' }}
         run: |
           cd src/github.com/cilium/cilium
           EXIT_STATUS=0


### PR DESCRIPTION
The checks for `CODEOWNERS` are run when some files are added to or removed from the repository, but not when the `CODEOWNERS` file itself is updated. Let's fix the conditions for running those checks.

Addresses https://github.com/cilium/cilium/pull/18972#issuecomment-1054613219, fixes https://github.com/cilium/cilium/pull/18260. Related: https://github.com/cilium/cilium/pull/18980.
