### PR TITLE
connectivity-check: Use ports outside ephemeral range

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -133,7 +133,7 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "41000"
+          value: "31000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -148,7 +148,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -160,7 +160,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -255,7 +255,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41002"
+          value: "31002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -270,7 +270,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41002
+            - localhost:31002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -282,7 +282,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41002
+            - localhost:31002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -133,7 +133,7 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "41000"
+          value: "31000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -148,7 +148,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -160,7 +160,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -77,7 +77,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41002"
+          value: "31002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -92,7 +92,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41002
+            - localhost:31002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -104,7 +104,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41002
+            - localhost:31002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1030,7 +1030,7 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "41000"
+          value: "31000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -1045,7 +1045,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1057,7 +1057,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1217,7 +1217,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41002"
+          value: "31002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -1232,7 +1232,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41002
+            - localhost:31002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1244,7 +1244,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41002
+            - localhost:31002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -814,7 +814,7 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "41000"
+          value: "31000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -829,7 +829,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -841,7 +841,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1001,7 +1001,7 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "41002"
+          value: "31002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -1016,7 +1016,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41002
+            - localhost:31002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1028,7 +1028,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41002
+            - localhost:31002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -133,7 +133,7 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "41000"
+          value: "31000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -148,7 +148,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -160,7 +160,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -133,7 +133,7 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "41000"
+          value: "31000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
         imagePullPolicy: IfNotPresent
@@ -148,7 +148,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -160,7 +160,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:41000
+            - localhost:31000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/echo-servers.cue
+++ b/examples/kubernetes/connectivity-check/echo-servers.cue
@@ -33,7 +33,7 @@ deployment: "echo-b": _echoDeployment & {
 }
 // Expose hostport by deploying a host pod and adding a headless service with no port.
 deployment: "echo-b-host": _echoDeploymentWithHostPort & {
-	_serverPort: "41000"
+	_serverPort: "31000"
 	_affinity:   "echo-b"
 
 	metadata: labels: component: "services-check"
@@ -72,7 +72,7 @@ ingressCNP: "echo-c": ingressL7Policy & {}
 // Expose hostport by deploying a host pod and adding a headless service with no port.
 // No ingress policy will apply in this case.
 deployment: "echo-c-host": _echoDeploymentWithHostPort & {
-	_serverPort: "41002"
+	_serverPort: "31002"
 	_affinity:   "echo-c"
 	metadata: labels: component: "proxy-check"
 }


### PR DESCRIPTION
In the connectivity-check-proxy, change the echo pods to listen on ports
that are outside of the emphemeral port range (<32768). This should
reduce CI flake failures for tests using this connectivity-check YAML.

Fixes: https://github.com/cilium/cilium/issues/16813

Suggested-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
