### PR TITLE
build: Fix cross compiling for amd64 on arm64

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -22,7 +22,9 @@ LIBDIR?=$(PREFIX)/lib
 LOCALSTATEDIR?=/var
 RUNDIR?=/var/run
 CONFDIR?=/etc
-export GOARCH ?= $(shell $(GO) env GOARCH)
+
+NATIVE_ARCH = $(shell GOARCH= $(GO) env GOARCH)
+export GOARCH ?= $(NATIVE_ARCH)
 
 INSTALL = install
 
@@ -125,10 +127,17 @@ else
 endif
 
 GO_BUILD = CGO_ENABLED=0 $(GO) build
-# Currently crosscompiling only enabled for arm64 targets
+
+# Support CGO cross-compiling for amd64 and arm64 targets
 CGO_CC =
-ifeq ($(GOARCH),arm64)
+CROSS_ARCH =
+ifneq ($(GOARCH),$(NATIVE_ARCH))
+    CROSS_ARCH = $(GOARCH)
+endif
+ifeq ($(CROSS_ARCH),arm64)
     CGO_CC = CC=aarch64-linux-gnu-gcc
+else ifeq ($(CROSS_ARCH),amd64)
+    CGO_CC = CC=x86_64-linux-gnu-gcc
 endif
 GO_BUILD_WITH_CGO = CGO_ENABLED=1 $(CGO_CC) $(GO) build
 

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -35,9 +35,12 @@ LLC   ?= llc
 HOST_CC    ?= gcc
 HOST_STRIP ?= strip
 
-ifeq ($(IMAGE_CROSS_TARGET_PLATFORM),linux/arm64)
+ifeq ($(GOARCH),arm64)
   HOST_CC = aarch64-linux-gnu-gcc
   HOST_STRIP = aarch64-linux-gnu-strip
+else ifeq ($(GOARCH),amd64)
+  HOST_CC = x86_64-linux-gnu-gcc
+  HOST_STRIP = x86_64-linux-gnu-strip
 endif
 
 # Define all at the top here so that Makefiles which include this one will hit

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -49,7 +49,7 @@ ARG LIBNETWORK_PLUGIN
 #
 WORKDIR /go/src/github.com/cilium/cilium
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
-    make IMAGE_CROSS_TARGET_PLATFORM=${TARGETOS}/${TARGETARCH} GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} PKG_BUILD=1 V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
+    make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} PKG_BUILD=1 V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
     DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} build-container install-container-binary
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \


### PR DESCRIPTION
Add support for cross-compiling for amd64 on arm64 in bpf Makefile as
well as with CGO.

Remove IMAGE_CROSS_TARGET_PLATFORM from Cilium Dockerfile as GOARCH is
used for the same purpose.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>