### PR TITLE
clustermesh: Correct shared service annotation behaviour

### DIFF
--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -35,7 +35,7 @@ var etcdConfig = []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddre
 
 func (s *ClusterMeshServicesTestSuite) prepareServiceUpdate(clusterSuffix, backendIP, portName, port string) (string, string) {
 	return "cilium/state/services/v1/" + s.randomName + clusterSuffix + "/default/foo",
-		`{"cluster":"` + s.randomName + clusterSuffix + `","namespace":"default","name":"foo","frontends":{"172.20.0.177":{"port":{"protocol":"TCP","port":80}}},"backends":{"` + backendIP + `":{"` + portName + `":{"protocol":"TCP","port":` + port + `}}},"labels":{},"selector":{"name":"foo"}}`
+		`{"cluster":"` + s.randomName + clusterSuffix + `","namespace":"default","name":"foo","frontends":{"172.20.0.177":{"port":{"protocol":"TCP","port":80}}},"backends":{"` + backendIP + `":{"` + portName + `":{"protocol":"TCP","port":` + port + `}}},"labels":{},"selector":{"name":"foo"},"shared":true,"includeExternal":true}`
 
 }
 

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -524,6 +524,9 @@ func NewClusterService(id ServiceID, k8sService *Service, k8sEndpoints *Endpoint
 		svc.Backends[ipString] = backend.Ports
 	}
 
+	svc.Shared = k8sService.Shared
+	svc.IncludeExternal = k8sService.IncludeExternal
+
 	return svc
 }
 

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -495,7 +495,7 @@ func (s *ServiceCache) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 		}
 	}
 
-	if svcFound && svc.IncludeExternal && svc.Shared {
+	if svcFound && svc.IncludeExternal {
 		externalEndpoints, hasExternalEndpoints := s.externalEndpoints[id]
 		if hasExternalEndpoints {
 			// remote cluster endpoints already contain all Endpoints from all
@@ -519,7 +519,7 @@ func (s *ServiceCache) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 	}
 
 	// Report the service as ready if a local endpoints object exists or if
-	// external endpoints have have been identified
+	// external endpoints have been identified
 	return endpoints, hasLocalEndpoints || len(endpoints.Backends) > 0
 }
 
@@ -548,23 +548,27 @@ func (s *ServiceCache) mergeServiceUpdateLocked(service *serviceStore.ClusterSer
 		s.externalEndpoints[id] = externalEndpoints
 	}
 
-	scopedLog.Debugf("Updating backends to %+v", service.Backends)
-	backends := map[string]*Backend{}
-	for ipString, portConfig := range service.Backends {
-		backends[ipString] = &Backend{Ports: portConfig}
-	}
-	externalEndpoints.endpoints[service.Cluster] = &Endpoints{
-		Backends: backends,
+	// we don't need to check if the current cluster is remote or local,
+	// as externalEndpoints should not have any local cluster endpoints anyway.
+	if service.IncludeExternal && !service.Shared {
+		delete(externalEndpoints.endpoints, service.Cluster)
+	} else {
+		scopedLog.Debugf("Updating backends to %+v", service.Backends)
+		backends := map[string]*Backend{}
+		for ipString, portConfig := range service.Backends {
+			backends[ipString] = &Backend{Ports: portConfig}
+		}
+		externalEndpoints.endpoints[service.Cluster] = &Endpoints{
+			Backends: backends,
+		}
 	}
 
 	svc, ok := s.services[id]
 
 	endpoints, serviceReady := s.correlateEndpoints(id)
 
-	// Only send event notification if service is shared and ready.
-	// External endpoints are still tracked but correlation will not happen
-	// until the service is marked as shared.
-	if ok && svc.Shared && serviceReady {
+	// Only send event notification if service is ready.
+	if ok && serviceReady {
 		swg.Add()
 		s.Events <- ServiceEvent{
 			Action:     UpdateService,
@@ -604,9 +608,7 @@ func (s *ServiceCache) MergeExternalServiceDelete(service *serviceStore.ClusterS
 
 		endpoints, serviceReady := s.correlateEndpoints(id)
 
-		// Only send event notification if service is shared. External
-		// endpoints are still tracked but correlation will not happen
-		// until the service is marked as shared.
+		// Only send event notification if service is shared.
 		if ok && svc.Shared {
 			swg.Add()
 			event := ServiceEvent{

--- a/pkg/service/store/store.go
+++ b/pkg/service/store/store.go
@@ -57,7 +57,7 @@ type ClusterService struct {
 	// Frontends is a map indexed by the frontend IP address
 	Frontends map[string]PortConfiguration `json:"frontends"`
 
-	// Backends is is map indexed by the backend IP address
+	// Backends is map indexed by the backend IP address
 	Backends map[string]PortConfiguration `json:"backends"`
 
 	// Labels are the labels of the service
@@ -65,6 +65,13 @@ type ClusterService struct {
 
 	// Selector is the label selector used to select backends
 	Selector map[string]string `json:"selector"`
+
+	// IncludeExternal is true when external endpoints from other clusters
+	// should be included
+	IncludeExternal bool `json:"includeExternal"`
+
+	// Shared is true when the service should be exposed/shared to other clusters
+	Shared bool `json:"shared"`
 }
 
 func (s *ClusterService) String() string {


### PR DESCRIPTION
### Description
    
The changes in previous PR #18766 was assumed shared service annotation
is for local cluster, rather than for remote cluster.

This commit is to perform the adjustment. It's easier to explain with
concrete example. Let's say we have one clusters A and B, if the service
in cluster B is having shared-service: false annotation added, below
behavior will happen:

- requests to cluster A service will LB to local endpoint only, as
  service B is no longer shared.
- requests to cluster B service will LB to local and remote endpoints
  as usual.

Relates #18766

Signed-off-by: Tam Mach <tam.mach@isovalent.com>


_Thanks to Duffie and Ray for pointing out my confusion_


### Testing

Testing was done locally with 2 kind clusters with sample services mentioned
in [docs](https://docs.cilium.io/en/latest/gettingstarted/clustermesh/services/#load-balancing-with-global-services)


<details>
<summary>After provision global service</summary>

```
$ kg services rebel-base --context kind-kind-1
NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
rebel-base   ClusterIP   10.96.196.167   <none>        80/TCP    118s

$ ksysex --context kind-kind-1 ds/cilium -- cilium bpf lb list                     
Defaulted container "cilium-agent" out of: cilium-agent, ebpf-mount (init), clean-cilium-state (init)
SERVICE ADDRESS     BACKEND ADDRESS
...      
10.96.196.167:80    10.244.1.38:80 (7)                        
                    10.244.1.69:80 (7)                        
                    10.244.1.147:80 (7)                       
                    10.244.1.44:80 (7)                        
                    0.0.0.0:0 (7) [ClusterIP, non-routable]  

$ kg services rebel-base --context kind-kind-2
NAME         TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
rebel-base   ClusterIP   10.96.228.46   <none>        80/TCP    2m52s

$  ksysex --context kind-kind-2 ds/cilium -- cilium bpf lb list        
Defaulted container "cilium-agent" out of: cilium-agent, ebpf-mount (init), clean-cilium-state (init)
SERVICE ADDRESS      BACKEND ADDRESS
10.96.0.1:443        172.18.0.7:6443 (3)                       
                     0.0.0.0:0 (3) [ClusterIP, non-routable]   
10.96.228.46:80      0.0.0.0:0 (7) [ClusterIP, non-routable]   
                     10.244.1.38:80 (7)                        
                     10.244.1.147:80 (7)                       
                     10.244.1.69:80 (7)                        
                     10.244.1.44:80 (7) 

$ cat temp_check.sh      
#!/usr/bin/env bash

echo 'Checking in cluster 1'
for i in $(seq 1 10); do kubectl exec -ti --context kind-kind-1 deployment/x-wing -- curl rebel-base; done

echo 'Checking in cluster 2'
for i in $(seq 1 10); do kubectl exec -ti --context kind-kind-2 deployment/x-wing -- curl rebel-base; done

$ ./temp_check.sh                                                                          
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}

```

</details>


<details>
<summary>Add `io.cilium/shared-service: false` annotation for service in cluster 1</summary>

```
$ k annotate service rebel-base io.cilium/shared-service="false" --context kind-kind-1 --overwrite
service/rebel-base annotated

$ ./temp_check.sh
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}

```

</details>


<details>
<summary>Add `io.cilium/shared-service: false` annotation for service in cluster 2</summary>

```
$ k annotate service rebel-base io.cilium/shared-service="false" --context kind-kind-2 --overwrite
service/rebel-base annotated

$ ./temp_check.sh                                                                                 
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}

```

</details>


<details>
<summary>Revert io.cilium/shared-service back to 'true' for 2 clusters one by one</summary>

```
$ k annotate service rebel-base io.cilium/shared-service="true" --context kind-kind-2 --overwrite
service/rebel-base annotated

$ ./temp_check.sh                                                                             
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}

$ k annotate service rebel-base io.cilium/shared-service="true" --context kind-kind-1 --overwrite
service/rebel-base annotated

$ ./temp_check.sh                                                                                
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
```

</details>


```release-note
clustermesh: Correct shared service annotation behaviour
```
