### PR TITLE
v1.11 backport: manual backport of "Recommend 'NoExecute' instead of 'NoSchedule'"

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -45,9 +45,9 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
            export NAME="$(whoami)-$RANDOM"
            # Create the node pool with the following taint to guarantee that
-           # Pods are only scheduled in the node when Cilium is ready.
+           # Pods are only scheduled/executed in the node when Cilium is ready.
            gcloud container clusters create "${NAME}" \
-            --node-taints node.cilium.io/agent-not-ready=true:NoSchedule \
+            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --zone us-west2-a
            gcloud container clusters get-credentials "${NAME}" --zone us-west2-a
 
@@ -91,14 +91,14 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
              --node-taints "CriticalAddonsOnly=true:NoSchedule" \
              --no-wait
 
-           # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoSchedule`
+           # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoExecute`
            az aks nodepool add \
              --resource-group "${AZURE_RESOURCE_GROUP}" \
              --cluster-name "${NAME}" \
              --name userpool \
              --mode user \
              --node-count 2 \
-             --node-taints "node.cilium.io/agent-not-ready=true:NoSchedule" \
+             --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
              --no-wait
 
            # Delete the initial system node pool
@@ -120,14 +120,14 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
        .. note::
 
           `Node pools <https://aka.ms/aks/nodepools>`_ must be tainted with
-          ``node.cilium.io/agent-not-ready=true:NoSchedule`` to ensure that
-          applications pods will only be scheduled once Cilium is ready to
-          manage them, however on AKS:
+          ``node.cilium.io/agent-not-ready=true:NoExecute`` to ensure that
+          applications pods will only be scheduled/executed once Cilium is ready
+          to manage them, however on AKS:
 
           * It is not possible to assign taints to the initial node pool at this
             time, cf. `Azure/AKS#1402 <https://github.com/Azure/AKS/issues/1402>`_.
 
-          * It is not possible to assign custom node taints such as ``node.cilium.io/agent-not-ready=true:NoSchedule``
+          * It is not possible to assign custom node taints such as ``node.cilium.io/agent-not-ready=true:NoExecute``
             to system node pools, cf. `Azure/AKS#2578 <https://github.com/Azure/AKS/issues/2578>`_.
 
           In order to have Cilium properly manage application pods on AKS with
@@ -137,8 +137,8 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
             with ``CriticalAddonsOnly=true:NoSchedule``, preventing application
             pods from being scheduled on it.
 
-          * Create a secondary user node pool tainted with ``node.cilium.io/agent-not-ready=true:NoSchedule``,
-            preventing application pods from being scheduled on it until Cilium
+          * Create a secondary user node pool tainted with ``node.cilium.io/agent-not-ready=true:NoExecute``,
+            preventing application pods from being scheduled/executed on it until Cilium
             is ready to manage them.
 
     .. group-tab:: EKS
@@ -169,7 +169,7 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
              taints:
               - key: "node.cilium.io/agent-not-ready"
                 value: "true"
-                effect: "NoSchedule"
+                effect: "NoExecute"
            EOF
            eksctl create cluster -f ./eks-config.yaml
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -659,11 +659,11 @@ As an instance example, ``m5n.xlarge`` is used in the config ``nodegroup-config.
       ssh:
         allow: true
       ## taint nodes so that application pods are
-      ## not scheduled until Cilium is deployed.
+      ## not scheduled/executed until Cilium is deployed.
       taints:
         - key: "node.cilium.io/agent-not-ready"
           value: "true"
-          effect: "NoSchedule"
+          effect: "NoExecute"
 
 The nodegroup is created with:
 

--- a/Documentation/gettingstarted/requirements-aks.rst
+++ b/Documentation/gettingstarted/requirements-aks.rst
@@ -23,13 +23,13 @@ Direct Routing  Azure IPAM          Kubernetes CRD
 * Node pools must be properly tainted to ensure applications pods are properly
   managed by Cilium:
 
-  * User node pools must be tainted with ``node.cilium.io/agent-not-ready=true:NoSchedule``
-    to ensure application pods will only be scheduled once Cilium is ready to
+  * User node pools must be tainted with ``node.cilium.io/agent-not-ready=true:NoExecute``
+    to ensure application pods will only be scheduled/executed once Cilium is ready to
     manage them.
 
   * System node pools must be tainted with ``CriticalAddonsOnly=true:NoSchedule``,
     preventing application pods from being scheduled on them. This is necessary
-    because it is not possible to assign custom node taints such as ``node.cilium.io/agent-not-ready=true:NoSchedule``
+    because it is not possible to assign custom node taints such as ``node.cilium.io/agent-not-ready=true:NoExecute``
     to system node pools, cf. `Azure/AKS#2578 <https://github.com/Azure/AKS/issues/2578>`_.
     
     * The initial node pool must be replaced with a new system node pool since

--- a/Documentation/gettingstarted/requirements-eks.rst
+++ b/Documentation/gettingstarted/requirements-eks.rst
@@ -23,7 +23,7 @@ For more information on AWS ENI mode, see :ref:`ipam_eni`.
   Cilium:
 
   * ``managedNodeGroups`` must be tainted with
-    ``node.cilium.io/agent-not-ready=true:NoSchedule`` to ensure application
+    ``node.cilium.io/agent-not-ready=true:NoExecute`` to ensure application
     pods will only be scheduled once Cilium is ready to manage them. For
     example, when using a `ClusterConfig <https://eksctl.io/usage/creating-and-managing-clusters/#using-config-files>`_
     file to create the cluster:
@@ -37,11 +37,11 @@ For more information on AWS ENI mode, see :ref:`ipam_eni`.
         - name: ng-1
           ...
           # taint nodes so that application pods are
-          # not scheduled until Cilium is deployed.
+          # not scheduled/executed until Cilium is deployed.
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"
-             effect: "NoSchedule"
+             effect: "NoExecute"
 
 **Limitations:**
 

--- a/Documentation/gettingstarted/requirements-gke.rst
+++ b/Documentation/gettingstarted/requirements-gke.rst
@@ -11,5 +11,5 @@ Direct Routing  Kubernetes PodCIDR  Kubernetes CRD
 
 **Requirements:**
 
-* The cluster must  be created with the taint ``node.cilium.io/agent-not-ready=true:NoSchedule``
+* The cluster must  be created with the taint ``node.cilium.io/agent-not-ready=true:NoExecute``
   using ``--node-taints`` option.


### PR DESCRIPTION
This is a manual backport of the second commit in https://github.com/cilium/cilium/pull/18486 (i.e. of b049574616e2effcaafa65cb5700e661aafc2076) which seemingly wasn't picked up by the backporting scripts.