### PR TITLE
Refactor IPCache to remove static package-level globals

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/health/probe"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/launcher"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -227,6 +228,7 @@ type EndpointAdder interface {
 func LaunchAsEndpoint(baseCtx context.Context,
 	owner regeneration.Owner,
 	policyGetter policyRepoGetter,
+	ipcache *ipcache.IPCache,
 	mtuConfig mtu.Configuration,
 	epMgr EndpointAdder,
 	proxy endpoint.EndpointProxy,
@@ -309,7 +311,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 	}
 
 	// Create the endpoint
-	ep, err := endpoint.NewEndpointFromChangeModel(baseCtx, owner, policyGetter, proxy, allocator, info)
+	ep, err := endpoint.NewEndpointFromChangeModel(baseCtx, owner, policyGetter, ipcache, proxy, allocator, info)
 	if err != nil {
 		return nil, fmt.Errorf("Error while creating endpoint model: %s", err)
 	}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -479,10 +479,11 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	if err := d.initPolicy(epMgr); err != nil {
 		return nil, nil, fmt.Errorf("error while initializing policy subsystem: %w", err)
 	}
-	d.ipcache = ipcache.NewIPCache().
-		WithIdentityAllocator(d.identityAllocator).
-		WithPolicyHandler(d.policy.GetSelectorCache()).
-		WithDatapathHandler(epMgr)
+	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{
+		IdentityAllocator: d.identityAllocator,
+		PolicyHandler:     d.policy.GetSelectorCache(),
+		DatapathHandler:   epMgr,
+	})
 	nodeMngr = nodeMngr.WithIPCache(d.ipcache)
 	nodeMngr = nodeMngr.WithSelectorCacheUpdater(d.policy.GetSelectorCache()) // must be after initPolicy
 	nodeMngr = nodeMngr.WithPolicyTriggerer(epMgr)                            // must be after initPolicy

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -515,6 +515,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		d.bgpSpeaker,
 		d.egressGatewayManager,
 		option.Config,
+		ipcache.IPIdentityCache,
 	)
 	nd.RegisterK8sNodeGetter(d.k8sWatcher)
 	// GH-17849: The daemon does not have a reference to the ipcache,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -667,7 +667,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// FIXME: Make the port range configurable.
 	if option.Config.EnableL7Proxy {
 		d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
-			&d, option.Config.AgentLabels, d.datapath, d.endpointManager)
+			&d, option.Config.AgentLabels, d.datapath, d.endpointManager, ipcache.IPIdentityCache)
 	} else {
 		log.Info("L7 proxies are disabled")
 	}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -82,6 +82,7 @@ import (
 	"github.com/cilium/cilium/pkg/sockops"
 	"github.com/cilium/cilium/pkg/status"
 	"github.com/cilium/cilium/pkg/trigger"
+	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
@@ -729,7 +730,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	if wgAgent := dp.WireguardAgent(); option.Config.EnableWireguard {
-		if err := wgAgent.Init(mtuConfig); err != nil {
+		if err := wgAgent.(*wg.Agent).Init(ipcache.IPIdentityCache, mtuConfig); err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize wireguard agent: %w", err)
 		}
 	}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -474,9 +474,15 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// Propagate identity allocator down to packages which themselves do not
 	// have types to which we can add an allocator member.
 	//
+	// **NOTE** The identity allocator is not yet initialized; that happens
+	// below. We've only allocated the structure at this point.
+	//
 	// TODO: convert these package level variables to types for easier unit
 	// testing in the future.
-	ipcache.IdentityAllocator = d.identityAllocator
+	ipcache.IPIdentityCache = ipcache.NewIPCache().
+		WithIdentityAllocator(d.identityAllocator).
+		WithPolicyHandler(d.policy.GetSelectorCache()).
+		WithDatapathHandler(epMgr)
 	proxy.Allocator = d.identityAllocator
 
 	d.endpointManager = epMgr

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1026,7 +1026,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// Start watcher for endpoint IP --> identity mappings in key-value store.
 	// this needs to be done *after* init() for the daemon in that function,
 	// we populate the IPCache with the host's IP(s).
-	ipcache.InitIPIdentityWatcher()
+	ipcache.IPIdentityCache.InitIPIdentityWatcher()
 	identitymanager.Subscribe(d.policy)
 
 	return &d, restoredEndpoints, nil
@@ -1064,6 +1064,7 @@ func (d *Daemon) bootstrapClusterMesh(nodeMngr *nodemanager.Manager) {
 				ServiceMerger:         &d.k8sWatcher.K8sSvcCache,
 				NodeManager:           nodeMngr,
 				RemoteIdentityWatcher: d.identityAllocator,
+				IPCache:               ipcache.IPIdentityCache,
 			})
 			if err != nil {
 				log.WithError(err).Fatal("Unable to initialize ClusterMesh")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -48,7 +48,6 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
@@ -1732,7 +1731,7 @@ func runDaemon() {
 	} else {
 		log.Info("Creating host endpoint")
 		if err := d.endpointManager.AddHostEndpoint(
-			d.ctx, d, d, ipcache.IPIdentityCache, d.l7Proxy, d.identityAllocator,
+			d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator,
 			"Create host endpoint", nodeTypes.GetName(),
 		); err != nil {
 			log.WithError(err).Fatal("Unable to create host endpoint")
@@ -2004,7 +2003,7 @@ func (d *Daemon) instantiateAPI() *restapi.CiliumAPIAPI {
 	}
 
 	// /ip/
-	restAPI.PolicyGetIPHandler = NewGetIPHandler()
+	restAPI.PolicyGetIPHandler = NewGetIPHandler(d)
 
 	return restAPI
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
@@ -1731,7 +1732,7 @@ func runDaemon() {
 	} else {
 		log.Info("Creating host endpoint")
 		if err := d.endpointManager.AddHostEndpoint(
-			d.ctx, d, d, d.l7Proxy, d.identityAllocator,
+			d.ctx, d, d, ipcache.IPIdentityCache, d.l7Proxy, d.identityAllocator,
 			"Create host endpoint", nodeTypes.GetName(),
 		); err != nil {
 			log.WithError(err).Fatal("Unable to create host endpoint")

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -406,7 +406,7 @@ func (d *Daemon) initMaps() error {
 	// used by syncEndpointsAndHostIPs()
 	// xDS cache will be added later by calling AddListener(), but only if necessary.
 	ipcache.IPIdentityCache.SetListeners([]ipcache.IPIdentityMappingListener{
-		datapathIpcache.NewListener(d, d),
+		datapathIpcache.NewListener(d, d, ipcache.IPIdentityCache),
 	})
 
 	if option.Config.EnableIPv4 && option.Config.EnableIPMasqAgent {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -251,7 +251,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 		// ipcache. Until then, it is expected to succeed.
 		d.ipcache.Upsert(ipIDPair.PrefixString(), nil, hostKey, nil, ipcache.Identity{
 			ID:     ipIDPair.ID,
-			Source: sourceByIP(ipIDPair.IP.String(), source.Local),
+			Source: d.sourceByIP(ipIDPair.IP.String(), source.Local),
 		})
 	}
 
@@ -265,7 +265,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 				log.Debugf("Removed outdated host ip %s from endpoint map", hostIP)
 			}
 
-			d.ipcache.Delete(hostIP, sourceByIP(hostIP, source.Local))
+			d.ipcache.Delete(hostIP, d.sourceByIP(hostIP, source.Local))
 		}
 	}
 
@@ -279,8 +279,8 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 	return nil
 }
 
-func sourceByIP(prefix string, defaultSrc source.Source) source.Source {
-	if lbls := ipcache.GetIDMetadataByIP(prefix); lbls.Has(
+func (d *Daemon) sourceByIP(prefix string, defaultSrc source.Source) source.Source {
+	if lbls := d.ipcache.GetIDMetadataByIP(prefix); lbls.Has(
 		labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer],
 	) {
 		return source.KubeAPIServer

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -249,7 +249,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 		// This upsert will fail with ErrOverwrite continuously as long as the
 		// EP / CN watcher have found an apiserver IP and upserted it into the
 		// ipcache. Until then, it is expected to succeed.
-		ipcache.IPIdentityCache.Upsert(ipIDPair.PrefixString(), nil, hostKey, nil, ipcache.Identity{
+		d.ipcache.Upsert(ipIDPair.PrefixString(), nil, hostKey, nil, ipcache.Identity{
 			ID:     ipIDPair.ID,
 			Source: sourceByIP(ipIDPair.IP.String(), source.Local),
 		})
@@ -265,7 +265,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 				log.Debugf("Removed outdated host ip %s from endpoint map", hostIP)
 			}
 
-			ipcache.IPIdentityCache.Delete(hostIP, sourceByIP(hostIP, source.Local))
+			d.ipcache.Delete(hostIP, sourceByIP(hostIP, source.Local))
 		}
 	}
 
@@ -405,8 +405,8 @@ func (d *Daemon) initMaps() error {
 	// Set up the list of IPCache listeners in the daemon, to be
 	// used by syncEndpointsAndHostIPs()
 	// xDS cache will be added later by calling AddListener(), but only if necessary.
-	ipcache.IPIdentityCache.SetListeners([]ipcache.IPIdentityMappingListener{
-		datapathIpcache.NewListener(d, d, ipcache.IPIdentityCache),
+	d.ipcache.SetListeners([]ipcache.IPIdentityMappingListener{
+		datapathIpcache.NewListener(d, d, d.ipcache),
 	})
 
 	if option.Config.EnableIPv4 && option.Config.EnableIPMasqAgent {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -25,6 +25,7 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -325,7 +326,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		"sync-build":            epTemplate.SyncBuildEndpoint,
 	}).Info("Create endpoint request")
 
-	ep, err := endpoint.NewEndpointFromChangeModel(d.ctx, owner, d, d.l7Proxy, d.identityAllocator, epTemplate)
+	ep, err := endpoint.NewEndpointFromChangeModel(d.ctx, owner, d, ipcache.IPIdentityCache, d.l7Proxy, d.identityAllocator, epTemplate)
 	if err != nil {
 		return invalidDataError(ep, fmt.Errorf("unable to parse endpoint parameters: %s", err))
 	}
@@ -596,7 +597,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	// Validate the template. Assignment afterwards is atomic.
 	// Note: newEp's labels are ignored.
-	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d.ctx, h.d, h.d, h.d.l7Proxy, h.d.identityAllocator, epTemplate)
+	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d.ctx, h.d, h.d, ipcache.IPIdentityCache, h.d.l7Proxy, h.d.identityAllocator, epTemplate)
 	if err2 != nil {
 		r.Error(err2)
 		return api.Error(PutEndpointIDInvalidCode, err2)

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -25,7 +25,6 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -326,7 +325,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		"sync-build":            epTemplate.SyncBuildEndpoint,
 	}).Info("Create endpoint request")
 
-	ep, err := endpoint.NewEndpointFromChangeModel(d.ctx, owner, d, ipcache.IPIdentityCache, d.l7Proxy, d.identityAllocator, epTemplate)
+	ep, err := endpoint.NewEndpointFromChangeModel(d.ctx, owner, d, d.ipcache, d.l7Proxy, d.identityAllocator, epTemplate)
 	if err != nil {
 		return invalidDataError(ep, fmt.Errorf("unable to parse endpoint parameters: %s", err))
 	}
@@ -597,7 +596,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	// Validate the template. Assignment afterwards is atomic.
 	// Note: newEp's labels are ignored.
-	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d.ctx, h.d, h.d, ipcache.IPIdentityCache, h.d.l7Proxy, h.d.identityAllocator, epTemplate)
+	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d.ctx, h.d, h.d, h.d.ipcache, h.d.l7Proxy, h.d.identityAllocator, epTemplate)
 	if err2 != nil {
 		r.Error(err2)
 		return api.Error(PutEndpointIDInvalidCode, err2)

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
 	"github.com/cilium/cilium/pkg/identity"
 	secIDCache "github.com/cilium/cilium/pkg/identity/cache"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
@@ -381,7 +380,7 @@ func (d *Daemon) lookupEPByIP(endpointIP net.IP) (endpoint *endpoint.Endpoint, e
 }
 
 func (d *Daemon) lookupIPsBySecID(nid identity.NumericIdentity) []string {
-	return ipcache.IPIdentityCache.LookupByIdentity(nid)
+	return d.ipcache.LookupByIdentity(nid)
 }
 
 // NotifyOnDNSMsg handles DNS data in the daemon by emitting monitor
@@ -546,7 +545,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		}).Debug("Waited for endpoints to regenerate due to a DNS response")
 
 		// Add new identities to the ipcache after the wait for the policy updates above
-		ipcache.IPIdentityCache.UpsertGeneratedIdentities(newlyAllocatedIdentities)
+		d.ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities)
 
 		endMetric()
 	}

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -546,7 +546,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		}).Debug("Waited for endpoints to regenerate due to a DNS response")
 
 		// Add new identities to the ipcache after the wait for the policy updates above
-		ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities)
+		ipcache.IPIdentityCache.UpsertGeneratedIdentities(newlyAllocatedIdentities)
 
 		endMetric()
 	}

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/health/defaults"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -70,6 +71,7 @@ func (d *Daemon) initHealth() {
 						ctx,
 						d,
 						d,
+						ipcache.IPIdentityCache,
 						d.mtuConfig,
 						d.endpointManager,
 						d.l7Proxy,

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/health/defaults"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -71,7 +70,7 @@ func (d *Daemon) initHealth() {
 						ctx,
 						d,
 						d,
-						ipcache.IPIdentityCache,
+						d.ipcache,
 						d.mtuConfig,
 						d.endpointManager,
 						d.l7Proxy,

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -351,7 +351,7 @@ func (d *Daemon) GetK8sMetadata(ip net.IP) *ipcache.K8sMetadata {
 	if ip == nil {
 		return nil
 	}
-	return ipcache.IPIdentityCache.GetK8sMetadata(ip.String())
+	return d.ipcache.GetK8sMetadata(ip.String())
 }
 
 // LookupSecIDByIP returns the security ID for the given IP. If the security ID
@@ -362,7 +362,7 @@ func (d *Daemon) LookupSecIDByIP(ip net.IP) (id ipcache.Identity, ok bool) {
 		return ipcache.Identity{}, false
 	}
 
-	if id, ok = ipcache.IPIdentityCache.LookupByIP(ip.String()); ok {
+	if id, ok = d.ipcache.LookupByIP(ip.String()); ok {
 		return id, ok
 	}
 
@@ -382,7 +382,7 @@ func (d *Daemon) LookupSecIDByIP(ip net.IP) (id ipcache.Identity, ok bool) {
 			IP:   ip.Mask(mask),
 			Mask: mask,
 		}
-		if id, ok = ipcache.IPIdentityCache.LookupByPrefix(cidr.String()); ok {
+		if id, ok = d.ipcache.LookupByPrefix(cidr.String()); ok {
 			return id, ok
 		}
 	}

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -110,9 +110,9 @@ func NewCachingIdentityAllocator(d *Daemon) cachingIdentityAllocator {
 }
 
 func (c cachingIdentityAllocator) AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error) {
-	return ipcache.AllocateCIDRsForIPs(ips, newlyAllocatedIdentities)
+	return ipcache.IPIdentityCache.AllocateCIDRsForIPs(ips, newlyAllocatedIdentities)
 }
 
 func (c cachingIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
-	ipcache.ReleaseCIDRIdentitiesByID(ctx, identities)
+	ipcache.IPIdentityCache.ReleaseCIDRIdentitiesByID(ctx, identities)
 }

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	identitymodel "github.com/cilium/cilium/pkg/identity/model"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -101,18 +100,20 @@ type CachingIdentityAllocator interface {
 
 type cachingIdentityAllocator struct {
 	*cache.CachingIdentityAllocator
+	d *Daemon
 }
 
 func NewCachingIdentityAllocator(d *Daemon) cachingIdentityAllocator {
 	return cachingIdentityAllocator{
 		CachingIdentityAllocator: cache.NewCachingIdentityAllocator(d),
+		d:                        d,
 	}
 }
 
 func (c cachingIdentityAllocator) AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error) {
-	return ipcache.IPIdentityCache.AllocateCIDRsForIPs(ips, newlyAllocatedIdentities)
+	return c.d.ipcache.AllocateCIDRsForIPs(ips, newlyAllocatedIdentities)
 }
 
 func (c cachingIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
-	ipcache.IPIdentityCache.ReleaseCIDRIdentitiesByID(ctx, identities)
+	c.d.ipcache.ReleaseCIDRIdentitiesByID(ctx, identities)
 }

--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -32,9 +32,7 @@ func (h *getIP) Handle(params GetIPParams) middleware.Responder {
 		}
 		listener.cidrFilter = cidrFilter
 	}
-	h.d.ipcache.RLock()
-	h.d.ipcache.DumpToListenerLocked(listener)
-	h.d.ipcache.RUnlock()
+	h.d.ipcache.DumpToListener(listener)
 	if len(listener.entries) == 0 {
 		return NewGetIPNotFound()
 	}

--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -14,11 +14,13 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 )
 
-type getIP struct{}
+type getIP struct {
+	d *Daemon
+}
 
 // NewGetIPHandler for the global IP cache
-func NewGetIPHandler() GetIPHandler {
-	return &getIP{}
+func NewGetIPHandler(d *Daemon) GetIPHandler {
+	return &getIP{d: d}
 }
 
 func (h *getIP) Handle(params GetIPParams) middleware.Responder {
@@ -30,9 +32,9 @@ func (h *getIP) Handle(params GetIPParams) middleware.Responder {
 		}
 		listener.cidrFilter = cidrFilter
 	}
-	ipcache.IPIdentityCache.RLock()
-	ipcache.IPIdentityCache.DumpToListenerLocked(listener)
-	ipcache.IPIdentityCache.RUnlock()
+	h.d.ipcache.RLock()
+	h.d.ipcache.DumpToListenerLocked(listener)
+	h.d.ipcache.RUnlock()
 	if len(listener.entries) == 0 {
 		return NewGetIPNotFound()
 	}

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -190,7 +190,7 @@ func prepareEndpointDirs() (cleanup func(), err error) {
 }
 
 func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa bool) *endpoint.Endpoint {
-	e := endpoint.NewEndpointWithState(ds.d, ds.d, ipcache.NewIPCache(), ds.d.l7Proxy, ds.d.identityAllocator, testEndpointID, endpoint.StateWaitingForIdentity)
+	e := endpoint.NewEndpointWithState(ds.d, ds.d, ipcache.NewIPCache(nil), ds.d.l7Proxy, ds.d.identityAllocator, testEndpointID, endpoint.StateWaitingForIdentity)
 	if qa {
 		e.IPv6 = QAIPv6Addr
 		e.IPv4 = QAIPv4Addr
@@ -1282,7 +1282,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 		rules, policyImportErr := args.cnp.Parse()
 		c.Assert(policyImportErr, checker.DeepEquals, want.err)
 
-		policyImportErr = k8s.PreprocessRules(rules, &ds.d.k8sWatcher.K8sSvcCache, ipcache.NewIPCache())
+		policyImportErr = k8s.PreprocessRules(rules, &ds.d.k8sWatcher.K8sSvcCache, ipcache.NewIPCache(nil))
 		c.Assert(policyImportErr, IsNil)
 
 		// Only add policies if we have successfully parsed them. Otherwise, if

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -1282,7 +1282,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 		rules, policyImportErr := args.cnp.Parse()
 		c.Assert(policyImportErr, checker.DeepEquals, want.err)
 
-		policyImportErr = k8s.PreprocessRules(rules, &ds.d.k8sWatcher.K8sSvcCache)
+		policyImportErr = k8s.PreprocessRules(rules, &ds.d.k8sWatcher.K8sSvcCache, ipcache.NewIPCache())
 		c.Assert(policyImportErr, IsNil)
 
 		// Only add policies if we have successfully parsed them. Otherwise, if

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
@@ -189,7 +190,7 @@ func prepareEndpointDirs() (cleanup func(), err error) {
 }
 
 func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa bool) *endpoint.Endpoint {
-	e := endpoint.NewEndpointWithState(ds.d, ds.d, ds.d.l7Proxy, ds.d.identityAllocator, testEndpointID, endpoint.StateWaitingForIdentity)
+	e := endpoint.NewEndpointWithState(ds.d, ds.d, ipcache.NewIPCache(), ds.d.l7Proxy, ds.d.identityAllocator, testEndpointID, endpoint.StateWaitingForIdentity)
 	if qa {
 		e.IPv6 = QAIPv6Addr
 		e.IPv4 = QAIPv4Addr

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -16,7 +16,6 @@ import (
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath/fake"
-	fakeIPCache "github.com/cilium/cilium/pkg/ipcache/fake"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -40,7 +39,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.NewManager("", fake.NewNodeHandler(), fakeIPCache.NewIPCache(false), &fakeConfig.Config{}, nil, nil)
+	nm, err = manager.NewManager("", fake.NewNodeHandler(), &fakeConfig.Config{}, nil, nil)
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
@@ -59,6 +60,8 @@ type Configuration struct {
 	// RemoteIdentityWatcher provides identities that have been allocated on a
 	// remote cluster.
 	RemoteIdentityWatcher RemoteIdentityWatcher
+
+	IPCache *ipcache.IPCache
 }
 
 // RemoteIdentityWatcher is any type which provides identities that have been
@@ -91,6 +94,8 @@ type ClusterMesh struct {
 	controllers   *controller.Manager
 	configWatcher *configDirectoryWatcher
 
+	ipcache *ipcache.IPCache
+
 	// globalServices is a list of all global services. The datastructure
 	// is protected by its own mutex inside the structure.
 	globalServices *globalServiceCache
@@ -114,6 +119,7 @@ func NewClusterMesh(c Configuration) (*ClusterMesh, error) {
 			Name:      "remote_clusters",
 			Help:      "The total number of remote clusters meshed with the local cluster",
 		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName}),
+		ipcache: c.IPCache,
 	}
 
 	w, err := createConfigDirectoryWatcher(c.ConfigDirectory, cm)

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
@@ -118,6 +119,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 		NodeKeyCreator:        testNodeCreator,
 		nodeObserver:          &testObserver{},
 		RemoteIdentityWatcher: mgr,
+		IPCache:               ipcache.NewIPCache(nil),
 	})
 	c.Assert(err, IsNil)
 	c.Assert(cm, Not(IsNil))

--- a/pkg/clustermesh/config_test.go
+++ b/pkg/clustermesh/config_test.go
@@ -14,6 +14,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
@@ -74,6 +75,7 @@ func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
 		ConfigDirectory:       dir,
 		NodeKeyCreator:        testNodeCreator,
 		RemoteIdentityWatcher: mgr,
+		IPCache:               ipcache.NewIPCache(nil),
 	})
 	c.Assert(err, IsNil)
 	c.Assert(cm, Not(IsNil))

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -223,7 +223,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 					return err
 				}
 
-				ipCacheWatcher := ipcache.NewIPIdentityWatcher(backend)
+				ipCacheWatcher := ipcache.NewIPIdentityWatcher(rc.mesh.ipcache, backend)
 				go ipCacheWatcher.Watch(ctx)
 
 				rc.mutex.Lock()

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -81,6 +82,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 		nodeObserver:          &testObserver{},
 		ServiceMerger:         &s.svcCache,
 		RemoteIdentityWatcher: mgr,
+		IPCache:               ipcache.NewIPCache(nil),
 	})
 	c.Assert(err, IsNil)
 	c.Assert(cm, Not(IsNil))

--- a/pkg/datapath/wireguard.go
+++ b/pkg/datapath/wireguard.go
@@ -7,12 +7,10 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/mtu"
 )
 
 // WireguardAgent manages the Wireguard peers
 type WireguardAgent interface {
-	Init(mtuConfig mtu.Configuration) error
 	UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP) error
 	DeletePeer(nodeName string) error
 	Status(includePeers bool) (*models.WireguardStatus, error)

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -49,12 +49,12 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 }
 
 // NewEndpointFromChangeModel creates a new endpoint from a request
-func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, base *models.EndpointChangeRequest) (*Endpoint, error) {
+func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, base *models.EndpointChangeRequest) (*Endpoint, error) {
 	if base == nil {
 		return nil, nil
 	}
 
-	ep := createEndpoint(owner, policyGetter, proxy, allocator, uint16(base.ID), base.InterfaceName)
+	ep := createEndpoint(owner, policyGetter, namedPortsGetter, proxy, allocator, uint16(base.ID), base.InterfaceName)
 	ep.ifIndex = int(base.InterfaceIndex)
 	ep.containerName = base.ContainerName
 	ep.containerID = base.ContainerID

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -15,11 +15,12 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/ipcache"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
 func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
-	e := NewEndpointWithState(s, s, &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, s, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
@@ -29,7 +30,7 @@ func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
 type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
-	e := NewEndpointWithState(&suite, &suite, &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(&suite, &suite, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil, nil)
 
 	targetComments := func(w io.Writer) error {

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
-	e := NewEndpointWithState(s, s, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
@@ -30,7 +30,7 @@ func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
 type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
-	e := NewEndpointWithState(&suite, &suite, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(&suite, &suite, ipcache.NewIPCache(nil), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil, nil)
 
 	targetComments := func(w io.Writer) error {

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -50,7 +50,7 @@ func (e endpointStatusConfiguration) EndpointStatusIsEnabled(name string) bool {
 }
 
 func (s *EndpointSuite) newEndpoint(c *check.C, spec endpointGeneratorSpec) *Endpoint {
-	e, err := NewEndpointFromChangeModel(context.TODO(), s, s, ipcache.NewIPCache(), &FakeEndpointProxy{}, s.mgr, &models.EndpointChangeRequest{
+	e, err := NewEndpointFromChangeModel(context.TODO(), s, s, ipcache.NewIPCache(nil), &FakeEndpointProxy{}, s.mgr, &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{},
 		ID:         200,
 		Labels: models.Labels{

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -49,7 +50,7 @@ func (e endpointStatusConfiguration) EndpointStatusIsEnabled(name string) bool {
 }
 
 func (s *EndpointSuite) newEndpoint(c *check.C, spec endpointGeneratorSpec) *Endpoint {
-	e, err := NewEndpointFromChangeModel(context.TODO(), s, s, &FakeEndpointProxy{}, s.mgr, &models.EndpointChangeRequest{
+	e, err := NewEndpointFromChangeModel(context.TODO(), s, s, ipcache.NewIPCache(), &FakeEndpointProxy{}, s.mgr, &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{},
 		ID:         200,
 		Labels: models.Labels{

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -256,7 +257,7 @@ func (s *EndpointSuite) TestEndpointStatus(c *C) {
 }
 
 func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
-	e := NewEndpointWithState(s, s, &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, s, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 
 	// Test that inserting identity labels works
 	rev := e.replaceIdentityLabels(labels.Map2Labels(map[string]string{"foo": "bar", "zip": "zop"}, "cilium"))
@@ -280,7 +281,7 @@ func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 }
 
 func (s *EndpointSuite) TestEndpointState(c *C) {
-	e := NewEndpointWithState(s, s, &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, s, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 	e.unconditionalLock()
 	defer e.unlock()
 
@@ -653,7 +654,7 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponStop(c *C) {
 		s.datapath = oldDatapath
 	}()
 
-	ep := NewEndpointWithState(s, s, &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewEndpointWithState(s, s, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	// In case deadlock occurs, provide a timeout of 3 (number of events) *
 	// deadlockTimeout + 1 seconds to ensure that we are actually testing for
@@ -724,7 +725,7 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponStop(c *C) {
 }
 
 func BenchmarkEndpointGetModel(b *testing.B) {
-	e := NewEndpointWithState(&suite, &suite, &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 123, StateWaitingForIdentity)
+	e := NewEndpointWithState(&suite, &suite, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 123, StateWaitingForIdentity)
 
 	for i := 0; i < 256; i++ {
 		e.LogStatusOK(BPF, "Hello World!")

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -257,7 +257,7 @@ func (s *EndpointSuite) TestEndpointStatus(c *C) {
 }
 
 func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
-	e := NewEndpointWithState(s, s, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 
 	// Test that inserting identity labels works
 	rev := e.replaceIdentityLabels(labels.Map2Labels(map[string]string{"foo": "bar", "zip": "zop"}, "cilium"))
@@ -281,7 +281,7 @@ func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 }
 
 func (s *EndpointSuite) TestEndpointState(c *C) {
-	e := NewEndpointWithState(s, s, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 	e.unconditionalLock()
 	defer e.unlock()
 
@@ -654,7 +654,7 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponStop(c *C) {
 		s.datapath = oldDatapath
 	}()
 
-	ep := NewEndpointWithState(s, s, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	// In case deadlock occurs, provide a timeout of 3 (number of events) *
 	// deadlockTimeout + 1 seconds to ensure that we are actually testing for
@@ -725,7 +725,7 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponStop(c *C) {
 }
 
 func BenchmarkEndpointGetModel(b *testing.B) {
-	e := NewEndpointWithState(&suite, &suite, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 123, StateWaitingForIdentity)
+	e := NewEndpointWithState(&suite, &suite, ipcache.NewIPCache(nil), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 123, StateWaitingForIdentity)
 
 	for i := 0; i < 256; i++ {
 		e.LogStatusOK(BPF, "Hello World!")

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -22,7 +22,7 @@ import (
 
 func (s *EndpointSuite) TestPolicyLog(c *C) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
-	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(nil), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	// Initially nil
 	policyLogger := ep.getPolicyLogger()

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -21,7 +22,7 @@ import (
 
 func (s *EndpointSuite) TestPolicyLog(c *C) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
-	ep := NewEndpointWithState(do, do, nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	// Initially nil
 	policyLogger := ep.getPolicyLogger()

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -54,7 +54,7 @@ func (e *Endpoint) GetNamedPort(ingress bool, name string, proto uint8) uint16 {
 		return e.getNamedPortIngress(k8sPorts, name, proto)
 	}
 	// egress needs named ports of all the pods
-	return e.getNamedPortEgress(ipcache.IPIdentityCache.GetNamedPorts(), name, proto)
+	return e.getNamedPortEgress(e.namedPortsGetter.GetNamedPorts(), name, proto)
 }
 
 // GetNamedPortLocked returns port for the given name. May return an invalid (0) port
@@ -65,7 +65,7 @@ func (e *Endpoint) GetNamedPortLocked(ingress bool, name string, proto uint8) ui
 		return e.getNamedPortIngress(e.k8sPorts, name, proto)
 	}
 	// egress needs named ports of all the pods
-	return e.getNamedPortEgress(ipcache.IPIdentityCache.GetNamedPorts(), name, proto)
+	return e.getNamedPortEgress(e.namedPortsGetter.GetNamedPorts(), name, proto)
 }
 
 func (e *Endpoint) getNamedPortIngress(npMap policy.NamedPortMap, name string, proto uint8) uint16 {

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -17,7 +17,7 @@ import (
 
 func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
-	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(nil), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 	ep.UpdateVisibilityPolicy(func(_, _ string) (string, error) {
 		return "", nil
 	})

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -9,6 +9,7 @@ package endpoint
 import (
 	"gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/policy"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -16,7 +17,7 @@ import (
 
 func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
-	ep := NewEndpointWithState(do, do, nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 	ep.UpdateVisibilityPolicy(func(_, _ string) (string, error) {
 		return "", nil
 	})

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -164,7 +164,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 		redirectPortUserMap: make(map[uint16][]string),
 	}
 
-	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(), rsp, mgr, 12345, StateRegenerating)
+	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(nil), rsp, mgr, 12345, StateRegenerating)
 
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	epIdentity, _, err := mgr.AllocateIdentity(context.Background(), qaBarLbls, true)

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -163,7 +164,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 		redirectPortUserMap: make(map[uint16][]string),
 	}
 
-	ep := NewEndpointWithState(do, do, rsp, mgr, 12345, StateRegenerating)
+	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(), rsp, mgr, 12345, StateRegenerating)
 
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	epIdentity, _, err := mgr.AllocateIdentity(context.Background(), qaBarLbls, true)

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -64,7 +64,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	repo := ds.GetPolicyRepository()
 	repo.GetPolicyCache().LocalEndpointIdentityAdded(identity)
 
-	ep := NewEndpointWithState(ds, ds, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, StateReady)
+	ep := NewEndpointWithState(ds, ds, ipcache.NewIPCache(nil), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.dockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -22,6 +22,7 @@ import (
 	linuxDatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -63,7 +64,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	repo := ds.GetPolicyRepository()
 	repo.GetPolicyCache().LocalEndpointIdentityAdded(identity)
 
-	ep := NewEndpointWithState(ds, ds, &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, StateReady)
+	ep := NewEndpointWithState(ds, ds, ipcache.NewIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.dockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -14,6 +14,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/ipcache"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
@@ -39,7 +40,7 @@ func (s *EndpointManagerSuite) TestmarkAndSweep(c *C) {
 	healthyEndpointIDs := []uint16{1, 3, 5, 7}
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
-		ep := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, endpoint.StateReady)
+		ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, endpoint.StateReady)
 		mgr.expose(ep)
 	}
 	c.Assert(len(mgr.GetEndpoints()), Equals, len(allEndpointIDs))

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -40,7 +40,7 @@ func (s *EndpointManagerSuite) TestmarkAndSweep(c *C) {
 	healthyEndpointIDs := []uint16{1, 3, 5, 7}
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
-		ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, endpoint.StateReady)
+		ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, endpoint.StateReady)
 		mgr.expose(ep)
 	}
 	c.Assert(len(mgr.GetEndpoints()), Equals, len(allEndpointIDs))

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager/idallocator"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -619,11 +620,12 @@ func (mgr *EndpointManager) AddHostEndpoint(
 	ctx context.Context,
 	owner regeneration.Owner,
 	policyGetter policyRepoGetter,
+	ipcache *ipcache.IPCache,
 	proxy endpoint.EndpointProxy,
 	allocator cache.IdentityAllocator,
 	reason, nodeName string,
 ) error {
-	ep, err := endpoint.CreateHostEndpoint(owner, policyGetter, proxy, allocator)
+	ep, err := endpoint.CreateHostEndpoint(owner, policyGetter, ipcache, proxy, allocator)
 	if err != nil {
 		return err
 	}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -119,7 +119,7 @@ func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) 
 }
 
 func (s *EndpointManagerSuite) TestLookup(c *C) {
-	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	type args struct {
 		id string
@@ -173,7 +173,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.ID = 0
 			},
 		},
@@ -196,7 +196,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.ID = 0
 			},
 		},
@@ -220,7 +220,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetContainerID("")
 			},
 		},
@@ -244,7 +244,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetDockerEndpointID("")
 			},
 		},
@@ -268,7 +268,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetContainerName("")
 			},
 		},
@@ -293,7 +293,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetK8sPodName("")
 			},
 		},
@@ -319,7 +319,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.IPv4 = nil
 			},
 		},
@@ -373,7 +373,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 2, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 2, endpoint.StateReady)
 	type args struct {
 		id uint16
 	}
@@ -442,7 +442,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 3, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 3, endpoint.StateReady)
 	type args struct {
 		id string
 	}
@@ -509,7 +509,7 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 4, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 4, endpoint.StateReady)
 	type args struct {
 		ip string
 	}
@@ -578,7 +578,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 5, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 5, endpoint.StateReady)
 	type args struct {
 		podName string
 	}
@@ -646,7 +646,7 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 
 func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 6, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 6, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -724,7 +724,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 
 func (s *EndpointManagerSuite) TestRemove(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 7, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 7, endpoint.StateReady)
 	type args struct {
 	}
 	type want struct {
@@ -764,7 +764,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 
 func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -792,7 +792,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -812,7 +812,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -829,7 +829,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 
 func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	type args struct {
 		ctx    context.Context
 		rev    uint64
@@ -867,7 +867,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -893,7 +893,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -919,7 +919,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 	}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -22,6 +22,7 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
@@ -118,7 +119,7 @@ func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) 
 }
 
 func (s *EndpointManagerSuite) TestLookup(c *C) {
-	ep := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	type args struct {
 		id string
@@ -172,7 +173,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.ID = 0
 			},
 		},
@@ -195,7 +196,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.ID = 0
 			},
 		},
@@ -219,7 +220,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetContainerID("")
 			},
 		},
@@ -243,7 +244,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetDockerEndpointID("")
 			},
 		},
@@ -267,7 +268,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetContainerName("")
 			},
 		},
@@ -292,7 +293,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.SetK8sPodName("")
 			},
 		},
@@ -318,7 +319,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
 				ep.IPv4 = nil
 			},
 		},
@@ -372,7 +373,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 2, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 2, endpoint.StateReady)
 	type args struct {
 		id uint16
 	}
@@ -441,7 +442,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 3, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 3, endpoint.StateReady)
 	type args struct {
 		id string
 	}
@@ -508,7 +509,7 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 4, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 4, endpoint.StateReady)
 	type args struct {
 		ip string
 	}
@@ -577,7 +578,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 5, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 5, endpoint.StateReady)
 	type args struct {
 		podName string
 	}
@@ -645,7 +646,7 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 
 func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 6, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 6, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -723,7 +724,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 
 func (s *EndpointManagerSuite) TestRemove(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 7, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 7, endpoint.StateReady)
 	type args struct {
 	}
 	type want struct {
@@ -763,7 +764,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 
 func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -791,7 +792,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -811,7 +812,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -828,7 +829,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 
 func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	type args struct {
 		ctx    context.Context
 		rev    uint64
@@ -866,7 +867,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -892,7 +893,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -918,7 +919,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 	}

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -63,7 +63,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 
 	log.Debugf("state log directory: %s", stateLogDir)
 
-	xdsServer := StartXDSServer(ipcache.NewIPCache(), stateLogDir)
+	xdsServer := StartXDSServer(ipcache.NewIPCache(nil), stateLogDir)
 	defer xdsServer.stop()
 	StartAccessLogServer(stateLogDir, xdsServer)
 
@@ -143,7 +143,7 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 
 	log.Debugf("state log directory: %s", stateLogDir)
 
-	xdsServer := StartXDSServer(ipcache.NewIPCache(), stateLogDir)
+	xdsServer := StartXDSServer(ipcache.NewIPCache(nil), stateLogDir)
 	defer xdsServer.stop()
 	StartAccessLogServer(stateLogDir, xdsServer)
 

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/flowdebug"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -62,7 +63,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 
 	log.Debugf("state log directory: %s", stateLogDir)
 
-	xdsServer := StartXDSServer(stateLogDir)
+	xdsServer := StartXDSServer(ipcache.NewIPCache(), stateLogDir)
 	defer xdsServer.stop()
 	StartAccessLogServer(stateLogDir, xdsServer)
 
@@ -142,7 +143,7 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 
 	log.Debugf("state log directory: %s", stateLogDir)
 
-	xdsServer := StartXDSServer(stateLogDir)
+	xdsServer := StartXDSServer(ipcache.NewIPCache(), stateLogDir)
 	defer xdsServer.stop()
 	StartAccessLogServer(stateLogDir, xdsServer)
 

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -29,20 +29,21 @@ const (
 
 // NPHDSCache is a cache of resources in the Network Policy Hosts Discovery
 // Service.
+//
+// NetworkPolicyHostsCache is the global cache of resources of type
+// NetworkPolicyHosts. Resources in this cache must have the
+// NetworkPolicyHostsTypeURL type URL.
 type NPHDSCache struct {
 	*xds.Cache
+
+	ipcache *ipcache.IPCache
 }
 
-func newNPHDSCache() NPHDSCache {
-	return NPHDSCache{Cache: xds.NewCache()}
+func newNPHDSCache(ipcache *ipcache.IPCache) NPHDSCache {
+	return NPHDSCache{Cache: xds.NewCache(), ipcache: ipcache}
 }
 
 var (
-	// NetworkPolicyHostsCache is the global cache of resources of type
-	// NetworkPolicyHosts. Resources in this cache must have the
-	// NetworkPolicyHostsTypeURL type URL.
-	NetworkPolicyHostsCache = newNPHDSCache()
-
 	observerOnce = sync.Once{}
 )
 
@@ -53,7 +54,7 @@ var (
 func (cache *NPHDSCache) HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, nodeIP string, resourceNames []string, typeURL string, detail string) {
 	// Start caching for IP/ID mappings on the first indication someone wants them
 	observerOnce.Do(func() {
-		ipcache.IPIdentityCache.AddListener(cache)
+		cache.ipcache.AddListener(cache)
 	})
 }
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -194,7 +194,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 			if s.restoring {
 				return nil, fmt.Errorf("No EPs available when restoring")
 			}
-			return endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady), nil
+			return endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady), nil
 		},
 		// LookupSecIDByIP
 		func(ip net.IP) (ipcache.Identity, bool) {
@@ -726,7 +726,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Restore rules
-	ep1 := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
 	ep1.DNSRules = restored1
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
@@ -772,7 +772,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Restore rules for epID3
-	ep3 := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID3), endpoint.StateReady)
+	ep3 := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID3), endpoint.StateReady)
 	ep3.DNSRules = restored3
 	s.proxy.RestoreRules(ep3)
 	_, exists = s.proxy.restored[epID3]
@@ -956,7 +956,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 
 	// restore rules, set the mock to restoring state
 	s.restoring = true
-	ep1 := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(nil), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
 	ep1.IPv4, _ = addressing.NewCiliumIPv4("127.0.0.1")
 	ep1.IPv6, _ = addressing.NewCiliumIPv6("::1")
 	ep1.DNSRules = restored

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -194,7 +194,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 			if s.restoring {
 				return nil, fmt.Errorf("No EPs available when restoring")
 			}
-			return endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady), nil
+			return endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady), nil
 		},
 		// LookupSecIDByIP
 		func(ip net.IP) (ipcache.Identity, bool) {
@@ -726,7 +726,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(allowed, Equals, false, Commentf("request was allowed when it should be rejected"))
 
 	// Restore rules
-	ep1 := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
 	ep1.DNSRules = restored1
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
@@ -772,7 +772,7 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 
 	// Restore rules for epID3
-	ep3 := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID3), endpoint.StateReady)
+	ep3 := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID3), endpoint.StateReady)
 	ep3.DNSRules = restored3
 	s.proxy.RestoreRules(ep3)
 	_, exists = s.proxy.restored[epID3]
@@ -956,7 +956,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 
 	// restore rules, set the mock to restoring state
 	s.restoring = true
-	ep1 := endpoint.NewEndpointWithState(s, s, &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewEndpointWithState(s, s, ipcache.NewIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
 	ep1.IPv4, _ = addressing.NewCiliumIPv4("127.0.0.1")
 	ep1.IPv6, _ = addressing.NewCiliumIPv6("::1")
 	ep1.DNSRules = restored

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -138,7 +138,7 @@ func allocate(prefix *net.IPNet, lbls labels.Labels) (*identity.Identity, bool, 
 	return id, isNew, err
 }
 
-func releaseCIDRIdentities(ctx context.Context, identities map[string]*identity.Identity) {
+func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, identities map[string]*identity.Identity) {
 	for prefix, id := range identities {
 		released, err := IdentityAllocator.Release(ctx, id, false)
 		if err != nil {
@@ -149,7 +149,7 @@ func releaseCIDRIdentities(ctx context.Context, identities map[string]*identity.
 		}
 
 		if released {
-			IPIdentityCache.Delete(prefix, source.Generated)
+			ipc.Delete(prefix, source.Generated)
 		}
 	}
 }
@@ -174,7 +174,7 @@ func ReleaseCIDRIdentitiesByCIDR(prefixes []*net.IPNet) {
 		}
 	}
 
-	releaseCIDRIdentities(releaseCtx, identities)
+	IPIdentityCache.releaseCIDRIdentities(releaseCtx, identities)
 }
 
 // ReleaseCIDRIdentitiesByID releases the specified identities.
@@ -199,5 +199,5 @@ func ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.Numeri
 		}
 	}
 
-	releaseCIDRIdentities(ctx, fullIdentities)
+	IPIdentityCache.releaseCIDRIdentities(ctx, fullIdentities)
 }

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -50,7 +50,7 @@ func (ipc *IPCache) AllocateCIDRs(
 		}
 
 		lbls := cidr.GetCIDRLabels(p)
-		lbls.MergeLabels(GetIDMetadataByIP(p.IP.String()))
+		lbls.MergeLabels(ipc.GetIDMetadataByIP(p.IP.String()))
 
 		id, isNew, err := ipc.allocate(p, lbls)
 		if err != nil {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -410,8 +410,18 @@ func (ipc *IPCache) upsertLocked(
 	return namedPortsChanged, nil
 }
 
+// DumpToListener dumps the entire contents of the IPCache by triggering
+// the listener's "OnIPIdentityCacheChange" method for each entry in the cache.
+func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
+	ipc.RLock()
+	ipc.DumpToListenerLocked(listener)
+	ipc.RUnlock()
+}
+
 // DumpToListenerLocked dumps the entire contents of the IPCache by triggering
 // the listener's "OnIPIdentityCacheChange" method for each entry in the cache.
+// The caller *MUST* grab the IPCache.Lock for reading before calling this
+// function.
 func (ipc *IPCache) DumpToListenerLocked(listener IPIdentityMappingListener) {
 	for ip, identity := range ipc.ipToIdentityCache {
 		if identity.shadowed {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -19,13 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/source"
 )
 
-var (
-	// IPIdentityCache caches the mapping of endpoint IPs to their corresponding
-	// security identities across the entire cluster in which this instance of
-	// Cilium is running.
-	IPIdentityCache = NewIPCache()
-)
-
 // Identity is the identity representation of an IP<->Identity cache.
 type Identity struct {
 	// ID is the numeric identity

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -87,6 +89,11 @@ type IPCache struct {
 	// k8sSyncedChecker knows how to check for whether the K8s watcher cache
 	// has been fully synced.
 	k8sSyncedChecker k8sSyncedChecker
+
+	// Accessors to other subsystems, provided by the daemon
+	identityAllocator cache.IdentityAllocator
+	policyHandler     ipcacheTypes.PolicyHandler
+	datapathHandler   ipcacheTypes.DatapathHandler
 }
 
 // NewIPCache returns a new IPCache with the mappings of endpoint IP to security
@@ -101,6 +108,22 @@ func NewIPCache() *IPCache {
 		controllers:       controller.NewManager(),
 		namedPorts:        nil,
 	}
+}
+
+func (ipc *IPCache) WithIdentityAllocator(idAllocator cache.IdentityAllocator) *IPCache {
+	IdentityAllocator = idAllocator
+	ipc.identityAllocator = idAllocator
+	return ipc
+}
+
+func (ipc *IPCache) WithPolicyHandler(updater ipcacheTypes.PolicyHandler) *IPCache {
+	ipc.policyHandler = updater
+	return ipc
+}
+
+func (ipc *IPCache) WithDatapathHandler(triggerer ipcacheTypes.DatapathHandler) *IPCache {
+	ipc.datapathHandler = triggerer
+	return ipc
 }
 
 // Lock locks the IPCache's mutex.

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -111,7 +111,6 @@ func NewIPCache() *IPCache {
 }
 
 func (ipc *IPCache) WithIdentityAllocator(idAllocator cache.IdentityAllocator) *IPCache {
-	IdentityAllocator = idAllocator
 	ipc.identityAllocator = idAllocator
 	return ipc
 }

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -87,6 +87,9 @@ type IPCache struct {
 	identityAllocator cache.IdentityAllocator
 	policyHandler     ipcacheTypes.PolicyHandler
 	datapathHandler   ipcacheTypes.DatapathHandler
+
+	// metadata is the ipcache identity metadata map, which maps IPs to labels.
+	metadata *metadata
 }
 
 // NewIPCache returns a new IPCache with the mappings of endpoint IP to security
@@ -100,6 +103,7 @@ func NewIPCache() *IPCache {
 		ipToK8sMetadata:   map[string]K8sMetadata{},
 		controllers:       controller.NewManager(),
 		namedPorts:        nil,
+		metadata:          newMetadata(),
 	}
 }
 

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -27,7 +27,7 @@ type IPCacheTestSuite struct{}
 
 var (
 	_               = Suite(&IPCacheTestSuite{})
-	IPIdentityCache = NewIPCache()
+	IPIdentityCache = NewIPCache(nil)
 )
 
 func Test(t *testing.T) {
@@ -546,7 +546,7 @@ func (s *IPCacheTestSuite) TestIPCacheShadowing(c *C) {
 	cidrOverlap := "10.0.0.15/32"
 	epIdentity := (identityPkg.NumericIdentity(68))
 	cidrIdentity := (identityPkg.NumericIdentity(202))
-	ipc := NewIPCache()
+	ipc := NewIPCache(nil)
 
 	// Assure sane state at start.
 	c.Assert(ipc.ipToIdentityCache, checker.DeepEquals, map[string]Identity{})

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -25,7 +25,10 @@ import (
 // Hook up gocheck into the "go test" runner.
 type IPCacheTestSuite struct{}
 
-var _ = Suite(&IPCacheTestSuite{})
+var (
+	_               = Suite(&IPCacheTestSuite{})
+	IPIdentityCache = NewIPCache()
+)
 
 func Test(t *testing.T) {
 	TestingT(t)

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -65,7 +65,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 
 	IPIdentityCache.removeLabelsFromIPs(map[string]labels.Labels{
 		"1.1.1.1": labels.LabelKubeAPIServer,
-	}, source.Local, &mockUpdater{}, &mockTriggerer{})
+	}, source.Local)
 	assert.Len(t, identityMetadata, 1)
 	assert.Equal(t, labels.LabelHost, identityMetadata["1.1.1.1"])
 
@@ -79,20 +79,20 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// called.
 	UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer)
 	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
-	id := IdentityAllocator.LookupIdentityByID(
+	id := IPIdentityCache.identityAllocator.LookupIdentityByID(
 		context.TODO(),
 		identity.LocalIdentityFlag, // we assume first local ID
 	)
 	assert.NotNil(t, id)
 	assert.Equal(t, 1, id.ReferenceCount)
 	// Simulate adding CIDR policy.
-	ids, err := AllocateCIDRsForIPs([]net.IP{net.ParseIP("1.1.1.1")}, nil)
+	ids, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{net.ParseIP("1.1.1.1")}, nil)
 	assert.Nil(t, err)
 	assert.Len(t, ids, 1)
 	assert.Equal(t, 2, id.ReferenceCount)
 	IPIdentityCache.removeLabelsFromIPs(map[string]labels.Labels{ // remove kube-apiserver policy
 		"1.1.1.1": labels.LabelKubeAPIServer,
-	}, source.Local, &mockUpdater{}, &mockTriggerer{})
+	}, source.Local)
 	assert.NotContains(t, identityMetadata["1.1.1.1"], labels.LabelKubeAPIServer)
 	assert.Equal(t, 1, id.ReferenceCount) // CIDR policy is left
 }

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -79,7 +79,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// called.
 	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer)
 	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
-	id := IPIdentityCache.identityAllocator.LookupIdentityByID(
+	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
 		context.TODO(),
 		identity.LocalIdentityFlag, // we assume first local ID
 	)
@@ -101,10 +101,11 @@ func setupTest(t *testing.T) {
 	t.Helper()
 
 	allocator := testidentity.NewMockIdentityAllocator(nil)
-	IPIdentityCache = NewIPCache().
-		WithIdentityAllocator(allocator).
-		WithPolicyHandler(&mockUpdater{}).
-		WithDatapathHandler(&mockTriggerer{})
+	IPIdentityCache = NewIPCache(&Configuration{
+		IdentityAllocator: allocator,
+		PolicyHandler:     &mockUpdater{},
+		DatapathHandler:   &mockTriggerer{},
+	})
 	IPIdentityCache.k8sSyncedChecker = &mockK8sSyncedChecker{}
 
 	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer)

--- a/pkg/ipcache/types/entries.go
+++ b/pkg/ipcache/types/entries.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package ipcachetypes
+package types
 
 import (
 	"bytes"

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package ipcachetypes
+package types
 
 import (
 	"context"

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcachetypes
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cilium/cilium/pkg/identity/cache"
+)
+
+// PolicyHandler is responsible for handling identity updates into the core
+// policy engine. See SelectorCache.UpdateIdentities() for more details.
+type PolicyHandler interface {
+	UpdateIdentities(added, deleted cache.IdentityCache, wg *sync.WaitGroup)
+}
+
+// DatapathHandler is responsible for ensuring that policy updates in the
+// core policy engine are pushed into the underlying BPF policy maps, to ensure
+// that the policies are actively being enforced in the datapath for any new
+// identities that have been updated using 'PolicyHandler'.
+//
+// Wait on the returned sync.WaitGroup to ensure that the operation is complete
+// before updating the datapath's IPCache maps.
+type DatapathHandler interface {
+	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
+}

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/policy"
@@ -64,7 +65,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{}, false)
+	translator := NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, false, map[string]string{}, false)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -78,7 +79,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, map[string]string{}, false)
+	translator = NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, true, map[string]string{}, false)
 	result, err = repo.TranslateRules(translator)
 	c.Assert(result.NumToServicesRules, Equals, 1)
 
@@ -120,7 +121,7 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 		},
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, false)
+	translator := NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, false, svcLabels, false)
 	c.Assert(translator.serviceMatches(service), Equals, true)
 }
 
@@ -170,7 +171,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, false)
+	translator := NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, false, svcLabels, false)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -184,7 +185,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, svcLabels, false)
+	translator = NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, true, svcLabels, false)
 	result, err = repo.TranslateRules(translator)
 
 	rule = repo.SearchRLocked(tag1)[0].Egress[0]
@@ -220,8 +221,13 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 			},
 		},
 	}
+	serviceInfo := ServiceID{
+		Name:      "svc",
+		Namespace: "default",
+	}
 
-	err := generateToCidrFromEndpoint(rule, endpointInfo, false)
+	translator := NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, false, map[string]string{}, false)
+	err := translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	cidrs := rule.ToCIDRSet.StringSlice()
@@ -233,7 +239,7 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	})
 
 	// second run, to make sure there are no duplicates added
-	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
+	err = translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	cidrs = rule.ToCIDRSet.StringSlice()
@@ -244,12 +250,12 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 		epIP2 + "/32",
 	})
 
-	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
+	err = translator.deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 0)
 
 	// third run, to make sure there are no duplicates added
-	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
+	err = translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	cidrs = rule.ToCIDRSet.StringSlice()
@@ -261,7 +267,7 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	})
 
 	// and one final delete
-	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
+	err = translator.deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 0)
 }
@@ -323,7 +329,7 @@ func (s *K8sSuite) TestPreprocessRules(c *C) {
 
 	rules := api.Rules{&rule1}
 
-	err := PreprocessRules(rules, &cache)
+	err := PreprocessRules(rules, &cache, ipcache.NewIPCache())
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule1.Egress[0].ToCIDRSet), Equals, 1)
@@ -356,21 +362,26 @@ func (s *K8sSuite) TestDontDeleteUserRules(c *C) {
 			},
 		},
 	}
+	serviceInfo := ServiceID{
+		Name:      "svc",
+		Namespace: "default",
+	}
 
-	err := generateToCidrFromEndpoint(rule, endpointInfo, false)
+	translator := NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, false, map[string]string{}, false)
+	err := translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 2)
 	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP+"/32")
 
 	// second run, to make sure there are no duplicates added
-	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
+	err = translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 2)
 	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP+"/32")
 
-	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
+	err = translator.deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, string(userCIDR))

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -65,7 +65,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, false, map[string]string{}, false)
+	translator := NewK8sTranslator(ipcache.NewIPCache(nil), serviceInfo, endpointInfo, false, map[string]string{}, false)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -79,7 +79,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	translator = NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, true, map[string]string{}, false)
+	translator = NewK8sTranslator(ipcache.NewIPCache(nil), serviceInfo, endpointInfo, true, map[string]string{}, false)
 	result, err = repo.TranslateRules(translator)
 	c.Assert(result.NumToServicesRules, Equals, 1)
 
@@ -121,7 +121,7 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 		},
 	}
 
-	translator := NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, false, svcLabels, false)
+	translator := NewK8sTranslator(ipcache.NewIPCache(nil), serviceInfo, endpointInfo, false, svcLabels, false)
 	c.Assert(translator.serviceMatches(service), Equals, true)
 }
 
@@ -171,7 +171,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, false, svcLabels, false)
+	translator := NewK8sTranslator(ipcache.NewIPCache(nil), serviceInfo, endpointInfo, false, svcLabels, false)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -185,7 +185,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	translator = NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, true, svcLabels, false)
+	translator = NewK8sTranslator(ipcache.NewIPCache(nil), serviceInfo, endpointInfo, true, svcLabels, false)
 	result, err = repo.TranslateRules(translator)
 
 	rule = repo.SearchRLocked(tag1)[0].Egress[0]
@@ -226,7 +226,7 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 		Namespace: "default",
 	}
 
-	translator := NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, false, map[string]string{}, false)
+	translator := NewK8sTranslator(ipcache.NewIPCache(nil), serviceInfo, endpointInfo, false, map[string]string{}, false)
 	err := translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
@@ -329,7 +329,7 @@ func (s *K8sSuite) TestPreprocessRules(c *C) {
 
 	rules := api.Rules{&rule1}
 
-	err := PreprocessRules(rules, &cache, ipcache.NewIPCache())
+	err := PreprocessRules(rules, &cache, ipcache.NewIPCache(nil))
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule1.Egress[0].ToCIDRSet), Equals, 1)
@@ -367,7 +367,7 @@ func (s *K8sSuite) TestDontDeleteUserRules(c *C) {
 		Namespace: "default",
 	}
 
-	translator := NewK8sTranslator(ipcache.NewIPCache(), serviceInfo, endpointInfo, false, map[string]string{}, false)
+	translator := NewK8sTranslator(ipcache.NewIPCache(nil), serviceInfo, endpointInfo, false, map[string]string{}, false)
 	err := translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -124,13 +124,13 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 					}
 				}
 				if !v4Added {
-					portsChanged := ipcache.IPIdentityCache.Delete(oldPair.IPV4, source.CustomResource)
+					portsChanged := k.ipcache.Delete(oldPair.IPV4, source.CustomResource)
 					if portsChanged {
 						namedPortsChanged = true
 					}
 				}
 				if !v6Added {
-					portsChanged := ipcache.IPIdentityCache.Delete(oldPair.IPV6, source.CustomResource)
+					portsChanged := k.ipcache.Delete(oldPair.IPV6, source.CustomResource)
 					if portsChanged {
 						namedPortsChanged = true
 					}
@@ -183,7 +183,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 	for _, pair := range endpoint.Networking.Addressing {
 		if pair.IPV4 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV4)
-			portsChanged, _ := ipcache.IPIdentityCache.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
+			portsChanged, _ := k.ipcache.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
 				ipcache.Identity{ID: id, Source: source.CustomResource})
 			if portsChanged {
 				namedPortsChanged = true
@@ -192,7 +192,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 
 		if pair.IPV6 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV6)
-			portsChanged, _ := ipcache.IPIdentityCache.Upsert(pair.IPV6, nodeIP, encryptionKey, k8sMeta,
+			portsChanged, _ := k.ipcache.Upsert(pair.IPV6, nodeIP, encryptionKey, k8sMeta,
 				ipcache.Identity{ID: id, Source: source.CustomResource})
 			if portsChanged {
 				namedPortsChanged = true
@@ -210,14 +210,14 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 		namedPortsChanged := false
 		for _, pair := range endpoint.Networking.Addressing {
 			if pair.IPV4 != "" {
-				portsChanged := ipcache.IPIdentityCache.DeleteOnMetadataMatch(pair.IPV4, source.CustomResource, endpoint.Namespace, endpoint.Name)
+				portsChanged := k.ipcache.DeleteOnMetadataMatch(pair.IPV4, source.CustomResource, endpoint.Namespace, endpoint.Name)
 				if portsChanged {
 					namedPortsChanged = true
 				}
 			}
 
 			if pair.IPV6 != "" {
-				portsChanged := ipcache.IPIdentityCache.DeleteOnMetadataMatch(pair.IPV6, source.CustomResource, endpoint.Namespace, endpoint.Name)
+				portsChanged := k.ipcache.DeleteOnMetadataMatch(pair.IPV6, source.CustomResource, endpoint.Namespace, endpoint.Name)
 				if portsChanged {
 					namedPortsChanged = true
 				}

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -167,7 +167,7 @@ func (k *K8sWatcher) addCiliumNetworkPolicyV2(ciliumNPClient clientset.Interface
 
 	rules, policyImportErr := cnp.Parse()
 	if policyImportErr == nil {
-		policyImportErr = k8s.PreprocessRules(rules, &k.K8sSvcCache)
+		policyImportErr = k8s.PreprocessRules(rules, &k.K8sSvcCache, k.ipcache)
 		// Replace all rules with the same name, namespace and
 		// resourceTypeCiliumNetworkPolicy
 		if policyImportErr == nil {

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -137,7 +136,7 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 	)
 
 	for ip := range desiredIPs {
-		ipcache.UpsertMetadata(ip, labels.LabelKubeAPIServer)
+		k.ipcache.UpsertMetadata(ip, labels.LabelKubeAPIServer)
 	}
 
 	k.ipcache.TriggerLabelInjection(src)

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -142,11 +142,7 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 		ipcache.UpsertMetadata(ip, labels.LabelKubeAPIServer)
 	}
 
-	k.ipcache.TriggerLabelInjection(
-		src,
-		k.policyRepository.GetSelectorCache(),
-		k.endpointManager,
-	)
+	k.ipcache.TriggerLabelInjection(src)
 }
 
 // TODO(christarazi): Convert to subscriber model along with the corresponding

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -130,12 +130,10 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 	//     an update event.
 	//   * if the entire object is deleted, then it will quickly be recreated
 	//     and this will be in the form of an add event.
-	ipcache.RemoveLabelsExcluded(
+	k.ipcache.RemoveLabelsExcluded(
 		labels.LabelKubeAPIServer,
 		desiredIPs,
 		src,
-		k.policyRepository.GetSelectorCache(),
-		k.endpointManager,
 	)
 
 	for ip := range desiredIPs {

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -142,7 +142,7 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 		ipcache.UpsertMetadata(ip, labels.LabelKubeAPIServer)
 	}
 
-	ipcache.IPIdentityCache.TriggerLabelInjection(
+	k.ipcache.TriggerLabelInjection(
 		src,
 		k.policyRepository.GetSelectorCache(),
 		k.endpointManager,

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -697,7 +697,7 @@ func (k *K8sWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPodIP
 					}
 				}
 				if !found {
-					npc := ipcache.IPIdentityCache.Delete(oldPodIP, source.Kubernetes)
+					npc := k.ipcache.Delete(oldPodIP, source.Kubernetes)
 					if npc {
 						namedPortsChanged = true
 					}
@@ -768,7 +768,7 @@ func (k *K8sWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPodIP
 		// Initial mapping of podIP <-> hostIP <-> identity. The mapping is
 		// later updated once the allocator has determined the real identity.
 		// If the endpoint remains unmanaged, the identity remains untouched.
-		npc, err := ipcache.IPIdentityCache.Upsert(podIP, hostIP, hostKey, k8sMeta, ipcache.Identity{
+		npc, err := k.ipcache.Upsert(podIP, hostIP, hostKey, k8sMeta, ipcache.Identity{
 			ID:     identity.ReservedIdentityUnmanaged,
 			Source: source.Kubernetes,
 		})
@@ -825,7 +825,7 @@ func (k *K8sWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 		// a small race condition exists here as deletion could occur in
 		// parallel based on another event but it doesn't matter as the
 		// identity is going away
-		id, exists := ipcache.IPIdentityCache.LookupByIP(podIP)
+		id, exists := k.ipcache.LookupByIP(podIP)
 		if !exists {
 			skipped = true
 			errs = append(errs, fmt.Sprintf("identity for IP %s does not exist in case", podIP))
@@ -838,7 +838,7 @@ func (k *K8sWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 			continue
 		}
 
-		ipcache.IPIdentityCache.DeleteOnMetadataMatch(podIP, source.Kubernetes, pod.Namespace, pod.Name)
+		k.ipcache.DeleteOnMetadataMatch(podIP, source.Kubernetes, pod.Namespace, pod.Name)
 	}
 
 	if len(errs) != 0 {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -511,7 +511,7 @@ func (k *K8sWatcher) k8sServiceHandler() {
 				return
 			}
 
-			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, false, svc.Labels, true)
+			translator := k8s.NewK8sTranslator(k.ipcache, event.ID, *event.Endpoints, false, svc.Labels, true)
 			result, err := k.policyRepository.TranslateRules(translator)
 			if err != nil {
 				log.WithError(err).Error("Unable to repopulate egress policies from ToService rules")
@@ -530,7 +530,7 @@ func (k *K8sWatcher) k8sServiceHandler() {
 				return
 			}
 
-			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, true, svc.Labels, true)
+			translator := k8s.NewK8sTranslator(k.ipcache, event.ID, *event.Endpoints, true, svc.Labels, true)
 			result, err := k.policyRepository.TranslateRules(translator)
 			if err != nil {
 				log.WithError(err).Error("Unable to depopulate egress policies from ToService rules")

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -201,6 +202,7 @@ type K8sWatcher struct {
 	redirectPolicyManager redirectPolicyManager
 	bgpSpeakerManager     bgpSpeakerManager
 	egressGatewayManager  egressGatewayManager
+	ipcache               *ipcache.IPCache
 
 	// controllersStarted is a channel that is closed when all controllers, i.e.,
 	// k8s watchers have started listening for k8s events.
@@ -236,6 +238,7 @@ func NewK8sWatcher(
 	bgpSpeakerManager bgpSpeakerManager,
 	egressGatewayManager egressGatewayManager,
 	cfg WatcherConfiguration,
+	ipcache *ipcache.IPCache,
 ) *K8sWatcher {
 	return &K8sWatcher{
 		K8sSvcCache:           k8s.NewServiceCache(datapath.LocalNodeAddressing()),
@@ -244,6 +247,7 @@ func NewK8sWatcher(
 		policyManager:         policyManager,
 		policyRepository:      policyRepository,
 		svcManager:            svcManager,
+		ipcache:               ipcache,
 		controllersStarted:    make(chan struct{}),
 		stop:                  make(chan struct{}),
 		podStoreSet:           make(chan struct{}),

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -234,7 +234,7 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
-		ipcache.NewIPCache(),
+		ipcache.NewIPCache(nil),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -541,7 +541,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
-		ipcache.NewIPCache(),
+		ipcache.NewIPCache(nil),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -685,7 +685,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
-		ipcache.NewIPCache(),
+		ipcache.NewIPCache(nil),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1135,7 +1135,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
-		ipcache.NewIPCache(),
+		ipcache.NewIPCache(nil),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1432,7 +1432,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
-		ipcache.NewIPCache(),
+		ipcache.NewIPCache(nil),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1722,7 +1722,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
-		ipcache.NewIPCache(),
+		ipcache.NewIPCache(nil),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -2577,7 +2577,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
-		ipcache.NewIPCache(),
+		ipcache.NewIPCache(nil),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -233,6 +234,7 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
+		ipcache.NewIPCache(),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -539,6 +541,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
+		ipcache.NewIPCache(),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -682,6 +685,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
+		ipcache.NewIPCache(),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1131,6 +1135,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
+		ipcache.NewIPCache(),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1427,6 +1432,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
+		ipcache.NewIPCache(),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1716,6 +1722,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
+		ipcache.NewIPCache(),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -2570,6 +2577,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		nil,
 		nil,
 		&fakeWatcherConfiguration{},
+		ipcache.NewIPCache(),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -51,6 +52,7 @@ type nodeEntry struct {
 type IPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error)
 	Delete(IP string, source source.Source) bool
+	TriggerLabelInjection(source.Source, ipcacheTypes.PolicyHandler, ipcacheTypes.DatapathHandler)
 }
 
 // Configuration is the set of configuration options the node manager depends
@@ -185,12 +187,11 @@ func (m *Manager) Iter(f func(nh datapath.NodeHandler)) {
 }
 
 // NewManager returns a new node manager
-func NewManager(name string, dp datapath.NodeHandler, ipcache IPCache, c Configuration, sc selectorCacheUpdater, pt policyTriggerer) (*Manager, error) {
+func NewManager(name string, dp datapath.NodeHandler, c Configuration, sc selectorCacheUpdater, pt policyTriggerer) (*Manager, error) {
 	m := &Manager{
 		name:                 name,
 		nodes:                map[nodeTypes.Identity]*nodeEntry{},
 		conf:                 c,
-		ipcache:              ipcache,
 		controllerManager:    controller.NewManager(),
 		selectorCacheUpdater: sc,
 		policyTriggerer:      pt,
@@ -239,6 +240,12 @@ func (m *Manager) WithSelectorCacheUpdater(sc selectorCacheUpdater) *Manager {
 // WithPolicyTriggerer sets the policy update trigger in the Manager.
 func (m *Manager) WithPolicyTriggerer(pt policyTriggerer) *Manager {
 	m.policyTriggerer = pt
+	return m
+}
+
+// WithIPCache sets the ipcache field in the Manager.
+func (m *Manager) WithIPCache(ipc IPCache) *Manager {
+	m.ipcache = ipc
 	return m
 }
 
@@ -437,7 +444,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			Source: n.Source,
 		})
 
-		upsertIntoIDMD(ipAddrStr, remoteHostIdentity)
+		m.upsertIntoIDMD(ipAddrStr, remoteHostIdentity)
 
 		// Upsert() will return true if the ipcache entry is owned by
 		// the source of the node update that triggered this node
@@ -519,7 +526,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		entry.mutex.Unlock()
 	}
 
-	ipcache.IPIdentityCache.TriggerLabelInjection(
+	m.ipcache.TriggerLabelInjection(
 		n.Source,
 		m.selectorCacheUpdater,
 		m.policyTriggerer,
@@ -529,14 +536,12 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 // upsertIntoIDMD upserts the given CIDR into the ipcache.identityMetadata
 // (IDMD) map. The given node identity determines which labels are associated
 // with the CIDR.
-func upsertIntoIDMD(prefix string, id identity.NumericIdentity) {
-	var lbls labels.Labels
+func (m *Manager) upsertIntoIDMD(prefix string, id identity.NumericIdentity) {
 	if id == identity.ReservedIdentityHost {
-		lbls = labels.LabelHost
+		ipcache.UpsertMetadata(prefix, labels.LabelHost)
 	} else {
-		lbls = labels.LabelRemoteNode
+		ipcache.UpsertMetadata(prefix, labels.LabelRemoteNode)
 	}
-	ipcache.UpsertMetadata(prefix, lbls)
 }
 
 // deleteIPCache deletes the IP addresses from the IPCache with the 'oldSource'

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -52,6 +52,7 @@ type IPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error)
 	Delete(IP string, source source.Source) bool
 	TriggerLabelInjection(source source.Source)
+	UpsertMetadata(string, labels.Labels)
 }
 
 // Configuration is the set of configuration options the node manager depends
@@ -533,9 +534,9 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 // with the CIDR.
 func (m *Manager) upsertIntoIDMD(prefix string, id identity.NumericIdentity) {
 	if id == identity.ReservedIdentityHost {
-		ipcache.UpsertMetadata(prefix, labels.LabelHost)
+		m.ipcache.UpsertMetadata(prefix, labels.LabelHost)
 	} else {
-		ipcache.UpsertMetadata(prefix, labels.LabelRemoteNode)
+		m.ipcache.UpsertMetadata(prefix, labels.LabelRemoteNode)
 	}
 }
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
-	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -52,7 +51,7 @@ type nodeEntry struct {
 type IPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error)
 	Delete(IP string, source source.Source) bool
-	TriggerLabelInjection(source.Source, ipcacheTypes.PolicyHandler, ipcacheTypes.DatapathHandler)
+	TriggerLabelInjection(source source.Source)
 }
 
 // Configuration is the set of configuration options the node manager depends
@@ -526,11 +525,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		entry.mutex.Unlock()
 	}
 
-	m.ipcache.TriggerLabelInjection(
-		n.Source,
-		m.selectorCacheUpdater,
-		m.policyTriggerer,
-	)
+	m.ipcache.TriggerLabelInjection(n.Source)
 }
 
 // upsertIntoIDMD upserts the given CIDR into the ipcache.identityMetadata

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
@@ -83,6 +84,9 @@ func (i *ipcacheMock) Delete(IP string, source source.Source) bool {
 }
 
 func (i *ipcacheMock) TriggerLabelInjection(s source.Source) {
+}
+
+func (i *ipcacheMock) UpsertMetadata(string, labels.Labels) {
 }
 
 type signalNodeHandler struct {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
-	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
@@ -84,7 +83,7 @@ func (i *ipcacheMock) Delete(IP string, source source.Source) bool {
 	return false
 }
 
-func (i *ipcacheMock) TriggerLabelInjection(s source.Source, ph ipcacheTypes.PolicyHandler, dp ipcacheTypes.DatapathHandler) {
+func (i *ipcacheMock) TriggerLabelInjection(s source.Source) {
 }
 
 type signalNodeHandler struct {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
-	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
 func Test(t *testing.T) {
@@ -151,7 +150,6 @@ func (n *signalNodeHandler) NodeCleanNeighbors(migrateOnly bool) {
 }
 
 func (s *managerTestSuite) SetUpSuite(c *check.C) {
-	ipcache.IdentityAllocator = testidentity.NewMockIdentityAllocator(nil)
 }
 
 func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
@@ -81,6 +82,9 @@ func (i *ipcacheMock) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *i
 func (i *ipcacheMock) Delete(IP string, source source.Source) bool {
 	i.events <- nodeEvent{"delete", net.ParseIP(IP)}
 	return false
+}
+
+func (i *ipcacheMock) TriggerLabelInjection(s source.Source, ph ipcacheTypes.PolicyHandler, dp ipcacheTypes.DatapathHandler) {
 }
 
 type signalNodeHandler struct {
@@ -156,7 +160,9 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := NewManager("test", dp, newIPcacheMock(), &configMock{}, nil, nil)
+	ipcacheMock := newIPcacheMock()
+	mngr, err := NewManager("test", dp, &configMock{}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
 	c.Assert(err, check.IsNil)
 
 	n1 := nodeTypes.Node{Name: "node1", Cluster: "c1"}
@@ -225,7 +231,9 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := NewManager("test", dp, newIPcacheMock(), &configMock{}, nil, nil)
+	ipcacheMock := newIPcacheMock()
+	mngr, err := NewManager("test", dp, &configMock{}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -294,7 +302,9 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 }
 
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
-	mngr, err := NewManager("test", fake.NewNodeHandler(), newIPcacheMock(), &configMock{}, nil, nil)
+	ipcacheMock := newIPcacheMock()
+	mngr, err := NewManager("test", fake.NewNodeHandler(), &configMock{}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -312,7 +322,9 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 }
 
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
-	mngr, err := NewManager("test", fake.NewNodeHandler(), newIPcacheMock(), &configMock{}, nil, nil)
+	ipcacheMock := newIPcacheMock()
+	mngr, err := NewManager("test", fake.NewNodeHandler(), &configMock{}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -337,7 +349,9 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
-	mngr, err := NewManager("test", signalNodeHandler, newIPcacheMock(), &configMock{}, nil, nil)
+	ipcacheMock := newIPcacheMock()
+	mngr, err := NewManager("test", signalNodeHandler, &configMock{}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -374,7 +388,8 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 
 func (s *managerTestSuite) TestIpcache(c *check.C) {
 	ipcacheMock := newIPcacheMock()
-	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{}, nil, nil)
+	mngr, err := NewManager("test", newSignalNodeHandler(), &configMock{}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -420,7 +435,8 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 
 func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 	ipcacheMock := newIPcacheMock()
-	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{}, nil, nil)
+	mngr, err := NewManager("test", newSignalNodeHandler(), &configMock{}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -494,7 +510,8 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 
 func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 	ipcacheMock := newIPcacheMock()
-	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{RemoteNodeIdentity: true}, nil, nil)
+	mngr, err := NewManager("test", newSignalNodeHandler(), &configMock{RemoteNodeIdentity: true}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -568,7 +585,8 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
-	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{NodeEncryption: true, Encryption: true}, nil, nil)
+	mngr, err := NewManager("test", newSignalNodeHandler(), &configMock{NodeEncryption: true, Encryption: true}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -655,7 +673,8 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := NewManager("test", dp, ipcacheMock, &configMock{}, nil, nil)
+	mngr, err := NewManager("test", dp, &configMock{}, nil, nil)
+	mngr = mngr.WithIPCache(ipcacheMock)
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -102,10 +103,11 @@ type Proxy struct {
 // and access log server.
 func StartProxySupport(minPort uint16, maxPort uint16, stateDir string,
 	accessLogNotifier logger.LogRecordNotifier, accessLogMetadata []string,
-	datapathUpdater DatapathUpdater, mgr EndpointLookup) *Proxy {
+	datapathUpdater DatapathUpdater, mgr EndpointLookup,
+	ipcache *ipcache.IPCache) *Proxy {
 	endpointManager = mgr
 	logger.SetEndpointInfoRegistry(DefaultEndpointInfoRegistry)
-	xdsServer := envoy.StartXDSServer(stateDir)
+	xdsServer := envoy.StartXDSServer(ipcache, stateDir)
 
 	if accessLogNotifier != nil {
 		logger.SetNotifier(accessLogNotifier)

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -87,7 +87,6 @@ func NewAgent(privKeyPath string) (*Agent, error) {
 
 	return &Agent{
 		wgClient:         wgClient,
-		ipCache:          ipcache.IPIdentityCache,
 		privKey:          key,
 		listenPort:       listenPort,
 		peerByNodeName:   map[string]*peerConfig{},
@@ -164,9 +163,10 @@ func (a *Agent) initUserspaceDevice(linkMTU int) (netlink.Link, error) {
 }
 
 // Init creates and configures the local WireGuard tunnel device.
-func (a *Agent) Init(mtuConfig mtu.Configuration) error {
+func (a *Agent) Init(ipcache *ipcache.IPCache, mtuConfig mtu.Configuration) error {
 	addIPCacheListener := false
 	a.Lock()
+	a.ipCache = ipcache
 	defer func() {
 		// IPCache will call back into OnIPIdentityCacheChange which requires
 		// us to release a.mutex before we can add ourself as a listener.

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -82,7 +82,7 @@ func containsIP(allowedIPs []net.IPNet, ipnet *net.IPNet) bool {
 }
 
 func (a *AgentSuite) TestAgent_PeerConfig(c *C) {
-	ipCache := ipcache.NewIPCache()
+	ipCache := ipcache.NewIPCache(nil)
 	wgAgent := &Agent{
 		wgClient:         &fakeWgClient{},
 		ipCache:          ipCache,

--- a/proxylib/npds/client_test.go
+++ b/proxylib/npds/client_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/proxylib/test"
 )
 
@@ -89,7 +90,7 @@ func (s *ClientSuite) TestRequestAllResources(c *C) {
 
 	// Some wait before server is made available
 	time.Sleep(500 * time.Millisecond)
-	xdsServer := envoy.StartXDSServer(test.Tmpdir)
+	xdsServer := envoy.StartXDSServer(ipcache.NewIPCache(), test.Tmpdir)
 	time.Sleep(500 * time.Millisecond)
 
 	// Create version 1 with resource 0.

--- a/proxylib/npds/client_test.go
+++ b/proxylib/npds/client_test.go
@@ -90,7 +90,7 @@ func (s *ClientSuite) TestRequestAllResources(c *C) {
 
 	// Some wait before server is made available
 	time.Sleep(500 * time.Millisecond)
-	xdsServer := envoy.StartXDSServer(ipcache.NewIPCache(), test.Tmpdir)
+	xdsServer := envoy.StartXDSServer(ipcache.NewIPCache(nil), test.Tmpdir)
 	time.Sleep(500 * time.Millisecond)
 
 	// Create version 1 with resource 0.


### PR DESCRIPTION
Meta: https://github.com/cilium/cilium/issues/21142

This PR refactors the IPCache to encapsulate the current package-level global variables into an individual instance of the IPCache, so that subsequent changes can be more easily made to extend the IPCache to hold more information and to resolve conflicts between information more easily. Initialization is moved away from an `init()` function and directly into the daemon.

Structurally this PR first moves the initialization into the daemon, then progressively changes individual packages to rely on that initialized copy of the IPCache, moves other subsystem interactions into the IPCache initialization functions, and finally removes the globals and plumbs the initialized copy of the IPCache from the daemon through to each individual package that needs it.

Fixes: #17849 
Related: #18301

Tasks:
- [x] Rebase
- [x] Fix up `RemoveLabelsExcluded()` so the callers don't have to pass policy, datapath triggerers
- [x] Move `identityMetadata` (and locking friends) into `IPCache`, possibly via dedicated `identityMetadata` structure
- [x] Better documentation
- [x] NewIPCache(config)