### PR TITLE
Fixed "No such file or directory" error when  configuring "vm_set_proxy"

### DIFF
--- a/contrib/vagrant/scripts/helpers.bash
+++ b/contrib/vagrant/scripts/helpers.bash
@@ -103,7 +103,8 @@ function download_to {
         log "Downloading ${component}..."
 
         rm -f "/tmp/${component}"
-        ${WGET} -O "/tmp/${component}" -nv "${url}"
+        # fix: No such file or directory
+        eval ${WGET} -O "/tmp/${component}" -nv "${url}"
         # Hide 'failed to preserve ownership' error
         mv "/tmp/${component}" "${cache_dir}/${component}" 2>/dev/null
 

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -233,7 +233,7 @@ if [ -z "${RELOAD}" ]; then
 fi
 
 if [ -n "${VM_PROXY}" ]; then
-    export WGET="HTTPS_PROXY=${VM_PROXY} wget"
+    export WGET="https_proxy=${VM_PROXY} wget"
 else
     export WGET="wget"
 fi
@@ -284,7 +284,7 @@ if [ -z "${RELOAD}" ]; then
 fi
 
 if [ -n "${VM_PROXY}" ]; then
-    export WGET="HTTPS_PROXY=${VM_PROXY} wget"
+    export WGET="https_proxy=${VM_PROXY} wget"
 else
     export WGET="wget"
 fi


### PR DESCRIPTION
This PR is used to fix the environment variable "VM_SET_PROXY" that was set when building the development environment, and an error occurred: "No such file or directory" error problem

Fixes: #19131
