### PR TITLE
wireguard: Fix invalid bits when agent init

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -260,7 +260,7 @@ func (a *Agent) Init(mtuConfig mtu.Configuration) error {
 
 		subnet := net.IPNet{
 			IP:   net.IPv4zero,
-			Mask: net.CIDRMask(0, net.IPv4len),
+			Mask: net.CIDRMask(0, 8*net.IPv4len),
 		}
 		rt.Prefix = subnet
 		if _, err := route.Upsert(rt); err != nil {
@@ -274,7 +274,7 @@ func (a *Agent) Init(mtuConfig mtu.Configuration) error {
 
 		subnet := net.IPNet{
 			IP:   net.IPv6zero,
-			Mask: net.CIDRMask(0, net.IPv6len),
+			Mask: net.CIDRMask(0, 8*net.IPv6len),
 		}
 		rt.Prefix = subnet
 		if _, err := route.Upsert(rt); err != nil {


### PR DESCRIPTION
This commit modifies the correct CIDR mask when wireguard agent init.
Fixes: https://github.com/cilium/cilium/issues/19106

Signed-off-by: Ye Sijun <junnplus@gmail.com>
