### PR TITLE
endpoint: Fix nil pointer panic when L7 proxy is disabled

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -349,7 +349,7 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 		oldValues    = make(policy.MapState)
 	)
 
-	if e.visibilityPolicy == nil {
+	if e.visibilityPolicy == nil || e.isProxyDisabled() {
 		return nil, finalizeList.Finalize, revertStack.Revert
 	}
 


### PR DESCRIPTION
This fixes an issue where Cilium tries to add a visibility redirect even
if the proxy is disabled, causing nil pointer panic.

Fixes: #18773
