### PR TITLE
[v1.11] pkg/k8s: use a single HTTP Client for all kube-apiserver connections

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -121,51 +121,40 @@ func createClient(config *rest.Config, cs kubernetes.Interface) error {
 	return err
 }
 
-func createDefaultClient() (rest.Interface, func(), error) {
-	restConfig, err := CreateConfig()
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create k8s client rest configuration: %s", err)
-	}
+func createDefaultClient(c *rest.Config, httpClient *http.Client) (rest.Interface, error) {
+	restConfig := *c
 	restConfig.ContentConfig.ContentType = `application/vnd.kubernetes.protobuf`
 
-	closeAllConns := setDialer(restConfig)
-
-	createdK8sClient, err := kubernetes.NewForConfig(restConfig)
+	createdK8sClient, err := kubernetes.NewForConfigAndClient(&restConfig, httpClient)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	err = createClient(restConfig, createdK8sClient)
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create k8s client: %s", err)
-	}
-
-	k8sCLI.Interface = createdK8sClient
-
-	createK8sWatcherCli, err := watcher_client.NewForConfig(restConfig)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	k8sWatcherCLI.Interface = createK8sWatcherCli
-
-	return createdK8sClient.RESTClient(), closeAllConns, nil
-}
-
-func createDefaultCiliumClient() (func(), error) {
-	restConfig, err := CreateConfig()
-	if err != nil {
-		return nil, fmt.Errorf("unable to create k8s client rest configuration: %s", err)
-	}
-
-	closeAllConns := setDialer(restConfig)
-	createdCiliumK8sClient, err := clientset.NewForConfig(restConfig)
+	err = createClient(&restConfig, createdK8sClient)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create k8s client: %s", err)
 	}
 
+	k8sCLI.Interface = createdK8sClient
+
+	createK8sWatcherCli, err := watcher_client.NewForConfigAndClient(&restConfig, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	k8sWatcherCLI.Interface = createK8sWatcherCli
+
+	return createdK8sClient.RESTClient(), nil
+}
+
+func createDefaultCiliumClient(c *rest.Config, httpClient *http.Client) error {
+	createdCiliumK8sClient, err := clientset.NewForConfigAndClient(c, httpClient)
+	if err != nil {
+		return fmt.Errorf("unable to create k8s client: %s", err)
+	}
+
 	k8sCiliumCLI.Interface = createdCiliumK8sClient
 
-	return closeAllConns, nil
+	return nil
 }
 
 func createAPIExtensionsClient() error {

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -134,12 +135,27 @@ func useNodeCIDR(n *nodeTypes.Node) {
 // Init initializes the Kubernetes package. It is required to call Configure()
 // beforehand.
 func Init(conf k8sconfig.Configuration) error {
-	k8sRestClient, closeAllDefaultClientConns, err := createDefaultClient()
+	restConfig, err := CreateConfig()
+	if err != nil {
+		return fmt.Errorf("unable to create k8s client rest configuration: %s", err)
+	}
+	closeAllDefaultClientConns := setDialer(restConfig)
+	// Use the same http client for all k8s connections. It does not matter that
+	// we are using a restConfig for the HTTP client that differs from each
+	// individual client since the rest.HTTPClientFor only does not use fields
+	// that are specific for each client, for example:
+	// restConfig.ContentConfig.ContentType.
+	httpClient, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		return fmt.Errorf("unable to create k8s REST client: %s", err)
+	}
+
+	k8sRestClient, err := createDefaultClient(restConfig, httpClient)
 	if err != nil {
 		return fmt.Errorf("unable to create k8s client: %s", err)
 	}
 
-	closeAllCiliumClientConns, err := createDefaultCiliumClient()
+	err = createDefaultCiliumClient(restConfig, httpClient)
 	if err != nil {
 		return fmt.Errorf("unable to create cilium k8s client: %s", err)
 	}
@@ -166,7 +182,6 @@ func Init(conf k8sconfig.Configuration) error {
 						heartBeat,
 						option.Config.K8sHeartbeatTimeout,
 						closeAllDefaultClientConns,
-						closeAllCiliumClientConns,
 					)
 					return nil
 				},

--- a/pkg/k8s/slim/k8s/clientset/clientset.go
+++ b/pkg/k8s/slim/k8s/clientset/clientset.go
@@ -6,6 +6,7 @@ package clientset
 
 import (
 	"fmt"
+	"net/http"
 
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/typed/core/v1"
 	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/typed/discovery/v1"
@@ -51,10 +52,11 @@ func (c *Clientset) NetworkingV1() networkingv1.NetworkingV1Interface {
 	return c.networkingV1
 }
 
-// NewForConfig creates a new Clientset for the given config.
+// NewForConfigAndClient creates a new Clientset for the given config and http client.
 // If config's RateLimiter is not set and QPS and Burst are acceptable,
 // NewForConfig will generate a rate-limiter in configShallowCopy.
-func NewForConfig(c *rest.Config) (*Clientset, error) {
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		if configShallowCopy.Burst <= 0 {
@@ -70,28 +72,28 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	}
 
 	// Wrap coreV1 with our own implementation
-	slimCoreV1, err := slim_corev1.NewForConfig(&configShallowCopy)
+	slimCoreV1, err := slim_corev1.NewForConfigAndClient(&configShallowCopy, h)
 	if err != nil {
 		return nil, err
 	}
 	cs.coreV1 = corev1.New(slimCoreV1.RESTClient())
 
 	// Wrap discoveryV1beta1 with our own implementation
-	slimDiscoveryV1beta1, err := slim_discovery_v1beta1.NewForConfig(&configShallowCopy)
+	slimDiscoveryV1beta1, err := slim_discovery_v1beta1.NewForConfigAndClient(&configShallowCopy, h)
 	if err != nil {
 		return nil, err
 	}
 	cs.discoveryV1beta1 = discoveryv1beta1.New(slimDiscoveryV1beta1.RESTClient())
 
 	// Wrap discoveryV1 with our own implementation
-	slimDiscoveryV1, err := slim_discovery_v1.NewForConfig(&configShallowCopy)
+	slimDiscoveryV1, err := slim_discovery_v1.NewForConfigAndClient(&configShallowCopy, h)
 	if err != nil {
 		return nil, err
 	}
 	cs.discoveryV1 = discoveryv1.New(slimDiscoveryV1.RESTClient())
 
 	// Wrap networkingV1 with our own implementation
-	slimNetworkingV1, err := slim_networkingv1.NewForConfig(&configShallowCopy)
+	slimNetworkingV1, err := slim_networkingv1.NewForConfigAndClient(&configShallowCopy, h)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Based on top of v1.11.3