### PR TITLE
ipcache: Fix node-to-node encryption with kube-apiserver

### DIFF
--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -471,6 +471,20 @@ func (id NumericIdentity) IsReservedIdentity() bool {
 	return isReservedIdentity
 }
 
+// IsReservedNodeIdentity returns true if id is one of
+// - ReservedIdentityHost
+// - ReservedIdentityRemoteNode
+// - ReservedIdentityKubeAPIServer
+func (id NumericIdentity) IsReservedNodeIdentity() bool {
+	switch id {
+	case ReservedIdentityHost,
+		ReservedIdentityRemoteNode,
+		ReservedIdentityKubeAPIServer:
+		return true
+	}
+	return false
+}
+
 // ClusterID returns the cluster ID associated with the identity
 func (id NumericIdentity) ClusterID() int {
 	return int((uint32(id) >> 16) & 0xFF)

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -358,7 +358,7 @@ func (ipc *IPCache) upsertLocked(
 	}
 	ipc.identityToIPCache[newIdentity.ID][ip] = struct{}{}
 
-	if hostIP == nil {
+	if hostIP == nil && hostKey == 0 {
 		delete(ipc.ipToHostIPCache, ip)
 	} else {
 		ipc.ipToHostIPCache[ip] = IPKeyPair{IP: hostIP, Key: hostKey}
@@ -401,6 +401,18 @@ func (ipc *IPCache) upsertLocked(
 	}
 
 	return namedPortsChanged, nil
+}
+
+// UpsertAuxiliary upserts an auxiliary data mapping for the given IP.
+// Auxiliary data is the host / tunnel IP and the encryption key.
+func (ipc *IPCache) UpsertAuxiliary(prefix string, hostIP net.IP, key uint8) {
+	ipc.mutex.Lock()
+	defer ipc.mutex.Unlock()
+
+	ipc.ipToHostIPCache[prefix] = IPKeyPair{
+		IP:  hostIP,
+		Key: key,
+	}
 }
 
 // DumpToListener dumps the entire contents of the IPCache by triggering

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -30,10 +30,13 @@ func TestInjectLabels(t *testing.T) {
 	// Insert kube-apiserver IP from outside of the cluster. This should create
 	// a CIDR ID for this IP.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer)
+	IPIdentityCache.UpsertAuxiliary("10.0.0.4", net.ParseIP("10.0.0.4"), 1)
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
 	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.True(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
+	assert.True(t, IPIdentityCache.ipToHostIPCache["10.0.0.4"].IP.Equal(net.ParseIP("10.0.0.4")))
+	assert.Equal(t, IPIdentityCache.ipToHostIPCache["10.0.0.4"].Key, uint8(1))
 
 	// Upsert node labels to the kube-apiserver to validate that the CIDR ID is
 	// deallocated and the kube-apiserver reserved ID is associated with this

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -53,6 +53,8 @@ type IPCache interface {
 	Delete(IP string, source source.Source) bool
 	TriggerLabelInjection(source source.Source)
 	UpsertMetadata(string, labels.Labels)
+	UpsertAuxiliary(string, net.IP, uint8)
+	RemoveLabels(map[string]labels.Labels, source.Source)
 }
 
 // Configuration is the set of configuration options the node manager depends
@@ -379,6 +381,24 @@ func (m *Manager) legacyNodeIpBehavior() bool {
 	return true
 }
 
+func (m *Manager) nodeLabel(n nodeTypes.Node) labels.Labels {
+	remoteHostIdentity := identity.ReservedIdentityHost
+	if m.conf.RemoteNodeIdentitiesEnabled() {
+		nid := identity.NumericIdentity(n.NodeIdentity)
+		if nid != identity.IdentityUnknown && nid != identity.ReservedIdentityHost {
+			remoteHostIdentity = nid
+		} else if !n.IsLocal() {
+			remoteHostIdentity = identity.ReservedIdentityRemoteNode
+		}
+	}
+
+	if remoteHostIdentity == identity.ReservedIdentityHost {
+		return labels.LabelHost
+	}
+
+	return labels.LabelRemoteNode
+}
+
 // NodeUpdated is called after the information of a node has been updated. The
 // node in the manager is added or updated if the source is allowed to update
 // the node. If an update or addition has occurred, NodeUpdate() of the datapath
@@ -389,16 +409,6 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 	nodeIdentity := n.Identity()
 	dpUpdate := true
 	nodeIP := n.GetNodeIP(false)
-
-	remoteHostIdentity := identity.ReservedIdentityHost
-	if m.conf.RemoteNodeIdentitiesEnabled() {
-		nid := identity.NumericIdentity(n.NodeIdentity)
-		if nid != identity.IdentityUnknown && nid != identity.ReservedIdentityHost {
-			remoteHostIdentity = nid
-		} else if !n.IsLocal() {
-			remoteHostIdentity = identity.ReservedIdentityRemoteNode
-		}
-	}
 
 	var ipsAdded, healthIPsAdded []string
 
@@ -439,22 +449,9 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		}
 
 		ipAddrStr := address.IP.String()
-		_, err := m.ipcache.Upsert(ipAddrStr, tunnelIP, key, nil, ipcache.Identity{
-			ID:     remoteHostIdentity,
-			Source: n.Source,
-		})
-
-		m.upsertIntoIDMD(ipAddrStr, remoteHostIdentity)
-
-		// Upsert() will return true if the ipcache entry is owned by
-		// the source of the node update that triggered this node
-		// update (kvstore, k8s, ...) The datapath is only updated if
-		// that source of truth is updated.
-		if err != nil {
-			dpUpdate = false
-		} else {
-			ipsAdded = append(ipsAdded, ipAddrStr)
-		}
+		m.ipcache.UpsertAuxiliary(ipAddrStr, tunnelIP, key)
+		m.ipcache.UpsertMetadata(ipAddrStr, m.nodeLabel(n))
+		ipsAdded = append(ipsAdded, ipAddrStr)
 	}
 
 	for _, address := range []net.IP{n.IPv4HealthIP, n.IPv6HealthIP} {
@@ -504,8 +501,10 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			}
 			oldNodeIPAddrs = append(oldNodeIPAddrs, address.IP)
 		}
-		m.deleteIPCache(oldNode.Source, oldNodeIPAddrs, ipsAdded)
 
+		// Remove node identity metadata from old node addresses
+		m.removeIPMetadata(oldNode.Source, oldNodeIPAddrs, ipsAdded, m.nodeLabel(oldNode))
+		m.deleteIPCache(oldNode.Source, oldNodeIPAddrs, ipsAdded)
 		// Delete the old health IP addresses if they have changed in this node.
 		m.deleteIPCache(oldNode.Source, []net.IP{oldNode.IPv4HealthIP, oldNode.IPv6HealthIP}, healthIPsAdded)
 
@@ -529,17 +528,6 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 	m.ipcache.TriggerLabelInjection(n.Source)
 }
 
-// upsertIntoIDMD upserts the given CIDR into the ipcache.identityMetadata
-// (IDMD) map. The given node identity determines which labels are associated
-// with the CIDR.
-func (m *Manager) upsertIntoIDMD(prefix string, id identity.NumericIdentity) {
-	if id == identity.ReservedIdentityHost {
-		m.ipcache.UpsertMetadata(prefix, labels.LabelHost)
-	} else {
-		m.ipcache.UpsertMetadata(prefix, labels.LabelRemoteNode)
-	}
-}
-
 // deleteIPCache deletes the IP addresses from the IPCache with the 'oldSource'
 // if they are not found in the newIPs slice.
 func (m *Manager) deleteIPCache(oldSource source.Source, oldIPs []net.IP, newIPs []string) {
@@ -561,6 +549,30 @@ func (m *Manager) deleteIPCache(oldSource source.Source, oldIPs []net.IP, newIPs
 			m.ipcache.Delete(addrStr, oldSource)
 		}
 	}
+}
+
+// deleteIPMetadata deletes the given labels from all IP addresses in the IPCache
+// with the 'oldSource' if they are not found in the newIPs slice.
+func (m *Manager) removeIPMetadata(oldSource source.Source, oldIPs []net.IP, newIPs []string, removedLabel labels.Labels) {
+	toRemove := map[string]labels.Labels{}
+	for _, address := range oldIPs {
+		if address == nil {
+			continue
+		}
+		addrStr := address.String()
+		var found bool
+		for _, ipAdded := range newIPs {
+			if ipAdded == addrStr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			toRemove[addrStr] = removedLabel
+		}
+	}
+
+	m.ipcache.RemoveLabels(toRemove, oldSource)
 }
 
 // NodeDeleted is called after a node has been deleted. It removes the node
@@ -596,6 +608,8 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 		return
 	}
 
+	toRemove := map[string]labels.Labels{}
+	oldNodeLabel := m.nodeLabel(entry.node)
 	for _, address := range entry.node.IPAddresses {
 		if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
 			iptables.RemoveFromNodeIpset(address.IP)
@@ -606,7 +620,9 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 		}
 
 		m.ipcache.Delete(address.IP.String(), n.Source)
+		toRemove[address.IP.String()] = oldNodeLabel
 	}
+	m.ipcache.RemoveLabels(toRemove, n.Source)
 
 	for _, address := range []net.IP{entry.node.IPv4HealthIP, entry.node.IPv6HealthIP} {
 		if address != nil {


### PR DESCRIPTION
The kube-apiserver reserved identity requires us to create a
IPCache entry based on the endpoints of the `default/kubernetes` K8s
service.

This kube-apiserver IPCache entry will overwrite any existing remote
host entries. The entry also blocks the creation of remote host entries
for the same IP (via `source.AllowsOverwrite`).

When the kube-apiserver entry is created, we check if there is an
existing remote node entry, and if so, copy over the IPSec keypair
information into the newly created kube-apiserver entry. If however the
order is reversed (we first create the kube-apiserver entry before the
remote node is discovered), then the IPSec keypair is never updated.
This in turn means that connectivity to any remote nodes which also run
the kube-apiserver is broken when node-to-node encryption is enabled.

This commit works around the issue by adding the IPKeyPair before the
labels are injected. This allows InjectLabels to look up the pair
whenever the entry is created or updated.

This work is also needed for the upcoming WireGuard node-to-node
encryption.

--

(Edit: This has been partially addressed) @joestringer @christarazi I would highly value your feedback on this, as this is rather hacky at the moment. I think an alternative (maybe cleaner?) approach would be to bring in the IPSec key pair via `UpsertMetadata`/`TriggerLabelInjection` or something, but it would require us to pass in the encrypt key and host IP to those methods.