### PR TITLE
docs: Add read:user scope for github token

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -77,7 +77,7 @@ One-time Setup
 ~~~~~~~~~~~~~~
 
 #. Make sure you have a GitHub developer access token with the ``public_repos``
-   ``workflow`` scopes available. You can do this directly from
+   ``workflow``, ``read:user`` scopes available. You can do this directly from
    https://github.com/settings/tokens or by opening GitHub and then navigating
    to: User Profile -> Settings -> Developer Settings -> Personal access token
    -> Generate new token.


### PR DESCRIPTION
This commit is to add read:user scope for github token, required by
command `hub api user --flat` in contrib/backporting/submit-backport
script. Without this scope, the below error will occur

```
$ GITHUB_TOKEN=XXX hub api user --flat
Error getting current user: Unauthorized (HTTP 401)
Bad credentials
```

Signed-off-by: Tam Mach <tam.mach@isovalent.com>
