### PR TITLE
test/RuntimePrivilegedUnitTests: Log timestamps

### DIFF
--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -42,7 +42,7 @@ var _ = Describe("RuntimePrivilegedUnitTests", func() {
 		path, _ := filepath.Split(vm.BasePath())
 		ctx, cancel := context.WithTimeout(context.Background(), privilegedUnitTestTimeout)
 		defer cancel()
-		res := vm.ExecContext(ctx, fmt.Sprintf("sudo make -C %s tests-privileged", path))
+		res := vm.ExecContext(ctx, fmt.Sprintf("sudo make -C %s tests-privileged | ts '[%%H:%%M:%%S]'", path))
 		res.ExpectSuccess("Failed to run privileged unit tests")
 	})
 })


### PR DESCRIPTION
RuntimePrivilegedUnitTests times out from time to time (cf. https://github.com/cilium/cilium/issues/18958), sometimes at the very end, while computing coverage. By dumping the timestamp for each test output line, this commit will help us determine where time is spent.

Note we already have timestamps in Jenkins, but since we dump all the unit test logs at once at the end, the timestamp is the same for the entire test.