### PR TITLE
Added ARCH to Hubble and cilium-cli install instructions for MacOS

### DIFF
--- a/Documentation/gettingstarted/cli-download.rst
+++ b/Documentation/gettingstarted/cli-download.rst
@@ -16,10 +16,11 @@ various features (e.g. clustermesh, Hubble).
 
     .. code-block:: shell-session
 
-      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-darwin-amd64.tar.gz{,.sha256sum}
-      shasum -a 256 -c cilium-darwin-amd64.tar.gz.sha256sum
-      sudo tar xzvfC cilium-darwin-amd64.tar.gz /usr/local/bin
-      rm cilium-darwin-amd64.tar.gz{,.sha256sum}
+      export ARCH=$(uname -p)
+      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-darwin-$ARCH.tar.gz{,.sha256sum}
+      shasum -a 256 -c cilium-darwin-$ARCH.tar.gz.sha256sum
+      sudo tar xzvfC cilium-darwin-$ARCH.tar.gz /usr/local/bin
+      rm cilium-darwin-$ARCH.tar.gz{,.sha256sum}
 
   .. group-tab:: Other
 

--- a/Documentation/gettingstarted/hubble-install.rst
+++ b/Documentation/gettingstarted/hubble-install.rst
@@ -18,11 +18,12 @@
 
       .. code-block:: shell-session
 
+         export ARCH=$(uname -p)
          export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
-         curl -L --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-amd64.tar.gz{,.sha256sum}
-         shasum -a 256 -c hubble-darwin-amd64.tar.gz.sha256sum
-         sudo tar xzvfC hubble-darwin-amd64.tar.gz /usr/local/bin
-         rm hubble-darwin-amd64.tar.gz{,.sha256sum}
+         curl -L --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-$ARCH.tar.gz{,.sha256sum}
+         shasum -a 256 -c hubble-darwin-$ARCH.tar.gz.sha256sum
+         sudo tar xzvfC hubble-darwin-$ARCH.tar.gz /usr/local/bin
+         rm hubble-darwin-$ARCH.tar.gz{,.sha256sum}
 
    .. group-tab:: Windows
 


### PR DESCRIPTION
Documentation: This change adds the env var ARCH to the install docs to distinct between intel and arm
architecture on MacOS.

Signed-off-by: Alexander Stielau (finleap connect GmbH) <alexander.stielau@finleap.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->
Documentation: Adds ARCH env var to MacOS installation path for hubble and cilium-cli to distinct between amd64 and arm64 binaries.

Bare with me, thats my 1st try to contribute...
