### PR TITLE
docs: fix tip about opening the Hubble server port on all nodes

### DIFF
--- a/Documentation/gettingstarted/hubble_setup.rst
+++ b/Documentation/gettingstarted/hubble_setup.rst
@@ -54,7 +54,7 @@ Enable Hubble in Cilium
 
         .. tip::
 
-           Enabling Hubble requires the TCP port 4245 to be open on all nodes running
+           Enabling Hubble requires the TCP port 4244 to be open on all nodes running
            Cilium. This is required for Relay to operate correctly.
 
         Run ``cilium status`` to validate that Hubble is enabled and running:


### PR DESCRIPTION
The documentation page about setting up Hubble observability wrongly
states that TCP port 4245 needs to be open on all nodes running Cilium
to allow Hubble Relay to operate correctly. This is incorrect. Port 4245
is actually the default port used by Hubble Relay, which is a regular
deployment and doesn't require any particular action from the user.

However, Hubble server uses port 4244 by default and, given that it is
embedded in the Cilium agent and uses a host port, it requires it to be
open on all nodes to allow Hubble Relay to connect to each Hubble server
instance.

PS: sorry for the large diff (better reviewed commit by commit).