### PR TITLE
v1.9 backports 2022-03-01

### DIFF
--- a/Documentation/concepts/networking/ipam/azure.rst
+++ b/Documentation/concepts/networking/ipam/azure.rst
@@ -194,17 +194,28 @@ When a node or instance terminates, the Kubernetes apiserver will send a node
 deletion event. This event will be picked up by the operator and the operator
 will delete the corresponding ``ciliumnodes.cilium.io`` custom resource.
 
+.. _ipam_azure_required_privileges:
+
 *******************
 Required Privileges
 *******************
 
 The following Azure API calls are being performed by the Cilium operator. The
-service principal provided must have privileges to perform these:
+Service Principal provided must have privileges to perform these within the
+scope of the AKS cluster node resource group:
 
  * `Network Interfaces - Create Or Update <https://docs.microsoft.com/en-us/rest/api/virtualnetwork/networkinterfaces/createorupdate>`__
  * `NetworkInterface In VMSS - List Virtual Machine Scale Set Network Interfaces <https://docs.microsoft.com/en-us/rest/api/virtualnetwork/networkinterface%20in%20vmss/listvirtualmachinescalesetnetworkinterfaces>`__
  * `Virtual Networks - List <https://docs.microsoft.com/en-us/rest/api/virtualnetwork/virtualnetworks/list>`__
  * `Virtual Machine Scale Sets - List All <https://docs.microsoft.com/en-us/rest/api/compute/virtualmachinescalesets/listall>`__
+
+.. note::
+
+   The node resource group is *not* the resource group of the AKS cluster. A
+   single resource group may hold multiple AKS clusters, but each AKS cluster
+   regroups all resources in an automatically managed secondary resource group.
+   See `Why are two resource groups created with AKS? <https://docs.microsoft.com/en-us/azure/aks/faq#why-are-two-resource-groups-created-with-aks>`__
+   for more details.
 
 *******
 Metrics

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -58,42 +58,35 @@ Deploy the Cluster
 .. note:: When setting up AKS, it is important to use the flag
           ``--network-plugin azure`` to ensure that CNI mode is enabled.
 
-Create a service principal for cilium-operator
+Create a Service principal for cilium-operator
 ==============================================
 
-In order to allow cilium-operator to interact with the Azure API, a service
-principal is required. You can reuse an existing service principal if you want
-but it is recommended to create a dedicated service principal for
-cilium-operator:
+In order to allow cilium-operator to interact with the Azure API, a Service
+Principal with ``Contributor`` privileges over the AKS cluster is required (see
+:ref:`Azure IPAM required privileges <ipam_azure_required_privileges>` for more
+details). It is recommended to create a dedicated Service Principal for each
+Cilium installation with minimal privileges over the AKS node resource group:
 
-.. code:: bash
+.. code-block:: shell-session
 
-    az ad sp create-for-rbac --name cilium-operator > azure-sp.json
+    AZURE_SUBSCRIPTION_ID=$(az account show --query "id" --output tsv)
+    AZURE_NODE_RESOURCE_GROUP=$(az aks show --resource-group ${RESOURCE_GROUP} --name ${CLUSTER_NAME} --query "nodeResourceGroup" --output tsv)
+    AZURE_SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --scopes /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_NODE_RESOURCE_GROUP} --role Contributor --output json --only-show-errors)
+    AZURE_TENANT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.tenant')
+    AZURE_CLIENT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.appId')
+    AZURE_CLIENT_SECRET=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.password')
 
-The contents of ``azure-sp.json`` should look like this:
+.. note::
 
-.. code:: bash
+    The ``AZURE_NODE_RESOURCE_GROUP`` node resource group is *not* the
+    resource group of the AKS cluster. A single resource group may hold
+    multiple AKS clusters, but each AKS cluster regroups all resources in
+    an automatically managed secondary resource group. See `Why are two
+    resource groups created with AKS? <https://docs.microsoft.com/en-us/azure/aks/faq#why-are-two-resource-groups-created-with-aks>`__
+    for more details.
 
-    {
-      "appId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-      "displayName": "cilium-operator",
-      "name": "http://cilium-operator",
-      "password": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-      "tenant": "cccccccc-cccc-cccc-cccc-cccccccccccc"
-    }
-
-Extract the relevant credentials to access the Azure API:
-
-.. code:: bash
-
-    AZURE_SUBSCRIPTION_ID="$(az account show | jq -r .id)"
-    AZURE_CLIENT_ID="$(jq -r .appId < azure-sp.json)"
-    AZURE_CLIENT_SECRET="$(jq -r .password < azure-sp.json)"
-    AZURE_TENANT_ID="$(jq -r .tenant < azure-sp.json)"
-    AZURE_NODE_RESOURCE_GROUP="$(az aks show --resource-group $RESOURCE_GROUP_NAME --name $CLUSTER_NAME | jq -r .nodeResourceGroup)"
-
-.. note:: ``AZURE_NODE_RESOURCE_GROUP`` must be set to the resource group of the
-           node pool, *not* the resource group of the AKS cluster.
+    This ensures the Service Principal only has privileges over the AKS
+    cluster itself and not any other resources within the resource group.
 
 Retrieve Credentials to access cluster
 ======================================

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -209,7 +209,8 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 		}
 		routerIP = result.IP
 	}
-	if option.Config.IPAM == ipamOption.IPAMENI && result != nil {
+	if (option.Config.IPAM == ipamOption.IPAMENI ||
+		option.Config.IPAM == ipamOption.IPAMAzure) && result != nil {
 		var routingInfo *linuxrouting.RoutingInfo
 		routingInfo, err = linuxrouting.NewRoutingInfo(result.GatewayIP, result.CIDRs,
 			result.PrimaryMAC, result.InterfaceNumber, option.Config.Masquerade)

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -120,7 +120,7 @@ pipeline {
         }
         stage ("Copy code and boot vms"){
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 50, unit: 'MINUTES')
             }
 
             environment {
@@ -134,11 +134,9 @@ pipeline {
                 sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                 withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
                     retry(3) {
-                        timeout(time: 30, unit: 'MINUTES'){
-                            dir("${TESTDIR}") {
-                                sh 'vagrant destroy runtime --force'
-                                sh 'KERNEL=$(python3 get-gh-comment-info.py "${ghprbCommentBody}" --retrieve=kernel_version | sed "s/^$/${DEFAULT_KERNEL}/") vagrant up runtime --provision'
-                            }
+                        dir("${TESTDIR}") {
+                            sh 'vagrant destroy runtime --force'
+                            sh 'KERNEL=$(python3 get-gh-comment-info.py "${ghprbCommentBody}" --retrieve=kernel_version | sed "s/^$/${DEFAULT_KERNEL}/") vagrant up runtime --provision'
                         }
                     }
                 }

--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -71,10 +71,6 @@ pipeline {
             }
         }
         stage('Preload vagrant boxes'){
-            options {
-                timeout(time: 20, unit: 'MINUTES')
-            }
-
             steps {
                 sh '/usr/local/bin/add_vagrant_box ${WORKSPACE}/${PROJ_PATH}/vagrant_box_defaults.rb'
             }

--- a/pkg/azure/api/api_interaction_test.go
+++ b/pkg/azure/api/api_interaction_test.go
@@ -28,21 +28,13 @@ import (
 // How to run these tests:
 //
 // 1. Modify testSubscription and testResourceGroup
-// 2. Create a service principal
-//      az ad sp create-for-rbac -n cilium-unit-test
-//      {
-//        "appId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-//        "displayName": "cilium-unit-test",
-//        "name": "http://cilium-unit-test",
-//        "password": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-//        "tenant": "cccccccc-cccc-cccc-cccc-cccccccccccc"
-//      }
-// 3. Set
-//      AZURE_SUBSCRIPTION_ID=$(az account show --query id | tr -d \")
-//      AZURE_CLIENT_ID=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
-//      AZURE_CLIENT_SECRET=bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
-//      AZURE_TENANT_ID=cccccccc-cccc-cccc-cccc-cccccccccccc
-//      AZURE_NODE_RESOURCE_GROUP=$(az aks show -n $CLUSTER_NAME -g $RESOURCE_GROUP | jq -r .nodeResourceGroup)
+// 2. Set
+//      AZURE_SUBSCRIPTION_ID=$(az account show --query "id" --output tsv)
+//      AZURE_NODE_RESOURCE_GROUP=$(az aks show --resource-group ${RESOURCE_GROUP} --name ${CLUSTER_NAME} --query "nodeResourceGroup" --output tsv)
+// 			AZURE_SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --scopes /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_NODE_RESOURCE_GROUP} --role Contributor --output json --only-show-errors)
+//      AZURE_TENANT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.tenant')
+//      AZURE_CLIENT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.appId')
+//      AZURE_CLIENT_SECRET=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.password')
 
 type ApiInteractionSuite struct{}
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -373,9 +373,11 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
 			}
 		}
-		// If we are using IPAMENI always use IP_POOLS datapath, the pod subnets
-		// will be auto-discovered later at runtime.
-		if (option.Config.IPAM == ipamOption.IPAMENI) ||
+		// If we are using EKS or AKS IPAM modes, we should use IP_POOLS
+		// datapath as the pod subnets will be auto-discovered later at
+		// runtime.
+		if option.Config.IPAM == ipamOption.IPAMENI ||
+			option.Config.IPAM == ipamOption.IPAMAzure ||
 			option.Config.IsPodSubnetsDefined() {
 			cDefinesMap["IP_POOLS"] = "1"
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1385,7 +1385,8 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 	if newConfig.EnableIPSec {
 		// For the ENI ipam mode on EKS, this will be the interface that
 		// the router (cilium_host) IP is associated to.
-		if option.Config.IPAM == ipamOption.IPAMENI && len(option.Config.IPv4PodSubnets) == 0 {
+		if (option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) &&
+			len(option.Config.IPv4PodSubnets) == 0 {
 			if info := node.GetRouterInfo(); info != nil {
 				var ipv4PodSubnets []*net.IPNet
 				for _, c := range info.GetIPv4CIDRs() {

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -251,14 +251,12 @@ func GetK8sExternalIPv4() net.IP {
 	return ipv4ExternalAddress
 }
 
-// GetRouterEniInfo returns additional information for the router. It is applicable
-// only in the ENI IPAM mode.
+// GetRouterInfo returns additional information for the router, the cilium_host interface.
 func GetRouterInfo() RouterInfo {
 	return routerInfo
 }
 
-// SetRouterEniInfo sets additional information for the router. It is applicable
-// only in the ENI IPAM mode.
+// SetRouterInfo sets additional information for the router, the cilium_host interface.
 func SetRouterInfo(info RouterInfo) {
 	routerInfo = info
 }


### PR DESCRIPTION
 * #18886 -- jenkinsfiles: bump runtime tests VM boot timeout (@nbusseneau)
 * #18891 -- docs: update Azure Service Principal / IPAM documentation (@nbusseneau)
 * #18911 -- Fix IPsec in Azure's IPAM mode (@pchaigno)
 * #18707 -- ci: remove box download timeout in upstream tests (@nbusseneau)

PRs skipped due conflicts:

 * #18877 -- hubble: Added nil check in filterByTCPFlags() to avoid segfault (@wazir-ahmed)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18886 18891 18911 18707; do contrib/backporting/set-labels.py $pr done 1.9; done
```
or with
```
$ make add-label branch=v1.9 issues=18886,18891,18911,18707
```