### PR TITLE
clustermesh: fix: identities allocation range

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -227,6 +227,9 @@ func runApiserver() error {
 	flags.Duration(option.AllocatorListTimeoutName, defaults.AllocatorListTimeout, "Timeout for listing allocator state before exiting")
 	option.BindEnv(option.AllocatorListTimeoutName)
 
+	flags.Bool(option.EnableWellKnownIdentities, defaults.EnableWellKnownIdentities, "Enable well-known identities for known Kubernetes components")
+	option.BindEnv(option.EnableWellKnownIdentities)
+
 	viper.BindPFlags(flags)
 
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
Identities has been calculated within improper range.

It is necessary to call the identity.InitWellKnownIdentities() in order to initialize proper
identity.MinimumAllocationIdentity and identity.MaximumAllocationIdentity limits.
Missing EnableWellKnownIdentities option has been added to provide the responsible code is executed.

Discussed here https://cilium.slack.com/archives/C2B917YHE/p1646220415345549

Signed-off-by: Adam Bocim <adam.bocim@seznam.cz>