### PR TITLE
docs: Update Sphinx to v4.5.0

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           persist-credentials: false
-      - uses: docker://cilium/docs-builder:2021-06-09@sha256:7126ea9182667ab1961bd8bb71265cbd3ec951e412910a116e24e0e74d7fc653
+      - uses: docker://cilium/docs-builder:2022-04-08@sha256:44f59d844a7e1162080e6fdd62c72a16fc268c893c6cb81e1fbd31cfa189e691
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.7.9-alpine3.11
+FROM docker.io/library/python:3.10.4-alpine3.15
 
 LABEL maintainer="maintainer@cilium.io"
 
@@ -8,12 +8,13 @@ RUN apk add --no-cache --virtual --update \
     npm \
     bash \
     ca-certificates \
-    enchant \
+    enchant2 \
+    enchant2-dev \
     git \
     libc6-compat \
     py-pip \
-    python \
-    sphinx-python \
+    python3 \
+    py3-sphinx \
     gcc \
     musl-dev \
     && true
@@ -27,4 +28,4 @@ ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION
 ## Workaround odd behaviour of sphinx versionwarning extension. It wants to
 ## write runtime data inside a system directory.
 ## We do rely on this extension, so we cannot just drop it.
-RUN install -m 0777 -d /usr/local/lib/python3.7/site-packages/versionwarning/_static/data
+RUN install -m 0777 -d /usr/local/lib/python3.10/site-packages/versionwarning/_static/data

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -120,4 +120,4 @@ live-preview: stop-server
 	$(QUIET)$(DOCKER_CTR) \
 		--publish $(DOCS_PORT):8000 \
 			cilium/docs-builder \
-		sphinx-autobuild -B -H 0.0.0.0 $(SPHINX_OPTS) -i *.swp -Q . _preview
+		sphinx-autobuild --open-browser --host 0.0.0.0 $(SPHINX_OPTS) --ignore *.swp -Q . _preview

--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -48,5 +48,5 @@ cilium-bugtool [OPTIONS] [flags]
 
 ### SEE ALSO
 
-* [cilium-bugtool completion](cilium-bugtool_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-bugtool completion](cilium-bugtool_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-bugtool_completion.md
+++ b/Documentation/cmdref/cilium-bugtool_completion.md
@@ -18,9 +18,9 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [cilium-bugtool](cilium-bugtool.html)	 - Collects agent & system information useful for bug reporting
-* [cilium-bugtool completion bash](cilium-bugtool_completion_bash.html)	 - Generate the autocompletion script for bash
-* [cilium-bugtool completion fish](cilium-bugtool_completion_fish.html)	 - Generate the autocompletion script for fish
-* [cilium-bugtool completion powershell](cilium-bugtool_completion_powershell.html)	 - Generate the autocompletion script for powershell
-* [cilium-bugtool completion zsh](cilium-bugtool_completion_zsh.html)	 - Generate the autocompletion script for zsh
+* [cilium-bugtool](cilium-bugtool.md)	 - Collects agent & system information useful for bug reporting
+* [cilium-bugtool completion bash](cilium-bugtool_completion_bash.md)	 - Generate the autocompletion script for bash
+* [cilium-bugtool completion fish](cilium-bugtool_completion_fish.md)	 - Generate the autocompletion script for fish
+* [cilium-bugtool completion powershell](cilium-bugtool_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [cilium-bugtool completion zsh](cilium-bugtool_completion_zsh.md)	 - Generate the autocompletion script for zsh
 

--- a/Documentation/cmdref/cilium-bugtool_completion_bash.md
+++ b/Documentation/cmdref/cilium-bugtool_completion_bash.md
@@ -41,5 +41,5 @@ cilium-bugtool completion bash
 
 ### SEE ALSO
 
-* [cilium-bugtool completion](cilium-bugtool_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-bugtool completion](cilium-bugtool_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-bugtool_completion_fish.md
+++ b/Documentation/cmdref/cilium-bugtool_completion_fish.md
@@ -32,5 +32,5 @@ cilium-bugtool completion fish [flags]
 
 ### SEE ALSO
 
-* [cilium-bugtool completion](cilium-bugtool_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-bugtool completion](cilium-bugtool_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-bugtool_completion_powershell.md
+++ b/Documentation/cmdref/cilium-bugtool_completion_powershell.md
@@ -29,5 +29,5 @@ cilium-bugtool completion powershell [flags]
 
 ### SEE ALSO
 
-* [cilium-bugtool completion](cilium-bugtool_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-bugtool completion](cilium-bugtool_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-bugtool_completion_zsh.md
+++ b/Documentation/cmdref/cilium-bugtool_completion_zsh.md
@@ -39,5 +39,5 @@ cilium-bugtool completion zsh [flags]
 
 ### SEE ALSO
 
-* [cilium-bugtool completion](cilium-bugtool_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-bugtool completion](cilium-bugtool_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-health.md
+++ b/Documentation/cmdref/cilium-health.md
@@ -24,8 +24,8 @@ cilium-health [flags]
 
 ### SEE ALSO
 
-* [cilium-health completion](cilium-health_completion.html)	 - Generate the autocompletion script for the specified shell
-* [cilium-health get](cilium-health_get.html)	 - Display local cilium agent status
-* [cilium-health ping](cilium-health_ping.html)	 - Check whether the cilium-health API is up
-* [cilium-health status](cilium-health_status.html)	 - Display cilium connectivity to other nodes
+* [cilium-health completion](cilium-health_completion.md)	 - Generate the autocompletion script for the specified shell
+* [cilium-health get](cilium-health_get.md)	 - Display local cilium agent status
+* [cilium-health ping](cilium-health_ping.md)	 - Check whether the cilium-health API is up
+* [cilium-health status](cilium-health_status.md)	 - Display cilium connectivity to other nodes
 

--- a/Documentation/cmdref/cilium-health_completion.md
+++ b/Documentation/cmdref/cilium-health_completion.md
@@ -27,9 +27,9 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [cilium-health](cilium-health.html)	 - Cilium Health Client
-* [cilium-health completion bash](cilium-health_completion_bash.html)	 - Generate the autocompletion script for bash
-* [cilium-health completion fish](cilium-health_completion_fish.html)	 - Generate the autocompletion script for fish
-* [cilium-health completion powershell](cilium-health_completion_powershell.html)	 - Generate the autocompletion script for powershell
-* [cilium-health completion zsh](cilium-health_completion_zsh.html)	 - Generate the autocompletion script for zsh
+* [cilium-health](cilium-health.md)	 - Cilium Health Client
+* [cilium-health completion bash](cilium-health_completion_bash.md)	 - Generate the autocompletion script for bash
+* [cilium-health completion fish](cilium-health_completion_fish.md)	 - Generate the autocompletion script for fish
+* [cilium-health completion powershell](cilium-health_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [cilium-health completion zsh](cilium-health_completion_zsh.md)	 - Generate the autocompletion script for zsh
 

--- a/Documentation/cmdref/cilium-health_completion_bash.md
+++ b/Documentation/cmdref/cilium-health_completion_bash.md
@@ -50,5 +50,5 @@ cilium-health completion bash
 
 ### SEE ALSO
 
-* [cilium-health completion](cilium-health_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-health completion](cilium-health_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-health_completion_fish.md
+++ b/Documentation/cmdref/cilium-health_completion_fish.md
@@ -41,5 +41,5 @@ cilium-health completion fish [flags]
 
 ### SEE ALSO
 
-* [cilium-health completion](cilium-health_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-health completion](cilium-health_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-health_completion_powershell.md
+++ b/Documentation/cmdref/cilium-health_completion_powershell.md
@@ -38,5 +38,5 @@ cilium-health completion powershell [flags]
 
 ### SEE ALSO
 
-* [cilium-health completion](cilium-health_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-health completion](cilium-health_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-health_completion_zsh.md
+++ b/Documentation/cmdref/cilium-health_completion_zsh.md
@@ -48,5 +48,5 @@ cilium-health completion zsh [flags]
 
 ### SEE ALSO
 
-* [cilium-health completion](cilium-health_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-health completion](cilium-health_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-health_get.md
+++ b/Documentation/cmdref/cilium-health_get.md
@@ -26,5 +26,5 @@ cilium-health get [flags]
 
 ### SEE ALSO
 
-* [cilium-health](cilium-health.html)	 - Cilium Health Client
+* [cilium-health](cilium-health.md)	 - Cilium Health Client
 

--- a/Documentation/cmdref/cilium-health_ping.md
+++ b/Documentation/cmdref/cilium-health_ping.md
@@ -25,5 +25,5 @@ cilium-health ping [flags]
 
 ### SEE ALSO
 
-* [cilium-health](cilium-health.html)	 - Cilium Health Client
+* [cilium-health](cilium-health.md)	 - Cilium Health Client
 

--- a/Documentation/cmdref/cilium-health_status.md
+++ b/Documentation/cmdref/cilium-health_status.md
@@ -29,5 +29,5 @@ cilium-health status [flags]
 
 ### SEE ALSO
 
-* [cilium-health](cilium-health.html)	 - Cilium Health Client
+* [cilium-health](cilium-health.md)	 - Cilium Health Client
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -74,6 +74,6 @@ cilium-operator-alibabacloud [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-alibabacloud completion](cilium-operator-alibabacloud_completion.html)	 - Generate the autocompletion script for the specified shell
-* [cilium-operator-alibabacloud metrics](cilium-operator-alibabacloud_metrics.html)	 - Access metric status of the operator
+* [cilium-operator-alibabacloud completion](cilium-operator-alibabacloud_completion.md)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-alibabacloud metrics](cilium-operator-alibabacloud_metrics.md)	 - Access metric status of the operator
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud_completion.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_completion.md
@@ -18,9 +18,9 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [cilium-operator-alibabacloud](cilium-operator-alibabacloud.html)	 - Run cilium-operator-alibabacloud
-* [cilium-operator-alibabacloud completion bash](cilium-operator-alibabacloud_completion_bash.html)	 - Generate the autocompletion script for bash
-* [cilium-operator-alibabacloud completion fish](cilium-operator-alibabacloud_completion_fish.html)	 - Generate the autocompletion script for fish
-* [cilium-operator-alibabacloud completion powershell](cilium-operator-alibabacloud_completion_powershell.html)	 - Generate the autocompletion script for powershell
-* [cilium-operator-alibabacloud completion zsh](cilium-operator-alibabacloud_completion_zsh.html)	 - Generate the autocompletion script for zsh
+* [cilium-operator-alibabacloud](cilium-operator-alibabacloud.md)	 - Run cilium-operator-alibabacloud
+* [cilium-operator-alibabacloud completion bash](cilium-operator-alibabacloud_completion_bash.md)	 - Generate the autocompletion script for bash
+* [cilium-operator-alibabacloud completion fish](cilium-operator-alibabacloud_completion_fish.md)	 - Generate the autocompletion script for fish
+* [cilium-operator-alibabacloud completion powershell](cilium-operator-alibabacloud_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [cilium-operator-alibabacloud completion zsh](cilium-operator-alibabacloud_completion_zsh.md)	 - Generate the autocompletion script for zsh
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud_completion_bash.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_completion_bash.md
@@ -41,5 +41,5 @@ cilium-operator-alibabacloud completion bash
 
 ### SEE ALSO
 
-* [cilium-operator-alibabacloud completion](cilium-operator-alibabacloud_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-alibabacloud completion](cilium-operator-alibabacloud_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud_completion_fish.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_completion_fish.md
@@ -32,5 +32,5 @@ cilium-operator-alibabacloud completion fish [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-alibabacloud completion](cilium-operator-alibabacloud_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-alibabacloud completion](cilium-operator-alibabacloud_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud_completion_powershell.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_completion_powershell.md
@@ -29,5 +29,5 @@ cilium-operator-alibabacloud completion powershell [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-alibabacloud completion](cilium-operator-alibabacloud_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-alibabacloud completion](cilium-operator-alibabacloud_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud_completion_zsh.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_completion_zsh.md
@@ -39,5 +39,5 @@ cilium-operator-alibabacloud completion zsh [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-alibabacloud completion](cilium-operator-alibabacloud_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-alibabacloud completion](cilium-operator-alibabacloud_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud_metrics.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_metrics.md
@@ -12,6 +12,6 @@ Access metric status of the operator
 
 ### SEE ALSO
 
-* [cilium-operator-alibabacloud](cilium-operator-alibabacloud.html)	 - Run cilium-operator-alibabacloud
-* [cilium-operator-alibabacloud metrics list](cilium-operator-alibabacloud_metrics_list.html)	 - List all metrics for the operator
+* [cilium-operator-alibabacloud](cilium-operator-alibabacloud.md)	 - Run cilium-operator-alibabacloud
+* [cilium-operator-alibabacloud metrics list](cilium-operator-alibabacloud_metrics_list.md)	 - List all metrics for the operator
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud_metrics_list.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_metrics_list.md
@@ -18,5 +18,5 @@ cilium-operator-alibabacloud metrics list [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-alibabacloud metrics](cilium-operator-alibabacloud_metrics.html)	 - Access metric status of the operator
+* [cilium-operator-alibabacloud metrics](cilium-operator-alibabacloud_metrics.md)	 - Access metric status of the operator
 

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -80,6 +80,6 @@ cilium-operator-aws [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-aws completion](cilium-operator-aws_completion.html)	 - Generate the autocompletion script for the specified shell
-* [cilium-operator-aws metrics](cilium-operator-aws_metrics.html)	 - Access metric status of the operator
+* [cilium-operator-aws completion](cilium-operator-aws_completion.md)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-aws metrics](cilium-operator-aws_metrics.md)	 - Access metric status of the operator
 

--- a/Documentation/cmdref/cilium-operator-aws_completion.md
+++ b/Documentation/cmdref/cilium-operator-aws_completion.md
@@ -18,9 +18,9 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [cilium-operator-aws](cilium-operator-aws.html)	 - Run cilium-operator-aws
-* [cilium-operator-aws completion bash](cilium-operator-aws_completion_bash.html)	 - Generate the autocompletion script for bash
-* [cilium-operator-aws completion fish](cilium-operator-aws_completion_fish.html)	 - Generate the autocompletion script for fish
-* [cilium-operator-aws completion powershell](cilium-operator-aws_completion_powershell.html)	 - Generate the autocompletion script for powershell
-* [cilium-operator-aws completion zsh](cilium-operator-aws_completion_zsh.html)	 - Generate the autocompletion script for zsh
+* [cilium-operator-aws](cilium-operator-aws.md)	 - Run cilium-operator-aws
+* [cilium-operator-aws completion bash](cilium-operator-aws_completion_bash.md)	 - Generate the autocompletion script for bash
+* [cilium-operator-aws completion fish](cilium-operator-aws_completion_fish.md)	 - Generate the autocompletion script for fish
+* [cilium-operator-aws completion powershell](cilium-operator-aws_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [cilium-operator-aws completion zsh](cilium-operator-aws_completion_zsh.md)	 - Generate the autocompletion script for zsh
 

--- a/Documentation/cmdref/cilium-operator-aws_completion_bash.md
+++ b/Documentation/cmdref/cilium-operator-aws_completion_bash.md
@@ -41,5 +41,5 @@ cilium-operator-aws completion bash
 
 ### SEE ALSO
 
-* [cilium-operator-aws completion](cilium-operator-aws_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-aws completion](cilium-operator-aws_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-aws_completion_fish.md
+++ b/Documentation/cmdref/cilium-operator-aws_completion_fish.md
@@ -32,5 +32,5 @@ cilium-operator-aws completion fish [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-aws completion](cilium-operator-aws_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-aws completion](cilium-operator-aws_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-aws_completion_powershell.md
+++ b/Documentation/cmdref/cilium-operator-aws_completion_powershell.md
@@ -29,5 +29,5 @@ cilium-operator-aws completion powershell [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-aws completion](cilium-operator-aws_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-aws completion](cilium-operator-aws_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-aws_completion_zsh.md
+++ b/Documentation/cmdref/cilium-operator-aws_completion_zsh.md
@@ -39,5 +39,5 @@ cilium-operator-aws completion zsh [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-aws completion](cilium-operator-aws_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-aws completion](cilium-operator-aws_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-aws_metrics.md
+++ b/Documentation/cmdref/cilium-operator-aws_metrics.md
@@ -12,6 +12,6 @@ Access metric status of the operator
 
 ### SEE ALSO
 
-* [cilium-operator-aws](cilium-operator-aws.html)	 - Run cilium-operator-aws
-* [cilium-operator-aws metrics list](cilium-operator-aws_metrics_list.html)	 - List all metrics for the operator
+* [cilium-operator-aws](cilium-operator-aws.md)	 - Run cilium-operator-aws
+* [cilium-operator-aws metrics list](cilium-operator-aws_metrics_list.md)	 - List all metrics for the operator
 

--- a/Documentation/cmdref/cilium-operator-aws_metrics_list.md
+++ b/Documentation/cmdref/cilium-operator-aws_metrics_list.md
@@ -18,5 +18,5 @@ cilium-operator-aws metrics list [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-aws metrics](cilium-operator-aws_metrics.html)	 - Access metric status of the operator
+* [cilium-operator-aws metrics](cilium-operator-aws_metrics.md)	 - Access metric status of the operator
 

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -77,6 +77,6 @@ cilium-operator-azure [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-azure completion](cilium-operator-azure_completion.html)	 - Generate the autocompletion script for the specified shell
-* [cilium-operator-azure metrics](cilium-operator-azure_metrics.html)	 - Access metric status of the operator
+* [cilium-operator-azure completion](cilium-operator-azure_completion.md)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-azure metrics](cilium-operator-azure_metrics.md)	 - Access metric status of the operator
 

--- a/Documentation/cmdref/cilium-operator-azure_completion.md
+++ b/Documentation/cmdref/cilium-operator-azure_completion.md
@@ -18,9 +18,9 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [cilium-operator-azure](cilium-operator-azure.html)	 - Run cilium-operator-azure
-* [cilium-operator-azure completion bash](cilium-operator-azure_completion_bash.html)	 - Generate the autocompletion script for bash
-* [cilium-operator-azure completion fish](cilium-operator-azure_completion_fish.html)	 - Generate the autocompletion script for fish
-* [cilium-operator-azure completion powershell](cilium-operator-azure_completion_powershell.html)	 - Generate the autocompletion script for powershell
-* [cilium-operator-azure completion zsh](cilium-operator-azure_completion_zsh.html)	 - Generate the autocompletion script for zsh
+* [cilium-operator-azure](cilium-operator-azure.md)	 - Run cilium-operator-azure
+* [cilium-operator-azure completion bash](cilium-operator-azure_completion_bash.md)	 - Generate the autocompletion script for bash
+* [cilium-operator-azure completion fish](cilium-operator-azure_completion_fish.md)	 - Generate the autocompletion script for fish
+* [cilium-operator-azure completion powershell](cilium-operator-azure_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [cilium-operator-azure completion zsh](cilium-operator-azure_completion_zsh.md)	 - Generate the autocompletion script for zsh
 

--- a/Documentation/cmdref/cilium-operator-azure_completion_bash.md
+++ b/Documentation/cmdref/cilium-operator-azure_completion_bash.md
@@ -41,5 +41,5 @@ cilium-operator-azure completion bash
 
 ### SEE ALSO
 
-* [cilium-operator-azure completion](cilium-operator-azure_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-azure completion](cilium-operator-azure_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-azure_completion_fish.md
+++ b/Documentation/cmdref/cilium-operator-azure_completion_fish.md
@@ -32,5 +32,5 @@ cilium-operator-azure completion fish [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-azure completion](cilium-operator-azure_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-azure completion](cilium-operator-azure_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-azure_completion_powershell.md
+++ b/Documentation/cmdref/cilium-operator-azure_completion_powershell.md
@@ -29,5 +29,5 @@ cilium-operator-azure completion powershell [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-azure completion](cilium-operator-azure_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-azure completion](cilium-operator-azure_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-azure_completion_zsh.md
+++ b/Documentation/cmdref/cilium-operator-azure_completion_zsh.md
@@ -39,5 +39,5 @@ cilium-operator-azure completion zsh [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-azure completion](cilium-operator-azure_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-azure completion](cilium-operator-azure_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-azure_metrics.md
+++ b/Documentation/cmdref/cilium-operator-azure_metrics.md
@@ -12,6 +12,6 @@ Access metric status of the operator
 
 ### SEE ALSO
 
-* [cilium-operator-azure](cilium-operator-azure.html)	 - Run cilium-operator-azure
-* [cilium-operator-azure metrics list](cilium-operator-azure_metrics_list.html)	 - List all metrics for the operator
+* [cilium-operator-azure](cilium-operator-azure.md)	 - Run cilium-operator-azure
+* [cilium-operator-azure metrics list](cilium-operator-azure_metrics_list.md)	 - List all metrics for the operator
 

--- a/Documentation/cmdref/cilium-operator-azure_metrics_list.md
+++ b/Documentation/cmdref/cilium-operator-azure_metrics_list.md
@@ -18,5 +18,5 @@ cilium-operator-azure metrics list [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-azure metrics](cilium-operator-azure_metrics.html)	 - Access metric status of the operator
+* [cilium-operator-azure metrics](cilium-operator-azure_metrics.md)	 - Access metric status of the operator
 

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -73,6 +73,6 @@ cilium-operator-generic [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-generic completion](cilium-operator-generic_completion.html)	 - Generate the autocompletion script for the specified shell
-* [cilium-operator-generic metrics](cilium-operator-generic_metrics.html)	 - Access metric status of the operator
+* [cilium-operator-generic completion](cilium-operator-generic_completion.md)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-generic metrics](cilium-operator-generic_metrics.md)	 - Access metric status of the operator
 

--- a/Documentation/cmdref/cilium-operator-generic_completion.md
+++ b/Documentation/cmdref/cilium-operator-generic_completion.md
@@ -18,9 +18,9 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [cilium-operator-generic](cilium-operator-generic.html)	 - Run cilium-operator-generic
-* [cilium-operator-generic completion bash](cilium-operator-generic_completion_bash.html)	 - Generate the autocompletion script for bash
-* [cilium-operator-generic completion fish](cilium-operator-generic_completion_fish.html)	 - Generate the autocompletion script for fish
-* [cilium-operator-generic completion powershell](cilium-operator-generic_completion_powershell.html)	 - Generate the autocompletion script for powershell
-* [cilium-operator-generic completion zsh](cilium-operator-generic_completion_zsh.html)	 - Generate the autocompletion script for zsh
+* [cilium-operator-generic](cilium-operator-generic.md)	 - Run cilium-operator-generic
+* [cilium-operator-generic completion bash](cilium-operator-generic_completion_bash.md)	 - Generate the autocompletion script for bash
+* [cilium-operator-generic completion fish](cilium-operator-generic_completion_fish.md)	 - Generate the autocompletion script for fish
+* [cilium-operator-generic completion powershell](cilium-operator-generic_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [cilium-operator-generic completion zsh](cilium-operator-generic_completion_zsh.md)	 - Generate the autocompletion script for zsh
 

--- a/Documentation/cmdref/cilium-operator-generic_completion_bash.md
+++ b/Documentation/cmdref/cilium-operator-generic_completion_bash.md
@@ -41,5 +41,5 @@ cilium-operator-generic completion bash
 
 ### SEE ALSO
 
-* [cilium-operator-generic completion](cilium-operator-generic_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-generic completion](cilium-operator-generic_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-generic_completion_fish.md
+++ b/Documentation/cmdref/cilium-operator-generic_completion_fish.md
@@ -32,5 +32,5 @@ cilium-operator-generic completion fish [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-generic completion](cilium-operator-generic_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-generic completion](cilium-operator-generic_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-generic_completion_powershell.md
+++ b/Documentation/cmdref/cilium-operator-generic_completion_powershell.md
@@ -29,5 +29,5 @@ cilium-operator-generic completion powershell [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-generic completion](cilium-operator-generic_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-generic completion](cilium-operator-generic_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-generic_completion_zsh.md
+++ b/Documentation/cmdref/cilium-operator-generic_completion_zsh.md
@@ -39,5 +39,5 @@ cilium-operator-generic completion zsh [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-generic completion](cilium-operator-generic_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator-generic completion](cilium-operator-generic_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator-generic_metrics.md
+++ b/Documentation/cmdref/cilium-operator-generic_metrics.md
@@ -12,6 +12,6 @@ Access metric status of the operator
 
 ### SEE ALSO
 
-* [cilium-operator-generic](cilium-operator-generic.html)	 - Run cilium-operator-generic
-* [cilium-operator-generic metrics list](cilium-operator-generic_metrics_list.html)	 - List all metrics for the operator
+* [cilium-operator-generic](cilium-operator-generic.md)	 - Run cilium-operator-generic
+* [cilium-operator-generic metrics list](cilium-operator-generic_metrics_list.md)	 - List all metrics for the operator
 

--- a/Documentation/cmdref/cilium-operator-generic_metrics_list.md
+++ b/Documentation/cmdref/cilium-operator-generic_metrics_list.md
@@ -18,5 +18,5 @@ cilium-operator-generic metrics list [flags]
 
 ### SEE ALSO
 
-* [cilium-operator-generic metrics](cilium-operator-generic_metrics.html)	 - Access metric status of the operator
+* [cilium-operator-generic metrics](cilium-operator-generic_metrics.md)	 - Access metric status of the operator
 

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -85,6 +85,6 @@ cilium-operator [flags]
 
 ### SEE ALSO
 
-* [cilium-operator completion](cilium-operator_completion.html)	 - Generate the autocompletion script for the specified shell
-* [cilium-operator metrics](cilium-operator_metrics.html)	 - Access metric status of the operator
+* [cilium-operator completion](cilium-operator_completion.md)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator metrics](cilium-operator_metrics.md)	 - Access metric status of the operator
 

--- a/Documentation/cmdref/cilium-operator_completion.md
+++ b/Documentation/cmdref/cilium-operator_completion.md
@@ -18,9 +18,9 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [cilium-operator](cilium-operator.html)	 - Run cilium-operator
-* [cilium-operator completion bash](cilium-operator_completion_bash.html)	 - Generate the autocompletion script for bash
-* [cilium-operator completion fish](cilium-operator_completion_fish.html)	 - Generate the autocompletion script for fish
-* [cilium-operator completion powershell](cilium-operator_completion_powershell.html)	 - Generate the autocompletion script for powershell
-* [cilium-operator completion zsh](cilium-operator_completion_zsh.html)	 - Generate the autocompletion script for zsh
+* [cilium-operator](cilium-operator.md)	 - Run cilium-operator
+* [cilium-operator completion bash](cilium-operator_completion_bash.md)	 - Generate the autocompletion script for bash
+* [cilium-operator completion fish](cilium-operator_completion_fish.md)	 - Generate the autocompletion script for fish
+* [cilium-operator completion powershell](cilium-operator_completion_powershell.md)	 - Generate the autocompletion script for powershell
+* [cilium-operator completion zsh](cilium-operator_completion_zsh.md)	 - Generate the autocompletion script for zsh
 

--- a/Documentation/cmdref/cilium-operator_completion_bash.md
+++ b/Documentation/cmdref/cilium-operator_completion_bash.md
@@ -41,5 +41,5 @@ cilium-operator completion bash
 
 ### SEE ALSO
 
-* [cilium-operator completion](cilium-operator_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator completion](cilium-operator_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator_completion_fish.md
+++ b/Documentation/cmdref/cilium-operator_completion_fish.md
@@ -32,5 +32,5 @@ cilium-operator completion fish [flags]
 
 ### SEE ALSO
 
-* [cilium-operator completion](cilium-operator_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator completion](cilium-operator_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator_completion_powershell.md
+++ b/Documentation/cmdref/cilium-operator_completion_powershell.md
@@ -29,5 +29,5 @@ cilium-operator completion powershell [flags]
 
 ### SEE ALSO
 
-* [cilium-operator completion](cilium-operator_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator completion](cilium-operator_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator_completion_zsh.md
+++ b/Documentation/cmdref/cilium-operator_completion_zsh.md
@@ -39,5 +39,5 @@ cilium-operator completion zsh [flags]
 
 ### SEE ALSO
 
-* [cilium-operator completion](cilium-operator_completion.html)	 - Generate the autocompletion script for the specified shell
+* [cilium-operator completion](cilium-operator_completion.md)	 - Generate the autocompletion script for the specified shell
 

--- a/Documentation/cmdref/cilium-operator_metrics.md
+++ b/Documentation/cmdref/cilium-operator_metrics.md
@@ -12,6 +12,6 @@ Access metric status of the operator
 
 ### SEE ALSO
 
-* [cilium-operator](cilium-operator.html)	 - Run cilium-operator
-* [cilium-operator metrics list](cilium-operator_metrics_list.html)	 - List all metrics for the operator
+* [cilium-operator](cilium-operator.md)	 - Run cilium-operator
+* [cilium-operator metrics list](cilium-operator_metrics_list.md)	 - List all metrics for the operator
 

--- a/Documentation/cmdref/cilium-operator_metrics_list.md
+++ b/Documentation/cmdref/cilium-operator_metrics_list.md
@@ -18,5 +18,5 @@ cilium-operator metrics list [flags]
 
 ### SEE ALSO
 
-* [cilium-operator metrics](cilium-operator_metrics.html)	 - Access metric status of the operator
+* [cilium-operator metrics](cilium-operator_metrics.md)	 - Access metric status of the operator
 

--- a/Documentation/cmdref/cilium.md
+++ b/Documentation/cmdref/cilium.md
@@ -19,27 +19,27 @@ CLI for interacting with the local Cilium Agent
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium cleanup](../cilium_cleanup)	 - Remove system state installed by Cilium at runtime
-* [cilium completion](../cilium_completion)	 - Output shell completion code
-* [cilium config](../cilium_config)	 - Cilium configuration options
-* [cilium debuginfo](../cilium_debuginfo)	 - Request available debugging information from agent
-* [cilium encrypt](../cilium_encrypt)	 - Manage transparent encryption
-* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
-* [cilium fqdn](../cilium_fqdn)	 - Manage fqdn proxy
-* [cilium identity](../cilium_identity)	 - Manage security identities
-* [cilium ip](../cilium_ip)	 - Manage IP addresses and associated information
-* [cilium kvstore](../cilium_kvstore)	 - Direct access to the kvstore
-* [cilium lrp](../cilium_lrp)	 - Manage local redirect policies
-* [cilium map](../cilium_map)	 - Access userspace cached content of BPF maps
-* [cilium metrics](../cilium_metrics)	 - Access metric status
-* [cilium monitor](../cilium_monitor)	 - Display BPF program events
-* [cilium node](../cilium_node)	 - Manage cluster nodes
-* [cilium policy](../cilium_policy)	 - Manage security policies
-* [cilium prefilter](../cilium_prefilter)	 - Manage XDP CIDR filters
-* [cilium preflight](../cilium_preflight)	 - cilium upgrade helper
-* [cilium recorder](../cilium_recorder)	 - Introspect or mangle pcap recorder
-* [cilium service](../cilium_service)	 - Manage services & loadbalancers
-* [cilium status](../cilium_status)	 - Display status of daemon
-* [cilium version](../cilium_version)	 - Print version information
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium cleanup](cilium_cleanup.md)	 - Remove system state installed by Cilium at runtime
+* [cilium completion](cilium_completion.md)	 - Output shell completion code
+* [cilium config](cilium_config.md)	 - Cilium configuration options
+* [cilium debuginfo](cilium_debuginfo.md)	 - Request available debugging information from agent
+* [cilium encrypt](cilium_encrypt.md)	 - Manage transparent encryption
+* [cilium endpoint](cilium_endpoint.md)	 - Manage endpoints
+* [cilium fqdn](cilium_fqdn.md)	 - Manage fqdn proxy
+* [cilium identity](cilium_identity.md)	 - Manage security identities
+* [cilium ip](cilium_ip.md)	 - Manage IP addresses and associated information
+* [cilium kvstore](cilium_kvstore.md)	 - Direct access to the kvstore
+* [cilium lrp](cilium_lrp.md)	 - Manage local redirect policies
+* [cilium map](cilium_map.md)	 - Access userspace cached content of BPF maps
+* [cilium metrics](cilium_metrics.md)	 - Access metric status
+* [cilium monitor](cilium_monitor.md)	 - Display BPF program events
+* [cilium node](cilium_node.md)	 - Manage cluster nodes
+* [cilium policy](cilium_policy.md)	 - Manage security policies
+* [cilium prefilter](cilium_prefilter.md)	 - Manage XDP CIDR filters
+* [cilium preflight](cilium_preflight.md)	 - cilium upgrade helper
+* [cilium recorder](cilium_recorder.md)	 - Introspect or mangle pcap recorder
+* [cilium service](cilium_service.md)	 - Manage services & loadbalancers
+* [cilium status](cilium_status.md)	 - Display status of daemon
+* [cilium version](cilium_version.md)	 - Print version information
 

--- a/Documentation/cmdref/cilium_bpf.md
+++ b/Documentation/cmdref/cilium_bpf.md
@@ -20,19 +20,19 @@ Direct access to local BPF maps
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium bpf bandwidth](../cilium_bpf_bandwidth)	 - BPF datapath bandwidth settings
-* [cilium bpf ct](../cilium_bpf_ct)	 - Connection tracking tables
-* [cilium bpf egress](../cilium_bpf_egress)	 - Manage the egress routing rules
-* [cilium bpf endpoint](../cilium_bpf_endpoint)	 - Local endpoint map
-* [cilium bpf fs](../cilium_bpf_fs)	 - BPF filesystem mount
-* [cilium bpf ipcache](../cilium_bpf_ipcache)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
-* [cilium bpf ipmasq](../cilium_bpf_ipmasq)	 - ip-masq-agent CIDRs
-* [cilium bpf lb](../cilium_bpf_lb)	 - Load-balancing configuration
-* [cilium bpf metrics](../cilium_bpf_metrics)	 - BPF datapath traffic metrics
-* [cilium bpf nat](../cilium_bpf_nat)	 - NAT mapping tables
-* [cilium bpf policy](../cilium_bpf_policy)	 - Manage policy related BPF maps
-* [cilium bpf recorder](../cilium_bpf_recorder)	 - PCAP recorder
-* [cilium bpf sha](../cilium_bpf_sha)	 - Manage compiled BPF template objects
-* [cilium bpf tunnel](../cilium_bpf_tunnel)	 - Tunnel endpoint map
+* [cilium](cilium.md)	 - CLI
+* [cilium bpf bandwidth](cilium_bpf_bandwidth.md)	 - BPF datapath bandwidth settings
+* [cilium bpf ct](cilium_bpf_ct.md)	 - Connection tracking tables
+* [cilium bpf egress](cilium_bpf_egress.md)	 - Manage the egress routing rules
+* [cilium bpf endpoint](cilium_bpf_endpoint.md)	 - Local endpoint map
+* [cilium bpf fs](cilium_bpf_fs.md)	 - BPF filesystem mount
+* [cilium bpf ipcache](cilium_bpf_ipcache.md)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
+* [cilium bpf ipmasq](cilium_bpf_ipmasq.md)	 - ip-masq-agent CIDRs
+* [cilium bpf lb](cilium_bpf_lb.md)	 - Load-balancing configuration
+* [cilium bpf metrics](cilium_bpf_metrics.md)	 - BPF datapath traffic metrics
+* [cilium bpf nat](cilium_bpf_nat.md)	 - NAT mapping tables
+* [cilium bpf policy](cilium_bpf_policy.md)	 - Manage policy related BPF maps
+* [cilium bpf recorder](cilium_bpf_recorder.md)	 - PCAP recorder
+* [cilium bpf sha](cilium_bpf_sha.md)	 - Manage compiled BPF template objects
+* [cilium bpf tunnel](cilium_bpf_tunnel.md)	 - Tunnel endpoint map
 

--- a/Documentation/cmdref/cilium_bpf_bandwidth.md
+++ b/Documentation/cmdref/cilium_bpf_bandwidth.md
@@ -20,6 +20,6 @@ BPF datapath bandwidth settings
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf bandwidth list](../cilium_bpf_bandwidth_list)	 - List BPF datapath bandwidth settings
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf bandwidth list](cilium_bpf_bandwidth_list.md)	 - List BPF datapath bandwidth settings
 

--- a/Documentation/cmdref/cilium_bpf_bandwidth_list.md
+++ b/Documentation/cmdref/cilium_bpf_bandwidth_list.md
@@ -25,5 +25,5 @@ cilium bpf bandwidth list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf bandwidth](../cilium_bpf_bandwidth)	 - BPF datapath bandwidth settings
+* [cilium bpf bandwidth](cilium_bpf_bandwidth.md)	 - BPF datapath bandwidth settings
 

--- a/Documentation/cmdref/cilium_bpf_ct.md
+++ b/Documentation/cmdref/cilium_bpf_ct.md
@@ -20,7 +20,7 @@ Connection tracking tables
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf ct flush](../cilium_bpf_ct_flush)	 - Flush all connection tracking entries
-* [cilium bpf ct list](../cilium_bpf_ct_list)	 - List connection tracking entries
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf ct flush](cilium_bpf_ct_flush.md)	 - Flush all connection tracking entries
+* [cilium bpf ct list](cilium_bpf_ct_list.md)	 - List connection tracking entries
 

--- a/Documentation/cmdref/cilium_bpf_ct_flush.md
+++ b/Documentation/cmdref/cilium_bpf_ct_flush.md
@@ -24,5 +24,5 @@ cilium bpf ct flush ( <endpoint identifier> | global ) [flags]
 
 ### SEE ALSO
 
-* [cilium bpf ct](../cilium_bpf_ct)	 - Connection tracking tables
+* [cilium bpf ct](cilium_bpf_ct.md)	 - Connection tracking tables
 

--- a/Documentation/cmdref/cilium_bpf_ct_list.md
+++ b/Documentation/cmdref/cilium_bpf_ct_list.md
@@ -28,5 +28,5 @@ cilium bpf ct list ( <endpoint identifier> | global ) [flags]
 
 ### SEE ALSO
 
-* [cilium bpf ct](../cilium_bpf_ct)	 - Connection tracking tables
+* [cilium bpf ct](cilium_bpf_ct.md)	 - Connection tracking tables
 

--- a/Documentation/cmdref/cilium_bpf_egress.md
+++ b/Documentation/cmdref/cilium_bpf_egress.md
@@ -20,9 +20,9 @@ Manage the egress routing rules
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf egress delete](../cilium_bpf_egress_delete)	 - Delete egress entries
-* [cilium bpf egress get](../cilium_bpf_egress_get)	 - Get egress entries
-* [cilium bpf egress list](../cilium_bpf_egress_list)	 - List egress policy entries
-* [cilium bpf egress update](../cilium_bpf_egress_update)	 - Update egress entries
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf egress delete](cilium_bpf_egress_delete.md)	 - Delete egress entries
+* [cilium bpf egress get](cilium_bpf_egress_get.md)	 - Get egress entries
+* [cilium bpf egress list](cilium_bpf_egress_list.md)	 - List egress policy entries
+* [cilium bpf egress update](cilium_bpf_egress_update.md)	 - Update egress entries
 

--- a/Documentation/cmdref/cilium_bpf_egress_delete.md
+++ b/Documentation/cmdref/cilium_bpf_egress_delete.md
@@ -29,5 +29,5 @@ cilium bpf egress delete [flags]
 
 ### SEE ALSO
 
-* [cilium bpf egress](../cilium_bpf_egress)	 - Manage the egress routing rules
+* [cilium bpf egress](cilium_bpf_egress.md)	 - Manage the egress routing rules
 

--- a/Documentation/cmdref/cilium_bpf_egress_get.md
+++ b/Documentation/cmdref/cilium_bpf_egress_get.md
@@ -29,5 +29,5 @@ cilium bpf egress get [flags]
 
 ### SEE ALSO
 
-* [cilium bpf egress](../cilium_bpf_egress)	 - Manage the egress routing rules
+* [cilium bpf egress](cilium_bpf_egress.md)	 - Manage the egress routing rules
 

--- a/Documentation/cmdref/cilium_bpf_egress_list.md
+++ b/Documentation/cmdref/cilium_bpf_egress_list.md
@@ -34,5 +34,5 @@ cilium bpf egress list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf egress](../cilium_bpf_egress)	 - Manage the egress routing rules
+* [cilium bpf egress](cilium_bpf_egress.md)	 - Manage the egress routing rules
 

--- a/Documentation/cmdref/cilium_bpf_egress_update.md
+++ b/Documentation/cmdref/cilium_bpf_egress_update.md
@@ -29,5 +29,5 @@ cilium bpf egress update [flags]
 
 ### SEE ALSO
 
-* [cilium bpf egress](../cilium_bpf_egress)	 - Manage the egress routing rules
+* [cilium bpf egress](cilium_bpf_egress.md)	 - Manage the egress routing rules
 

--- a/Documentation/cmdref/cilium_bpf_endpoint.md
+++ b/Documentation/cmdref/cilium_bpf_endpoint.md
@@ -20,7 +20,7 @@ Local endpoint map
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf endpoint delete](../cilium_bpf_endpoint_delete)	 - Delete local endpoint entries
-* [cilium bpf endpoint list](../cilium_bpf_endpoint_list)	 - List local endpoint entries
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf endpoint delete](cilium_bpf_endpoint_delete.md)	 - Delete local endpoint entries
+* [cilium bpf endpoint list](cilium_bpf_endpoint_list.md)	 - List local endpoint entries
 

--- a/Documentation/cmdref/cilium_bpf_endpoint_delete.md
+++ b/Documentation/cmdref/cilium_bpf_endpoint_delete.md
@@ -24,5 +24,5 @@ cilium bpf endpoint delete [flags]
 
 ### SEE ALSO
 
-* [cilium bpf endpoint](../cilium_bpf_endpoint)	 - Local endpoint map
+* [cilium bpf endpoint](cilium_bpf_endpoint.md)	 - Local endpoint map
 

--- a/Documentation/cmdref/cilium_bpf_endpoint_list.md
+++ b/Documentation/cmdref/cilium_bpf_endpoint_list.md
@@ -25,5 +25,5 @@ cilium bpf endpoint list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf endpoint](../cilium_bpf_endpoint)	 - Local endpoint map
+* [cilium bpf endpoint](cilium_bpf_endpoint.md)	 - Local endpoint map
 

--- a/Documentation/cmdref/cilium_bpf_fs.md
+++ b/Documentation/cmdref/cilium_bpf_fs.md
@@ -20,6 +20,6 @@ BPF filesystem mount
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf fs show](../cilium_bpf_fs_show)	 - Show bpf filesystem mount details
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf fs show](cilium_bpf_fs_show.md)	 - Show bpf filesystem mount details
 

--- a/Documentation/cmdref/cilium_bpf_fs_show.md
+++ b/Documentation/cmdref/cilium_bpf_fs_show.md
@@ -31,5 +31,5 @@ cilium bpf fs show
 
 ### SEE ALSO
 
-* [cilium bpf fs](../cilium_bpf_fs)	 - BPF filesystem mount
+* [cilium bpf fs](cilium_bpf_fs.md)	 - BPF filesystem mount
 

--- a/Documentation/cmdref/cilium_bpf_ipcache.md
+++ b/Documentation/cmdref/cilium_bpf_ipcache.md
@@ -20,7 +20,7 @@ Manage the IPCache mappings for IP/CIDR <-> Identity
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf ipcache get](../cilium_bpf_ipcache_get)	 - Retrieve identity for an ip
-* [cilium bpf ipcache list](../cilium_bpf_ipcache_list)	 - List endpoint IPs (local and remote) and their corresponding security identities
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf ipcache get](cilium_bpf_ipcache_get.md)	 - Retrieve identity for an ip
+* [cilium bpf ipcache list](cilium_bpf_ipcache_list.md)	 - List endpoint IPs (local and remote) and their corresponding security identities
 

--- a/Documentation/cmdref/cilium_bpf_ipcache_get.md
+++ b/Documentation/cmdref/cilium_bpf_ipcache_get.md
@@ -24,5 +24,5 @@ cilium bpf ipcache get [flags]
 
 ### SEE ALSO
 
-* [cilium bpf ipcache](../cilium_bpf_ipcache)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
+* [cilium bpf ipcache](cilium_bpf_ipcache.md)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
 

--- a/Documentation/cmdref/cilium_bpf_ipcache_list.md
+++ b/Documentation/cmdref/cilium_bpf_ipcache_list.md
@@ -36,5 +36,5 @@ cilium bpf ipcache list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf ipcache](../cilium_bpf_ipcache)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
+* [cilium bpf ipcache](cilium_bpf_ipcache.md)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
 

--- a/Documentation/cmdref/cilium_bpf_ipmasq.md
+++ b/Documentation/cmdref/cilium_bpf_ipmasq.md
@@ -20,6 +20,6 @@ ip-masq-agent CIDRs
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf ipmasq list](../cilium_bpf_ipmasq_list)	 - List ip-masq-agent CIDRs
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf ipmasq list](cilium_bpf_ipmasq_list.md)	 - List ip-masq-agent CIDRs
 

--- a/Documentation/cmdref/cilium_bpf_ipmasq_list.md
+++ b/Documentation/cmdref/cilium_bpf_ipmasq_list.md
@@ -29,5 +29,5 @@ cilium bpf ipmasq list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf ipmasq](../cilium_bpf_ipmasq)	 - ip-masq-agent CIDRs
+* [cilium bpf ipmasq](cilium_bpf_ipmasq.md)	 - ip-masq-agent CIDRs
 

--- a/Documentation/cmdref/cilium_bpf_lb.md
+++ b/Documentation/cmdref/cilium_bpf_lb.md
@@ -20,7 +20,7 @@ Load-balancing configuration
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf lb list](../cilium_bpf_lb_list)	 - List load-balancing configuration
-* [cilium bpf lb maglev](../cilium_bpf_lb_maglev)	 - Maglev lookup table
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf lb list](cilium_bpf_lb_list.md)	 - List load-balancing configuration
+* [cilium bpf lb maglev](cilium_bpf_lb_maglev.md)	 - Maglev lookup table
 

--- a/Documentation/cmdref/cilium_bpf_lb_list.md
+++ b/Documentation/cmdref/cilium_bpf_lb_list.md
@@ -28,5 +28,5 @@ cilium bpf lb list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf lb](../cilium_bpf_lb)	 - Load-balancing configuration
+* [cilium bpf lb](cilium_bpf_lb.md)	 - Load-balancing configuration
 

--- a/Documentation/cmdref/cilium_bpf_lb_maglev.md
+++ b/Documentation/cmdref/cilium_bpf_lb_maglev.md
@@ -20,7 +20,7 @@ Maglev lookup table
 
 ### SEE ALSO
 
-* [cilium bpf lb](../cilium_bpf_lb)	 - Load-balancing configuration
-* [cilium bpf lb maglev get](../cilium_bpf_lb_maglev_get)	 - Get Maglev lookup table for given service by ID
-* [cilium bpf lb maglev list](../cilium_bpf_lb_maglev_list)	 - List Maglev lookup tables
+* [cilium bpf lb](cilium_bpf_lb.md)	 - Load-balancing configuration
+* [cilium bpf lb maglev get](cilium_bpf_lb_maglev_get.md)	 - Get Maglev lookup table for given service by ID
+* [cilium bpf lb maglev list](cilium_bpf_lb_maglev_list.md)	 - List Maglev lookup tables
 

--- a/Documentation/cmdref/cilium_bpf_lb_maglev_get.md
+++ b/Documentation/cmdref/cilium_bpf_lb_maglev_get.md
@@ -25,5 +25,5 @@ cilium bpf lb maglev get <service id> [flags]
 
 ### SEE ALSO
 
-* [cilium bpf lb maglev](../cilium_bpf_lb_maglev)	 - Maglev lookup table
+* [cilium bpf lb maglev](cilium_bpf_lb_maglev.md)	 - Maglev lookup table
 

--- a/Documentation/cmdref/cilium_bpf_lb_maglev_list.md
+++ b/Documentation/cmdref/cilium_bpf_lb_maglev_list.md
@@ -25,5 +25,5 @@ cilium bpf lb maglev list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf lb maglev](../cilium_bpf_lb_maglev)	 - Maglev lookup table
+* [cilium bpf lb maglev](cilium_bpf_lb_maglev.md)	 - Maglev lookup table
 

--- a/Documentation/cmdref/cilium_bpf_metrics.md
+++ b/Documentation/cmdref/cilium_bpf_metrics.md
@@ -20,6 +20,6 @@ BPF datapath traffic metrics
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf metrics list](../cilium_bpf_metrics_list)	 - List BPF datapath traffic metrics
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf metrics list](cilium_bpf_metrics_list.md)	 - List BPF datapath traffic metrics
 

--- a/Documentation/cmdref/cilium_bpf_metrics_list.md
+++ b/Documentation/cmdref/cilium_bpf_metrics_list.md
@@ -25,5 +25,5 @@ cilium bpf metrics list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf metrics](../cilium_bpf_metrics)	 - BPF datapath traffic metrics
+* [cilium bpf metrics](cilium_bpf_metrics.md)	 - BPF datapath traffic metrics
 

--- a/Documentation/cmdref/cilium_bpf_nat.md
+++ b/Documentation/cmdref/cilium_bpf_nat.md
@@ -20,7 +20,7 @@ NAT mapping tables
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf nat flush](../cilium_bpf_nat_flush)	 - Flush all NAT mapping entries
-* [cilium bpf nat list](../cilium_bpf_nat_list)	 - List all NAT mapping entries
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf nat flush](cilium_bpf_nat_flush.md)	 - Flush all NAT mapping entries
+* [cilium bpf nat list](cilium_bpf_nat_list.md)	 - List all NAT mapping entries
 

--- a/Documentation/cmdref/cilium_bpf_nat_flush.md
+++ b/Documentation/cmdref/cilium_bpf_nat_flush.md
@@ -24,5 +24,5 @@ cilium bpf nat flush [flags]
 
 ### SEE ALSO
 
-* [cilium bpf nat](../cilium_bpf_nat)	 - NAT mapping tables
+* [cilium bpf nat](cilium_bpf_nat.md)	 - NAT mapping tables
 

--- a/Documentation/cmdref/cilium_bpf_nat_list.md
+++ b/Documentation/cmdref/cilium_bpf_nat_list.md
@@ -25,5 +25,5 @@ cilium bpf nat list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf nat](../cilium_bpf_nat)	 - NAT mapping tables
+* [cilium bpf nat](cilium_bpf_nat.md)	 - NAT mapping tables
 

--- a/Documentation/cmdref/cilium_bpf_policy.md
+++ b/Documentation/cmdref/cilium_bpf_policy.md
@@ -20,8 +20,8 @@ Manage policy related BPF maps
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf policy add](../cilium_bpf_policy_add)	 - Add/update policy entry
-* [cilium bpf policy delete](../cilium_bpf_policy_delete)	 - Delete a policy entry
-* [cilium bpf policy get](../cilium_bpf_policy_get)	 - List contents of a policy BPF map
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf policy add](cilium_bpf_policy_add.md)	 - Add/update policy entry
+* [cilium bpf policy delete](cilium_bpf_policy_delete.md)	 - Delete a policy entry
+* [cilium bpf policy get](cilium_bpf_policy_get.md)	 - List contents of a policy BPF map
 

--- a/Documentation/cmdref/cilium_bpf_policy_add.md
+++ b/Documentation/cmdref/cilium_bpf_policy_add.md
@@ -25,5 +25,5 @@ cilium bpf policy add <endpoint id> <traffic-direction> <identity> [port/proto] 
 
 ### SEE ALSO
 
-* [cilium bpf policy](../cilium_bpf_policy)	 - Manage policy related BPF maps
+* [cilium bpf policy](cilium_bpf_policy.md)	 - Manage policy related BPF maps
 

--- a/Documentation/cmdref/cilium_bpf_policy_delete.md
+++ b/Documentation/cmdref/cilium_bpf_policy_delete.md
@@ -25,5 +25,5 @@ cilium bpf policy delete <endpoint id> <identity> [port/proto] [flags]
 
 ### SEE ALSO
 
-* [cilium bpf policy](../cilium_bpf_policy)	 - Manage policy related BPF maps
+* [cilium bpf policy](cilium_bpf_policy.md)	 - Manage policy related BPF maps
 

--- a/Documentation/cmdref/cilium_bpf_policy_get.md
+++ b/Documentation/cmdref/cilium_bpf_policy_get.md
@@ -27,5 +27,5 @@ cilium bpf policy get [flags]
 
 ### SEE ALSO
 
-* [cilium bpf policy](../cilium_bpf_policy)	 - Manage policy related BPF maps
+* [cilium bpf policy](cilium_bpf_policy.md)	 - Manage policy related BPF maps
 

--- a/Documentation/cmdref/cilium_bpf_recorder.md
+++ b/Documentation/cmdref/cilium_bpf_recorder.md
@@ -20,6 +20,6 @@ PCAP recorder
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf recorder list](../cilium_bpf_recorder_list)	 - List PCAP recorder entries
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf recorder list](cilium_bpf_recorder_list.md)	 - List PCAP recorder entries
 

--- a/Documentation/cmdref/cilium_bpf_recorder_list.md
+++ b/Documentation/cmdref/cilium_bpf_recorder_list.md
@@ -25,5 +25,5 @@ cilium bpf recorder list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf recorder](../cilium_bpf_recorder)	 - PCAP recorder
+* [cilium bpf recorder](cilium_bpf_recorder.md)	 - PCAP recorder
 

--- a/Documentation/cmdref/cilium_bpf_sha.md
+++ b/Documentation/cmdref/cilium_bpf_sha.md
@@ -20,7 +20,7 @@ Manage compiled BPF template objects
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf sha get](../cilium_bpf_sha_get)	 - Get datapath SHA header
-* [cilium bpf sha list](../cilium_bpf_sha_list)	 - List BPF template objects.
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf sha get](cilium_bpf_sha_get.md)	 - Get datapath SHA header
+* [cilium bpf sha list](cilium_bpf_sha_list.md)	 - List BPF template objects.
 

--- a/Documentation/cmdref/cilium_bpf_sha_get.md
+++ b/Documentation/cmdref/cilium_bpf_sha_get.md
@@ -25,5 +25,5 @@ cilium bpf sha get <sha> [flags]
 
 ### SEE ALSO
 
-* [cilium bpf sha](../cilium_bpf_sha)	 - Manage compiled BPF template objects
+* [cilium bpf sha](cilium_bpf_sha.md)	 - Manage compiled BPF template objects
 

--- a/Documentation/cmdref/cilium_bpf_sha_list.md
+++ b/Documentation/cmdref/cilium_bpf_sha_list.md
@@ -25,5 +25,5 @@ cilium bpf sha list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf sha](../cilium_bpf_sha)	 - Manage compiled BPF template objects
+* [cilium bpf sha](cilium_bpf_sha.md)	 - Manage compiled BPF template objects
 

--- a/Documentation/cmdref/cilium_bpf_tunnel.md
+++ b/Documentation/cmdref/cilium_bpf_tunnel.md
@@ -20,6 +20,6 @@ Tunnel endpoint map
 
 ### SEE ALSO
 
-* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
-* [cilium bpf tunnel list](../cilium_bpf_tunnel_list)	 - List tunnel endpoint entries
+* [cilium bpf](cilium_bpf.md)	 - Direct access to local BPF maps
+* [cilium bpf tunnel list](cilium_bpf_tunnel_list.md)	 - List tunnel endpoint entries
 

--- a/Documentation/cmdref/cilium_bpf_tunnel_list.md
+++ b/Documentation/cmdref/cilium_bpf_tunnel_list.md
@@ -25,5 +25,5 @@ cilium bpf tunnel list [flags]
 
 ### SEE ALSO
 
-* [cilium bpf tunnel](../cilium_bpf_tunnel)	 - Tunnel endpoint map
+* [cilium bpf tunnel](cilium_bpf_tunnel.md)	 - Tunnel endpoint map
 

--- a/Documentation/cmdref/cilium_cleanup.md
+++ b/Documentation/cmdref/cilium_cleanup.md
@@ -35,5 +35,5 @@ cilium cleanup [flags]
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
+* [cilium](cilium.md)	 - CLI
 

--- a/Documentation/cmdref/cilium_completion.md
+++ b/Documentation/cmdref/cilium_completion.md
@@ -66,5 +66,5 @@ cilium completion [shell] [flags]
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
+* [cilium](cilium.md)	 - CLI
 

--- a/Documentation/cmdref/cilium_config.md
+++ b/Documentation/cmdref/cilium_config.md
@@ -29,6 +29,6 @@ cilium config [<option>=(enable|disable) ...] [flags]
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium config get](../cilium_config_get)	 - Retrieve cilium configuration
+* [cilium](cilium.md)	 - CLI
+* [cilium config get](cilium_config_get.md)	 - Retrieve cilium configuration
 

--- a/Documentation/cmdref/cilium_config_get.md
+++ b/Documentation/cmdref/cilium_config_get.md
@@ -25,5 +25,5 @@ cilium config get <config name> [flags]
 
 ### SEE ALSO
 
-* [cilium config](../cilium_config)	 - Cilium configuration options
+* [cilium config](cilium_config.md)	 - Cilium configuration options
 

--- a/Documentation/cmdref/cilium_debuginfo.md
+++ b/Documentation/cmdref/cilium_debuginfo.md
@@ -28,5 +28,5 @@ cilium debuginfo [flags]
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
+* [cilium](cilium.md)	 - CLI
 

--- a/Documentation/cmdref/cilium_encrypt.md
+++ b/Documentation/cmdref/cilium_encrypt.md
@@ -20,7 +20,7 @@ Manage transparent encryption
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium encrypt flush](../cilium_encrypt_flush)	 - Flushes the current IPsec state
-* [cilium encrypt status](../cilium_encrypt_status)	 - Display the current encryption state
+* [cilium](cilium.md)	 - CLI
+* [cilium encrypt flush](cilium_encrypt_flush.md)	 - Flushes the current IPsec state
+* [cilium encrypt status](cilium_encrypt_status.md)	 - Display the current encryption state
 

--- a/Documentation/cmdref/cilium_encrypt_flush.md
+++ b/Documentation/cmdref/cilium_encrypt_flush.md
@@ -29,5 +29,5 @@ cilium encrypt flush [flags]
 
 ### SEE ALSO
 
-* [cilium encrypt](../cilium_encrypt)	 - Manage transparent encryption
+* [cilium encrypt](cilium_encrypt.md)	 - Manage transparent encryption
 

--- a/Documentation/cmdref/cilium_encrypt_status.md
+++ b/Documentation/cmdref/cilium_encrypt_status.md
@@ -25,5 +25,5 @@ cilium encrypt status [flags]
 
 ### SEE ALSO
 
-* [cilium encrypt](../cilium_encrypt)	 - Manage transparent encryption
+* [cilium encrypt](cilium_encrypt.md)	 - Manage transparent encryption
 

--- a/Documentation/cmdref/cilium_endpoint.md
+++ b/Documentation/cmdref/cilium_endpoint.md
@@ -20,13 +20,13 @@ Manage endpoints
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium endpoint config](../cilium_endpoint_config)	 - View & modify endpoint configuration
-* [cilium endpoint disconnect](../cilium_endpoint_disconnect)	 - Disconnect an endpoint from the network
-* [cilium endpoint get](../cilium_endpoint_get)	 - Display endpoint information
-* [cilium endpoint health](../cilium_endpoint_health)	 - View endpoint health
-* [cilium endpoint labels](../cilium_endpoint_labels)	 - Manage label configuration of endpoint
-* [cilium endpoint list](../cilium_endpoint_list)	 - List all endpoints
-* [cilium endpoint log](../cilium_endpoint_log)	 - View endpoint status log
-* [cilium endpoint regenerate](../cilium_endpoint_regenerate)	 - Force regeneration of endpoint program
+* [cilium](cilium.md)	 - CLI
+* [cilium endpoint config](cilium_endpoint_config.md)	 - View & modify endpoint configuration
+* [cilium endpoint disconnect](cilium_endpoint_disconnect.md)	 - Disconnect an endpoint from the network
+* [cilium endpoint get](cilium_endpoint_get.md)	 - Display endpoint information
+* [cilium endpoint health](cilium_endpoint_health.md)	 - View endpoint health
+* [cilium endpoint labels](cilium_endpoint_labels.md)	 - Manage label configuration of endpoint
+* [cilium endpoint list](cilium_endpoint_list.md)	 - List all endpoints
+* [cilium endpoint log](cilium_endpoint_log.md)	 - View endpoint status log
+* [cilium endpoint regenerate](cilium_endpoint_regenerate.md)	 - Force regeneration of endpoint program
 

--- a/Documentation/cmdref/cilium_endpoint_config.md
+++ b/Documentation/cmdref/cilium_endpoint_config.md
@@ -32,5 +32,5 @@ endpoint config 5421 DropNotification=false TraceNotification=false PolicyVerdic
 
 ### SEE ALSO
 
-* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
+* [cilium endpoint](cilium_endpoint.md)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_disconnect.md
+++ b/Documentation/cmdref/cilium_endpoint_disconnect.md
@@ -24,5 +24,5 @@ cilium endpoint disconnect <endpoint-id> [flags]
 
 ### SEE ALSO
 
-* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
+* [cilium endpoint](cilium_endpoint.md)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_get.md
+++ b/Documentation/cmdref/cilium_endpoint_get.md
@@ -32,5 +32,5 @@ cilium endpoint get 4598, cilium endpoint get pod-name:default:foobar, cilium en
 
 ### SEE ALSO
 
-* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
+* [cilium endpoint](cilium_endpoint.md)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_health.md
+++ b/Documentation/cmdref/cilium_endpoint_health.md
@@ -31,5 +31,5 @@ cilium endpoint health 5421
 
 ### SEE ALSO
 
-* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
+* [cilium endpoint](cilium_endpoint.md)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_labels.md
+++ b/Documentation/cmdref/cilium_endpoint_labels.md
@@ -26,5 +26,5 @@ cilium endpoint labels [flags]
 
 ### SEE ALSO
 
-* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
+* [cilium endpoint](cilium_endpoint.md)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_list.md
+++ b/Documentation/cmdref/cilium_endpoint_list.md
@@ -26,5 +26,5 @@ cilium endpoint list [flags]
 
 ### SEE ALSO
 
-* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
+* [cilium endpoint](cilium_endpoint.md)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_log.md
+++ b/Documentation/cmdref/cilium_endpoint_log.md
@@ -31,5 +31,5 @@ cilium endpoint log 5421
 
 ### SEE ALSO
 
-* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
+* [cilium endpoint](cilium_endpoint.md)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_regenerate.md
+++ b/Documentation/cmdref/cilium_endpoint_regenerate.md
@@ -24,5 +24,5 @@ cilium endpoint regenerate <endpoint-id> [flags]
 
 ### SEE ALSO
 
-* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
+* [cilium endpoint](cilium_endpoint.md)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_fqdn.md
+++ b/Documentation/cmdref/cilium_fqdn.md
@@ -24,7 +24,7 @@ cilium fqdn [flags]
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium fqdn cache](../cilium_fqdn_cache)	 - Manage fqdn proxy cache
-* [cilium fqdn names](../cilium_fqdn_names)	 - show internal state Cilium has for DNS names / regexes
+* [cilium](cilium.md)	 - CLI
+* [cilium fqdn cache](cilium_fqdn_cache.md)	 - Manage fqdn proxy cache
+* [cilium fqdn names](cilium_fqdn_names.md)	 - show internal state Cilium has for DNS names / regexes
 

--- a/Documentation/cmdref/cilium_fqdn_cache.md
+++ b/Documentation/cmdref/cilium_fqdn_cache.md
@@ -24,7 +24,7 @@ cilium fqdn cache [flags]
 
 ### SEE ALSO
 
-* [cilium fqdn](../cilium_fqdn)	 - Manage fqdn proxy
-* [cilium fqdn cache clean](../cilium_fqdn_cache_clean)	 - Clean fqdn cache
-* [cilium fqdn cache list](../cilium_fqdn_cache_list)	 - List fqdn cache contents
+* [cilium fqdn](cilium_fqdn.md)	 - Manage fqdn proxy
+* [cilium fqdn cache clean](cilium_fqdn_cache_clean.md)	 - Clean fqdn cache
+* [cilium fqdn cache list](cilium_fqdn_cache_list.md)	 - List fqdn cache contents
 

--- a/Documentation/cmdref/cilium_fqdn_cache_clean.md
+++ b/Documentation/cmdref/cilium_fqdn_cache_clean.md
@@ -26,5 +26,5 @@ cilium fqdn cache clean [flags]
 
 ### SEE ALSO
 
-* [cilium fqdn cache](../cilium_fqdn_cache)	 - Manage fqdn proxy cache
+* [cilium fqdn cache](cilium_fqdn_cache.md)	 - Manage fqdn proxy cache
 

--- a/Documentation/cmdref/cilium_fqdn_cache_list.md
+++ b/Documentation/cmdref/cilium_fqdn_cache_list.md
@@ -27,5 +27,5 @@ cilium fqdn cache list [flags]
 
 ### SEE ALSO
 
-* [cilium fqdn cache](../cilium_fqdn_cache)	 - Manage fqdn proxy cache
+* [cilium fqdn cache](cilium_fqdn_cache.md)	 - Manage fqdn proxy cache
 

--- a/Documentation/cmdref/cilium_fqdn_names.md
+++ b/Documentation/cmdref/cilium_fqdn_names.md
@@ -24,5 +24,5 @@ cilium fqdn names [flags]
 
 ### SEE ALSO
 
-* [cilium fqdn](../cilium_fqdn)	 - Manage fqdn proxy
+* [cilium fqdn](cilium_fqdn.md)	 - Manage fqdn proxy
 

--- a/Documentation/cmdref/cilium_identity.md
+++ b/Documentation/cmdref/cilium_identity.md
@@ -20,7 +20,7 @@ Manage security identities
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium identity get](../cilium_identity_get)	 - Retrieve information about an identity
-* [cilium identity list](../cilium_identity_list)	 - List identities
+* [cilium](cilium.md)	 - CLI
+* [cilium identity get](cilium_identity_get.md)	 - Retrieve information about an identity
+* [cilium identity list](cilium_identity_list.md)	 - List identities
 

--- a/Documentation/cmdref/cilium_identity_get.md
+++ b/Documentation/cmdref/cilium_identity_get.md
@@ -26,5 +26,5 @@ cilium identity get [flags]
 
 ### SEE ALSO
 
-* [cilium identity](../cilium_identity)	 - Manage security identities
+* [cilium identity](cilium_identity.md)	 - Manage security identities
 

--- a/Documentation/cmdref/cilium_identity_list.md
+++ b/Documentation/cmdref/cilium_identity_list.md
@@ -26,5 +26,5 @@ cilium identity list [LABELS] [flags]
 
 ### SEE ALSO
 
-* [cilium identity](../cilium_identity)	 - Manage security identities
+* [cilium identity](cilium_identity.md)	 - Manage security identities
 

--- a/Documentation/cmdref/cilium_ip.md
+++ b/Documentation/cmdref/cilium_ip.md
@@ -20,6 +20,6 @@ Manage IP addresses and associated information
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium ip list](../cilium_ip_list)	 - List IP addresses in the userspace IPcache
+* [cilium](cilium.md)	 - CLI
+* [cilium ip list](cilium_ip_list.md)	 - List IP addresses in the userspace IPcache
 

--- a/Documentation/cmdref/cilium_ip_list.md
+++ b/Documentation/cmdref/cilium_ip_list.md
@@ -27,5 +27,5 @@ cilium ip list [flags]
 
 ### SEE ALSO
 
-* [cilium ip](../cilium_ip)	 - Manage IP addresses and associated information
+* [cilium ip](cilium_ip.md)	 - Manage IP addresses and associated information
 

--- a/Documentation/cmdref/cilium_kvstore.md
+++ b/Documentation/cmdref/cilium_kvstore.md
@@ -22,8 +22,8 @@ Direct access to the kvstore
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium kvstore delete](../cilium_kvstore_delete)	 - Delete a key
-* [cilium kvstore get](../cilium_kvstore_get)	 - Retrieve a key
-* [cilium kvstore set](../cilium_kvstore_set)	 - Set a key and value
+* [cilium](cilium.md)	 - CLI
+* [cilium kvstore delete](cilium_kvstore_delete.md)	 - Delete a key
+* [cilium kvstore get](cilium_kvstore_get.md)	 - Retrieve a key
+* [cilium kvstore set](cilium_kvstore_set.md)	 - Set a key and value
 

--- a/Documentation/cmdref/cilium_kvstore_delete.md
+++ b/Documentation/cmdref/cilium_kvstore_delete.md
@@ -33,5 +33,5 @@ cilium kvstore delete --recursive foo
 
 ### SEE ALSO
 
-* [cilium kvstore](../cilium_kvstore)	 - Direct access to the kvstore
+* [cilium kvstore](cilium_kvstore.md)	 - Direct access to the kvstore
 

--- a/Documentation/cmdref/cilium_kvstore_get.md
+++ b/Documentation/cmdref/cilium_kvstore_get.md
@@ -34,5 +34,5 @@ cilium kvstore get --recursive foo
 
 ### SEE ALSO
 
-* [cilium kvstore](../cilium_kvstore)	 - Direct access to the kvstore
+* [cilium kvstore](cilium_kvstore.md)	 - Direct access to the kvstore
 

--- a/Documentation/cmdref/cilium_kvstore_set.md
+++ b/Documentation/cmdref/cilium_kvstore_set.md
@@ -34,5 +34,5 @@ cilium kvstore set foo=bar
 
 ### SEE ALSO
 
-* [cilium kvstore](../cilium_kvstore)	 - Direct access to the kvstore
+* [cilium kvstore](cilium_kvstore.md)	 - Direct access to the kvstore
 

--- a/Documentation/cmdref/cilium_lrp.md
+++ b/Documentation/cmdref/cilium_lrp.md
@@ -20,6 +20,6 @@ Manage local redirect policies
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium lrp list](../cilium_lrp_list)	 - List local redirect policies
+* [cilium](cilium.md)	 - CLI
+* [cilium lrp list](cilium_lrp_list.md)	 - List local redirect policies
 

--- a/Documentation/cmdref/cilium_lrp_list.md
+++ b/Documentation/cmdref/cilium_lrp_list.md
@@ -25,5 +25,5 @@ cilium lrp list [flags]
 
 ### SEE ALSO
 
-* [cilium lrp](../cilium_lrp)	 - Manage local redirect policies
+* [cilium lrp](cilium_lrp.md)	 - Manage local redirect policies
 

--- a/Documentation/cmdref/cilium_map.md
+++ b/Documentation/cmdref/cilium_map.md
@@ -20,7 +20,7 @@ Access userspace cached content of BPF maps
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium map get](../cilium_map_get)	 - Display cached content of given BPF map
-* [cilium map list](../cilium_map_list)	 - List all open BPF maps
+* [cilium](cilium.md)	 - CLI
+* [cilium map get](cilium_map_get.md)	 - Display cached content of given BPF map
+* [cilium map list](cilium_map_list.md)	 - List all open BPF maps
 

--- a/Documentation/cmdref/cilium_map_get.md
+++ b/Documentation/cmdref/cilium_map_get.md
@@ -31,5 +31,5 @@ cilium map get cilium_ipcache
 
 ### SEE ALSO
 
-* [cilium map](../cilium_map)	 - Access userspace cached content of BPF maps
+* [cilium map](cilium_map.md)	 - Access userspace cached content of BPF maps
 

--- a/Documentation/cmdref/cilium_map_list.md
+++ b/Documentation/cmdref/cilium_map_list.md
@@ -32,5 +32,5 @@ cilium map list
 
 ### SEE ALSO
 
-* [cilium map](../cilium_map)	 - Access userspace cached content of BPF maps
+* [cilium map](cilium_map.md)	 - Access userspace cached content of BPF maps
 

--- a/Documentation/cmdref/cilium_metrics.md
+++ b/Documentation/cmdref/cilium_metrics.md
@@ -20,6 +20,6 @@ Access metric status
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium metrics list](../cilium_metrics_list)	 - List all metrics
+* [cilium](cilium.md)	 - CLI
+* [cilium metrics list](cilium_metrics_list.md)	 - List all metrics
 

--- a/Documentation/cmdref/cilium_metrics_list.md
+++ b/Documentation/cmdref/cilium_metrics_list.md
@@ -26,5 +26,5 @@ cilium metrics list [flags]
 
 ### SEE ALSO
 
-* [cilium metrics](../cilium_metrics)	 - Access metric status
+* [cilium metrics](cilium_metrics.md)	 - Access metric status
 

--- a/Documentation/cmdref/cilium_monitor.md
+++ b/Documentation/cmdref/cilium_monitor.md
@@ -42,5 +42,5 @@ cilium monitor [flags]
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
+* [cilium](cilium.md)	 - CLI
 

--- a/Documentation/cmdref/cilium_node.md
+++ b/Documentation/cmdref/cilium_node.md
@@ -20,6 +20,6 @@ Manage cluster nodes
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium node list](../cilium_node_list)	 - List nodes
+* [cilium](cilium.md)	 - CLI
+* [cilium node list](cilium_node_list.md)	 - List nodes
 

--- a/Documentation/cmdref/cilium_node_list.md
+++ b/Documentation/cmdref/cilium_node_list.md
@@ -25,5 +25,5 @@ cilium node list [flags]
 
 ### SEE ALSO
 
-* [cilium node](../cilium_node)	 - Manage cluster nodes
+* [cilium node](cilium_node.md)	 - Manage cluster nodes
 

--- a/Documentation/cmdref/cilium_policy.md
+++ b/Documentation/cmdref/cilium_policy.md
@@ -20,11 +20,11 @@ Manage security policies
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium policy delete](../cilium_policy_delete)	 - Delete policy rules
-* [cilium policy get](../cilium_policy_get)	 - Display policy node information
-* [cilium policy import](../cilium_policy_import)	 - Import security policy in JSON format
-* [cilium policy selectors](../cilium_policy_selectors)	 - Display cached information about selectors
-* [cilium policy validate](../cilium_policy_validate)	 - Validate a policy
-* [cilium policy wait](../cilium_policy_wait)	 - Wait for all endpoints to have updated to a given policy revision
+* [cilium](cilium.md)	 - CLI
+* [cilium policy delete](cilium_policy_delete.md)	 - Delete policy rules
+* [cilium policy get](cilium_policy_get.md)	 - Display policy node information
+* [cilium policy import](cilium_policy_import.md)	 - Import security policy in JSON format
+* [cilium policy selectors](cilium_policy_selectors.md)	 - Display cached information about selectors
+* [cilium policy validate](cilium_policy_validate.md)	 - Validate a policy
+* [cilium policy wait](cilium_policy_wait.md)	 - Wait for all endpoints to have updated to a given policy revision
 

--- a/Documentation/cmdref/cilium_policy_delete.md
+++ b/Documentation/cmdref/cilium_policy_delete.md
@@ -26,5 +26,5 @@ cilium policy delete [<labels>] [flags]
 
 ### SEE ALSO
 
-* [cilium policy](../cilium_policy)	 - Manage security policies
+* [cilium policy](cilium_policy.md)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_policy_get.md
+++ b/Documentation/cmdref/cilium_policy_get.md
@@ -25,5 +25,5 @@ cilium policy get [<labels>] [flags]
 
 ### SEE ALSO
 
-* [cilium policy](../cilium_policy)	 - Manage security policies
+* [cilium policy](cilium_policy.md)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_policy_import.md
+++ b/Documentation/cmdref/cilium_policy_import.md
@@ -33,5 +33,5 @@ cilium policy import <path> [flags]
 
 ### SEE ALSO
 
-* [cilium policy](../cilium_policy)	 - Manage security policies
+* [cilium policy](cilium_policy.md)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_policy_selectors.md
+++ b/Documentation/cmdref/cilium_policy_selectors.md
@@ -25,5 +25,5 @@ cilium policy selectors [flags]
 
 ### SEE ALSO
 
-* [cilium policy](../cilium_policy)	 - Manage security policies
+* [cilium policy](cilium_policy.md)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_policy_validate.md
+++ b/Documentation/cmdref/cilium_policy_validate.md
@@ -26,5 +26,5 @@ cilium policy validate <path> [flags]
 
 ### SEE ALSO
 
-* [cilium policy](../cilium_policy)	 - Manage security policies
+* [cilium policy](cilium_policy.md)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_policy_wait.md
+++ b/Documentation/cmdref/cilium_policy_wait.md
@@ -27,5 +27,5 @@ cilium policy wait <revision> [flags]
 
 ### SEE ALSO
 
-* [cilium policy](../cilium_policy)	 - Manage security policies
+* [cilium policy](cilium_policy.md)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_prefilter.md
+++ b/Documentation/cmdref/cilium_prefilter.md
@@ -20,8 +20,8 @@ Manage XDP CIDR filters
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium prefilter delete](../cilium_prefilter_delete)	 - Delete CIDR filters
-* [cilium prefilter list](../cilium_prefilter_list)	 - List CIDR filters
-* [cilium prefilter update](../cilium_prefilter_update)	 - Update CIDR filters
+* [cilium](cilium.md)	 - CLI
+* [cilium prefilter delete](cilium_prefilter_delete.md)	 - Delete CIDR filters
+* [cilium prefilter list](cilium_prefilter_list.md)	 - List CIDR filters
+* [cilium prefilter update](cilium_prefilter_update.md)	 - Update CIDR filters
 

--- a/Documentation/cmdref/cilium_prefilter_delete.md
+++ b/Documentation/cmdref/cilium_prefilter_delete.md
@@ -26,5 +26,5 @@ cilium prefilter delete [flags]
 
 ### SEE ALSO
 
-* [cilium prefilter](../cilium_prefilter)	 - Manage XDP CIDR filters
+* [cilium prefilter](cilium_prefilter.md)	 - Manage XDP CIDR filters
 

--- a/Documentation/cmdref/cilium_prefilter_list.md
+++ b/Documentation/cmdref/cilium_prefilter_list.md
@@ -25,5 +25,5 @@ cilium prefilter list [flags]
 
 ### SEE ALSO
 
-* [cilium prefilter](../cilium_prefilter)	 - Manage XDP CIDR filters
+* [cilium prefilter](cilium_prefilter.md)	 - Manage XDP CIDR filters
 

--- a/Documentation/cmdref/cilium_prefilter_update.md
+++ b/Documentation/cmdref/cilium_prefilter_update.md
@@ -26,5 +26,5 @@ cilium prefilter update [flags]
 
 ### SEE ALSO
 
-* [cilium prefilter](../cilium_prefilter)	 - Manage XDP CIDR filters
+* [cilium prefilter](cilium_prefilter.md)	 - Manage XDP CIDR filters
 

--- a/Documentation/cmdref/cilium_preflight.md
+++ b/Documentation/cmdref/cilium_preflight.md
@@ -24,8 +24,8 @@ CLI to help upgrade cilium
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium preflight fqdn-poller](../cilium_preflight_fqdn-poller)	 - Prepare for DNS Polling upgrades to cilium 1.4
-* [cilium preflight migrate-identity](../cilium_preflight_migrate-identity)	 - Migrate KVStore-backed identities to kubernetes CRD-backed identities
-* [cilium preflight validate-cnp](../cilium_preflight_validate-cnp)	 - Validate Cilium Network Policies deployed in the cluster
+* [cilium](cilium.md)	 - CLI
+* [cilium preflight fqdn-poller](cilium_preflight_fqdn-poller.md)	 - Prepare for DNS Polling upgrades to cilium 1.4
+* [cilium preflight migrate-identity](cilium_preflight_migrate-identity.md)	 - Migrate KVStore-backed identities to kubernetes CRD-backed identities
+* [cilium preflight validate-cnp](cilium_preflight_validate-cnp.md)	 - Validate Cilium Network Policies deployed in the cluster
 

--- a/Documentation/cmdref/cilium_preflight_fqdn-poller.md
+++ b/Documentation/cmdref/cilium_preflight_fqdn-poller.md
@@ -36,5 +36,5 @@ cilium preflight fqdn-poller [flags]
 
 ### SEE ALSO
 
-* [cilium preflight](../cilium_preflight)	 - cilium upgrade helper
+* [cilium preflight](cilium_preflight.md)	 - cilium upgrade helper
 

--- a/Documentation/cmdref/cilium_preflight_migrate-identity.md
+++ b/Documentation/cmdref/cilium_preflight_migrate-identity.md
@@ -39,5 +39,5 @@ cilium preflight migrate-identity [flags]
 
 ### SEE ALSO
 
-* [cilium preflight](../cilium_preflight)	 - cilium upgrade helper
+* [cilium preflight](cilium_preflight.md)	 - cilium upgrade helper
 

--- a/Documentation/cmdref/cilium_preflight_validate-cnp.md
+++ b/Documentation/cmdref/cilium_preflight_validate-cnp.md
@@ -33,5 +33,5 @@ cilium preflight validate-cnp [flags]
 
 ### SEE ALSO
 
-* [cilium preflight](../cilium_preflight)	 - cilium upgrade helper
+* [cilium preflight](cilium_preflight.md)	 - cilium upgrade helper
 

--- a/Documentation/cmdref/cilium_recorder.md
+++ b/Documentation/cmdref/cilium_recorder.md
@@ -20,9 +20,9 @@ Introspect or mangle pcap recorder
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium recorder delete](../cilium_recorder_delete)	 - Delete individual pcap recorder
-* [cilium recorder get](../cilium_recorder_get)	 - Display individual pcap recorder
-* [cilium recorder list](../cilium_recorder_list)	 - List current pcap recorders
-* [cilium recorder update](../cilium_recorder_update)	 - Update individual pcap recorder
+* [cilium](cilium.md)	 - CLI
+* [cilium recorder delete](cilium_recorder_delete.md)	 - Delete individual pcap recorder
+* [cilium recorder get](cilium_recorder_get.md)	 - Display individual pcap recorder
+* [cilium recorder list](cilium_recorder_list.md)	 - List current pcap recorders
+* [cilium recorder update](cilium_recorder_update.md)	 - Update individual pcap recorder
 

--- a/Documentation/cmdref/cilium_recorder_delete.md
+++ b/Documentation/cmdref/cilium_recorder_delete.md
@@ -24,5 +24,5 @@ cilium recorder delete <recorder id> [flags]
 
 ### SEE ALSO
 
-* [cilium recorder](../cilium_recorder)	 - Introspect or mangle pcap recorder
+* [cilium recorder](cilium_recorder.md)	 - Introspect or mangle pcap recorder
 

--- a/Documentation/cmdref/cilium_recorder_get.md
+++ b/Documentation/cmdref/cilium_recorder_get.md
@@ -25,5 +25,5 @@ cilium recorder get <recorder id> [flags]
 
 ### SEE ALSO
 
-* [cilium recorder](../cilium_recorder)	 - Introspect or mangle pcap recorder
+* [cilium recorder](cilium_recorder.md)	 - Introspect or mangle pcap recorder
 

--- a/Documentation/cmdref/cilium_recorder_list.md
+++ b/Documentation/cmdref/cilium_recorder_list.md
@@ -25,5 +25,5 @@ cilium recorder list [flags]
 
 ### SEE ALSO
 
-* [cilium recorder](../cilium_recorder)	 - Introspect or mangle pcap recorder
+* [cilium recorder](cilium_recorder.md)	 - Introspect or mangle pcap recorder
 

--- a/Documentation/cmdref/cilium_recorder_update.md
+++ b/Documentation/cmdref/cilium_recorder_update.md
@@ -27,5 +27,5 @@ cilium recorder update [flags]
 
 ### SEE ALSO
 
-* [cilium recorder](../cilium_recorder)	 - Introspect or mangle pcap recorder
+* [cilium recorder](cilium_recorder.md)	 - Introspect or mangle pcap recorder
 

--- a/Documentation/cmdref/cilium_service.md
+++ b/Documentation/cmdref/cilium_service.md
@@ -20,9 +20,9 @@ Manage services & loadbalancers
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
-* [cilium service delete](../cilium_service_delete)	 - Delete a service
-* [cilium service get](../cilium_service_get)	 - Display service information
-* [cilium service list](../cilium_service_list)	 - List services
-* [cilium service update](../cilium_service_update)	 - Update a service
+* [cilium](cilium.md)	 - CLI
+* [cilium service delete](cilium_service_delete.md)	 - Delete a service
+* [cilium service get](cilium_service_get.md)	 - Display service information
+* [cilium service list](cilium_service_list.md)	 - List services
+* [cilium service update](cilium_service_update.md)	 - Update a service
 

--- a/Documentation/cmdref/cilium_service_delete.md
+++ b/Documentation/cmdref/cilium_service_delete.md
@@ -25,5 +25,5 @@ cilium service delete { <service id> | --all } [flags]
 
 ### SEE ALSO
 
-* [cilium service](../cilium_service)	 - Manage services & loadbalancers
+* [cilium service](cilium_service.md)	 - Manage services & loadbalancers
 

--- a/Documentation/cmdref/cilium_service_get.md
+++ b/Documentation/cmdref/cilium_service_get.md
@@ -25,5 +25,5 @@ cilium service get <service id> [flags]
 
 ### SEE ALSO
 
-* [cilium service](../cilium_service)	 - Manage services & loadbalancers
+* [cilium service](cilium_service.md)	 - Manage services & loadbalancers
 

--- a/Documentation/cmdref/cilium_service_list.md
+++ b/Documentation/cmdref/cilium_service_list.md
@@ -25,5 +25,5 @@ cilium service list [flags]
 
 ### SEE ALSO
 
-* [cilium service](../cilium_service)	 - Manage services & loadbalancers
+* [cilium service](cilium_service.md)	 - Manage services & loadbalancers
 

--- a/Documentation/cmdref/cilium_service_update.md
+++ b/Documentation/cmdref/cilium_service_update.md
@@ -34,5 +34,5 @@ cilium service update [flags]
 
 ### SEE ALSO
 
-* [cilium service](../cilium_service)	 - Manage services & loadbalancers
+* [cilium service](cilium_service.md)	 - Manage services & loadbalancers
 

--- a/Documentation/cmdref/cilium_status.md
+++ b/Documentation/cmdref/cilium_status.md
@@ -34,5 +34,5 @@ cilium status [flags]
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
+* [cilium](cilium.md)	 - CLI
 

--- a/Documentation/cmdref/cilium_version.md
+++ b/Documentation/cmdref/cilium_version.md
@@ -25,5 +25,5 @@ cilium version [flags]
 
 ### SEE ALSO
 
-* [cilium](../cilium)	 - CLI
+* [cilium](cilium.md)	 - CLI
 

--- a/Documentation/concepts/kubernetes/compatibility.rst
+++ b/Documentation/concepts/kubernetes/compatibility.rst
@@ -17,12 +17,12 @@ with Cilium. Older Kubernetes versions not listed in this table do not have
 Cilium support. Newer Kubernetes versions, while not listed, will depend on the
 backward compatibility offered by Kubernetes.
 
-+------------------------------------------------+---------------------------+----------------------------+
-| k8s Version                                    | k8s NetworkPolicy API     | CiliumNetworkPolicy        |
-+------------------------------------------------+---------------------------+----------------------------+
-|                                                |                           | ``cilium.io/v2`` has a     |
-| 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22, 1.23 | * `networking.k8s.io/v1`_ | `CustomResourceDefinition` |
-+------------------------------------------------+---------------------------+----------------------------+
++------------------------------------------------+---------------------------+----------------------------------+
+| k8s Version                                    | k8s NetworkPolicy API     | CiliumNetworkPolicy              |
++------------------------------------------------+---------------------------+----------------------------------+
+|                                                |                           | ``cilium.io/v2`` has a           |
+| 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22, 1.23 | * `networking.k8s.io/v1`_ | :term:`CustomResourceDefinition` |
++------------------------------------------------+---------------------------+----------------------------------+
 
 Cilium CRD schema validation
 ============================

--- a/Documentation/concepts/kubernetes/concepts.rst
+++ b/Documentation/concepts/kubernetes/concepts.rst
@@ -36,7 +36,7 @@ several Kubernetes resources:
 Networking For Existing Pods
 ============================
 
-In case pods were already running before the Cilium `DaemonSet` was deployed,
+In case pods were already running before the Cilium :term:`DaemonSet` was deployed,
 these pods will still be connected using the previous networking plugin
 according to the CNI configuration. A typical example for this is the
 ``kube-dns`` service which runs in the ``kube-system`` namespace by default.

--- a/Documentation/concepts/kubernetes/configuration.rst
+++ b/Documentation/concepts/kubernetes/configuration.rst
@@ -13,7 +13,7 @@ Configuration
 ConfigMap Options
 -----------------
 
-In the `ConfigMap` there are several options that can be configured according
+In the :term:`ConfigMap` there are several options that can be configured according
 to your preferences:
 
 * ``debug`` - Sets to run Cilium in full debug mode, which enables verbose
@@ -69,7 +69,7 @@ to your preferences:
   is modified, then during the next Cilium startup connectivity may be
   temporarily disrupted for endpoints with active connections.
 
-Any changes that you perform in the Cilium `ConfigMap` and in
+Any changes that you perform in the Cilium :term:`ConfigMap` and in
 ``cilium-etcd-secrets`` ``Secret`` will require you to restart any existing
 Cilium pods in order for them to pick the latest configuration.
 
@@ -80,7 +80,7 @@ Cilium pods in order for them to pick the latest configuration.
    information see the official Kubernetes docs:
    `Mounted ConfigMaps are updated automatically <https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically>`__
 
-The following `ConfigMap` is an example where the etcd cluster is running in 2
+The following :term:`ConfigMap` is an example where the etcd cluster is running in 2
 nodes, ``node-1`` and ``node-2`` with TLS, and client to server authentication
 enabled.
 
@@ -125,25 +125,25 @@ enabled.
 CNI
 ===
 
-`CNI` - Container Network Interface is the plugin layer used by Kubernetes to
+:term:`CNI` - Container Network Interface is the plugin layer used by Kubernetes to
 delegate networking configuration. You can find additional information on the
-`CNI` project website.
+:term:`CNI` project website.
 
-.. note:: Kubernetes `` >= 1.3.5`` requires the ``loopback`` `CNI` plugin to be
+.. note:: Kubernetes `` >= 1.3.5`` requires the ``loopback`` :term:`CNI` plugin to be
           installed on all worker nodes. The binary is typically provided by
           most Kubernetes distributions. See section :ref:`install_cni` for
-          instructions on how to install `CNI` in case the ``loopback`` binary
+          instructions on how to install :term:`CNI` in case the ``loopback`` binary
           is not already installed on your worker nodes.
 
 CNI configuration is automatically being taken care of when deploying Cilium
-via the provided `DaemonSet`. The script ``cni-install.sh`` is automatically run
+via the provided :term:`DaemonSet`. The script ``cni-install.sh`` is automatically run
 via the ``postStart`` mechanism when the ``cilium`` pod is started.
 
 .. note:: In order for the ``cni-install.sh`` script to work properly, the
           ``kubelet`` task must either be running on the host filesystem of the
           worker node, or the ``/etc/cni/net.d`` and ``/opt/cni/bin``
           directories must be mounted into the container where ``kubelet`` is
-          running. This can be achieved with `Volumes` mounts.
+          running. This can be achieved with :term:`Volumes` mounts.
 
 The CNI auto installation is performed as follows:
 
@@ -190,7 +190,7 @@ configuration file by adding the following to the ``env:`` section of the
           value: "true"
 
 The CNI installation can be configured with environment variables. These
-environment variables can be specified in the `DaemonSet` file like this:
+environment variables can be specified in the :term:`DaemonSet` file like this:
 
 .. code-block:: yaml
 

--- a/Documentation/concepts/kubernetes/intro.rst
+++ b/Documentation/concepts/kubernetes/intro.rst
@@ -16,11 +16,11 @@ What does Cilium provide in your Kubernetes Cluster?
 The following functionality is provided as your run Cilium in your Kubernetes
 cluster:
 
-* `CNI` plugin support to provide pod_connectivity_ with
+* :term:`CNI` plugin support to provide pod_connectivity_ with
   `multi host networking`.
-* Identity based implementation of the `NetworkPolicy` resource to isolate `pod`
-  to `pod` connectivity on Layer 3 and 4.
-* An extension to NetworkPolicy in the form of a `CustomResourceDefinition`
+* Identity based implementation of the `NetworkPolicy` resource to isolate :term:`pod<Pod>`
+  to pod connectivity on Layer 3 and 4.
+* An extension to NetworkPolicy in the form of a :term:`CustomResourceDefinition`
   which extends policy control to add:
 
   * Layer 7 policy enforcement on ingress and egress for the following
@@ -40,7 +40,7 @@ cluster:
 Pod-to-Pod Connectivity
 =======================
 
-In Kubernetes, containers are deployed within units referred to as `Pod`, which
+In Kubernetes, containers are deployed within units referred to as :term:`Pods<Pod>`, which
 include one or more containers reachable via a single IP address.  With Cilium,
 each Pod gets an IP address from the node prefix of the Linux node running the
 Pod. See :ref:`address_management` for additional details. In the absence of any

--- a/Documentation/concepts/kubernetes/policy.rst
+++ b/Documentation/concepts/kubernetes/policy.rst
@@ -21,11 +21,11 @@ with Kubernetes:
   as beta.
 
 - The extended `CiliumNetworkPolicy` format which is available as a
-  `CustomResourceDefinition` which supports specification of policies
+  :term:`CustomResourceDefinition` which supports specification of policies
   at Layers 3-7 for both ingress and egress.
 
 - The `CiliumClusterwideNetworkPolicy` format which is a cluster-scoped
-  `CustomResourceDefinition` for specifying cluster-wide policies to be enforced
+  :term:`CustomResourceDefinition` for specifying cluster-wide policies to be enforced
   by Cilium. The specification is same as that of `CiliumNetworkPolicy` with
   no specified namespace.
 

--- a/Documentation/concepts/kubernetes/requirements.rst
+++ b/Documentation/concepts/kubernetes/requirements.rst
@@ -36,7 +36,7 @@ full details on all systems requirements.
 Enable CNI in Kubernetes
 ========================
 
-`CNI` - Container Network Interface is the plugin layer used by Kubernetes to
+:term:`CNI` - Container Network Interface is the plugin layer used by Kubernetes to
 delegate networking configuration. CNI must be enabled in your Kubernetes
 cluster in order to install Cilium. This is done by passing
 ``--network-plugin=cni`` to kubelet on all nodes. For more information, see

--- a/Documentation/concepts/kubernetes/troubleshooting.rst
+++ b/Documentation/concepts/kubernetes/troubleshooting.rst
@@ -13,7 +13,7 @@ Troubleshooting
 Verifying the installation
 ==========================
 
-Check the status of the `DaemonSet` and verify that all desired instances are in
+Check the status of the :term:`DaemonSet` and verify that all desired instances are in
 "ready" state:
 
 .. code-block:: shell-session
@@ -51,7 +51,7 @@ In this example, the cause for the failure is a Linux kernel running on the
 worker node which is not meeting :ref:`admin_system_reqs`.
 
 If the cause for the problem is not apparent based on these simple steps,
-please come and seek help on our `Slack channel`.
+please come and seek help on our :term:`Slack channel`.
 
 Apiserver outside of cluster
 ==============================

--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -114,7 +114,7 @@ In addition, if the ``masqLinkLocal`` is not set or set to false, then
 The agent uses Fsnotify to track updates to the configuration file, so the original
 ``resyncInterval`` option is unnecessary.
 
-The example below shows how to configure the agent via `ConfigMap` and to verify it:
+The example below shows how to configure the agent via :term:`ConfigMap` and to verify it:
 
 .. code-block:: shell-session
 

--- a/Documentation/concepts/networking/routing.rst
+++ b/Documentation/concepts/networking/routing.rst
@@ -19,7 +19,7 @@ is the mode with the fewest requirements on the underlying networking
 infrastructure.
 
 In this mode, all cluster nodes form a mesh of tunnels using the UDP-based
-encapsulation protocols `VXLAN` or `Geneve`. All traffic between Cilium nodes
+encapsulation protocols :term:`VXLAN` or :term:`Geneve`. All traffic between Cilium nodes
 is encapsulated.
 
 Requirements on the network

--- a/Documentation/concepts/terminology.rst
+++ b/Documentation/concepts/terminology.rst
@@ -80,7 +80,7 @@ Endpoint
 
 Cilium makes application containers available on the network by assigning them
 IP addresses. Multiple application containers can share the same IP address; a
-typical example for this model is a Kubernetes `Pod`. All application containers
+typical example for this model is a Kubernetes :term:`Pod`. All application containers
 which share a common address are grouped together in what Cilium refers to as
 an endpoint.
 

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -36,7 +36,8 @@ import cilium_spellfilters
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 html_logo = "images/logo.svg"
-extensions = ['sphinx.ext.ifconfig',
+extensions = ['myst_parser',
+              'sphinx.ext.ifconfig',
               'sphinx.ext.githubpages',
               'sphinx.ext.extlinks',
               'sphinxcontrib.openapi',
@@ -52,9 +53,6 @@ templates_path = ['_templates']
 #
 # source_suffix = ['.rst', '.md']
 source_suffix = ['.rst', '.md']
-source_parsers = {
-    '.md': 'recommonmark.parser.CommonMarkParser',
-}
 
 # The master toctree document.
 master_doc = 'index'
@@ -159,6 +157,9 @@ todo_include_todos = False
 # Add custom filters for spell checks.
 spelling_filters = [cilium_spellfilters.WireGuardFilter]
 
+# Ignore some warnings from MyST parser
+suppress_warnings = ['myst.header']
+
 
 # -- Options for HTML output ----------------------------------------------
 
@@ -251,9 +252,9 @@ default_role = 'any'
 
 
 def setup(app):
-    app.add_stylesheet('parsed-literal.css')
-    app.add_stylesheet('copybutton.css')
-    app.add_stylesheet('editbutton.css')
-    app.add_javascript('clipboardjs.min.js')
-    app.add_javascript("copybutton.js")
-    app.add_stylesheet('helm-reference.css')
+    app.add_css_file('parsed-literal.css')
+    app.add_css_file('copybutton.css')
+    app.add_css_file('editbutton.css')
+    app.add_js_file('clipboardjs.min.js')
+    app.add_js_file("copybutton.js")
+    app.add_css_file('helm-reference.css')

--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -31,7 +31,7 @@ Create an AKS + Cilium CNI configuration
 ========================================
 
 Create a ``chaining.yaml`` file based on the following template to specify the
-desired CNI chaining configuration. This ConfigMap will be installed as the CNI
+desired CNI chaining configuration. This :term:`ConfigMap` will be installed as the CNI
 configuration file on all nodes and defines the chaining configuration. In the
 example below, the Azure CNI, portmap, and Cilium are chained together.
 
@@ -67,7 +67,7 @@ example below, the Azure CNI, portmap, and Cilium are chained together.
           ]
         }
 
-Deploy the `ConfigMap`:
+Deploy the :term:`ConfigMap`:
 
 .. code-block:: shell-session
 

--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -59,7 +59,7 @@ desired CNI chaining configuration:
           ]
         }
 
-Deploy the `ConfigMap`:
+Deploy the :term:`ConfigMap`:
 
 .. code-block:: shell-session
 

--- a/Documentation/gettingstarted/cni-chaining-generic-veth.rst
+++ b/Documentation/gettingstarted/cni-chaining-generic-veth.rst
@@ -66,7 +66,7 @@ desired CNI chaining configuration:
           ]
         }
 
-Deploy the `ConfigMap`:
+Deploy the :term:`ConfigMap`:
 
 .. code-block:: shell-session
 

--- a/Documentation/gettingstarted/cni-chaining-weave.rst
+++ b/Documentation/gettingstarted/cni-chaining-weave.rst
@@ -49,7 +49,7 @@ desired CNI chaining configuration:
             ]
         }
 
-Deploy the `ConfigMap`:
+Deploy the :term:`ConfigMap`:
 
 .. code-block:: shell-session
 

--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -43,7 +43,7 @@ replace the variables with values from your environment:
     curl -sfL https://get.k3s.io | K3S_URL='https://${MASTER_IP}:6443' K3S_TOKEN=${NODE_TOKEN} sh -
 
 Should you encounter any issues during the installation, please refer to the
-:ref:`troubleshooting_k8s` section and / or seek help on the `Slack channel`.
+:ref:`troubleshooting_k8s` section and / or seek help on the :term:`Slack channel`.
 
 Please consult the Kubernetes :ref:`k8s_requirements` for information on  how
 you need to configure your Kubernetes cluster to operate with Cilium.

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -21,7 +21,7 @@ environments (> 500 nodes) or if you want to run specific datapath modes, refer
 to the :ref:`k8s_install_advanced` guide.
 
 Should you encounter any issues during the installation, please refer to the
-:ref:`troubleshooting_k8s` section and / or seek help on the `Slack channel`.
+:ref:`troubleshooting_k8s` section and / or seek help on the :term:`Slack channel`.
 
 .. _create_cluster:
 

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -44,7 +44,7 @@ Configure Cilium
 
 When using an external kvstore, the address of the external kvstore needs to be
 configured in the ConfigMap. Download the base YAML and configure it with
-`Helm`:
+:term:`Helm`:
 
 .. include:: k8s-install-download-release.rst
 

--- a/Documentation/glossary.rst
+++ b/Documentation/glossary.rst
@@ -64,7 +64,6 @@ with words you expected to see here.
      https://tools.ietf.org/html/draft-ietf-nvo3-geneve-04
 
    Pod
-   Pods
      https://kubernetes.io/docs/concepts/workloads/pods/pod/
 
    Service

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -429,7 +429,7 @@ Privileges
 ==========
 
 The following privileges are required to run Cilium. When running the standard
-Kubernetes `DaemonSet`, the privileges are automatically granted to Cilium.
+Kubernetes :term:`DaemonSet`, the privileges are automatically granted to Cilium.
 
 * Cilium interacts with the Linux kernel to install eBPF program which will then
   perform networking tasks and implement security rules. In order to install

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -13,7 +13,7 @@ Upgrade Guide
 .. _upgrade_general:
 
 This upgrade guide is intended for Cilium running on Kubernetes. If you have
-questions, feel free to ping us on the `Slack channel`.
+questions, feel free to ping us on the :term:`Slack channel`.
 
 .. include:: upgrade-warning.rst
 
@@ -106,7 +106,7 @@ continuing with the upgrade.
 Clean up pre-flight check
 -------------------------
 
-Once the number of READY for the preflight `DaemonSet` is the same as the number
+Once the number of READY for the preflight :term:`DaemonSet` is the same as the number
 of cilium pods running and the preflight ``Deployment`` is marked as READY ``1/1``
 you can delete the cilium-preflight and proceed with the upgrade.
 
@@ -151,7 +151,7 @@ corner.
 Step 2: Use Helm to Upgrade your Cilium deployment
 --------------------------------------------------------------------------------------
 
-`Helm` can be used to either upgrade Cilium directly or to generate a new set of
+:term:`Helm` can be used to either upgrade Cilium directly or to generate a new set of
 YAML files that can be used to upgrade an existing deployment via ``kubectl``.
 By default, Helm will generate the new templates using the default values files
 packaged with each new release. You still need to ensure that you are
@@ -198,7 +198,7 @@ version which was installed in this cluster. Valid options are:
    Instead of using ``--set``, you can also save the values relative to your
    deployment in a YAML file and use it to regenerate the YAML for the latest
    Cilium version. Running any of the previous commands will overwrite
-   the existing cluster's `ConfigMap` so it is critical to preserve any existing
+   the existing cluster's :term:`ConfigMap` so it is critical to preserve any existing
    options, either by setting them at the command line or storing them in a
    YAML file, similar to:
 
@@ -268,7 +268,7 @@ Cilium to the state it was in prior to the upgrade.
     incompatible feature use before downgrading/rolling back. This step is only
     required after new functionality introduced in the new minor version has
     already been explicitly used by creating new resources or by opting into
-    new features via the `ConfigMap`.
+    new features via the :term:`ConfigMap`.
 
 .. _version_notes:
 .. _upgrade_version_specifics:
@@ -493,7 +493,7 @@ available during the upgrade:
 Rebasing a ConfigMap
 --------------------
 
-This section describes the procedure to rebase an existing `ConfigMap` to the
+This section describes the procedure to rebase an existing :term:`ConfigMap` to the
 template of another version.
 
 Export the current ConfigMap
@@ -529,7 +529,7 @@ Export the current ConfigMap
           selfLink: /api/v1/namespaces/kube-system/configmaps/cilium-config
 
 
-In the `ConfigMap` above, we can verify that Cilium is using ``debug`` with
+In the :term:`ConfigMap` above, we can verify that Cilium is using ``debug`` with
 ``true``, it has a etcd endpoint running with `TLS <https://etcd.io/docs/latest/op-guide/security/>`_,
 and the etcd is set up to have `client to server authentication <https://etcd.io/docs/latest/op-guide/security/#example-2-client-to-server-authentication-with-https-client-certificates>`_.
 
@@ -548,7 +548,7 @@ Generate the latest ConfigMap
 Add new options
 ~~~~~~~~~~~~~~~
 
-Add the new options manually to your old `ConfigMap`, and make the necessary
+Add the new options manually to your old :term:`ConfigMap`, and make the necessary
 changes.
 
 In this example, the ``debug`` option is meant to be kept with ``true``, the
@@ -556,7 +556,7 @@ In this example, the ``debug`` option is meant to be kept with ``true``, the
 option, but after reading the :ref:`version_notes` the value was kept unchanged
 from the default value.
 
-After making the necessary changes, the old `ConfigMap` was migrated with the
+After making the necessary changes, the old :term:`ConfigMap` was migrated with the
 new options while keeping the configuration that we wanted:
 
 ::
@@ -593,15 +593,15 @@ Apply new ConfigMap
 ~~~~~~~~~~~~~~~~~~~
 
 After adding the options, manually save the file with your changes and install
-the `ConfigMap` in the ``kube-system`` namespace of your cluster.
+the :term:`ConfigMap` in the ``kube-system`` namespace of your cluster.
 
 .. code-block:: shell-session
 
         $ kubectl apply -n kube-system -f ./cilium-cm-old.yaml
 
-As the `ConfigMap` is successfully upgraded we can start upgrading Cilium
+As the :term:`ConfigMap` is successfully upgraded we can start upgrading Cilium
 ``DaemonSet`` and ``RBAC`` which will pick up the latest configuration from the
-`ConfigMap`.
+:term:`ConfigMap`.
 
 
 .. _cidr_limitations:

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -1,34 +1,36 @@
 alabaster==0.7.12
 Babel==2.9.1
-certifi==2018.10.15
-chardet==3.0.4
+certifi==2021.10.8
+chardet==4.0.0
 docutils==0.17
-idna==2.7
-imagesize==1.1.0
-Jinja2==2.11.3
-jsonschema==2.6.0
-MarkupSafe==1.1.1
+idna==3.3
+imagesize==1.3.0
+Jinja2==3.0.3
+jsonschema==4.4.0
+# for m2r (dependency to sphinxcontrib-openapi), see https://github.com/miyakogi/m2r/issues/66
+mistune<2.0.0
+MarkupSafe==2.1.0
 myst-parser==0.17.0
 pyenchant==3.2.2
-Pygments==2.7.4
-pytz==2018.7
-PyYAML==5.4
-requests==2.25.1
-semver==2.9.0
-six==1.15.0
-snowballstemmer==1.2.1
+Pygments==2.11.2
+pytz==2021.3
+PyYAML==6.0
+requests==2.27.1
+semver==2.13.0
+six==1.16.0
+snowballstemmer==2.2.0
 Sphinx==4.5.0
-sphinx-autobuild==0.7.1
+sphinx-autobuild==2021.3.14
 # forked read the docs themez
 git+https://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
 sphinx-rtd-theme==0.2.4; platform_machine == "aarch64"
 sphinxcontrib-httpdomain==1.8.0
-sphinxcontrib-openapi==0.3.2
-sphinxcontrib-spelling==4.2.1
-sphinxcontrib-websupport==1.1.0
+sphinxcontrib-openapi==0.7.0
+sphinxcontrib-spelling==7.3.2
+sphinxcontrib-websupport==1.2.4
 sphinx-tabs==3.3.1
 sphinx-version-warning==1.1.2
-typing==3.6.6
-urllib3==1.26.5
-yamllint==1.22.0
+typing==3.7.4.3
+urllib3==1.26.8
+yamllint==1.26.3
 rstcheck==3.3.1

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -22,8 +22,7 @@ snowballstemmer==2.2.0
 Sphinx==4.5.0
 sphinx-autobuild==2021.3.14
 # forked read the docs themez
-git+https://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
-sphinx-rtd-theme==0.2.4; platform_machine == "aarch64"
+git+https://github.com/cilium/sphinx_rtd_theme.git@v1.0
 sphinxcontrib-httpdomain==1.8.0
 sphinxcontrib-openapi==0.7.0
 sphinxcontrib-spelling==7.3.2

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -9,7 +9,7 @@ Jinja2==2.11.3
 jsonschema==2.6.0
 MarkupSafe==1.1.1
 myst-parser==0.17.0
-pyenchant==2.0.0
+pyenchant==3.2.2
 Pygments==2.7.4
 pytz==2018.7
 PyYAML==5.4

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -2,31 +2,31 @@ alabaster==0.7.12
 Babel==2.9.1
 certifi==2018.10.15
 chardet==3.0.4
-docutils==0.14
+docutils==0.17
 idna==2.7
 imagesize==1.1.0
 Jinja2==2.11.3
 jsonschema==2.6.0
 MarkupSafe==1.1.1
+myst-parser==0.17.0
 pyenchant==2.0.0
 Pygments==2.7.4
 pytz==2018.7
 PyYAML==5.4
-recommonmark==0.4.0
 requests==2.25.1
 semver==2.9.0
 six==1.15.0
 snowballstemmer==1.2.1
-Sphinx==1.8.1
+Sphinx==4.5.0
 sphinx-autobuild==0.7.1
 # forked read the docs themez
 git+https://github.com/cilium/sphinx_rtd_theme.git@v0.7; platform_machine != "aarch64"
 sphinx-rtd-theme==0.2.4; platform_machine == "aarch64"
-sphinxcontrib-httpdomain==1.7.0
+sphinxcontrib-httpdomain==1.8.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-spelling==4.2.1
 sphinxcontrib-websupport==1.1.0
-sphinx-tabs==1.1.13
+sphinx-tabs==3.3.1
 sphinx-version-warning==1.1.2
 typing==3.6.6
 urllib3==1.26.5

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -128,6 +128,7 @@ Terraform
 Tierney
 Tu
 Twilio
+Uptime
 VM
 VPC
 Vagrantcloud
@@ -258,6 +259,7 @@ cnpStatusUpdates
 codebase
 committer
 committers
+compat
 compinit
 conf
 confFileMountPath
@@ -307,6 +309,7 @@ decapsulated
 decapsulation
 decrypt
 decrypted
+deepcopy
 deletetopic
 demux
 dereference
@@ -471,6 +474,7 @@ identityChangeGracePeriod
 identityGCInterval
 identityHeartbeatTimeout
 ie
+ifindex
 imagePullSecrets
 incrementing
 indices
@@ -685,6 +689,7 @@ originatingTLS
 pahole
 parserfactory
 parsers
+passthrough
 pc
 pcap
 perf
@@ -728,6 +733,7 @@ prog
 programmability
 prometheus
 protobuf
+proxying
 proxylib
 pullPolicy
 qdisc

--- a/api/v1/models/dns_lookup.go
+++ b/api/v1/models/dns_lookup.go
@@ -33,7 +33,7 @@ type DNSLookup struct {
 	// IP addresses returned in this lookup
 	Ips []string `json:"ips"`
 
-	// The absolute time when this data was recieved
+	// The absolute time when this data was received
 	// Format: date-time
 	LookupTime strfmt.DateTime `json:"lookup-time,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3064,7 +3064,7 @@ definitions:
         description: The TTL in the DNS response
         type: integer
       lookup-time:
-        description: The absolute time when this data was recieved
+        description: The absolute time when this data was received
         type: string
         format: date-time
       expiration-time:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1876,7 +1876,7 @@ func init() {
           }
         },
         "lookup-time": {
-          "description": "The absolute time when this data was recieved",
+          "description": "The absolute time when this data was received",
           "type": "string",
           "format": "date-time"
         },
@@ -6358,7 +6358,7 @@ func init() {
           }
         },
         "lookup-time": {
-          "description": "The absolute time when this data was recieved",
+          "description": "The absolute time when this data was received",
           "type": "string",
           "format": "date-time"
         },

--- a/bugtool/cmd/cmdref.go
+++ b/bugtool/cmd/cmdref.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -32,10 +31,7 @@ func genCmdRef() {
 	}
 }
 func linkHandler(s string) string {
-	// The generated files have a 'See also' section but the URL's are
-	// hardcoded to use Markdown but we only want / have them in HTML
-	// later.
-	return strings.Replace(s, ".md", ".html", 1)
+	return s
 }
 
 func filePrepend(s string) string {

--- a/cilium-health/cmd/root.go
+++ b/cilium-health/cmd/root.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -104,10 +103,7 @@ func run(cmd *cobra.Command, args []string) {
 }
 
 func linkHandler(s string) string {
-	// The generated files have a 'See also' section but the URL's are
-	// hardcoded to use Markdown but we only want / have them in HTML
-	// later.
-	return strings.Replace(s, ".md", ".html", 1)
+	return s
 }
 
 func filePrepend(s string) string {

--- a/cilium/cmd/cmdref.go
+++ b/cilium/cmd/cmdref.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -31,10 +30,7 @@ func genCmdRef() {
 }
 
 func linkHandler(s string) string {
-	// The generated files have a 'See also' section but the URL's are
-	// hardcoded to use Markdown but we only want / have them in HTML
-	// later.
-	return "../" + strings.Replace(s, ".md", "", 1)
+	return s
 }
 
 func filePrepend(s string) string {

--- a/daemon/cmd/cmdref.go
+++ b/daemon/cmd/cmdref.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -20,10 +19,7 @@ func genMarkdown(cmd *cobra.Command, cmdRefDir string) {
 }
 
 func linkHandler(s string) string {
-	// The generated files have a 'See also' section but the URL's are
-	// hardcoded to use Markdown but we only want / have them in HTML
-	// later.
-	return strings.Replace(s, ".md", ".html", 1)
+	return s
 }
 
 func filePrepend(s string) string {

--- a/operator/cmdref.go
+++ b/operator/cmdref.go
@@ -5,17 +5,13 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
 
 func linkHandler(s string) string {
-	// The generated files have a 'See also' section but the URL's are
-	// hardcoded to use Markdown but we only want / have them in HTML
-	// later.
-	return strings.Replace(s, ".md", ".html", 1)
+	return s
 }
 
 func filePrepend(s string) string {


### PR DESCRIPTION
This PR updates Sphinx to v4.5.0. A number of dependencies are updated as well. In particular, the Alpine image for the builder for the docs is updated.

This comes with a number of minor adjustments, please refer to individual commit descriptions for details.

Note that the last commit update the theme for the documentation: this is required after the Sphinx upgrade. The current version of this commit points to [my own clone of the theme](https://github.com/qmonnet/sphinx_rtd_theme/commits/wip/rebase) (with our changes rebased on latest upstream), because this is still under test. If everything goes well this new version should be pushed to a dedicated branch on Cilium's fork of the theme, and the last commit of this PR should be updated to point to it. The last commit, updating the CI image for building the documentation, is also to be removed after the main image has been updated.

Motivations:
- More add-ons available, e.g. `<details>` blocks (and Mermaid rendering?)
- No more `npm install` (broken on M1 Macs) for using the theme
- More configuration options in Sphinx and add-ons, some of which we wanted to use in the past
- Slightly better context information provided on build errors
- More up-to-date software and Docker images

Fixes: #18885