### PR TITLE
go.mod: update kevinburke/ssh_config dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.3.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jeremywohl/flatten v1.0.1
-	github.com/kevinburke/ssh_config v1.1.0
+	github.com/kevinburke/ssh_config v1.2.0
 	github.com/kr/pretty v0.3.0
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/miekg/dns v1.1.43

--- a/go.sum
+++ b/go.sum
@@ -823,8 +823,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/kevinburke/ssh_config v1.1.0 h1:pH/t1WS9NzT8go394IqZeJTMHVm6Cr6ZJ6AQ+mdNo/o=
-github.com/kevinburke/ssh_config v1.1.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
+github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/keybase/go-ps v0.0.0-20190827175125-91aafc93ba19/go.mod h1:hY+WOq6m2FpbvyrI93sMaypsttvaIL5nhVR92dTMUcQ=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/vendor/github.com/kevinburke/ssh_config/AUTHORS.txt
+++ b/vendor/github.com/kevinburke/ssh_config/AUTHORS.txt
@@ -1,6 +1,9 @@
+Carlos A Becker <caarlos0@gmail.com>
+Dustin Spicuzza <dustin@virtualroadside.com>
 Eugene Terentev <eugene@terentev.net>
 Kevin Burke <kevin@burke.dev>
 Mark Nevill <nev@improbable.io>
+Scott Lessans <slessans@gmail.com>
 Sergey Lukjanov <me@slukjanov.name>
 Wayne Ashley Berry <wayneashleyberry@gmail.com>
 santosh653 <70637961+santosh653@users.noreply.github.com>

--- a/vendor/github.com/kevinburke/ssh_config/CHANGELOG.md
+++ b/vendor/github.com/kevinburke/ssh_config/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changes
+
+## Version 1.2
+
+Previously, if a Host declaration or a value had trailing whitespace, that
+whitespace would have been included as part of the value. This led to unexpected
+consequences. For example:
+
+```
+Host example       # A comment
+    HostName example.com      # Another comment
+```
+
+Prior to version 1.2, the value for Host would have been "example " and the
+value for HostName would have been "example.com      ". Both of these are
+unintuitive.
+
+Instead, we strip the trailing whitespace in the configuration, which leads to
+more intuitive behavior.

--- a/vendor/github.com/kevinburke/ssh_config/Makefile
+++ b/vendor/github.com/kevinburke/ssh_config/Makefile
@@ -19,8 +19,11 @@ race-test: lint
 $(BUMP_VERSION):
 	go get -u github.com/kevinburke/bump_version
 
+$(WRITE_MAILMAP):
+	go get -u github.com/kevinburke/write_mailmap
+
 release: test | $(BUMP_VERSION)
-	$(BUMP_VERSION) minor config.go
+	$(BUMP_VERSION) --tag-prefix=v minor config.go
 
 force: ;
 

--- a/vendor/github.com/kevinburke/ssh_config/README.md
+++ b/vendor/github.com/kevinburke/ssh_config/README.md
@@ -84,6 +84,9 @@ file format.
 
 ## Donating
 
-Donations free up time to make improvements to the library, and respond to
-bug reports. You can send donations via Paypal's "Send Money" feature to
-kev@inburke.com. Donations are not tax deductible in the USA.
+I don't get paid to maintain this project. Donations free up time to make
+improvements to the library, and respond to bug reports. You can send donations
+via Paypal's "Send Money" feature to kev@inburke.com. Donations are not tax
+deductible in the USA.
+
+You can also reach out about a consulting engagement: https://burke.services

--- a/vendor/github.com/kevinburke/ssh_config/config.go
+++ b/vendor/github.com/kevinburke/ssh_config/config.go
@@ -34,7 +34,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	osuser "os/user"
 	"path/filepath"
@@ -44,7 +43,7 @@ import (
 	"sync"
 )
 
-const version = "1.0"
+const version = "1.2"
 
 var _ = version
 
@@ -279,7 +278,7 @@ func parseFile(filename string) (*Config, error) {
 }
 
 func parseWithDepth(filename string, depth uint8) (*Config, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -294,10 +293,16 @@ func isSystem(filename string) bool {
 // Decode reads r into a Config, or returns an error if r could not be parsed as
 // an SSH config file.
 func Decode(r io.Reader) (*Config, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
+	return decodeBytes(b, false, 0)
+}
+
+// DecodeBytes reads b into a Config, or returns an error if r could not be
+// parsed as an SSH config file.
+func DecodeBytes(b []byte) (*Config, error) {
 	return decodeBytes(b, false, 0)
 }
 
@@ -493,7 +498,10 @@ type Host struct {
 	// A Node is either a key/value pair or a comment line.
 	Nodes []Node
 	// EOLComment is the comment (if any) terminating the Host line.
-	EOLComment   string
+	EOLComment string
+	// Whitespace if any between the Host declaration and a trailing comment.
+	spaceBeforeComment string
+
 	hasEquals    bool
 	leadingSpace int // TODO: handle spaces vs tabs here.
 	// The file starts with an implicit "Host *" declaration.
@@ -525,7 +533,7 @@ func (h *Host) Matches(alias string) bool {
 // String prints h as it would appear in a config file. Minor tweaks may be
 // present in the whitespace in the printed file.
 func (h *Host) String() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	//lint:ignore S1002 I prefer to write it this way
 	if h.implicit == false {
 		buf.WriteString(strings.Repeat(" ", int(h.leadingSpace)))
@@ -541,8 +549,9 @@ func (h *Host) String() string {
 				buf.WriteString(" ")
 			}
 		}
+		buf.WriteString(h.spaceBeforeComment)
 		if h.EOLComment != "" {
-			buf.WriteString(" #")
+			buf.WriteByte('#')
 			buf.WriteString(h.EOLComment)
 		}
 		buf.WriteByte('\n')
@@ -563,12 +572,14 @@ type Node interface {
 // KV is a line in the config file that contains a key, a value, and possibly
 // a comment.
 type KV struct {
-	Key          string
-	Value        string
-	Comment      string
-	hasEquals    bool
-	leadingSpace int // Space before the key. TODO handle spaces vs tabs.
-	position     Position
+	Key   string
+	Value string
+	// Whitespace after the value but before any comment
+	spaceAfterValue string
+	Comment         string
+	hasEquals       bool
+	leadingSpace    int // Space before the key. TODO handle spaces vs tabs.
+	position        Position
 }
 
 // Pos returns k's Position.
@@ -576,8 +587,7 @@ func (k *KV) Pos() Position {
 	return k.position
 }
 
-// String prints k as it was parsed in the config file. There may be slight
-// changes to the whitespace between values.
+// String prints k as it was parsed in the config file.
 func (k *KV) String() string {
 	if k == nil {
 		return ""
@@ -586,9 +596,9 @@ func (k *KV) String() string {
 	if k.hasEquals {
 		equals = " = "
 	}
-	line := fmt.Sprintf("%s%s%s%s", strings.Repeat(" ", int(k.leadingSpace)), k.Key, equals, k.Value)
+	line := strings.Repeat(" ", int(k.leadingSpace)) + k.Key + equals + k.Value + k.spaceAfterValue
 	if k.Comment != "" {
-		line += " #" + k.Comment
+		line += "#" + k.Comment
 	}
 	return line
 }

--- a/vendor/github.com/kevinburke/ssh_config/parser.go
+++ b/vendor/github.com/kevinburke/ssh_config/parser.go
@@ -3,6 +3,7 @@ package ssh_config
 import (
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 type sshParser struct {
@@ -122,11 +123,16 @@ func (p *sshParser) parseKV() sshParserStateFn {
 			}
 			patterns = append(patterns, pat)
 		}
+		// val.val at this point could be e.g. "example.com       "
+		hostval := strings.TrimRightFunc(val.val, unicode.IsSpace)
+		spaceBeforeComment := val.val[len(hostval):]
+		val.val = hostval
 		p.config.Hosts = append(p.config.Hosts, &Host{
-			Patterns:   patterns,
-			Nodes:      make([]Node, 0),
-			EOLComment: comment,
-			hasEquals:  hasEquals,
+			Patterns:           patterns,
+			Nodes:              make([]Node, 0),
+			EOLComment:         comment,
+			spaceBeforeComment: spaceBeforeComment,
+			hasEquals:          hasEquals,
 		})
 		return p.parseStart
 	}
@@ -144,13 +150,16 @@ func (p *sshParser) parseKV() sshParserStateFn {
 		lastHost.Nodes = append(lastHost.Nodes, inc)
 		return p.parseStart
 	}
+	shortval := strings.TrimRightFunc(val.val, unicode.IsSpace)
+	spaceAfterValue := val.val[len(shortval):]
 	kv := &KV{
-		Key:          key.val,
-		Value:        val.val,
-		Comment:      comment,
-		hasEquals:    hasEquals,
-		leadingSpace: key.Position.Col - 1,
-		position:     key.Position,
+		Key:             key.val,
+		Value:           shortval,
+		spaceAfterValue: spaceAfterValue,
+		Comment:         comment,
+		hasEquals:       hasEquals,
+		leadingSpace:    key.Position.Col - 1,
+		position:        key.Position,
 	}
 	lastHost.Nodes = append(lastHost.Nodes, kv)
 	return p.parseStart

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -523,7 +523,7 @@ github.com/josharian/native
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/kevinburke/ssh_config v1.1.0
+# github.com/kevinburke/ssh_config v1.2.0
 ## explicit
 github.com/kevinburke/ssh_config
 # github.com/kr/pretty v0.3.0


### PR DESCRIPTION
Previously if you tried to read a HostName in a SSH config file that
looked like this:

```
Host github
    HostName github.com        # This is the host for code review
```

DefaultUserSettings.Get("HostName") would return "github.com        ",
which I think is unintuitive and unexpected.

This behavior is fixed in v1.2 which would return "github.com" in the
above example.

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Thanks for contributing!
