### PR TITLE
envoy: Limit accesslog socket permissions

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -222,6 +222,7 @@ cilium-agent [flags]
       --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
       --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-gid uint                                       Group ID for proxy control plane sockets. (default 1337)
       --proxy-max-connection-duration-seconds int            Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
       --proxy-max-requests-per-connection int                Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-prometheus-port int                            Port to serve Envoy metrics on. Default 0 (disabled).

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -446,6 +446,9 @@ func initializeFlags() {
 	flags.Uint(option.ProxyConnectTimeout, 1, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
 	option.BindEnv(option.ProxyConnectTimeout)
 
+	flags.Uint(option.ProxyGID, 1337, "Group ID for proxy control plane sockets.")
+	option.BindEnv(option.ProxyGID)
+
 	flags.Int(option.ProxyPrometheusPort, 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
 	option.BindEnv(option.ProxyPrometheusPort)
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -154,10 +154,14 @@ func StartXDSServer(ipcache *ipcache.IPCache, stateDir string) *XDSServer {
 		log.WithError(err).Fatalf("Envoy: Failed to open xDS listen socket at %s", xdsPath)
 	}
 
-	// Make the socket accessible by non-root Envoy proxies, e.g. running in
-	// sidecar containers.
-	if err = os.Chmod(xdsPath, 0777); err != nil {
+	// Make the socket accessible by owner and group only. Group access is needed for Istio
+	// sidecar proxies.
+	if err = os.Chmod(xdsPath, 0660); err != nil {
 		log.WithError(err).Fatalf("Envoy: Failed to change mode of xDS listen socket at %s", xdsPath)
+	}
+	// Change the group to ProxyGID allowing access from any process from that group.
+	if err = os.Chown(xdsPath, -1, option.Config.ProxyGID); err != nil {
+		log.WithError(err).Warningf("Envoy: Failed to change the group of xDS listen socket at %s, sidecar proxies may not work", xdsPath)
 	}
 
 	ldsCache := xds.NewCache()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1083,6 +1083,10 @@ const (
 	// is considered timed out
 	ProxyConnectTimeout = "proxy-connect-timeout"
 
+	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
+	// agent for proxy configuration and access logging.
+	ProxyGID = "proxy-gid"
+
 	// ReadCNIConfiguration reads the CNI configuration file and extracts
 	// Cilium relevant information. This can be used to pass per node
 	// configuration to Cilium.
@@ -1428,6 +1432,10 @@ type DaemonConfig struct {
 	// ProxyConnectTimeout is the time in seconds after which Envoy considers a TCP
 	// connection attempt to have timed out.
 	ProxyConnectTimeout int
+
+	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
+	// agent for proxy configuration and access logging.
+	ProxyGID int
 
 	// ProxyPrometheusPort specifies the port to serve Envoy metrics on.
 	ProxyPrometheusPort int
@@ -2715,6 +2723,7 @@ func (c *DaemonConfig) Populate() {
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
 	c.PrometheusServeAddr = viper.GetString(PrometheusServeAddr)
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
+	c.ProxyGID = viper.GetInt(ProxyGID)
 	c.ProxyPrometheusPort = viper.GetInt(ProxyPrometheusPort)
 	c.ProxyMaxRequestsPerConnection = viper.GetInt(ProxyMaxRequestsPerConnection)
 	c.ProxyMaxConnectionDuration = time.Duration(viper.GetInt64(ProxyMaxConnectionDuration))


### PR DESCRIPTION
Limit access to Cilium xDS and access log sockets to root and group 1337
used by Istio sidecars.

Fixes: #3131
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
