### PR TITLE
Consider VPC's secondary CIDRs during cilium_host IP restoration

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -13,11 +13,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/ebpf/rlimit"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sync/semaphore"
-
-	"github.com/cilium/ebpf/rlimit"
 
 	"github.com/cilium/cilium/api/v1/models"
 	health "github.com/cilium/cilium/cilium-health/launch"
@@ -261,9 +260,9 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 // that the most up-to-date information has been retrieved. At this point, the
 // daemon is aware of all the necessary information to restore the appropriate
 // IP.
-func restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
+func (d *Daemon) restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
 	var (
-		cidr   *cidr.CIDR
+		cidrs  []*cidr.CIDR
 		fromFS net.IP
 	)
 
@@ -271,23 +270,27 @@ func restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
 		switch option.Config.IPAMMode() {
 		case ipamOption.IPAMCRD:
 			// The native routing CIDR is the pod CIDR in these IPAM modes.
-			cidr = option.Config.GetIPv6NativeRoutingCIDR()
+			cidrs = []*cidr.CIDR{option.Config.GetIPv6NativeRoutingCIDR()}
 		default:
-			cidr = node.GetIPv6AllocRange()
+			cidrs = []*cidr.CIDR{node.GetIPv6AllocRange()}
 		}
 		fromFS = node.GetIPv6Router()
 	} else {
 		switch option.Config.IPAMMode() {
-		case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
-			// The native routing CIDR is the pod CIDR in these IPAM modes.
-			cidr = option.Config.GetIPv4NativeRoutingCIDR()
+		case ipamOption.IPAMCRD:
+			// The native routing CIDR is the pod CIDR in CRD mode.
+			cidrs = []*cidr.CIDR{option.Config.GetIPv4NativeRoutingCIDR()}
+		case ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
+			// d.startIPAM() has already been called at this stage to initialize sharedNodeStore with ownNode info
+			// needed for GetVpcCIDRs()
+			cidrs = d.ipam.GetVpcCIDRs()
 		default:
-			cidr = node.GetIPv4AllocRange()
+			cidrs = []*cidr.CIDR{node.GetIPv4AllocRange()}
 		}
 		fromFS = node.GetInternalIPv4Router()
 	}
 
-	restoredIP := node.RestoreHostIPs(ipv6, fromK8s, fromFS, cidr)
+	restoredIP := node.RestoreHostIPs(ipv6, fromK8s, fromFS, cidrs)
 	if err := removeOldRouterState(restoredIP); err != nil {
 		log.WithError(err).Warnf(
 			"Failed to remove old router IPs (restored IP: %s) from cilium_host. Manual intervention is required to remove all other old IPs.",
@@ -905,17 +908,16 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	// Start IPAM
 	d.startIPAM()
-
 	// After the IPAM is started, in particular IPAM modes (CRD, ENI, Alibaba)
 	// which use the VPC CIDR as the pod CIDR, we must attempt restoring the
 	// router IPs from the K8s resources if we weren't able to restore them
 	// from the fs. We must do this after IPAM because we must wait until the
 	// K8s resources have been synced. Part 2/2 of restoration.
 	if option.Config.EnableIPv4 {
-		restoreCiliumHostIPs(false, router4FromK8s)
+		d.restoreCiliumHostIPs(false, router4FromK8s)
 	}
 	if option.Config.EnableIPv6 {
-		restoreCiliumHostIPs(true, router6FromK8s)
+		d.restoreCiliumHostIPs(true, router6FromK8s)
 	}
 
 	// restore endpoints before any IPs are allocated to avoid eventual IP

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
+	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -113,4 +114,20 @@ func (ipam *IPAM) DebugStatus() string {
 	str := spew.Sdump(ipam)
 	ipam.allocatorMutex.RUnlock()
 	return str
+}
+
+// GetVpcCIDRs returns all the CIDRs associated with the VPC this node belongs to.
+// This works only cloud provider IPAM modes and returns nil for other modes.
+// sharedNodeStore must be initialized before calling this method.
+func (ipam *IPAM) GetVpcCIDRs() (vpcCIDRs []*cidr.CIDR) {
+	sharedNodeStore.mutex.RLock()
+	defer sharedNodeStore.mutex.RUnlock()
+	primary, secondary := deriveVpcCIDRs(sharedNodeStore.ownNode)
+	if primary == nil {
+		return nil
+	}
+	if secondary == nil {
+		return []*cidr.CIDR{primary}
+	}
+	return append(secondary, primary)
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -174,8 +174,11 @@ const (
 	// IPv6CIDRs is a list of IPv6 CIDRs
 	IPv6CIDRs = "ipv6CIDRs"
 
-	// CIDR is a IPv4/IPv4 subnet/CIDR
+	// CIDR is a IPv4/IPv6 subnet/CIDR
 	CIDR = "cidr"
+
+	// CIDRS is a list of IPv4/IPv6 CIDRs
+	CIDRS = "cidrs"
 
 	// OldCIDR is the previous subnet/CIDR
 	OldCIDR = "oldCIDR"

--- a/pkg/node/address_test.go
+++ b/pkg/node/address_test.go
@@ -113,7 +113,7 @@ func (s *NodeSuite) Test_chooseHostIPsToRestore(c *C) {
 	}
 	for _, tt := range tests {
 		c.Log("Test: " + tt.name)
-		got, err := chooseHostIPsToRestore(tt.ipv6, tt.fromK8s, tt.fromFS, tt.cidr)
+		got, err := chooseHostIPsToRestore(tt.ipv6, tt.fromK8s, tt.fromFS, []*cidr.CIDR{tt.cidr})
 		if tt.expect == nil {
 			// If we don't expect to change it, set it to what's currently the
 			// router IP.


### PR DESCRIPTION
During the cilium_host IP restoration process, agent verifies if the IP
is contained in the VPC CIDRs. However the check is only made against
the VPC's primary CIDR. This commit adds support to include secondary
CIDRs as well.

When router IP restoration fails, cilium_host can end up with multiple
IPs attached to it because removeOldRouterState() considers nil IP as
IPv6 and doesn't remove stale IPv4 IPs. Will address this issue in a
separate PR.

Credits to @lbernail and @jaredledvina for help with debugging this.

Signed-off-by: Hemanth Malla <hemanth.malla@datadoghq.com>
