### PR TITLE
bpf, Hubble: Add `is_reply` information (when available) at the `TO_OVERLAY` observability point

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -276,9 +276,11 @@ skip_host_firewall:
 	dst = (union v6addr *) &ip6->daddr;
 	info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN);
 	if (info != NULL && info->tunnel_endpoint != 0) {
+		/* TODO We know the reason when host firewall is enabled  */
 		ret = encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
-							 info->key,
-							 secctx, TRACE_PAYLOAD_LEN);
+						     info->key, secctx,
+						     TRACE_REASON_UNKNOWN,
+						     TRACE_PAYLOAD_LEN);
 
 		/* If IPSEC is needed recirc through ingress to use xfrm stack
 		 * and then result will routed back through bpf_netdev on egress
@@ -299,7 +301,10 @@ skip_host_firewall:
 		key.ip6.p4 = 0;
 		key.family = ENDPOINT_KEY_IPV6;
 
-		ret = encap_and_redirect_netdev(ctx, &key, secctx, TRACE_PAYLOAD_LEN);
+		/* TODO We know the reason when host firewall is enabled  */
+		ret = encap_and_redirect_netdev(ctx, &key, secctx,
+						TRACE_REASON_UNKNOWN,
+						TRACE_PAYLOAD_LEN);
 		if (ret == IPSEC_ENDPOINT)
 			return CTX_ACT_OK;
 		else if (ret != DROP_NO_TUNNEL_ENDPOINT)
@@ -563,8 +568,10 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 #ifdef TUNNEL_MODE
 	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
 	if (info != NULL && info->tunnel_endpoint != 0) {
+		/* TODO We know the reason when host firewall is enabled  */
 		ret = encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
 						     info->key, secctx,
+						     TRACE_REASON_UNKNOWN,
 						     TRACE_PAYLOAD_LEN);
 
 		if (ret == IPSEC_ENDPOINT)
@@ -579,7 +586,10 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 		key.family = ENDPOINT_KEY_IPV4;
 
 		cilium_dbg(ctx, DBG_NETDEV_ENCAP4, key.ip4, secctx);
-		ret = encap_and_redirect_netdev(ctx, &key, secctx, TRACE_PAYLOAD_LEN);
+		/* TODO We know the reason when host firewall is enabled  */
+		ret = encap_and_redirect_netdev(ctx, &key, secctx,
+						TRACE_REASON_UNKNOWN,
+						TRACE_PAYLOAD_LEN);
 		if (ret == IPSEC_ENDPOINT)
 			return CTX_ACT_OK;
 		else if (ret != DROP_NO_TUNNEL_ENDPOINT)
@@ -835,7 +845,9 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 	ctx->mark = 0;
 
 	bpf_clear_meta(ctx);
-	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, src_id, TRACE_PAYLOAD_LEN);
+	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, src_id,
+						TRACE_REASON_UNKNOWN,
+						TRACE_PAYLOAD_LEN);
 }
 
 static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto __maybe_unused,

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -845,7 +845,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 
 	bpf_clear_meta(ctx);
 	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, src_id,
-						TRACE_REASON_UNKNOWN,
+						TRACE_REASON_ENCRYPTED,
 						TRACE_PAYLOAD_LEN);
 }
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1125,7 +1125,7 @@ out:
 					      METRIC_EGRESS);
 #endif
 	send_trace_notify(ctx, TRACE_TO_NETWORK, src_id, 0, 0, 0,
-			  TRACE_REASON_UNKNOWN, trace.monitor);
+			  trace.reason, trace.monitor);
 
 	return ret;
 }

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -369,7 +369,9 @@ ct_recreate6:
 		 * (c) packet was redirected to tunnel device so return.
 		 */
 		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
-					     &key, SECLABEL, monitor);
+					     &key, SECLABEL,
+					     (enum trace_reason)ct_status,
+					     monitor);
 		if (ret == IPSEC_ENDPOINT)
 			goto encrypt_to_stack;
 		else if (ret != DROP_NO_TUNNEL_ENDPOINT)
@@ -823,7 +825,9 @@ ct_recreate4:
 		 * direct to external interface.
 		 */
 		ret = encap_and_redirect_lxc(ctx, egress_gw_policy->gateway_ip, encrypt_key,
-					     &key, SECLABEL, monitor);
+					     &key, SECLABEL,
+					     (enum trace_reason)ct_status,
+					     monitor);
 		if (ret == IPSEC_ENDPOINT)
 			goto encrypt_to_stack;
 		else
@@ -848,7 +852,8 @@ skip_egress_gateway:
 			if (eth_store_daddr(ctx, (__u8 *)&vtep_mac, 0) < 0)
 				return DROP_WRITE_ERROR;
 			return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint,
-									WORLD_ID, monitor);
+								WORLD_ID, ct_status,
+								monitor);
 		}
 	}
 #endif
@@ -867,7 +872,9 @@ skip_egress_gateway:
 		key.family = ENDPOINT_KEY_IPV4;
 
 		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
-					     &key, SECLABEL, monitor);
+					     &key, SECLABEL,
+					     (enum trace_reason)ct_status,
+					     monitor);
 		if (ret == DROP_NO_TUNNEL_ENDPOINT)
 			goto pass_to_stack;
 		/* If not redirected noteably due to IPSEC then pass up to stack

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -374,8 +374,11 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 
 	for (i = 0; i < VTEP_NUMS; i++) {
 		if (info->tunnel_endpoint == VTEP_ENDPOINT[i])
-			return __encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
-									info->sec_label, monitor);
+			return __encap_and_redirect_with_nodeid(ctx,
+								info->tunnel_endpoint,
+								info->sec_label,
+								TRACE_REASON_UNKNOWN,
+								monitor);
 	}
 
 	return send_drop_notify_error(ctx, 0, DROP_UNKNOWN_L3, CTX_ACT_DROP, METRIC_EGRESS);

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -350,9 +350,12 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 {
 	union macaddr mac = NODE_MAC;
 	union macaddr smac;
+	struct trace_ctx trace = {
+		.reason = TRACE_REASON_CT_REPLY,
+		.monitor = TRACE_PAYLOAD_LEN,
+	};
 	__be32 sip;
 	__be32 tip;
-	__u32 monitor = TRACE_PAYLOAD_LEN;
 	int i;
 	int ret;
 	struct remote_endpoint_info *info;
@@ -377,15 +380,14 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 			return __encap_and_redirect_with_nodeid(ctx,
 								info->tunnel_endpoint,
 								info->sec_label,
-								TRACE_REASON_CT_REPLY,
-								monitor);
+								&trace);
 	}
 
 	return send_drop_notify_error(ctx, 0, DROP_UNKNOWN_L3, CTX_ACT_DROP, METRIC_EGRESS);
 
 pass_to_stack:
 	send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0, ctx->ingress_ifindex,
-			  TRACE_REASON_CT_REPLY, monitor);
+			  trace.reason, trace.monitor);
 	return CTX_ACT_OK;
 }
 #endif /* ENABLE_VTEP */

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -377,7 +377,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 			return __encap_and_redirect_with_nodeid(ctx,
 								info->tunnel_endpoint,
 								info->sec_label,
-								TRACE_REASON_UNKNOWN,
+								TRACE_REASON_CT_REPLY,
 								monitor);
 	}
 
@@ -385,7 +385,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 
 pass_to_stack:
 	send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0, ctx->ingress_ifindex,
-			  TRACE_REASON_UNKNOWN, monitor);
+			  TRACE_REASON_CT_REPLY, monitor);
 	return CTX_ACT_OK;
 }
 #endif /* ENABLE_VTEP */

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -114,7 +114,7 @@ encap_remap_v6_host_address(struct __ctx_buff *ctx __maybe_unused,
 
 static __always_inline int
 __encap_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
-		    __u32 seclabel, __u32 monitor)
+		    __u32 seclabel, enum trace_reason ct_reason, __u32 monitor)
 {
 	struct bpf_tunnel_key key = {};
 	__u32 node_id;
@@ -139,7 +139,7 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 		return DROP_WRITE_ERROR;
 
 	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, 0, 0, ENCAP_IFINDEX,
-			  TRACE_REASON_UNKNOWN, monitor);
+			  ct_reason, monitor);
 	return 0;
 }
 
@@ -147,7 +147,8 @@ static __always_inline int
 __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 				 __u32 seclabel, __u32 monitor)
 {
-	int ret = __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
+	int ret = __encap_with_nodeid(ctx, tunnel_endpoint, seclabel,
+				      TRACE_REASON_UNKNOWN, monitor);
 	if (ret != 0)
 		return ret;
 
@@ -202,7 +203,8 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 		 * the tunnel, to apply the correct reverse DNAT.
 		 * See #14674 for details.
 		 */
-		return __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
+		return __encap_with_nodeid(ctx, tunnel_endpoint, seclabel,
+					   TRACE_REASON_UNKNOWN, monitor);
 #else
 		return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
 #endif /* !ENABLE_NODEPORT && (ENABLE_IPSEC || ENABLE_HOST_FIREWALL) */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -608,7 +608,7 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 		if (info != NULL && info->tunnel_endpoint != 0) {
 			ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 						  WORLD_ID,
-						  TRACE_REASON_UNKNOWN,
+						  (enum trace_reason)CT_NEW,
 						  TRACE_PAYLOAD_LEN);
 			if (ret)
 				goto drop_err;
@@ -1637,7 +1637,7 @@ int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 			 */
 			ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 						  WORLD_ID,
-						  TRACE_REASON_UNKNOWN,
+						  (enum trace_reason)CT_NEW,
 						  TRACE_PAYLOAD_LEN);
 			if (ret)
 				goto drop_err;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -996,9 +996,13 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 	/* We only enforce the host policies if nodeport.h is included from
 	 * bpf_host.
 	 */
+	struct trace_ctx __maybe_unused trace = {
+		.reason = TRACE_REASON_UNKNOWN,
+		.monitor = 0,
+	};
 	__u32 src_id = 0;
 
-	ret = ipv6_host_policy_ingress(ctx, &src_id);
+	ret = ipv6_host_policy_ingress(ctx, &src_id, &trace);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
 					      METRIC_INGRESS);
@@ -2070,9 +2074,13 @@ int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 	/* We only enforce the host policies if nodeport.h is included from
 	 * bpf_host.
 	 */
+	struct trace_ctx __maybe_unused trace = {
+		.reason = TRACE_REASON_UNKNOWN,
+		.monitor = 0,
+	};
 	__u32 src_id = 0;
 
-	ret = ipv4_host_policy_ingress(ctx, &src_id);
+	ret = ipv4_host_policy_ingress(ctx, &src_id, &trace);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
 					      METRIC_INGRESS);

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -123,6 +123,13 @@ update_trace_metrics(struct __ctx_buff *ctx, enum trace_point obs_point,
 	}
 }
 
+struct trace_ctx {
+	enum trace_reason reason;
+	__u32 monitor;	/* Monitor length for number of bytes to forward in
+			 * trace message. 0 means do not monitor.
+			 */
+};
+
 #ifdef TRACE_NOTIFY
 struct trace_notify {
 	NOTIFY_CAPTURE_HDR


### PR DESCRIPTION
The objective of this PR is to add the relevant information to indicate to Hubble whether an event is a reply packet or not, at the `TO_OVERLAY` observability point (for encapsulated packets).

We have the information available in most cases, but it requires some piping through the encapsulating functions. There are also a few cases where we only get the information when the host firewall is enabled.

Please refer to individual commit logs for details.
