### PR TITLE
v1.9 backports 2022-03-29

### DIFF
--- a/Documentation/gettingstarted/local-redirect-policy.rst
+++ b/Documentation/gettingstarted/local-redirect-policy.rst
@@ -12,7 +12,8 @@ Local Redirect Policy (beta)
 
 This document explains how to configure Cilium's Local Redirect Policy, that
 enables pod traffic destined to an IP address and port/protocol tuple
-or Kubernetes service to be redirected locally to a backend pod within a node.
+or Kubernetes service to be redirected locally to backend pod(s) within a node,
+using eBPF. The namespace of backend pod(s) need to match with that of the policy.
 The CiliumLocalRedirectPolicy is configured as a ``CustomResourceDefinition``.
 
 There are two types of Local Redirect Policies supported. When traffic for a

--- a/install/kubernetes/cilium/templates/cilium-agent-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-clusterrole.yaml
@@ -37,18 +37,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/finalizers
   verbs:
-  - get
-  - list
-  - watch
   - update
-  - delete
 - apiGroups:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/templates/cilium-preflight-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-clusterrole.yaml
@@ -37,18 +37,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/finalizers
   verbs:
-  - get
-  - list
-  - watch
   - update
-  - delete
 - apiGroups:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrole.yaml
@@ -7,6 +7,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   - namespaces
   - services

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -321,18 +321,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/finalizers
   verbs:
-  - get
-  - list
-  - watch
   - update
-  - delete
 - apiGroups:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -188,18 +188,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/finalizers
   verbs:
-  - get
-  - list
-  - watch
   - update
-  - delete
 - apiGroups:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -302,7 +302,7 @@ func (rpm *Manager) OnUpdatePodLocked(pod *slimcorev1.Pod, removeOld bool, upser
 	if upsertNew {
 		// Check if any of the current redirect policies select this pod.
 		for _, config := range rpm.policyConfigs {
-			if config.policyConfigSelectsPod(podData) {
+			if config.checkNamespace(pod.GetNamespace()) && config.policyConfigSelectsPod(podData) {
 				rpm.processConfig(config, podData)
 			}
 		}

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -559,4 +559,30 @@ func (m *ManagerSuite) TestManager_AddrMatcherConfigDualStack(c *C) {
 	}
 }
 
-//TODO Tests for svcMatcher
+// Tests add and update pod operations with namespace mismatched pods.
+func (m *ManagerSuite) TestManager_OnAddandUpdatePod(c *C) {
+	configFe := configAddrType
+	m.rpm.policyFrontendsByHash[fe1.Hash()] = configFe.id
+	configSvc := configSvcType
+	m.rpm.policyConfigs[configSvc.id] = &configSvc
+	pod := pod1.DeepCopy()
+	pod.Namespace = "ns2"
+	podID := k8s.ServiceID{
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+
+	m.rpm.OnAddPod(pod)
+
+	// Namespace mismatched pod not selected.
+	c.Assert(len(m.rpm.policyPods), Equals, 0)
+	_, found := m.rpm.policyPods[podID]
+	c.Assert(found, Equals, false)
+
+	m.rpm.OnUpdatePod(pod, true, true)
+
+	// Namespace mismatched pod not selected.
+	c.Assert(len(m.rpm.policyPods), Equals, 0)
+	_, found = m.rpm.policyPods[podID]
+	c.Assert(found, Equals, false)
+}


### PR DESCRIPTION
 * #19053 -- helm: Remove Unnecessary RBAC Permissions for Agent (@nathanjsweet)
 * #19071 -- helm: Add RBAC Permissions to Clustermesh APIServer Clusterrole (@nathanjsweet)
 * #19193 -- pkg/redirectpolicy: Add missing namespace check in pod update handler (@aditighag)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19053 19071 19193; do contrib/backporting/set-labels.py $pr done 1.9; done
```
or with
```
$ make add-label BRANCH=v1.9 ISSUES=19053,19071,19193
```