### PR TITLE
workflows: pin Cyclonus image to its SHA

### DIFF
--- a/test/k8s/manifests/netpol-cyclonus/install-cyclonus.yml
+++ b/test/k8s/manifests/netpol-cyclonus/install-cyclonus.yml
@@ -17,5 +17,5 @@ spec:
             - --cleanup-namespaces=true
           name: cyclonus
           imagePullPolicy: IfNotPresent
-          image: mfenwick100/cyclonus:v0.2.0
+          image: mfenwick100/cyclonus:v0.2.0@sha256:e489de547399d248703623fb471c0d6221d3f479
       serviceAccount: cyclonus


### PR DESCRIPTION
We pin the Cyclonus image used in our scheduled Cyclonus CI tests to its SHA, for increased security against supply chain attacks and as per our general security policy at Cilium.