### PR TITLE
Documentation: Use same RTD theme for aarch64 as everywhere else

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -20,8 +20,7 @@ snowballstemmer==1.2.1
 Sphinx==1.8.1
 sphinx-autobuild==0.7.1
 # forked read the docs themez
-git+https://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
-sphinx-rtd-theme==0.2.4; platform_machine == "aarch64"
+git+https://github.com/cilium/sphinx_rtd_theme.git@v0.7
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-spelling==4.2.1


### PR DESCRIPTION
Previously, installing the python package ran `npm install` to
regenerate the assets, which would fail on arm64 due to node-sass, but
with https://github.com/cilium/sphinx_rtd_theme/pull/15, installing the
package does not run npm anymore, so this work-around should no longer
be necessary.

This requires https://github.com/cilium/sphinx_rtd_theme/pull/15 to be merged first.
