### PR TITLE
cilium: nat46/64 ci codeowner & monitor drop reason

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -282,6 +282,7 @@ jenkinsfiles @cilium/ci-structure
 /test/runtime/memcache.go @cilium/proxy @cilium/ci-structure
 # Standalone L4LB tests
 /test/l4lb @cilium/loadbalancer @cilium/ci-structure
+/test/nat46x64 @cilium/loadbalancer @cilium/ci-structure
 # Misc. tests
 /test/k8s/cli.go @cilium/cli @cilium/ci-structure
 /test/k8s/health.go @cilium/health @cilium/ci-structure

--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -56,7 +56,7 @@ var errors = map[uint8]string{
 	157: "IP fragmentation not supported",
 	158: "Service backend not found",
 	160: "No tunnel/encapsulation endpoint (datapath BUG!)",
-	161: "Failed to insert into proxymap", // Unused
+	161: "NAT 46/64 not enabled",
 	162: "Reached EDT rate-limiting drop horizon",
 	163: "Unknown connection tracking state",
 	164: "Local host is unreachable",


### PR DESCRIPTION
Two tiny follow-ups.