### PR TITLE
egressgateway: Remove unnecessary check on entry deletions

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -226,7 +226,7 @@ func (manager *Manager) removeUnusedEgressRules() {
 		})
 
 nextPolicyKey:
-	for policyKey, policyVal := range egressPolicies {
+	for policyKey := range egressPolicies {
 		for _, policyConfig := range manager.policyConfigs {
 			for _, endpoint := range manager.epDataStore {
 				if !policyConfig.selectsEndpoint(endpoint) {
@@ -235,8 +235,7 @@ nextPolicyKey:
 
 				for _, endpointIP := range endpoint.ips {
 					for _, dstCIDR := range policyConfig.dstCIDRs {
-						if policyKey.Match(endpointIP, dstCIDR) &&
-							policyVal.Match(policyConfig.egressIP, policyConfig.egressIP) {
+						if policyKey.Match(endpointIP, dstCIDR) {
 							continue nextPolicyKey
 						}
 					}


### PR DESCRIPTION
When reconciling the egress gateway map with the corresponding k8s policies, we first (1) add/update any missing/outdated entries then (2) remove all stale entries. Currently, in that second part, we remove any entry that has either a different key or a different value. It is however not necessary to check the value because any outdated value will already be updated as part of (1).

If (1) was buggy and left some outdated values, then this commit would cause a behavior change: instead of removing any `(k,v)` entry that has an incorrect value `v`, we would leave it there. In both cases, the resulting map won't match the k8s policies anyway.