### PR TITLE
test: Fix whitespace in docker-run-cilium

### DIFF
--- a/test/provision/docker-run-cilium.sh
+++ b/test/provision/docker-run-cilium.sh
@@ -4,7 +4,7 @@
 CILIUM_OPTS=$@
 # Default kvstore to consul
 if [[ "${CILIUM_OPTS}" != *--kvstore* ]]; then
-    CILIUM_OPTS+="--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500"
+    CILIUM_OPTS+=" --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500"
 fi
 
 CILIUM_IMAGE=${CILIUM_IMAGE:-cilium/cilium:latest}


### PR DESCRIPTION
Add space between provided and default args.

Fixes: #19310
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
