### PR TITLE
Making operator aware of pending pod backlog on nodes for IP allocations

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -331,12 +331,18 @@ following criteria:
 
  * The subnet associated with the ENI has IPs available for allocation
 
-The following formula is used to determine how many IPs are allocated on the
-ENI:
+The following formula is used to determine how many IPs are allocated on the ENI:
 
 .. code-block:: go
 
-      min(AvailableOnSubnet, min(AvailableOnENI, NeededAddresses + spec.ipam.max-above-watermark))
+      // surgeAllocate kicks in if numPendingPods is greater than NeededAddresses
+      min(AvailableOnSubnet, min(AvailableOnENI, NeededAddresses + spec.ipam.max-above-watermark + surgeAllocate))
+
+.. note::
+
+   In scenarios where the pre-allocated number is lower than the number of pending pods on the node, the operator will
+   pro-actively allocate more than the pre-allocated number of IPs to avoid having to wait for the next allocation
+   cycles.
 
 This means that the number of IPs allocated in a single allocation cycle can be
 less than what is required to fulfill ``spec.ipam.pre-allocate``.

--- a/operator/watchers/pod.go
+++ b/operator/watchers/pod.go
@@ -16,6 +16,8 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
+const PodNodeNameIndex = "pod-node"
+
 var (
 	// PodStore has a minimal copy of all pods running in the cluster.
 	// Warning: The pods stored in the cache are not intended to be used for Update
@@ -36,15 +38,28 @@ var (
 	UnmanagedPodStoreSynced = make(chan struct{})
 )
 
+// podNodeNameIndexFunc indexes pods by node name
+func podNodeNameIndexFunc(obj interface{}) ([]string, error) {
+	pod := obj.(*slim_corev1.Pod)
+	if pod.Spec.NodeName != "" {
+		return []string{pod.Spec.NodeName}, nil
+	}
+	return []string{}, nil
+}
+
 func PodsInit(k8sClient kubernetes.Interface, stopCh <-chan struct{}) {
 	var podInformer cache.Controller
-	PodStore, podInformer = informer.NewInformer(
+	PodStore = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{
+		PodNodeNameIndex: podNodeNameIndexFunc,
+	})
+	podInformer = informer.NewInformerWithStore(
 		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
 			"pods", v1.NamespaceAll, fields.Everything()),
 		&slim_corev1.Pod{},
 		0,
 		cache.ResourceEventHandlerFuncs{},
 		convertToPod,
+		PodStore,
 	)
 	go podInformer.Run(stopCh)
 
@@ -65,6 +80,9 @@ func convertToPod(obj interface{}) interface{} {
 				Namespace:       concreteObj.Namespace,
 				ResourceVersion: concreteObj.ResourceVersion,
 			},
+			Spec: slim_corev1.PodSpec{
+				NodeName: concreteObj.Spec.NodeName,
+			},
 			Status: slim_corev1.PodStatus{
 				Phase: concreteObj.Status.Phase,
 			},
@@ -84,6 +102,9 @@ func convertToPod(obj interface{}) interface{} {
 					Name:            pod.Name,
 					Namespace:       pod.Namespace,
 					ResourceVersion: pod.ResourceVersion,
+				},
+				Spec: slim_corev1.PodSpec{
+					NodeName: pod.Spec.NodeName,
 				},
 				Status: slim_corev1.PodStatus{
 					Phase: pod.Status.Phase,

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -17,6 +17,7 @@ import (
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 
@@ -271,6 +272,7 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 			manager:             n,
 			ipsMarkedForRelease: make(map[string]time.Time),
 			ipReleaseStatus:     make(map[string]string),
+			logLimiter:          logging.NewLimiter(10*time.Second, 3), // 1 log / 10 secs, burst of 3
 		}
 
 		node.ops = n.instancesAPI.CreateNode(resource, node)


### PR DESCRIPTION
On large clusters with really low pre-allocate values, IP allocations
can be very slow. Especially in scenarios like replacement of a node
with high pod density. This is because every time maintenance is
performed on a node only pre-allocate number of IPs are allocated in a
batch even though there might be a higher backlog of pending pods
scheduled on the node.

This commit adds a new indexer to the pod informer cache which allows
for querying the cache by node name. This allows the operator to look at
the backlog and allocate more IPs up-to what's available on the
interface. Max above watermark could be used to achieve a similar
effect, but it can result in IP wastage.

Note : https://github.com/cilium/cilium/pull/18864/commits/40164bcb69c0b5ffbda64f862f04697758ca88f4 also adds nodeName to the slim version of pod spec. Will remove https://github.com/cilium/cilium/commit/bc60bcac112052149a914b15cc6a9c8c5a82492b if https://github.com/cilium/cilium/pull/18864 lands earlier.
