### PR TITLE
v1.11 backports 2022-04-05

### DIFF
--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/$image/tag/?specificTag=${{ steps.vars.outputs.sha }}" &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ github.repository_owner }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -88,7 +88,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/${image}/tag/?specificTag=${{ steps.vars.outputs.tag }}" &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ github.repository_owner }}/$image:${{ steps.vars.outputs.tag }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Install cilium chart

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -133,7 +133,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until curl --silent -f -lSL "https://quay.io/api/v1/repository/${{ github.repository_owner }}/${image}/tag/?specificTag=${{ steps.vars.outputs.tag }}" &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ github.repository_owner }}/$image:${{ steps.vars.outputs.tag }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Install cilium chart

--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -112,6 +112,10 @@ to them:
          ]
        }
 
+Additional parameters may be configured in the ``eni`` or ``ipam`` section of
+the CNI configuration file. See the list of ENI allocation parameters below
+for a reference of the supported options.
+
 Deploy the ``ConfigMap``:
 
 .. code-block:: shell-session
@@ -121,14 +125,13 @@ Deploy the ``ConfigMap``:
 Configure Cilium with subnet-tags-filter
 ----------------------------------------
 
-Using the instructions above to deploy Cilium, specify the following additional
-arguments to Helm:
+Using the instructions above to deploy Cilium and CNI config, specify the
+following additional arguments to Helm:
 
 .. code-block:: shell-session
 
    --set cni.customConf=true \
-   --set cni.configMap=cni-configuration \
-   --set eni.subnetTagsFilter="foo=true"
+   --set cni.configMap=cni-configuration
 
 ENI Allocation Parameters
 =========================

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -430,11 +430,11 @@
      - string
      - ``""``
    * - eni.subnetIDsFilter
-     - Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs
+     - Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead.
      - string
      - ``""``
    * - eni.subnetTagsFilter
-     - Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs
+     - Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead.
      - string
      - ``""``
    * - eni.updateEC2AdapterLimitViaAPI

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -158,8 +158,8 @@ contributors across the globe, there is almost always someone available to help.
 | eni.enabled | bool | `false` | Enable Elastic Network Interface (ENI) integration. |
 | eni.eniTags | object | `{}` | Tags to apply to the newly created ENIs |
 | eni.iamRole | string | `""` | If using IAM role for Service Accounts will not try to inject identity values from cilium-aws kubernetes secret. Adds annotation to service account if managed by Helm. See https://github.com/aws/amazon-eks-pod-identity-webhook |
-| eni.subnetIDsFilter | string | `""` | Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs |
-| eni.subnetTagsFilter | string | `""` | Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs |
+| eni.subnetIDsFilter | string | `""` | Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead. |
+| eni.subnetTagsFilter | string | `""` | Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead. |
 | eni.updateEC2AdapterLimitViaAPI | bool | `false` | Update ENI Adapter limits from the EC2 API |
 | etcd.clusterDomain | string | `"cluster.local"` | Cluster domain for cilium-etcd-operator. |
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -505,8 +505,14 @@ eni:
   # See https://github.com/aws/amazon-eks-pod-identity-webhook
   iamRole: ""
   # -- Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs
+  # Important note: This requires that each instance has an ENI with a matching subnet attached
+  # when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium,
+  # use the CNI configuration file settings (cni.customConf) instead.
   subnetIDsFilter: ""
   # -- Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs
+  # Important note: This requires that each instance has an ENI with a matching subnet attached
+  # when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium,
+  # use the CNI configuration file settings (cni.customConf) instead.
   subnetTagsFilter: ""
 
 externalIPs:

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -92,9 +92,9 @@ pipeline {
                     steps {
                         retry(25) {
                             sleep(time: 60)
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/cilium-ci/tag/?specificTag=${DOCKER_TAG}"'
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/operator-generic-ci/tag/?specificTag=${DOCKER_TAG}"'
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/hubble-relay-ci/tag/?specificTag=${DOCKER_TAG}"'
+                            sh 'docker manifest inspect quay.io/cilium/cilium-ci:${DOCKER_TAG}} &> /dev/null'
+                            sh 'docker manifest inspect quay.io/cilium/operator-generic-ci:${DOCKER_TAG}} &> /dev/null'
+                            sh 'docker manifest inspect quay.io/cilium/hubble-relay-ci:${DOCKER_TAG}} &> /dev/null'
                         }
                     }
                 }

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -180,9 +180,9 @@ pipeline {
                     steps {
                         retry(25) {
                             sleep(time: 60)
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/cilium-ci/tag/?specificTag=${DOCKER_TAG}"'
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/operator-generic-ci/tag/?specificTag=${DOCKER_TAG}"'
-                            sh 'curl --silent -f -lSL "https://quay.io/api/v1/repository/cilium/hubble-relay-ci/tag/?specificTag=${DOCKER_TAG}"'
+                            sh 'docker manifest inspect quay.io/cilium/cilium-ci:${DOCKER_TAG} &> /dev/null'
+                            sh 'docker manifest inspect quay.io/cilium/operator-generic-ci:${DOCKER_TAG} &> /dev/null'
+                            sh 'docker manifest inspect quay.io/cilium/hubble-relay-ci:${DOCKER_TAG} &> /dev/null'
                         }
                     }
                     post {

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -125,8 +125,8 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(len(IPIdentityCache.ipToK8sMetadata), Equals, 0)
 
 	// Test mapping of multiple IPs to same identity.
-	endpointIPs := []string{"192.168.0.1", "20.3.75.3", "27.2.2.2", "127.0.0.1", "127.0.0.1"}
-	identities := []identityPkg.NumericIdentity{5, 67, 29, 29, 29}
+	endpointIPs := []string{"192.168.0.1", "20.3.75.3", "27.2.2.2", "127.0.0.1", "127.0.0.1", "10.1.1.250"}
+	identities := []identityPkg.NumericIdentity{5, 67, 29, 29, 29, 42}
 
 	for index := range endpointIPs {
 		IPIdentityCache.Upsert(endpointIPs[index], nil, 0, nil, Identity{
@@ -166,6 +166,36 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	_, exists = IPIdentityCache.LookupByPrefix("127.0.0.1/32")
 	c.Assert(exists, Equals, false)
 
+	// Assert IPCache entry is overwritten when a different pod (different
+	// k8sMeta) with the same IP as what's already inside the IPCache is
+	// inserted.
+	_, err = IPIdentityCache.Upsert("10.1.1.250", net.ParseIP("10.0.0.1"), 0, &K8sMetadata{
+		Namespace: "ns-1",
+		PodName:   "pod1",
+	}, Identity{
+		ID:     42,
+		Source: source.KVStore,
+	})
+	c.Assert(err, IsNil)
+	_, exists = IPIdentityCache.LookupByPrefix("10.1.1.250/32")
+	c.Assert(exists, Equals, true)
+	// Insert different pod now.
+	_, err = IPIdentityCache.Upsert("10.1.1.250", net.ParseIP("10.0.0.2"), 0, &K8sMetadata{
+		Namespace: "ns-1",
+		PodName:   "pod2",
+	}, Identity{
+		ID:     43,
+		Source: source.KVStore,
+	})
+	c.Assert(err, IsNil)
+	cachedIdentity, _ = IPIdentityCache.LookupByPrefix("10.1.1.250/32")
+	c.Assert(cachedIdentity.ID, Equals, identityPkg.NumericIdentity(43)) // Assert entry overwritten.
+	// Assuming different pod with same IP 10.1.1.250 as a previous pod was
+	// deleted, assert IPCache entry is deleted is still deleted.
+	IPIdentityCache.Delete("10.1.1.250", source.KVStore)
+	_, exists = IPIdentityCache.LookupByPrefix("10.1.1.250/32")
+	c.Assert(exists, Equals, false) // Assert entry deleted.
+
 	// Clean up.
 	for index := range endpointIPs {
 		IPIdentityCache.Delete(endpointIPs[index], source.KVStore)
@@ -178,7 +208,6 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
 	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 0)
-
 }
 
 func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -134,17 +135,32 @@ func useNodeCIDR(n *nodeTypes.Node) {
 // Init initializes the Kubernetes package. It is required to call Configure()
 // beforehand.
 func Init(conf k8sconfig.Configuration) error {
-	k8sRestClient, closeAllDefaultClientConns, err := createDefaultClient()
+	restConfig, err := CreateConfig()
+	if err != nil {
+		return fmt.Errorf("unable to create k8s client rest configuration: %s", err)
+	}
+	closeAllDefaultClientConns := setDialer(restConfig)
+	// Use the same http client for all k8s connections. It does not matter that
+	// we are using a restConfig for the HTTP client that differs from each
+	// individual client since the rest.HTTPClientFor only does not use fields
+	// that are specific for each client, for example:
+	// restConfig.ContentConfig.ContentType.
+	httpClient, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		return fmt.Errorf("unable to create k8s REST client: %s", err)
+	}
+
+	k8sRestClient, err := createDefaultClient(restConfig, httpClient)
 	if err != nil {
 		return fmt.Errorf("unable to create k8s client: %s", err)
 	}
 
-	closeAllCiliumClientConns, err := createDefaultCiliumClient()
+	err = createDefaultCiliumClient(restConfig, httpClient)
 	if err != nil {
 		return fmt.Errorf("unable to create cilium k8s client: %s", err)
 	}
 
-	if err := createAPIExtensionsClient(); err != nil {
+	if err := createAPIExtensionsClient(restConfig, httpClient); err != nil {
 		return fmt.Errorf("unable to create k8s apiextensions client: %s", err)
 	}
 
@@ -166,7 +182,6 @@ func Init(conf k8sconfig.Configuration) error {
 						heartBeat,
 						option.Config.K8sHeartbeatTimeout,
 						closeAllDefaultClientConns,
-						closeAllCiliumClientConns,
 					)
 					return nil
 				},

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -7,6 +7,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/cilium/cilium/pkg/backoff"
@@ -25,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/rest"
 )
 
@@ -139,7 +141,9 @@ func Init(conf k8sconfig.Configuration) error {
 	if err != nil {
 		return fmt.Errorf("unable to create k8s client rest configuration: %s", err)
 	}
-	closeAllDefaultClientConns := setDialer(restConfig)
+
+	defaultCloseAllConns := setDialer(restConfig)
+
 	// Use the same http client for all k8s connections. It does not matter that
 	// we are using a restConfig for the HTTP client that differs from each
 	// individual client since the rest.HTTPClientFor only does not use fields
@@ -164,6 +168,17 @@ func Init(conf k8sconfig.Configuration) error {
 		return fmt.Errorf("unable to create k8s apiextensions client: %s", err)
 	}
 
+	// We are implementing the same logic as Kubelet, see
+	// https://github.com/kubernetes/kubernetes/blob/v1.24.0-beta.0/cmd/kubelet/app/server.go#L852.
+	var closeAllConns func()
+	if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
+		closeAllConns = defaultCloseAllConns
+	} else {
+		closeAllConns = func() {
+			utilnet.CloseIdleConnectionsFor(restConfig.Transport)
+		}
+	}
+
 	heartBeat := func(ctx context.Context) error {
 		// Kubernetes does a get node of the node that kubelet is running [0]. This seems excessive in
 		// our case because the amount of data transferred is bigger than doing a Get of /healthz.
@@ -181,7 +196,7 @@ func Init(conf k8sconfig.Configuration) error {
 					runHeartbeat(
 						heartBeat,
 						option.Config.K8sHeartbeatTimeout,
-						closeAllDefaultClientConns,
+						closeAllConns,
 					)
 					return nil
 				},

--- a/pkg/k8s/slim/k8s/apiextensions-clientset/clientset.go
+++ b/pkg/k8s/slim/k8s/apiextensions-clientset/clientset.go
@@ -6,6 +6,7 @@ package clientset
 
 import (
 	"fmt"
+	"net/http"
 
 	slim_apiextensionsv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apiextensions-client/clientset/versioned/typed/apiextensions/v1"
 
@@ -34,10 +35,11 @@ func (c *Clientset) ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1b
 	return c.apiextensionsV1beta1
 }
 
-// NewForConfig creates a new Clientset for the given config.
+// NewForConfigAndClient creates a new Clientset for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
 // If config's RateLimiter is not set and QPS and Burst are acceptable,
-// NewForConfig will generate a rate-limiter in configShallowCopy.
-func NewForConfig(c *rest.Config) (*Clientset, error) {
+// NewForConfigAndClient will generate a rate-limiter in configShallowCopy.
+func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		if configShallowCopy.Burst <= 0 {
@@ -47,13 +49,13 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	}
 	var cs Clientset
 	var err error
-	cs.Clientset, err = apiextclientset.NewForConfig(&configShallowCopy)
+	cs.Clientset, err = apiextclientset.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
 
 	// Wrap extensionsV1 with our own implementation
-	extensionsV1, err := slim_apiextensionsv1.NewForConfig(&configShallowCopy)
+	extensionsV1, err := slim_apiextensionsv1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/slim/k8s/clientset/clientset.go
+++ b/pkg/k8s/slim/k8s/clientset/clientset.go
@@ -6,6 +6,7 @@ package clientset
 
 import (
 	"fmt"
+	"net/http"
 
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/typed/core/v1"
 	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/typed/discovery/v1"
@@ -51,10 +52,11 @@ func (c *Clientset) NetworkingV1() networkingv1.NetworkingV1Interface {
 	return c.networkingV1
 }
 
-// NewForConfig creates a new Clientset for the given config.
+// NewForConfigAndClient creates a new Clientset for the given config and http client.
 // If config's RateLimiter is not set and QPS and Burst are acceptable,
 // NewForConfig will generate a rate-limiter in configShallowCopy.
-func NewForConfig(c *rest.Config) (*Clientset, error) {
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		if configShallowCopy.Burst <= 0 {
@@ -70,28 +72,28 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	}
 
 	// Wrap coreV1 with our own implementation
-	slimCoreV1, err := slim_corev1.NewForConfig(&configShallowCopy)
+	slimCoreV1, err := slim_corev1.NewForConfigAndClient(&configShallowCopy, h)
 	if err != nil {
 		return nil, err
 	}
 	cs.coreV1 = corev1.New(slimCoreV1.RESTClient())
 
 	// Wrap discoveryV1beta1 with our own implementation
-	slimDiscoveryV1beta1, err := slim_discovery_v1beta1.NewForConfig(&configShallowCopy)
+	slimDiscoveryV1beta1, err := slim_discovery_v1beta1.NewForConfigAndClient(&configShallowCopy, h)
 	if err != nil {
 		return nil, err
 	}
 	cs.discoveryV1beta1 = discoveryv1beta1.New(slimDiscoveryV1beta1.RESTClient())
 
 	// Wrap discoveryV1 with our own implementation
-	slimDiscoveryV1, err := slim_discovery_v1.NewForConfig(&configShallowCopy)
+	slimDiscoveryV1, err := slim_discovery_v1.NewForConfigAndClient(&configShallowCopy, h)
 	if err != nil {
 		return nil, err
 	}
 	cs.discoveryV1 = discoveryv1.New(slimDiscoveryV1.RESTClient())
 
 	// Wrap networkingV1 with our own implementation
-	slimNetworkingV1, err := slim_networkingv1.NewForConfig(&configShallowCopy)
+	slimNetworkingV1, err := slim_networkingv1.NewForConfigAndClient(&configShallowCopy, h)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* #19259 -- pkg/k8s: use a single HTTP Client for all kube-apiserver connections (@aanm)
     - Minor conflict on imports in pkg/k8s/init.go.
 * #19276 -- docs: Clarify use of the `eni.subnetTagsFilter` option (@gandro)
 * #19258 -- ipcache: Add test asserting out-of-order Kubernetes events (@christarazi)
 * #19290 -- k8s: Use kubelet's logic to close all idle connections (@christarazi)
     - Minor conflict on imports in pkg/k8s/init.go.
 * #19307 -- workflows: Use docker manifest inspect for waiting images (@YutaroHayakawa)
     - Minor conflicts on workflow files that don't exist in v1.11.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19259 19276 19258 19290 19307; do contrib/backporting/set-labels.py $pr done 1.11; done
```