### PR TITLE
Use identity labels for selector matching for Egress NAT Gateway

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -574,7 +574,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	if option.Config.EnableIPv4EgressGateway {
-		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(&d)
+		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(&d, d.identityAllocator)
 	}
 
 	d.k8sWatcher = watchers.NewK8sWatcher(

--- a/pkg/egressgateway/endpoint.go
+++ b/pkg/egressgateway/endpoint.go
@@ -27,7 +27,7 @@ type endpointMetadata struct {
 // endpointID includes endpoint name and namespace
 type endpointID = types.NamespacedName
 
-func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint) (*endpointMetadata, error) {
+func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels labels.Labels) (*endpointMetadata, error) {
 	var ipv4s []net.IP
 	id := types.NamespacedName{
 		Name:      endpoint.GetName(),
@@ -50,7 +50,7 @@ func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint) (*endpointMetadata, 
 
 	data := &endpointMetadata{
 		ips:    ipv4s,
-		labels: labels.NewLabelsFromModel(endpoint.Identity.Labels).K8sStringMap(),
+		labels: identityLabels.K8sStringMap(),
 		id:     id,
 	}
 

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -4,16 +4,22 @@
 package egressgateway
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/cilium/cilium/pkg/identity"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -39,19 +45,39 @@ type Manager struct {
 
 	// epDataStore stores endpointId to endpoint metadata mapping
 	epDataStore map[endpointID]*endpointMetadata
+
+	// identityAllocator is used to fetch identity labels for endpoint updates
+	identityAllocator identityCache.IdentityAllocator
 }
 
 // NewEgressGatewayManager returns a new Egress Gateway Manager.
-func NewEgressGatewayManager(k8sCacheSyncedChecker k8sCacheSyncedChecker) *Manager {
+func NewEgressGatewayManager(k8sCacheSyncedChecker k8sCacheSyncedChecker, identityAlocator identityCache.IdentityAllocator) *Manager {
 	manager := &Manager{
 		k8sCacheSyncedChecker: k8sCacheSyncedChecker,
 		policyConfigs:         make(map[policyID]*PolicyConfig),
 		epDataStore:           make(map[endpointID]*endpointMetadata),
+		identityAllocator:     identityAlocator,
 	}
 
 	manager.runReconciliationAfterK8sSync()
 
 	return manager
+}
+
+// getIdentityLabels waits for the global identities to be populated to the cache,
+// then looks up identity by ID from the cached identity allocator and return its labels.
+func (manager *Manager) getIdentityLabels(securityIdentity uint32) (labels.Labels, error) {
+	identityCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
+	defer cancel()
+	if err := manager.identityAllocator.WaitForInitialGlobalIdentities(identityCtx); err != nil {
+		return nil, fmt.Errorf("failed to wait for initial global identities: %v", err)
+	}
+
+	identity := manager.identityAllocator.LookupIdentityByID(identityCtx, identity.NumericIdentity(securityIdentity))
+	if identity == nil {
+		return nil, fmt.Errorf("identity %d not found", securityIdentity)
+	}
+	return identity.Labels, nil
 }
 
 // runReconciliationAfterK8sSync spawns a goroutine that waits for the agent to
@@ -118,6 +144,7 @@ func (manager *Manager) OnDeleteEgressPolicy(configID policyID) {
 func (manager *Manager) OnUpdateEndpoint(endpoint *k8sTypes.CiliumEndpoint) {
 	var epData *endpointMetadata
 	var err error
+	var identityLabels labels.Labels
 
 	manager.mutex.Lock()
 	defer manager.mutex.Unlock()
@@ -133,7 +160,13 @@ func (manager *Manager) OnUpdateEndpoint(endpoint *k8sTypes.CiliumEndpoint) {
 		return
 	}
 
-	if epData, err = getEndpointMetadata(endpoint); err != nil {
+	if identityLabels, err = manager.getIdentityLabels(uint32(endpoint.Identity.ID)); err != nil {
+		logger.WithError(err).
+			Error("Failed to get idenity labels for endpoint, skipping update to egress policy.")
+		return
+	}
+
+	if epData, err = getEndpointMetadata(endpoint, identityLabels); err != nil {
 		logger.WithError(err).
 			Error("Failed to get valid endpoint metadata, skipping update to egress policy.")
 		return

--- a/test/k8s/egress.go
+++ b/test/k8s/egress.go
@@ -87,10 +87,7 @@ var _ = SkipDescribeIf(func() bool {
 		// We deploy cilium, to run the echo server and assign egress IP, and redeploy with
 		// different configurations for the tests.
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename,
-			// TODO Disable CES until https://github.com/cilium/cilium/issues/17669
-			//      has been resolved
-			map[string]string{"enableCiliumEndpointSlice": "false"})
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
 
 		runEchoServer()
 		assignEgressIP()


### PR DESCRIPTION
With the introduction of cilium endpoint slices (CES), pod labels are no
longer in the cilium endpoint struct, breaking the matching logic for
egress NAT gateway. This change fetches the labels from the identify
cache and use identity labels to do the same matching. It makes Egress
NAT Gateway compatible with CES.

Signed-off-by: Bolun Zhao <blzhao@google.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #17669

This is tested manually to verify that

- The egress NAT functionality remains unchanged
- The policy manager correctly fetched the Identity labels for matching
- Egress NAT is compatible with CES enablement

Unit Test Results:
```
=== RUN   Test
START: manager_privileged_test.go:87: EgressGatewayTestSuite.SetUpSuite
level=info msg="Detected mounted BPF filesystem at /sys/fs/bpf" subsys=bpf
PASS: manager_privileged_test.go:87: EgressGatewayTestSuite.SetUpSuite  0.145s

START: manager_privileged_test.go:97: EgressGatewayTestSuite.TestEgressGatewayManager
level=info msg="Added CiliumEgressNATPolicy" ciliumEgressNATPolicyName=policy-1 subsys=egressgateway
Allocated ID:  {1000 k8s:test-key=test-value-1 {0 {0 0}}  []  1}
level=info msg="Egress gateway policy applied" destinationCIDR="{1.1.1.0 ffffff00}" egressIP=192.168.101.1 gatewayIP=192.168.101.1 sourceIP=10.0.0.1 subsys=egressgateway
Released old ID:  {1000 k8s:test-key=test-value-1 {0 {0 0}}  []  1}
Allocated new ID:  {1001  {0 {0 0}}  []  1}
level=info msg="Egress gateway policy removed" destinationCIDR=1.1.1.0/24 sourceIP=10.0.0.1 subsys=egressgateway
Released old ID:  {1001  {0 {0 0}}  []  1}
Allocated new ID:  {1002 k8s:test-key=test-value-1 {0 {0 0}}  []  1}
level=info msg="Egress gateway policy applied" destinationCIDR="{1.1.1.0 ffffff00}" egressIP=192.168.101.1 gatewayIP=192.168.101.1 sourceIP=10.0.0.1 subsys=egressgateway
level=info msg="Added CiliumEgressNATPolicy" ciliumEgressNATPolicyName=policy-2 subsys=egressgateway
Allocated ID:  {1003 k8s:test-key=test-value-2 {0 {0 0}}  []  1}
level=info msg="Egress gateway policy applied" destinationCIDR="{1.1.1.0 ffffff00}" egressIP=192.168.102.1 gatewayIP=192.168.102.1 sourceIP=10.0.0.2 subsys=egressgateway
Released old ID:  {1002 k8s:test-key=test-value-1 {0 {0 0}}  []  1}
Allocated new ID:  {1004  {0 {0 0}}  []  1}
level=info msg="Egress gateway policy removed" destinationCIDR=1.1.1.0/24 sourceIP=10.0.0.1 subsys=egressgateway
PASS: manager_privileged_test.go:97: EgressGatewayTestSuite.TestEgressGatewayManager    0.000s

level=info msg="Egress gateway policy applied" destinationCIDR="{1.1.1.0 ffffff00}" egressIP=192.168.102.1 gatewayIP=192.168.102.1 sourceIP=10.0.0.2 subsys=egressgateway
OK: 1 passed
--- PASS: Test (0.15s)
PASS
```