### PR TITLE
Fix 'node-init' in GKE's 'cos' images.

### DIFF
--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -22,9 +22,11 @@ fi
 {{- end }}
 
 {{- if .Values.nodeinit.reconfigureKubelet }}
-# Check if we're running on a GKE containerd flavor.
+# Check if we're running on a GKE containerd flavor as indicated by the presence
+# of the '--container-runtime-endpoint' flag in '/etc/default/kubelet'.
 GKE_KUBERNETES_BIN_DIR="/home/kubernetes/bin"
-if [[ -f "${GKE_KUBERNETES_BIN_DIR}/gke" ]] && command -v containerd &>/dev/null; then
+KUBELET_DEFAULTS_FILE="/etc/default/kubelet"
+if [[ -f "${GKE_KUBERNETES_BIN_DIR}/gke" ]] && [[ $(grep -cF -- '--container-runtime-endpoint' "${KUBELET_DEFAULTS_FILE}") == "1" ]]; then
   echo "GKE *_containerd flavor detected..."
 
   # (GKE *_containerd) Upon node restarts, GKE's containerd images seem to reset
@@ -98,7 +100,7 @@ else
   # (Generic) Alter the kubelet configuration to run in CNI mode
   echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir={{ .Values.cni.binPath }}"
   mkdir -p {{ .Values.cni.binPath }}
-  sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir={{ .Values.cni.binPath }}:g" /etc/default/kubelet
+  sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir={{ .Values.cni.binPath }}:g" "${KUBELET_DEFAULTS_FILE}"
 fi
 echo "Restarting the kubelet..."
 systemctl restart kubelet


### PR DESCRIPTION
Turns out that in GKE's `cos` images the `containerd` binary is still present even though `/etc/containerd/config.toml` is not. Hence, the kubelet wrapper would still be installed for these images according to the current check, even though it's not necessary. What's worse, starting the kubelet would fail because the `sed` command targeting the aforementioned file would fail.

This PR changes the check to rely on the presence of the `--container-runtime-endpoint` flag in the kubelet, which is probably a more reliable way of detecting `*_containerd` flavours and only applying the fix in these cases.

Fixes #19015.

```release-note
Fix 'node-init' in GKE's 'cos' images.
```