### PR TITLE
.github: Exclude Runtime CI job from flake tracker

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -63,7 +63,6 @@ flake-tracker:
     - cilium-master-k8s-1.22-kernel-4.19
     - cilium-master-k8s-1.23-kernel-net-next
     - cilium-master-k8s-upstream
-    - cilium-master-runtime-kernel-net-next
     pr-jobs:
       Cilium-PR-K8s-1.16-kernel-4.9:
         correlate-with-stable-jobs:
@@ -128,9 +127,6 @@ flake-tracker:
       Cilium-PR-K8s-Upstream:
         correlate-with-stable-jobs:
         - cilium-master-k8s-upstream
-      Cilium-PR-Runtime-net-next:
-        correlate-with-stable-jobs:
-        - cilium-master-runtime-kernel-net-next
   max-flakes-per-test: 5
   flake-similarity: 0.85
   ignore-failures:


### PR DESCRIPTION
The flake tracker attempts to match test failures with known flakes. To that end, it looks at the Jenkins test's title, stacktrace, and failure output. In particular, it computes a similarity score between two strings [by computing the ratio of the size of the differences on the average size of the two strings](https://github.com/cilium/github-actions/blob/7df41a49d319c70a7d54da2f24c0cb5fd6c44522/pkg/jenkins/flakes.go#L55):

    conf = 1 - len(diffs) / mean(len(string1), len(string2))

As a result, the similarity score will be higher if the size of the differences is small compared to the total size of the strings.

That is often the case for the RuntimePrivilegedUnitTests test, even when two different unit tests are causing it to fail. Because that test has a fairly long output, with always the same unit tests running, even if two different unit tests fail at the end, the outputs will look fairly similar. For this reason, MLH often incorrectly identifies one RuntimePrivilegedUnitTests flake as another.

This commit therefore removes the Runtime CI job from the flake tracker. That means we will have to manually triage failures in that CI job, but it's probably less work than having to watch for incorrect classifications after the fact. We're also less likely to miss a new flake that way.