### PR TITLE
helm: Remove Unnecessary RBAC Permissions for Agent

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -37,18 +37,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/finalizers
   verbs:
-  - get
-  - list
-  - watch
   - update
-  - delete
 - apiGroups:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -37,18 +37,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/finalizers
   verbs:
-  - get
-  - list
-  - watch
   - update
-  - delete
 - apiGroups:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list


### PR DESCRIPTION
In October 2020, [we made changes](https://github.com/cilium/cilium/pull/13369) to the cilium-agent's
ClusterRole to be more permissive. We did this, because
[Openshift enables](https://docs.openshift.com/container-platform/4.6/architecture/admission-plug-ins.html) the [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement)
admission controller. This admissions controller prevents
changes to the metadata.ownerReferences of any object
unless the entity (the cilium-agent in this case) has
permission to delete the object as well. Furthermore,
the controller allows protects metadata.ownerReferences[x].blockOwnerDeletion
of a resource unless the entity (again, the cilium-agent) has
"update" access to the finalizer of the object having its
deletion blocked. The original PR mistakenly assumed we
set ownerReferences on pods and expanded cilium-agent's
permissions beyond what was necessary. Cilium-agent
only sets ownerReferences on a CiliumEndpoint and the
blockOwnerDeletion field propagates up to the "owning"
pod of the endpoint. Cilium-agent only needs to be able
to delete CiliumEndpoints (which it has always been able to)
and "update" pod/finalizers (to set the blockOwnerDeletion field
on CiliumEndpoints). All other changes contained in #13369
were unnecessary.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

```release-note
helm: Removed unnecessary Kubernetes RBAC permissions for cilium-agent
```
