### PR TITLE
bpf: switch to cilium/ebpf loader and native netlink calls

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -485,12 +485,10 @@ for iface in $(ip -o -a l | awk '{print $2}' | cut -d: -f1 | cut -d@ -f1 | grep 
 	done
 	$found && continue
 	for where in ingress egress; do
-		if tc filter show dev "$iface" "$where" | grep -q "bpf_netdev.*[.]o"; then
-			echo "Removing bpf_netdev.o from $where of $iface"
-			tc filter del dev "$iface" "$where" || true
-		fi
-		if tc filter show dev "$iface" "$where" | grep -q "bpf_host.o"; then
-			echo "Removing bpf_host.o from $where of $iface"
+		# Filters created Go bpf loader are of format 'cilium-<iface>'.
+		# iproute2 would use the filename and section, e.g. bpf_overlay.o:[from-overlay].
+		if tc filter show dev "$iface" "$where" | grep -q "bpf_netdev\|bpf_host\|cilium"; then
+			echo "Removing $where TC filter from interface $iface"
 			tc filter del dev "$iface" "$where" || true
 		fi
 	done

--- a/cilium/cmd/bpf_migrate_maps.go
+++ b/cilium/cmd/bpf_migrate_maps.go
@@ -59,13 +59,23 @@ original locations. If the return code is 0, the :pending maps will be unpinned.
 			}
 
 			if start != "" {
-				if err := bpf.StartBPFFSMigration(bpffsPath, start); err != nil {
+				spec, err := bpf.LoadCollectionSpec(start)
+				if err != nil {
+					return fmt.Errorf("loading eBPF ELF %q: %v", start, err)
+				}
+
+				if err := bpf.StartBPFFSMigration(bpffsPath, spec); err != nil {
 					return fmt.Errorf("error starting map migration for %q: %v", start, err)
 				}
 			}
 
 			if end != "" {
-				if err := bpf.FinalizeBPFFSMigration(bpffsPath, end, rc != 0); err != nil {
+				spec, err := bpf.LoadCollectionSpec(end)
+				if err != nil {
+					return fmt.Errorf("loading eBPF ELF %q: %v", end, err)
+				}
+
+				if err := bpf.FinalizeBPFFSMigration(bpffsPath, spec, rc != 0); err != nil {
 					return fmt.Errorf("error finalizing map migration for %q: %v", end, err)
 				}
 			}

--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -486,11 +486,14 @@ func getTCFilters(link netlink.Link) ([]*netlink.BpfFilter, error) {
 		}
 		for _, f := range filters {
 			if bpfFilter, ok := f.(*netlink.BpfFilter); ok {
+				// Filters created Go bpf loader are of format 'cilium-<iface>'.
+				// iproute2 would use the filename and section, e.g. bpf_overlay.o:[from-overlay].
 				if strings.Contains(bpfFilter.Name, "bpf_netdev") ||
 					strings.Contains(bpfFilter.Name, "bpf_network") ||
 					strings.Contains(bpfFilter.Name, "bpf_host") ||
 					strings.Contains(bpfFilter.Name, "bpf_lxc") ||
-					strings.Contains(bpfFilter.Name, "bpf_overlay") {
+					strings.Contains(bpfFilter.Name, "bpf_overlay") ||
+					strings.Contains(bpfFilter.Name, "cilium") {
 					allFilters = append(allFilters, bpfFilter)
 				}
 			}

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -284,6 +284,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		log.WithField(logfields.EndpointID, ep.ID).Info("Successfully restored endpoint. Scheduling regeneration")
 		go func(ep *endpoint.Endpoint, epRegenerated chan<- bool) {
 			if err := ep.RegenerateAfterRestore(); err != nil {
+				log.WithField(logfields.EndpointID, ep.ID).WithError(err).Debug("error regenerating during restore")
 				epRegenerated <- false
 				return
 			}

--- a/pkg/bpf/bpffs_migrate.go
+++ b/pkg/bpf/bpffs_migrate.go
@@ -24,10 +24,9 @@ const bpffsPending = ":pending"
 // Takes a bpffsPath explicitly since it does not necessarily execute within
 // the same runtime as the agent. It is imported from a Cilium cmd that takes
 // its bpffs path from an env.
-func StartBPFFSMigration(bpffsPath, elfPath string) error {
-	coll, err := ebpf.LoadCollectionSpec(elfPath)
-	if err != nil {
-		return err
+func StartBPFFSMigration(bpffsPath string, coll *ebpf.CollectionSpec) error {
+	if coll == nil {
+		return errors.New("can't migrate a nil CollectionSpec")
 	}
 
 	for name, spec := range coll.Maps {
@@ -59,10 +58,9 @@ func StartBPFFSMigration(bpffsPath, elfPath string) error {
 // Takes a bpffsPath explicitly since it does not necessarily execute within
 // the same runtime as the agent. It is imported from a Cilium cmd that takes
 // its bpffs path from an env.
-func FinalizeBPFFSMigration(bpffsPath, elfPath string, revert bool) error {
-	coll, err := ebpf.LoadCollectionSpec(elfPath)
-	if err != nil {
-		return err
+func FinalizeBPFFSMigration(bpffsPath string, coll *ebpf.CollectionSpec, revert bool) error {
+	if coll == nil {
+		return errors.New("can't migrate a nil CollectionSpec")
 	}
 
 	for name, spec := range coll.Maps {

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -1,0 +1,163 @@
+package bpf
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+)
+
+// LoadCollectionSpec loads the eBPF ELF at the given path and parses it into
+// a CollectionSpec. This spec is only a blueprint of the contents of the ELF
+// and does not represent any live resources that have been loaded into the
+// kernel.
+//
+// This is a wrapper around ebpf.LoadCollectionSpec that parses legacy iproute2
+// bpf_elf_map definitions (only used for prog_arrays at the time of writing)
+// and assigns tail calls annotated with `__section_tail` macros to their
+// intended maps and slots.
+func LoadCollectionSpec(path string) (*ebpf.CollectionSpec, error) {
+	spec, err := ebpf.LoadCollectionSpec(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := iproute2Compat(spec); err != nil {
+		return nil, err
+	}
+
+	classifyProgramTypes(spec)
+
+	return spec, nil
+}
+
+// iproute2Compat parses the Extra field of each MapSpec in the CollectionSpec.
+// This extra portion is present in legacy bpf_elf_map definitions and must be
+// handled before the map can be loaded into the kernel.
+//
+// It parses the ELF section name of each ProgramSpec to extract any map/slot
+// mappings for prog arrays used as tail call maps. The spec's programs are then
+// inserted into the appropriate map and slot.
+//
+// TODO(timo): Remove when bpf_elf_map map definitions are no longer used after
+// moving away from iproute2+libbpf.
+func iproute2Compat(spec *ebpf.CollectionSpec) error {
+	// Parse legacy iproute2 u32 id and pinning fields.
+	maps := make(map[uint32]*ebpf.MapSpec)
+	for _, m := range spec.Maps {
+		if m.Extra != nil && m.Extra.Len() > 0 {
+			tail := struct {
+				ID      uint32
+				Pinning uint32
+				_       uint64 // inner_id + inner_idx
+			}{}
+			if err := binary.Read(m.Extra, spec.ByteOrder, &tail); err != nil {
+				return fmt.Errorf("reading iproute2 map definition: %w", err)
+			}
+
+			if tail.Pinning > 0 {
+				m.Pinning = 1 // LIBBPF_PIN_BY_NAME
+			}
+
+			// Index maps by their iproute2 .id if any, so X/Y ELF section names can
+			// be matched against them.
+			if tail.ID != 0 {
+				if m2 := maps[tail.ID]; m2 != nil {
+					return fmt.Errorf("maps %s and %s have duplicate iproute2 map ID %d", m.Name, m2.Name, tail.ID)
+				}
+				maps[tail.ID] = m
+			}
+		}
+	}
+
+	for n, p := range spec.Programs {
+		// Parse the program's section name to determine which prog array and slot it
+		// needs to be inserted into. For example, a section name of '2/14' means to
+		// insert into the map with the .id field of 2 at index 14.
+		// Uses %v to automatically detect slot's mathematical base, since they can
+		// appear either in dec or hex, e.g. 1/0x0515.
+		var id, slot uint32
+		if _, err := fmt.Sscanf(p.SectionName, "%d/%v", &id, &slot); err == nil {
+			// Assign the prog name and slot to the map with the iproute2 .id obtained
+			// from the program's section name. The lib will load the ProgramSpecs
+			// and insert the corresponding Programs into the prog array at load time.
+			m := maps[id]
+			if m == nil {
+				return fmt.Errorf("no map with iproute2 map .id %d", id)
+			}
+			m.Contents = append(maps[id].Contents, ebpf.MapKV{Key: slot, Value: n})
+		}
+	}
+
+	return nil
+}
+
+// LoadCollection loads the given spec into the kernel with the specified opts.
+//
+// Any maps marked as pinned in the spec are automatically loaded from the path
+// given in opts.Maps.PinPath and will be used instead of creating new ones.
+// MapSpecs that differ (type/key/value/max/flags) from their pinned versions
+// will result in an ebpf.ErrMapIncompatible here and the map must be removed
+// before loading the CollectionSpec.
+func LoadCollection(spec *ebpf.CollectionSpec, opts ebpf.CollectionOptions) (*ebpf.Collection, error) {
+	if spec == nil {
+		return nil, errors.New("can't load nil CollectionSpec")
+	}
+
+	// By default, allocate a 1MiB verifier log buffer if first load attempt
+	// fails. This was adjusted around Cilium 1.11 for fitting bpf_lxc insn
+	// limit messages.
+	if opts.Programs.LogSize == 0 {
+		opts.Programs.LogSize = 1 << 20
+	}
+
+	// Copy spec so the modifications below don't affect the input parameter,
+	// allowing the spec to be safely re-used by the caller.
+	spec = spec.Copy()
+
+	coll, err := ebpf.NewCollectionWithOptions(spec, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return coll, nil
+}
+
+// classifyProgramTypes sets the type of ProgramSpecs which the library cannot
+// automatically classify due to them being in unrecognized ELF sections. Only
+// programs of type UnspecifiedProgram are modified.
+//
+// Cilium uses the iproute2 X/Y section name convention for assigning programs
+// to prog array slots, which is also not supported.
+func classifyProgramTypes(spec *ebpf.CollectionSpec) {
+	// Assign a program type based on the first recognized function name.
+	var t ebpf.ProgramType
+	for name := range spec.Programs {
+		switch name {
+		// bpf_xdp.c
+		case "bpf_xdp_entry":
+			t = ebpf.XDP
+		case
+			// bpf_lxc.c
+			"handle_xgress", "handle_to_container",
+			// bpf_host.c
+			"from_netdev", "from_host", "to_netdev", "to_host",
+			// bpf_network.c
+			"from_network",
+			// bpf_overlay.c
+			"to_overlay", "from_overlay":
+			t = ebpf.SchedCLS
+		default:
+			continue
+		}
+
+		break
+	}
+
+	for _, p := range spec.Programs {
+		if p.Type == ebpf.UnspecifiedProgram {
+			p.Type = t
+		}
+	}
+}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -431,7 +431,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		args[initArgProxyRule] = "false"
 	}
 
-	args[initTCFilterPriority] = strconv.Itoa(option.Config.TCFilterPriority)
+	args[initTCFilterPriority] = strconv.Itoa(int(option.Config.TCFilterPriority))
 
 	// "Legacy" datapath inizialization with the init.sh script
 	// TODO(mrostecki): Rewrite the whole init.sh in Go, step by step.

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -312,7 +312,7 @@ func (o *objectCache) fetchOrCompile(ctx context.Context, cfg datapath.EndpointC
 	}
 
 	// Wait until the build completes.
-	if err = fq.Wait(ctx); err != nil {
+	if err := fq.Wait(); err != nil {
 		return "", false, fmt.Errorf("BPF template compilation failed: %w", err)
 	}
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -453,7 +453,7 @@ func (l *Loader) CompileOrLoad(ctx context.Context, ep datapath.Endpoint, stats 
 	return l.ReloadDatapath(ctx, ep, stats)
 }
 
-// ReloadDatapath reloads the BPF datapath pgorams for the specified endpoint.
+// ReloadDatapath reloads the BPF datapath programs for the specified endpoint.
 func (l *Loader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) (err error) {
 	dirs := directoryInfo{
 		Library: option.Config.BpfDir,

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -32,14 +32,16 @@ import (
 const (
 	Subsystem = "datapath-loader"
 
-	symbolFromEndpoint = "from-container"
-	symbolToEndpoint   = "to-container"
-	symbolFromNetwork  = "from-network"
+	symbolFromEndpoint = "handle_xgress"
+	symbolToEndpoint   = "handle_to_container"
+	symbolFromNetwork  = "from_network"
 
-	symbolFromHostNetdevEp = "from-netdev"
-	symbolToHostNetdevEp   = "to-netdev"
-	symbolFromHostEp       = "from-host"
-	symbolToHostEp         = "to-host"
+	symbolFromHostNetdevEp = "from_netdev"
+	symbolToHostNetdevEp   = "to_netdev"
+	symbolFromHostEp       = "from_host"
+	symbolToHostEp         = "to_host"
+
+	symbolFromHostNetdevXDP = "bpf_xdp_entry"
 
 	dirIngress = "ingress"
 	dirEgress  = "egress"
@@ -251,7 +253,7 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 
 	for i, interfaceName := range interfaceNames {
 		symbol := symbols[i]
-		finalize, err := replaceDatapath(ctx, interfaceName, objPaths[i], symbol, directions[i], false, "")
+		finalize, err := replaceDatapath(ctx, interfaceName, objPaths[i], symbol, directions[i], "")
 		if err != nil {
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
@@ -282,7 +284,7 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 			return err
 		}
 	} else {
-		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, "")
 		if err != nil {
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
@@ -299,7 +301,7 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 		defer finalize()
 
 		if ep.RequireEgressProg() {
-			finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolToEndpoint, dirEgress, false, "")
+			finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolToEndpoint, dirEgress, "")
 			if err != nil {
 				scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 					logfields.Path: objPath,
@@ -346,7 +348,7 @@ func (l *Loader) replaceNetworkDatapath(ctx context.Context, interfaces []string
 		log.WithError(err).Fatal("failed to compile encryption programs")
 	}
 	for _, iface := range option.Config.EncryptInterface {
-		finalize, err := replaceDatapath(ctx, iface, networkObj, symbolFromNetwork, dirIngress, false, "")
+		finalize, err := replaceDatapath(ctx, iface, networkObj, symbolFromNetwork, dirIngress, "")
 		if err != nil {
 			log.WithField(logfields.Interface, iface).WithError(err).Fatal("Load encryption network failed")
 		}

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -294,7 +294,7 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 			// this log message should only represent failures with respect to
 			// loading the program.
 			if ctx.Err() == nil {
-				scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+				scopedLog.WithError(err).Warn("JoinEP: Failed to attach ingress program")
 			}
 			return err
 		}
@@ -311,7 +311,7 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 				// this log message should only represent failures with respect to
 				// loading the program.
 				if ctx.Err() == nil {
-					scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+					scopedLog.WithError(err).Warn("JoinEP: Failed to attach egress program")
 				}
 				return err
 			}

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -197,11 +197,11 @@ func (s *LoaderTestSuite) TestReload(c *C) {
 	c.Assert(err, IsNil)
 
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
-	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, "")
 	c.Assert(err, IsNil)
 	finalize()
 
-	finalize, err = replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+	finalize, err = replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, "")
 	c.Assert(err, IsNil)
 	finalize()
 }
@@ -285,7 +285,7 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, "")
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -5,14 +5,16 @@ package loader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/ebpf"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
@@ -24,15 +26,19 @@ type baseDeviceMode string
 const (
 	directMode = baseDeviceMode("direct")
 	tunnelMode = baseDeviceMode("tunnel")
-
-	libbpfFixupMsg = "struct bpf_elf_map fixup performed due to size mismatch!"
 )
 
-func replaceQdisc(ifName string) error {
-	link, err := netlink.LinkByName(ifName)
-	if err != nil {
-		return err
+func directionToParent(dir string) uint32 {
+	switch dir {
+	case dirIngress:
+		return netlink.HANDLE_MIN_INGRESS
+	case dirEgress:
+		return netlink.HANDLE_MIN_EGRESS
 	}
+	return 0
+}
+
+func replaceQdisc(link netlink.Link) error {
 	attrs := netlink.QdiscAttrs{
 		LinkIndex: link.Attrs().Index,
 		Handle:    netlink.MakeHandle(0xffff, 0),
@@ -44,13 +50,7 @@ func replaceQdisc(ifName string) error {
 		QdiscType:  "clsact",
 	}
 
-	if err = netlink.QdiscReplace(qdisc); err != nil {
-		return fmt.Errorf("netlink: Replacing qdisc for %s failed: %s", ifName, err)
-	} else {
-		log.Debugf("netlink: Replacing qdisc for %s succeeded", ifName)
-	}
-
-	return nil
+	return netlink.QdiscReplace(qdisc)
 }
 
 // replaceDatapath replaces the qdisc and BPF program for an endpoint or XDP program.
@@ -66,60 +66,124 @@ func replaceQdisc(ifName string) error {
 // For example, this is the case with from-netdev and to-netdev. If eth0:to-netdev
 // gets its program and maps replaced and unpinned, its eth0:from-netdev counterpart
 // will miss tail calls (and drop packets) until it has been replaced as well.
-func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirection string, xdp bool, xdpMode string) (func(), error) {
-	var (
-		loaderProg string
-		args       []string
-	)
+func replaceDatapath(ctx context.Context, ifName, objPath, progName, direction string, xdpMode string) (func(), error) {
+	// Avoid unnecessarily loading a prog.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
-	if !xdp {
-		if err := replaceQdisc(ifName); err != nil {
-			return nil, fmt.Errorf("Failed to replace Qdisc for %s: %s", ifName, err)
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return nil, fmt.Errorf("getting interface %s by name: %w", ifName, err)
+	}
+
+	l := log.WithField("device", ifName).WithField("objPath", objPath).
+		WithField("progName", progName).WithField("direction", direction).
+		WithField("ifindex", link.Attrs().Index)
+
+	// Load the ELF from disk.
+	l.Debug("Loading CollectionSpec from ELF")
+	spec, err := bpf.LoadCollectionSpec(objPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading eBPF ELF: %w", err)
+	}
+
+	if spec.Programs[progName] == nil {
+		return nil, fmt.Errorf("no program %s found in eBPF ELF", progName)
+	}
+
+	// Load the CollectionSpec into the kernel, picking up any pinned maps from
+	// bpffs in the process.
+	finalize := func() {}
+	opts := ebpf.CollectionOptions{
+		Maps: ebpf.MapOptions{PinPath: bpf.MapPrefixPath()},
+	}
+	l.Debug("Loading Collection into kernel")
+	coll, err := bpf.LoadCollection(spec, opts)
+	if errors.Is(err, ebpf.ErrMapIncompatible) {
+		// Temporarily rename bpffs pins of maps whose definitions have changed in
+		// a new version of a datapath ELF.
+		l.Debug("Starting bpffs map migration")
+		if err := bpf.StartBPFFSMigration(bpf.MapPrefixPath(), spec); err != nil {
+			return nil, fmt.Errorf("Failed to start bpffs map migration: %w", err)
 		}
-	}
 
-	// Temporarily rename bpffs pins of maps whose definitions have changed in
-	// a new version of a datapath ELF.
-	if err := bpf.StartBPFFSMigration(bpf.MapPrefixPath(), objPath); err != nil {
-		return nil, fmt.Errorf("Failed to start bpffs map migration: %w", err)
-	}
-
-	// FIXME: replace exec with native call
-	if xdp {
-		loaderProg = "ip"
-		args = []string{"-force", "link", "set", "dev", ifName, xdpMode,
-			"obj", objPath, "sec", progSec}
-	} else {
-		loaderProg = "tc"
-
-		tcPrio := strconv.Itoa(option.Config.TCFilterPriority)
-		log.Debugf("tc filter using priority %s for interface %s", tcPrio, ifName)
-		args = []string{"filter", "replace", "dev", ifName, progDirection,
-			"prio", tcPrio, "handle", "1", "bpf", "da", "obj", objPath,
-			"sec", progSec,
+		finalize = func() {
+			l.Debug("Finalizing bpffs map migration")
+			if err := bpf.FinalizeBPFFSMigration(bpf.MapPrefixPath(), spec, false); err != nil {
+				l.WithError(err).Error("Could not finalize bpffs map migration")
+			}
 		}
+
+		// Retry loading the Collection after starting map migration.
+		l.Debug("Retrying loading Collection into kernel after map migration")
+		coll, err = bpf.LoadCollection(spec, opts)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error loading eBPF collection into the kernel: %w", err)
+	}
+	defer coll.Close()
+
+	// Avoid attaching a prog to a stale interface.
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
-	// If the iproute2 call below is successful, any 'pending' map pins will be removed.
-	// If not, any pending maps will be re-pinned back to their initial paths.
-	cmd := exec.CommandContext(ctx, loaderProg, args...).WithFilters(libbpfFixupMsg)
-	if _, err := cmd.CombinedOutput(log, true); err != nil {
-		// Program/object replacement unsuccessful, revert bpffs migration.
-		if err := bpf.FinalizeBPFFSMigration(bpf.MapPrefixPath(), objPath, true); err != nil {
-			return nil, fmt.Errorf("Failed to revert bpffs map migration: %w", err)
+	l.Debug("Attaching program to interface")
+	if err := attachProgram(link, coll.Programs[progName], directionToParent(direction), xdpModeToFlag(xdpMode)); err != nil {
+		// Program replacement unsuccessful, revert bpffs migration.
+		l.Debug("Reverting bpffs map migration")
+		if err := bpf.FinalizeBPFFSMigration(bpf.MapPrefixPath(), spec, true); err != nil {
+			l.WithError(err).Error("Failed to revert bpffs map migration")
 		}
-		return nil, fmt.Errorf("Failed to load prog with %s: %w", loaderProg, err)
+
+		return nil, fmt.Errorf("program %s: %w", progName, err)
 	}
 
-	finalize := func() {
-		l := log.WithField("device", ifName).WithField("objPath", objPath)
-		l.Debug("Finalizing bpffs map migration")
-		if err := bpf.FinalizeBPFFSMigration(bpf.MapPrefixPath(), objPath, false); err != nil {
-			l.WithError(err).Error("Could not finalize bpffs map migration")
-		}
-	}
+	l.Debugf("Successfully attached program to interface")
 
 	return finalize, nil
+}
+
+// attachProgram attaches prog to link.
+// If xdpFlags is non-zero, attaches prog to XDP.
+func attachProgram(link netlink.Link, prog *ebpf.Program, qdiscParent uint32, xdpFlags uint32) error {
+	if prog == nil {
+		return errors.New("cannot attach a nil program")
+	}
+
+	if xdpFlags != 0 {
+		// Omitting XDP_FLAGS_UPDATE_IF_NOEXIST equals running 'ip' with -force,
+		// and will clobber any existing XDP attachment to the interface.
+		if err := netlink.LinkSetXdpFdWithFlags(link, prog.FD(), int(xdpFlags)); err != nil {
+			return fmt.Errorf("attaching XDP program to interface %s: %w", link.Attrs().Name, err)
+		}
+
+		return nil
+	}
+
+	if err := replaceQdisc(link); err != nil {
+		return fmt.Errorf("replacing clsact qdisc for interface %s: %w", link.Attrs().Name, err)
+	}
+
+	filter := &netlink.BpfFilter{
+		FilterAttrs: netlink.FilterAttrs{
+			LinkIndex: link.Attrs().Index,
+			Parent:    qdiscParent,
+			Handle:    1,
+			Protocol:  unix.ETH_P_ALL,
+			Priority:  option.Config.TCFilterPriority,
+		},
+		Fd:           prog.FD(),
+		Name:         fmt.Sprintf("cilium-%s", link.Attrs().Name),
+		DirectAction: true,
+	}
+
+	if err := netlink.FilterReplace(filter); err != nil {
+		return fmt.Errorf("replacing tc filter: %w", err)
+	}
+
+	return nil
 }
 
 // RemoveTCFilters removes all tc filters from the given interface.

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -118,7 +118,7 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev, xdpMode string, extraCAr
 	}
 
 	objPath := path.Join(dirs.Output, prog.Output)
-	finalize, err := replaceDatapath(ctx, xdpDev, objPath, symbolFromHostNetdevEp, "", true, xdpMode)
+	finalize, err := replaceDatapath(ctx, xdpDev, objPath, symbolFromHostNetdevXDP, "", xdpMode)
 	if err != nil {
 		return err
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -692,7 +692,7 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 			err = e.owner.Datapath().Loader().CompileOrLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
 			if err == nil {
 				e.getLogger().Info("Rewrote endpoint BPF program")
-			} else {
+			} else if !errors.Is(err, context.Canceled) {
 				e.getLogger().WithError(err).Error("Error while rewriting endpoint BPF program")
 			}
 			compilationExecuted = true

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -366,6 +366,12 @@ func (e *Endpoint) Stop() {
 	// closed elsewhere.
 	e.eventQueue.Stop()
 
+	// Cancel active controllers for the endpoint tied to e.aliveCtx.
+	// Needs to be performed before draining the event queue to allow
+	// in-flight functions to act before the Endpoint's underlying resources
+	// are removed by the container runtime.
+	e.aliveCancel()
+
 	// Wait for the queue to be drained in case an event which is currently
 	// running for the endpoint tries to acquire the lock - we cannot be sure
 	// what types of events will be pushed onto the EventQueue for an endpoint
@@ -379,7 +385,4 @@ func (e *Endpoint) Stop() {
 	// if anything is blocking on it. If a delete request has already been
 	// enqueued for this endpoint, this is a no-op.
 	e.closeBPFProgramChannel()
-
-	// Cancel active controllers for the endpoint tied to e.aliveCtx.
-	e.aliveCancel()
 }

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -76,7 +76,7 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGe
 				logfields.EndpointID: epDirName,
 			})
 			fullDirName := filepath.Join(basePath, epDirName)
-			scopedLog.Warning(fmt.Sprintf("Found incomplete restore directory %s. Removing it...", fullDirName))
+			scopedLog.Info(fmt.Sprintf("Found incomplete restore directory %s. Removing it...", fullDirName))
 			if err := os.RemoveAll(epDirName); err != nil {
 				scopedLog.WithError(err).Warn(fmt.Sprintf("Error while removing directory %s. Ignoring it...", fullDirName))
 			}
@@ -212,7 +212,6 @@ func (e *Endpoint) RegenerateAfterRestore() error {
 		RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
 	}
 	if buildSuccess := <-e.Regenerate(regenerationMetadata); !buildSuccess {
-		scopedLog.Warn("Failed while regenerating endpoint")
 		return fmt.Errorf("failed while regenerating endpoint")
 	}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -2234,7 +2235,7 @@ type DaemonConfig struct {
 
 	// TCFilterPriority sets the priority of the cilium tc filter, enabling other
 	// filters to be inserted prior to the cilium filter.
-	TCFilterPriority int
+	TCFilterPriority uint16
 
 	// Enables BGP control plane features.
 	EnableBGPControlPlane bool
@@ -2940,7 +2941,6 @@ func (c *DaemonConfig) Populate() {
 	c.BGPAnnouncePodCIDR = viper.GetBool(BGPAnnouncePodCIDR)
 	c.BGPConfigPath = viper.GetString(BGPConfigPath)
 	c.ExternalClusterIP = viper.GetBool(ExternalClusterIPName)
-	c.TCFilterPriority = viper.GetInt(TCFilterPriority)
 
 	c.EnableIPv4Masquerade = viper.GetBool(EnableIPv4Masquerade) && c.EnableIPv4
 	c.EnableIPv6Masquerade = viper.GetBool(EnableIPv6Masquerade) && c.EnableIPv6
@@ -2961,6 +2961,12 @@ func (c *DaemonConfig) Populate() {
 		}
 		c.VLANBPFBypass = append(c.VLANBPFBypass, vlanID)
 	}
+
+	tcFilterPrio := viper.GetUint32(TCFilterPriority)
+	if tcFilterPrio > math.MaxUint16 {
+		log.Fatalf("%s cannot be higher than %d", TCFilterPriority, math.MaxUint16)
+	}
+	c.TCFilterPriority = uint16(tcFilterPrio)
 
 	c.Tunnel = viper.GetString(TunnelName)
 	c.TunnelPort = viper.GetInt(TunnelPortName)

--- a/pkg/serializer/func_queue.go
+++ b/pkg/serializer/func_queue.go
@@ -3,91 +3,50 @@
 
 package serializer
 
-var (
-	// NoRetry always returns false independently of the number of retries.
-	NoRetry = func(int) bool { return false }
-)
-
-// WaitFunc will be invoked each time a queued function has returned an error.
-// nRetries will be set to the number of consecutive execution failures that
-// have occurred so far. The WaitFunc must return true if execution must be
-// retried or false if the function must be returned from the queue.
-type WaitFunc func(nRetries int) bool
-
-type queuedFunction struct {
-	f        func() error
-	waitFunc WaitFunc
-}
-
 type FunctionQueue struct {
-	queue  chan queuedFunction
+	queue  chan func() error
 	stopCh chan struct{}
 	err    error
 }
 
 // NewFunctionQueue returns a FunctionQueue that will be used to execute
 // functions in the same order they are enqueued.
-func NewFunctionQueue(queueSize uint) *FunctionQueue {
+func NewFunctionQueue() *FunctionQueue {
 	fq := &FunctionQueue{
-		queue:  make(chan queuedFunction, queueSize),
+		queue:  make(chan func() error),
 		stopCh: make(chan struct{}),
 	}
 	go fq.run()
 	return fq
 }
 
-// run starts the FunctionQueue internal worker. It will be stopped once
-// `stopCh` is closed or receives a value.
+// run the queue's internal worker. Returns when stopCh is closed or when
+// a function has been dequeued and executed. Closes stopCh after invoking
+// a function.
 func (fq *FunctionQueue) run() {
-	for {
-		select {
-		case <-fq.stopCh:
-			return
-		case f := <-fq.queue:
-			retries := 0
-			for {
-				select {
-				case <-fq.stopCh:
-					return
-				default:
-				}
-				retries++
-				fq.err = f.f()
-				if fq.err != nil {
-					if !f.waitFunc(retries) {
-						break
-					}
-				} else {
-					break
-				}
-			}
-		}
+	select {
+	case f := <-fq.queue:
+		fq.err = f()
+		// Unblock all callers to Wait().
+		close(fq.stopCh)
+	case <-fq.stopCh:
+		return
 	}
 }
 
-// Stop stops the function queue from processing the functions on the queue.
-// If there are functions in the queue waiting for them to be processed, they
-// won't be executed.
-func (fq *FunctionQueue) Stop() {
-	close(fq.stopCh)
-}
-
-// Wait until the FunctionQueue is stopped, or the specified context deadline
-// expires. Returns the error from the context, or nil if the FunctionQueue
-// was completed before the context deadline.
+// Wait for the queue to be stopped.
+//
+// Returns any error returned by an enqueued function.
 func (fq *FunctionQueue) Wait() error {
 	<-fq.stopCh
 	return fq.err
 }
 
-// Enqueue enqueues the receiving function `f` to be executed by the function
-// queue. Depending on the size of the function queue and the amount
-// of functions queued, this function can block until the function queue
-// is ready to receive more requests.
-// If `f` returns an error, `waitFunc` will be executed and, depending on the
-// return value of `waitFunc`, `f` will be executed again or not.
-// The return value of `f` will not be logged and it's up to the caller to log
-// it properly.
-func (fq *FunctionQueue) Enqueue(f func() error, waitFunc WaitFunc) {
-	fq.queue <- queuedFunction{f: f, waitFunc: waitFunc}
+// Enqueue f to the queue. Blocks if the queue is full.
+// Returns immediately if the queue has been closed.
+func (fq *FunctionQueue) Enqueue(f func() error) {
+	select {
+	case fq.queue <- f:
+	case <-fq.stopCh:
+	}
 }

--- a/pkg/serializer/func_queue.go
+++ b/pkg/serializer/func_queue.go
@@ -84,7 +84,7 @@ func (fq *FunctionQueue) Wait(ctx context.Context) error {
 	case <-ctx.Done():
 	}
 	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("serializer %s", err)
+		return fmt.Errorf("serializer: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Description taken from the main commit. Best reviewed per commit.

> This commit mainly modifies replaceDatapath() to invoke the cilium/ebpf ELF
loader instead of shelling out to iproute2's tc and ip commands.
>
> Note that this patch focuses on a 1:1 conversion to minimize churn and to keep
it reasonably reviewable. Many changes of larger magnitude are planned to make
the datapath and loader provide an actual API that will serve as a foundation
for testing infrastructure and higher-level packages. The goal here is to get
the ball rolling.
>
> Programs are no longer being referred to using their ELF section names, but
using their C function names instead.
>
> Changes to init.sh are notably excluded because they require additional care
and attention, as well as adding CLI commands to the agent that wrap the Go
loader code to replace tc/ip invocations. This will be tackled in follow-ups.
>
> ctx and `xdp bool` were removed from replaceDatapath(). ctx is no longer used,
ebpf library code is generally not cancellable. All uses of xdp/xdpMode were
either 'true, xdpMode' or 'false, ""', so this was reduced to a single flag
xdpMode that is acted upon when non-zero. This simplifies logic and doesn't
allow both parameters to contradict each other.

```release-note
Load datapath ELFs using cilium/ebpf
```
