### PR TITLE
routing: Fix the incorrect deletion of IP rules

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -231,7 +231,8 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerI
 		option.Config.IPAM == ipamOption.IPAMAzure) && result != nil {
 		var routingInfo *linuxrouting.RoutingInfo
 		routingInfo, err = linuxrouting.NewRoutingInfo(result.GatewayIP, result.CIDRs,
-			result.PrimaryMAC, result.InterfaceNumber, option.Config.EnableIPv4Masquerade)
+			result.PrimaryMAC, result.InterfaceNumber, option.Config.IPAM,
+			option.Config.EnableIPv4Masquerade)
 		if err != nil {
 			err = fmt.Errorf("failed to create router info %w", err)
 			return
@@ -411,6 +412,7 @@ func (d *Daemon) parseHealthEndpointInfo(result *ipam.AllocationResult) error {
 		result.CIDRs,
 		result.PrimaryMAC,
 		result.InterfaceNumber,
+		option.Config.IPAM,
 		option.Config.EnableIPv4Masquerade,
 	)
 	return err

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -39,6 +39,9 @@ type RoutingInfo struct {
 	// egress traffic is directed to. This is used to compute the table ID for
 	// the per-ENI tables.
 	InterfaceNumber int
+
+	// IpamMode tells us which IPAM mode is being used (e.g., ENI, AKS).
+	IpamMode string
 }
 
 func (info *RoutingInfo) GetIPv4CIDRs() []net.IPNet {
@@ -58,11 +61,11 @@ func (info *RoutingInfo) GetInterfaceNumber() int {
 // (on either ENI or Azure interface) is the only supported path currently.
 // Azure does not support masquerade yet (subnets CIDRs aren't provided):
 // until it does, we forward a masquerade bool to opt out ipam.Cidrs use.
-func NewRoutingInfo(gateway string, cidrs []string, mac, ifaceNum string, masquerade bool) (*RoutingInfo, error) {
-	return parse(gateway, cidrs, mac, ifaceNum, masquerade)
+func NewRoutingInfo(gateway string, cidrs []string, mac, ifaceNum, ipamMode string, masquerade bool) (*RoutingInfo, error) {
+	return parse(gateway, cidrs, mac, ifaceNum, ipamMode, masquerade)
 }
 
-func parse(gateway string, cidrs []string, macAddr, ifaceNum string, masquerade bool) (*RoutingInfo, error) {
+func parse(gateway string, cidrs []string, macAddr, ifaceNum, ipamMode string, masquerade bool) (*RoutingInfo, error) {
 	ip := net.ParseIP(gateway)
 	if ip == nil {
 		return nil, fmt.Errorf("invalid ip: %s", gateway)
@@ -98,5 +101,6 @@ func parse(gateway string, cidrs []string, macAddr, ifaceNum string, masquerade 
 		MasterIfMAC:     parsedMAC,
 		Masquerade:      masquerade,
 		InterfaceNumber: parsedIfaceNum,
+		IpamMode:        ipamMode,
 	}, nil
 }

--- a/pkg/datapath/linux/routing/info_test.go
+++ b/pkg/datapath/linux/routing/info_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/checker"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/mac"
 )
 
@@ -116,6 +117,7 @@ func (e *LinuxRoutingSuite) TestParse(c *check.C) {
 				IPv4CIDRs:       validCIDRs,
 				MasterIfMAC:     fakeMAC,
 				InterfaceNumber: 1,
+				IpamMode:        ipamOption.IPAMENI,
 			},
 			wantErr: false,
 		},
@@ -130,6 +132,7 @@ func (e *LinuxRoutingSuite) TestParse(c *check.C) {
 				IPv4Gateway: net.ParseIP("192.168.1.1"),
 				IPv4CIDRs:   []net.IPNet{},
 				MasterIfMAC: fakeMAC,
+				IpamMode:    ipamOption.IPAMENI,
 			},
 			wantErr: false,
 		},
@@ -145,7 +148,7 @@ func (e *LinuxRoutingSuite) TestParse(c *check.C) {
 	}
 	for _, tt := range tests {
 		c.Log(tt.name)
-		rInfo, err := NewRoutingInfo(tt.gateway, tt.cidrs, tt.macAddr, tt.ifaceNum, tt.masq)
+		rInfo, err := NewRoutingInfo(tt.gateway, tt.cidrs, tt.macAddr, tt.ifaceNum, ipamOption.IPAMENI, tt.masq)
 		c.Assert(rInfo, checker.DeepEquals, tt.wantRInfo)
 		c.Assert((err != nil), check.Equals, tt.wantErr)
 	}

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -177,7 +177,9 @@ func Delete(ip net.IP, compat bool) error {
 	}
 
 	// Egress rules
-	if info := node.GetRouterInfo(); info != nil && option.Config.IPAM == ipamOption.IPAMENI {
+	// The condition here should mirror the conditions in Configure.
+	info := node.GetRouterInfo()
+	if info != nil && option.Config.EnableIPv4Masquerade && option.Config.IPAM == ipamOption.IPAMENI {
 		ipv4CIDRs := info.GetIPv4CIDRs()
 		cidrs := make([]*net.IPNet, 0, len(ipv4CIDRs))
 		for i := range ipv4CIDRs {

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -74,7 +74,8 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool) error {
 		tableID = computeTableIDFromIfaceNumber(info.InterfaceNumber)
 	}
 
-	if info.Masquerade {
+	// The condition here should mirror the condition in Delete.
+	if info.Masquerade && info.IpamMode == ipamOption.IPAMENI {
 		// Lookup a VPC specific table for all traffic from an endpoint to the
 		// CIDR configured for the VPC on which the endpoint has the IP on.
 		for _, cidr := range info.IPv4CIDRs {

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/mac"
 )
 
@@ -249,6 +250,7 @@ func getFakes(c *C) (net.IP, RoutingInfo) {
 		[]string{fakeCIDR.String()},
 		fakeMAC.String(),
 		"1",
+		ipamOption.IPAMENI,
 		true,
 	)
 	c.Assert(err, IsNil)

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -51,6 +51,7 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 		cidrs,
 		ipam.MasterMac,
 		ipam.InterfaceNumber,
+		conf.IpamMode,
 		masq,
 	)
 	if err != nil {


### PR DESCRIPTION
### First commit

The IP rules for ENI can have two forms, with or without the `to x.x.x.x/x` part. There is a bug between the creation and deletion of rules, where the conditions to decide which form to use aren't the same. As a result, we would attempt to remove the wrong IP rules on pod deletion, causing a warning message in logs and leaving a stale IP rule behind:

    level=warning msg="No rule matching found" rule="111: from 100.69.11.94/32 to 10.244.0.0/16 lookup 0" subsys=linux-routing

In case a new rule is later added for a new pod with the same IP, we can end up with a conflict if the new pod is on a different ENI. We will then have two rules for the same IP with lookups in different routing tables.

    111: from 10.19.192.168 lookup 10
    111: from 10.19.192.168 lookup 11

This conflict can then cause connectivity issues because of pod traffic leaving through the wrong interface.

Flag `--aws-release-excess-ips` needs to be enabled for the bug to occur. Otherwise the IP address stays attached to the same ENI and we don't end up with an IP rule conflict.

### Second commit

See commit for details. It fixes another inconsistency, this time without any consequence.

```release-note
Fix bug that would cause some pod traffic to leave through the wrong interface if --aws-release-excess-ips is used and masquerading disabled.
```