### PR TITLE
helm: Fix Hubble Service when ServiceMonitor is being used

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
@@ -10,8 +10,10 @@ metadata:
     {{- with .Values.hubble.metrics.serviceAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- if not .Values.hubble.metrics.serviceMonitor.enabled }}
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.hubble.metrics.port | quote }}
+    {{- end }}
 spec:
   clusterIP: None
   type: ClusterIP


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Hubble Service manifest includes "prometheus.io" annotations even when ServiceMonitor manifest is being used. This patch only adds the annotations when ServiceMonitor is not used.
