### PR TITLE
Rename bpf.hostRouting to bpf.hostLegacyRouting in ciliumconfig

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -346,6 +346,11 @@ Removed Options
   ``disable-conntrack`` option and made it non-operational. It will be removed
   in version 1.13.
 
+Deprecated Options
+~~~~~~~~~~~~~~~~~~
+
+* ``bpf.hostRouting`` has been deprecated in favor of ``bpf.hostLegacyRouting``, and will be removed in 1.13.
+
 .. _1.11_upgrade_notes:
 
 1.11 Upgrade Notes

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -264,7 +264,10 @@ data:
   bpf-map-dynamic-size-ratio: {{ $defaultBpfMapDynamicSizeRatio | quote }}
 {{- end }}
 
-{{- if hasKey .Values.bpf "hostRouting" }}
+{{- if hasKey .Values.bpf "hostLegacyRouting" }}
+  enable-host-legacy-routing: {{ .Values.bpf.hostLegacyRouting | quote }}
+{{- else if hasKey .Values.bpf "hostRouting" }}
+  # DEPRECATED: this block should be removed in 1.13
   enable-host-legacy-routing: {{ .Values.bpf.hostRouting | quote }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -269,11 +269,17 @@ bpf:
   # -- Enable native IP masquerade support in eBPF
   #masquerade: false
 
+  # -- Deprecated in favor of bpf.hostLegacyRouting. To be removed in 1.13.
+  # Configure whether direct routing mode should route traffic via
+  # host stack (true) or directly and more efficiently out of BPF (false) if
+  # the kernel supports it.
+  #hostRouting: true
+
   # -- Configure whether direct routing mode should route traffic via
   # host stack (true) or directly and more efficiently out of BPF (false) if
   # the kernel supports it. The latter has the implication that it will also
   # bypass netfilter in the host namespace.
-  #hostRouting: true
+  #hostLegacyRouting: false
 
   # -- Configure the eBPF-based TPROXY to reduce reliance on iptables rules
   # for implementing Layer 7 policy.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

The config `bpf.hostRouting`  in ciliumconfig means whether use linux stack routing. In fact, it is legacy routing in cilium.


Fixes: https://github.com/cilium/cilium/issues/18924

```release-note
Rename bpf.hostRouting to bpf.hostLegacyRouting in ciliumconfig
```
