### PR TITLE
v1.10 backports 2022-03-29

### DIFF
--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -59,8 +59,8 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/operator-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/?specificTag=${{ steps.vars.outputs.tag }}" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/operator-ci/tag/?specificTag=${{ steps.vars.outputs.tag }}" &> /dev/null; do sleep 45s; done
 
       - name: Create kind cluster
         uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/${{ steps.vars.outputs.sha }}/images" &> /dev/null; do sleep 45s; done
+            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/?specificTag=${{ steps.vars.outputs.sha }}" &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -87,8 +87,8 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/operator-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/?specificTag=${{ steps.vars.outputs.tag }}" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/operator-ci/tag/?specificTag=${{ steps.vars.outputs.tag }}" &> /dev/null; do sleep 45s; done
 
       - name: Install cilium chart
         run: |

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -132,8 +132,8 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
-          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/operator-ci/tag/${{ steps.vars.outputs.tag }}/images" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/cilium-ci/tag/?specificTag=${{ steps.vars.outputs.tag }}" &> /dev/null; do sleep 45s; done
+          until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/operator-ci/tag/?specificTag=${{ steps.vars.outputs.tag }}" &> /dev/null; do sleep 45s; done
 
       - name: Install cilium chart
         run: |

--- a/Documentation/gettingstarted/local-redirect-policy.rst
+++ b/Documentation/gettingstarted/local-redirect-policy.rst
@@ -12,7 +12,8 @@ Local Redirect Policy (beta)
 
 This document explains how to configure Cilium's Local Redirect Policy, that
 enables pod traffic destined to an IP address and port/protocol tuple
-or Kubernetes service to be redirected locally to a backend pod within a node.
+or Kubernetes service to be redirected locally to backend pod(s) within a node,
+using eBPF. The namespace of backend pod(s) need to match with that of the policy.
 The CiliumLocalRedirectPolicy is configured as a ``CustomResourceDefinition``.
 
 There are two types of Local Redirect Policies supported. When traffic for a

--- a/install/kubernetes/cilium/templates/cilium-agent-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-clusterrole.yaml
@@ -37,18 +37,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/finalizers
   verbs:
-  - get
-  - list
-  - watch
   - update
-  - delete
 - apiGroups:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/templates/cilium-preflight-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-clusterrole.yaml
@@ -37,18 +37,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/finalizers
   verbs:
-  - get
-  - list
-  - watch
   - update
-  - delete
 - apiGroups:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrole.yaml
@@ -7,6 +7,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   - namespaces
   - services

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -92,9 +92,9 @@ pipeline {
                     steps {
                         retry(25) {
                             sleep(time: 60)
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/cilium-ci/tag/${DOCKER_TAG}/images"'
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/operator-ci/tag/${DOCKER_TAG}/images"'
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/hubble-relay-ci/tag/${DOCKER_TAG}/images"'
+                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/cilium-ci/tag/?specificTag=${DOCKER_TAG}"'
+                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/operator-ci/tag/?specificTag=${DOCKER_TAG}"'
+                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/hubble-relay-ci/tag/?specificTag=${DOCKER_TAG}"'
                         }
                     }
                 }

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -180,9 +180,9 @@ pipeline {
                     steps {
                         retry(25) {
                             sleep(time: 60)
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/cilium-ci/tag/${DOCKER_TAG}/images"'
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/operator-ci/tag/${DOCKER_TAG}/images"'
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/hubble-relay-ci/tag/${DOCKER_TAG}/images"'
+                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/cilium-ci/tag/?specificTag=${DOCKER_TAG}"'
+                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/operator-ci/tag/?specificTag=${DOCKER_TAG}"'
+                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/hubble-relay-ci/tag/?specificTag=${DOCKER_TAG}"'
                         }
                     }
                     post {

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -434,19 +434,19 @@ func (c *OperatorConfig) Populate() {
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), IPAMSubnetsTags); err != nil {
 		log.Fatalf("unable to parse %s: %s", IPAMSubnetsTags, err)
-	} else if len(m) != 0 {
+	} else {
 		c.IPAMSubnetsTags = m
 	}
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), AWSInstanceLimitMapping); err != nil {
 		log.Fatalf("unable to parse %s: %s", AWSInstanceLimitMapping, err)
-	} else if len(m) != 0 {
+	} else {
 		c.AWSInstanceLimitMapping = m
 	}
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), ENITags); err != nil {
 		log.Fatalf("unable to parse %s: %s", ENITags, err)
-	} else if len(m) != 0 {
+	} else {
 		c.ENITags = m
 	}
 }

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -40,6 +40,15 @@ func TestGetStringMapString(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "valid empty json",
+			args: args{
+				key:   "FOO_BAR",
+				value: "{}",
+			},
+			want:    map[string]string{},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "invalid json format with extra comma at the end",
 			args: args{
 				key:   "FOO_BAR",

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -103,12 +103,13 @@ func (l *Loader) writeNetdevHeader(dir string, o datapath.BaseProgramOwner) erro
 func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
 	headerPath := filepath.Join(dir, preFilterHeaderFileName)
 	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
+
 	f, err := os.Create(headerPath)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s for writing: %s", headerPath, err)
-
 	}
 	defer f.Close()
+
 	fw := bufio.NewWriter(f)
 	fmt.Fprint(fw, "/*\n")
 	fmt.Fprintf(fw, " * XDP devices: %s\n", strings.Join(option.Config.Devices, " "))
@@ -405,7 +406,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	// Datapath initialization
 	hostDev1, hostDev2, err := setupBaseDevice(devices, mode, deviceMTU)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to setup base devices in mode %s: %w", mode, err)
 	}
 	args[initArgHostDev1] = hostDev1.Attrs().Name
 	args[initArgHostDev2] = hostDev2.Attrs().Name

--- a/pkg/hubble/recorder/service.go
+++ b/pkg/hubble/recorder/service.go
@@ -224,6 +224,8 @@ func (s *Service) Record(stream recorderpb.Recorder_RecordServer) error {
 
 const fileExistsRetries = 100
 
+var allowedFileChars = regexp.MustCompile("[^a-zA-Z0-9_.-]")
+
 func createPcapFile(basedir, prefix string) (f *os.File, filePath string, err error) {
 	try := 0
 	for {
@@ -231,7 +233,8 @@ func createPcapFile(basedir, prefix string) (f *os.File, filePath string, err er
 		random := rand.Uint32()
 		nodeName := nodeTypes.GetName()
 		name := fmt.Sprintf("%s_%d_%d_%s.pcap", prefix, startTime, random, nodeName)
-		filePath = path.Join(basedir, name)
+		sanitizedName := allowedFileChars.ReplaceAllLiteralString(name, "_")
+		filePath = path.Join(basedir, sanitizedName)
 		f, err = os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 		if err != nil {
 			if os.IsExist(err) {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2679,19 +2679,19 @@ func (c *DaemonConfig) Populate() {
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), KVStoreOpt); err != nil {
 		log.Fatalf("unable to parse %s: %s", KVStoreOpt, err)
-	} else if len(m) != 0 {
+	} else {
 		c.KVStoreOpt = m
 	}
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), LogOpt); err != nil {
 		log.Fatalf("unable to parse %s: %s", LogOpt, err)
-	} else if len(m) != 0 {
+	} else {
 		c.LogOpt = m
 	}
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), APIRateLimitName); err != nil {
 		log.Fatalf("unable to parse %s: %s", APIRateLimitName, err)
-	} else if len(m) != 0 {
+	} else {
 		c.APIRateLimit = m
 	}
 

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -155,10 +155,10 @@ type identitySelector interface {
 	// Called with NameManager and SelectorCache locks held
 	removeUser(CachedSelectionUser, identityNotifier) (last bool)
 
-	// releaseIdentityMappings must be called exactly once upon release of
-	// this selector to ensure that resources are cleaned up upon deletion
-	// of the selector.
-	releaseIdentityMappings(cache.IdentityAllocator)
+	// fetchIdentityMappings returns all of the identities currently
+	// reference-counted by this selector. It is used during cleanup of the
+	// selector.
+	fetchIdentityMappings(cache.IdentityAllocator) []identity.NumericIdentity
 
 	// This may be called while the NameManager lock is held. wg.Wait()
 	// returns after user notifications have been completed, which may require
@@ -469,12 +469,12 @@ func (f *fqdnSelector) notifyUsers(sc *SelectorCache, added, deleted []identity.
 // SelectorCache.mutex.Lock()
 // duplicateIdentities := fqdnSelector.transferIdentityReferencesToSelector(...)
 // SelectorCache.mutex.Unlock()
-// ReleaseCIDRIdentitiesByID(duplicateIdentities)
+// SelectorCache.releaseIdentityMappings(duplicateIdentities)
 // ... (active usage of the selector)
 // SelectorCache.mutex.Lock()
 // remainingIdentities := SelectorCache.removeSelectorLocked(...)
 // SelectorCache.mutex.Unlock()
-// ReleaseCIDRIdentitiesByID(duplicateIdentities)
+// SelectorCache.releaseIdentityMappings(remainingIdentities)
 //
 // sc.mutex MUST NOT be held while calling this function.
 func (sc *SelectorCache) allocateIdentityMappings(sel api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) []*identity.Identity {
@@ -539,18 +539,31 @@ func (f *fqdnSelector) transferIdentityReferencesToSelector(currentlyAllocatedId
 	return identitiesToRelease
 }
 
-// releaseIdentityMappings must be called exactly once for the received
-// 'fqdnSelector' in order to release CIDR identity references held in this
-// selector's cachedSelections.
-func (f *fqdnSelector) releaseIdentityMappings(idAllocator cache.IdentityAllocator) {
+// fetchIdentityMappings returns the set of identities that this selector
+// holds references for. This should be used during cleanup of the selector
+// to ensure that all remaining references to local identities are released,
+// in order to prevent leaking of identities.
+func (f *fqdnSelector) fetchIdentityMappings(idAllocator cache.IdentityAllocator) []identity.NumericIdentity {
 	ids := make([]identity.NumericIdentity, 0, len(f.cachedSelections))
 	for id := range f.cachedSelections {
 		ids = append(ids, id)
 	}
 
+	return ids
+}
+
+// releaseIdentityMappings must be called exactly once for each selector that
+// is removed from the selectorcache, in order to release local identity
+// references held in the selector's cachedSelections.
+//
+// See SelectorCache.allocateIdentityMappings() for a lifecycle description.
+//
+// sc.mutex MUST NOT be held while calling this function.
+func (sc *SelectorCache) releaseIdentityMappings(identitiesToRelease []identity.NumericIdentity) {
+	// TODO: Remove timeouts for CIDR identity allocation (as it is local).
 	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
 	defer cancel()
-	idAllocator.ReleaseCIDRIdentitiesByID(ctx, ids)
+	sc.idAllocator.ReleaseCIDRIdentitiesByID(ctx, identitiesToRelease)
 }
 
 // identityNotifier provides a means for other subsystems to be made aware of a
@@ -634,8 +647,9 @@ func (l *labelIdentitySelector) matches(identity scIdentity) bool {
 	return l.matchesNamespace(identity.namespace) && l.selector.Matches(identity.lbls)
 }
 
-func (l *labelIdentitySelector) releaseIdentityMappings(idAllocator cache.IdentityAllocator) {
+func (l *labelIdentitySelector) fetchIdentityMappings(idAllocator cache.IdentityAllocator) []identity.NumericIdentity {
 	// labelIdentitySelectors don't retain identity references, so no-op.
+	return nil
 }
 
 //
@@ -655,10 +669,7 @@ func (sc *SelectorCache) UpdateFQDNSelector(fqdnSelec api.FQDNSelector, identiti
 	sc.mutex.Lock()
 	identitiesToRelease := sc.updateFQDNSelector(fqdnSelec, identities, wg)
 	sc.mutex.Unlock()
-	// TODO: Remove timeouts for CIDR identity allocation (as it is local).
-	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
-	defer cancel()
-	sc.idAllocator.ReleaseCIDRIdentitiesByID(ctx, identitiesToRelease)
+	sc.releaseIdentityMappings(identitiesToRelease)
 }
 
 func (sc *SelectorCache) updateFQDNSelector(fqdnSelec api.FQDNSelector, identities []identity.NumericIdentity, wg *sync.WaitGroup) (identitiesToRelease []identity.NumericIdentity) {
@@ -849,9 +860,7 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 	added = newFQDNSel.addUser(user)
 	sc.mutex.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
-	defer cancel()
-	sc.idAllocator.ReleaseCIDRIdentitiesByID(ctx, identitiesToRelease)
+	sc.releaseIdentityMappings(identitiesToRelease)
 
 	return newFQDNSel, added
 }
@@ -923,35 +932,43 @@ func (sc *SelectorCache) AddIdentitySelector(user CachedSelectionUser, selector 
 }
 
 // lock must be held
-func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user CachedSelectionUser) {
+func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user CachedSelectionUser) (identitiesToRelease []identity.NumericIdentity) {
 	key := selector.String()
 	sel, exists := sc.selectors[key]
 	if exists {
 		if sel.removeUser(user, sc.localIdentityNotifier) {
 			delete(sc.selectors, key)
-			sel.releaseIdentityMappings(sc.idAllocator)
+			identitiesToRelease = sel.fetchIdentityMappings(sc.idAllocator)
 		}
 	}
+	return identitiesToRelease
 }
 
 // RemoveSelector removes CachedSelector for the user.
 func (sc *SelectorCache) RemoveSelector(selector CachedSelector, user CachedSelectionUser) {
 	sc.localIdentityNotifier.Lock()
 	sc.mutex.Lock()
-	sc.removeSelectorLocked(selector, user)
+	identitiesToRelease := sc.removeSelectorLocked(selector, user)
 	sc.mutex.Unlock()
 	sc.localIdentityNotifier.Unlock()
+
+	sc.releaseIdentityMappings(identitiesToRelease)
 }
 
 // RemoveSelectors removes CachedSelectorSlice for the user.
 func (sc *SelectorCache) RemoveSelectors(selectors CachedSelectorSlice, user CachedSelectionUser) {
+	var identitiesToRelease []identity.NumericIdentity
+
 	sc.localIdentityNotifier.Lock()
 	sc.mutex.Lock()
 	for _, selector := range selectors {
-		sc.removeSelectorLocked(selector, user)
+		identities := sc.removeSelectorLocked(selector, user)
+		identitiesToRelease = append(identitiesToRelease, identities...)
 	}
 	sc.mutex.Unlock()
 	sc.localIdentityNotifier.Unlock()
+
+	sc.releaseIdentityMappings(identitiesToRelease)
 }
 
 // ChangeUser changes the CachedSelectionUser that gets updates on the
@@ -1056,8 +1073,5 @@ func (sc *SelectorCache) RemoveIdentitiesFQDNSelectors(fqdnSels []api.FQDNSelect
 		identitiesToRelease = append(identitiesToRelease, ids...)
 	}
 	sc.mutex.Unlock()
-	// TODO: Remove timeouts for CIDR identity allocation (as it is local).
-	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
-	defer cancel()
-	sc.idAllocator.ReleaseCIDRIdentitiesByID(ctx, identitiesToRelease)
+	sc.releaseIdentityMappings(identitiesToRelease)
 }

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -456,41 +456,47 @@ func (f *fqdnSelector) notifyUsers(sc *SelectorCache, added, deleted []identity.
 	}
 }
 
-// allocateIdentityMappings is an initializer for 'fqdnSelector' that takes a
-// slice of IPs that should be associated with the selector and caches those
-// selections. No notifications are propagated to the users.
+// allocateIdentityMappings is a wrapper for the underlying identity allocator
+// which takes a slice of IPs that should be allocated with a specified
+// selector, and allocates identities for each of them. This may cause
+// allocation of new identities, or take reference counts on existing local
+// identities. Therefore, the caller must take care to ensure that these
+// identities are eventually released via a call to releaseIdentityMappings().
 //
-// This function may be called at initialization for a new fqdnSelector, or
-// upon new use of an FQDN selector with the same string representation of a
-// previously-cached selector (for example the same toFQDNs match pattern in
-// different rules).
+// The typical usage to properly track identity references is roughly:
 //
-// Calls to allocateIdentityMappings() will allocate identities and associate
-// them with the fqdnSelector, therefore the corresponding
-// releaseIdentityMappings() function must also be eventually called to clean
-// up this selector.
-func (f *fqdnSelector) allocateIdentityMappings(idAllocator cache.IdentityAllocator, selectorIPMapping map[api.FQDNSelector][]net.IP) {
-	// We don't know whether the IPs are associated with this selector
-	// until we map those IPs to identities, which requires potentially
-	// allocating a CIDR identity for those IPs. Therefore, below we
-	// unconditionally allocate identities for all IPs in
-	// 'selectorIPMapping', then find out if any are duplicated with the
-	// existing selector content, and then release any that are already
-	// referenced by this selector. The new IPs will be then added to the
-	// cached selections and the corresponding identity reference will be
-	// released in releaseIdentityMappings(). This balances the
-	// allocation/release of all identities allocated from this function.
+// identities := SelectorCache.allocateIdentityMappings(...)
+// SelectorCache.mutex.Lock()
+// duplicateIdentities := fqdnSelector.transferIdentityReferencesToSelector(...)
+// SelectorCache.mutex.Unlock()
+// ReleaseCIDRIdentitiesByID(duplicateIdentities)
+// ... (active usage of the selector)
+// SelectorCache.mutex.Lock()
+// remainingIdentities := SelectorCache.removeSelectorLocked(...)
+// SelectorCache.mutex.Unlock()
+// ReleaseCIDRIdentitiesByID(duplicateIdentities)
+//
+// sc.mutex MUST NOT be held while calling this function.
+func (sc *SelectorCache) allocateIdentityMappings(sel api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) []*identity.Identity {
+	// We don't know whether the IPs are associated with the cached copy
+	// of this selector until we map those IPs to identities and look
+	// up the cached copy of the selector. This requires potentially
+	// allocating a CIDR identity for those IPs, and grabbing the
+	// SelectorCache mutex (which cannot be held during allocations due
+	// to pkg/identity/cache/cache.identityWatcher).
+	//
+	// Therefore, here we unconditionally allocate identities for all IPs
+	// in 'selectorIPMapping', then find out if any are duplicated with the
+	// existing selector content later on.
 	var (
 		currentlyAllocatedIdentities []*identity.Identity
 		selectorIPs                  []net.IP
-		ids                          []identity.NumericIdentity
 		err                          error
 	)
 
-	// Allocate identities for each IPNet and then map to selector
-	selectorIPs = selectorIPMapping[f.selector]
+	selectorIPs = selectorIPMapping[sel]
 	log.WithFields(logrus.Fields{
-		"fqdnSelector": f.selector,
+		"fqdnSelector": sel,
 		"ips":          selectorIPs,
 	}).Debug("getting identities for IPs associated with FQDNSelector")
 
@@ -499,27 +505,38 @@ func (f *fqdnSelector) allocateIdentityMappings(idAllocator cache.IdentityAlloca
 	// any existing IPs would typically already have been pushed to the ipcache as they would
 	// not be newly allocated. We need the 'allocation' here to get a reference count on the
 	// allocations.
-	if currentlyAllocatedIdentities, err = idAllocator.AllocateCIDRsForIPs(selectorIPs, nil); err != nil {
+	currentlyAllocatedIdentities, err = sc.idAllocator.AllocateCIDRsForIPs(selectorIPs, nil)
+	if err != nil {
 		log.WithError(err).WithField("prefixes", selectorIPs).Warn(
 			"failed to allocate identities for IPs")
-		return
+		return nil
 	}
-	ids = make([]identity.NumericIdentity, 0, len(currentlyAllocatedIdentities))
-	for i := range currentlyAllocatedIdentities {
-		ids = append(ids, currentlyAllocatedIdentities[i].ID)
-	}
+	return currentlyAllocatedIdentities
+}
 
-	identitiesToRelease := make([]identity.NumericIdentity, 0, len(ids))
-	for _, id := range ids {
-		if _, exists := f.cachedSelections[id]; exists {
-			identitiesToRelease = append(identitiesToRelease, id)
+// transferIdentityReferencesToSelector walks through the specified slice of
+// identities, and associates them with the received selector. If any of the
+// identities passed into this function are already associated with the
+// selector, then these identities are returned to the caller.
+//
+// The goal of this function is to ensure that at any given point in time,
+// the selector holds a maximum of one reference to any given identity.
+// If the calling code opportunistically allocates references to identities
+// twice for a given selector, this function will detect this case and collect
+// the set of identities that are referenced twice.
+//
+// The caller MUST release references to each identity in the returned slice
+// after releasing SelectorCache.mutex.
+func (f *fqdnSelector) transferIdentityReferencesToSelector(currentlyAllocatedIdentities []*identity.Identity) []identity.NumericIdentity {
+	identitiesToRelease := make([]identity.NumericIdentity, 0, len(currentlyAllocatedIdentities))
+	for _, id := range currentlyAllocatedIdentities {
+		if _, exists := f.cachedSelections[id.ID]; exists {
+			identitiesToRelease = append(identitiesToRelease, id.ID)
 		}
-		f.cachedSelections[id] = struct{}{}
+		f.cachedSelections[id.ID] = struct{}{}
 	}
 
-	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
-	defer cancel()
-	idAllocator.ReleaseCIDRIdentitiesByID(ctx, identitiesToRelease)
+	return identitiesToRelease
 }
 
 // releaseIdentityMappings must be called exactly once for the received
@@ -805,6 +822,13 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 	selectors := map[api.FQDNSelector]struct{}{newFQDNSel.selector: {}}
 	_, selectorIPMapping := sc.localIdentityNotifier.MapSelectorsToIPsLocked(selectors)
 
+	// Allocate identities corresponding to the slice of IPs identified as
+	// being selected by this FQDN selector above. This could plausibly
+	// happen twice, once with an empty 'ids' slice and once with the real
+	// 'ids' slice. Either way, they are added to the selector that is
+	// stored in 'sc.selectors[]'.
+	currentlyAllocatedIdentities := sc.allocateIdentityMappings(fqdnSelec, selectorIPMapping)
+
 	// Note: No notifications are sent for the existing
 	// identities. Caller must use GetSelections() to get the
 	// current selections after adding a selector. This way the
@@ -812,8 +836,6 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 	// is already cached, or is a new one).
 
 	sc.mutex.Lock()
-	defer sc.mutex.Unlock()
-
 	// Check whether the selectorCache was updated while 'newFQDNSel' was
 	// being registered without the 'sc.mutex'. If so, use it. Otherwise
 	// we can use the one we just created/configured above.
@@ -822,16 +844,16 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 	} else {
 		sc.selectors[key] = newFQDNSel
 	}
-
-	// Allocate identities corresponding to the slice of IPs identified as
-	// being selected by this FQDN selector above. This could plausibly
-	// happen twice, once with an empty 'ids' slice and once with the real
-	// 'ids' slice. Either way, they are added to the selector that is
-	// stored in 'sc.selectors[]'.
-	newFQDNSel.allocateIdentityMappings(sc.idAllocator, selectorIPMapping)
+	identitiesToRelease := newFQDNSel.transferIdentityReferencesToSelector(currentlyAllocatedIdentities)
 	newFQDNSel.updateSelections()
+	added = newFQDNSel.addUser(user)
+	sc.mutex.Unlock()
 
-	return newFQDNSel, newFQDNSel.addUser(user)
+	ctx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
+	defer cancel()
+	sc.idAllocator.ReleaseCIDRIdentitiesByID(ctx, identitiesToRelease)
+
+	return newFQDNSel, added
 }
 
 // FindCachedIdentitySelector finds the given api.EndpointSelector in the

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -302,7 +302,7 @@ func (rpm *Manager) OnUpdatePodLocked(pod *slimcorev1.Pod, removeOld bool, upser
 	if upsertNew {
 		// Check if any of the current redirect policies select this pod.
 		for _, config := range rpm.policyConfigs {
-			if config.policyConfigSelectsPod(podData) {
+			if config.checkNamespace(pod.GetNamespace()) && config.policyConfigSelectsPod(podData) {
 				rpm.processConfig(config, podData)
 			}
 		}

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -559,4 +559,30 @@ func (m *ManagerSuite) TestManager_AddrMatcherConfigDualStack(c *C) {
 	}
 }
 
-//TODO Tests for svcMatcher
+// Tests add and update pod operations with namespace mismatched pods.
+func (m *ManagerSuite) TestManager_OnAddandUpdatePod(c *C) {
+	configFe := configAddrType
+	m.rpm.policyFrontendsByHash[fe1.Hash()] = configFe.id
+	configSvc := configSvcType
+	m.rpm.policyConfigs[configSvc.id] = &configSvc
+	pod := pod1.DeepCopy()
+	pod.Namespace = "ns2"
+	podID := k8s.ServiceID{
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+
+	m.rpm.OnAddPod(pod)
+
+	// Namespace mismatched pod not selected.
+	c.Assert(len(m.rpm.policyPods), Equals, 0)
+	_, found := m.rpm.policyPods[podID]
+	c.Assert(found, Equals, false)
+
+	m.rpm.OnUpdatePod(pod, true, true)
+
+	// Namespace mismatched pod not selected.
+	c.Assert(len(m.rpm.policyPods), Equals, 0)
+	_, found = m.rpm.policyPods[podID]
+	c.Assert(found, Equals, false)
+}

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -171,7 +171,7 @@ func (a *Agent) Init(mtuConfig mtu.Configuration) error {
 
 		subnet := net.IPNet{
 			IP:   net.IPv4zero,
-			Mask: net.CIDRMask(0, net.IPv4len),
+			Mask: net.CIDRMask(0, 8*net.IPv4len),
 		}
 		rt.Prefix = subnet
 		if _, err := route.Upsert(rt); err != nil {
@@ -185,7 +185,7 @@ func (a *Agent) Init(mtuConfig mtu.Configuration) error {
 
 		subnet := net.IPNet{
 			IP:   net.IPv6zero,
-			Mask: net.CIDRMask(0, net.IPv6len),
+			Mask: net.CIDRMask(0, 8*net.IPv6len),
 		}
 		rt.Prefix = subnet
 		if _, err := route.Upsert(rt); err != nil {


### PR DESCRIPTION
 * [x] #18011 -- add context when return errors during datapath initialization (@kerthcet)
 * [x] #18612 -- hubble/recorder: Sanitize pcap filename (@gandro)
 * [x] #19053 -- helm: Remove Unnecessary RBAC Permissions for Agent (@nathanjsweet)
 * [x] #19031 -- selectorcache: Move identity alloc/release outside of critical section (@joestringer) :warning: Some conflicts, see commit description for details
 * [x] #19071 -- helm: Add RBAC Permissions to Clustermesh APIServer Clusterrole (@nathanjsweet)
 * [x] #19118 -- wireguard: Fix invalid bits when agent init (@Junnplus)
 * [x] #19228 -- workflows: Update call to Quay API (@pchaigno) :warning: Some minor conflicts
 * [x] #19229 -- jenkinsfiles: Update calls to Quay API (@pchaigno) :warning: Some minor conflicts
 * [x] #19172 -- cmd: Fix issue where a ConfigMap value of `{}` was parsed as `map["{}":""]`. (@gandro)
 * [ ] #19193 -- pkg/redirectpolicy: Add missing namespace check in pod update handler (@aditighag)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18011 18612 19053 19031 19071 19118 19228 19229 19172 19193; do contrib/backporting/set-labels.py $pr done 1.10; done
```
or with
```
$ make add-label BRANCH=v1.10 ISSUES=18011,18612,19053,19031,19071,19118,19228,19229,19172,19193
```