### PR TITLE
Revert "ipsec: set interface ID different from 0"

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -33,9 +33,6 @@ const (
 	IPSecDirOut     IPSecDir = "IPSEC_OUT"
 	IPSecDirBoth    IPSecDir = "IPSEC_BOTH"
 	IPSecDirOutNode IPSecDir = "IPSEC_OUT_NODE"
-	// XfrmInterfaceID must be different from 0 to avoid
-	// error while constructing xfrm state or policy.
-	XfrmInterfaceID int = 1
 )
 
 type ipSecKey struct {
@@ -63,15 +60,12 @@ func ipSecNewState() *netlink.XfrmState {
 		Mode:  netlink.XFRM_MODE_TUNNEL,
 		Proto: netlink.XFRM_PROTO_ESP,
 		ESN:   false,
-		Ifid:  XfrmInterfaceID,
 	}
 	return &state
 }
 
 func ipSecNewPolicy() *netlink.XfrmPolicy {
-	policy := netlink.XfrmPolicy{
-		Ifid: XfrmInterfaceID,
-	}
+	policy := netlink.XfrmPolicy{}
 	return &policy
 }
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -171,7 +171,6 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 			Mask:  linux_defaults.IPsecMarkMaskIn,
 			Value: linux_defaults.RouteMarkToProxy,
 		},
-		Ifid: XfrmInterfaceID,
 	})
 	c.Assert(err, IsNil)
 	c.Assert(toProxyPolicy, Not(IsNil))


### PR DESCRIPTION
This reverts pull request https://github.com/cilium/cilium/pull/18789.

Linux commit [`68ac0f3810e7`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=68ac0f3810e7) ("xfrm: state and policy should fail if XFRMA_IF_ID 0") broke userspace applications by refusing xfrm states and policies with a zero `XFRMA_IF_ID`. Commit 735ac6a7 ("ipsec: set interface ID different from 0") attempted to work around this by defining a non-zero `XFRMA_IF_ID`.

Unfortunately, this workaround breaks IPsec connectivity between nodes. Once the `XFRMA_IF_ID` is set to the placeholder value (1), traffic that should be encrypted leave the node without any encryption. On GKE and self-managed clusters, that's the only noticeable impact. However, on AKS and EKS, we also have BPF logic to rewrite the outer IP address to the proper IP. This still happens despite the failure to encrypt traffic, leading to packet drops.

The traffic leaves the node unencrypted because packets don't match the xfrm policies anymore, due to the non-zero `XFRMA_IF_ID`.

Thus, we didn't notice this regression in the pull request introducing the workaround because 1) GKE and Jenkins tests didn't fail and 2) the EKS and AKS IPsec tests are currently disabled. This was noticed while attempting to reenable the AKS IPsec test.

This revert was tested in CI by running the whole AKS+IPsec workflow three times successfully (at https://github.com/cilium/cilium/runs/5407467510, the two failures are because I restarted too soon and the previous cluster was not deleted yet) and locally by running the connectivity tests 10 times on the same AKS cluster.

/cc @tormath1 