### PR TITLE
helm: Add RBAC Permissions to Clustermesh APIServer Clusterrole

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -7,6 +7,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   - namespaces
   - services


### PR DESCRIPTION
The Clustermesh-APIServer creates a CiliumEndPoint and sets
a node as its ownerReference, also setting blockOwnerDeletion
to "true". If the OwnerReferencesPermissionEnforcement admission
controller is enabled (such as in environments like Openshift) then
the Clustermesh-APIServer will fail to create the CiliumEndPoint
as it has insufficient privileges to set blockOwnerDeletion of
a node. It needs to be able to "update" "nodes/finalizers" in order
to do this. See #19053 for more details and references.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

```release-note
helm: Update Clustermesh-APIServer RBAC permissions for platforms (like Openshift) that have the OwnerReferencesPermissionEnforcement admission controller enabled.
```
