### PR TITLE
install/kubernetes: fix hubble-ui with TLS

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -30,6 +30,8 @@ spec:
       {{- if .Values.hubble.ui.securityContext.enabled }}
       securityContext:
         runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
       {{- end }}
       priorityClassName: {{ .Values.hubble.ui.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.ui.name | quote }}


### PR DESCRIPTION
We are mounting the 'hubble-ui-client-certs' volume with the octal
permissions 0400 and hubble-ui is running as user 1001. This effectively
means that this volume can't be read by the hubble-ui user 1001 because
the filesystem is mounted as root. To fix this problem will set the
fsGroup and runAsGroup to 1001 as well so that the volume can be read by
hubble-ui frontend container.

Fixes: e9cb43c03179 ("Helm: full refactor of helm charts, default values implemented, tests updated, kind cni integration")
Signed-off-by: André Martins <andre@cilium.io>