### PR TITLE
pull skb data at the entrance of from-containter

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -473,7 +473,7 @@ int tail_handle_ipv6(struct __ctx_buff *ctx)
 	struct ipv6hdr *ip6;
 	int ret;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	/* Handle special ICMPv6 messages. This includes echo requests to the
@@ -980,7 +980,7 @@ int tail_handle_ipv4(struct __ctx_buff *ctx)
 	struct iphdr *ip4;
 	int ret;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 /* If IPv4 fragmentation is disabled


### PR DESCRIPTION
When the skb is non-linear, revalidate_data drops the packet
immediately. For example, This can happen when pods are using AF_PACKET + mmap ring buffer.

calling revalidate_data_pull (bpf_skb_pull_data) helps to "Pull in non-linear data in case the skb is non-linear and not all of len are part of the linear section."

Fixes #18951

Signed-off-by: Yuan Liu <liuyuan@google.com>

```release-note
Fix drop for packets sent via AF_PACKET + mmap ring buffer in pod
```
