### PR TITLE
Policy fix mapstate owners

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1283,14 +1283,16 @@ func (e *Endpoint) syncPolicyMap() error {
 	}
 
 	// Diffs between the maps are expected here, so do not bother collecting them
-	_, _, err = e.syncDesiredPolicyMapWith(e.realizedPolicy.PolicyMapState, false)
+	_, _, err = e.syncPolicyMapsWith(e.realizedPolicy.PolicyMapState, false)
 	return err
 }
 
-// syncDesiredPolicyMapWith updates the bpf policy map state based on the
+// syncPolicyMapsWith updates the bpf policy map state based on the
 // difference between the given 'realized' and desired policy state without
 // dumping the bpf policy map.
-func (e *Endpoint) syncDesiredPolicyMapWith(realized policy.MapState, withDiffs bool) (diffCount int, diffs []policy.MapChange, err error) {
+// Changes are synced to endpoint's realized policy mapstate, 'realized' is
+// not modified.
+func (e *Endpoint) syncPolicyMapsWith(realized policy.MapState, withDiffs bool) (diffCount int, diffs []policy.MapChange, err error) {
 	errors := 0
 
 	// Add policy map entries before deleting to avoid transient drops
@@ -1412,7 +1414,7 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	e.PolicyDebug(logrus.Fields{"dumpedPolicyMap": currentMap}, "syncPolicyMapWithDump")
 	// Diffs between the maps indicate an error in the policy map update logic.
 	// Collect and log diffs if policy logging is enabled.
-	diffCount, diffs, err := e.syncDesiredPolicyMapWith(currentMap, e.getPolicyLogger() != nil)
+	diffCount, diffs, err := e.syncPolicyMapsWith(currentMap, e.getPolicyLogger() != nil)
 
 	if diffCount > 0 {
 		e.getLogger().WithField(logfields.Count, diffCount).Warning("Policy map sync fixed errors, consider running with debug verbose = policy to get detailed dumps")

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -165,7 +165,10 @@ func (a *PerSelectorPolicy) Equal(b *PerSelectorPolicy) bool {
 
 // IsRedirect returns true if the L7Rules are a redirect.
 func (a *PerSelectorPolicy) IsRedirect() bool {
-	// Deny policies do not support L7 rules
+	// policy is for an L7 redirect if it:
+	// - is not nil,
+	// - has some L7 rules, and
+	// - it is not a deny policy, as deny policies do not support L7 rules
 	return !a.IsEmpty() && !a.IsDeny
 }
 

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -197,7 +197,7 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(policyMapState MapSt
 // locking the selector cache to make sure concurrent identity updates
 // have completed.
 // PolicyOwner (aka Endpoint) is also locked during this call.
-func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes MapState) {
+func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
 	p.selectorPolicy.SelectorCache.mutex.Lock()
 	defer p.selectorPolicy.SelectorCache.mutex.Unlock()
 	return p.policyMapChanges.consumeMapChanges(p.PolicyMapState)

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -483,12 +483,12 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 	adds, deletes := policy.ConsumeMapChanges()
 	// maps on the policy got cleared
 
-	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
+	c.Assert(adds, checker.Equals, Keys{
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: {},
 	})
-	c.Assert(deletes, checker.Equals, MapState{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
+	c.Assert(deletes, checker.Equals, Keys{
+		{Identity: 193, DestPort: 80, Nexthdr: 6}: {},
 	})
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -662,12 +662,12 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	// maps on the policy got cleared
 	c.Assert(policy.policyMapChanges.changes, IsNil)
 
-	c.Assert(adds, checker.Equals, MapState{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
+	c.Assert(adds, checker.Equals, Keys{
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: {},
 	})
-	c.Assert(deletes, checker.Equals, MapState{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithoutOwners(),
+	c.Assert(deletes, checker.Equals, Keys{
+		{Identity: 193, DestPort: 80, Nexthdr: 6}: {},
 	})
 
 	// Assign an empty mutex so that checker.Equal does not complain about the


### PR DESCRIPTION
When an identity is deleted, the agent processes the incremental policy
map changes against previously saved policy state with owners and
dependents of the identity key to decide if an identity can be marked for
deletion. In some cases, the `owners` field for the identity entry was
nil (due to them being redacted when returned by ConsumeMapChanges()
previously), and the deleteKeyWithChanges would return early without
tracking the identity for deletion. As a result, when this information is
consumed later to delete the identity from the BPF maps, the identity was
being leaked in those cases.

Callers of ConsumeMapChanges() and AddVisibilityKeys() depend on the
returned added and deleted keys to perform datapath policy map updates
without iterating whole policy maps. Moreover, the "realized" version of
endpoint's policy map used to be updated solely based on these returned
entries.

Make this less fragile and error prone by only returning the added and
deleted map keys (no values). AddVisibilityKeys() supports reverting the
changes, so it still needs to return the full MapState (keys and values)
for any changed entries.

Now that ConsumeMapChanges() and AddVisibilityKeys() return the keys of
added entries, the caller needs to find the value to be inserted from the
desired policy map using the given key.

Fixes: #18581
Fixes: 0d585f110846237eb3611e88d0992ba26a162f72
Fixes: https://github.com/cilium/cilium/issues/19003
Co-authored-by: Aditi Ghag <aditi@cilium.io>
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
Fixed a bug where deleted identities would remain in BPF policy maps.
```
