### PR TITLE
docs: Update alibabacloud RAM permission requirements

### DIFF
--- a/Documentation/gettingstarted/alibabacloud-eni.rst
+++ b/Documentation/gettingstarted/alibabacloud-eni.rst
@@ -107,7 +107,8 @@ These keys need to have certain `RAM Permissions
             "ecs:DescribeInstanceTypes",
             "ecs:AssignPrivateIpAddresses",
             "ecs:UnassignPrivateIpAddresses",
-            "ecs:DescribeInstances"
+            "ecs:DescribeInstances",
+            "ecs:DescribeSecurityGroups"
           ],
           "Resource": [
             "*"
@@ -117,7 +118,8 @@ These keys need to have certain `RAM Permissions
         {
           "Action": [
             "vpc:DescribeVSwitches",
-            "vpc:ListTagResources"
+            "vpc:ListTagResources",
+            "vpc:DescribeVpcs"
           ],
           "Resource": [
             "*"


### PR DESCRIPTION
The following RAM permission actions are necessary for alibabacloud cilium-operator, added:

    vpc:DescribeVpcs
    ecs:DescribeSecurityGroups

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

```release-note
docs: Update alibabacloud RAM permission requirements
```
