### PR TITLE
test/RuntimePrivilegedUnitTests: Fix always-passing test

### DIFF
--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -42,7 +42,7 @@ var _ = Describe("RuntimePrivilegedUnitTests", func() {
 		path, _ := filepath.Split(vm.BasePath())
 		ctx, cancel := context.WithTimeout(context.Background(), privilegedUnitTestTimeout)
 		defer cancel()
-		res := vm.ExecContext(ctx, fmt.Sprintf("sudo make -C %s tests-privileged | ts '[%%H:%%M:%%S]'", path))
+		res := vm.ExecContext(ctx, fmt.Sprintf("bash -c 'sudo make -C %s tests-privileged | ts \"[%%H:%%M:%%S]\"; exit \"${PIPESTATUS[0]}\"'", path))
 		res.ExpectSuccess("Failed to run privileged unit tests")
 	})
 })


### PR DESCRIPTION
Commit 1b03f0b4 ("test/RuntimePrivilegedUnitTests: Log timestamps") made use of the `ts` command to log timestamps for the privileged unit tests. The ts command however doesn't preserve the return code of the previous command, so the `make | ts` command ends up always succeeding.

Given `ts` doesn't even offer a `--preserve-status` option, we can fix this by using `$PIPESTATUS` to get the first command's return code.

Fixes: https://github.com/cilium/cilium/pull/19129.