### PR TITLE
Bpf fix conditional compilation

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1492,9 +1492,9 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, enum ct_status
 					   verdict, policy_match_type, audited);
 	}
 
-#if !defined(ENABLE_HOST_SERVICES_FULL) && !defined(DISABLE_LOOPBACK_LB)
+#if defined(ENABLE_PER_PACKET_LB) && !defined(DISABLE_LOOPBACK_LB)
 skip_policy_enforcement:
-#endif /* !ENABLE_HOST_SERVICES_FULL && !DISABLE_LOOPBACK_LB */
+#endif /* ENABLE_PER_PACKET_LB && !DISABLE_LOOPBACK_LB */
 
 #ifdef ENABLE_NODEPORT
 	if (ret == CT_NEW || ret == CT_REOPENED) {

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1239,7 +1239,7 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 	ifindex = ctx_load_meta(ctx, CB_IFINDEX);
 	if (ifindex)
 		return redirect_ep(ctx, ifindex, from_host);
-#endif /* ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
+#endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
 
 	return CTX_ACT_OK;
 }
@@ -1564,7 +1564,7 @@ skip_policy_enforcement:
 	ifindex = ctx_load_meta(ctx, CB_IFINDEX);
 	if (ifindex)
 		return redirect_ep(ctx, ifindex, from_host);
-#endif /* ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
+#endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
 
 	return CTX_ACT_OK;
 }


### PR DESCRIPTION
Use the same condition in defining the label 'skip_policy_enforcement' as
for jumping to it. Otherwise we could jump to a nonexisting label given a
suitable datapath configuration. This does not seem possible now, as
ENABLE_HOST_SERVICES_FULL should not be defined if
ENABLE_SOCKET_LB_HOST_ONLY is defined. However, as the conditions for
defining ENABLE_PER_PACKET_LB evolve, this would become a compilation
bug.

2nd commit fixes comments relating to conditional compilation.

This is a prerequisite for #18894

Fixes: #17154
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
