### PR TITLE
wireguard: Reject duplicate public keys

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -67,6 +67,7 @@ type Agent struct {
 	privKey          wgtypes.Key
 	peerByNodeName   map[string]*peerConfig
 	nodeNameByNodeIP map[string]string
+	nodeNameByPubKey map[wgtypes.Key]string
 	restoredPubKeys  map[wgtypes.Key]struct{}
 	cleanup          []func()
 }
@@ -91,6 +92,7 @@ func NewAgent(privKeyPath string) (*Agent, error) {
 		listenPort:       listenPort,
 		peerByNodeName:   map[string]*peerConfig{},
 		nodeNameByNodeIP: map[string]string{},
+		nodeNameByPubKey: map[wgtypes.Key]string{},
 		restoredPubKeys:  map[wgtypes.Key]struct{}{},
 		cleanup:          []func(){},
 	}, nil
@@ -320,10 +322,22 @@ func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 	a.Lock()
 	defer a.Unlock()
 
+	pubKey, err := wgtypes.ParseKey(pubKeyHex)
+	if err != nil {
+		return err
+	}
+
+	if prevNodeName, ok := a.nodeNameByPubKey[pubKey]; ok {
+		if nodeName != prevNodeName {
+			return fmt.Errorf("detected duplicate public key. "+
+				"node %q uses same key as existing node %q", nodeName, prevNodeName)
+		}
+	}
+
 	var allowedIPs []net.IPNet = nil
 	if prev := a.peerByNodeName[nodeName]; prev != nil {
 		// Handle pubKey change
-		if prev.pubKey.String() != pubKeyHex {
+		if prev.pubKey != pubKey {
 			log.WithField(logfields.NodeName, nodeName).Debug("Pubkey has changed")
 			// pubKeys differ, so delete old peer
 			if err := a.deletePeerByPubKey(prev.pubKey); err != nil {
@@ -357,11 +371,6 @@ func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 			lookupIPv6 = nodeIPv6
 		}
 		allowedIPs = append(allowedIPs, a.ipCache.LookupByHostRLocked(lookupIPv4, lookupIPv6)...)
-	}
-
-	pubKey, err := wgtypes.ParseKey(pubKeyHex)
-	if err != nil {
-		return err
 	}
 
 	ep := ""
@@ -398,6 +407,7 @@ func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 	}
 
 	a.peerByNodeName[nodeName] = peer
+	a.nodeNameByPubKey[pubKey] = nodeName
 	if nodeIPv4 != nil {
 		a.nodeNameByNodeIP[nodeIPv4.String()] = nodeName
 	}
@@ -422,6 +432,8 @@ func (a *Agent) DeletePeer(nodeName string) error {
 	}
 
 	delete(a.peerByNodeName, nodeName)
+	delete(a.nodeNameByPubKey, peer.pubKey)
+
 	if peer.nodeIPv4 != nil {
 		delete(a.nodeNameByNodeIP, peer.nodeIPv4.String())
 	}

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -88,6 +88,7 @@ func (a *AgentSuite) TestAgent_PeerConfig(c *C) {
 		listenPort:       listenPort,
 		peerByNodeName:   map[string]*peerConfig{},
 		nodeNameByNodeIP: map[string]string{},
+		nodeNameByPubKey: map[wgtypes.Key]string{},
 	}
 	ipCache.AddListener(wgAgent)
 
@@ -184,8 +185,14 @@ func (a *AgentSuite) TestAgent_PeerConfig(c *C) {
 	c.Assert(containsIP(k8s2.allowedIPs, pod3IPv4), Equals, true)
 	c.Assert(containsIP(k8s2.allowedIPs, pod3IPv6), Equals, true)
 
+	// Tests that duplicate public keys are rejected (k8s2 imitates k8s1)
+	err = wgAgent.UpdatePeer(k8s2NodeName, k8s1PubKey, k8s2NodeIPv4, k8s2NodeIPv6)
+	c.Assert(err, ErrorMatches, "detected duplicate public key.*")
+
 	// Node Deletion
 	wgAgent.DeletePeer(k8s1NodeName)
 	wgAgent.DeletePeer(k8s2NodeName)
 	c.Assert(wgAgent.peerByNodeName, HasLen, 0)
+	c.Assert(wgAgent.nodeNameByNodeIP, HasLen, 0)
+	c.Assert(wgAgent.nodeNameByPubKey, HasLen, 0)
 }


### PR DESCRIPTION
This fixes an issue where a malicious node could duplicate another node's public
key and thereby force all cilium-agent instances to overwrite the
original node's WireGuard peer.

While the impersonating node cannot decrypt any traffic (it does not
know the original node's public key, nor would traffic be redirected to
the impersonating node due to the lack of AllowedIPs on the
impersonating peer entry), the impersonating node could still effectively
deny any traffic to the original node.

This commit fixes the issues by keeping track of which node has added a
given public key. Because node names are guaranteed to be unique, only
one node can own a certain public key this way. Any attempt to upsert a
public key already owned by another node will be rejected and a warning
will be emitted in the cilium-agent logs.
