### PR TITLE
workflows: Increase timeout for AKS workflow

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -118,7 +118,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
     steps:
       - name: Set up job variables
         id: vars

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -118,7 +118,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
     steps:
       - name: Set up job variables
         id: vars

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -121,7 +121,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
     steps:
       - name: Set up job variables
         id: vars


### PR DESCRIPTION
This commit increases the timeout for the whole AKS workflow from 35 to 45 minutes. The AKS cluster creation can sometimes take a long time and the workflow [timed out already once on master](https://github.com/cilium/cilium/runs/5387016255). And that's despite the fact that the IPsec test is currently disabled.

As a point of comparison, GKE, which has the fastest cluster creations, has a timeout of 45 minutes today.