### PR TITLE
Makefile: Fix TESTPKGS commandline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ endif
 GOFILES_EVAL := $(subst _$(ROOT_DIR)/,,$(shell $(GO_LIST) -find -e ./...))
 GOFILES ?= $(GOFILES_EVAL)
 TESTPKGS_EVAL := $(subst github.com/cilium/cilium/,,$(shell echo $(GOFILES) | \
-	sed 's/ /\n/g' | \
-	grep -v '/api/v1\|/vendor\|/contrib' | \
-	grep -v '/test'))
-TESTPKGS_EVAL += "test/helpers/logutils"
+		sed 's/ /\n\//g' | \
+		grep -v '/api/v1\|/vendor\|/contrib\|/test' | \
+		sed 's/^\///g')) \
+	test/helpers/logutils
 TESTPKGS ?= $(TESTPKGS_EVAL)
 GOLANG_SRCFILES := $(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor | sort | uniq)
 


### PR DESCRIPTION
Commit 51647bbdbd22 ("Makefile: Simplify to run faster")
added a '/' to the end of the '$(ROOT_DIR)' in the substitution, which
invalidated the greps that attempted to exclude directories that do not
need to trigger unit tests, for instance the `test/` directory. As a
result, when running commands like `make integration-tests`, it was easy
to inadvertently attempt to run the end-to-end tests in an environment
that cannot run the end-to-end-tests.

Fix this issue by injecting a leading '/' before each package, so that
the package grep can match on that leading '/' in order to properly
select directories based on their path from the root directory. The
extra sed command will then filter the leading '/' back out before
passing that variable on.

While we're at it, fold the '/test' match into the main grep expression
and avoid updating the TESTPKGS_EVAL during initial Makefile evaluation,
to further speed up the calculation.

Fixes: 51647bbdbd22 ("Makefile: Simplify to run faster")
