### PR TITLE
daemon, install/kubernetes: fix typo in DNS policy rule unload flag/value doc

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -71,7 +71,7 @@ cilium-agent [flags]
       --disable-endpoint-crd                                 Disable use of CiliumEndpoint CRD
       --disable-iptables-feeder-rules strings                Chains to ignore when installing feeder rules.
       --dns-max-ips-per-restored-rule int                    Maximum number of IPs to maintain for each restored DNS rule (default 1000)
-      --dns-policy-unload-on-shutdown                        Unload DNS policy rules on graceful showdown
+      --dns-policy-unload-on-shutdown                        Unload DNS policy rules on graceful shutdown
       --egress-masquerade-interfaces string                  Limit egress masquerading to interface selector
       --egress-multi-home-ip-rule-compat                     Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
       --enable-auto-protect-node-port-range                  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -893,7 +893,7 @@ func initializeFlags() {
 	flags.Int(option.DNSMaxIPsPerRestoredRule, defaults.DNSMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored DNS rule")
 	option.BindEnv(option.DNSMaxIPsPerRestoredRule)
 
-	flags.Bool(option.DNSPolicyUnloadOnShutdown, false, "Unload DNS policy rules on graceful showdown")
+	flags.Bool(option.DNSPolicyUnloadOnShutdown, false, "Unload DNS policy rules on graceful shutdown")
 	option.BindEnv(option.DNSPolicyUnloadOnShutdown)
 
 	flags.Int(option.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxDeferredConnectionDeletes, "Maximum number of IPs to retain for expired DNS lookups with still-active connections")

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -815,7 +815,7 @@ data:
 {{- end }}
 
 {{- if hasKey .Values "dnsPolicyUnloadOnShutdown" }}
-  # Unload DNS policy rules on graceful showdown
+  # Unload DNS policy rules on graceful shutdown
   dns-policy-unload-on-shutdown: {{.Values.dnsPolicyUnloadOnShutdown | quote }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1938,5 +1938,5 @@ cgroup:
 # in order to support graceful termination.
 enableK8sTerminatingEndpoint: true
 
-# -- Configure whether to unload DNS policy rules on graceful showdown
+# -- Configure whether to unload DNS policy rules on graceful shutdown
 # dnsPolicyUnloadOnShutdown: false


### PR DESCRIPTION
Fixes: 708873d06934 ("daemon: allow unloading DNS policy rules on graceful shutdown")
Fixes: f602a58d874e ("install/kubernetes: expose DNS policy rule unload agent flag as helm value")