### PR TITLE
cilium: BBR for Pods

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -231,7 +231,7 @@ jobs:
             --set tunnel=disabled \
             --set nodeinit.enabled=true \
             --set bpf.monitorAggregation=none \
-            --set bandwidthManager=false
+            --set bandwidthManager.enabled=false
 
       - name: Enable Relay
         run: |

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -76,6 +76,7 @@ cilium-agent [flags]
       --egress-multi-home-ip-rule-compat                     Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
       --enable-auto-protect-node-port-range                  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
       --enable-bandwidth-manager                             Enable BPF bandwidth manager
+      --enable-bbr                                           Enable BBR for the bandwidth manager
       --enable-bpf-clock-probe                               Enable BPF clock source probing for more efficient tick retrieval
       --enable-bpf-masquerade                                Masquerade packets from endpoints leaving the host with BPF instead of iptables
       --enable-bpf-tproxy                                    Enable BPF-based proxy redirection, if support available

--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -86,7 +86,7 @@ is enforced:
 .. code-block:: shell-session
 
     $ kubectl -n kube-system exec ds/cilium -- cilium status | grep BandwidthManager
-    BandwidthManager:       EDT with BPF   [eth0]
+    BandwidthManager:       EDT with BPF [BBR] [eth0]
 
 To verify that egress bandwidth limits are indeed being enforced, one can deploy two
 ``netperf`` Pods in different nodes — one acting as a server and one acting as the client:

--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -50,7 +50,7 @@ To install Cilium with the bandwidth manager enabled, run
 
    helm install cilium |CHART_RELEASE| \\
      --namespace kube-system \\
-     --set bandwidthManager=true
+     --set bandwidthManager.enabled=true
 
 To enable the bandwidth manager on an existing installation, run
 
@@ -59,7 +59,7 @@ To enable the bandwidth manager on an existing installation, run
    helm upgrade cilium |CHART_RELEASE| \\
      --namespace kube-system \\
      --reuse-values \\
-     --set bandwidthManager=true
+     --set bandwidthManager.enabled=true
    kubectl -n kube-system rollout restart ds/cilium
 
 The native host networking devices are auto detected as native devices which have

--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -6,9 +6,9 @@
 
 .. _bandwidth-manager:
 
-************************
-Bandwidth Manager (beta)
-************************
+*****************
+Bandwidth Manager
+*****************
 
 This guide explains how to configure Cilium's bandwidth manager to
 optimize TCP and UDP workloads and efficiently rate limit individual Pods

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -30,7 +30,15 @@
      - bool
      - ``false``
    * - bandwidthManager
-     - Optimize TCP and UDP workloads and enable rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation.
+     - Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation.
+     - object
+     - ``{"bbr":false,"enabled":false}``
+   * - bandwidthManager.bbr
+     - Activate BBR TCP congestion control for Pods
+     - bool
+     - ``false``
+   * - bandwidthManager.enabled
+     - Enable bandwidth manager infrastructure (also prerequirement for BBR)
      - bool
      - ``false``
    * - bgp

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -137,7 +137,7 @@ To enable the Bandwidth Manager:
 
            helm install cilium |CHART_RELEASE| \\
              --namespace kube-system \\
-             --set bandwidthManager=true \\
+             --set bandwidthManager.enabled=true \\
              --set kubeProxyReplacement=strict
 
 To validate whether your installation is running with Bandwidth Manager,

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -338,6 +338,8 @@ Removed Options
 Helm Options
 ~~~~~~~~~~~~
 
+* ``bandwidthManager`` has been deprecated in favor of ``bandwidthManager.enabled``,
+  and will be removed in 1.13.
 * ``bpf.hostRouting`` has been deprecated in favor of ``bpf.hostLegacyRouting``, and
   will be removed in 1.13.
 * ``hubble.tls.ca.cert`` has been deprecated in favor of ``tls.ca.cert``, and

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -1,10 +1,10 @@
 ACK
 AKS
-Anthos
 APIEndpoint
 AdapterLimitViaAPI
 Alemayhu
 Alibaba
+Anthos
 BPF
 Bertin
 Blanco
@@ -90,7 +90,6 @@ MaskSize
 Mbit
 Mellanox
 Menlo
-mentees
 Mesos
 MiB
 Minikube
@@ -189,6 +188,7 @@ balancer
 balancers
 bandwidthManager
 battlestation
+bbr
 bcc
 behaviour
 benchmarking
@@ -446,6 +446,7 @@ hostPort
 hostRoot
 hostServices
 hostname
+hostns
 hostonlyif
 hostonlyifs
 hostport
@@ -606,6 +607,7 @@ mediabot
 memcache
 memcached
 memcd
+mentees
 metadata
 metricsServer
 microk
@@ -714,6 +716,7 @@ preloading
 prem
 prepend
 prepulls
+prerequirement
 priori
 priorityClassName
 productpage
@@ -759,6 +762,7 @@ requireIPv
 resourceQuotas
 retpoline
 retransmission
+retransmissions
 retrigger
 retryTimeout
 rn

--- a/api/v1/models/bandwidth_manager.go
+++ b/api/v1/models/bandwidth_manager.go
@@ -9,8 +9,12 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
+
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // BandwidthManager Status of bandwidth manager
@@ -19,6 +23,10 @@ import (
 //
 // swagger:model BandwidthManager
 type BandwidthManager struct {
+
+	// congestion control
+	// Enum: [cubic bbr]
+	CongestionControl string `json:"congestionControl,omitempty"`
 
 	// devices
 	Devices []string `json:"devices"`
@@ -29,6 +37,58 @@ type BandwidthManager struct {
 
 // Validate validates this bandwidth manager
 func (m *BandwidthManager) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateCongestionControl(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+var bandwidthManagerTypeCongestionControlPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["cubic","bbr"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		bandwidthManagerTypeCongestionControlPropEnum = append(bandwidthManagerTypeCongestionControlPropEnum, v)
+	}
+}
+
+const (
+
+	// BandwidthManagerCongestionControlCubic captures enum value "cubic"
+	BandwidthManagerCongestionControlCubic string = "cubic"
+
+	// BandwidthManagerCongestionControlBbr captures enum value "bbr"
+	BandwidthManagerCongestionControlBbr string = "bbr"
+)
+
+// prop value enum
+func (m *BandwidthManager) validateCongestionControlEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, bandwidthManagerTypeCongestionControlPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *BandwidthManager) validateCongestionControl(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.CongestionControl) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCongestionControlEnum("congestionControl", "body", m.CongestionControl); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2800,6 +2800,11 @@ definitions:
         type: array
         items:
           type: string
+      congestionControl:
+        type: string
+        enum:
+        - cubic
+        - bbr
   Masquerading:
     description: |-
       Status of masquerading

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1605,6 +1605,13 @@ func init() {
       "description": "Status of bandwidth manager\n\n+k8s:deepcopy-gen=true",
       "type": "object",
       "properties": {
+        "congestionControl": {
+          "type": "string",
+          "enum": [
+            "cubic",
+            "bbr"
+          ]
+        },
         "devices": {
           "type": "array",
           "items": {
@@ -6028,6 +6035,13 @@ func init() {
       "description": "Status of bandwidth manager\n\n+k8s:deepcopy-gen=true",
       "type": "object",
       "properties": {
+        "congestionControl": {
+          "type": "string",
+          "enum": [
+            "cubic",
+            "bbr"
+          ]
+        },
         "devices": {
           "type": "array",
           "items": {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -573,6 +573,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableBandwidthManager, false, "Enable BPF bandwidth manager")
 	option.BindEnv(option.EnableBandwidthManager)
 
+	flags.Bool(option.EnableBBR, false, "Enable BBR for the bandwidth manager")
+	option.BindEnv(option.EnableBBR)
+
 	flags.Bool(option.EnableRecorder, false, "Enable BPF datapath pcap recorder")
 	option.BindEnv(option.EnableRecorder)
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -157,6 +157,11 @@ func (d *Daemon) getBandwidthManagerStatus() *models.BandwidthManager {
 		return s
 	}
 
+	s.CongestionControl = models.BandwidthManagerCongestionControlCubic
+	if option.Config.EnableBBR {
+		s.CongestionControl = models.BandwidthManagerCongestionControlBbr
+	}
+
 	devices := make([]string, len(option.Config.Devices))
 	for i, iface := range option.Config.Devices {
 		devices[i] = iface

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -58,7 +58,9 @@ contributors across the globe, there is almost always someone available to help.
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |
 | azure.enabled | bool | `false` | Enable Azure integration |
-| bandwidthManager | bool | `false` | Optimize TCP and UDP workloads and enable rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
+| bandwidthManager | object | `{"bbr":false,"enabled":false}` | Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
+| bandwidthManager.bbr | bool | `false` | Activate BBR TCP congestion control for Pods |
+| bandwidthManager.enabled | bool | `false` | Enable bandwidth manager infrastructure (also prerequirement for BBR) |
 | bgp | object | `{"announce":{"loadbalancerIP":false,"podCIDR":false},"enabled":false}` | Configure BGP |
 | bgp.announce.loadbalancerIP | bool | `false` | Enable allocation and announcement of service LoadBalancer IPs |
 | bgp.announce.podCIDR | bool | `false` | Enable announcement of node pod CIDR |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -493,7 +493,18 @@ data:
 {{- end }}
 
   auto-direct-node-routes: {{ .Values.autoDirectNodeRoutes | quote }}
+
+{{- if .Values.bandwidthManager }}
+{{- if typeIs "bool" .Values.bandwidthManager }}
+  # DEPRECATED: this block should be removed in 1.13
   enable-bandwidth-manager: {{ .Values.bandwidthManager | quote }}
+{{- else }}
+{{- if .Values.bandwidthManager.enabled }}
+  enable-bandwidth-manager: {{ .Values.bandwidthManager.enabled | quote }}
+  enable-bbr: {{ .Values.bandwidthManager.bbr | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{- if hasKey .Values "localRedirectPolicy" }}
   enable-local-redirect-policy: {{ .Values.localRedirectPolicy | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -199,10 +199,20 @@ alibabacloud:
   # -- Enable AlibabaCloud ENI integration
   enabled: false
 
-# -- Optimize TCP and UDP workloads and enable rate-limiting traffic from
-# individual Pods with EDT (Earliest Departure Time)
-# through the "kubernetes.io/egress-bandwidth" Pod annotation.
-bandwidthManager: false
+# -- Deprecated in favor of bandwidthManager.enabled. To be removed in 1.13.
+# Optimize TCP and UDP workloads and enable rate-limiting traffic from
+# individual Pods with EDT (Earliest Departure Time) through the
+# "kubernetes.io/egress-bandwidth" Pod annotation.
+#bandwidthManager: false
+
+# -- Enable bandwidth manager to optimize TCP and UDP workloads and allow
+# for rate-limiting traffic from individual Pods with EDT (Earliest Departure
+# Time) through the "kubernetes.io/egress-bandwidth" Pod annotation.
+bandwidthManager:
+  # -- Enable bandwidth manager infrastructure (also prerequirement for BBR)
+  enabled: false
+  # -- Activate BBR TCP congestion control for Pods
+  bbr: false
 
 # -- Configure BGP
 bgp:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -386,7 +386,8 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 		if !sr.BandwidthManager.Enabled {
 			status = "Disabled"
 		} else {
-			status = fmt.Sprintf("EDT with BPF\t[%s]",
+			status = fmt.Sprintf("EDT with BPF [%s] [%s]",
+				strings.ToUpper(sr.BandwidthManager.CongestionControl),
 				strings.Join(sr.BandwidthManager.Devices, ", "))
 		}
 		fmt.Fprintf(w, "BandwidthManager:\t%s\n", status)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -313,6 +313,9 @@ const (
 	// EnableBandwidthManager enables EDT-based pacing
 	EnableBandwidthManager = "enable-bandwidth-manager"
 
+	// EnableBBR enables BBR TCP congestion control for the node including Pods
+	EnableBBR = "enable-bbr"
+
 	// EnableRecorder enables the datapath pcap recorder
 	EnableRecorder = "enable-recorder"
 
@@ -1788,6 +1791,9 @@ type DaemonConfig struct {
 	// EnableBandwidthManager enables EDT-based pacing
 	EnableBandwidthManager bool
 
+	// EnableBBR enables BBR TCP congestion control for the node including Pods
+	EnableBBR bool
+
 	// ResetQueueMapping resets the Pod's skb queue mapping
 	ResetQueueMapping bool
 
@@ -2627,6 +2633,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableSessionAffinity = viper.GetBool(EnableSessionAffinity)
 	c.EnableServiceTopology = viper.GetBool(EnableServiceTopology)
 	c.EnableBandwidthManager = viper.GetBool(EnableBandwidthManager)
+	c.EnableBBR = viper.GetBool(EnableBBR)
 	c.EnableRecorder = viper.GetBool(EnableRecorder)
 	c.EnableMKE = viper.GetBool(EnableMKE)
 	c.CgroupPathMKE = viper.GetString(CgroupPathMKE)


### PR DESCRIPTION
See commit messages.

```release-note
Add support for enabling BBR congestion control for Pods, and move bandwidth manager out of beta.
```