### PR TITLE
policy: Track policy entries with no owners to avoid BPF state leaks

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -241,7 +241,7 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 }
 
 // deleteKeyWithChanges deletes a 'key' from 'keys' keeping track of incremental changes in 'adds' and 'deletes'.
-// The key is unconditionally deleted if 'cs' is nil, otherwise only the contribution of this 'cs' is removed.
+// The key is unconditionally deleted if 'owner' is nil, otherwise only the contribution of this 'owner' is removed.
 // They key is also deleted from the map state if it doesn't have any owners anymore.
 func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, adds, deletes MapState) {
 	if entry, exists := keys[key]; exists {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -242,9 +242,11 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 
 // deleteKeyWithChanges deletes a 'key' from 'keys' keeping track of incremental changes in 'adds' and 'deletes'.
 // The key is unconditionally deleted if 'cs' is nil, otherwise only the contribution of this 'cs' is removed.
+// They key is also deleted from the map state if it doesn't have any owners anymore.
 func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, adds, deletes MapState) {
 	if entry, exists := keys[key]; exists {
-		if owner != nil {
+		// Check contributions of the passed owner.
+		if owner != nil && len(entry.owners) != 0 {
 			// remove the contribution of the given selector only
 			if _, exists = entry.owners[owner]; exists {
 				// Remove the contribution of this selector from the entry


### PR DESCRIPTION
When an identity is deleted, the agent processes the incremental policy
map changes against previously saved policy state with owners
and dependents of the identity key to decide if an identity can be marked for
deletion in the `deletes` map. In some cases, the `owners` field for the identity
entry was nil, and the deleteKeyWithChanges would return early without tracking
the identity for deletion. As a result, when this information is consumed
later to delete the identity from the BPF maps, the identity was being leaked
in those cases.

Fix : While removing contributions of an owner passed via incremental map
changes to an identity entry, check if the store policy map state for the
entry had any previously populated owners.
If no owners found, the key entry will be removed from the map as expected
so that the deleted identity is correctly tracked in the `deletes` map.

See this issue for more details about how the design
can be improved - https://github.com/cilium/cilium/issues/19003.

Snippet of leaked identity entries in an affected cluster -

```
$ kubectl get ciliumidentity 2025
NAME   NAMESPACE   AGE
2025   default     99s

$ kubectl -n kube-system exec cilium-ktdhh -c cilium-agent -- cilium bpf policy get -n 2382 | grep 2025

$ kubectl get ciliumidentity 2025
Error from server (NotFound): ciliumidentities.cilium.io "2025" not found

$ kubectl -n kube-system exec cilium-ktdhh -c cilium-agent -- cilium bpf policy get -n 2382 | grep 2025
Allow    Ingress     2025       ANY          NONE         0          0

```

Fixes: #18581
Fixes: https://github.com/cilium/cilium/commit/0d585f110846237eb3611e88d0992ba26a162f72

**Release note**
```release-note
Fix issue with deleted identities not getting cleaned up from BPF maps leading to policy sync-up issues because of map being full.
```