### PR TITLE
pkg/redirectpolicy: Add missing namespace check in pod update handler

### DIFF
--- a/Documentation/gettingstarted/local-redirect-policy.rst
+++ b/Documentation/gettingstarted/local-redirect-policy.rst
@@ -12,7 +12,8 @@ Local Redirect Policy (beta)
 
 This document explains how to configure Cilium's Local Redirect Policy, that
 enables pod traffic destined to an IP address and port/protocol tuple
-or Kubernetes service to be redirected locally to a backend pod within a node.
+or Kubernetes service to be redirected locally to backend pod(s) within a node,
+using eBPF. The namespace of backend pod(s) need to match with that of the policy.
 The CiliumLocalRedirectPolicy is configured as a ``CustomResourceDefinition``.
 
 There are two types of Local Redirect Policies supported. When traffic for a

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -291,7 +291,7 @@ func (rpm *Manager) OnUpdatePodLocked(pod *slimcorev1.Pod, removeOld bool, upser
 	if upsertNew {
 		// Check if any of the current redirect policies select this pod.
 		for _, config := range rpm.policyConfigs {
-			if config.policyConfigSelectsPod(podData) {
+			if config.checkNamespace(pod.GetNamespace()) && config.policyConfigSelectsPod(podData) {
 				rpm.processConfig(config, podData)
 			}
 		}

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -549,4 +549,30 @@ func (m *ManagerSuite) TestManager_AddrMatcherConfigDualStack(c *C) {
 	}
 }
 
-//TODO Tests for svcMatcher
+// Tests add and update pod operations with namespace mismatched pods.
+func (m *ManagerSuite) TestManager_OnAddandUpdatePod(c *C) {
+	configFe := configAddrType
+	m.rpm.policyFrontendsByHash[fe1.Hash()] = configFe.id
+	configSvc := configSvcType
+	m.rpm.policyConfigs[configSvc.id] = &configSvc
+	pod := pod1.DeepCopy()
+	pod.Namespace = "ns2"
+	podID := k8s.ServiceID{
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+
+	m.rpm.OnAddPod(pod)
+
+	// Namespace mismatched pod not selected.
+	c.Assert(len(m.rpm.policyPods), Equals, 0)
+	_, found := m.rpm.policyPods[podID]
+	c.Assert(found, Equals, false)
+
+	m.rpm.OnUpdatePod(pod, true, true)
+
+	// Namespace mismatched pod not selected.
+	c.Assert(len(m.rpm.policyPods), Equals, 0)
+	_, found = m.rpm.policyPods[podID]
+	c.Assert(found, Equals, false)
+}


### PR DESCRIPTION
pkg/redirectpolicy: Add missing namespace check

Local Redirect Policy (LRP) namespace needs to match
with the backend pods selected by the LRP.

This check was missing in the case where backend
pods are deployed after an LRP that selects them
was applied.

Reported-By: Joe Stringer <joe@covalent.io>

**Release note**
```release-note
Fix a bug where a backend pod can be selected by a local redirect policy deployed in a different namespace if the local redirect policy was deployed first. 
```