### PR TITLE
Fixed "No such file or directory" error when configuring "vm_set_proxy"

### DIFF
--- a/contrib/vagrant/scripts/helpers.bash
+++ b/contrib/vagrant/scripts/helpers.bash
@@ -103,7 +103,7 @@ function download_to {
         log "Downloading ${component}..."
 
         rm -f "/tmp/${component}"
-        ${WGET} -O "/tmp/${component}" -nv "${url}"
+        eval ${WGET} -O "/tmp/${component}" -nv "${url}"
         # Hide 'failed to preserve ownership' error
         mv "/tmp/${component}" "${cache_dir}/${component}" 2>/dev/null
 


### PR DESCRIPTION
This PR is used to fix the environment variable "VM_SET_PROXY" that was set when building the development environment, and an error occurred: "No such file or directory" error problem

Fixes: #19131

Signed-off-by：Jian Ping Xu xujianxy@gmail.com

