### PR TITLE
fix(helm): use a directory to store bootstrap time

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1100,7 +1100,7 @@
    * - nodeinit.bootstrapFile
      - bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet
      - string
-     - ``"/tmp/cilium-bootstrap-time"``
+     - ``"/tmp/cilium-bootstrap.d/cilium-bootstrap-time"``
    * - nodeinit.enabled
      - Enable the node initialization DaemonSet
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -325,7 +325,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for cilium-agent. |
 | nodeinit.affinity | object | `{}` | Affinity for cilium-nodeinit |
-| nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
+| nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap.d/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraEnv | list | `[]` | Additional nodeinit environment variables. |
 | nodeinit.image | object | `{"override":null,"pullPolicy":"Always","repository":"quay.io/cilium/startup-script","tag":"62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"}` | node-init image. |

--- a/install/kubernetes/cilium/files/nodeinit/prestop.bash
+++ b/install/kubernetes/cilium/files/nodeinit/prestop.bash
@@ -23,7 +23,7 @@ if ip link show cilium_host; then
 fi
 
 {{- if not (eq .Values.nodeinit.bootstrapFile "") }}
-rm -f {{ .Values.nodeinit.bootstrapFile }}
+rm -f {{ .Values.nodeinit.bootstrapFile | quote }}
 {{- end }}
 
 rm -f /tmp/node-init.cilium.io

--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -120,7 +120,8 @@ iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq: ensure nat POST
 {{- end }}
 
 {{- if not (eq .Values.nodeinit.bootstrapFile "") }}
-date > {{ .Values.nodeinit.bootstrapFile }}
+mkdir -p {{ .Values.nodeinit.bootstrapFile | dir | quote }}
+date > {{ .Values.nodeinit.bootstrapFile | quote }}
 {{- end }}
 
 {{- if .Values.azure.enabled }}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -372,13 +372,13 @@ spec:
         - sh
         - -c
         - |
-          until test -s {{ .Values.nodeinit.bootstrapFile | quote }}; do
+          until test -s {{ (print "/tmp/cilium-bootstrap.d/" (.Values.nodeinit.bootstrapFile | base)) | quote }}; do
             echo "Waiting on node-init to run...";
             sleep 1;
           done
         volumeMounts:
-        - name: cilium-bootstrap-file
-          mountPath: {{ .Values.nodeinit.bootstrapFile }}
+        - name: cilium-bootstrap-file-dir
+          mountPath: "/tmp/cilium-bootstrap.d"
       {{- end }}
       - name: clean-cilium-state
         image: {{ include "cilium.image" .Values.image | quote }}
@@ -515,10 +515,10 @@ spec:
           type: FileOrCreate
       {{- end }}
       {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
-      - name: cilium-bootstrap-file
+      - name: cilium-bootstrap-file-dir
         hostPath:
-          path: {{ .Values.nodeinit.bootstrapFile }}
-          type: FileOrCreate
+          path: {{ .Values.nodeinit.bootstrapFile | dir | quote }}
+          type: DirectoryOrCreate
       {{- end }}
       {{- if .Values.etcd.enabled }}
         # To read the etcd config stored in config maps

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -72,8 +72,6 @@ spec:
           {{- with .Values.nodeinit.extraEnv }}
           {{- toYaml . | trim | nindent 10 }}
           {{- end }}
-          - name: CHECKPOINT_PATH
-            value: /tmp/node-init.cilium.io
           # STARTUP_SCRIPT is the script run on node bootstrap. Node
           # bootstrapping can be customized in this script. This script is invoked
           # using nsenter, so it runs in the host's network and mount namespace using

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1611,7 +1611,7 @@ nodeinit:
 
   # -- bootstrapFile is the location of the file where the bootstrap timestamp is
   # written by the node-init DaemonSet
-  bootstrapFile: "/tmp/cilium-bootstrap-time"
+  bootstrapFile: "/tmp/cilium-bootstrap.d/cilium-bootstrap-time"
 
 preflight:
   # -- Enable Cilium pre-flight resources (required for upgrade)


### PR DESCRIPTION
Fixes: #14483


```release-note
Fixed node init in RKE
```

Signed-off-by: Raphaël Pinson <raphael@isovalent.com>