### PR TITLE
daemon, k8s: Convert CEP event handling to subscriber model

### DIFF
--- a/pkg/k8s/cep/cep.go
+++ b/pkg/k8s/cep/cep.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package cep contains the CiliumEndpoint event handling logic from Kubernetes.
+package cep
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "k8s-watcher-cep")
+
+func (s *Subscriber) OnAddCiliumEndpoint(ep *types.CiliumEndpoint) error {
+	return s.OnUpdateCiliumEndpoint(nil, ep)
+}
+
+func (s *Subscriber) OnUpdateCiliumEndpoint(oldCEP, newCEP *types.CiliumEndpoint) error {
+	var namedPortsChanged bool
+	defer func() {
+		if namedPortsChanged {
+			s.pt.TriggerPolicyUpdates(true, "Named ports added or updated")
+		}
+	}()
+
+	var ipsAdded []string
+	if oldCEP != nil && oldCEP.Networking != nil {
+		// Delete the old IP addresses from the IP cache
+		defer func() {
+			for _, oldPair := range oldCEP.Networking.Addressing {
+				v4Added, v6Added := false, false
+				for _, ipAdded := range ipsAdded {
+					if ipAdded == oldPair.IPV4 {
+						v4Added = true
+					}
+					if ipAdded == oldPair.IPV6 {
+						v6Added = true
+					}
+				}
+				if !v4Added {
+					portsChanged := s.ipc.Delete(oldPair.IPV4, source.CustomResource)
+					if portsChanged {
+						namedPortsChanged = true
+					}
+				}
+				if !v6Added {
+					portsChanged := s.ipc.Delete(oldPair.IPV6, source.CustomResource)
+					if portsChanged {
+						namedPortsChanged = true
+					}
+				}
+			}
+		}()
+	}
+
+	// default to the standard sey
+	encryptionKey := node.GetIPsecKeyIdentity()
+
+	id := identity.ReservedIdentityUnmanaged
+	if newCEP.Identity != nil {
+		id = identity.NumericIdentity(newCEP.Identity.ID)
+	}
+
+	if newCEP.Encryption != nil {
+		encryptionKey = uint8(newCEP.Encryption.Key)
+	}
+
+	if newCEP.Networking == nil || newCEP.Networking.NodeIP == "" {
+		// When upgrading from an older version, the nodeIP may
+		// not be available yet in the CiliumEndpoint and we
+		// have to wait for it to be propagated
+		return nil
+	}
+
+	nodeIP := net.ParseIP(newCEP.Networking.NodeIP)
+	if nodeIP == nil {
+		log.WithField("nodeIP", newCEP.Networking.NodeIP).Warning("Unable to parse node IP while processing CiliumEndpoint update")
+		return nil
+	}
+
+	k8sMeta := &ipcache.K8sMetadata{
+		Namespace:  newCEP.Namespace,
+		PodName:    newCEP.Name,
+		NamedPorts: make(policy.NamedPortMap, len(newCEP.NamedPorts)),
+	}
+	for _, port := range newCEP.NamedPorts {
+		p, err := u8proto.ParseProtocol(port.Protocol)
+		if err != nil {
+			continue
+		}
+		k8sMeta.NamedPorts[port.Name] = policy.PortProto{
+			Port:  port.Port,
+			Proto: uint8(p),
+		}
+	}
+
+	for _, pair := range newCEP.Networking.Addressing {
+		if pair.IPV4 != "" {
+			ipsAdded = append(ipsAdded, pair.IPV4)
+			portsChanged, _ := s.ipc.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
+				ipcache.Identity{ID: id, Source: source.CustomResource})
+			if portsChanged {
+				namedPortsChanged = true
+			}
+		}
+
+		if pair.IPV6 != "" {
+			ipsAdded = append(ipsAdded, pair.IPV6)
+			portsChanged, _ := s.ipc.Upsert(pair.IPV6, nodeIP, encryptionKey, k8sMeta,
+				ipcache.Identity{ID: id, Source: source.CustomResource})
+			if portsChanged {
+				namedPortsChanged = true
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *Subscriber) OnDeleteCiliumEndpoint(ep *types.CiliumEndpoint) error {
+	if ep.Networking != nil {
+		namedPortsChanged := false
+		for _, pair := range ep.Networking.Addressing {
+			if pair.IPV4 != "" {
+				portsChanged := s.ipc.DeleteOnMetadataMatch(pair.IPV4, source.CustomResource, ep.Namespace, ep.Name)
+				if portsChanged {
+					namedPortsChanged = true
+				}
+			}
+
+			if pair.IPV6 != "" {
+				portsChanged := s.ipc.DeleteOnMetadataMatch(pair.IPV6, source.CustomResource, ep.Namespace, ep.Name)
+				if portsChanged {
+					namedPortsChanged = true
+				}
+			}
+		}
+		if namedPortsChanged {
+			s.pt.TriggerPolicyUpdates(true, "Named ports deleted")
+		}
+	}
+	return nil
+}
+
+func New(pt policyTriggerer, ipc *ipcache.IPCache) *Subscriber {
+	return &Subscriber{
+		pt:  pt,
+		ipc: ipc,
+	}
+}
+
+type Subscriber struct {
+	pt  policyTriggerer
+	ipc *ipcache.IPCache
+}
+
+type policyTriggerer interface {
+	TriggerPolicyUpdates(bool, string)
+}

--- a/pkg/k8s/watchers/cilium_egress_gateway_policy.go
+++ b/pkg/k8s/watchers/cilium_egress_gateway_policy.go
@@ -82,6 +82,9 @@ func (k *K8sWatcher) addCiliumEgressNATPolicy(cenp *cilium_v2alpha1.CiliumEgress
 		scopedLog.WithError(err).Warn("Failed to add CiliumEgressNATPolicy: malformed policy config.")
 		return err
 	}
+	// GH-15471: Create egress policy subscriber and convert logic here to the
+	// new subscriber. Remove egressGatewayManager interface from the
+	// K8sWatcher.
 	k.egressGatewayManager.OnAddEgressPolicy(*ep)
 
 	return err

--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
@@ -40,7 +40,7 @@ func (cs *cesSubscriber) OnAdd(ces *cilium_v2a1.CiliumEndpointSlice) {
 			timeSinceCepCreated := time.Since(p.GetCreatedAt())
 			metrics.EndpointPropagationDelay.WithLabelValues().Observe(timeSinceCepCreated.Seconds())
 		}
-		cs.kWatcher.endpointUpdated(nil, c)
+		cs.kWatcher.CiliumEndpointChain.OnAddCiliumEndpoint(c)
 	}
 }
 
@@ -78,7 +78,7 @@ func (cs *cesSubscriber) OnUpdate(oldCES, newCES *cilium_v2a1.CiliumEndpointSlic
 			// Delete CEP if and only if that CEP is owned by a CES, that was used during CES updated.
 			// Delete CEP only if there is match in CEPToCES map and also delete CEPName in CEPToCES map.
 			if cesName := cepMap.getCESName(CEPName); cesName == oldCES.GetName() {
-				cs.kWatcher.endpointDeleted(c)
+				cs.kWatcher.CiliumEndpointChain.OnDeleteCiliumEndpoint(c)
 				cepMap.deleteCEP(CEPName)
 			}
 		}
@@ -96,7 +96,7 @@ func (cs *cesSubscriber) OnUpdate(oldCES, newCES *cilium_v2a1.CiliumEndpointSlic
 				timeSinceCepCreated := time.Since(p.GetCreatedAt())
 				metrics.EndpointPropagationDelay.WithLabelValues().Observe(timeSinceCepCreated.Seconds())
 			}
-			cs.kWatcher.endpointUpdated(nil, c)
+			cs.kWatcher.CiliumEndpointChain.OnUpdateCiliumEndpoint(nil, c)
 			cepMap.insertCEP(CEPName, oldCES.GetName())
 		}
 	}
@@ -113,7 +113,7 @@ func (cs *cesSubscriber) OnUpdate(oldCES, newCES *cilium_v2a1.CiliumEndpointSlic
 			}).Debug("CES updated, calling endpointUpdated")
 			newC := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(newCEP, newCES.Namespace)
 			oldC := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(oldCEP, oldCES.Namespace)
-			cs.kWatcher.endpointUpdated(oldC, newC)
+			cs.kWatcher.CiliumEndpointChain.OnUpdateCiliumEndpoint(oldC, newC)
 			cepMap.insertCEP(CEPName, oldCES.GetName())
 		}
 	}
@@ -136,7 +136,7 @@ func (cs *cesSubscriber) OnDelete(ces *cilium_v2a1.CiliumEndpointSlice) {
 		// Delete CEP if and only if that CEP is owned by a CES, that was used during CES updated.
 		// Delete CEP only if there is match in CEPToCES map and also delete CEPName in CEPToCES map.
 		if cesName := cepMap.getCESName(ces.Namespace + "/" + ep.Name); cesName == ces.GetName() {
-			cs.kWatcher.endpointDeleted(c)
+			cs.kWatcher.CiliumEndpointChain.OnDeleteCiliumEndpoint(c)
 			cepMap.deleteCEP(ep.Name)
 		}
 	}

--- a/pkg/k8s/watchers/subscriber/ciliumendpoint.go
+++ b/pkg/k8s/watchers/subscriber/ciliumendpoint.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package subscriber
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/k8s/types"
+)
+
+var _ CiliumEndpoint = (*CiliumEndpointChain)(nil)
+
+// CiliumEndpoint is implemented by event handlers responding to CiliumEndpoint events.
+type CiliumEndpoint interface {
+	OnAddCiliumEndpoint(cep *types.CiliumEndpoint) error
+	OnUpdateCiliumEndpoint(oldEP, newCEP *types.CiliumEndpoint) error
+	OnDeleteCiliumEndpoint(cep *types.CiliumEndpoint) error
+}
+
+// CiliumEndpointChain holds the subsciber.CiliumEndpoint implementations that
+// are notified when reacting to CiliumEndpoint resource / object changes in
+// the K8s watchers.
+//
+// CiliumEndpointChain itself is an implementation of
+// subscriber.CiliumEndpointChain with an additional Register method for
+// attaching children subscribers to the chain.
+type CiliumEndpointChain struct {
+	list
+
+	subs []CiliumEndpoint
+}
+
+// NewCiliumEndpointChain creates a CiliumEndpointChain ready for its Register
+// method to be called.
+func NewCiliumEndpointChain() *CiliumEndpointChain {
+	return &CiliumEndpointChain{}
+}
+
+// Register registers s as a subscriber for reacting to CiliumEndpoint objects
+// into the list.
+func (l *CiliumEndpointChain) Register(s CiliumEndpoint) {
+	l.Lock()
+	l.subs = append(l.subs, s)
+	l.Unlock()
+}
+
+// OnAddCiliumEndpoint notifies all the subscribers of an add event to a CiliumEndpoint.
+func (l *CiliumEndpointChain) OnAddCiliumEndpoint(cep *types.CiliumEndpoint) error {
+	l.RLock()
+	defer l.RUnlock()
+	errs := []error{}
+	for _, s := range l.subs {
+		if err := s.OnAddCiliumEndpoint(cep); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("Errors: %v", errs)
+	}
+	return nil
+}
+
+// OnUpdateCiliumEndpoint notifies all the subscribers of an update event to a CiliumEndpoint.
+func (l *CiliumEndpointChain) OnUpdateCiliumEndpoint(oldCEP, newCEP *types.CiliumEndpoint) error {
+	l.RLock()
+	defer l.RUnlock()
+	errs := []error{}
+	for _, s := range l.subs {
+		if err := s.OnUpdateCiliumEndpoint(oldCEP, newCEP); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("Errors: %v", errs)
+	}
+	return nil
+}
+
+// OnDeleteCiliumEndpoint notifies all the subscribers of a delete event to a
+// CiliumEndpoint.
+func (l *CiliumEndpointChain) OnDeleteCiliumEndpoint(cep *types.CiliumEndpoint) error {
+	l.RLock()
+	defer l.RUnlock()
+	errs := []error{}
+	for _, s := range l.subs {
+		if err := s.OnDeleteCiliumEndpoint(cep); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("Errors: %v", errs)
+	}
+	return nil
+}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -162,8 +162,8 @@ type bgpSpeakerManager interface {
 type egressGatewayManager interface {
 	OnAddEgressPolicy(config egressgateway.PolicyConfig)
 	OnDeleteEgressPolicy(configID types.NamespacedName)
-	OnUpdateEndpoint(endpoint *k8sTypes.CiliumEndpoint)
-	OnDeleteEndpoint(endpoint *k8sTypes.CiliumEndpoint)
+	OnUpdateCiliumEndpoint(oldCEP, endpoint *k8sTypes.CiliumEndpoint) error
+	OnDeleteCiliumEndpoint(endpoint *k8sTypes.CiliumEndpoint) error
 }
 
 type K8sWatcher struct {
@@ -192,6 +192,9 @@ type K8sWatcher struct {
 	// On CiliumNode events all registered subscriber.CiliumNode implementations will
 	// have their event handling methods called in order of registration.
 	CiliumNodeChain *subscriber.CiliumNodeChain
+
+	// CiliumEndpointChain is like CiliumNodeChain but for CiliumEndpoints.
+	CiliumEndpointChain *subscriber.CiliumEndpointChain
 
 	endpointManager endpointManager
 
@@ -260,6 +263,7 @@ func NewK8sWatcher(
 		egressGatewayManager:  egressGatewayManager,
 		NodeChain:             subscriber.NewNodeChain(),
 		CiliumNodeChain:       subscriber.NewCiliumNodeChain(),
+		CiliumEndpointChain:   subscriber.NewCiliumEndpointChain(),
 		cfg:                   cfg,
 	}
 }


### PR DESCRIPTION
As part of https://github.com/cilium/cilium/issues/15471, move the CEP
handling to the new subscriber model.

This commit should have no functional changes.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
