### PR TITLE
workflows: Wait for first AKS systempool to be deleted

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -230,8 +230,7 @@ jobs:
           az aks nodepool delete \
             --resource-group ${{ env.name }} \
             --cluster-name ${{ env.name }} \
-            --name "${nodepool_to_delete}" \
-            --no-wait
+            --name "${nodepool_to_delete}"
 
       - name: Get cluster credentials
         run: |

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -230,8 +230,7 @@ jobs:
           az aks nodepool delete \
             --resource-group ${{ env.name }} \
             --cluster-name ${{ env.name }} \
-            --name "${nodepool_to_delete}" \
-            --no-wait
+            --name "${nodepool_to_delete}"
 
       - name: Get cluster credentials
         run: |

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -229,8 +229,7 @@ jobs:
           az aks nodepool delete \
             --resource-group ${{ env.name }} \
             --cluster-name ${{ env.name }} \
-            --name "${nodepool_to_delete}" \
-            --no-wait
+            --name "${nodepool_to_delete}"
 
       - name: Get cluster credentials
         run: |


### PR DESCRIPTION
[The AKS workflow sometimes fails](https://github.com/cilium/cilium/runs/5475820232?check_suite_focus=true) because it seems to expect a fourth Cilium agent that doesn't exist (anymore?). The Cilium agent seems to exist at the beginning of the connectivity test, but disappears before the end:

    🔥 Error reading Cilium logs: error getting cilium-agent logs for kube-system/cilium-fjzdt: pods "cilium-fjzdt" not found

If we look at the sysdump collected afterward, we find only three Cilium agents. They were all created around the same time (~3min ago), so this error is not due to a cilium-agent pod being deleted and recreated:

    kube-system   cilium-qlzq5                          1/1     Running   0          3m6s    10.240.0.35    aks-systempool-31935459-vmss000000   <none>           <none>
    kube-system   cilium-wjdbq                          1/1     Running   0          2m59s   10.240.0.64    aks-userpool-37605757-vmss000000     <none>           <none>
    kube-system   cilium-zqd7f                          1/1     Running   0          2m56s   10.240.0.93    aks-userpool-37605757-vmss000001     <none>           <none>

As part of the cluster creation, we create a new systempool and delete the initial one. We currently don't wait for the creation to succeed before proceeding with the test (i.e., we use `--no-wait`). So it's possible that a Cilium agent running on the first systempool was still present at the beginning of the connectivity tests and disappeared before the end because the systempool was finally deleted.

This pull request makes us wait for the deletion to complete before proceeding, in an attempt to fix this.