### PR TITLE
[v1.10] backport: Clarify taint effects in the documentation.

### DIFF
--- a/Documentation/gettingstarted/index.rst
+++ b/Documentation/gettingstarted/index.rst
@@ -26,6 +26,8 @@ Installation
    k8s-install-default
    k8s-install-helm
    k8s-install-advanced
+   taints
+
 
 Observability
 -------------

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -46,10 +46,15 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
            export NAME="$(whoami)-$RANDOM"
            # Create the node pool with the following taint to guarantee that
            # Pods are only scheduled/executed in the node when Cilium is ready.
+           # Alternatively, see the note below.
            gcloud container clusters create "${NAME}" \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --zone us-west2-a
            gcloud container clusters get-credentials "${NAME}" --zone us-west2-a
+
+       .. note::
+
+          Please make sure to read and understand the documentation page on :ref:`taint effects and unmanaged pods<taint_effects>`.
 
     .. group-tab:: AKS
 
@@ -119,10 +124,13 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
        .. note::
 
-          `Node pools <https://aka.ms/aks/nodepools>`_ must be tainted with
+          `Node pools <https://aka.ms/aks/nodepools>`_ should be tainted with
           ``node.cilium.io/agent-not-ready=true:NoExecute`` to ensure that
           applications pods will only be scheduled/executed once Cilium is ready
-          to manage them, however on AKS:
+          to manage them. However, there are other options. Please make sure to
+          read and understand the documentation page on :ref:`taint effects and unmanaged pods<taint_effects>`.
+
+          Additionally on AKS:
 
           * It is not possible to assign taints to the initial node pool at this
             time, cf. `Azure/AKS#1402 <https://github.com/Azure/AKS/issues/1402>`_.
@@ -165,13 +173,18 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
              desiredCapacity: 2
              privateNetworking: true
              # taint nodes so that application pods are
-             # not scheduled until Cilium is deployed.
+             # not scheduled/executed until Cilium is deployed.
+             # Alternatively, see the note below.
              taints:
               - key: "node.cilium.io/agent-not-ready"
                 value: "true"
                 effect: "NoExecute"
            EOF
            eksctl create cluster -f ./eks-config.yaml
+
+       .. note::
+
+          Please make sure to read and understand the documentation page on :ref:`taint effects and unmanaged pods<taint_effects>`.
 
     .. group-tab:: kind
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -659,10 +659,15 @@ As an instance example, ``m5n.xlarge`` is used in the config ``nodegroup-config.
         allow: true
       ## taint nodes so that application pods are
       ## not scheduled/executed until Cilium is deployed.
+      ## Alternatively, see the note below.
       taints:
         - key: "node.cilium.io/agent-not-ready"
           value: "true"
           effect: "NoExecute"
+
+.. note::
+
+  Please make sure to read and understand the documentation page on :ref:`taint effects and unmanaged pods<taint_effects>`.
 
 The nodegroup is created with:
 

--- a/Documentation/gettingstarted/requirements-aks.rst
+++ b/Documentation/gettingstarted/requirements-aks.rst
@@ -23,9 +23,10 @@ Direct Routing  Azure IPAM          Kubernetes CRD
 * Node pools must be properly tainted to ensure applications pods are properly
   managed by Cilium:
 
-  * User node pools must be tainted with ``node.cilium.io/agent-not-ready=true:NoExecute``
+  * User node pools should be tainted with ``node.cilium.io/agent-not-ready=true:NoExecute``
     to ensure application pods will only be scheduled/executed once Cilium is ready to
-    manage them.
+    manage them. However, there are other options. Please make sure to
+    read and understand the documentation page on :ref:`taint effects and unmanaged pods<taint_effects>`.
 
   * System node pools must be tainted with ``CriticalAddonsOnly=true:NoSchedule``,
     preventing application pods from being scheduled on them. This is necessary

--- a/Documentation/gettingstarted/requirements-eks.rst
+++ b/Documentation/gettingstarted/requirements-eks.rst
@@ -22,10 +22,13 @@ For more information on AWS ENI mode, see :ref:`ipam_eni`.
   be properly tainted to ensure applications pods are properly managed by
   Cilium:
 
-  * ``managedNodeGroups`` must be tainted with
+  * ``managedNodeGroups`` should be tainted with
     ``node.cilium.io/agent-not-ready=true:NoExecute`` to ensure application
-    pods will only be scheduled once Cilium is ready to manage them. For
-    example, when using a `ClusterConfig <https://eksctl.io/usage/creating-and-managing-clusters/#using-config-files>`_
+    pods will only be scheduled once Cilium is ready to manage them. However,
+    there are other options. Please make sure to read and understand the
+    documentation page on :ref:`taint effects and unmanaged pods<taint_effects>`.
+  
+    Below is an example on how to use `ClusterConfig <https://eksctl.io/usage/creating-and-managing-clusters/#using-config-files>`_
     file to create the cluster:
 
     .. code-block:: yaml
@@ -38,6 +41,7 @@ For more information on AWS ENI mode, see :ref:`ipam_eni`.
           ...
           # taint nodes so that application pods are
           # not scheduled/executed until Cilium is deployed.
+          # Alternatively, see the note above regarding taint effects.
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"

--- a/Documentation/gettingstarted/requirements-gke.rst
+++ b/Documentation/gettingstarted/requirements-gke.rst
@@ -11,5 +11,6 @@ Direct Routing  Kubernetes PodCIDR  Kubernetes CRD
 
 **Requirements:**
 
-* The cluster must  be created with the taint ``node.cilium.io/agent-not-ready=true:NoExecute``
-  using ``--node-taints`` option.
+* The cluster should be created with the taint ``node.cilium.io/agent-not-ready=true:NoExecute``
+  using ``--node-taints`` option. However, there are other options. Please make
+  sure to read and understand the documentation page on :ref:`taint effects and unmanaged pods<taint_effects>`.

--- a/Documentation/gettingstarted/taints.rst
+++ b/Documentation/gettingstarted/taints.rst
@@ -1,0 +1,92 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _taint_effects:
+
+#####################################################
+Considerations on node pool taints and unmanaged pods
+#####################################################
+
+Depending on the environment or cloud provider being used, a CNI plugin and/or
+configuration file may be pre-installed in nodes belonging to a given cluster
+where Cilium is being installed or already running. Upon starting on a given
+node, and if it is intended as the exclusive CNI plugin for the cluster, Cilium
+does its best to take ownership of CNI on the node. However, a couple situations
+can prevent this from happening:
+
+* Cilium can only take ownership of CNI on a node after starting. Pods starting
+  before Cilium runs on a given node may get IPs from the pre-configured CNI.
+
+* Some cloud providers may revert changes made to the CNI configuration by
+  Cilium during operations such as node reboots, updates or routine maintenance.
+
+This is notably the case with GKE (non-Dataplane V2), in which node reboots and
+upgrades will undo changes made by Cilium and re-instate the default CNI
+configuration.
+
+To help overcome this situation to the largest possible extent in environments
+and cloud providers where Cilium isn't supported as the single CNI, Cilium can
+manipulate Kubernetes's `taints <https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>`_
+on a given node to help preventing pods from starting before Cilium runs on said
+node. The mechanism works as follows:
+
+1. The cluster administrator places a taint with key
+   ``node.cilium.io/agent-not-ready`` on a given uninitialized node. Depending on
+   the taint's effect (see below), this prevents pods that don't have a matching
+   toleration from either being scheduled or altogether running on the node until
+   the taint is removed.
+
+2. Cilium runs on the node, initializes it and, once ready, removes the
+   ``node.cilium.io/agent-not-ready`` taint.
+
+3. From this point on, pods will start being scheduled and running on the node,
+   having their networking managed by Cilium.
+
+The taint's effect should be chosen taking into account the following
+considerations:
+
+* If ``NoSchedule`` is used, pods won't be *scheduled* to a node until Cilium
+  has the chance to remove the taint. However, one practical effect of this is
+  that if some external process (such as a reboot) resets the CNI configuration on
+  said node, pods that were already scheduled will be allowed to start
+  concurrently with Cilium when the node next reboots, and hence may become
+  unmanaged and have their networking being managed by another CNI plugin.
+
+* If ``NoExecute`` is used, pods won't be *executed* (nor *scheduled*) on a node
+  until Cilium has had the chance to remove the taint. One practical effect of
+  this is that whenever the taint is added back to the node by some external
+  process (such as during an upgrade or eventually a routine operation), pods
+  will be evicted from the node until Cilium has had the chance to remove the
+  taint.
+
+Another important thing to consider is the concept of node itself, and the
+different point of views over a node. For example, the instance/VM which backs a
+Kubernetes node can be patched or reset filesystem-wise by a cloud provider, or
+altogether replaced with an entirely new instance/VM that comes back with the
+same name as the already-existing Kubernetes ``Node`` resource. Even though in
+said scenarios the node-pool-level taint will be added back to the ``Node``
+resource, pods that were already scheduled to the node having this name will run
+on the node at the same time as Cilium, potentially becoming unmanaged. This is
+why ``NoExecute`` is recommended, as assuming the taint is added back in this
+scenario, already-scheduled pods won't run.
+
+However, on some environments or cloud providers, and as mentioned above, it may
+happen that a taint established at the node-pool level is added back to a node
+after Cilium has removed it and for reasons other than a node upgrade/reset.
+The exact circumstances in which this may happen may vary, but this may lead to
+unexpected/undesired pod evictions in the particular case when ``NoExecute`` is
+being used as the taint effect. It is, thus, recommended that in each deployment
+and depending on the environment or cloud provider, a careful decision is made
+regarding the taint effect (or even regarding whether to use the taint-based
+approach at all) based on the information above, on the environment or cloud
+provider's documentation, and on the fact that one is essentially establishing
+a trade-off between having unmanaged pods in the cluster (which can lead to
+dropped traffic and other issues) and having unexpected/undesired evictions
+(which can lead to application downtime).
+
+Taking into account all of the above, throughout the Cilium documentation we
+recommend ``NoExecute`` to be used as we believe it to be the least disruptive
+mode that users can use to deploy Cilium on cloud providers.

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -30,6 +30,7 @@ DSR
 DTrace
 Dangaard
 Datapath
+Dataplane
 Deathstar
 Dinan
 Dockerfile


### PR DESCRIPTION
Manual backport for https://github.com/cilium/cilium/pull/19186.

Magic command:
```
for pr in 19186; do contrib/backporting/set-labels.py $pr done 1.10; done
```