### PR TITLE
daemon: Deprecate --host-reachable-services-protos

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -136,7 +136,6 @@ cilium-agent [flags]
       --force-local-policy-eval-at-source                    Force policy evaluation of all local communication at the source endpoint (default true)
       --gops-port int                                        Port for gops server to listen on (default 9890)
   -h, --help                                                 help for cilium-agent
-      --host-reachable-services-protos strings               Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
       --http-idle-timeout uint                               Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
       --http-max-grpc-timeout uint                           Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
       --http-normalize-path                                  Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution. (default true)

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -345,6 +345,8 @@ Removed Options
   connection tracking was removed. In addition, we deprecated the
   ``disable-conntrack`` option and made it non-operational. It will be removed
   in version 1.13.
+* The ``host-reachable-services-protos`` option (``.hostServices.protocols`` in
+  Helm) was deprecated, and it will be removed in version 1.13.
 
 .. _1.11_upgrade_notes:
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -366,6 +366,7 @@ func initializeFlags() {
 
 	flags.StringSlice(option.HostReachableServicesProtos, []string{option.HostServicesTCP, option.HostServicesUDP}, "Only enable reachability of services for host applications for specific protocols")
 	option.BindEnv(option.HostReachableServicesProtos)
+	flags.MarkDeprecated(option.HostReachableServicesProtos, "This option will be removed in v1.13")
 
 	flags.Bool(option.EnableAutoDirectRoutingName, defaults.EnableAutoDirectRouting, "Enable automatic L2 routing between nodes")
 	option.BindEnv(option.EnableAutoDirectRoutingName)


### PR DESCRIPTION
So far we haven't learned about any users who would specify particular
socket-lb protos (e.g., to enable only TCP).

Being able to set the socket-lb protos might have made sense when some
distros had a kernel w/o the BPF_CGROUP_UDP{4,6}_RECVMSG hooks. However,
this is no longer the case as many distros have switched to at least 5.4
kernel.

Let's simplify the agent/datapath code.