### PR TITLE
localdev: fix kind helm install shell function

### DIFF
--- a/contrib/scripts/kind-shell-helpers.sh
+++ b/contrib/scripts/kind-shell-helpers.sh
@@ -63,7 +63,7 @@ cilium-helm-install(){
         echo "\e[34mIf incorrect, set CILIUM_SRC env var to Cilium's source code"
         printf "%0.s\e[34m=" {1..$COLUMNS}
         ciliumVersion=${1}
-        cd $SRC
+        cd $SRC/install/kubernetes
         CILIUM_CI_TAG="${1}"
         helm template cilium ./cilium \
           --namespace kube-system \


### PR DESCRIPTION
the `cilium-helm-install` shell function must `cd` into the
`install/kuberenetes` directory before generating the templates.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>