### PR TITLE
bpf: fix native local build

### DIFF
--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -35,10 +35,10 @@ LLC   ?= llc
 HOST_CC    ?= gcc
 HOST_STRIP ?= strip
 
-ifeq ($(GOARCH),arm64)
+ifeq ($(CROSS_ARCH),arm64)
   HOST_CC = aarch64-linux-gnu-gcc
   HOST_STRIP = aarch64-linux-gnu-strip
-else ifeq ($(GOARCH),amd64)
+else ifeq ($(CROSS_ARCH),amd64)
   HOST_CC = x86_64-linux-gnu-gcc
   HOST_STRIP = x86_64-linux-gnu-strip
 endif


### PR DESCRIPTION
Setting HOST_CC and HOST_STRIP on environments that are not
cross-compiled results in a failed compilation such as:

```
x86_64-linux-gnu-gcc -Wall -O2 -Wno-format-truncation -I include/ cilium-probe-kernel-hz.c -o cilium-probe-kernel-hz
cilium-probe-kernel-hz.c:6:10: fatal error: stdio.h: No such file or directory
    6 | #include <stdio.h>
      |          ^~~~~~~~~
```

Thus, HOST_CC and HOST_STRIP are only set when cross-compilation is
being performed.

Fixes: 9f05489ad35f ("build: Fix cross compiling for amd64 on arm64")
Signed-off-by: André Martins <andre@cilium.io>