### PR TITLE
bpf: Add missing packet trace in handle_nat_fwd

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1064,7 +1064,6 @@ int to_netdev(struct __ctx_buff *ctx __maybe_unused)
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
-	__u32 __maybe_unused src_id = 0;
 	__u16 __maybe_unused proto = 0;
 	__u32 __maybe_unused vlan_id;
 	int ret = CTX_ACT_OK;
@@ -1127,7 +1126,7 @@ int to_netdev(struct __ctx_buff *ctx __maybe_unused)
 	}
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
 					      METRIC_EGRESS);
 #endif /* ENABLE_HOST_FIREWALL */
 
@@ -1164,8 +1163,8 @@ out:
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
 					      METRIC_EGRESS);
 #endif
-	send_trace_notify(ctx, TRACE_TO_NETWORK, src_id, 0, 0, 0,
-			  trace.reason, trace.monitor);
+	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0,
+			  0, trace.reason, trace.monitor);
 
 	return ret;
 }

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1047,13 +1047,23 @@ declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
 		    CILIUM_CALL_IPV6_ENCAP_NODEPORT_NAT)
 int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 {
+	int ret;
+	enum trace_point obs_point;
 #if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
 	union v6addr addr = { .p1 = 0 };
 	BPF_V6(addr, ROUTER_IP);
+	obs_point = TRACE_TO_OVERLAY;
 #else
 	union v6addr addr = IPV6_DIRECT_ROUTING;
+	obs_point = TRACE_TO_NETWORK;
 #endif
-	return nodeport_nat_ipv6_fwd(ctx, &addr);
+	ret = nodeport_nat_ipv6_fwd(ctx, &addr);
+	if (IS_ERR(ret))
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
+
+	send_trace_notify(ctx, obs_point, 0, 0, 0, 0, TRACE_REASON_UNKNOWN, 0);
+
+	return ret;
 }
 #endif /* ENABLE_IPV6 */
 
@@ -2126,7 +2136,22 @@ declare_tailcall_if(__or3(__and(is_defined(ENABLE_IPV4),
 		    CILIUM_CALL_IPV4_ENCAP_NODEPORT_NAT)
 int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 {
-	return nodeport_nat_ipv4_fwd(ctx);
+	int ret;
+	enum trace_point obs_point;
+
+#if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
+	obs_point = TRACE_TO_OVERLAY;
+#else
+	obs_point = TRACE_TO_NETWORK;
+#endif
+
+	ret = nodeport_nat_ipv4_fwd(ctx);
+	if (IS_ERR(ret))
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
+
+	send_trace_notify(ctx, obs_point, 0, 0, 0, 0, TRACE_REASON_UNKNOWN, 0);
+
+	return ret;
 }
 #endif /* ENABLE_IPV4 */
 


### PR DESCRIPTION
Please see the commit message for more details.

Fixes: #18909

```release-note
Add missing packet trace for some non-NodePort SNAT egress
```