### PR TITLE
bpf: Allow to override HOST_CC and HOST_STRIP

### DIFF
--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -36,11 +36,11 @@ HOST_CC    ?= gcc
 HOST_STRIP ?= strip
 
 ifeq ($(CROSS_ARCH),arm64)
-  HOST_CC = aarch64-linux-gnu-gcc
-  HOST_STRIP = aarch64-linux-gnu-strip
+  HOST_CC ?= aarch64-linux-gnu-gcc
+  HOST_STRIP ?= aarch64-linux-gnu-strip
 else ifeq ($(CROSS_ARCH),amd64)
-  HOST_CC = x86_64-linux-gnu-gcc
-  HOST_STRIP = x86_64-linux-gnu-strip
+  HOST_CC ?= x86_64-linux-gnu-gcc
+  HOST_STRIP ?= x86_64-linux-gnu-strip
 endif
 
 # Define all at the top here so that Makefiles which include this one will hit


### PR DESCRIPTION
Otherwise, "make build" fails on hosts which don't have the predefined
symlink (e.g., "x86_64-linux-gnu-gcc") to "gcc".