### PR TITLE
bpf, hubble: explicitly mark trace reason as "unknown" when relevant

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -868,11 +868,13 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 #endif
 
 		send_trace_notify(ctx, trace, identity, 0, 0,
-				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
+				  ctx->ingress_ifindex,
+				  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);
 	} else {
 		bpf_skip_nodeport_clear(ctx);
 		send_trace_notify(ctx, TRACE_FROM_NETWORK, 0, 0, 0,
-				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
+				  ctx->ingress_ifindex,
+				  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);
 	}
 
 	bpf_clear_meta(ctx);
@@ -953,7 +955,8 @@ handle_netdev(struct __ctx_buff *ctx, const bool from_host)
 		return send_drop_notify(ctx, SECLABEL, WORLD_ID, 0, ret,
 					CTX_ACT_DROP, METRIC_EGRESS);
 #else
-		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, 0, 0, 0, 0, 0);
+		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, 0, 0, 0,
+				  TRACE_REASON_UNKNOWN, 0);
 		/* Pass unknown traffic to the stack */
 		return CTX_ACT_OK;
 #endif /* ENABLE_HOST_FIREWALL */
@@ -1099,8 +1102,8 @@ out:
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
 					      METRIC_EGRESS);
 #endif
-	send_trace_notify(ctx, TRACE_TO_NETWORK, src_id, 0, 0,
-			  0, 0, monitor);
+	send_trace_notify(ctx, TRACE_TO_NETWORK, src_id, 0, 0, 0,
+			  TRACE_REASON_UNKNOWN, monitor);
 
 	return ret;
 }
@@ -1183,7 +1186,7 @@ out:
 
 	if (!traced)
 		send_trace_notify(ctx, TRACE_TO_STACK, src_id, 0, 0,
-				  CILIUM_IFINDEX, 0, 0);
+				  CILIUM_IFINDEX, TRACE_REASON_UNKNOWN, 0);
 
 	return ret;
 }

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1084,8 +1084,8 @@ int handle_xgress(struct __ctx_buff *ctx)
 	bpf_clear_meta(ctx);
 	reset_queue_mapping(ctx);
 
-	send_trace_notify(ctx, TRACE_FROM_LXC, SECLABEL, 0, 0, 0, 0,
-			  TRACE_PAYLOAD_LEN);
+	send_trace_notify(ctx, TRACE_FROM_LXC, SECLABEL, 0, 0, 0,
+			  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);
 
 	if (!validate_ethertype(ctx, &proto)) {
 		ret = DROP_UNSUPPORTED_L2;
@@ -1863,8 +1863,8 @@ int handle_to_container(struct __ctx_buff *ctx)
 	if (magic == MARK_MAGIC_PROXY_INGRESS || magic == MARK_MAGIC_PROXY_EGRESS)
 		trace = TRACE_FROM_PROXY;
 
-	send_trace_notify(ctx, trace, identity, 0, 0,
-			  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
+	send_trace_notify(ctx, trace, identity, 0, 0, ctx->ingress_ifindex,
+			  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);
 
 #if defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_ROUTING)
 	/* If the packet comes from the hostns and per-endpoint routes are enabled,

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -17,7 +17,7 @@ int from_network(struct __ctx_buff *ctx)
 	int ret = CTX_ACT_OK;
 
 	__u16 proto __maybe_unused;
-	enum trace_reason reason = 0;
+	enum trace_reason reason = TRACE_REASON_UNKNOWN;
 	enum trace_point obs_point_to = TRACE_TO_STACK;
 	enum trace_point obs_point_from = TRACE_FROM_NETWORK;
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -381,7 +381,8 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 	return send_drop_notify_error(ctx, 0, DROP_UNKNOWN_L3, CTX_ACT_DROP, METRIC_EGRESS);
 
 pass_to_stack:
-	send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0, ctx->ingress_ifindex, 0, monitor);
+	send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0, ctx->ingress_ifindex,
+			  TRACE_REASON_UNKNOWN, monitor);
 	return CTX_ACT_OK;
 }
 #endif /* ENABLE_VTEP */
@@ -477,7 +478,8 @@ int from_overlay(struct __ctx_buff *ctx)
 		}
 
 		send_trace_notify(ctx, obs_point, identity, 0, 0,
-				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
+				  ctx->ingress_ifindex,
+				  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);
 	}
 
 	switch (proto) {

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -139,7 +139,7 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 		return DROP_WRITE_ERROR;
 
 	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, 0, 0, ENCAP_IFINDEX,
-			  0, monitor);
+			  TRACE_REASON_UNKNOWN, monitor);
 	return 0;
 }
 

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -51,7 +51,11 @@ enum trace_reason {
 	TRACE_REASON_CT_REPLY = CT_REPLY,
 	TRACE_REASON_CT_RELATED = CT_RELATED,
 	TRACE_REASON_CT_REOPENED = CT_REOPENED,
-	TRACE_REASON_ENCRYPTED = 0x80
+	TRACE_REASON_UNKNOWN,
+	/* Note: TRACE_REASON_ENCRYPTED is used as a mask. Beware if you add
+	 * new values below it, they would match with that mask.
+	 */
+	TRACE_REASON_ENCRYPTED = 0x80,
 } __packed;
 
 /* Trace aggregation levels. */

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -603,11 +603,12 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
 	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
 
-	// TRACE_FROM_LXC (traffic direction not supported)
+	// TRACE_FROM_LXC unknown
 	tn = monitor.TraceNotifyV0{
 		Type:     byte(api.MessageTypeTrace),
 		Source:   localEP,
 		ObsPoint: api.TraceFromLxc,
+		Reason:   monitor.TraceReasonUnknown,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
 	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
@@ -677,20 +678,11 @@ func TestDecodeIsReply(t *testing.T) {
 	assert.Equal(t, true, f.GetIsReply().GetValue())
 	assert.Equal(t, true, f.GetReply())
 
-	// TRACE_FROM_LXC (connection tracking not supported)
+	// TRACE_FROM_LXC
 	tn = monitor.TraceNotifyV0{
 		Type:     byte(api.MessageTypeTrace),
 		ObsPoint: api.TraceFromLxc,
-		Reason:   monitor.TraceReasonCtReply,
-	}
-	f = parseFlow(tn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.Equal(t, false, f.GetReply())
-
-	tn = monitor.TraceNotifyV0{
-		Type:     byte(api.MessageTypeTrace),
-		ObsPoint: api.TraceFromLxc,
-		Reason:   0,
+		Reason:   monitor.TraceReasonUnknown,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
 	assert.Nil(t, f.GetIsReply())

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -165,21 +165,6 @@ func TraceObservationPoint(obsPoint uint8) string {
 	return fmt.Sprintf("%d", obsPoint)
 }
 
-// TraceObservationPointHasConnState returns true if the observation point
-// obsPoint populates the TraceNotify.Reason field with connection tracking
-// information.
-func TraceObservationPointHasConnState(obsPoint uint8) bool {
-	switch obsPoint {
-	case TraceToLxc,
-		TraceToProxy,
-		TraceToHost,
-		TraceToStack:
-		return true
-	default:
-		return false
-	}
-}
-
 // AgentNotify is a notification from the agent. The notification is stored
 // in its JSON-encoded representation
 type AgentNotify struct {

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -84,6 +84,7 @@ const (
 	TraceReasonCtReply
 	TraceReasonCtRelated
 	TraceReasonCtReopened
+	TraceReasonUnknown
 )
 
 var traceReasons = map[uint8]string{
@@ -92,6 +93,7 @@ var traceReasons = map[uint8]string{
 	TraceReasonCtReply:       "reply",
 	TraceReasonCtRelated:     "related",
 	TraceReasonCtReopened:    "reopened",
+	TraceReasonUnknown:       "unknown",
 }
 
 func connState(reason uint8) string {
@@ -100,6 +102,15 @@ func connState(reason uint8) string {
 		return str
 	}
 	return fmt.Sprintf("%d", reason)
+}
+
+func TraceReasonIsKnown(reason uint8) bool {
+	switch reason {
+	case TraceReasonUnknown:
+		return false
+	default:
+		return true
+	}
 }
 
 // DecodeTraceNotify will decode 'data' into the provided TraceNotify structure


### PR DESCRIPTION
So far, the "reason" for a trace would be set to 0 when not known at an observability point in the datapath. This was problematic, because 0 is also a valid value for a specific reason (`CT_NEW`). As a result, the monitor package had to explicitly filter the observability points, based on whether they are supposed to provide a valid reason or not.

Instead, we can simply mark the reason as "unknown" when we ignore its value. This makes it straightforward to ignore an unknown reason when decoding the trace in Hubble.

This is in the context of https://github.com/cilium/cilium/pull/19185, which should be rebased on top, should this PR be accepted and merged.

Cc: @gandro [Note: Contrary to our offline discussion, I did not attempt to shift the values of the existing reasons and to assign 0 as the unknown trace reason, because I figured this would introduce some complications when upgrading/downgrading Cilium (regarding the states stored in the Conntrack table).]