### PR TITLE
test: Extend validateCiliumSvc to consider all cluster IPs

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4328,8 +4328,17 @@ func validateCiliumSvc(cSvc models.Service, k8sSvcs []v1.Service, k8sEps []v1.En
 	}
 
 	for _, k8sSvc := range k8sSvcs {
-		if k8sSvc.Spec.ClusterIP == cSvc.Status.Realized.FrontendAddress.IP {
-			k8sService = &k8sSvc
+		clusterIPs := k8sSvc.Spec.ClusterIPs
+		if clusterIPs == nil || len(clusterIPs) == 0 {
+			clusterIPs = []string{k8sSvc.Spec.ClusterIP}
+		}
+		for _, clusterIP := range clusterIPs {
+			if clusterIP == cSvc.Status.Realized.FrontendAddress.IP {
+				k8sService = &k8sSvc
+				break
+			}
+		}
+		if k8sService != nil {
 			break
 		}
 		for _, clusterIP := range k8sSvc.Spec.ClusterIPs {


### PR DESCRIPTION
Previously, the validateCiliumSvc(), which checks whether "cilium
service list" is in sync with "kubectl get svc", did not consider all
cluster IPs. It was only comparing against ".spec.ClusterIP", and did
not compare against ".spec.ClusterIPs" which can store a ClusterIP per
family when the DualStack is on.

The limitation was obvious when trying to backport the recent
K8sServices suite refactoring to the v1.11. The CI was failing with:

    Could not find Cilium service with ip fd03::e44e in k8s

Further investigation showed, that the svc IP addr was in
".spec.ClusterIPs", but not in ".spec.ClusterIP".