### PR TITLE
docs: Clarify use of the `eni.subnetTagsFilter` option

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -112,6 +112,10 @@ to them:
          ]
        }
 
+Additional parameters may be configured in the ``eni`` or ``ipam`` section of
+the CNI configuration file. See the list of ENI allocation parameters below
+for a reference of the supported options.
+
 Deploy the ``ConfigMap``:
 
 .. code-block:: shell-session
@@ -121,14 +125,13 @@ Deploy the ``ConfigMap``:
 Configure Cilium with subnet-tags-filter
 ----------------------------------------
 
-Using the instructions above to deploy Cilium, specify the following additional
-arguments to Helm:
+Using the instructions above to deploy Cilium and CNI config, specify the
+following additional arguments to Helm:
 
 .. code-block:: shell-session
 
    --set cni.customConf=true \
-   --set cni.configMap=cni-configuration \
-   --set eni.subnetTagsFilter="foo=true"
+   --set cni.configMap=cni-configuration
 
 ENI Allocation Parameters
 =========================

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -466,11 +466,11 @@
      - string
      - ``""``
    * - eni.subnetIDsFilter
-     - Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs
+     - Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead.
      - string
      - ``""``
    * - eni.subnetTagsFilter
-     - Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs
+     - Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead.
      - string
      - ``""``
    * - eni.updateEC2AdapterLimitViaAPI

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -167,8 +167,8 @@ contributors across the globe, there is almost always someone available to help.
 | eni.enabled | bool | `false` | Enable Elastic Network Interface (ENI) integration. |
 | eni.eniTags | object | `{}` | Tags to apply to the newly created ENIs |
 | eni.iamRole | string | `""` | If using IAM role for Service Accounts will not try to inject identity values from cilium-aws kubernetes secret. Adds annotation to service account if managed by Helm. See https://github.com/aws/amazon-eks-pod-identity-webhook |
-| eni.subnetIDsFilter | string | `""` | Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs |
-| eni.subnetTagsFilter | string | `""` | Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs |
+| eni.subnetIDsFilter | string | `""` | Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead. |
+| eni.subnetTagsFilter | string | `""` | Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead. |
 | eni.updateEC2AdapterLimitViaAPI | bool | `false` | Update ENI Adapter limits from the EC2 API |
 | etcd.clusterDomain | string | `"cluster.local"` | Cluster domain for cilium-etcd-operator. |
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -507,8 +507,14 @@ eni:
   # See https://github.com/aws/amazon-eks-pod-identity-webhook
   iamRole: ""
   # -- Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs
+  # Important note: This requires that each instance has an ENI with a matching subnet attached
+  # when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium,
+  # use the CNI configuration file settings (cni.customConf) instead.
   subnetIDsFilter: ""
   # -- Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs
+  # Important note: This requires that each instance has an ENI with a matching subnet attached
+  # when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium,
+  # use the CNI configuration file settings (cni.customConf) instead.
   subnetTagsFilter: ""
 
 externalIPs:


### PR DESCRIPTION
The `eni.subnetTagsFilter` option is notoriously hard to use correctly.
If it is used with tags that don't match the subnet of the pre-attached
ENI, Cilium agent will never become ready (#18239).

This PR removes it from the ENI documentation (which most users will use
as a reference configuration) such that no one enables this option
without being aware of its requirements. This PR also adds additional
context the Helm value. We might deprecate and remove the option in the
future as well (#19181).

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
