### PR TITLE
aws: Add ability to mark ENIs as unmanaged

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -223,6 +223,14 @@ allocation:
 
   If unspecified, no tags are required.
 
+``spec.eni.exclude-interface-tags``
+  The tags used to exclude interfaces from IP allocation. Any ENI attached to
+  a node which matches this set of tags will be ignored by Cilium and may be
+  used for other purposes. This parameter can be used in combination with
+  ``subnet-tags`` or ``first-interface-index`` to exclude additional interfaces.
+
+  If unspecified, no tags are used to exclude interfaces.
+
 ``spec.eni.delete-on-termination``
   Remove the ENI when the instance is terminated
 

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -209,6 +209,11 @@ func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMa
 		}
 	}
 
+	eni.Tags = make(map[string]string, len(iface.TagSet))
+	for _, tag := range iface.TagSet {
+		eni.Tags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+
 	return
 }
 

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -414,14 +414,25 @@ func (e *API) TagENI(ctx context.Context, eniID string, eniTags map[string]strin
 	e.rateLimit()
 	e.delaySim.Delay(TagENI)
 
-	e.mutex.RLock()
-	defer e.mutex.RUnlock()
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
 
 	if err, ok := e.errors[TagENI]; ok {
 		return err
 	}
 
-	return nil
+	if eni, ok := e.unattached[eniID]; ok {
+		eni.Tags = eniTags
+		return nil
+	}
+
+	for _, enis := range e.enis {
+		if eni, ok := enis[eniID]; ok {
+			eni.Tags = eniTags
+			return nil
+		}
+	}
+	return fmt.Errorf("Unable to find ENI with ID %s", eniID)
 }
 
 func (e *API) GetSecurityGroups(ctx context.Context) (types.SecurityGroupMap, error) {

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -138,7 +138,7 @@ func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *logrus.Entry) *ipam.Re
 			"numAddresses": len(e.Addresses),
 		}).Debug("Considering ENI for IP release")
 
-		if e.Number < *n.k8sObj.Spec.ENI.FirstInterfaceIndex {
+		if e.IsExcludedBySpec(n.k8sObj.Spec.ENI) {
 			continue
 		}
 
@@ -205,7 +205,8 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 			"numAddresses": len(e.Addresses),
 		}).Debug("Considering ENI for allocation")
 
-		if e.Number < *n.k8sObj.Spec.ENI.FirstInterfaceIndex {
+		if e.IsExcludedBySpec(n.k8sObj.Spec.ENI) {
+			scopedLog.WithField(fieldEniID, e.ID).Debug("ENI is excluded by spec")
 			continue
 		}
 
@@ -492,9 +493,7 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 			}
 
 			n.enis[e.ID] = *e
-			index := *n.k8sObj.Spec.ENI.FirstInterfaceIndex
-
-			if e.Number < index {
+			if e.IsExcludedBySpec(n.k8sObj.Spec.ENI) {
 				return nil
 			}
 

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -529,6 +529,73 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(node.Stats().UsedIPs, check.Equals, 10)
 }
 
+// TestNodeManagerENIExcludeInterfaceTags tests ENI allocation with interface exclusion
+//
+// - m5.large (3x ENIs, 2x10-2 IPs)
+// - MinAllocate 0
+// - MaxAllocate 0
+// - PreAllocate 8
+// - FirstInterfaceIndex 0
+// - ExcludeInterfaceTags {cilium.io/no_manage=true}
+func (e *ENISuite) TestNodeManagerENIExcludeInterfaceTags(c *check.C) {
+	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
+	instances := NewInstancesManager(ec2api)
+	c.Assert(instances, check.Not(check.IsNil))
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"})
+	c.Assert(err, check.IsNil)
+	err = ec2api.TagENI(context.TODO(), eniID1, map[string]string{
+		"foo":                 "bar",
+		"cilium.io/no_manage": "true",
+	})
+	c.Assert(err, check.IsNil)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerDefaultAllocation-0", eniID1)
+	c.Assert(err, check.IsNil)
+	instances.Resync(context.TODO())
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false)
+	c.Assert(err, check.IsNil)
+	c.Assert(mngr, check.Not(check.IsNil))
+
+	// Announce node wait for IPs to become available
+	cn := newCiliumNode("node1", "i-testNodeManagerDefaultAllocation-0", "m5.large", "us-west-1", "vpc-1", 0, 8, 0, 0)
+	cn.Spec.ENI.ExcludeInterfaceTags = map[string]string{
+		"cilium.io/no_manage": "true",
+	}
+	mngr.Update(cn)
+	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
+
+	node := mngr.Get("node1")
+	c.Assert(node, check.Not(check.IsNil))
+	c.Assert(node.Stats().AvailableIPs, check.Equals, 8)
+	c.Assert(node.Stats().UsedIPs, check.Equals, 0)
+
+	// Checks that we have created a new interface, and not allocated any IPs
+	// to the existing one
+	eniNode, castOK := node.Ops().(*Node)
+	c.Assert(castOK, check.Equals, true)
+	eniNode.mutex.RLock()
+	c.Assert(eniNode.enis, check.HasLen, 2)
+	c.Assert(eniNode.enis[eniID1].Addresses, check.HasLen, 0)
+	c.Assert(eniNode.enis[eniID1].Tags["cilium.io/no_manage"], check.Equals, "true")
+	eniNode.mutex.RUnlock()
+
+	// Use 7 out of 8 IPs
+	mngr.Update(updateCiliumNode(cn, 8, 7))
+	mngr.Resync(context.TODO(), instances.Resync(context.TODO()))
+	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
+
+	node = mngr.Get("node1")
+	c.Assert(node, check.Not(check.IsNil))
+	c.Assert(node.Stats().AvailableIPs, check.Equals, 15)
+	c.Assert(node.Stats().UsedIPs, check.Equals, 7)
+
+	// Unmanaged ENI remains unmanaged
+	eniNode.mutex.RLock()
+	c.Assert(eniNode.enis, check.HasLen, 3)
+	c.Assert(eniNode.enis[eniID1].Addresses, check.HasLen, 0)
+	c.Assert(eniNode.enis[eniID1].Tags["cilium.io/no_manage"], check.Equals, "true")
+	eniNode.mutex.RUnlock()
+}
+
 // TestNodeManagerExceedENICapacity tests exceeding ENI capacity
 //
 // - t2.xlarge (3x ENIs, 3x15-3 IPs)

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -109,6 +109,13 @@ type ENISpec struct {
 	// +kubebuilder:validation:Optional
 	AvailabilityZone string `json:"availability-zone,omitempty"`
 
+	// ExcludeInterfaceTags is the list of tags to use when excluding ENIs for
+	// Cilium IP allocation. Any interface matching this set of tags will not
+	// be managed by Cilium.
+	//
+	// +kubebuilder:validation:Optional
+	ExcludeInterfaceTags map[string]string `json:"exclude-interface-tags,omitempty"`
+
 	// DeleteOnTermination defines that the ENI should be deleted when the
 	// associated instance is terminated. If the parameter is not set the
 	// default behavior is to delete the ENI on instance termination.
@@ -170,6 +177,12 @@ type ENI struct {
 
 	// SecurityGroups are the security groups associated with the ENI
 	SecurityGroups []string `json:"security-groups,omitempty"`
+
+	// Tags is the set of tags of the ENI. Used to detect ENIs which should
+	// not be managed by Cilium
+	//
+	// +optional
+	Tags map[string]string `json:"tags,omitempty"`
 }
 
 // InterfaceID returns the identifier of the interface
@@ -186,6 +199,22 @@ func (e *ENI) ForeachAddress(id string, fn types.AddressIterator) error {
 	}
 
 	return nil
+}
+
+// IsExcludedBySpec returns true if the ENI is excluded by the provided spec and
+// therefore should not be managed by Cilium.
+func (e *ENI) IsExcludedBySpec(spec ENISpec) bool {
+	if spec.FirstInterfaceIndex != nil && e.Number < *spec.FirstInterfaceIndex {
+		return true
+	}
+
+	if len(spec.ExcludeInterfaceTags) > 0 {
+		if types.Tags(e.Tags).Match(spec.ExcludeInterfaceTags) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ENIStatus is the status of ENI addressing of the node

--- a/pkg/aws/eni/types/zz_generated.deepcopy.go
+++ b/pkg/aws/eni/types/zz_generated.deepcopy.go
@@ -60,6 +60,13 @@ func (in *ENI) DeepCopyInto(out *ENI) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -100,6 +107,13 @@ func (in *ENISpec) DeepCopyInto(out *ENISpec) {
 	}
 	if in.SubnetTags != nil {
 		in, out := &in.SubnetTags, &out.SubnetTags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ExcludeInterfaceTags != nil {
+		in, out := &in.ExcludeInterfaceTags, &out.ExcludeInterfaceTags
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/aws/eni/types/zz_generated.deepequal.go
+++ b/pkg/aws/eni/types/zz_generated.deepequal.go
@@ -125,6 +125,27 @@ func (in *ENI) DeepEqual(other *ENI) bool {
 		}
 	}
 
+	if ((in.Tags != nil) && (other.Tags != nil)) || ((in.Tags == nil) != (other.Tags == nil)) {
+		in, other := &in.Tags, &other.Tags
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for key, inValue := range *in {
+				if otherValue, present := (*other)[key]; !present {
+					return false
+				} else {
+					if inValue != otherValue {
+						return false
+					}
+				}
+			}
+		}
+	}
+
 	return true
 }
 
@@ -240,6 +261,27 @@ func (in *ENISpec) DeepEqual(other *ENISpec) bool {
 	if in.AvailabilityZone != other.AvailabilityZone {
 		return false
 	}
+	if ((in.ExcludeInterfaceTags != nil) && (other.ExcludeInterfaceTags != nil)) || ((in.ExcludeInterfaceTags == nil) != (other.ExcludeInterfaceTags == nil)) {
+		in, other := &in.ExcludeInterfaceTags, &other.ExcludeInterfaceTags
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for key, inValue := range *in {
+				if otherValue, present := (*other)[key]; !present {
+					return false
+				} else {
+					if inValue != otherValue {
+						return false
+					}
+				}
+			}
+		}
+	}
+
 	if (in.DeleteOnTermination == nil) != (other.DeleteOnTermination == nil) {
 		return false
 	} else if in.DeleteOnTermination != nil {

--- a/pkg/ipam/crd_eni.go
+++ b/pkg/ipam/crd_eni.go
@@ -38,9 +38,8 @@ func configureENIDevices(oldNode, newNode *ciliumv2.CiliumNode, mtuConfig MtuCon
 	if oldNode != nil {
 		existingENIByName = oldNode.Status.ENI.ENIs
 	}
-	firstInterfaceIndex := *newNode.Spec.ENI.FirstInterfaceIndex
 	for name, eni := range newNode.Status.ENI.ENIs {
-		if eni.Number < firstInterfaceIndex {
+		if eni.IsExcludedBySpec(newNode.Spec.ENI) {
 			continue
 		}
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -126,6 +126,13 @@ spec:
                       is not set the default behavior is to delete the ENI on instance
                       termination.
                     type: boolean
+                  exclude-interface-tags:
+                    additionalProperties:
+                      type: string
+                    description: ExcludeInterfaceTags is the list of tags to use when
+                      excluding ENIs for Cilium IP allocation. Any interface matching
+                      this set of tags will not be managed by Cilium.
+                    type: object
                   first-interface-index:
                     description: FirstInterfaceIndex is the index of the first ENI
                       to use for IP allocation, e.g. if the node has eth0, eth1, eth2
@@ -505,6 +512,12 @@ spec:
                             id:
                               description: ID is the ID of the subnet
                               type: string
+                          type: object
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is the set of tags of the ENI. Used to
+                            detect ENIs which should not be managed by Cilium
                           type: object
                         vpc:
                           description: VPC is the VPC information to which the ENI

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -526,6 +526,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 				nodeResource.Spec.ENI.VpcID = c.ENI.VpcID
 			}
 
+			if len(c.ENI.ExcludeInterfaceTags) > 0 {
+				nodeResource.Spec.ENI.ExcludeInterfaceTags = c.ENI.ExcludeInterfaceTags
+			}
+
 			nodeResource.Spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination
 		}
 

--- a/plugins/cilium-cni/types/types_test.go
+++ b/plugins/cilium-cni/types/types_test.go
@@ -97,6 +97,9 @@ func (t *CNITypesSuite) TestReadCNIConfENIWithPlugins(c *check.C) {
         ],
         "subnet-tags":{
           "foo":"true"
+        },
+        "exclude-interface-tags":{
+          "baz":"false"
         }
       }
     }
@@ -116,6 +119,9 @@ func (t *CNITypesSuite) TestReadCNIConfENIWithPlugins(c *check.C) {
 			SubnetIDs:           []string{"subnet-xxx"},
 			SubnetTags: map[string]string{
 				"foo": "true",
+			},
+			ExcludeInterfaceTags: map[string]string{
+				"baz": "false",
 			},
 		},
 	}
@@ -140,6 +146,10 @@ func (t *CNITypesSuite) TestReadCNIConfENI(c *check.C) {
       "key1": "val1",
       "key2": "val2"
     },
+    "exclude-interface-tags": {
+      "key3": "val3",
+      "key4": "val4"
+    },
     "vpc-id": "vpc-1",
     "availability-zone": "us-west1"
   }
@@ -160,6 +170,10 @@ func (t *CNITypesSuite) TestReadCNIConfENI(c *check.C) {
 			SubnetTags: map[string]string{
 				"key1": "val1",
 				"key2": "val2",
+			},
+			ExcludeInterfaceTags: map[string]string{
+				"key3": "val3",
+				"key4": "val4",
 			},
 			VpcID:            "vpc-1",
 			AvailabilityZone: "us-west1",
@@ -187,6 +201,9 @@ func (t *CNITypesSuite) TestReadCNIConfENIv2WithPlugins(c *check.C) {
         ],
         "subnet-tags":{
           "foo":"true"
+        },
+        "exclude-interface-tags":{
+          "bar":"false"
         }
       },
       "ipam": {
@@ -208,6 +225,9 @@ func (t *CNITypesSuite) TestReadCNIConfENIv2WithPlugins(c *check.C) {
 			SubnetIDs:           []string{"subnet-xxx"},
 			SubnetTags: map[string]string{
 				"foo": "true",
+			},
+			ExcludeInterfaceTags: map[string]string{
+				"bar": "false",
 			},
 		},
 		IPAM: ipamTypes.IPAMSpec{


### PR DESCRIPTION
This PR adds the ability to specify a set of tags in the ENI spec to
exclude certain ENIs from Cilium's IP allocation. To exclude interfaces
based on tags, a user may set the `exclude-interface-tags` option in the
CNI config (same as other ENI IPAM parameters). If an interface matches
all tags specified in the parameter, it will be ignored by Cilium.

This new mechanism works similar to the existing
`first-interface-index` value, but is able to also exclude interfaces
which are added to worker nodes dynamically after Cilium is already
running.