### PR TITLE
alibabacloud: Fix derived VPC CIDR block

### DIFF
--- a/pkg/alibabacloud/metadata/metadata.go
+++ b/pkg/alibabacloud/metadata/metadata.go
@@ -40,9 +40,9 @@ func GetVPCID(ctx context.Context) (string, error) {
 	return getMetadata(ctx, "vpc-id")
 }
 
-// GetCIDRBlock returns the IPv4 CIDR that belongs to the ECS instance from metadata
-func GetCIDRBlock(ctx context.Context) (string, error) {
-	return getMetadata(ctx, "vswitch-cidr-block")
+// GetVPCCIDRBlock returns the IPv4 CIDR block of the VPC to which the instance belongs
+func GetVPCCIDRBlock(ctx context.Context) (string, error) {
+	return getMetadata(ctx, "vpc-cidr-block")
 }
 
 // getMetadata gets metadata

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -579,9 +579,9 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		if err != nil {
 			log.WithError(err).Fatal("Unable to retrieve VPC ID of own ECS instance")
 		}
-		cidrBlock, err := alibabaCloudMetadata.GetCIDRBlock(context.TODO())
+		vpcCidrBlock, err := alibabaCloudMetadata.GetVPCCIDRBlock(context.TODO())
 		if err != nil {
-			log.WithError(err).Fatal("Unable to retrieve CIDR block of own ECS instance")
+			log.WithError(err).Fatal("Unable to retrieve VPC CIDR block of own ECS instance")
 		}
 		zoneID, err := alibabaCloudMetadata.GetZoneID(context.TODO())
 		if err != nil {
@@ -590,7 +590,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		nodeResource.Spec.InstanceID = instanceID
 		nodeResource.Spec.AlibabaCloud.InstanceType = instanceType
 		nodeResource.Spec.AlibabaCloud.VPCID = vpcID
-		nodeResource.Spec.AlibabaCloud.CIDRBlock = cidrBlock
+		nodeResource.Spec.AlibabaCloud.CIDRBlock = vpcCidrBlock
 		nodeResource.Spec.AlibabaCloud.AvailabilityZone = zoneID
 
 		if c := n.NetConf; c != nil {


### PR DESCRIPTION
Currently in alibabacloud ipam mode, by default the ipv4NativeRoutingCIDR
is mistakenly set as the derived vswitch CIDRBlock (the subnet CIDR of the
primary ENI), which should be the CIDR of the VPC. Since the cilium internal
router IP is allocated from the CIDR of a secondary ENI and most likely does
not belong to the wrong ipv4NativeRoutingCIDR range mentioned above, everytime
the agent restarts, the restoration of old router IP would be ignored and a new IP
would be allocated. This further causes multiple stale IP addresses to be
set on cilium_host interface, and pod identity overwritten by host identity.

This patch fixes this by setting the alibabacloud CIDRBlock as VPC CIDRBlock.

Alibabacloud instance metadata items reference:
https://www.alibabacloud.com/help/en/doc-detail/214777.html

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

```release-note
alibabacloud: Fix derived VPC CIDR block
```
