### PR TITLE
fix seg fault in logs

### DIFF
--- a/pkg/bgp/manager/metallb.go
+++ b/pkg/bgp/manager/metallb.go
@@ -68,7 +68,7 @@ func (c *metalLBController) SetBalancer(name string, srvRo *v1.Service, eps k8s.
 	var (
 		l = log.WithFields(logrus.Fields{
 			"component": "metalLBController.SetBalancer",
-			"service":   srvRo.Name,
+			"service":   name,
 		})
 	)
 	l.Debug("assigning load balancer ip for service")


### PR DESCRIPTION
Signed-off-by: ivan <i.makarychev@tinkoff.ru>

srvRo will be nil when we remove the Service resource, which results iin a SIGSEGV error.

```release-note
metallb: fix SIGSEGV error when Service resource is deleted.
```
