### PR TITLE
ci: Pin down image for the documentation workflow

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           persist-credentials: false
-      - uses: docker://cilium/docs-builder:latest
+      - uses: docker://cilium/docs-builder:2021-06-09@sha256:7126ea9182667ab1961bd8bb71265cbd3ec951e412910a116e24e0e74d7fc653
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           filters: |
             src:
+              - .github/workflows/documentation.yaml
               - 'Documentation/**'
               - 'bugtool/cmd/**'
               - 'cilium/cmd/**'


### PR DESCRIPTION
Pin down the `docs-builder` image used for building Documentation in the GitHub workflow, and make sure we run this workflow when its YAML description change. Please look at individual commit descriptions for more details.
