### PR TITLE
ip: Exclude loopback addresses

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -408,18 +408,19 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	var mtuConfig mtu.Configuration
-	externalIP := node.GetIPv4()
-	if externalIP == nil {
-		externalIP = node.GetIPv6()
+	ipForMTU := node.GetInternalIPv4Router()
+	if ipForMTU == nil {
+		ipForMTU = node.GetIPv6Router()
 	}
-	// ExternalIP could be nil but we are covering that case inside NewConfiguration
+	log.WithField("ip-for-mtu", ipForMTU).Info("MICHI STRUGGLE")
+	// ipForMTU could be nil but we are covering that case inside NewConfiguration
 	mtuConfig = mtu.NewConfiguration(
 		authKeySize,
 		option.Config.EnableIPSec,
 		option.Config.TunnelingEnabled(),
 		option.Config.EnableWireguard,
 		configuredMTU,
-		externalIP,
+		ipForMTU,
 	)
 
 	nodeMngr, err := nodemanager.NewManager("all", dp.Node(), option.Config, nil, nil)

--- a/pkg/node/ip_linux.go
+++ b/pkg/node/ip_linux.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 func init() {
@@ -36,6 +37,11 @@ func initExcludedIPs() {
 					skip = false
 					break
 				}
+
+			}
+			// Exclude loopback addresses.
+			if (l.Attrs().RawFlags & unix.IFF_LOOPBACK) != 0 {
+				skip = false
 			}
 			if skip {
 				continue


### PR DESCRIPTION
Exclude loopback IP addresses to ensure that node.GetIPv{4,6} doesn't
return a loopback address. daemon.NewDaemon gets the MTU from the IP
address returned from node.GetIPv{4,6}. Loopback interfaces typically
have the MTU set to 65536, and datapath.Loader.Reinitialize fails with
"invalid argument" error at setupBaseDevice() if the physical network
has a lower MTU.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

```release-note
Don't use loopback addresses to derive the MTU from.
```
