### PR TITLE
v1.10 backports 2022-03-07

### DIFF
--- a/Documentation/gettingstarted/hubble_setup.rst
+++ b/Documentation/gettingstarted/hubble_setup.rst
@@ -54,7 +54,7 @@ Enable Hubble in Cilium
 
         .. tip::
 
-           Enabling Hubble requires the TCP port 4245 to be open on all nodes running
+           Enabling Hubble requires the TCP port 4244 to be open on all nodes running
            Cilium. This is required for Relay to operate correctly.
 
         Run ``cilium status`` to validate that Hubble is enabled and running:

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -846,7 +846,7 @@ skip_egress_gateway:
 		key.family = ENDPOINT_KEY_IPV4;
 
 		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
-									 &key, SECLABEL, monitor);
+					     &key, SECLABEL, monitor);
 		if (ret == DROP_NO_TUNNEL_ENDPOINT)
 			goto pass_to_stack;
 		/* If not redirected noteably due to IPSEC then pass up to stack

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -100,9 +100,9 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
 	void *data, *data_end;
-	union v6addr *daddr, orig_dip;
-	__u32 tunnel_endpoint = 0;
-	__u8 encrypt_key = 0;
+	union v6addr *daddr __maybe_unused, orig_dip;
+	__u32 __maybe_unused tunnel_endpoint = 0;
+	__u8 __maybe_unused encrypt_key = 0;
 	__u32 monitor = 0;
 	__u8 reason;
 	bool hairpin_flow = false; /* endpoint wants to access itself via service IP */
@@ -524,8 +524,8 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
 	__be32 orig_dip;
-	__u32 tunnel_endpoint = 0;
-	__u8 encrypt_key = 0;
+	__u32 __maybe_unused tunnel_endpoint = 0;
+	__u8 __maybe_unused encrypt_key = 0;
 	__u32 monitor = 0;
 	__u8 ct_ret;
 	bool hairpin_flow = false; /* endpoint wants to access itself via service IP */

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -154,21 +154,17 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 }
 #endif /* SKIP_POLICY_MAP */
 
-static __always_inline __u8 get_encrypt_key(__u32 ctx)
+static __always_inline __u8 get_min_encrypt_key(__u8 peer_key __maybe_unused)
 {
-	struct encrypt_key key = {.ctx = ctx};
+#ifdef ENABLE_IPSEC
+	__u8 local_key = 0;
+	struct encrypt_key key = {.ctx = 0};
 	struct encrypt_config *cfg;
 
 	cfg = map_lookup_elem(&ENCRYPT_MAP, &key);
 	/* Having no key info for a context is the same as no encryption */
-	if (!cfg)
-		return 0;
-	return cfg->encrypt_key;
-}
-
-static __always_inline __u8 get_min_encrypt_key(__u8 peer_key)
-{
-	__u8 local_key = get_encrypt_key(0);
+	if (cfg)
+		local_key = cfg->encrypt_key;
 
 	/* If both ends can encrypt/decrypt use smaller of the two this
 	 * way both ends will have keys installed assuming key IDs are
@@ -183,6 +179,9 @@ static __always_inline __u8 get_min_encrypt_key(__u8 peer_key)
 	if (local_key == MAX_KEY_INDEX)
 		return peer_key == 1 ? local_key : peer_key;
 	return local_key < peer_key ? local_key : peer_key;
+#else
+	return 0;
+#endif /* ENABLE_IPSEC */
 }
 
 #endif

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -406,7 +406,7 @@ spec:
 {{- end }}
 {{- if and .Values.nodeinit.enabled (not (eq .Values.nodeinit.bootstrapFile "")) }}
       - name: wait-for-node-init
-        command: ['sh', '-c', 'until stat {{ .Values.nodeinit.bootstrapFile }} > /dev/null 2>&1; do echo "Waiting on node-init to run..."; sleep 1; done']
+        command: ['sh', '-c', 'until test -s {{ .Values.nodeinit.bootstrapFile | quote }}; do echo "Waiting on node-init to run..."; sleep 1; done']
         image: "{{ if .Values.image.override }}{{ .Values.image.override }}{{ else }}{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}{{ end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -145,9 +145,11 @@ spec:
                     touch /tmp/node-deinit.cilium.io
 
 {{- if .Values.nodeinit.reconfigureKubelet }}
-                    # Check if we're running on a GKE containerd flavor.
+                    # Check if we're running on a GKE containerd flavor as indicated by the presence
+                    # of the '--container-runtime-endpoint' flag in '/etc/default/kubelet'.
                     GKE_KUBERNETES_BIN_DIR="/home/kubernetes/bin"
-                    if [[ -f "${GKE_KUBERNETES_BIN_DIR}/gke" ]] && command -v containerd &>/dev/null; then
+                    KUBELET_DEFAULTS_FILE="/etc/default/kubelet"
+                    if [[ -f "${GKE_KUBERNETES_BIN_DIR}/gke" ]] && [[ $(grep -cF -- '--container-runtime-endpoint' "${KUBELET_DEFAULTS_FILE}") == "1" ]]; then
                       CONTAINERD_CONFIG="/etc/containerd/config.toml"
                       echo "Reverting changes to the containerd configuration"
                       sed -Ei "s/^\#(\s+conf_template)/\1/g" "${CONTAINERD_CONFIG}"
@@ -155,7 +157,7 @@ spec:
                       [[ -f "${GKE_KUBERNETES_BIN_DIR}/the-kubelet" ]] && mv "${GKE_KUBERNETES_BIN_DIR}/the-kubelet" "${GKE_KUBERNETES_BIN_DIR}/kubelet"
                     else
                       echo "Changing kubelet configuration to --network-plugin=kubenet"
-                      sed -i "s:--network-plugin=cni\ --cni-bin-dir={{ .Values.cni.binPath }}:--network-plugin=kubenet:g" /etc/default/kubelet
+                      sed -i "s:--network-plugin=cni\ --cni-bin-dir={{ .Values.cni.binPath }}:--network-plugin=kubenet:g" "${KUBELET_DEFAULTS_FILE}"
                     fi
                     echo "Restarting the kubelet"
                     systemctl restart kubelet

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -139,12 +139,19 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg 
 				defer func() { k8sEventReg.K8sEventReceived("CiliumNode", "update", valid, equal) }()
 				if oldNode, ok := oldObj.(*ciliumv2.CiliumNode); ok {
 					if newNode, ok := newObj.(*ciliumv2.CiliumNode); ok {
+						valid = true
+						newNode = newNode.DeepCopy()
 						if oldNode.DeepEqual(newNode) {
+							// The UpdateStatus call in refreshNode requires an up-to-date
+							// CiliumNode.ObjectMeta.ResourceVersion. Therefore, we store the most
+							// recent version here even if the nodes are equal, because
+							// CiliumNode.DeepEqual will consider two nodes to be equal even if
+							// their resource version differs.
+							store.setOwnNodeWithoutPoolUpdate(newNode)
 							equal = true
 							return
 						}
-						valid = true
-						store.updateLocalNodeResource(newNode.DeepCopy())
+						store.updateLocalNodeResource(newNode)
 						k8sEventReg.K8sEventProcessed("CiliumNode", "update", true)
 					} else {
 						log.Warningf("Unknown CiliumNode object type %T received: %+v", oldNode, oldNode)
@@ -334,6 +341,14 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 			}
 		}
 	}
+}
+
+// setOwnNodeWithoutPoolUpdate overwrites the local node copy (e.g. to update
+// its resourceVersion) without updating the available IP pool.
+func (n *nodeStore) setOwnNodeWithoutPoolUpdate(node *ciliumv2.CiliumNode) {
+	n.mutex.Lock()
+	n.ownNode = node
+	n.mutex.Unlock()
 }
 
 // refreshNodeTrigger is called to refresh the custom resource after taking the


### PR DESCRIPTION
* #17840 -- bpf: avoid encrypt_key map lookup if IPsec is disabled (@tklauser). :warning: Please review due to conflicts
 * #17856 -- ipam/crd: Fix spurious CiliumNode update status failures (@gandro)
 * #18897 -- helm: check for contents of bootstartFile (@aanm) :warning: Please review due to conflicts
 * #19017 -- Fix 'node-init' in GKE's 'cos' images. (@bmcustodio) :warning: Please review due to conflicts
 * #19036 -- docs: fix tip about opening the Hubble server port on all nodes (@rolinh)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 17840 17856 18897 19017 19036; do contrib/backporting/set-labels.py $pr done 1.10; done
```