### PR TITLE
add support to override not ready taint to be ignored by the CA

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -151,6 +151,7 @@ jobs:
             --helm-set=clustermesh.apiserver.image.useDigest=false \
             --helm-set=hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${SHA} \
+            --helm-set=agentNotReadyTaintKey=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
@@ -209,7 +210,7 @@ jobs:
             --machine-type e2-custom-2-4096 \
             --disk-type pd-standard \
             --disk-size 10GB \
-            --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
+            --node-taints ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute \
             --preemptible
 
       - name: Get cluster credentials

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -13,6 +13,7 @@ cilium-agent [flags]
 ```
       --agent-health-port int                                   TCP port for agent health status API (default 9879)
       --agent-labels strings                                    Additional labels to identify this agent
+      --agent-not-ready-taint-key string                        Key of the taint indicating that Cilium is not ready on the node (default "node.cilium.io/agent-not-ready")
       --allocator-list-timeout duration                         Timeout for listing allocator state before exiting (default 3m0s)
       --allow-icmp-frag-needed                                  Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
       --allow-localhost string                                  Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")

--- a/Documentation/gettingstarted/taints.rst
+++ b/Documentation/gettingstarted/taints.rst
@@ -33,17 +33,24 @@ manipulate Kubernetes's `taints <https://kubernetes.io/docs/concepts/scheduling-
 on a given node to help preventing pods from starting before Cilium runs on said
 node. The mechanism works as follows:
 
-1. The cluster administrator places a taint with key
-   ``node.cilium.io/agent-not-ready`` on a given uninitialized node. Depending on
-   the taint's effect (see below), this prevents pods that don't have a matching
-   toleration from either being scheduled or altogether running on the node until
-   the taint is removed.
+1. The cluster administrator places a specific taint (see below) on a given
+   uninitialized node. Depending on the taint's effect (see below), this prevents
+   pods that don't have a matching toleration from either being scheduled or
+   altogether running on the node until the taint is removed.
 
 2. Cilium runs on the node, initializes it and, once ready, removes the
-   ``node.cilium.io/agent-not-ready`` taint.
+   aforementioned taint.
 
 3. From this point on, pods will start being scheduled and running on the node,
    having their networking managed by Cilium.
+
+By default, the taint key is ``node.cilium.io/agent-not-ready``, but in some
+scenarios (such as when Cluster Autoscaler is being used but its flags cannot be
+configured) this key may need to be tweaked. This can be done using the
+``agent-not-ready-taint-key`` option. In the aforementioned example, users should
+specify a key starting with ``ignore-taint.cluster-autoscaler.kubernetes.io/``.
+When such a value is used, the Cluster Autoscaler will ignore it when simulating
+scheduling, allowing the cluster to scale up.
 
 The taint's effect should be chosen taking into account the following
 considerations:

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -17,6 +17,10 @@
      - Install the cilium agent resources.
      - bool
      - ``true``
+   * - agentNotReadyTaintKey
+     - Configure the key of the taint indicating that Cilium is not ready on the node. When set to a value starting with ``ignore-taint.cluster-autoscaler.kubernetes.io/``\ , the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up.
+     - string
+     - ``"node.cilium.io/agent-not-ready"``
    * - alibabacloud.enabled
      - Enable AlibabaCloud ENI integration
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -146,6 +146,7 @@ Zhou
 Zookeeper
 aarch
 admin
+agentNotReadyTaintKey
 alibabacloud
 allocator
 allocators

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -511,6 +511,9 @@ func initializeFlags() {
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium is deployed in")
 	option.BindEnv(option.K8sNamespaceName)
 
+	flags.String(option.AgentNotReadyNodeTaintKeyName, defaults.AgentNotReadyNodeTaint, "Key of the taint indicating that Cilium is not ready on the node")
+	option.BindEnv(option.AgentNotReadyNodeTaintKeyName)
+
 	flags.Bool(option.JoinClusterName, false, "Join a Cilium cluster via kvstore registration")
 	option.BindEnv(option.JoinClusterName)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -55,6 +55,7 @@ contributors across the globe, there is almost always someone available to help.
 |-----|------|---------|-------------|
 | affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-agent. |
 | agent | bool | `true` | Install the cilium agent resources. |
+| agentNotReadyTaintKey | string | `"node.cilium.io/agent-not-ready"` | Configure the key of the taint indicating that Cilium is not ready on the node. When set to a value starting with `ignore-taint.cluster-autoscaler.kubernetes.io/`, the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up. |
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -888,4 +888,9 @@ data:
 {{- if .Values.extraConfig }}
   {{ toYaml .Values.extraConfig | nindent 2 }}
 {{- end }}
+
+{{- if hasKey .Values "agentNotReadyTaintKey" }}
+  agent-not-ready-taint-key: {{ .Values.agentNotReadyTaintKey | quote }}
+{{- end }}
+
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2036,3 +2036,7 @@ enableK8sTerminatingEndpoint: true
 
 # -- Configure whether to unload DNS policy rules on graceful shutdown
 # dnsPolicyUnloadOnShutdown: false
+
+# -- Configure the key of the taint indicating that Cilium is not ready on the node.
+# When set to a value starting with `ignore-taint.cluster-autoscaler.kubernetes.io/`, the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up.
+agentNotReadyTaintKey: "node.cilium.io/agent-not-ready"

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -13,8 +13,8 @@ import (
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/option"
+	pkgOption "github.com/cilium/cilium/pkg/option"
 )
 
 func init() {
@@ -327,7 +327,7 @@ func init() {
 	flags.String(operatorOption.CiliumPodLabels, "k8s-app=cilium", "Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false")
 	option.BindEnv(operatorOption.CiliumPodLabels)
 
-	flags.Bool(operatorOption.RemoveCiliumNodeTaints, true, fmt.Sprintf("Remove node taint %q from Kubernetes nodes once Cilium is up and running", ciliumio.AgentNotReadyNodeTaint))
+	flags.Bool(operatorOption.RemoveCiliumNodeTaints, true, fmt.Sprintf("Remove node taint %q from Kubernetes nodes once Cilium is up and running", pkgOption.Config.AgentNotReadyNodeTaintValue()))
 	option.BindEnv(operatorOption.RemoveCiliumNodeTaints)
 
 	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -12,12 +12,12 @@ import (
 	"github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s"
-	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	pkgOption "github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -203,7 +203,7 @@ func isCiliumPodRunning(nodeName string) bool {
 // Not Ready Node Taint.
 func hasAgentNotReadyTaint(k8sNode *slim_corev1.Node) bool {
 	for _, taint := range k8sNode.Spec.Taints {
-		if taint.Key == ciliumio.AgentNotReadyNodeTaint {
+		if taint.Key == pkgOption.Config.AgentNotReadyNodeTaintValue() {
 			return true
 		}
 	}
@@ -325,7 +325,7 @@ func removeNodeTaint(ctx context.Context, c kubernetes.Interface, nodeGetter sli
 
 	var taints []slim_corev1.Taint
 	for _, taint := range k8sNode.Spec.Taints {
-		if taint.Key != ciliumio.AgentNotReadyNodeTaint {
+		if taint.Key != pkgOption.Config.AgentNotReadyNodeTaintValue() {
 			taints = append(taints, taint)
 		} else {
 			taintFound = true
@@ -336,13 +336,13 @@ func removeNodeTaint(ctx context.Context, c kubernetes.Interface, nodeGetter sli
 	if !taintFound {
 		log.WithFields(logrus.Fields{
 			logfields.NodeName: nodeName,
-			"taint":            ciliumio.AgentNotReadyNodeTaint,
+			"taint":            pkgOption.Config.AgentNotReadyNodeTaintValue(),
 		}).Debug("Taint not found in node")
 		return nil
 	}
 	log.WithFields(logrus.Fields{
 		logfields.NodeName: nodeName,
-		"taint":            ciliumio.AgentNotReadyNodeTaint,
+		"taint":            pkgOption.Config.AgentNotReadyNodeTaintValue(),
 	}).Debug("Removing Node Taint")
 
 	createStatusAndNodePatch := []k8s.JSONPatch{

--- a/operator/watchers/node_taint_test.go
+++ b/operator/watchers/node_taint_test.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/k8s"
-	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	pkgOption "github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -60,7 +60,7 @@ func (n *NodeTaintSuite) TestNodeTaintWithoutCondition(c *check.C) {
 		Spec: slim_corev1.NodeSpec{
 			Taints: []slim_corev1.Taint{
 				{
-					Key: ciliumio.AgentNotReadyNodeTaint, Value: "Foo",
+					Key: pkgOption.Config.AgentNotReadyNodeTaintValue(), Value: "Foo",
 				},
 				{
 					Key: "DoNoRemoveThisTaint", Value: "Foo",
@@ -106,7 +106,7 @@ func (n *NodeTaintSuite) TestNodeTaintWithoutCondition(c *check.C) {
 				Path: "/spec/taints",
 				Value: []slim_corev1.Taint{
 					{
-						Key: ciliumio.AgentNotReadyNodeTaint, Value: "Foo",
+						Key: pkgOption.Config.AgentNotReadyNodeTaintValue(), Value: "Foo",
 					},
 					{
 						Key: "DoNoRemoveThisTaint", Value: "Foo",
@@ -196,7 +196,7 @@ func (n *NodeTaintSuite) TestNodeCondition(c *check.C) {
 		Spec: slim_corev1.NodeSpec{
 			Taints: []slim_corev1.Taint{
 				{
-					Key: ciliumio.AgentNotReadyNodeTaint, Value: "Foo",
+					Key: pkgOption.Config.AgentNotReadyNodeTaintValue(), Value: "Foo",
 				},
 				{
 					Key: "DoNoRemoveThisTaint", Value: "Foo",
@@ -329,7 +329,7 @@ func (n *NodeTaintSuite) TestNodeConditionIfCiliumIsNotReady(c *check.C) {
 		Spec: slim_corev1.NodeSpec{
 			Taints: []slim_corev1.Taint{
 				{
-					Key: ciliumio.AgentNotReadyNodeTaint, Value: "Foo",
+					Key: pkgOption.Config.AgentNotReadyNodeTaintValue(), Value: "Foo",
 				},
 				{
 					Key: "DoNoRemoveThisTaint", Value: "Foo",

--- a/pkg/defaults/node.go
+++ b/pkg/defaults/node.go
@@ -19,8 +19,18 @@ const (
 	// HostDevice is the name of the device that connects the cilium IP
 	// space with the host's networking model
 	HostDevice = "cilium_host"
+
 	// SecondHostDevice is the name of the second interface of the host veth pair.
 	SecondHostDevice = "cilium_net"
+
+	// CiliumK8sAnnotationPrefix is the prefix key for the annotations used in kubernetes.
+	CiliumK8sAnnotationPrefix = "cilium.io/"
+
+	// AgentNotReadyNodeTaint is a node taint which prevents pods from being
+	// scheduled. Once cilium is setup it is removed from the node. Mostly
+	// used in cloud providers to prevent existing CNI plugins from managing
+	// pods.
+	AgentNotReadyNodeTaint = "node." + CiliumK8sAnnotationPrefix + "agent-not-ready"
 )
 
 var (

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -62,17 +62,8 @@ const (
 	// to sync the CNP with kube-apiserver.
 	CtrlPrefixPolicyStatus = "sync-cnp-policy-status"
 
-	// CiliumK8sAnnotationPrefix is the prefix key for the annotations used in kubernetes.
-	CiliumK8sAnnotationPrefix = "cilium.io/"
-
 	// CiliumIdentityAnnotationDeprecated is the previous annotation key used to map to an endpoint's security identity.
 	CiliumIdentityAnnotationDeprecated = "cilium-identity"
-
-	// AgentNotReadyNodeTaint is a node taint which prevents pods from being
-	// scheduled. Once cilium is setup it is removed from the node. Mostly
-	// used in cloud providers to prevent existing CNI plugins from managing
-	// pods.
-	AgentNotReadyNodeTaint = "node." + CiliumK8sAnnotationPrefix + "agent-not-ready"
 )
 
 const (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -645,6 +645,10 @@ const (
 	// K8sNamespaceName is the name of the K8sNamespace option
 	K8sNamespaceName = "k8s-namespace"
 
+	// AgentNotReadyNodeTaintKeyName is the name of the option to set
+	// AgentNotReadyNodeTaintKey
+	AgentNotReadyNodeTaintKeyName = "agent-not-ready-taint-key"
+
 	// JoinClusterName is the name of the JoinCluster Option
 	JoinClusterName = "join-cluster"
 
@@ -1524,6 +1528,12 @@ type DaemonConfig struct {
 	// K8sNamespace is the name of the namespace in which Cilium is
 	// deployed in when running in Kubernetes mode
 	K8sNamespace string
+
+	// AgentNotReadyNodeTaint is a node taint which prevents pods from being
+	// scheduled. Once cilium is setup it is removed from the node. Mostly
+	// used in cloud providers to prevent existing CNI plugins from managing
+	// pods.
+	AgentNotReadyNodeTaintKey string
 
 	// JoinCluster is 'true' if the agent should join a Cilium cluster via kvstore
 	// registration
@@ -2481,6 +2491,16 @@ func (c *DaemonConfig) CiliumNamespaceName() string {
 	return c.K8sNamespace
 }
 
+// AgentNotReadyNodeTaintValue returns the value of the taint key that cilium agents
+// will manage on their nodes
+func (c *DaemonConfig) AgentNotReadyNodeTaintValue() string {
+	if c.AgentNotReadyNodeTaintKey != "" {
+		return c.AgentNotReadyNodeTaintKey
+	} else {
+		return defaults.AgentNotReadyNodeTaint
+	}
+}
+
 // K8sAPIDiscoveryEnabled returns true if API discovery of API groups and
 // resources is enabled
 func (c *DaemonConfig) K8sAPIDiscoveryEnabled() bool {
@@ -3165,6 +3185,7 @@ func (c *DaemonConfig) Populate() {
 	c.HTTP403Message = viper.GetString(HTTP403Message)
 	c.DisableEnvoyVersionCheck = viper.GetBool(DisableEnvoyVersionCheck)
 	c.K8sNamespace = viper.GetString(K8sNamespaceName)
+	c.AgentNotReadyNodeTaintKey = viper.GetString(AgentNotReadyNodeTaintKeyName)
 	c.MaxControllerInterval = viper.GetInt(MaxCtrlIntervalName)
 	c.PolicyQueueSize = sanitizeIntParam(PolicyQueueSize, defaults.PolicyQueueSize)
 	c.EndpointQueueSize = sanitizeIntParam(EndpointQueueSize, defaults.EndpointQueueSize)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

As described in [this issue](https://github.com/cilium/cilium/issues/19241), if you scale a node pool down to zero, agent-not-ready taints can prevent the cluster autoscaler from scaling the node pool up from zero nodes because it thinks nothing will be able to run on the node (or at least the pending app pods won't be able to).

This PR adds the ability to pass a prefix that will be prepended to the agent-not-ready taint in order for it to be ignored by the cluster autoscaler when generating sanitized node templates in order to make scaling decisions. More specifically, this allows scaling node pools up from zero in GKE, where you can not customize the command line arguments of the cluster autoscaler, and where a multi-zone node pool is made up of multiple node pools under the hood, making it very easy to end up with a "node pool" with no nodes in it if you scale below 1 node per zone.

Fixes: #19241

```release-note
Add config flag to add a prefix to AgentNotReadyNodeTaint value in order to enable the taint being ignored by cluster autoscaler.
```
