### PR TITLE
cmd: Fix issue where a ConfigMap value of `{}` was parsed as `map["{}":""]`.

### DIFF
--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -449,19 +449,19 @@ func (c *OperatorConfig) Populate() {
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), IPAMSubnetsTags); err != nil {
 		log.Fatalf("unable to parse %s: %s", IPAMSubnetsTags, err)
-	} else if len(m) != 0 {
+	} else {
 		c.IPAMSubnetsTags = m
 	}
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), AWSInstanceLimitMapping); err != nil {
 		log.Fatalf("unable to parse %s: %s", AWSInstanceLimitMapping, err)
-	} else if len(m) != 0 {
+	} else {
 		c.AWSInstanceLimitMapping = m
 	}
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), ENITags); err != nil {
 		log.Fatalf("unable to parse %s: %s", ENITags, err)
-	} else if len(m) != 0 {
+	} else {
 		c.ENITags = m
 	}
 }

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -39,6 +39,15 @@ func TestGetStringMapString(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "valid empty json",
+			args: args{
+				key:   "FOO_BAR",
+				value: "{}",
+			},
+			want:    map[string]string{},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "invalid json format with extra comma at the end",
 			args: args{
 				key:   "FOO_BAR",

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2881,19 +2881,19 @@ func (c *DaemonConfig) Populate() {
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), KVStoreOpt); err != nil {
 		log.Fatalf("unable to parse %s: %s", KVStoreOpt, err)
-	} else if len(m) != 0 {
+	} else {
 		c.KVStoreOpt = m
 	}
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), LogOpt); err != nil {
 		log.Fatalf("unable to parse %s: %s", LogOpt, err)
-	} else if len(m) != 0 {
+	} else {
 		c.LogOpt = m
 	}
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), APIRateLimitName); err != nil {
 		log.Fatalf("unable to parse %s: %s", APIRateLimitName, err)
-	} else if len(m) != 0 {
+	} else {
 		c.APIRateLimit = m
 	}
 


### PR DESCRIPTION
Because string map options are declared with `flags.Var`, they are assigned
twice: Once in `flags.Var`, and then again in `option.Config.Populate()`
with `GetStringMapString`. 

The latter is needed because it works around a viper bug where ConfigMap
options were not properly parsed (see https://github.com/cilium/cilium/issues/18328). 

This commit ensures we're always using the result of the fallback parser,
which fixes a bug where a ConfigMap value of `{}` was parsed as `map["{}":""]`.

This most prominently affects the `eni-tags` operator ConfigMap option,
which we set to `{}` by default. This resulted in Cilium creating ENIs with
a tag with `"{}"` and value `""`.

Fixes: 768659f2fe1520e89330cdc3f12aa26e219e9669 ("cmd: Fix issue reading string map type via config map")