### PR TITLE
test: Runtime check that container create succeeds

### DIFF
--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -175,7 +175,8 @@ func (s *SSHMeta) SampleContainersActions(mode string, networkName string, creat
 	switch mode {
 	case Create:
 		for k, v := range images {
-			s.ContainerCreate(k, v, networkName, fmt.Sprintf("-l id.%s %s", k, createOptionsString))
+			res := s.ContainerCreate(k, v, networkName, fmt.Sprintf("-l id.%s %s", k, createOptionsString))
+			res.ExpectSuccess("failed to create container %s", k)
 		}
 		s.WaitEndpointsReady()
 	case Delete:

--- a/test/runtime/benchmark.go
+++ b/test/runtime/benchmark.go
@@ -104,9 +104,11 @@ var _ = Describe("BenchmarkNetperfPerformance", func() {
 
 	createContainers := func() {
 		By("create Client container")
-		vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
-		By("create Server containers")
-		vm.ContainerCreate(helpers.Server, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
+		res := vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+		res.ExpectSuccess("failed to create client container")
+		By("create Server container")
+		res = vm.ContainerCreate(helpers.Server, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
+		res.ExpectSuccess("failed to create server container")
 		vm.PolicyDelAll()
 		Expect(vm.WaitEndpointsReady()).To(BeNil(), "Endpoints are not ready")
 	}

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -23,8 +23,10 @@ var _ = Describe("RuntimeChaos", func() {
 		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
 		ExpectCiliumReady(vm)
 
-		vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
-		vm.ContainerCreate(helpers.Server, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
+		res := vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+		res.ExpectSuccess("failed to create client container")
+		res = vm.ContainerCreate(helpers.Server, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
+		res.ExpectSuccess("failed to create server container")
 	})
 
 	BeforeEach(func() {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -211,12 +211,18 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 
 		BeforeEach(func() {
 			// TODO: provide map[string]string instead of one string representing KV pair.
-			vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
-			vm.ContainerCreate(helpers.Server, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
-			vm.ContainerCreate(helpers.Httpd1, constants.HttpdImage, helpers.CiliumDockerNetwork, "-l id.httpd")
-			vm.ContainerCreate(helpers.Httpd2, constants.HttpdImage, helpers.CiliumDockerNetwork, "-l id.httpd_deny")
-			vm.ContainerCreate(curl1ContainerName, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.curl")
-			vm.ContainerCreate(curl2ContainerName, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.curl2")
+			res := vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+			res.ExpectSuccess("failed to create client container")
+			res = vm.ContainerCreate(helpers.Server, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
+			res.ExpectSuccess("failed to create server container")
+			res = vm.ContainerCreate(helpers.Httpd1, constants.HttpdImage, helpers.CiliumDockerNetwork, "-l id.httpd")
+			res.ExpectSuccess("failed to create httpd1 container")
+			res = vm.ContainerCreate(helpers.Httpd2, constants.HttpdImage, helpers.CiliumDockerNetwork, "-l id.httpd_deny")
+			res.ExpectSuccess("failed to create httpd2 container")
+			res = vm.ContainerCreate(curl1ContainerName, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.curl")
+			res.ExpectSuccess("failed to create curl container")
+			res = vm.ContainerCreate(curl2ContainerName, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.curl2")
+			res.ExpectSuccess("failed to create curl2 container")
 
 			vm.PolicyDelAll().ExpectSuccess("cannot delete all policies")
 

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -175,8 +175,10 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		}
 
 		for name, image := range ciliumTestImages {
-			vm.ContainerCreate(name, image, helpers.WorldDockerNetwork, fmt.Sprintf("-l id.%s", name))
-			res := vm.ContainerInspect(name)
+			res := vm.ContainerCreate(name, image, helpers.WorldDockerNetwork, fmt.Sprintf("-l id.%s", name))
+			res.ExpectSuccess("failed to create container %s", name)
+
+			res = vm.ContainerInspect(name)
 			res.ExpectSuccess("Container is not ready after create it")
 			ip, err := res.Filter(fmt.Sprintf(`{[0].NetworkSettings.Networks.%s.IPAddress}`, helpers.WorldDockerNetwork))
 			Expect(err).To(BeNil(), "Cannot retrieve network info for %q", name)
@@ -193,8 +195,10 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		Expect(err).To(BeNil(), "bind file can't be created")
 
 		for name, image := range ciliumOutsideImages {
-			vm.ContainerCreate(name, image, helpers.WorldDockerNetwork, fmt.Sprintf("-l id.%s", name))
-			res := vm.ContainerInspect(name)
+			res := vm.ContainerCreate(name, image, helpers.WorldDockerNetwork, fmt.Sprintf("-l id.%s", name))
+			res.ExpectSuccess("failed to create container %s", name)
+
+			res = vm.ContainerInspect(name)
 			res.ExpectSuccess("Container is not ready after create it")
 			ip, err := res.Filter(fmt.Sprintf(`{[0].NetworkSettings.Networks.%s.IPAddress}`, helpers.WorldDockerNetwork))
 			Expect(err).To(BeNil(), "Cannot retrieve network info for %q", name)

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -41,13 +41,15 @@ var _ = Describe("RuntimeKafka", func() {
 		switch mode {
 		case "create":
 			for k, v := range images {
-				vm.ContainerCreate(k, v, helpers.CiliumDockerNetwork, fmt.Sprintf("-l id.%s", k))
+				res := vm.ContainerCreate(k, v, helpers.CiliumDockerNetwork, fmt.Sprintf("-l id.%s", k))
+				res.ExpectSuccess("failed to create container %s", k)
 			}
 			zook, err := vm.ContainerInspectNet("zook")
 			Expect(err).Should(BeNil())
 
-			vm.ContainerCreate("kafka", constants.KafkaImage, helpers.CiliumDockerNetwork, fmt.Sprintf(
+			res := vm.ContainerCreate("kafka", constants.KafkaImage, helpers.CiliumDockerNetwork, fmt.Sprintf(
 				"-l id.kafka -e KAFKA_ZOOKEEPER_CONNECT=%s:2181 -e KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS=60000 -e KAFKA_LISTENERS=PLAINTEXT://:9092 -e KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS=60000", zook["IPv4"]))
+			res.ExpectSuccess("failed to create kafka container")
 
 		case "delete":
 			for k := range images {

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -29,7 +29,8 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		switch option {
 		case helpers.Create:
 			vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
-			vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+			res := vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+			res.ExpectSuccess("failed to create client container")
 		case helpers.Delete:
 			vm.ContainerRm(helpers.Client)
 

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -59,7 +59,8 @@ var _ = Describe("RuntimeLB", func() {
 		By("Creating containers for traffic test")
 
 		for k, v := range images {
-			vm.ContainerCreate(k, v, helpers.CiliumDockerNetwork, fmt.Sprintf("-l id.%s", k))
+			res := vm.ContainerCreate(k, v, helpers.CiliumDockerNetwork, fmt.Sprintf("-l id.%s", k))
+			res.ExpectSuccess("failed to create container %s", k)
 		}
 		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoint are not ready after timeout")
 	}

--- a/test/runtime/net_policies.go
+++ b/test/runtime/net_policies.go
@@ -596,7 +596,9 @@ var _ = Describe("RuntimePolicies", func() {
 			res = vm.NetworkGet(helpers.WorldDockerNetwork)
 			res.ExpectSuccess("Docker network for world containers is unavailable")
 
-			vm.ContainerCreate(helpers.WorldHttpd1, constants.HttpdImage, helpers.WorldDockerNetwork, fmt.Sprintf("-l id.%s", helpers.WorldHttpd1))
+			res = vm.ContainerCreate(helpers.WorldHttpd1, constants.HttpdImage, helpers.WorldDockerNetwork, fmt.Sprintf("-l id.%s", helpers.WorldHttpd1))
+			res.ExpectSuccess("failed to create world httpd1 container")
+
 			res = vm.ContainerInspect(helpers.WorldHttpd1)
 			res.ExpectSuccess("World container is not ready")
 
@@ -1733,7 +1735,8 @@ var _ = Describe("RuntimePolicies", func() {
 			// allocated an identity from the key-value store.
 			By("Creating new container with label id.httpd1, which has already " +
 				"been allocated an identity from the key-value store")
-			vm.ContainerCreate(newContainerName, constants.HttpdImage, helpers.CiliumDockerNetwork, fmt.Sprintf("-l id.%s", helpers.Httpd1))
+			res := vm.ContainerCreate(newContainerName, constants.HttpdImage, helpers.CiliumDockerNetwork, fmt.Sprintf("-l id.%s", helpers.Httpd1))
+			res.ExpectSuccess("failed to create httpd container")
 
 			By("Waiting for newly added endpoint to be ready")
 			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")


### PR DESCRIPTION
Had container create fail on local testing, and test was trying to send traffic to non-existing container.
Maybe it helps if we check that container creation succeeds?

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
