### PR TITLE
CI: Wait for policy deletion to take effect

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3068,10 +3068,10 @@ func getPolicyEnforcingJqFilter(numNodes int) string {
 // to be applied in all Cilium endpoints. Returns an error if the policy is not
 // imported before the timeout is
 // exceeded.
-func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action ResourceLifeCycleAction, timeout time.Duration) (string, error) {
+func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action ResourceLifeCycleAction, timeout time.Duration) error {
 	podRevisions, err := kub.getPodRevisions()
 	if err != nil {
-		return "", err
+		return err
 	}
 	numNodes := len(podRevisions)
 
@@ -3079,7 +3079,7 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 
 	status := kub.Action(action, filepath, namespace)
 	if !status.WasSuccessful() {
-		return "", status.GetErr(fmt.Sprintf("Cannot perform '%s' on resource '%s'", action, filepath))
+		return status.GetErr(fmt.Sprintf("Cannot perform '%s' on resource '%s'", action, filepath))
 	}
 	unchanged := action == KubectlApply && strings.HasSuffix(status.Stdout(), " unchanged\n")
 
@@ -3124,24 +3124,24 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 			&TimeoutConfig{Timeout: timeout})
 
 		if err != nil {
-			return "", err
+			return err
 		}
 	}
 
 	// If the applied policy was unchanged, we don't need to wait for the next policy revision.
 	if unchanged {
-		return "", nil
+		return nil
 	}
 
-	return "", kub.waitNextPolicyRevisions(podRevisions, timeout)
+	return kub.waitNextPolicyRevisions(podRevisions, timeout)
 }
 
 // CiliumClusterwidePolicyAction applies a clusterwide policy action as described in action argument. It
 // then wait till timeout Duration for the policy to be applied to all the cilium endpoints.
-func (kub *Kubectl) CiliumClusterwidePolicyAction(filepath string, action ResourceLifeCycleAction, timeout time.Duration) (string, error) {
+func (kub *Kubectl) CiliumClusterwidePolicyAction(filepath string, action ResourceLifeCycleAction, timeout time.Duration) error {
 	podRevisions, err := kub.getPodRevisions()
 	if err != nil {
-		return "", err
+		return err
 	}
 	numNodes := len(podRevisions)
 
@@ -3149,7 +3149,7 @@ func (kub *Kubectl) CiliumClusterwidePolicyAction(filepath string, action Resour
 
 	status := kub.Action(action, filepath)
 	if !status.WasSuccessful() {
-		return "", status.GetErr(fmt.Sprintf("Cannot perform '%s' on resource '%s'", action, filepath))
+		return status.GetErr(fmt.Sprintf("Cannot perform '%s' on resource '%s'", action, filepath))
 	}
 	unchanged := action == KubectlApply && strings.HasSuffix(status.Stdout(), " unchanged\n")
 
@@ -3188,16 +3188,16 @@ func (kub *Kubectl) CiliumClusterwidePolicyAction(filepath string, action Resour
 			&TimeoutConfig{Timeout: timeout})
 
 		if err != nil {
-			return "", err
+			return err
 		}
 	}
 
 	// If the applied policy was unchanged, we don't need to wait for the next policy revision.
 	if unchanged {
-		return "", nil
+		return nil
 	}
 
-	return "", kub.waitNextPolicyRevisions(podRevisions, timeout)
+	return kub.waitNextPolicyRevisions(podRevisions, timeout)
 }
 
 // CiliumReport report the cilium pod to the log and appends the logs for the

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -662,7 +662,7 @@ func (t *TestSpec) NetworkPolicyApply(base string) error {
 		return fmt.Errorf("Network policy cannot be written prefix=%s: %s", t.Prefix, err)
 	}
 
-	_, err = t.Kub.CiliumPolicyAction(
+	err = t.Kub.CiliumPolicyAction(
 		helpers.DefaultNamespace,
 		fmt.Sprintf("%s/%s", base, t.NetworkPolicyName()),
 		helpers.KubectlApply,

--- a/test/k8s/bookinfo.go
+++ b/test/k8s/bookinfo.go
@@ -71,16 +71,16 @@ var _ = SkipDescribeIf(func() bool {
 		})
 
 		AfterAll(func() {
-
-			// Explicitly do not check result to avoid having assertions in AfterAll.
-			_ = kubectl.Delete(policyPath)
-
 			for _, resourcePath := range resourceYAMLs {
 				By("Deleting resource %s", resourcePath)
 				// Explicitly do not check result to avoid having assertions in AfterAll.
 				_ = kubectl.Delete(resourcePath)
 			}
 			ExpectAllPodsTerminated(kubectl)
+		})
+
+		AfterEach(func() {
+			kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 		})
 
 		It("Tests bookinfo demo", func() {

--- a/test/k8s/bookinfo.go
+++ b/test/k8s/bookinfo.go
@@ -180,9 +180,7 @@ var _ = SkipDescribeIf(func() bool {
 			policyCmd := "cilium policy get io.cilium.k8s.policy.name=cnp-specs"
 
 			By("Importing policy")
-
-			err = kubectl.CiliumPolicyAction(helpers.DefaultNamespace, policyPath, helpers.KubectlCreate, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Error creating policy %q", policyPath)
+			applyPolicyDefault(kubectl, policyPath)
 
 			By("Checking that policies were correctly imported into Cilium")
 

--- a/test/k8s/bookinfo.go
+++ b/test/k8s/bookinfo.go
@@ -181,7 +181,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			By("Importing policy")
 
-			_, err = kubectl.CiliumPolicyAction(helpers.DefaultNamespace, policyPath, helpers.KubectlCreate, helpers.HelperTimeout)
+			err = kubectl.CiliumPolicyAction(helpers.DefaultNamespace, policyPath, helpers.KubectlCreate, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Error creating policy %q", policyPath)
 
 			By("Checking that policies were correctly imported into Cilium")

--- a/test/k8s/chaos.go
+++ b/test/k8s/chaos.go
@@ -244,7 +244,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sChaosTest", func() {
 				fmt.Sprintf("netperf -l 60 -t TCP_STREAM -H %s", podsIps[netperfServer]))
 
 			By("Installing the L3-L4 Policy")
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				helpers.DefaultNamespace, netperfPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot install %q policy", netperfPolicy)
 

--- a/test/k8s/chaos.go
+++ b/test/k8s/chaos.go
@@ -193,7 +193,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sChaosTest", func() {
 		})
 
 		AfterEach(func() {
-			_ = kubectl.Delete(netperfPolicy)
+			kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 		})
 
 		restartCilium := func() {

--- a/test/k8s/chaos.go
+++ b/test/k8s/chaos.go
@@ -244,9 +244,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sChaosTest", func() {
 				fmt.Sprintf("netperf -l 60 -t TCP_STREAM -H %s", podsIps[netperfServer]))
 
 			By("Installing the L3-L4 Policy")
-			err := kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, netperfPolicy, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Cannot install %q policy", netperfPolicy)
+			applyPolicyDefault(kubectl, netperfPolicy)
 
 			restartCilium()
 

--- a/test/k8s/cli.go
+++ b/test/k8s/cli.go
@@ -123,7 +123,7 @@ var _ = Describe("K8sCLI", func() {
 				Expect(err).To(BeNil(),
 					"testapp pods are not ready after timeout in namespace %q", namespaceForTest)
 
-				_, err = kubectl.CiliumPolicyAction(
+				err = kubectl.CiliumPolicyAction(
 					namespaceForTest, l3L4DenyPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Cannot apply L3 Deny Policy")
 
@@ -151,7 +151,7 @@ var _ = Describe("K8sCLI", func() {
 
 				Expect((countAfterK8s1 + countAfterK8s2) - (countBeforeK8s1 + countBeforeK8s2)).To(Equal(3))
 
-				_, err = kubectl.CiliumPolicyAction(
+				err = kubectl.CiliumPolicyAction(
 					namespaceForTest, l3L4DenyPolicy, helpers.KubectlDelete, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Cannot delete L3 Policy")
 

--- a/test/k8s/cli.go
+++ b/test/k8s/cli.go
@@ -83,6 +83,10 @@ var _ = Describe("K8sCLI", func() {
 				ExpectAllPodsTerminated(kubectl)
 			})
 
+			AfterEach(func() {
+				kubectl.DeleteAllPoliciesAndWait(namespaceForTest, helpers.HelperTimeout)
+			})
+
 			It("Test labelsSHA256", func() {
 				cmd := fmt.Sprintf("cilium identity get %d -o json", identity)
 				res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
@@ -151,8 +155,6 @@ var _ = Describe("K8sCLI", func() {
 				countAfterK8s2, _ := helpers.GetBPFPacketsCount(kubectl, ciliumPodK8s2, "Policy denied by denylist", "ingress")
 
 				Expect((countAfterK8s1 + countAfterK8s2) - (countBeforeK8s1 + countBeforeK8s2)).To(Equal(3))
-
-				deletePolicy(kubectl, namespaceForTest, l3L4DenyPolicy)
 			})
 		})
 

--- a/test/k8s/cli.go
+++ b/test/k8s/cli.go
@@ -123,9 +123,7 @@ var _ = Describe("K8sCLI", func() {
 				Expect(err).To(BeNil(),
 					"testapp pods are not ready after timeout in namespace %q", namespaceForTest)
 
-				err = kubectl.CiliumPolicyAction(
-					namespaceForTest, l3L4DenyPolicy, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "Cannot apply L3 Deny Policy")
+				applyPolicy(kubectl, namespaceForTest, l3L4DenyPolicy)
 
 				ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 				ExpectWithOffset(2, err).Should(BeNil(), "Cannot get cilium pod on k8s1")
@@ -151,9 +149,7 @@ var _ = Describe("K8sCLI", func() {
 
 				Expect((countAfterK8s1 + countAfterK8s2) - (countBeforeK8s1 + countBeforeK8s2)).To(Equal(3))
 
-				err = kubectl.CiliumPolicyAction(
-					namespaceForTest, l3L4DenyPolicy, helpers.KubectlDelete, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "Cannot delete L3 Policy")
+				deletePolicy(kubectl, namespaceForTest, l3L4DenyPolicy)
 
 				kubectl.NamespaceDelete(namespaceForTest)
 			})

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -955,7 +955,7 @@ func testHostFirewall(kubectl *helpers.Kubectl) {
 
 	demoHostPolicies := helpers.ManifestGet(kubectl.BasePath(), "host-policies.yaml")
 	By(fmt.Sprintf("Applying policies %s", demoHostPolicies))
-	_, err := kubectl.CiliumClusterwidePolicyAction(demoHostPolicies, helpers.KubectlApply, helpers.HelperTimeout)
+	err := kubectl.CiliumClusterwidePolicyAction(demoHostPolicies, helpers.KubectlApply, helpers.HelperTimeout)
 	ExpectWithOffset(1, err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", demoHostPolicies, err))
 
 	var wg sync.WaitGroup
@@ -1091,7 +1091,7 @@ func fetchPodsWithOffset(kubectl *helpers.Kubectl, namespace, name, filter, host
 func applyL3Policy(kubectl *helpers.Kubectl, ns string) {
 	demoPolicyL3 := helpers.ManifestGet(kubectl.BasePath(), "l3-policy-demo.yaml")
 	By(fmt.Sprintf("Applying policy %s", demoPolicyL3))
-	_, err := kubectl.CiliumPolicyAction(ns, demoPolicyL3, helpers.KubectlApply, helpers.HelperTimeout)
+	err := kubectl.CiliumPolicyAction(ns, demoPolicyL3, helpers.KubectlApply, helpers.HelperTimeout)
 	ExpectWithOffset(1, err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", demoPolicyL3, err))
 }
 

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -1088,11 +1088,10 @@ func fetchPodsWithOffset(kubectl *helpers.Kubectl, namespace, name, filter, host
 	return targetPod, targetPodJSON
 }
 
+// 'ns' is managed by deployment manager, so also the policy will be cleaned up with it.
 func applyL3Policy(kubectl *helpers.Kubectl, ns string) {
 	demoPolicyL3 := helpers.ManifestGet(kubectl.BasePath(), "l3-policy-demo.yaml")
-	By(fmt.Sprintf("Applying policy %s", demoPolicyL3))
-	err := kubectl.CiliumPolicyAction(ns, demoPolicyL3, helpers.KubectlApply, helpers.HelperTimeout)
-	ExpectWithOffset(1, err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", demoPolicyL3, err))
+	applyPolicy(kubectl, ns, demoPolicyL3)
 }
 
 func testPodConnectivityAndReturnIP(kubectl *helpers.Kubectl, requireMultiNode bool, callOffset int) (bool, string) {

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -838,7 +838,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 
 		AfterEach(func() {
-			kubectl.Exec(fmt.Sprintf("%s delete --all ccnp", helpers.KubectlCmd))
+			kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 		})
 
 		SkipItIf(func() bool {

--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -151,12 +151,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 			res.ExpectFail("%q can connect when it should not work", helpers.App2)
 		}
 
-		fqndProxyPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-policy.yaml")
-
-		err = kubectl.CiliumPolicyAction(
-			helpers.DefaultNamespace, fqndProxyPolicy,
-			helpers.KubectlApply, helpers.HelperTimeout)
-		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
+		fqdnProxyPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-policy.yaml")
+		applyPolicyDefault(kubectl, fqdnProxyPolicy)
 
 		connectivityTest()
 		By("restarting cilium pods")
@@ -247,14 +243,11 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 	It("Validate that multiple specs are working correctly", func() {
 		// To make sure that UUID in multiple specs are plumbed correctly to
 		// Cilium Policy
-		fqdnPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs.yaml")
 		world1Target := worldTarget
 		world2Target := worldInvalidTarget
 
-		err := kubectl.CiliumPolicyAction(
-			helpers.DefaultNamespace, fqdnPolicy,
-			helpers.KubectlApply, helpers.HelperTimeout)
-		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
+		fqdnPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs.yaml")
+		applyPolicyDefault(kubectl, fqdnPolicy)
 
 		By("Validating APP2 policy connectivity")
 		res := kubectl.ExecPodCmd(
@@ -283,14 +276,11 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 	It("Validate that FQDN policy continues to work after being updated", func() {
 		// To make sure that UUID in multiple specs are plumbed correctly to
 		// Cilium Policy
-		fqdnPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs.yaml")
 		world1Target := worldTarget
 		world2Target := worldInvalidTarget
 
-		err := kubectl.CiliumPolicyAction(
-			helpers.DefaultNamespace, fqdnPolicy,
-			helpers.KubectlApply, helpers.HelperTimeout)
-		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
+		fqdnPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs.yaml")
+		applyPolicyDefault(kubectl, fqdnPolicy)
 
 		By("Validating APP2 policy connectivity")
 		res := kubectl.ExecPodCmd(
@@ -305,10 +295,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 
 		By("Updating the policy to include an extra FQDN allow statement")
 		fqdnPolicy2 := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs-v2.yaml")
-		err = kubectl.CiliumPolicyAction(
-			helpers.DefaultNamespace, fqdnPolicy2,
-			helpers.KubectlApply, helpers.HelperTimeout)
-		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
+		applyPolicyDefault(kubectl, fqdnPolicy2)
 
 		By("Validating APP2 policy connectivity after policy change")
 		res = kubectl.ExecPodCmd(

--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -153,7 +153,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 
 		fqndProxyPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-policy.yaml")
 
-		_, err = kubectl.CiliumPolicyAction(
+		err = kubectl.CiliumPolicyAction(
 			helpers.DefaultNamespace, fqndProxyPolicy,
 			helpers.KubectlApply, helpers.HelperTimeout)
 		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
@@ -251,7 +251,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 		world1Target := worldTarget
 		world2Target := worldInvalidTarget
 
-		_, err := kubectl.CiliumPolicyAction(
+		err := kubectl.CiliumPolicyAction(
 			helpers.DefaultNamespace, fqdnPolicy,
 			helpers.KubectlApply, helpers.HelperTimeout)
 		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
@@ -287,7 +287,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 		world1Target := worldTarget
 		world2Target := worldInvalidTarget
 
-		_, err := kubectl.CiliumPolicyAction(
+		err := kubectl.CiliumPolicyAction(
 			helpers.DefaultNamespace, fqdnPolicy,
 			helpers.KubectlApply, helpers.HelperTimeout)
 		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
@@ -305,7 +305,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 
 		By("Updating the policy to include an extra FQDN allow statement")
 		fqdnPolicy2 := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs-v2.yaml")
-		_, err = kubectl.CiliumPolicyAction(
+		err = kubectl.CiliumPolicyAction(
 			helpers.DefaultNamespace, fqdnPolicy2,
 			helpers.KubectlApply, helpers.HelperTimeout)
 		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")

--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -91,7 +91,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
 	})
 
 	AfterEach(func() {
-		_ = kubectl.Exec(fmt.Sprintf("%s delete --all cnp", helpers.KubectlCmd))
+		kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 	})
 
 	SkipItIf(helpers.SkipQuarantined, "Restart Cilium validate that FQDN is still working", func() {

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -265,7 +265,7 @@ var _ = Describe("K8sHubbleTest", func() {
 			fqdnProxyPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-policy.yaml")
 			fqdnTarget := "vagrant-cache.ci.cilium.io"
 
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, fqdnProxyPolicy,
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -174,6 +174,10 @@ var _ = Describe("K8sHubbleTest", func() {
 			kubectl.CloseSSHClient()
 		})
 
+		AfterEach(func() {
+			kubectl.DeleteAllPoliciesAndWait(namespaceForTest, helpers.HelperTimeout)
+		})
+
 		It("Test L3/L4 Flow", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), helpers.MidCommandTimeout)
 			defer cancel()
@@ -266,7 +270,6 @@ var _ = Describe("K8sHubbleTest", func() {
 
 			fqdnProxyPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-policy.yaml")
 			applyPolicy(kubectl, namespaceForTest, fqdnProxyPolicy)
-			defer deletePolicy(kubectl, namespaceForTest, fqdnProxyPolicy)
 
 			res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s", fqdnTarget)))

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -262,15 +262,11 @@ var _ = Describe("K8sHubbleTest", func() {
 		})
 
 		It("Test FQDN Policy with Relay", func() {
-			fqdnProxyPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-policy.yaml")
 			fqdnTarget := "vagrant-cache.ci.cilium.io"
 
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, fqdnProxyPolicy,
-				helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
-			defer kubectl.CiliumPolicyAction(namespaceForTest, fqdnProxyPolicy,
-				helpers.KubectlDelete, helpers.HelperTimeout)
+			fqdnProxyPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-policy.yaml")
+			applyPolicy(kubectl, namespaceForTest, fqdnProxyPolicy)
+			defer deletePolicy(kubectl, namespaceForTest, fqdnProxyPolicy)
 
 			res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s", fqdnTarget)))

--- a/test/k8s/istio.go
+++ b/test/k8s/istio.go
@@ -317,9 +317,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 			// creation in this case.
 			policyPaths = []string{l7PolicyPath}
 			for _, policyPath := range policyPaths {
-				By("Creating policy in file %q", policyPath)
-				err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, policyPath, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "Unable to create policy %q", policyPath)
+				applyPolicyDefault(kubectl, policyPath)
 			}
 
 			resourceYAMLPaths = []string{bookinfoV2YAML, bookinfoV1YAML}

--- a/test/k8s/istio.go
+++ b/test/k8s/istio.go
@@ -191,12 +191,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 				// Explicitly do not check result to avoid having assertions in AfterEach.
 				_ = kubectl.Delete(resourcePath)
 			}
+			resourceYAMLPaths = nil
 
-			for _, policyPath := range policyPaths {
-				By("Deleting policy in file %q", policyPath)
-				// Explicitly do not check result to avoid having assertions in AfterEach.
-				_ = kubectl.Delete(policyPath)
-			}
+			kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		// shouldWgetConnect checks that srcPod can connect to dstURI.

--- a/test/k8s/istio.go
+++ b/test/k8s/istio.go
@@ -318,7 +318,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
 			policyPaths = []string{l7PolicyPath}
 			for _, policyPath := range policyPaths {
 				By("Creating policy in file %q", policyPath)
-				_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, policyPath, helpers.KubectlApply, helpers.HelperTimeout)
+				err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, policyPath, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Unable to create policy %q", policyPath)
 			}
 

--- a/test/k8s/kafka_policies.go
+++ b/test/k8s/kafka_policies.go
@@ -175,7 +175,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 
 			By("Apply L7 kafka policy and wait")
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				helpers.DefaultNamespace, l7Policy,
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).To(BeNil(), "L7 policy cannot be imported correctly")

--- a/test/k8s/kafka_policies.go
+++ b/test/k8s/kafka_policies.go
@@ -97,10 +97,12 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 		})
 
 		AfterEach(func() {
+			kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
+		})
+
+		AfterAll(func() {
 			// On aftereach don't make assertions to delete all.
 			_ = kubectl.Delete(demoPath)
-			_ = kubectl.Delete(l7Policy)
-
 			ExpectAllPodsTerminated(kubectl)
 		})
 

--- a/test/k8s/kafka_policies.go
+++ b/test/k8s/kafka_policies.go
@@ -173,12 +173,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 				helpers.DefaultNamespace, appPods[outpostApp], prodOutAnnounce)
 			Expect(err).Should(BeNil(), "Failed to produce to outpost on topic empire-announce")
 
-			By("Apply L7 kafka policy and wait")
-
-			err = kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, l7Policy,
-				helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).To(BeNil(), "L7 policy cannot be imported correctly")
+			applyPolicyDefault(kubectl, l7Policy)
 
 			By("Testing Kafka L7 policy enforcement status")
 			err = kubectl.ExecKafkaPodCmd(

--- a/test/k8s/l7_demos.go
+++ b/test/k8s/l7_demos.go
@@ -99,10 +99,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDemosTest", func() {
 			helpers.CurlFail("http://%s/v1", deathstarFQDN))
 		res.ExpectSuccess("unable to curl %s/v1: %s", deathstarFQDN, res.Stdout())
 
-		By("Importing L7 Policy which restricts access to %q", exhaustPortPath)
-		err = kubectl.CiliumPolicyAction(
-			helpers.DefaultNamespace, l7PolicyYAMLLink, helpers.KubectlApply, helpers.HelperTimeout)
-		Expect(err).Should(BeNil(), "Unable to apply %s", l7PolicyYAMLLink)
+		applyPolicyDefault(kubectl, l7PolicyYAMLLink)
 
 		By("Waiting for endpoints to be ready after importing policy")
 		err = kubectl.CiliumEndpointWaitReady()

--- a/test/k8s/l7_demos.go
+++ b/test/k8s/l7_demos.go
@@ -100,7 +100,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDemosTest", func() {
 		res.ExpectSuccess("unable to curl %s/v1: %s", deathstarFQDN, res.Stdout())
 
 		By("Importing L7 Policy which restricts access to %q", exhaustPortPath)
-		_, err = kubectl.CiliumPolicyAction(
+		err = kubectl.CiliumPolicyAction(
 			helpers.DefaultNamespace, l7PolicyYAMLLink, helpers.KubectlApply, helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Unable to apply %s", l7PolicyYAMLLink)
 

--- a/test/k8s/l7_demos.go
+++ b/test/k8s/l7_demos.go
@@ -45,7 +45,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDemosTest", func() {
 
 	AfterEach(func() {
 		By("Deleting all resources created during test")
-		kubectl.Delete(l7PolicyYAMLLink)
+		kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 		kubectl.Delete(deathStarYAMLLink)
 		kubectl.Delete(xwingYAMLLink)
 

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -240,13 +240,10 @@ var _ = SkipDescribeIf(func() bool {
 			logger.Infof("PolicyRulesTest: cluster service ip '%s'", clusterIP)
 
 			By("Testing L3/L4 rules")
-
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, l3Policy, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil())
+			applyPolicy(kubectl, namespaceForTest, l3Policy)
 
 			for _, appName := range []string{helpers.App1, helpers.App2, helpers.App3} {
-				err = kubectl.WaitForCEPIdentity(namespaceForTest, appPods[appName])
+				err := kubectl.WaitForCEPIdentity(namespaceForTest, appPods[appName])
 				Expect(err).Should(BeNil())
 			}
 
@@ -271,10 +268,7 @@ var _ = SkipDescribeIf(func() bool {
 			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
 			By("Testing L3/L4 deny rules")
-
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, l3PolicyDeny, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil())
+			applyPolicy(kubectl, namespaceForTest, l3PolicyDeny)
 
 			trace = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, fmt.Sprintf(
 				"cilium policy trace --src-k8s-pod %s:%s --dst-k8s-pod %s:%s --dport 80/TCP",
@@ -296,21 +290,11 @@ var _ = SkipDescribeIf(func() bool {
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, l3Policy,
-				helpers.KubectlDelete, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Cannot delete L3 Policy")
-
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, l3PolicyDeny,
-				helpers.KubectlDelete, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Cannot delete L3 Policy Deny")
+			deletePolicy(kubectl, namespaceForTest, l3Policy)
+			deletePolicy(kubectl, namespaceForTest, l3PolicyDeny)
 
 			By("Testing L7 Policy")
-
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, l7Policy, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Cannot install %q policy", l7Policy)
+			applyPolicy(kubectl, namespaceForTest, l7Policy)
 
 			// Cilium launches Envoy with path normalization enabled by default, so '//public' will be seen as '/public'.
 			// Note that 'hhtpd' performs slash merging and serves '/public' when '//public' is requested.
@@ -340,10 +324,7 @@ var _ = SkipDescribeIf(func() bool {
 				appPods[helpers.App3], clusterIP)
 
 			By("Testing L7 Policy with L3/L4 deny rules")
-
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, l3PolicyDeny, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil())
+			applyPolicy(kubectl, namespaceForTest, l3PolicyDeny)
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
@@ -375,13 +356,10 @@ var _ = SkipDescribeIf(func() bool {
 			logger.Infof("PolicyRulesTest: cluster service ip '%s'", clusterIP)
 
 			By("Testing L3/L4 rules with named ports")
-
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, l3NamedPortPolicy, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil())
+			applyPolicy(kubectl, namespaceForTest, l3NamedPortPolicy)
 
 			for _, appName := range []string{helpers.App1, helpers.App2, helpers.App3} {
-				err = kubectl.WaitForCEPIdentity(namespaceForTest, appPods[appName])
+				err := kubectl.WaitForCEPIdentity(namespaceForTest, appPods[appName])
 				Expect(err).Should(BeNil())
 			}
 
@@ -406,10 +384,7 @@ var _ = SkipDescribeIf(func() bool {
 			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
 			By("Testing L3/L4 deny rules with named ports")
-
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, l3NamedPortPolicyDeny, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil())
+			applyPolicy(kubectl, namespaceForTest, l3NamedPortPolicyDeny)
 
 			trace = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, fmt.Sprintf(
 				"cilium policy trace --src-k8s-pod %s:%s --dst-k8s-pod %s:%s --dport http-80/TCP",
@@ -431,21 +406,11 @@ var _ = SkipDescribeIf(func() bool {
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, l3NamedPortPolicy,
-				helpers.KubectlDelete, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Cannot delete L3 Policy")
-
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, l3NamedPortPolicyDeny,
-				helpers.KubectlDelete, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Cannot delete L3 Policy Deny")
+			deletePolicy(kubectl, namespaceForTest, l3NamedPortPolicy)
+			deletePolicy(kubectl, namespaceForTest, l3NamedPortPolicyDeny)
 
 			By("Testing L7 Policy with named port")
-
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, l7NamedPortPolicy, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Cannot install %q policy", l7NamedPortPolicy)
+			applyPolicy(kubectl, namespaceForTest, l7NamedPortPolicy)
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
@@ -472,10 +437,7 @@ var _ = SkipDescribeIf(func() bool {
 				appPods[helpers.App3], clusterIP)
 
 			By("Testing L7 Policy with L3/L4 deny rules with named ports")
-
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, l3NamedPortPolicyDeny, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil())
+			applyPolicy(kubectl, namespaceForTest, l3NamedPortPolicyDeny)
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
@@ -520,9 +482,7 @@ var _ = SkipDescribeIf(func() bool {
 			res = kubectl.CopyFileToPod(namespaceForTest, appPods[helpers.App2], TLSCaCerts, "/cacert.pem")
 			res.ExpectSuccess("Cannot copy certs to %s", appPods[helpers.App2])
 
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, l7PolicyTLS, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Cannot install %q policy", l7PolicyTLS)
+			applyPolicy(kubectl, namespaceForTest, l7PolicyTLS)
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
@@ -578,12 +538,10 @@ var _ = SkipDescribeIf(func() bool {
 		It("ServiceAccount Based Enforcement", func() {
 			// Load policy allowing serviceAccount of app2 to talk
 			// to app1 on port 80 TCP
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, serviceAccountPolicy, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil())
+			applyPolicy(kubectl, namespaceForTest, serviceAccountPolicy)
 
 			for _, appName := range []string{helpers.App1, helpers.App2, helpers.App3} {
-				err = kubectl.WaitForCEPIdentity(namespaceForTest, appPods[appName])
+				err := kubectl.WaitForCEPIdentity(namespaceForTest, appPods[appName])
 				Expect(err).Should(BeNil())
 			}
 
@@ -611,12 +569,10 @@ var _ = SkipDescribeIf(func() bool {
 
 			// Load policy denying serviceAccount of app2 to talk
 			// to app1 on port 80 TCP
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, serviceAccountPolicyDeny, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil())
+			applyPolicy(kubectl, namespaceForTest, serviceAccountPolicyDeny)
 
 			for _, appName := range []string{helpers.App1, helpers.App2, helpers.App3} {
-				err = kubectl.WaitForCEPIdentity(namespaceForTest, appPods[appName])
+				err := kubectl.WaitForCEPIdentity(namespaceForTest, appPods[appName])
 				Expect(err).Should(BeNil())
 			}
 
@@ -643,9 +599,7 @@ var _ = SkipDescribeIf(func() bool {
 		}, 500)
 
 		It("CNP test MatchExpressions key", func() {
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, cnpMatchExpression, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "cannot install policy %s", cnpMatchExpression)
+			applyPolicy(kubectl, namespaceForTest, cnpMatchExpression)
 
 			res := kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
@@ -658,10 +612,7 @@ var _ = SkipDescribeIf(func() bool {
 			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
 			By("Testing CNP test MatchExpressions key with policy Denies")
-
-			err = kubectl.CiliumPolicyAction(
-				namespaceForTest, cnpMatchExpressionDeny, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "cannot install policy %s", cnpMatchExpression)
+			applyPolicy(kubectl, namespaceForTest, cnpMatchExpressionDeny)
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
@@ -688,12 +639,7 @@ var _ = SkipDescribeIf(func() bool {
 			res.ExpectSuccess("%q cannot curl to %q", appPods[helpers.App3], clusterIP)
 
 			By("Installing knp ingress default-deny")
-
-			// Import the policy and wait for all required endpoints to enforce the policy
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, knpDenyIngress, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(),
-				"L3 deny-ingress Policy cannot be applied in %q namespace", namespaceForTest)
+			applyPolicy(kubectl, namespaceForTest, knpDenyIngress)
 
 			By("Testing connectivity with ingress default-deny policy loaded")
 
@@ -710,11 +656,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		It("Denies traffic with k8s default-deny egress policy", func() {
 			By("Installing knp egress default-deny")
-
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, knpDenyEgress, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(),
-				"L3 deny-egress Policy cannot be applied in %q namespace", namespaceForTest)
+			applyPolicy(kubectl, namespaceForTest, knpDenyEgress)
 
 			By("Testing if egress policy enforcement is enabled on the endpoint")
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
@@ -737,11 +679,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		It("Denies traffic with k8s default-deny ingress-egress policy", func() {
 			By("Installing knp ingress-egress default-deny")
-
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, knpDenyIngressEgress, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(),
-				"L3 deny-ingress-egress policy cannot be applied in %q namespace", namespaceForTest)
+			applyPolicy(kubectl, namespaceForTest, knpDenyIngressEgress)
 
 			By("Testing if egress and ingress policy enforcement is enabled on the endpoint")
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
@@ -776,11 +714,7 @@ var _ = SkipDescribeIf(func() bool {
 		It("Denies traffic with cnp default-deny ingress policy", func() {
 
 			By("Installing cnp ingress default-deny")
-
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, cnpDenyIngress, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(),
-				"L3 deny-ingress Policy cannot be applied in %q namespace", namespaceForTest)
+			applyPolicy(kubectl, namespaceForTest, cnpDenyIngress)
 
 			By("Testing connectivity with ingress default-deny policy loaded")
 
@@ -799,10 +733,7 @@ var _ = SkipDescribeIf(func() bool {
 		It("Denies traffic with cnp default-deny egress policy", func() {
 
 			By("Installing cnp egress default-deny")
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, cnpDenyEgress, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(),
-				"L3 deny-egress Policy cannot be applied in %q namespace", namespaceForTest)
+			applyPolicy(kubectl, namespaceForTest, cnpDenyEgress)
 
 			for _, pod := range apps {
 				res := kubectl.ExecPodCmd(
@@ -824,10 +755,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		It("Allows traffic with k8s default-allow ingress policy", func() {
 			By("Installing ingress default-allow")
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, knpAllowIngress, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(),
-				"L3 allow-ingress Policy cannot be applied in %q namespace", namespaceForTest)
+			applyPolicy(kubectl, namespaceForTest, knpAllowIngress)
 
 			By("Testing connectivity with ingress default-allow policy loaded")
 			res := kubectl.ExecPodCmd(
@@ -843,10 +771,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		It("Allows traffic with k8s default-allow egress policy", func() {
 			By("Installing egress default-allow")
-			err := kubectl.CiliumPolicyAction(
-				namespaceForTest, knpAllowEgress, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(),
-				"L3 allow-egress Policy cannot be applied in %q namespace", namespaceForTest)
+			applyPolicy(kubectl, namespaceForTest, knpAllowEgress)
 
 			By("Checking connectivity between pods and external services after installing egress policy")
 
@@ -896,13 +821,13 @@ var _ = SkipDescribeIf(func() bool {
 
 			It("Validate toEntities All", func() {
 				By("Installing toEntities All")
-				importPolicy(kubectl, namespaceForTest, cnpToEntitiesAll, "to-entities-all")
+				applyPolicy(kubectl, namespaceForTest, cnpToEntitiesAll)
 
 				By("Verifying policy correctness")
 				validateConnectivity(WorldConnectivityAllow, ClusterConnectivityAllow)
 
 				By("Installing deny toEntities All")
-				importPolicy(kubectl, namespaceForTest, ccnpToEntitiesAllDeny, "to-entities-all-deny")
+				applyPolicy(kubectl, namespaceForTest, ccnpToEntitiesAllDeny)
 
 				By("Verifying policy correctness")
 				validateConnectivity(WorldConnectivityDeny, ClusterConnectivityDeny)
@@ -910,7 +835,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			It("Validate toEntities World", func() {
 				By("Installing toEntities World")
-				importPolicy(kubectl, namespaceForTest, cnpToEntitiesWorld, "to-entities-world")
+				applyPolicy(kubectl, namespaceForTest, cnpToEntitiesWorld)
 
 				By("Verifying policy correctness")
 				validateConnectivity(WorldConnectivityAllow, ClusterConnectivityDeny)
@@ -919,7 +844,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			It("Validate toEntities Cluster", func() {
 				By("Installing toEntities Cluster")
-				importPolicy(kubectl, namespaceForTest, cnpToEntitiesCluster, "to-entities-cluster")
+				applyPolicy(kubectl, namespaceForTest, cnpToEntitiesCluster)
 
 				By("Verifying policy correctness")
 				validateConnectivity(WorldConnectivityDeny, ClusterConnectivityAllow)
@@ -927,7 +852,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			It("Validate toEntities Host", func() {
 				By("Installing toEntities Host")
-				importPolicy(kubectl, namespaceForTest, cnpToEntitiesHost, "to-entities-host")
+				applyPolicy(kubectl, namespaceForTest, cnpToEntitiesHost)
 
 				By("Verifying policy correctness")
 				validateConnectivity(WorldConnectivityDeny, ClusterConnectivityDeny)
@@ -985,16 +910,12 @@ var _ = SkipDescribeIf(func() bool {
 
 			It("Enforces connectivity correctly when the same L3/L4 CNP is updated", func() {
 				By("Applying default allow policy")
-				err := kubectl.CiliumPolicyAction(
-					namespaceForTest, cnpUpdateAllow, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
+				applyPolicy(kubectl, namespaceForTest, cnpUpdateAllow)
 
 				validateL3L4(allowAll)
 
 				By("Applying l3-l4 policy")
-				err = kubectl.CiliumPolicyAction(
-					namespaceForTest, cnpUpdateDeny, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateDeny)
+				applyPolicy(kubectl, namespaceForTest, cnpUpdateDeny)
 
 				validateL3L4(denyFromApp3)
 
@@ -1010,23 +931,17 @@ var _ = SkipDescribeIf(func() bool {
 				validateL3L4(denyFromApp3)
 
 				By("Applying l3-l4 policy with user-specified labels")
-				err = kubectl.CiliumPolicyAction(
-					namespaceForTest, cnpUpdateDenyLabelled, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateDenyLabelled)
+				applyPolicy(kubectl, namespaceForTest, cnpUpdateDenyLabelled)
 
 				validateL3L4(denyFromApp3)
 
 				By("Applying default allow policy (should remove policy with user labels)")
-				err = kubectl.CiliumPolicyAction(
-					namespaceForTest, cnpUpdateAllow, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
+				applyPolicy(kubectl, namespaceForTest, cnpUpdateAllow)
 
 				validateL3L4(allowAll)
 
 				By("Applying a full deny policy on all endpoints")
-				err = kubectl.CiliumPolicyAction(
-					namespaceForTest, cnpUpdateDenyAll, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateDenyAll)
+				applyPolicy(kubectl, namespaceForTest, cnpUpdateDenyAll)
 
 				validateL3L4(denyAll)
 			})
@@ -1038,17 +953,13 @@ var _ = SkipDescribeIf(func() bool {
 				// This HTTP policy was already validated in the
 				// test "checks all kind of Kubernetes policies".
 				// Install it then move on.
-				err := kubectl.CiliumPolicyAction(
-					namespaceForTest, l7Policy, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "Cannot install %q policy", l7Policy)
+				applyPolicy(kubectl, namespaceForTest, l7Policy)
 
 				// Update existing policy on port 80 from http to kafka
 				// to test ability to change L7 parser type of a port.
 				// Traffic cannot flow but policy must be able to be
 				// imported and applied to the endpoints.
-				err = kubectl.CiliumPolicyAction(
-					namespaceForTest, l7PolicyKafka, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "Cannot update L7 policy (%q) from parser http to kafka", l7PolicyKafka)
+				applyPolicy(kubectl, namespaceForTest, l7PolicyKafka)
 
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, appPods[helpers.App3],
@@ -1254,37 +1165,23 @@ var _ = SkipDescribeIf(func() bool {
 				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 
 				By("Importing policy which selects app1")
-
-				err := kubectl.CiliumPolicyAction(
-					namespaceForTest, l3Policy, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(),
-					"policy %s cannot be applied in %q namespace", l3Policy, namespaceForTest)
+				applyPolicy(kubectl, namespaceForTest, l3Policy)
 
 				By("Checking that proxy visibility annotation is still applied even while a policy was imported")
 				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 
-				err = kubectl.CiliumPolicyAction(
-					namespaceForTest, l3Policy, helpers.KubectlDelete, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(),
-					"policy %s cannot be deleted in %q namespace", l3Policy, namespaceForTest)
+				deletePolicy(kubectl, namespaceForTest, l3Policy)
 
 				By("Checking that proxy visibility annotation is still applied after policy is removed")
 				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 
 				By("Importing policy using named ports which selects app1; proxy-visibility annotation should remain")
-
-				err = kubectl.CiliumPolicyAction(
-					namespaceForTest, l3NamedPortPolicy, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(),
-					"policy %s cannot be applied in %q namespace", l3NamedPortPolicy, namespaceForTest)
+				applyPolicy(kubectl, namespaceForTest, l3NamedPortPolicy)
 
 				By("Checking that proxy visibility annotation is still applied to policy being added")
 				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 
-				err = kubectl.CiliumPolicyAction(
-					namespaceForTest, l3NamedPortPolicy, helpers.KubectlDelete, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(),
-					"policy %s cannot be deleted in %q namespace", l3NamedPortPolicy, namespaceForTest)
+				deletePolicy(kubectl, namespaceForTest, l3NamedPortPolicy)
 
 				By("Checking that proxy visibility annotation is still applied after policy is removed")
 				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
@@ -1434,7 +1331,7 @@ var _ = SkipDescribeIf(func() bool {
 				By("Importing a default deny policy on ingress")
 				cnpDenyIngress := helpers.ManifestGet(kubectl.BasePath(),
 					"cnp-default-deny-ingress.yaml")
-				importPolicy(kubectl, testNamespace, cnpDenyIngress, "default-deny-ingress")
+				applyPolicy(kubectl, testNamespace, cnpDenyIngress)
 
 				count := testConnectivity(backendPodIP, false)
 				defer monitorCancel()
@@ -1450,7 +1347,7 @@ var _ = SkipDescribeIf(func() bool {
 				By("Importing a default deny policy on ingress")
 				cnpDenyIngress := helpers.ManifestGet(kubectl.BasePath(),
 					"cnp-default-deny-ingress.yaml")
-				importPolicy(kubectl, testNamespace, cnpDenyIngress, "default-deny-ingress")
+				applyPolicy(kubectl, testNamespace, cnpDenyIngress)
 
 				By("Running cilium monitor in the background")
 				ciliumPod, err := kubectl.GetCiliumPodOnNode(hostNodeName)
@@ -1466,7 +1363,7 @@ var _ = SkipDescribeIf(func() bool {
 				By("Importing fromCIDR+toPorts policy on ingress")
 				cnpAllowIngress := helpers.ManifestGet(kubectl.BasePath(),
 					"cnp-ingress-from-cidr-to-ports.yaml")
-				importPolicy(kubectl, testNamespace, cnpAllowIngress, "ingress-from-cidr-to-ports")
+				applyPolicy(kubectl, testNamespace, cnpAllowIngress)
 				count := testConnectivity(backendPodIP, true)
 				defer monitorCancel()
 
@@ -1513,7 +1410,7 @@ var _ = SkipDescribeIf(func() bool {
 
 					By("Importing a default-deny host policy on ingress")
 					ccnpDenyHostIngress := helpers.ManifestGet(kubectl.BasePath(), "ccnp-default-deny-host-ingress.yaml")
-					importPolicy(kubectl, testNamespace, ccnpDenyHostIngress, "default-deny-host-ingress")
+					applyPolicy(kubectl, testNamespace, ccnpDenyHostIngress)
 
 					testConnectivity(backendPodIP, true)
 					count := testConnectivity(hostIPOfBackendPod, false)
@@ -1529,7 +1426,7 @@ var _ = SkipDescribeIf(func() bool {
 				It("Connectivity is restored after importing ingress policy", func() {
 					By("Importing a default-deny host policy on ingress")
 					ccnpDenyHostIngress := helpers.ManifestGet(kubectl.BasePath(), "ccnp-default-deny-host-ingress.yaml")
-					importPolicy(kubectl, testNamespace, ccnpDenyHostIngress, "default-deny-host-ingress")
+					applyPolicy(kubectl, testNamespace, ccnpDenyHostIngress)
 
 					By("Running cilium monitor in the background")
 					ciliumPod, err := kubectl.GetCiliumPodOnNode(hostNodeName)
@@ -1544,7 +1441,7 @@ var _ = SkipDescribeIf(func() bool {
 					By("Importing fromCIDR+toPorts host policy on ingress")
 					ccnpAllowHostIngress := helpers.ManifestGet(kubectl.BasePath(),
 						"ccnp-host-ingress-from-cidr-to-ports.yaml")
-					importPolicy(kubectl, testNamespace, ccnpAllowHostIngress, "host-ingress-from-cidr-to-ports")
+					applyPolicy(kubectl, testNamespace, ccnpAllowHostIngress)
 
 					testConnectivity(backendPodIP, true)
 					count := testConnectivity(hostIPOfBackendPod, true)
@@ -1692,7 +1589,7 @@ var _ = SkipDescribeIf(func() bool {
 				It("Allows from all hosts with cnp fromEntities host policy", func() {
 
 					By("Installing fromEntities host policy")
-					importPolicy(kubectl, testNamespace, cnpFromEntitiesHost, "from-entities-host")
+					applyPolicy(kubectl, testNamespace, cnpFromEntitiesHost)
 
 					By("Checking policy correctness")
 					validateConnectivity(HostConnectivityAllow, RemoteNodeConnectivityAllow, PodConnectivityDeny, WorldConnectivityDeny)
@@ -1713,7 +1610,7 @@ var _ = SkipDescribeIf(func() bool {
 					installDefaultDenyIngressPolicy(kubectl, testNamespace, validateConnectivity)
 
 					By("Installing fromEntities remote-node policy")
-					importPolicy(kubectl, testNamespace, cnpFromEntitiesRemoteNode, "from-entities-remote-node")
+					applyPolicy(kubectl, testNamespace, cnpFromEntitiesRemoteNode)
 
 					By("Checking policy correctness")
 					validateConnectivity(HostConnectivityAllow, RemoteNodeConnectivityAllow, PodConnectivityDeny, WorldConnectivityDeny)
@@ -1724,7 +1621,7 @@ var _ = SkipDescribeIf(func() bool {
 				installDefaultDenyIngressPolicy(kubectl, testNamespace, validateConnectivity)
 
 				By("Installing fromEntities cluster policy")
-				importPolicy(kubectl, testNamespace, cnpFromEntitiesCluster, "from-entities-cluster")
+				applyPolicy(kubectl, testNamespace, cnpFromEntitiesCluster)
 
 				By("Checking policy correctness")
 				validateConnectivity(HostConnectivityAllow, RemoteNodeConnectivityAllow, PodConnectivityAllow, WorldConnectivityDeny)
@@ -1737,7 +1634,7 @@ var _ = SkipDescribeIf(func() bool {
 				installDefaultDenyIngressPolicy(kubectl, testNamespace, validateConnectivity)
 
 				By("Installing fromEntities all policy")
-				importPolicy(kubectl, testNamespace, cnpFromEntitiesAll, "from-entities-all")
+				applyPolicy(kubectl, testNamespace, cnpFromEntitiesAll)
 
 				By("Checking policy correctness")
 				validateConnectivity(HostConnectivityAllow, RemoteNodeConnectivityAllow, PodConnectivityAllow, WorldConnectivityAllow)
@@ -1779,7 +1676,6 @@ var _ = SkipDescribeIf(func() bool {
 		)
 
 		var ciliumPods []string
-		var err error
 
 		BeforeEach(func() {
 			kubectl.ApplyDefault(helpers.ManifestGet(kubectl.BasePath(), deployment))
@@ -1857,10 +1753,7 @@ var _ = SkipDescribeIf(func() bool {
 			waitforPods()
 
 			By("Apply policy to web")
-			err = kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, helpers.ManifestGet(kubectl.BasePath(), webPolicy),
-				helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Cannot apply web-policy")
+			applyPolicyDefault(kubectl, helpers.ManifestGet(kubectl.BasePath(), webPolicy))
 
 			policyCheck := fmt.Sprintf("%s=%s %s=%s",
 				helpers.KubectlPolicyNameLabel, webPolicyName,
@@ -1868,11 +1761,7 @@ var _ = SkipDescribeIf(func() bool {
 			policyCheckStatus(policyCheck)
 
 			By("Apply policy to Redis")
-			err = kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, helpers.ManifestGet(kubectl.BasePath(), redisPolicy),
-				helpers.KubectlApply, helpers.HelperTimeout)
-
-			Expect(err).Should(BeNil(), "Cannot apply redis policy")
+			applyPolicyDefault(kubectl, helpers.ManifestGet(kubectl.BasePath(), redisPolicy))
 
 			policyCheck = fmt.Sprintf("%s=%s %s=%s",
 				helpers.KubectlPolicyNameLabel, redisPolicyName,
@@ -1880,18 +1769,13 @@ var _ = SkipDescribeIf(func() bool {
 			policyCheckStatus(policyCheck)
 
 			testConnectivitytoRedis()
-
-			err = kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, helpers.ManifestGet(kubectl.BasePath(), redisPolicy),
-				helpers.KubectlDelete, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Cannot apply redis policy")
+			deletePolicyDefault(kubectl, helpers.ManifestGet(kubectl.BasePath(), redisPolicy))
 		})
 	})
 
 	Context("Namespaces policies", func() {
 
 		var (
-			err               error
 			secondNS          string
 			appPods           map[string]string
 			appPodsNS         map[string]string
@@ -1975,16 +1859,10 @@ var _ = SkipDescribeIf(func() bool {
 			// Tests that the same policy(name,labels) can enforce based on the
 			// namespace and all works as expected.
 			By("Applying Policy in %q namespace", secondNS)
-			err = kubectl.CiliumPolicyAction(
-				secondNS, l3l4PolicySecondNS, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(),
-				"%q Policy cannot be applied in %q namespace", l3l4PolicySecondNS, secondNS)
+			applyPolicy(kubectl, secondNS, l3l4PolicySecondNS)
 
 			By("Applying Policy in default namespace")
-			err = kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, l3L4Policy, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(),
-				"%q Policy cannot be applied in %q namespace", l3L4Policy, helpers.DefaultNamespace)
+			applyPolicyDefault(kubectl, l3L4Policy)
 
 			By("Testing connectivity in %q namespace", secondNS)
 
@@ -2031,9 +1909,7 @@ var _ = SkipDescribeIf(func() bool {
 			}
 
 			By("Applying Policy in %q namespace", secondNS)
-			err = kubectl.CiliumPolicyAction(
-				secondNS, netpolNsSelector, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Policy cannot be applied")
+			applyPolicy(kubectl, secondNS, netpolNsSelector)
 
 			for _, pod := range []string{helpers.App2, helpers.App3} {
 				// Make sure that the Default namespace can NOT connect to
@@ -2052,9 +1928,7 @@ var _ = SkipDescribeIf(func() bool {
 			}
 
 			By("Delete Kubernetes Network Policies in %q namespace", secondNS)
-			err = kubectl.CiliumPolicyAction(
-				secondNS, netpolNsSelector, helpers.KubectlDelete, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Policy %q cannot be deleted", netpolNsSelector)
+			deletePolicy(kubectl, secondNS, netpolNsSelector)
 
 			for _, pod := range []string{helpers.App2, helpers.App3} {
 				res := kubectl.ExecPodCmd(
@@ -2070,10 +1944,7 @@ var _ = SkipDescribeIf(func() bool {
 		})
 
 		It("Cilium Network policy using namespace label and L7", func() {
-
-			err := kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, cnpSecondNS, helpers.KubectlApply, helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpSecondNS)
+			applyPolicyDefault(kubectl, cnpSecondNS)
 
 			By("Testing connectivity in %q namespace", secondNS)
 			res := kubectl.ExecPodCmd(
@@ -2406,7 +2277,7 @@ var _ = SkipDescribeIf(func() bool {
 			res := kubectl.ApplyDefault(endpointPath)
 			res.ExpectSuccess()
 
-			applyPolicy(kubectl, policyPath)
+			applyPolicyDefault(kubectl, policyPath)
 			validateEgress(kubectl)
 
 			kubectl.Delete(policyPath)
@@ -2415,7 +2286,7 @@ var _ = SkipDescribeIf(func() bool {
 		})
 
 		It("To Services first policy", func() {
-			applyPolicy(kubectl, policyPath)
+			applyPolicyDefault(kubectl, policyPath)
 			res := kubectl.ApplyDefault(endpointPath)
 			res.ExpectSuccess()
 
@@ -2431,7 +2302,7 @@ var _ = SkipDescribeIf(func() bool {
 			res := kubectl.ApplyDefault(endpointPath)
 			res.ExpectSuccess()
 
-			applyPolicy(kubectl, policyLabeledPath)
+			applyPolicyDefault(kubectl, policyLabeledPath)
 
 			validateEgress(kubectl)
 
@@ -2441,7 +2312,7 @@ var _ = SkipDescribeIf(func() bool {
 		})
 
 		It("To Services first policy, match service by labels", func() {
-			applyPolicy(kubectl, policyLabeledPath)
+			applyPolicyDefault(kubectl, policyLabeledPath)
 
 			By("Creating Kubernetes Endpoint")
 			res := kubectl.ApplyDefault(endpointPath)
@@ -2674,11 +2545,10 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 				)
 
 				By("Installing toEntities KubeAPIServer")
-				importPolicy(
+				applyPolicy(
 					kubectl,
 					testNamespace,
 					cnpToEntitiesKubeAPIServer,
-					"to-entities-kube-apiserver",
 				)
 
 				By("Verifying policy correctness")
@@ -2720,31 +2590,23 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 					validateConnectivity,
 				)
 				By("Installing toEntities KubeAPIServer")
-				importPolicy(
+				applyPolicy(
 					kubectl,
 					testNamespace,
 					cnpToEntitiesKubeAPIServer,
-					"to-entities-kube-apiserver",
 				)
 
 				By("Installing duplicate toEntities KubeAPIServer")
-				importPolicy(
+				applyPolicy(
 					kubectl,
 					testNamespace,
 					helpers.ManifestGet(
 						kubectl.BasePath(), "cnp-to-entities-kube-apiserver-2.yaml",
 					),
-					"to-entities-kube-apiserver-2",
 				)
 
 				By("Removing the previous toEntities KubeAPIServer policy")
-				err := kubectl.CiliumPolicyAction(
-					testNamespace, cnpToEntitiesKubeAPIServer, helpers.KubectlDelete, helpers.HelperTimeout,
-				)
-				Expect(err).Should(
-					BeNil(),
-					"policy %s cannot be deleted in %q namespace", cnpToEntitiesKubeAPIServer, testNamespace,
-				)
+				deletePolicy(kubectl, testNamespace, cnpToEntitiesKubeAPIServer)
 
 				By("Verifying KubeAPIServer connectivity is still allowed")
 				// See previous It() about the assertion on 403 HTTP code.
@@ -2764,19 +2626,17 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 
 			It("Denies connection to KubeAPIServer", func() {
 				By("Installing allow-all egress policy")
-				importPolicy(
+				applyPolicy(
 					kubectl,
 					testNamespace,
 					helpers.ManifestGet(kubectl.BasePath(), "cnp-to-entities-all.yaml"),
-					"allow-all-egress",
 				)
 
 				By("Installing toEntities KubeAPIServer")
-				importPolicy(
+				applyPolicy(
 					kubectl,
 					testNamespace,
 					cnpToEntitiesKubeAPIServerDeny,
-					"to-entities-kube-apiserver-deny",
 				)
 
 				By("Verifying policy correctness")
@@ -2804,15 +2664,6 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 		})
 	})
 
-func importPolicy(kubectl *helpers.Kubectl, namespace, file, name string) {
-	err := kubectl.CiliumPolicyAction(namespace,
-		file,
-		helpers.KubectlApply,
-		helpers.HelperTimeout)
-	ExpectWithOffset(1, err).Should(BeNil(),
-		"policy %s cannot be applied in %q namespace", file, namespace)
-}
-
 func installDefaultDenyIngressPolicy(
 	kubectl *helpers.Kubectl,
 	ns string,
@@ -2821,7 +2672,7 @@ func installDefaultDenyIngressPolicy(
 	denyIngress := helpers.ManifestGet(kubectl.BasePath(), "cnp-default-deny-ingress.yaml")
 
 	By("Installing default-deny ingress policy")
-	importPolicy(kubectl, ns, denyIngress, "default-deny-ingress")
+	applyPolicy(kubectl, ns, denyIngress)
 
 	By("Checking that remote-node is disallowed by default")
 	f(
@@ -2840,7 +2691,7 @@ func installDefaultDenyEgressPolicy(
 	denyEgress := helpers.ManifestGet(kubectl.BasePath(), "cnp-default-deny-egress.yaml")
 
 	By("Installing default-deny egress policy")
-	importPolicy(kubectl, ns, denyEgress, "default-deny-egress")
+	applyPolicy(kubectl, ns, denyEgress)
 
 	By("Checking that remote-node is disallowed by default")
 	f(

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -241,7 +241,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			By("Testing L3/L4 rules")
 
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, l3Policy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
@@ -272,7 +272,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			By("Testing L3/L4 deny rules")
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, l3PolicyDeny, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
@@ -296,19 +296,19 @@ var _ = SkipDescribeIf(func() bool {
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, l3Policy,
 				helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot delete L3 Policy")
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, l3PolicyDeny,
 				helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot delete L3 Policy Deny")
 
 			By("Testing L7 Policy")
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, l7Policy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot install %q policy", l7Policy)
 
@@ -341,7 +341,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			By("Testing L7 Policy with L3/L4 deny rules")
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, l3PolicyDeny, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
@@ -376,7 +376,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			By("Testing L3/L4 rules with named ports")
 
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, l3NamedPortPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
@@ -407,7 +407,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			By("Testing L3/L4 deny rules with named ports")
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, l3NamedPortPolicyDeny, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
@@ -431,19 +431,19 @@ var _ = SkipDescribeIf(func() bool {
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, l3NamedPortPolicy,
 				helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot delete L3 Policy")
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, l3NamedPortPolicyDeny,
 				helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot delete L3 Policy Deny")
 
 			By("Testing L7 Policy with named port")
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, l7NamedPortPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot install %q policy", l7NamedPortPolicy)
 
@@ -473,7 +473,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			By("Testing L7 Policy with L3/L4 deny rules with named ports")
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, l3NamedPortPolicyDeny, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
@@ -520,7 +520,7 @@ var _ = SkipDescribeIf(func() bool {
 			res = kubectl.CopyFileToPod(namespaceForTest, appPods[helpers.App2], TLSCaCerts, "/cacert.pem")
 			res.ExpectSuccess("Cannot copy certs to %s", appPods[helpers.App2])
 
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, l7PolicyTLS, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot install %q policy", l7PolicyTLS)
 
@@ -578,7 +578,7 @@ var _ = SkipDescribeIf(func() bool {
 		It("ServiceAccount Based Enforcement", func() {
 			// Load policy allowing serviceAccount of app2 to talk
 			// to app1 on port 80 TCP
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, serviceAccountPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
@@ -611,7 +611,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			// Load policy denying serviceAccount of app2 to talk
 			// to app1 on port 80 TCP
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, serviceAccountPolicyDeny, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
@@ -643,7 +643,7 @@ var _ = SkipDescribeIf(func() bool {
 		}, 500)
 
 		It("CNP test MatchExpressions key", func() {
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, cnpMatchExpression, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "cannot install policy %s", cnpMatchExpression)
 
@@ -659,7 +659,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			By("Testing CNP test MatchExpressions key with policy Denies")
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				namespaceForTest, cnpMatchExpressionDeny, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "cannot install policy %s", cnpMatchExpression)
 
@@ -690,7 +690,7 @@ var _ = SkipDescribeIf(func() bool {
 			By("Installing knp ingress default-deny")
 
 			// Import the policy and wait for all required endpoints to enforce the policy
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, knpDenyIngress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 deny-ingress Policy cannot be applied in %q namespace", namespaceForTest)
@@ -711,7 +711,7 @@ var _ = SkipDescribeIf(func() bool {
 		It("Denies traffic with k8s default-deny egress policy", func() {
 			By("Installing knp egress default-deny")
 
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, knpDenyEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 deny-egress Policy cannot be applied in %q namespace", namespaceForTest)
@@ -738,7 +738,7 @@ var _ = SkipDescribeIf(func() bool {
 		It("Denies traffic with k8s default-deny ingress-egress policy", func() {
 			By("Installing knp ingress-egress default-deny")
 
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, knpDenyIngressEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 deny-ingress-egress policy cannot be applied in %q namespace", namespaceForTest)
@@ -777,7 +777,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			By("Installing cnp ingress default-deny")
 
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, cnpDenyIngress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 deny-ingress Policy cannot be applied in %q namespace", namespaceForTest)
@@ -799,7 +799,7 @@ var _ = SkipDescribeIf(func() bool {
 		It("Denies traffic with cnp default-deny egress policy", func() {
 
 			By("Installing cnp egress default-deny")
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, cnpDenyEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 deny-egress Policy cannot be applied in %q namespace", namespaceForTest)
@@ -824,7 +824,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		It("Allows traffic with k8s default-allow ingress policy", func() {
 			By("Installing ingress default-allow")
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, knpAllowIngress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 allow-ingress Policy cannot be applied in %q namespace", namespaceForTest)
@@ -843,7 +843,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		It("Allows traffic with k8s default-allow egress policy", func() {
 			By("Installing egress default-allow")
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				namespaceForTest, knpAllowEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 allow-egress Policy cannot be applied in %q namespace", namespaceForTest)
@@ -985,14 +985,14 @@ var _ = SkipDescribeIf(func() bool {
 
 			It("Enforces connectivity correctly when the same L3/L4 CNP is updated", func() {
 				By("Applying default allow policy")
-				_, err := kubectl.CiliumPolicyAction(
+				err := kubectl.CiliumPolicyAction(
 					namespaceForTest, cnpUpdateAllow, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
 
 				validateL3L4(allowAll)
 
 				By("Applying l3-l4 policy")
-				_, err = kubectl.CiliumPolicyAction(
+				err = kubectl.CiliumPolicyAction(
 					namespaceForTest, cnpUpdateDeny, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateDeny)
 
@@ -1010,21 +1010,21 @@ var _ = SkipDescribeIf(func() bool {
 				validateL3L4(denyFromApp3)
 
 				By("Applying l3-l4 policy with user-specified labels")
-				_, err = kubectl.CiliumPolicyAction(
+				err = kubectl.CiliumPolicyAction(
 					namespaceForTest, cnpUpdateDenyLabelled, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateDenyLabelled)
 
 				validateL3L4(denyFromApp3)
 
 				By("Applying default allow policy (should remove policy with user labels)")
-				_, err = kubectl.CiliumPolicyAction(
+				err = kubectl.CiliumPolicyAction(
 					namespaceForTest, cnpUpdateAllow, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
 
 				validateL3L4(allowAll)
 
 				By("Applying a full deny policy on all endpoints")
-				_, err = kubectl.CiliumPolicyAction(
+				err = kubectl.CiliumPolicyAction(
 					namespaceForTest, cnpUpdateDenyAll, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateDenyAll)
 
@@ -1038,7 +1038,7 @@ var _ = SkipDescribeIf(func() bool {
 				// This HTTP policy was already validated in the
 				// test "checks all kind of Kubernetes policies".
 				// Install it then move on.
-				_, err := kubectl.CiliumPolicyAction(
+				err := kubectl.CiliumPolicyAction(
 					namespaceForTest, l7Policy, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Cannot install %q policy", l7Policy)
 
@@ -1046,7 +1046,7 @@ var _ = SkipDescribeIf(func() bool {
 				// to test ability to change L7 parser type of a port.
 				// Traffic cannot flow but policy must be able to be
 				// imported and applied to the endpoints.
-				_, err = kubectl.CiliumPolicyAction(
+				err = kubectl.CiliumPolicyAction(
 					namespaceForTest, l7PolicyKafka, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Cannot update L7 policy (%q) from parser http to kafka", l7PolicyKafka)
 
@@ -1255,7 +1255,7 @@ var _ = SkipDescribeIf(func() bool {
 
 				By("Importing policy which selects app1")
 
-				_, err := kubectl.CiliumPolicyAction(
+				err := kubectl.CiliumPolicyAction(
 					namespaceForTest, l3Policy, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(),
 					"policy %s cannot be applied in %q namespace", l3Policy, namespaceForTest)
@@ -1263,7 +1263,7 @@ var _ = SkipDescribeIf(func() bool {
 				By("Checking that proxy visibility annotation is still applied even while a policy was imported")
 				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 
-				_, err = kubectl.CiliumPolicyAction(
+				err = kubectl.CiliumPolicyAction(
 					namespaceForTest, l3Policy, helpers.KubectlDelete, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(),
 					"policy %s cannot be deleted in %q namespace", l3Policy, namespaceForTest)
@@ -1273,7 +1273,7 @@ var _ = SkipDescribeIf(func() bool {
 
 				By("Importing policy using named ports which selects app1; proxy-visibility annotation should remain")
 
-				_, err = kubectl.CiliumPolicyAction(
+				err = kubectl.CiliumPolicyAction(
 					namespaceForTest, l3NamedPortPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(),
 					"policy %s cannot be applied in %q namespace", l3NamedPortPolicy, namespaceForTest)
@@ -1281,7 +1281,7 @@ var _ = SkipDescribeIf(func() bool {
 				By("Checking that proxy visibility annotation is still applied to policy being added")
 				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
 
-				_, err = kubectl.CiliumPolicyAction(
+				err = kubectl.CiliumPolicyAction(
 					namespaceForTest, l3NamedPortPolicy, helpers.KubectlDelete, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(),
 					"policy %s cannot be deleted in %q namespace", l3NamedPortPolicy, namespaceForTest)
@@ -1857,7 +1857,7 @@ var _ = SkipDescribeIf(func() bool {
 			waitforPods()
 
 			By("Apply policy to web")
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				helpers.DefaultNamespace, helpers.ManifestGet(kubectl.BasePath(), webPolicy),
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply web-policy")
@@ -1868,7 +1868,7 @@ var _ = SkipDescribeIf(func() bool {
 			policyCheckStatus(policyCheck)
 
 			By("Apply policy to Redis")
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				helpers.DefaultNamespace, helpers.ManifestGet(kubectl.BasePath(), redisPolicy),
 				helpers.KubectlApply, helpers.HelperTimeout)
 
@@ -1881,7 +1881,7 @@ var _ = SkipDescribeIf(func() bool {
 
 			testConnectivitytoRedis()
 
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				helpers.DefaultNamespace, helpers.ManifestGet(kubectl.BasePath(), redisPolicy),
 				helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply redis policy")
@@ -1975,13 +1975,13 @@ var _ = SkipDescribeIf(func() bool {
 			// Tests that the same policy(name,labels) can enforce based on the
 			// namespace and all works as expected.
 			By("Applying Policy in %q namespace", secondNS)
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				secondNS, l3l4PolicySecondNS, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Policy cannot be applied in %q namespace", l3l4PolicySecondNS, secondNS)
 
 			By("Applying Policy in default namespace")
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				helpers.DefaultNamespace, l3L4Policy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Policy cannot be applied in %q namespace", l3L4Policy, helpers.DefaultNamespace)
@@ -2031,7 +2031,7 @@ var _ = SkipDescribeIf(func() bool {
 			}
 
 			By("Applying Policy in %q namespace", secondNS)
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				secondNS, netpolNsSelector, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Policy cannot be applied")
 
@@ -2052,7 +2052,7 @@ var _ = SkipDescribeIf(func() bool {
 			}
 
 			By("Delete Kubernetes Network Policies in %q namespace", secondNS)
-			_, err = kubectl.CiliumPolicyAction(
+			err = kubectl.CiliumPolicyAction(
 				secondNS, netpolNsSelector, helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Policy %q cannot be deleted", netpolNsSelector)
 
@@ -2071,7 +2071,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		It("Cilium Network policy using namespace label and L7", func() {
 
-			_, err := kubectl.CiliumPolicyAction(
+			err := kubectl.CiliumPolicyAction(
 				helpers.DefaultNamespace, cnpSecondNS, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpSecondNS)
 
@@ -2184,7 +2184,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		It("Test clusterwide connectivity with policies", func() {
 			By("Applying Egress deny all clusterwide policy")
-			_, err := kubectl.CiliumClusterwidePolicyAction(
+			err := kubectl.CiliumClusterwidePolicyAction(
 				egressDenyAllPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Clusterwide Policy cannot be applied", egressDenyAllPolicy)
@@ -2210,13 +2210,13 @@ var _ = SkipDescribeIf(func() bool {
 			res.ExpectFail("Egress DNS connectivity should be denied for pod %q", helpers.App3)
 
 			By("Deleting Egress deny all clusterwide policy")
-			_, err = kubectl.CiliumClusterwidePolicyAction(
+			err = kubectl.CiliumClusterwidePolicyAction(
 				egressDenyAllPolicy, helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Clusterwide Policy cannot be deleted", egressDenyAllPolicy)
 
 			By("Applying Ingress deny all clusterwide policy")
-			_, err = kubectl.CiliumClusterwidePolicyAction(
+			err = kubectl.CiliumClusterwidePolicyAction(
 				ingressDenyAllPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Clusterwide Policy cannot be applied", egressDenyAllPolicy)
@@ -2249,13 +2249,13 @@ var _ = SkipDescribeIf(func() bool {
 			// Apply both ingress deny and egress deny all policies and override the policies with
 			// global allow all policy.
 			By("Applying Egress deny all clusterwide policy")
-			_, err = kubectl.CiliumClusterwidePolicyAction(
+			err = kubectl.CiliumClusterwidePolicyAction(
 				egressDenyAllPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Clusterwide Policy cannot be applied", egressDenyAllPolicy)
 
 			By("Applying Allow all clusterwide policy over ingress deny all and egress deny all")
-			_, err = kubectl.CiliumClusterwidePolicyAction(
+			err = kubectl.CiliumClusterwidePolicyAction(
 				allowAllPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Clusterwide Policy cannot be applied", allowAllPolicy)
@@ -2291,13 +2291,13 @@ var _ = SkipDescribeIf(func() bool {
 			// 3. Check denied ingress from app3.firstNS to app1.firstNS
 			// 4. Check denied ingress from app3.secondNS to app1.firstNS
 			By("Update allow all policy to allow ingress from a particular app only.")
-			_, err = kubectl.CiliumClusterwidePolicyAction(
+			err = kubectl.CiliumClusterwidePolicyAction(
 				allowIngressPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Clusterwide Policy cannot be applied", allowIngressPolicy)
 
 			By("Deleting Egress deny all clusterwide policy")
-			_, err = kubectl.CiliumClusterwidePolicyAction(
+			err = kubectl.CiliumClusterwidePolicyAction(
 				egressDenyAllPolicy, helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Clusterwide Policy cannot be deleted", egressDenyAllPolicy)
@@ -2328,13 +2328,13 @@ var _ = SkipDescribeIf(func() bool {
 
 			// Cleanup all tested policies
 			By("Delete allow ingress from particular app policy")
-			_, err = kubectl.CiliumClusterwidePolicyAction(
+			err = kubectl.CiliumClusterwidePolicyAction(
 				allowIngressPolicy, helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Clusterwide Policy cannot be deleted", allowIngressPolicy)
 
 			By("Deleting Ingress deny all clusterwide policy")
-			_, err = kubectl.CiliumClusterwidePolicyAction(
+			err = kubectl.CiliumClusterwidePolicyAction(
 				ingressDenyAllPolicy, helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Clusterwide Policy cannot be deleted", ingressDenyAllPolicy)
@@ -2738,7 +2738,7 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 				)
 
 				By("Removing the previous toEntities KubeAPIServer policy")
-				_, err := kubectl.CiliumPolicyAction(
+				err := kubectl.CiliumPolicyAction(
 					testNamespace, cnpToEntitiesKubeAPIServer, helpers.KubectlDelete, helpers.HelperTimeout,
 				)
 				Expect(err).Should(
@@ -2805,7 +2805,7 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 	})
 
 func importPolicy(kubectl *helpers.Kubectl, namespace, file, name string) {
-	_, err := kubectl.CiliumPolicyAction(namespace,
+	err := kubectl.CiliumPolicyAction(namespace,
 		file,
 		helpers.KubectlApply,
 		helpers.HelperTimeout)

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -35,7 +35,7 @@ func getTFTPLink(host string, port int32) string {
 
 func applyPolicy(kubectl *helpers.Kubectl, path string) {
 	By(fmt.Sprintf("Applying policy %s", path))
-	_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, path, helpers.KubectlApply, helpers.HelperTimeout)
+	err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, path, helpers.KubectlApply, helpers.HelperTimeout)
 	ExpectWithOffset(1, err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", path, err))
 }
 

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -33,10 +33,24 @@ func getTFTPLink(host string, port int32) string {
 		net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 }
 
-func applyPolicy(kubectl *helpers.Kubectl, path string) {
+func applyPolicy(kubectl *helpers.Kubectl, namespace, path string) {
 	By(fmt.Sprintf("Applying policy %s", path))
-	err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, path, helpers.KubectlApply, helpers.HelperTimeout)
+	err := kubectl.CiliumPolicyAction(namespace, path, helpers.KubectlApply, helpers.HelperTimeout)
 	ExpectWithOffset(1, err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", path, err))
+}
+
+func applyPolicyDefault(kubectl *helpers.Kubectl, path string) {
+	applyPolicy(kubectl, helpers.DefaultNamespace, path)
+}
+
+func deletePolicy(kubectl *helpers.Kubectl, namespace, path string) {
+	By(fmt.Sprintf("Deleting policy %s", path))
+	err := kubectl.CiliumPolicyAction(namespace, path, helpers.KubectlDelete, helpers.HelperTimeout)
+	ExpectWithOffset(1, err).Should(BeNil(), fmt.Sprintf("Error deleting resource %s: %s", path, err))
+}
+
+func deletePolicyDefault(kubectl *helpers.Kubectl, path string) {
+	deletePolicy(kubectl, helpers.DefaultNamespace, path)
 }
 
 func ciliumAddService(kubectl *helpers.Kubectl, id int64, frontend string, backends []string, svcType, trafficPolicy string) {

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -609,12 +609,12 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			}
 
 			netpol = helpers.ManifestGet(kubectl.BasePath(), "netpol-deny-ns-lb-test-k8s2.yaml")
-			_, err = kubectl.CiliumClusterwidePolicyAction(netpol,
+			err = kubectl.CiliumClusterwidePolicyAction(netpol,
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Policy %s cannot be applied", netpol)
 
 			defer func() {
-				_, err := kubectl.CiliumClusterwidePolicyAction(netpol,
+				err := kubectl.CiliumClusterwidePolicyAction(netpol,
 					helpers.KubectlDelete, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Policy %s cannot be deleted", netpol)
 			}()
@@ -772,14 +772,14 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				})
 
 				ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
-				_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
+				err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
 					helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(),
-					"Policy %s cannot be applied", ccnpHostPolicy)
+					"Policy %s cannot be Applied", ccnpHostPolicy)
 			})
 
 			AfterAll(func() {
-				_, err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
+				err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
 					helpers.KubectlDelete, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(),
 					"Policy %s cannot be deleted", ccnpHostPolicy)

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -102,6 +102,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			ExpectAllPodsTerminated(kubectl)
 		})
 
+		AfterEach(func() {
+			kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
+		})
+
 		// This is testing bpf_lxc LB (= KPR=disabled) when both client and
 		// server are running on the same node. Thus, skipping when running with
 		// KPR.
@@ -215,11 +219,14 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 
 			Context("with L7 policy", func() {
 				AfterAll(func() {
-					kubectl.Delete(demoPolicyL7)
 					// Remove CT entries to avoid packet drops which could happen
 					// due to matching stale entries with proxy_redirect = 1
 					kubectl.CiliumExecMustSucceedOnAll(context.TODO(),
 						"cilium bpf ct flush global", "Unable to flush CT maps")
+				})
+
+				AfterEach(func() {
+					kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 				})
 
 				It("Tests NodePort with L7 Policy", func() {
@@ -382,8 +389,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				demoPolicy = helpers.ManifestGet(kubectl.BasePath(), "l4-policy-demo.yaml")
 			})
 
-			AfterAll(func() {
-				kubectl.Delete(demoPolicy)
+			AfterEach(func() {
+				kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 			})
 
 			It("Tests TFTP from DNS Proxy Port", func() {
@@ -446,8 +453,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				demoPolicy = helpers.ManifestGet(kubectl.BasePath(), "l4-policy-demo.yaml")
 			})
 
-			AfterAll(func() {
-				kubectl.Delete(demoPolicy)
+			AfterEach(func() {
+				kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 			})
 
 			It("Tests NodePort with L4 Policy", func() {
@@ -477,10 +484,13 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			})
 
 			AfterAll(func() {
-				kubectl.Delete(demoPolicyL7)
 				// Same reason as in other L7 test above
 				kubectl.CiliumExecMustSucceedOnAll(context.TODO(),
 					"cilium bpf ct flush global", "Unable to flush CT maps")
+			})
+
+			AfterEach(func() {
+				kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 			})
 
 			It("Tests NodePort with L7 Policy", func() {
@@ -540,6 +550,10 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				kubectl.Delete(yaml)
 			}
 			ExpectAllPodsTerminated(kubectl)
+		})
+
+		AfterEach(func() {
+			kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 		})
 
 		It("Tests NodePort with sessionAffinity from outside", func() {
@@ -612,12 +626,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			err = kubectl.CiliumClusterwidePolicyAction(netpol,
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Policy %s cannot be applied", netpol)
-
-			defer func() {
-				err := kubectl.CiliumClusterwidePolicyAction(netpol,
-					helpers.KubectlDelete, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "Policy %s cannot be deleted", netpol)
-			}()
 
 			// Now let's apply the policy. All request should fail.
 			for _, addr := range svcAddrs {
@@ -764,30 +772,27 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 		})
 
 		SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
-			var ccnpHostPolicy string
+			ccnpHostPolicy := helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
 
 			BeforeAll(func() {
 				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 					"hostFirewall.enabled": "true",
 				})
-
-				ccnpHostPolicy = helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
-				err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
-					helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(),
-					"Policy %s cannot be Applied", ccnpHostPolicy)
 			})
 
 			AfterAll(func() {
-				err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
-					helpers.KubectlDelete, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(),
-					"Policy %s cannot be deleted", ccnpHostPolicy)
-
 				DeployCiliumAndDNS(kubectl, ciliumFilename)
 			})
 
+			AfterEach(func() {
+				kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
+			})
+
 			It("Tests NodePort", func() {
+				err := kubectl.CiliumClusterwidePolicyAction(ccnpHostPolicy,
+					helpers.KubectlApply, helpers.HelperTimeout)
+				Expect(err).Should(BeNil(),
+					"Policy %s cannot be applied", ccnpHostPolicy)
 				testNodePort(kubectl, ni, true, true, 0)
 			})
 		})

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -223,7 +223,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				})
 
 				It("Tests NodePort with L7 Policy", func() {
-					applyPolicy(kubectl, demoPolicyL7)
+					applyPolicyDefault(kubectl, demoPolicyL7)
 					testNodePort(kubectl, ni, false, false, 0)
 				})
 			})
@@ -399,7 +399,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 					helpers.WriteToReportFile(monitorRes2.CombineOutput().Bytes(), "tftp-with-l4-policy-monitor-k8s2.log")
 				}()
 
-				applyPolicy(kubectl, demoPolicy)
+				applyPolicyDefault(kubectl, demoPolicy)
 
 				var data v1.Service
 				err := kubectl.Get(helpers.DefaultNamespace, "service test-nodeport").Unmarshal(&data)
@@ -464,7 +464,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 					helpers.WriteToReportFile(monitorRes2.CombineOutput().Bytes(), "nodeport-with-l4-policy-monitor-k8s2.log")
 				}()
 
-				applyPolicy(kubectl, demoPolicy)
+				applyPolicyDefault(kubectl, demoPolicy)
 				testNodePort(kubectl, ni, false, false, 0)
 			})
 		})
@@ -497,7 +497,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 					helpers.WriteToReportFile(monitorRes2.CombineOutput().Bytes(), "nodeport-with-l7-policy-monitor-k8s2.log")
 				}()
 
-				applyPolicy(kubectl, demoPolicyL7)
+				applyPolicyDefault(kubectl, demoPolicyL7)
 				testNodePort(kubectl, ni, false, false, 0)
 			})
 		})

--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -330,7 +330,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
 		Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
 
-		_, err = kubectl.CiliumPolicyAction(
+		err = kubectl.CiliumPolicyAction(
 			helpers.DefaultNamespace, l7Policy, helpers.KubectlApply, timeout)
 		Expect(err).Should(BeNil(), "cannot import l7 policy: %v", l7Policy)
 

--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -330,9 +330,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
 		Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
 
-		err = kubectl.CiliumPolicyAction(
-			helpers.DefaultNamespace, l7Policy, helpers.KubectlApply, timeout)
-		Expect(err).Should(BeNil(), "cannot import l7 policy: %v", l7Policy)
+		applyPolicyDefault(kubectl, l7Policy)
 
 		By("Creating service and clients for migration")
 

--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -65,8 +65,8 @@ var _ = Describe("K8sUpdates", func() {
 
 		kubectl.Delete(migrateSVCClient)
 		kubectl.Delete(migrateSVCServer)
-		kubectl.Delete(l7Policy)
 		kubectl.Delete(demoPath)
+		kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 
 		_ = kubectl.DeleteResource(
 			"deploy", fmt.Sprintf("-n %s cilium-operator", helpers.CiliumNamespace))
@@ -181,7 +181,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 	cleanupCallback := func() {
 		kubectl.Delete(migrateSVCClient)
 		kubectl.Delete(migrateSVCServer)
-		kubectl.Delete(l7Policy)
+		kubectl.DeleteAllPoliciesAndWait(helpers.DefaultNamespace, helpers.HelperTimeout)
 		kubectl.Delete(demoPath)
 
 		if res := kubectl.DeleteResource("pod", fmt.Sprintf("-n %s -l k8s-app=kube-dns", helpers.KubeSystemNamespace)); !res.WasSuccessful() {


### PR DESCRIPTION
Wait for policy deletions to propagate to all Cilium agents before continuing with the next test. This fixes the problem seen in the CI where a test that does not apply any policies still has policies applied to some of the Cilium endpoints.
