### PR TITLE
docs: Mention KPR in DR mode sec ID limitation

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -315,6 +315,13 @@ Annotations:
 * The Cilium agent does not support the legacy ``nat46-range`` option as well
   as the per-endpoint ``NAT46`` configuration anymore. Both are replaced in
   favor of NAT46/64 handling for services.
+* The kube-proxy replacement in the tunneling mode (i.e., ``vxlan`` or
+  ``geneve``) will set the ``reserved:world`` security identity for all service
+  requests coming from outside the cluster. Previously, when a selected service
+  endpoint was on a different node, the security identity was set to the
+  ``reserved:remote-node``. The change might impact those who have a network policy
+  allowing access to the service from inside the cluster, and the policy was used
+  to allow access from outside.
 
 New Options
 ~~~~~~~~~~~

--- a/Documentation/policy/caveats.rst
+++ b/Documentation/policy/caveats.rst
@@ -1,0 +1,27 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _policy_caveats:
+
+*******
+Caveats
+*******
+
+Security Identity for N/S Service Traffic
+=========================================
+
+When accessing a Kubernetes service from outside the cluster, the
+:ref:`arch_id_security` assignment depends on the routing mode.
+
+In the tunneling mode (i.e., ``--tunnel=vxlan`` or ``--tunnel=geneve``), the request
+to the service will have the ``reserved:world`` security identity.
+
+In the direct-routing mode (i.e., ``--tunnel=disabled``), the security identity
+will be set to the ``reserved:world`` if the request was sent to the node which runs the
+selected endpoint by the LB. If not, i.e., the request needs to be forwarded to
+another node after the service endpoint selection, then it will have the ``reserved:remote-node``.
+
+The latter traffic will match ``fromEntities: cluster`` policies.

--- a/Documentation/policy/index.rst
+++ b/Documentation/policy/index.rst
@@ -33,3 +33,4 @@ mechanisms:
    kubernetes
    lifecycle
    troubleshooting
+   caveats


### PR DESCRIPTION
The commit 595ddcdd ("datapath: Set WORLD_ID in fwd-ed NodePort BPF
requests") changed the security ID for the N/S LB fwd-ed over tunnel
requests.

Document the change in the upgrade guide, and make users more aware of
the policy enforcement for the KPR in its guide.

We don't expect that the change will have a huge upgrade impact, as
previously, the host id was used only for requests which had to be
fwd-ed, while the world id was used for requests which hit the node
which ran the selected service endpoint. This means that if a user had
the netpol, it's very likely they have spotted the discrepancy.