### PR TITLE
helm: Fix invalid type for Certificate spec.ipAddresses

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -15,9 +15,11 @@ spec:
   {{- range $dns := .Values.hubble.relay.tls.server.extraDnsNames }}
   - {{ $dns | quote }}
   {{- end }}
+  {{- if .Values.hubble.relay.tls.server.extraIpAddresses }}
   ipAddresses:
   {{- range $ip := .Values.hubble.relay.tls.server.extraIpAddresses }}
   - {{ $ip | quote }}
+  {{- end }}
   {{- end }}
   duration: {{ printf "%dh" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -16,9 +16,11 @@ spec:
   {{- range $dns := .Values.hubble.tls.server.extraDnsNames }}
   - {{ $dns | quote }}
   {{- end }}
+  {{- if .Values.hubble.tls.server.extraIpAddresses }}
   ipAddresses:
   {{- range $ip := .Values.hubble.tls.server.extraIpAddresses }}
   - {{ $ip | quote }}
+  {{- end }}
   {{- end }}
   duration: {{ printf "%dh" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
 {{- end }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Certificate spec.ipAddresses field must be an array, but will be null if
an empty array is specified in values.yaml. This will be reported as an
invalid type by validator such as kubeconfirm or kubeval.

The difference from the master branch is as follows:
```
$ git show -q
commit 774a91f0e7497d9c9085234005ec81f1065c3783 (HEAD -> master, origin/master, origin/HEAD)
Author: Daniel Borkmann <daniel@iogearbox.net>
Date:   Fri Mar 18 15:50:16 2022 +0000

    bpf: Add trace reason for TRACE_TO_PROXY

    TRACE_TO_PROXY was missing the trace reason argument in bpf_lxc. Given
    we just got it from CT lookup anyway, pass it onwards.

    Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

$ helm template cilium install/kubernetes/cilium \
--set hubble.tls.auto.enabled=true \
--set hubble.tls.auto.method=certmanager \
--set hubble.tls.auto.certManagerIssuerRef.group="cert-manager.io" \
--set hubble.tls.auto.certManagerIssuerRef.kind="ClusterIssuer" \
--set hubble.tls.auto.certManagerIssuerRef.name="ca-issuer" \
--set hubble.relay.enabled=true \
--set hubble.relay.tls.server.enabled=true >/tmp/cilium-master.yaml

$ git show -q
commit 2832e8eb438746645670a01b475b892f081e3f5a (HEAD -> fix-cert-ipAddresses-null)
Author: Kazuki Suda <kazuki.suda@gmail.com>
Date:   Mon Mar 21 22:29:23 2022 +0900

    helm: Fix invalid type for Certificate spec.ipAddresses

    Certificate spec.ipAddresses field must be an array, but will be null if
    an empty array is specified in values.yaml. This will be reported as an
    invalid type by linter such as kubeconfirm or kubeval.

    Signed-off-by: Kazuki Suda <kazuki.suda@gmail.com>

$ helm template cilium install/kubernetes/cilium \
--set hubble.tls.auto.enabled=true \
--set hubble.tls.auto.method=certmanager \
--set hubble.tls.auto.certManagerIssuerRef.group="cert-manager.io" \
--set hubble.tls.auto.certManagerIssuerRef.kind="ClusterIssuer" \
--set hubble.tls.auto.certManagerIssuerRef.name="ca-issuer" \
--set hubble.relay.enabled=true \
--set hubble.relay.tls.server.enabled=true >/tmp/cilium-fix-cert-ipAddresses-null.yaml

$ diff -u /tmp/cilium-master.yaml /tmp/cilium-fix-cert-ipAddresses-null.yaml
--- /tmp/cilium-master.yaml     2022-03-21 22:46:08.035415103 +0900
+++ /tmp/cilium-fix-cert-ipAddresses-null.yaml  2022-03-21 22:45:24.622872275 +0900
@@ -925,7 +925,6 @@
   commonName: "*.hubble-relay.cilium.io"
   dnsNames:
   - "*.hubble-relay.cilium.io"
-  ipAddresses:
   duration: 26280h
 ---
 # Source: cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -943,5 +942,4 @@
   commonName: "*.default.hubble-grpc.cilium.io"
   dnsNames:
   - "*.default.hubble-grpc.cilium.io"
-  ipAddresses:
   duration: 26280h
```

Using kubeconform to validate the Certificate object, we can see that there are no errors in the manifest generated on this branch, compared to errors in the manifest generated on the master branch.

```
$ mkdir -p crd_schemas && cd crd_schemas
$ wget https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
$ wget https://raw.githubusercontent.com/yannh/kubeconform/v0.4.13/scripts/openapi2jsonschema.py
$ python openapi2jsonschema.py cert-manager.crds.yaml
JSON schema written to certificaterequest_v1.json
JSON schema written to certificate_v1.json
JSON schema written to challenge_v1.json
JSON schema written to clusterissuer_v1.json
JSON schema written to issuer_v1.json
JSON schema written to order_v1.json
$ curl -s -L https://github.com/yannh/kubeconform/releases/download/v0.4.13/kubeconform-linux-amd64.tar.gz | tar xvzf
- kubeconform
kubeconform

# The branch of this PR
$ cat /tmp/cilium-fix-cert-ipAddresses-null.yaml | ./kubeconform -strict -schema-location "certificate_v1.json" | grep Certificate

# The master branch
$ cat /tmp/cilium-master.yaml | ./kubeconform -strict -schema-location "certificate_v1.json" | grep Certificate
stdin - Certificate hubble-relay-server-certs is invalid: For field spec.ipAddresses: Invalid type. Expected: array, given: null
stdin - Certificate hubble-server-certs is invalid: For field spec.ipAddresses: Invalid type. Expected: array, given: null
```