### PR TITLE
add enable-unsafe-external-ips

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -120,6 +120,7 @@ cilium-agent [flags]
       --enable-svc-source-range-check                        Enable check of service source ranges (currently, only for LoadBalancer) (default true)
       --enable-tracing                                       Enable tracing while determining policy (debugging)
       --enable-unreachable-routes                            Add unreachable routes on pod deletion
+      --enable-unsafe-external-ips                           Enable externalIPs from pods on same host feature (requires enabling enable-external-ips)
       --enable-vtep                                          Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)
       --enable-well-known-identities                         Enable well-known identities for known Kubernetes components (default true)
       --enable-wireguard                                     Enable wireguard

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -51,7 +51,7 @@
 #include "lib/nodeport.h"
 #include "lib/policy_log.h"
 
-#if !defined(ENABLE_HOST_SERVICES_FULL) || defined(ENABLE_SOCKET_LB_HOST_ONLY)
+#if !defined(ENABLE_HOST_SERVICES_FULL) || defined(ENABLE_SOCKET_LB_HOST_ONLY) || (defined(ENABLE_EXTERNAL_IP) && !defined(BPF_HAVE_NETNS_COOKIE) && defined(ENABLE_UNSAFE_EXTERNAL_IP))
 # define ENABLE_PER_PACKET_LB
 #endif
 
@@ -154,7 +154,7 @@ ipv6_l3_from_lxc(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 		 * state in the address.
 		 */
 		svc = lb6_lookup_service(&key, is_defined(ENABLE_NODEPORT));
-		if (svc) {
+		if (svc && lb6_svc_needs_lxc_xlation(svc)) {
 			ret = lb6_local(get_ct_map6(tuple), ctx, l3_off, l4_off,
 					&csum_off, &key, tuple, svc, &ct_state_new,
 					false);
@@ -592,7 +592,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 		}
 
 		svc = lb4_lookup_service(&key, is_defined(ENABLE_NODEPORT));
-		if (svc) {
+		if (svc && lb4_svc_needs_lxc_xlation(svc)) {
 			ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off,
 					&csum_off, &key, &tuple, svc, &ct_state_new,
 					ip4->saddr, has_l4_header, false);

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -233,6 +233,26 @@ bool lb6_svc_is_external_ip(const struct lb6_service *svc __maybe_unused)
 }
 
 static __always_inline
+bool lb4_svc_needs_lxc_xlation(const struct lb4_service *svc __maybe_unused)
+{
+#if defined(ENABLE_HOST_SERVICES_FULL) && defined(ENABLE_EXTERNAL_IP) && defined(ENABLE_UNSAFE_EXTERNAL_IP)
+	return lb4_svc_is_external_ip(svc);
+#else
+	return true;
+#endif
+}
+
+static __always_inline
+bool lb6_svc_needs_lxc_xlation(const struct lb6_service *svc __maybe_unused)
+{
+#if defined(ENABLE_HOST_SERVICES_FULL) && defined(ENABLE_EXTERNAL_IP) && defined(ENABLE_UNSAFE_EXTERNAL_IP)
+	return lb6_svc_is_external_ip(svc);
+#else
+	return true;
+#endif
+}
+
+static __always_inline
 bool lb4_svc_is_hostport(const struct lb4_service *svc __maybe_unused)
 {
 	return svc->flags & SVC_FLAG_HOSTPORT;

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -385,6 +385,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableExternalIPs, defaults.EnableExternalIPs, fmt.Sprintf("Enable k8s service externalIPs feature (requires enabling %s)", option.EnableNodePort))
 	option.BindEnv(option.EnableExternalIPs)
 
+	flags.Bool(option.EnableUnsafeExternalIPs, defaults.EnableUnsafeExternalIPs, fmt.Sprintf("Enable externalIPs from pods on same host feature (requires enabling %s)", option.EnableExternalIPs))
+	option.BindEnv(option.EnableUnsafeExternalIPs)
+
 	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it")
 	option.BindEnv(option.K8sEnableEndpointSlice)
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -370,6 +370,12 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
 			cDefinesMap["ENABLE_NODEPORT_ACCELERATION"] = "1"
 		}
+		if option.Config.EnableExternalIPs {
+			cDefinesMap["ENABLE_EXTERNAL_IP"] = "1"
+		}
+		if option.Config.EnableUnsafeExternalIPs {
+			cDefinesMap["ENABLE_UNSAFE_EXTERNAL_IP"] = "1"
+		}
 		if !option.Config.EnableHostLegacyRouting {
 			cDefinesMap["ENABLE_HOST_ROUTING"] = "1"
 		}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -168,6 +168,9 @@ const (
 	// EnableExternalIPs is the default value for k8s service with externalIPs feature.
 	EnableExternalIPs = true
 
+	// EnableUnsafeExternalIPs is the default value for allowing pods to reach externalIPs on the same node
+	EnableUnsafeExternalIPs = false
+
 	// K8sEnableEndpointSlice is the default value for k8s EndpointSlice feature.
 	K8sEnableEndpointSlice = true
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -136,6 +136,9 @@ const (
 	// EnableExternalIPs enables implementation of k8s services with externalIPs in datapath
 	EnableExternalIPs = "enable-external-ips"
 
+	// EnableUnsafeExternalIPs enables pods to connect to externalIPs on the same host
+	EnableUnsafeExternalIPs = "enable-unsafe-external-ips"
+
 	// K8sEnableEndpointSlice enables the k8s EndpointSlice feature into Cilium
 	K8sEnableEndpointSlice = "enable-k8s-endpoint-slice"
 
@@ -1802,6 +1805,9 @@ type DaemonConfig struct {
 	// EnableExternalIPs enables implementation of k8s services with externalIPs in datapath
 	EnableExternalIPs bool
 
+	// EnableUnsafeExternalIPs enables pods on to reach externalIPs on the same host
+	EnableUnsafeExternalIPs bool
+
 	// EnableHostFirewall enables network policies for the host
 	EnableHostFirewall bool
 
@@ -2607,6 +2613,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableLocalNodeRoute = viper.GetBool(EnableLocalNodeRoute)
 	c.EnablePolicy = strings.ToLower(viper.GetString(EnablePolicy))
 	c.EnableExternalIPs = viper.GetBool(EnableExternalIPs)
+	c.EnableUnsafeExternalIPs = viper.GetBool(EnableUnsafeExternalIPs)
 	c.EnableL7Proxy = viper.GetBool(EnableL7Proxy)
 	c.EnableTracing = viper.GetBool(EnableTracing)
 	c.EnableUnreachableRoutes = viper.GetBool(EnableUnreachableRoutes)

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -778,3 +778,11 @@ func CiliumEndpointSliceFeatureEnabled() bool {
 	return k8sVersionGreaterEqual121(k8sVersion) && (GetCurrentIntegration() == "" ||
 		IsIntegration(CIIntegrationKind))
 }
+
+func DoesRunWithUnsafeExternalIPs() bool {
+	return os.Getenv("ENABLE_UNSAFE_EXTERNAL_IP") == "1"
+}
+
+func DoesNotRunWithUnsafeExternalIPs() bool {
+	return !DoesRunWithUnsafeExternalIPs()
+}

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -505,7 +505,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 
 	SkipContextIf(func() bool {
 		return helpers.DoesNotRunWithKubeProxyReplacement() ||
-			helpers.DoesNotExistNodeWithoutCilium()
+			helpers.DoesNotExistNodeWithoutCilium() ||
+			helpers.DoesRunWithUnsafeExternalIPs()
 	}, "Checks N/S loadbalancing", func() {
 		var yamls []string
 
@@ -547,7 +548,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 		})
 
 		It("Tests externalIPs", func() {
-			testExternalIPs(kubectl, ni)
+			testExternalIPs(kubectl, ni, false)
 		})
 
 		It("Tests GH#10983", func() {
@@ -826,6 +827,16 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				Expect(curlClusterIPFromExternalHost(kubectl, ni)).
 					Should(helpers.CMDSuccess(), "Could not curl ClusterIP %s from external host", svcIP)
 			})
+		})
+	})
+
+	SkipContextIf(func() bool {
+		return helpers.DoesNotRunWithKubeProxyReplacement() ||
+			helpers.DoesNotExistNodeWithoutCilium() ||
+			helpers.DoesNotRunWithUnsafeExternalIPs()
+	}, "Checks N/S loadbalancing with unsafe external IPs", func() {
+		It("Tests externalIPs", func() {
+			testExternalIPs(kubectl, ni, true)
 		})
 	})
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Adds unsafe external IP support.

Refers to [#14136](https://github.com/cilium/cilium/issues/14136)

This PR adds the ability for the host and workloads on the host to access externalIPs for users where CVE-2020-8554 does not provide a threat.