### PR TITLE
Improve endpoint and DNS proxy lock contention during bursty DNS traffic

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -141,9 +141,9 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	return fw.Flush()
 }
 
-// writeHeaderfile writes the lxc_config.h header file of an endpoint
+// writeHeaderfile writes the lxc_config.h header file of an endpoint.
 //
-// e.mutex must be RLock()ed.
+// e.mutex must be write-locked.
 func (e *Endpoint) writeHeaderfile(prefix string) error {
 	headerPath := filepath.Join(prefix, common.CHeaderFileName)
 	e.getLogger().WithFields(logrus.Fields{


### PR DESCRIPTION
Upon a successful DNS response, Cilium's DNS proxy code will sync the
DNS history state to the individual endpoint's header file. Previously,
this sync was done inside a trigger, however the calling code,
(*Endpoint).SyncEndpointHeaderFile(), acquired a write-lock for no good
reason. This effectively negated the benefits of having the DNS history
sync behind a trigger of 5 seconds.

This is especially suboptimal because the header file sync is actually
causing Cilium to serialize processing the DNS request for a single
endpoint.

To illustrate the impact of the above a bit more concretely, if a single
endpoint does 10 DNS requests at the same time, acquiring the write-lock
causes the processing of those 10 requests to be done one at a time. For
the sake of posterity, this is not the case if 10 endpoints were to make
DNS requests in parallel.

This obviously has a performance impact both in terms of being slow
CPU-wise, but also memory-wise. Take for example a DNS request bursty
environment, it could cause an uptick in memory usage due to many
goroutines being created and blocking due to the serialized nature of
locking.

Now that the code is all executing behind a trigger, we can remove the
lock completely and initialize the trigger setup where the Endpoint
object is created (e.g. createEndpoint(), parseEndpoint()). Now the lock
is only taken in every 5 seconds when the trigger runs.

This should relieve the lock contention drastrically. For context, in a
user's environment where the pprof was shared with us, there were around
440 goroutines with 203 of them stuck waiting inside
SyncEndpointHeaderFile().

We can also modify SyncEndpointHeaderFile() to no longer return an
error, because it's not possible for invoking the trigger to fail. If we
fail to initialize the trigger itself, then we log an error, but this is
essentially impossible because it can only fail if the trigger func is
nil (which we control).

Understanding the locking contention came from inspecting the pprof via
the following command and subsequent code inspection.

```
go tool trace -http :8080 ./cilium ./pprof-trace
```

Suggested-by: Michi Mutsuzaki <michi@isovalent.com>
Suggested-by: André Martins <andre@cilium.io>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
