### PR TITLE
test/bpf: Fix mock dependencies

### DIFF
--- a/bpf/mock/Makefile
+++ b/bpf/mock/Makefile
@@ -42,3 +42,6 @@ mock_customized: builder-image
 	# Generate the corresponding mock library.
 	$(QUIET) $(DOCKER_RUN) ./mock_customized.sh $(filename)
 
+clean:
+	@$(ECHO_CLEAN)
+	-$(QUIET)rm -r -- mocks

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -41,17 +41,19 @@ elf-demo.o: elf-demo.c
 	@$(ECHO_CC)
 	$(CLANG) ${FLAGS_CLANG} ${FLAGS} -I../../bpf/ $< -o $@
 
-nat-test: nat-test.c $(LIB)
-	@$(ECHO_CC)
+mocks:
 	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock generate_helper_headers
 	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock mock_helpers
+
+$(ROOT_DIR)/bpf/mock/mocks/mock_conntrack_stub.c: mocks $(LIB)
 	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock mock_customized filename=conntrack_stub.h
+
+nat-test: nat-test.c $(LIB) $(ROOT_DIR)/bpf/mock/mocks/mock_conntrack_stub.c
+	@$(ECHO_CC)
 	$(QUIET) $(DOCKER_RUN) $(CLANG) $(FLAGS) -I../../bpf/mock -I $../../bpf/ -I../../../CMock/src -I../../../CMock/vendor/unity/src -I../../../hashmap/include  $< ../../../CMock/vendor/unity/src/unity.c ../../../CMock/src/cmock.c ../../../hashmap/src/hashmap.c ../../bpf/mock/mocks/mock_helpers.c ../../bpf/mock/mocks/mock_helpers_skb.c ../../bpf/mock/mocks/mock_conntrack_stub.c -o $@
 
-drop-notify-test: drop-notify-test.c $(LIB)
+drop-notify-test: drop-notify-test.c $(LIB) mocks
 	@$(ECHO_CC)
-	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock generate_helper_headers
-	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock mock_helpers
 	$(QUIET) $(DOCKER_RUN) $(CLANG) $(FLAGS) -I../../bpf/mock -I $../../bpf/ -I../../../CMock/src -I../../../CMock/vendor/unity/src  $< ../../../CMock/vendor/unity/src/unity.c ../../../CMock/src/cmock.c ../../bpf/mock/mocks/mock_helpers.c ../../bpf/mock/mocks/mock_helpers_skb.c -o $@
 
 unit-tests: $(ALL_TESTS)
@@ -64,5 +66,4 @@ unit-tests: $(ALL_TESTS)
 clean:
 	@$(ECHO_CLEAN)
 	-$(QUIET)rm -f $(TARGETS)
-	-$(QUIET)rm -r ../../bpf/mock/mocks
-
+	$(MAKE) -C $(ROOT_DIR)/bpf/mock clean


### PR DESCRIPTION
When running make with parallel builds, it was previously possible to
trigger build of the mocks at the same time as building the test that
depended on the mocks. This would cause build failures.

Fix this issue by moving the dependencies into dedicated targets with
proper dependencies. While we're at it, move the clean target into the
proper bpf/mock/Makefile.

Fixes: #19098
