### PR TITLE
proxy: pass connection options from agent

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -222,6 +222,8 @@ cilium-agent [flags]
       --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
       --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-max-connection-duration-seconds int            Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
+      --proxy-max-requests-per-connection int                Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-prometheus-port int                            Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                                 Read to the CNI configuration at specified path to extract per node configuration
       --restore                                              Restores state, if possible, from previous daemon (default true)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -449,6 +449,12 @@ func initializeFlags() {
 	flags.Int(option.ProxyPrometheusPort, 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
 	option.BindEnv(option.ProxyPrometheusPort)
 
+	flags.Int(option.ProxyMaxRequestsPerConnection, 0, "Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)")
+	option.BindEnv(option.ProxyMaxRequestsPerConnection)
+
+	flags.Int64(option.ProxyMaxConnectionDuration, 0, "Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)")
+	option.BindEnv(option.ProxyMaxConnectionDuration)
+
 	flags.Bool(option.DisableEnvoyVersionCheck, false, "Do not perform Envoy binary version check on startup")
 	flags.MarkHidden(option.DisableEnvoyVersionCheck)
 	// Disable version check if Envoy build is disabled

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -911,6 +911,10 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 
 	useDownstreamProtocol := map[string]*anypb.Any{
 		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": toAny(&envoy_config_upstream.HttpProtocolOptions{
+			CommonHttpProtocolOptions: &envoy_config_core.HttpProtocolOptions{
+				MaxRequestsPerConnection: wrapperspb.UInt32(uint32(option.Config.ProxyMaxRequestsPerConnection)),
+				MaxConnectionDuration:    durationpb.New(option.Config.ProxyMaxConnectionDuration * time.Second),
+			},
 			UpstreamProtocolOptions: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamProtocolConfig{
 				UseDownstreamProtocolConfig: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamHttpConfig{},
 			},
@@ -922,6 +926,10 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 			UpstreamHttpProtocolOptions: &envoy_config_core.UpstreamHttpProtocolOptions{
 				AutoSni:           true,
 				AutoSanValidation: true,
+			},
+			CommonHttpProtocolOptions: &envoy_config_core.HttpProtocolOptions{
+				MaxRequestsPerConnection: wrapperspb.UInt32(uint32(option.Config.ProxyMaxRequestsPerConnection)),
+				MaxConnectionDuration:    durationpb.New(option.Config.ProxyMaxConnectionDuration * time.Second),
 			},
 			UpstreamProtocolOptions: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamProtocolConfig{
 				UseDownstreamProtocolConfig: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamHttpConfig{},

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -166,6 +166,12 @@ const (
 	// ProxyPrometheusPort specifies the port to serve Cilium host proxy metrics on.
 	ProxyPrometheusPort = "proxy-prometheus-port"
 
+	// ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for the proxy
+	ProxyMaxRequestsPerConnection = "proxy-max-requests-per-connection"
+
+	// ProxyMaxConnectionDuration specifies the max_connection_duration setting for the proxy in seconds
+	ProxyMaxConnectionDuration = "proxy-max-connection-duration-seconds"
+
 	// FixedIdentityMapping is the key-value for the fixed identity mapping
 	// which allows to use reserved label for fixed identities
 	FixedIdentityMapping = "fixed-identity-mapping"
@@ -1425,6 +1431,12 @@ type DaemonConfig struct {
 
 	// ProxyPrometheusPort specifies the port to serve Envoy metrics on.
 	ProxyPrometheusPort int
+
+	// ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for the proxy
+	ProxyMaxRequestsPerConnection int
+
+	// ProxyMaxConnectionDuration specifies the max_connection_duration setting for the proxy
+	ProxyMaxConnectionDuration time.Duration
 
 	// EnvoyLogPath specifies where to store the Envoy proxy logs when Envoy
 	// runs in the same container as Cilium.
@@ -2704,6 +2716,8 @@ func (c *DaemonConfig) Populate() {
 	c.PrometheusServeAddr = viper.GetString(PrometheusServeAddr)
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
 	c.ProxyPrometheusPort = viper.GetInt(ProxyPrometheusPort)
+	c.ProxyMaxRequestsPerConnection = viper.GetInt(ProxyMaxRequestsPerConnection)
+	c.ProxyMaxConnectionDuration = time.Duration(viper.GetInt64(ProxyMaxConnectionDuration))
 	c.ReadCNIConfiguration = viper.GetString(ReadCNIConfiguration)
 	c.RestoreState = viper.GetBool(Restore)
 	c.RouteMetric = viper.GetInt(RouteMetric)


### PR DESCRIPTION
This change allows the cilium-agent to specify key connection options to deal with connection reuse issues. The motivation for this change comes from connection issues from cilium-envoy to S3. As seen in this article https://forums.aws.amazon.com/thread.jspa?threadID=110998, S3 will reset a connection that is re-used after 100 requests. Envoy can address this by creating a new connection after that number of requests, but we need to pass that configuration from cilium-agent to cilium-envoy.

Signed-off-by: jmcshane <james.mcshane@superorbital.io>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #19136

```release-note
proxy: Add proxy common http options arguments to agent
```
