### PR TITLE
bpf: Remove `CB_POLICY` mark

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1226,8 +1226,6 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 		goto out;
 	}
 
-	policy_clear_mark(ctx);
-
 	switch (proto) {
 # if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER
 	case bpf_htons(ETH_P_ARP):
@@ -1358,8 +1356,6 @@ int cil_to_host(struct __ctx_buff *ctx)
 		ret = DROP_UNSUPPORTED_L2;
 		goto out;
 	}
-
-	policy_clear_mark(ctx);
 
 	switch (proto) {
 # if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -378,8 +378,6 @@ ct_recreate6:
 
 	case CT_RELATED:
 	case CT_REPLY:
-		policy_mark_skip(ctx);
-
 		hdrlen = ipv6_hdrlen(ctx, &tuple->nexthdr);
 		if (hdrlen < 0)
 			return hdrlen;
@@ -413,12 +411,6 @@ ct_recreate6:
 					  ct_state->rev_nat_index, tuple, 0);
 			if (IS_ERR(ret))
 				return ret;
-
-			/* A reverse translate packet is always allowed except
-			 * for delivery on the local node in which case this
-			 * marking is cleared again.
-			 */
-			policy_mark_skip(ctx);
 		}
 		break;
 
@@ -464,7 +456,6 @@ ct_recreate6:
 #endif
 			}
 #endif /* ENABLE_ROUTING */
-			policy_clear_mark(ctx);
 			/* If the packet is from L7 LB it is coming from the host */
 			return ipv6_local_delivery(ctx, ETH_HLEN, SECLABEL, ep,
 						   METRIC_EGRESS, from_l7lb);
@@ -902,8 +893,6 @@ ct_recreate4:
 
 	case CT_RELATED:
 	case CT_REPLY:
-		policy_mark_skip(ctx);
-
 #ifdef ENABLE_NODEPORT
 # ifdef ENABLE_DSR
 		if (ct_state->dsr) {
@@ -986,7 +975,6 @@ ct_recreate4:
 #endif
 			}
 #endif /* ENABLE_ROUTING */
-			policy_clear_mark(ctx);
 			/* If the packet is from L7 LB it is coming from the host */
 			return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL, ip4,
 						   ep, METRIC_EGRESS, from_l7lb);
@@ -1396,8 +1384,6 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	policy_clear_mark(ctx);
-
 	ipv6_addr_copy(&orig_sip, (union v6addr *)&ip6->saddr);
 
 	/* If packet is coming from the ingress proxy we have to skip
@@ -1706,8 +1692,6 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, enum ct_status
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
-
-	policy_clear_mark(ctx);
 
 	/* If packet is coming from the ingress proxy we have to skip
 	 * redirection to the ingress proxy as we would loop forever.

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -645,10 +645,9 @@ enum {
 #define	CB_ENCRYPT_IDENTITY	CB_IFINDEX	/* Alias, non-overlapping */
 #define	CB_IPCACHE_SRC_LABEL	CB_IFINDEX	/* Alias, non-overlapping */
 #define CB_SRV6_SID_2		CB_IFINDEX	/* Alias, non-overlapping */
-	CB_POLICY,
-#define	CB_ADDR_V6_2		CB_POLICY	/* Alias, non-overlapping */
-#define	CB_BACKEND_ID		CB_POLICY	/* Alias, non-overlapping */
-#define CB_SRV6_SID_3		CB_POLICY	/* Alias, non-overlapping */
+	CB_ADDR_V6_2,
+#define	CB_BACKEND_ID		CB_ADDR_V6_2	/* Alias, non-overlapping */
+#define CB_SRV6_SID_3		CB_ADDR_V6_2	/* Alias, non-overlapping */
 	CB_NAT,
 #define	CB_ADDR_V6_3		CB_NAT		/* Alias, non-overlapping */
 #define	CB_FROM_HOST		CB_NAT		/* Alias, non-overlapping */

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -969,7 +969,6 @@ static __always_inline void lb6_ctx_restore_state(struct __ctx_buff *ctx,
 	/* No loopback support for IPv6, see lb6_local() above. */
 
 	state->backend_id = ctx_load_meta(ctx, CB_BACKEND_ID);
-	/* Must clear to avoid policy bypass as CB_BACKEND_ID aliases CB_POLICY. */
 	ctx_store_meta(ctx, CB_BACKEND_ID, 0);
 
 	*proxy_port = ctx_load_meta(ctx, CB_PROXY_MAGIC) >> 16;
@@ -1667,7 +1666,6 @@ lb4_ctx_restore_state(struct __ctx_buff *ctx, struct ct_state *state,
 	ctx_store_meta(ctx, CB_CT_STATE, 0);
 
 	state->backend_id = ctx_load_meta(ctx, CB_BACKEND_ID);
-	/* must clear to avoid policy bypass as CB_BACKEND_ID aliases CB_POLICY. */
 	ctx_store_meta(ctx, CB_BACKEND_ID, 0);
 
 	*proxy_port = ctx_load_meta(ctx, CB_PROXY_MAGIC) >> 16;

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -212,9 +212,6 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 		return CTX_ACT_OK;
 	}
 
-	if (ctx_load_meta(ctx, CB_POLICY))
-		return CTX_ACT_OK;
-
 	if (is_untracked_fragment)
 		return DROP_FRAG_NOSUPPORT;
 
@@ -311,23 +308,6 @@ static __always_inline int policy_can_egress4(struct __ctx_buff *ctx,
 {
 	return policy_can_egress(ctx, src_id, dst_id, tuple->dport,
 				 tuple->nexthdr, match_type, audited);
-}
-
-/**
- * Mark ctx to skip policy enforcement
- * @arg ctx	packet
- *
- * Will cause the packet to ignore the policy enforcement verdict for allow rules and
- * be considered accepted despite of the policy outcome. Has no effect on deny rules.
- */
-static __always_inline void policy_mark_skip(struct __ctx_buff *ctx)
-{
-	ctx_store_meta(ctx, CB_POLICY, 1);
-}
-
-static __always_inline void policy_clear_mark(struct __ctx_buff *ctx)
-{
-	ctx_store_meta(ctx, CB_POLICY, 0);
 }
 #endif /* SOCKMAP */
 #endif


### PR DESCRIPTION
When the `CB_POLICY` flag is set, we allow packets through even if no policy rule allows them. That flag is however unused because we always set it *after* enforcing policies and clear it before enforcing any new policy (e.g., before tail calling into the destination pod's policy enforcement). This flag also wouldn't account for deny policies which would not be skipped regardless of the value of the flag.

This pull request thus removes the flag to:
- avoid misuses at a later time.
- reduce complexity at the policy enforcement layer.