### PR TITLE
Improve JSON marshaling performance for policy subsystem

### DIFF
--- a/daemon/cmd/kube_proxy_healthz_test.go
+++ b/daemon/cmd/kube_proxy_healthz_test.go
@@ -7,7 +7,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"time"

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -39,7 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/trigger"
 )
 
-var json = jsoniter.ConfigCompatibleWithStandardLibrary
+var json = jsoniter.ConfigFastest
 
 // initPolicy initializes the core policy components of the daemon.
 func (d *Daemon) initPolicy(epMgr *endpointmanager.EndpointManager) error {

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	stdlog "log"
 	"net"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/google/uuid"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
@@ -38,6 +38,8 @@ import (
 	"github.com/cilium/cilium/pkg/safetime"
 	"github.com/cilium/cilium/pkg/trigger"
 )
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 // initPolicy initializes the core policy components of the daemon.
 func (d *Daemon) initPolicy(epMgr *endpointmanager.EndpointManager) error {

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.3.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jeremywohl/flatten v1.0.1
+	github.com/json-iterator/go v1.1.12
 	github.com/kevinburke/ssh_config v1.1.0
 	github.com/kr/pretty v0.3.0
 	github.com/mattn/go-shellwords v1.0.12
@@ -162,7 +163,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v0.0.0-20200817173448-b6b71def0850 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/cilium/cilium/pkg/labels"
 )

--- a/pkg/policy/api/rule_test.go
+++ b/pkg/policy/api/rule_test.go
@@ -7,8 +7,6 @@
 package api
 
 import (
-	"encoding/json"
-
 	. "gopkg.in/check.v1"
 )
 

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
-var json = jsoniter.ConfigCompatibleWithStandardLibrary
+var json = jsoniter.ConfigFastest
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "policy-api")
 

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -68,7 +68,7 @@ func (n *EndpointSelector) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if n.MatchLabels != nil {
-		ml := map[string]string{}
+		ml := make(map[string]string, len(n.MatchLabels))
 		for k, v := range n.MatchLabels {
 			ml[labels.GetExtendedKeyFrom(k)] = v
 		}
@@ -96,7 +96,7 @@ func (n EndpointSelector) MarshalJSON() ([]byte, error) {
 	}
 
 	if n.MatchLabels != nil {
-		newLabels := map[string]string{}
+		newLabels := make(map[string]string, len(n.MatchLabels))
 		for k, v := range n.MatchLabels {
 			newLabels[labels.GetCiliumKeyFrom(k)] = v
 		}

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -4,9 +4,10 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
+
+	jsoniter "github.com/json-iterator/go"
 
 	k8sLbls "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -16,6 +17,8 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 )
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "policy-api")
 

--- a/pkg/policy/api/selector_test.go
+++ b/pkg/policy/api/selector_test.go
@@ -113,3 +113,52 @@ func BenchmarkMatchesInvalid1000Parallel(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMarshalJSON(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		es := EndpointSelector{
+			LabelSelector: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k8s:io.kubernetes.pod.namespace": "default",
+					"random":                          "label1",
+					"random2":                         "label3",
+					"random3":                         "label4",
+					"random4":                         "label5",
+					"random5":                         "label6",
+					"averylonggarbagevaluethatweareusingtotestjson": "averylonggarbagevaluethatweareusingtotestjson",
+				},
+			},
+		}
+		_, err := es.MarshalJSON()
+		if err != nil {
+			b.Fatalf("error marshaling: %v", err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalJSON(b *testing.B) {
+	j := []byte(`
+{
+  "endpointSelector": {
+    "matchLabels": {
+      "k8s:io.kubernetes.pod.namespace": "default",
+      "random": "label1",
+      "random2": "label3",
+      "random3": "label4",
+      "random4": "label5",
+      "random5": "label6",
+      "averylonggarbagevaluethatweareusingtotestjson": "averylonggarbagevaluethatweareusingtotestjson"
+    }
+  }
+}
+`)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		es := new(EndpointSelector)
+		err := es.UnmarshalJSON(j)
+		if err != nil {
+			b.Fatalf("error unmarshaling: %v", err)
+		}
+	}
+}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -5,7 +5,6 @@ package policy
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -5,12 +5,12 @@ package policy
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"sync/atomic"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/eventqueue"
@@ -24,6 +24,8 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 type CertificateManager interface {
 	GetTLSContext(ctx context.Context, tls *api.TLSContext, defaultNs string) (ca, public, private string, err error)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
-var json = jsoniter.ConfigCompatibleWithStandardLibrary
+var json = jsoniter.ConfigFastest
 
 type CertificateManager interface {
 	GetTLSContext(ctx context.Context, tls *api.TLSContext, defaultNs string) (ca, public, private string, err error)

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -6,7 +6,6 @@ package policy
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"net"
 	"sort"
 	"strings"


### PR DESCRIPTION
- pkg/policy/api: Add benchmark for JSON marshaling
- daemon, policy, vendor: Use github.com/json-iterator/go
- daemon, policy: Use json.ConfigFastest
- pkg/policy/api: Preallocate MatchLabels slice during marshaling

This PR does not attempt to convert all of Cilium's `encoding/json` usage over to the new library (`github.com/json-iterator/go`), but rather the policy subsystem which can have a noticeable performance impact in policy churning environments. If this PR proves useful, we can consider converting all of Cilium to use the new JSON library.