### PR TITLE
workflow CI image bug

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -177,13 +177,6 @@ jobs:
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
 
-      - name: CI Image Releases digests
-        if: ${{ github.event_name == 'pull_request_target' }}
-        shell: bash
-        run: |
-          mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
-
       - name: CI race detection Build ${{ matrix.name }}
         if: ${{ github.event_name == 'pull_request_target' }}
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
@@ -206,7 +199,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p image-digest/
-          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
           echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_pr_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests


### PR DESCRIPTION
Signed-off-by: weizhou.lan@daocloud.io <weizhou.lan@daocloud.io>

when triggered by pull_request_target , the 'build-images-ci.yaml' repeatedly prints out the same CI image digest to image-digest artifact
It could see two lines with same digest in the step of 'Image Digests Output' , for each ci image

```
quay.io/cilium/cilium-ci:830c6cc40f5a93e1aa1cbad13597e4c6d5d357eb@sha256:7cc62469abd44197b569e0f4829e52e141e1cf3075e2c7269647481cf83cbfff
quay.io/cilium/cilium-ci:830c6cc40f5a93e1aa1cbad13597e4c6d5d357eb@sha256:7cc62469abd44197b569e0f4829e52e141e1cf3075e2c7269647481cf83cbfff
quay.io/cilium/cilium-ci:830c6cc40f5a93e1aa1cbad13597e4c6d5d357eb-race@sha256:81e0c7e88be28170e4a1e0ee55b75092162dfb679109670090d03a5400b7a9cc
........
```