### PR TITLE
docs: configuration for host-only networks with latest virtualbox

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -317,6 +317,22 @@ to enable NFS.
       # vers3=y
       ...
 
+.. note::
+
+   A later version of VirtualBox (v6.1.28 or above) restricts IP ranges
+   for host-only networks by default. Make sure IP ranges used for VMs
+   are specified explicitly:
+
+   .. code-block:: none
+
+      # cat /etc/vbox/networks.conf
+      ...
+      * 192.168.56.0/21
+      * FD00::/16
+      ...
+
+   See `VirtualBox Host-Only Networking <https://www.virtualbox.org/manual/ch06.html#network_hostonly>`_ for more detail.
+
 If for some reason, running of the provisioning script fails, you should bring the VM down before trying again:
 
 .. code-block:: shell-session


### PR DESCRIPTION
A later version of VirtualBox restricts IP ranges that can be used for host-only
networks by default. Added a note that describes required configuration of
host-only networks to launch VMs with latest VirtualBox.

Signed-off-by: Keisuke Kondo<k.gryphus@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #18932

```release-note
docs: configuration for host-only networks with latest VirtualBox
```
