### PR TITLE
datapath/config: Fix L2 addr retrieval

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -703,7 +703,7 @@ func devMacros() (string, string, error) {
 		}
 		idx := link.Attrs().Index
 		m := link.Attrs().HardwareAddr
-		if m == nil {
+		if m == nil || len(m) != 6 {
 			l3DevIfIndices = append(l3DevIfIndices, idx)
 		}
 		macByIfIndex[idx] = mac.CArrayString(m)

--- a/pkg/mac/mac.go
+++ b/pkg/mac/mac.go
@@ -128,7 +128,7 @@ func HaveMACAddrs(ifaces []string) bool {
 // CArrayString returns a string which can be used for assigning the given
 // MAC addr to "union macaddr" in C.
 func CArrayString(m net.HardwareAddr) string {
-	if m == nil || len(m) == 0 {
+	if m == nil || len(m) != 6 {
 		return "{0x0,0x0,0x0,0x0,0x0,0x0}"
 	}
 


### PR DESCRIPTION
Previously, the config code was assuming that a netdev is L3 (i.e.,
NOARP) if its L2 addr was nil or 0.

Recently, we saw a bug report in which a user reported that an ipip
tunnel device (L3) had L2 addr of 4 bytes. This was confirmed with the
following:
```
    ip link add name ipip1 type ipip local 10.0.0.3 remote 10.0.0.4
    cat > /tmp/main.go <<EOF
package main

import "fmt"
import "github.com/vishvananda/netlink"

func main() {
	link, _ := netlink.LinkByName("ipip1")
	fmt.Println(link.Attrs().HardwareAddr)
}
EOF
    go run /tmp/main.go
    0a:00:00:03
```

Fix this by making sure that the L2 addr is 6 bytes long. If it's not,
then assume that the device is of the L3 type.

Reported-by: @sepich
Signed-off-by: Martynas Pumputis <m@lambda.lt>

Fix #18828