### PR TITLE
docs: Update shared service annotation docs

### DIFF
--- a/Documentation/gettingstarted/clustermesh/services.rst
+++ b/Documentation/gettingstarted/clustermesh/services.rst
@@ -24,14 +24,12 @@ Cilium will automatically perform load-balancing to pods in both clusters.
 .. literalinclude:: ../../../examples/kubernetes/clustermesh/global-service-example/rebel-base-global-shared.yaml
   :language: YAML
 
-Load-balancing Only to a Remote Cluster
-#######################################
+Disabling Global Service Sharing
+################################
 
 By default, a Global Service will load-balance across backends in multiple clusters.
 This implicitly configures ``io.cilium/shared-service: "true"``. To prevent service
-backends from being shared to other clusters, and to ensure that the service
-will only load-balance to backends in remote clusters, this option should be
-disabled.
+backends from being shared to other clusters, this option should be disabled.
 
 Below example will expose remote endpoint without sharing local endpoints.
 
@@ -76,3 +74,39 @@ Deploying a Simple Example Service
       kubectl exec -ti deployment/x-wing -- curl rebel-base
 
    You will see replies from pods in both clusters.
+
+4. In cluster 1, add ``io.cilium/shared-service="false"`` to existing global service
+
+   .. code-block:: shell-session
+
+      kubectl annotate service rebel-base io.cilium/shared-service="false" --overwrite
+
+5. From cluster 1, access the global service one more time:
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+   You will still see replies from pods in both clusters.
+
+6. From cluster 2, access the global service again:
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+   You will see replies from pods only from cluster 2, as the global service in cluster 1 is no longer shared.
+
+7. In cluster 1, remove ``io.cilium/shared-service`` annotation of existing global service
+
+   .. code-block:: shell-session
+
+      kubectl annotate service rebel-base io.cilium/shared-service-
+
+8. From either cluster, access the global service:
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+   You will see replies from pods in both clusters again.


### PR DESCRIPTION
This commit is to update related docs for io.cilium/shared-service
annotation, along with steps and expected behavior.

Fixes #19273

Signed-off-by: Tam Mach <tam.mach@isovalent.com>
