### PR TITLE
eni: Fix broken build due to unit test

### DIFF
--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -588,7 +588,7 @@ func (e *ENISuite) TestNodeManagerENIExcludeInterfaceTags(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"})
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	c.Assert(err, check.IsNil)
 	err = ec2api.TagENI(context.TODO(), eniID1, map[string]string{
 		"foo":                 "bar",
@@ -598,7 +598,7 @@ func (e *ENISuite) TestNodeManagerENIExcludeInterfaceTags(c *check.C) {
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerDefaultAllocation-0", eniID1)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
-	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false)
+	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 


### PR DESCRIPTION
PR #18463 changed the signature of the CreateNetworkInterface and
NewNodeManager methods. This change was merged last week.  PR #19096
added a unit test in TestNodeManagerENIExcludeInterfaceTags which calls
those methods with the old signature.

Because the latter PR was not rebased after a merge, we accidentally
merged a non-compilable unit test into master, even though CI was green
(as CI was run before the signature was changed).
