### PR TITLE
ingress: Fix conformance tests for host-rules and path-rule

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -385,10 +385,6 @@
      - Enables masquerading of IPv6 traffic leaving the node from endpoints.
      - bool
      - ``true``
-   * - enableIngressController
-     - Enable cilium ingress controller This will automatically set enable-envoy-config as well.
-     - bool
-     - ``false``
    * - enableK8sEventHandover
      - Configures the use of the KVStore to optimize Kubernetes event handling by mirroring it into the KVstore for reduced overhead in large clusters.
      - bool
@@ -981,6 +977,14 @@
      - Configure image pull secrets for pulling container images
      - string
      - ``nil``
+   * - ingressController.enabled
+     - Enable cilium ingress controller This will automatically set enable-envoy-config as well.
+     - bool
+     - ``false``
+   * - ingressController.enforceHttps
+     - Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header.
+     - bool
+     - ``true``
    * - installIptablesRules
      - Configure whether to install iptables rules to allow for TPROXY (L7 proxy injection), iptables-based masquerading and compatibility with kube-proxy.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -363,6 +363,7 @@ endpointRoutes
 endpointSelector
 endpointStatus
 endpointmanager
+enforceHttps
 eni
 eniTags
 etcd
@@ -478,6 +479,7 @@ ifindex
 imagePullSecrets
 incrementing
 indices
+ingressController
 ingressing
 init
 initContainer

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -147,7 +147,6 @@ contributors across the globe, there is almost always someone available to help.
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |
 | enableIPv4Masquerade | bool | `true` | Enables masquerading of IPv4 traffic leaving the node from endpoints. |
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
-| enableIngressController | bool | `false` | Enable cilium ingress controller This will automatically set enable-envoy-config as well. |
 | enableK8sEventHandover | bool | `false` | Configures the use of the KVStore to optimize Kubernetes event handling by mirroring it into the KVstore for reduced overhead in large clusters. |
 | enableK8sTerminatingEndpoint | bool | `true` | Configure whether to enable auto detect of terminating state for endpoints in order to support graceful termination. |
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel. |
@@ -296,6 +295,8 @@ contributors across the globe, there is almost always someone available to help.
 | identityAllocationMode | string | `"crd"` | Method to use for identity allocation (`crd` or `kvstore`). |
 | image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium","tag":"latest","useDigest":false}` | Agent container image. |
 | imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
+| ingressController.enabled | bool | `false` | Enable cilium ingress controller This will automatically set enable-envoy-config as well. |
+| ingressController.enforceHttps | bool | `true` | Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. |
 | installIptablesRules | bool | `true` | Configure whether to install iptables rules to allow for TPROXY (L7 proxy injection), iptables-based masquerading and compatibility with kube-proxy. |
 | installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup. |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -189,9 +189,10 @@ data:
   skip-crd-creation: "true"
 {{- end }}
 
-{{- if .Values.enableIngressController }}
+{{- if .Values.ingressController.enabled }}
   enable-ingress-controller: "true"
   enable-envoy-config: "true"
+  enforce-ingress-https: {{ .Values.ingressController.enforceHttps | quote }}
 {{- end }}
 
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -43,7 +43,7 @@ rules:
   resources:
   # to check apiserver connectivity
   - namespaces
-{{- if .Values.enableIngressController }}
+{{- if .Values.ingressController.enabled }}
   - secrets
 {{- end }}
   verbs:
@@ -60,7 +60,7 @@ rules:
   - get
   - list
   - watch
-{{- if .Values.enableIngressController }}
+{{- if .Values.ingressController.enabled }}
   - create
   - update
   - delete
@@ -121,7 +121,7 @@ rules:
   - create
   - get
   - update
-{{- if .Values.enableIngressController }}
+{{- if .Values.ingressController.enabled }}
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -435,9 +435,14 @@ enableK8sEventHandover: false
 # -- Enable CiliumEndpointSlice feature.
 enableCiliumEndpointSlice: false
 
-# -- Enable cilium ingress controller
-# This will automatically set enable-envoy-config as well.
-enableIngressController: false
+ingressController:
+  # -- Enable cilium ingress controller
+  # This will automatically set enable-envoy-config as well.
+  enabled: false
+
+  # -- Enforce https for host having matching TLS host in Ingress.
+  # Incoming traffic to http listener will return 308 http error code with respective location in header.
+  enforceHttps: true
 
 # -- Enables the fallback compatibility solution for when the xt_socket kernel
 # module is missing and it is needed for the datapath L7 redirection to work

--- a/operator/main.go
+++ b/operator/main.go
@@ -559,7 +559,7 @@ func onOperatorStartLeading(ctx context.Context) {
 	}
 
 	if operatorOption.Config.EnableIngressController {
-		ingressController, err := ingress.NewIngressController()
+		ingressController, err := ingress.NewIngressController(ingress.WithHTTPSEnforced(operatorOption.Config.EnforceIngressHTTPS))
 		if err != nil {
 			log.WithError(err).WithField(logfields.LogSubsys, ingress.Subsys).Fatal(
 				"Failed to start ingress controller")

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -218,6 +218,10 @@ const (
 	// EnableIngressController enables cilium ingress controller
 	// This must be enabled along with enable-envoy-config in cilium agent.
 	EnableIngressController = "enable-ingress-controller"
+
+	// EnforceIngressHttps enforces https for host having matching TLS host in Ingress.
+	// Incoming traffic to http listener will return 308 http error code with respective location in header.
+	EnforceIngressHttps = "enforce-ingress-https"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -403,6 +407,9 @@ type OperatorConfig struct {
 
 	// EnableIngressController enables cilium ingress controller
 	EnableIngressController bool
+
+	// EnforceIngressHTTPS enforces https if required
+	EnforceIngressHTTPS bool
 }
 
 // Populate sets all options with the values from viper.
@@ -433,6 +440,7 @@ func (c *OperatorConfig) Populate() {
 	c.BGPConfigPath = viper.GetString(BGPConfigPath)
 	c.SkipCRDCreation = viper.GetBool(SkipCRDCreation)
 	c.EnableIngressController = viper.GetBool(EnableIngressController)
+	c.EnforceIngressHTTPS = viper.GetBool(EnforceIngressHttps)
 
 	if c.BGPAnnounceLBIP {
 		c.SyncK8sServices = true

--- a/operator/pkg/ingress/envoy_config.go
+++ b/operator/pkg/ingress/envoy_config.go
@@ -16,6 +16,7 @@ import (
 	envoy_extensions_filters_network_http_connection_manager_v3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/cilium/proxy/go/envoy/extensions/transport_sockets/tls/v3"
 	envoy_config_upstream "github.com/cilium/proxy/go/envoy/extensions/upstreams/http/v3"
+	envoy_type_matcher_v3 "github.com/cilium/proxy/go/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -406,8 +407,11 @@ func getRouteMatch(ingressPath slim_networkingv1.HTTPIngressPath) *envoy_config_
 	if ingressPath.PathType == nil || *ingressPath.PathType == slim_networkingv1.PathTypeImplementationSpecific ||
 		*ingressPath.PathType == slim_networkingv1.PathTypePrefix {
 		return &envoy_config_route_v3.RouteMatch{
-			PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
-				Prefix: ingressPath.Path,
+			PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
+				SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
+					EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
+					Regex:      getMatchingPrefixRegex(ingressPath.Path),
+				},
 			},
 		}
 	}

--- a/operator/pkg/ingress/envoy_config_test.go
+++ b/operator/pkg/ingress/envoy_config_test.go
@@ -149,7 +149,7 @@ func Test_getRouteConfigurationResource(t *testing.T) {
 	require.Len(t, routeConfig.VirtualHosts[1].Routes, 1)
 
 	require.Equal(t, "/dummy-path", routeConfig.VirtualHosts[0].Routes[0].Match.GetPath())
-	require.Equal(t, "/another-dummy-path", routeConfig.VirtualHosts[0].Routes[1].Match.GetPrefix())
+	require.Equal(t, "/another-dummy-path(/.*)?$", routeConfig.VirtualHosts[0].Routes[1].Match.GetSafeRegex().GetRegex())
 	require.Equal(t, "/", routeConfig.VirtualHosts[1].Routes[0].Match.GetPrefix())
 
 	clusters := []string{routeConfig.VirtualHosts[0].Routes[0].GetRoute().GetCluster(), routeConfig.VirtualHosts[0].Routes[1].GetRoute().GetCluster()}

--- a/operator/pkg/ingress/envoy_config_test.go
+++ b/operator/pkg/ingress/envoy_config_test.go
@@ -143,6 +143,7 @@ func Test_getRouteConfigurationResource(t *testing.T) {
 	require.Equal(t, "*", routeConfig.VirtualHosts[0].Name)
 	require.Equal(t, []string{"*"}, routeConfig.VirtualHosts[0].Domains)
 	require.Len(t, routeConfig.VirtualHosts[0].Routes, 2)
+	require.Len(t, routeConfig.VirtualHosts[0].Routes[0].Match.GetHeaders(), 0)
 
 	require.Equal(t, "default-backend", routeConfig.VirtualHosts[1].Name)
 	require.Equal(t, []string{"*"}, routeConfig.VirtualHosts[1].Domains)
@@ -151,6 +152,7 @@ func Test_getRouteConfigurationResource(t *testing.T) {
 	require.Equal(t, "/dummy-path", routeConfig.VirtualHosts[0].Routes[0].Match.GetPath())
 	require.Equal(t, "/another-dummy-path(/.*)?$", routeConfig.VirtualHosts[0].Routes[1].Match.GetSafeRegex().GetRegex())
 	require.Equal(t, "/", routeConfig.VirtualHosts[1].Routes[0].Match.GetPrefix())
+	require.Len(t, routeConfig.VirtualHosts[1].Routes[0].Match.GetHeaders(), 0)
 
 	clusters := []string{routeConfig.VirtualHosts[0].Routes[0].GetRoute().GetCluster(), routeConfig.VirtualHosts[0].Routes[1].GetRoute().GetCluster()}
 	require.Contains(t, clusters, "dummy-namespace/dummy-backend")

--- a/operator/pkg/ingress/ingress_options.go
+++ b/operator/pkg/ingress/ingress_options.go
@@ -5,12 +5,14 @@ package ingress
 
 // Options stores all the configurations values for cilium ingress controller.
 type Options struct {
-	MaxRetries int
+	MaxRetries    int
+	EnforcedHTTPS bool
 }
 
 // DefaultIngressOptions specifies default values for cilium ingress controller.
 var DefaultIngressOptions = Options{
-	MaxRetries: 10,
+	MaxRetries:    10,
+	EnforcedHTTPS: true,
 }
 
 // Option customizes the configuration of cilium ingress controller
@@ -20,6 +22,14 @@ type Option func(o *Options) error
 func WithMaxRetries(maxRetries int) Option {
 	return func(o *Options) error {
 		o.MaxRetries = maxRetries
+		return nil
+	}
+}
+
+// WithHTTPSEnforced specifies if https enforcement should be done or not
+func WithHTTPSEnforced(enforcedHTTPS bool) Option {
+	return func(o *Options) error {
+		o.EnforcedHTTPS = enforcedHTTPS
 		return nil
 	}
 }

--- a/operator/pkg/ingress/regex_helper.go
+++ b/operator/pkg/ingress/regex_helper.go
@@ -8,7 +8,13 @@ import (
 	"strings"
 )
 
-const slash = "/"
+const (
+	slash       = "/"
+	dot         = "."
+	starDot     = "*."
+	dotRegex    = "[.]"
+	notDotRegex = "[^.]"
+)
 
 // getMatchingPrefixRegex returns safe regex used by envoy to match the prefix.
 // By default, prefix matching in envoy will not reject /foobar if the original path is only /foo. Hence, conversion
@@ -24,4 +30,13 @@ func getMatchingPrefixRegex(path string) string {
 		removedTrailingSlash = removedTrailingSlash[:len(removedTrailingSlash)-1]
 	}
 	return fmt.Sprintf("%s(/.*)?$", removedTrailingSlash)
+}
+
+// getMatchingHeaderRegex is to make sure that one and only one single subdomain is matched e.g.
+// For example, *.foo.com should only match bar.foo.com but not baz.bar.foo.com
+func getMatchingHeaderRegex(host string) string {
+	if strings.HasPrefix(host, starDot) {
+		return fmt.Sprintf("^%s+%s%s$", notDotRegex, dotRegex, strings.ReplaceAll(host[2:], dot, dotRegex))
+	}
+	return fmt.Sprintf("^%s$", strings.ReplaceAll(host, dot, dotRegex))
 }

--- a/operator/pkg/ingress/regex_helper.go
+++ b/operator/pkg/ingress/regex_helper.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ingress
+
+import (
+	"fmt"
+	"strings"
+)
+
+const slash = "/"
+
+// getMatchingPrefixRegex returns safe regex used by envoy to match the prefix.
+// By default, prefix matching in envoy will not reject /foobar if the original path is only /foo. Hence, conversion
+// with safe regex is required.
+//
+// If the original path is /foo, the returned regex will be /foo(/.*)?$
+// - /foo -> matched
+// - /foo/ -> matched
+// - /foobar -> not matched
+func getMatchingPrefixRegex(path string) string {
+	removedTrailingSlash := path
+	if strings.HasSuffix(path, slash) {
+		removedTrailingSlash = removedTrailingSlash[:len(removedTrailingSlash)-1]
+	}
+	return fmt.Sprintf("%s(/.*)?$", removedTrailingSlash)
+}

--- a/operator/pkg/ingress/regex_helper_test.go
+++ b/operator/pkg/ingress/regex_helper_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package ingress
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getMatchingPrefixRegex(t *testing.T) {
+	t.Run("simple slash path", func(t *testing.T) {
+		rx, err := regexp.Compile(getMatchingPrefixRegex("/"))
+		assert.NoError(t, err)
+
+		assert.True(t, rx.MatchString("/"))
+		assert.True(t, rx.MatchString("/foo"))
+		assert.True(t, rx.MatchString("/foo/bar"))
+	})
+
+	t.Run("simple /foo path", func(t *testing.T) {
+		rx, err := regexp.Compile(getMatchingPrefixRegex("/foo"))
+		assert.NoError(t, err)
+
+		assert.False(t, rx.MatchString("/"))
+		assert.False(t, rx.MatchString("/foobar"))
+
+		assert.True(t, rx.MatchString("/foo"))
+		assert.True(t, rx.MatchString("/foo/"))
+		assert.True(t, rx.MatchString("/foo/bar"))
+	})
+
+	t.Run("path with trailing slash /foo/ path", func(t *testing.T) {
+		rx, err := regexp.Compile(getMatchingPrefixRegex("/foo/"))
+		assert.NoError(t, err)
+
+		assert.False(t, rx.MatchString("/"))
+		assert.False(t, rx.MatchString("/foobar"))
+
+		assert.True(t, rx.MatchString("/foo"))
+		assert.True(t, rx.MatchString("/foo/"))
+		assert.True(t, rx.MatchString("/foo/bar"))
+	})
+}

--- a/operator/pkg/ingress/regex_helper_test.go
+++ b/operator/pkg/ingress/regex_helper_test.go
@@ -46,3 +46,33 @@ func Test_getMatchingPrefixRegex(t *testing.T) {
 		assert.True(t, rx.MatchString("/foo/bar"))
 	})
 }
+
+func Test_getMatchingHeaderRegex(t *testing.T) {
+	t.Run("starting with *.", func(t *testing.T) {
+		result := getMatchingHeaderRegex("*.foo.com")
+		rx, err := regexp.Compile(result)
+		assert.NoError(t, err)
+
+		// Match entire host
+		assert.True(t, rx.MatchString("bar.foo.com"))
+
+		// Not match
+		assert.False(t, rx.MatchString("foo.com"))
+		assert.False(t, rx.MatchString("baz.bar.foo.com"))
+		assert.False(t, rx.MatchString("some.random.host.com"))
+	})
+
+	t.Run("not starting with *.", func(t *testing.T) {
+		result := getMatchingHeaderRegex("foo.com")
+		rx, err := regexp.Compile(result)
+		assert.NoError(t, err)
+
+		// Match entire host
+		assert.True(t, rx.MatchString("foo.com"))
+
+		// Not match
+		assert.False(t, rx.MatchString("bar.foo.com"))
+		assert.False(t, rx.MatchString("abc.bar.foo.com"))
+		assert.False(t, rx.MatchString("some.random.host.com"))
+	})
+}

--- a/operator/pkg/ingress/service.go
+++ b/operator/pkg/ingress/service.go
@@ -208,16 +208,14 @@ func getServiceForIngress(ingress *slim_networkingv1.Ingress) *v1.Service {
 			TargetPort: intstr.FromInt((int)(targetPort)),
 		},
 	}
-	if len(ingress.Spec.TLS) > 0 {
-		ports = []v1.ServicePort{
-			{
-				Name:     "https",
-				Protocol: "TCP",
-				Port:     443,
-				// TODO(michi) how do we deal with multiple target ports?
-				TargetPort: intstr.FromInt((int)(ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)),
-			},
-		}
+	if tlsEnabled(ingress) {
+		ports = append(ports, v1.ServicePort{
+			Name:     "https",
+			Protocol: "TCP",
+			Port:     443,
+			// TODO(michi) how do we deal with multiple target ports?
+			TargetPort: intstr.FromInt((int)(targetPort)),
+		})
 	}
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/pkg/ingress/service_test.go
+++ b/operator/pkg/ingress/service_test.go
@@ -186,6 +186,12 @@ func Test_getServiceForIngress(t *testing.T) {
 		assert.Equal(t, v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+				},
+				{
 					Name:       "https",
 					Protocol:   "TCP",
 					Port:       443,

--- a/operator/pkg/ingress/types.go
+++ b/operator/pkg/ingress/types.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ingress
+
+import envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
+
+// SortableRoute is a slice of envoy Route, which can be sorted based on matching order as per Ingress requirement.
+//
+// - Exact Match must have the highest priority
+// - If multiple prefix matches are satisfied, the longest path is having higher priority
+//
+// As Envoy route matching logic is done sequentially, we need to enforce such sorting order.
+type SortableRoute []*envoy_config_route_v3.Route
+
+func (s SortableRoute) Len() int {
+	return len(s)
+}
+
+func (s SortableRoute) Less(i, j int) bool {
+	// Make sure Exact Match always comes first
+	isExactMatch1 := len(s[i].Match.GetPath()) != 0
+	isExactMatch2 := len(s[j].Match.GetPath()) != 0
+	if isExactMatch1 {
+		return true
+	}
+	if isExactMatch2 {
+		return false
+	}
+
+	// Make sure longest Prefix match always comes first
+	regexMatch1 := len(s[i].Match.GetSafeRegex().String())
+	regexMatch2 := len(s[j].Match.GetSafeRegex().String())
+	return regexMatch1 > regexMatch2
+}
+
+func (s SortableRoute) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/operator/pkg/ingress/types_test.go
+++ b/operator/pkg/ingress/types_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package ingress
+
+import (
+	"sort"
+	"testing"
+
+	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
+	envoy_type_matcher_v3 "github.com/cilium/proxy/go/envoy/type/matcher/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortableRoute(t *testing.T) {
+	arr := SortableRoute{
+		{
+			Name: "exact match 1",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
+					Path: "/exact/match",
+				},
+			},
+		},
+		{
+			Name: "another exact match",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
+					Path: "/exact/match/another",
+				},
+			},
+		},
+		{
+			Name: "prefix match",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
+					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
+						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
+						Regex:      "/prefix/match",
+					},
+				},
+			},
+		},
+		{
+			Name: "another prefix match",
+			Match: &envoy_config_route_v3.RouteMatch{
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
+					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
+						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
+						Regex:      "/prefix/match/another",
+					},
+				},
+			},
+		},
+	}
+
+	sort.Sort(arr)
+
+	// Exact match comes first in any order
+	assert.True(t, len(arr[0].Match.GetPath()) != 0)
+	assert.True(t, len(arr[1].Match.GetPath()) != 0)
+
+	// Prefix match with longer path comes first
+	assert.Equal(t, "/prefix/match/another", arr[2].Match.GetSafeRegex().GetRegex())
+	assert.Equal(t, "/prefix/match", arr[3].Match.GetSafeRegex().GetRegex())
+}

--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -100,7 +100,7 @@ func ParseResources(namePrefix string, anySlice []cilium_v2alpha1.XDSResource, v
 						foundCiliumNetworkFilter = true
 					}
 					tc := filter.GetTypedConfig()
-					if tc == nil || tc.GetTypeUrl() != "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager" {
+					if tc == nil || tc.GetTypeUrl() != HttpConnectionManagerTypeURL {
 						continue
 					}
 					any, err := tc.UnmarshalNew()

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -26,6 +26,9 @@ const (
 	// ClusterTypeURL is the type URL of Cluster resources.
 	ClusterTypeURL = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
 
+	// HttpConnectionManagerTypeURL is the type URL of HttpConnectionManager resources.
+	HttpConnectionManagerTypeURL = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+
 	// EndpointTypeURL is the type URL of Endpoint resources.
 	EndpointTypeURL = "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment"
 


### PR DESCRIPTION
### Description

Please refer to individual commit for more details.

I am very much on the fence for the first commit. Basically, Ingress conformance test didn't really enforce TLS only, hence there will be 2 listeners (e.g. 80 and 443), possible options can be considered:
- keep the behavior aligned with k8s Ingress [conformance test](https://github.com/kubernetes-sigs/ingress-controller-conformance)
- always enforce HTTPs and return 308 http code with https location. One drawback is that conformance test will fail for 3 related test.
- add flag to control behavior (e.g. --enforce-ingress-https) :heavy_check_mark: 
   - default value can be true. This is the approach that nginx controller is taking. I have a local branch for this approach, so can easily swap it out. :heavy_check_mark: 
   - default value is set as false, let user set it accordingly.
 
 ### Testing
 
Testing was done locally with minikube, all the tests are passing now.