### PR TITLE
workflow: Wait for AKS nodes to be ready

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -224,8 +224,7 @@ jobs:
             --mode user \
             --node-count 2 \
             --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
-            ${{ env.cost_reduction }} \
-            --no-wait
+            ${{ env.cost_reduction }}
 
           # Delete the initial system node pool
           az aks nodepool delete \

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -224,8 +224,7 @@ jobs:
             --mode user \
             --node-count 2 \
             --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
-            ${{ env.cost_reduction }} \
-            --no-wait
+            ${{ env.cost_reduction }}
 
           # Delete the initial system node pool
           az aks nodepool delete \

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -223,8 +223,7 @@ jobs:
             --mode user \
             --node-count 2 \
             --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
-            ${{ env.cost_reduction }} \
-            --no-wait
+            ${{ env.cost_reduction }}
 
           # Delete the initial system node pool
           az aks nodepool delete \


### PR DESCRIPTION
The AKS workflow sometimes fails on master because some of the Cilium agents took too long to reach a working status (cilium status). Looking in the logs, we can see that when this happens, it's usually because the agents in question spent a while waiting for the cilium-operator to be ready.

We suspect this may happen because the AKS nodepool creations are not complete yet when Cilium is installed. Indeed, since we run all AKS nodepool commands with `--no-wait`, and given the Cilium images are already ready when running on master, the Cilium deployment starts right after we execute the last aks nodepool command. As a result, it's possible that the cilium-operator takes a little while longer to come up.

In an attempt to fix this, we want to make sure all nodes are ready before proceeding with the Cilium deployment. We have three nodepool operations at the end: systempool creation, userpool creation, previous systempool deletion. The deletion of the previous systempool already implicitly waits for the new systempool to be created. Thus, if we simply wait for the userpool creation to complete before proceeding, all nodes should be ready.

The AKS workflow tested with the `pull_request` trigger passed: https://github.com/cilium/cilium/runs/5410557799.