### PR TITLE
daemon: Bypass K8s cache check if K8s disabled

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1187,6 +1187,9 @@ func (d *Daemon) GetNodeSuffix() string {
 // K8sCacheIsSynced returns true if the agent has fully synced its k8s cache
 // with the API server
 func (d *Daemon) K8sCacheIsSynced() bool {
+	if !k8s.IsEnabled() {
+		return true
+	}
 	select {
 	case <-d.k8sCachesSynced:
 		return true


### PR DESCRIPTION
One of the main callers of the K8s cache sync checker is the logic of
the kube-apiserver policy feature. However, if K8s is disabled, this is
all moot and the kube-apiserver policy feature, well, isn't relevant.
Bypass the check on the cache channel if K8s is disabled.

The reason why this commit chooses to return true here instead of at the
ipcache.InjectLabels() call site is because the ipcache package would
have an import cycle with the k8s package. The logic implemented in this
commit isn't in the ideal location, but until the k8s & ipcache packages
are reasonably well isolated from each other, then this is the only
approach to workaround the problem.

Signed-off-by: Chris Tarazi <chris@isovalent.com>

Fixes: https://github.com/cilium/cilium/issues/19164

```release-note
Fix bug where the 'ipcache-inject-labels' controller constantly fails in non-Kubernetes environments
```
