### PR TITLE
[v1.9] Prevent CiliumEndpoint removal by non-owning agent

### DIFF
--- a/operator/k8s_cep_gc.go
+++ b/operator/k8s_cep_gc.go
@@ -162,8 +162,15 @@ func doCiliumEndpointSyncGC(ctx context.Context, once bool, stopCh chan struct{}
 		err := ciliumClient.CiliumEndpoints(cep.Namespace).Delete(
 			ctx,
 			cep.Name,
-			meta_v1.DeleteOptions{PropagationPolicy: &PropagationPolicy})
-		if err != nil && !k8serrors.IsNotFound(err) {
+			meta_v1.DeleteOptions{
+				PropagationPolicy: &PropagationPolicy,
+				// Set precondition to ensure we are only deleting CEPs owned by
+				// this agent.
+				Preconditions: &meta_v1.Preconditions{
+					UID: &cep.UID,
+				},
+			})
+		if err != nil && !k8serrors.IsNotFound(err) && !k8serrors.IsConflict(err) {
 			scopedLog.WithError(err).Warning("Unable to delete orphaned CEP")
 			return err
 		}

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -87,6 +87,10 @@ var (
 
 	// IdentityGCRuns records how many times identity GC has run
 	IdentityGCRuns *prometheus.GaugeVec
+
+	// EndpointGCObjects records the number of times endpoint objects have been
+	// garbage-collected.
+	EndpointGCObjects *prometheus.CounterVec
 )
 
 const (
@@ -125,6 +129,13 @@ func registerMetrics() []prometheus.Collector {
 		Help:      "The number of times identity garbage collector has run",
 	}, []string{LabelOutcome})
 	collectors = append(collectors, IdentityGCRuns)
+
+	EndpointGCObjects = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "endpoint_gc_objects",
+		Help:      "The number of times endpoint objects have been garbage-collected",
+	}, []string{LabelOutcome})
+	collectors = append(collectors, EndpointGCObjects)
 
 	Registry.MustRegister(collectors...)
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -67,8 +67,8 @@ import (
 	"github.com/cilium/cilium/pkg/trigger"
 
 	"github.com/sirupsen/logrus"
-
 	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -343,6 +343,8 @@ type Endpoint struct {
 	allocator cache.IdentityAllocator
 
 	isHost bool
+
+	ciliumEndpointUID types.UID
 }
 
 // EndpointSyncControllerName returns the controller name to synchronize
@@ -2484,4 +2486,18 @@ func (e *Endpoint) setDefaultPolicyConfig() {
 // GetCreatedAt returns the endpoint creation time.
 func (e *Endpoint) GetCreatedAt() time.Time {
 	return e.createdAt
+}
+
+// GetCiliumEndpointUID returns the UID of the CiliumEndpoint.
+func (e *Endpoint) GetCiliumEndpointUID() types.UID {
+	e.unconditionalRLock()
+	defer e.runlock()
+	return e.ciliumEndpointUID
+}
+
+// SetCiliumEndpointUID modifies the endpoint's CiliumEndpoint UID.
+func (e *Endpoint) SetCiliumEndpointUID(uid types.UID) {
+	e.unconditionalLock()
+	e.ciliumEndpointUID = uid
+	e.unlock()
 }

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -30,12 +28,15 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	pkgLabels "github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 
 	go_version "github.com/blang/semver"
+	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -142,6 +143,11 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					localCEP, err = ciliumClient.CiliumEndpoints(namespace).Get(ctx, podName, meta_v1.GetOptions{})
 					// It's only an error if it exists but something else happened
 					switch {
+					case err == nil:
+						// Backfill the CEP UID as we need to do if the CEP was
+						// created on an agent version that did not yet store the
+						// UID at CEP create time.
+						updateCEPUIDIfNeeded(scopedLog, e, localCEP)
 					case k8serrors.IsNotFound(err):
 						pod := e.GetPod()
 						if pod == nil {
@@ -180,12 +186,14 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 							return err
 						}
 
+						scopedLog.WithField(logfields.CEPUID, localCEP.UID).Debug("storing CEP UID after create")
+						e.SetCiliumEndpointUID(localCEP.UID)
+
 						// continue the execution so we update the endpoint
 						// status immediately upon endpoint creation
-					case err != nil:
+					default:
 						scopedLog.WithError(err).Warn("Error getting CEP")
 						return err
-					default:
 					}
 
 					// We return earlier for all error cases so we don't need
@@ -199,24 +207,30 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 				if localCEP == nil {
 					localCEP, err = ciliumClient.CiliumEndpoints(namespace).Get(ctx, podName, meta_v1.GetOptions{})
 					switch {
+					case err == nil:
+						// Backfill the CEP UID as we need to do if the CEP was
+						// created on an agent version that did not yet store the
+						// UID at CEP create time.
+						updateCEPUIDIfNeeded(scopedLog, e, localCEP)
+
 					// The CEP doesn't exist in k8s. This is unexpetected but may occur
 					// if the endpoint was removed from k8s but not yet within the agent.
 					// Mark the CEP for creation on the next controller iteration. This
 					// may never occur if the controller is stopped on Endpoint delete.
-					case err != nil && k8serrors.IsNotFound(err):
+					case k8serrors.IsNotFound(err):
 						needInit = true
 						return err
 
 					// We cannot read the upstream CEP. needInit will cause the next
 					// iteration to delete and create the CEP. This is an unexpected
 					// situation.
-					case err != nil && k8serrors.IsInvalid(err):
+					case k8serrors.IsInvalid(err):
 						scopedLog.WithError(err).Warn("Invalid CEP during update")
 						needInit = true
 						return nil
 
 					// A real error
-					case err != nil:
+					default:
 						scopedLog.WithError(err).Error("Cannot get CEP during update")
 						return err
 					}
@@ -242,7 +256,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					}
 					localCEP, err = ciliumClient.CiliumEndpoints(namespace).Patch(
 						ctx, podName,
-						types.JSONPatchType,
+						k8stypes.JSONPatchType,
 						createStatusPatch,
 						meta_v1.PatchOptions{},
 						"status")
@@ -289,6 +303,20 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 		})
 }
 
+// updateCEPUIDIfNeeded updates the endpoint's CEP UID from the local CEP if the
+// CEP UID is different (i.e., has never been set on the endpoint or has
+// changed).
+func updateCEPUIDIfNeeded(scopedLog *logrus.Entry, e *endpoint.Endpoint, localCEP *cilium_v2.CiliumEndpoint) {
+	if cepUID := e.GetCiliumEndpointUID(); cepUID != localCEP.UID {
+		scopedLog.WithFields(logrus.Fields{
+			logfields.Node:           types.GetName(),
+			"old" + logfields.CEPUID: cepUID,
+			logfields.CEPUID:         localCEP.UID,
+		}).Debug("updating CEP UID")
+		e.SetCiliumEndpointUID(localCEP.UID)
+	}
+}
+
 // DeleteK8sCiliumEndpointSync replaces the endpoint controller to remove the
 // CEP from Kubernetes once the endpoint is stopped / removed from the
 // Cilium agent.
@@ -331,8 +359,32 @@ func deleteCEP(ctx context.Context, scopedLog *logrus.Entry, ciliumClient v2.Cil
 		scopedLog.Debug("Skipping CiliumEndpoint deletion because it has no k8s namespace")
 		return nil
 	}
-	if err := ciliumClient.CiliumEndpoints(namespace).Delete(ctx, podName, meta_v1.DeleteOptions{}); err != nil {
-		if !k8serrors.IsNotFound(err) {
+
+	// A CEP should be only be deleted by the agent that manages the
+	// corresponding pod. However, it is possible for a pod to restart and be
+	// scheduled onto a different node while the agent on the original node was
+	// down, which would cause the CEP to be deleted once the original agent came
+	// back up. (This holds for StatefulSets in particular that come with stable
+	// pod identifiers and thus do not guard against such accidental deletes
+	// through unique pod names.) Storing the CEP UID at CEP create/fetch time
+	// and using it as a precondition for deletion ensures that agents may only
+	// delete CEPs they own.
+	// It is possible for the CEP UID to not be populated when an agent tries to
+	// clean up a CEP. In that case, skip deletion and rely on cilium operator
+	// garbage collection to clean up eventually.
+	cepUID := e.GetCiliumEndpointUID()
+	if cepUID == "" {
+		scopedLog.Debug("Skipping CiliumEndpoint deletion because it has no UID")
+		return nil
+	}
+
+	scopedLog.WithField(logfields.CEPUID, cepUID).Debug("deleting CEP with UID")
+	if err := ciliumClient.CiliumEndpoints(namespace).Delete(ctx, podName, meta_v1.DeleteOptions{
+		Preconditions: &meta_v1.Preconditions{
+			UID: &cepUID,
+		},
+	}); err != nil {
+		if !k8serrors.IsNotFound(err) && !k8serrors.IsConflict(err) {
 			scopedLog.WithError(err).Warning("Unable to delete CEP")
 		}
 	}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -519,4 +519,7 @@ const (
 
 	// Hint helps nudge the user in the right direction when troubleshooting.
 	Hint = "hint"
+
+	// CEPUID is the UID of the CiliumEndpoint.
+	CEPUID = "ciliumEndpointUID"
 )


### PR DESCRIPTION
Cherry pick of https://github.com/timoreimann/cilium/tree/fix-cilium-endpoint-delete-1.9.

---

* #18864 -- Prevent CiliumEndpoint removal by non-owning agent (@timoreimann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18864; do contrib/backporting/set-labels.py $pr done 1.9; done
```

cc @timoreimann 