### PR TITLE
[Docs] Update docs to use enable endpoint route Azure cni

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -90,7 +90,8 @@ Deploy Cilium release via Helm:
      --set nodeinit.enabled=true \\
      --set cni.configMap=cni-configuration \\
      --set tunnel=disabled \\
-     --set enableIPv4Masquerade=false
+     --set enableIPv4Masquerade=false \\
+     --set endpointRoutes.enabled=true
 
 This will create both the main cilium daemonset, as well as the cilium-node-init daemonset, which handles tasks like mounting the eBPF filesystem and updating the
 existing Azure CNI plugin to run in 'transparent' mode.


### PR DESCRIPTION
Added the `endpointRoute.enabled=true` value to the helm install when
running Azure CNI in chaining mode.

Signed-off-by: Nitish Malhotra <nitishm@microsoft.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Added the `endpointRoute.enabled=true` value to the helm install when
running Azure CNI in chaining mode.

Fixes: #19087 

```release-note
Fixes L7 policies with Azure CNI chaining.
```
