### PR TITLE
ipcache: Use incremental policy updates

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -469,7 +469,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		return nil, nil, fmt.Errorf("error while initializing policy subsystem: %w", err)
 	}
 	nodeMngr = nodeMngr.WithSelectorCacheUpdater(d.policy.GetSelectorCache()) // must be after initPolicy
-	nodeMngr = nodeMngr.WithPolicyTriggerer(d.policyUpdater)                  // must be after initPolicy
+	nodeMngr = nodeMngr.WithPolicyTriggerer(epMgr)                            // must be after initPolicy
 
 	// Propagate identity allocator down to packages which themselves do not
 	// have types to which we can add an allocator member.

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -139,6 +139,8 @@ func waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup) error {
 
 // UpdatePolicyMaps returns a WaitGroup which is signaled upon once all endpoints
 // have had their PolicyMaps updated against the Endpoint's desired policy state.
+//
+// Endpoints will wait on the 'notifyWg' parameter before updating policy maps.
 func (mgr *EndpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup {
 	var epWG sync.WaitGroup
 	var wg sync.WaitGroup

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -118,4 +118,6 @@ func (m *mockUpdater) UpdateIdentities(_, _ cache.IdentityCache, _ *sync.WaitGro
 
 type mockTriggerer struct{}
 
-func (m *mockTriggerer) TriggerPolicyUpdates(bool, string) {}
+func (m *mockTriggerer) UpdatePolicyMaps(ctx context.Context, wg *sync.WaitGroup) *sync.WaitGroup {
+	return wg
+}

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -135,7 +135,7 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 		desiredIPs,
 		src,
 		k.policyRepository.GetSelectorCache(),
-		k.policyManager,
+		k.endpointManager,
 	)
 
 	for ip := range desiredIPs {
@@ -145,7 +145,7 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 	ipcache.IPIdentityCache.TriggerLabelInjection(
 		src,
 		k.policyRepository.GetSelectorCache(),
-		k.policyManager,
+		k.endpointManager,
 	)
 }
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -115,6 +115,7 @@ type endpointManager interface {
 	GetHostEndpoint() *endpoint.Endpoint
 	LookupPodName(string) *endpoint.Endpoint
 	WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error
+	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
 }
 
 type nodeDiscoverManager interface {

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -149,7 +149,7 @@ type selectorCacheUpdater interface {
 }
 
 type policyTriggerer interface {
-	TriggerPolicyUpdates(bool, string)
+	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
 }
 
 // Subscribe subscribes the given node handler to node events.


### PR DESCRIPTION
Previously, this kube-apiserver code would trigger policy updates
globally with no synchronization to the policymap updates. This would
ensure a full re-evaluation of the policy for all endpoints, rather than
just targeting the policy updates that need to occur as a result of the
ipcache metadata injection (for associating the kube-apiserver label
with specific IP addresses).

Reuse EndpointManager.UpdatePolicyMaps() to ensure synchronous updates
of the underlying BPF policymaps, which should improve the ability to
consistently apply policy whenever there is an update involving the
kube-apiserver (for instance, if it moves to another node).

This will also serve as a basis to improve more general metadata
association with addresses as planned in upcoming changes.

Note that this will change the locking behaviour where previously, this
critical section would only synchronize the SelectorCache while holding
the IPcache, and asynchronously update the datapath. Now, policy map
updates for each endpoint will be performed while holding the IPcache
lock. This includes potentially updating the proxy policy.


Before this patch:

```mermaid
sequenceDiagram
    participant K8s_EndpointHandler
    participant IPCache
    participant IdentityAllocator
    participant Policy_SelectorCache
    participant Daemon_PolicyUpdater
    participant Endpoint_Regenerate
    participant EndpointManager
    note over EndpointManager: unused
    participant Endpoint_Policy
    participant BPF_policy
    participant BPF_ipcache

    K8s_EndpointHandler->>+IPCache: kube-apiserver has IP X
    IPCache->>+IdentityAllocator: Create identity for X with labels {...,reserved:kube-apiserver}
    IdentityAllocator->>+IPCache: Identity α has labels {...}
    IPCache->>+Policy_SelectorCache: Update the policy selectors to handle the identity α
    Policy_SelectorCache->>+Endpoint_Policy: Calculate incremental policy map updates (unused)
    
    par Update BPF policy maps
    IPCache-)+Daemon_PolicyUpdater: Trigger updates into the BPF PolicyMaps
    loop Regenerate policies for all endpoints
    Daemon_PolicyUpdater->>+Endpoint_Regenerate: Trigger endpoint regeneration
    Endpoint_Regenerate->>+Endpoint_Policy: Calculate policy for current endpoint (expensive)
    Endpoint_Policy->>+BPF_policy: Push policymap updates into per-endpoint BPF maps
    end
    and Update BPF ipcache map
    IPCache->>+BPF_ipcache: Update the datapath to map IP X to identity α
    end
```

After this patch:

```mermaid
sequenceDiagram
    participant K8s_EndpointHandler
    participant IPCache
    participant IdentityAllocator
    participant Policy_SelectorCache
    participant Daemon_PolicyUpdater
    note over Daemon_PolicyUpdater: unused
    participant Endpoint_Regenerate
    note over Endpoint_Regenerate: unused
    participant EndpointManager
    participant Endpoint_Policy
    participant BPF_policy
    participant BPF_ipcache

    K8s_EndpointHandler->>+IPCache: kube-apiserver has IP X
    IPCache->>+IdentityAllocator: Create identity for X with labels {...,reserved:kube-apiserver}
    IdentityAllocator->>+IPCache: Identity α has labels {...}
    IPCache->>+Policy_SelectorCache: Update the policy selectors to handle the identity α
    Policy_SelectorCache->>+Endpoint_Policy: Calculate incremental policy map updates
    
    IPCache->>+EndpointManager: Trigger incremental policy updates into the BPF PolicyMaps
    loop Push incremental policies for all endpoints
    EndpointManager->>+Endpoint_Policy: Trigger incremental policy update for current endpoint
    Endpoint_Policy->>+BPF_policy: Push policymap updates into per-endpoint BPF maps
    end
    IPCache->>+BPF_ipcache: Update the datapath to map IP X to identity α
```