### PR TITLE
datapath: Fix security ID propagation in tunnel header for NodePort BPF forwarded requests

### DIFF
--- a/test/k8s/manifests/netpol-deny-ns-lb-test-k8s2.yaml
+++ b/test/k8s/manifests/netpol-deny-ns-lb-test-k8s2.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "global-deny-test-k8s2"
+spec:
+  endpointSelector:
+    matchLabels:
+      zgroup: test-k8s2
+  ingress:
+  - fromEntities:
+    - cluster


### PR DESCRIPTION
See commit msgs.

Fix #19010 

**For v1.10 backport**: feel free to drop tests, as many merge conflicts are expected and we will have a good coverage in the v1.11/main.