### PR TITLE
alibabacloud: Fix missing instance due to incomplete subnet list

### DIFF
--- a/pkg/alibabacloud/api/api.go
+++ b/pkg/alibabacloud/api/api.go
@@ -95,7 +95,6 @@ func (c *Client) GetVSwitches(ctx context.Context) (ipamTypes.SubnetMap, error) 
 		req := vpc.CreateDescribeVSwitchesRequest()
 		req.PageNumber = requests.NewInteger(i)
 		req.PageSize = requests.NewInteger(50)
-		req.VpcId = c.filters[VPCID]
 		c.limiter.Limit(ctx, "DescribeVSwitches")
 		resp, err := c.vpcClient.DescribeVSwitches(req)
 		if err != nil {


### PR DESCRIPTION
Currently, the result of `DescribeVSwitches` (list subnet) is filtered
by VPC ID (the VPC where cilium-operator is running if not specified),
only instances in this VPC could be discovered and maintained by
cilium-operator.

Fix this by removing the VPC ID filter.

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

```release-note
alibabacloud: Fix missing instance due to incomplete subnet list
```
