### PR TITLE
daemon: Restore old CIDR identities

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -164,6 +164,7 @@ cilium-agent [flags]
       --hubble-tls-key-file string                           Path to the private key file for the Hubble server. The file must contain PEM encoded data.
       --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
       --identity-change-grace-period duration                Time to wait before using new identity on endpoint identity change (default 5s)
+      --identity-restore-grace-period duration               Time to wait before releasing unused restored CIDR identities during agent restart (default 10m0s)
       --install-iptables-rules                               Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
       --install-no-conntrack-iptables-rules                  Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
       --ip-allocation-timeout duration                       Time after which an incomplete CIDR allocation is considered failed (default 2m0s)

--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -242,7 +242,7 @@ func (m *VMManager) AllocateNodeIdentity(n *nodeTypes.RegisterNode) *identity.Id
 		return id
 	}
 
-	id, allocated, err := m.identityAllocator.AllocateIdentity(ctx, vmLabels, true)
+	id, allocated, err := m.identityAllocator.AllocateIdentity(ctx, vmLabels, true, identity.InvalidIdentity)
 	if err != nil {
 		log.WithError(err).Error("unable to resolve identity")
 	} else {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -469,6 +469,9 @@ func initializeFlags() {
 	flags.Duration(option.IdentityChangeGracePeriod, defaults.IdentityChangeGracePeriod, "Time to wait before using new identity on endpoint identity change")
 	option.BindEnv(option.IdentityChangeGracePeriod)
 
+	flags.Duration(option.IdentityRestoreGracePeriod, defaults.IdentityRestoreGracePeriod, "Time to wait before releasing unused restored CIDR identities during agent restart")
+	option.BindEnv(option.IdentityRestoreGracePeriod)
+
 	flags.String(option.IdentityAllocationMode, option.IdentityAllocationModeKVstore, "Method to use for identity allocation")
 	option.BindEnv(option.IdentityAllocationMode)
 
@@ -1768,6 +1771,23 @@ func runDaemon() {
 			})
 			ms.CollectStaleMapGarbage()
 			ms.RemoveDisabledMaps()
+
+			if len(d.restoredCIDRs) > 0 {
+				// Release restored CIDR identities after a grace period (default 10
+				// minutes).  Any identities actually in use will still exist after
+				// this.
+				//
+				// This grace period is needed when running on an external workload
+				// where policy synchronization is not done via k8s. Also in k8s
+				// case it is prudent to allow concurrent endpoint regenerations to
+				// (re-)allocate the restored identities before we release them.
+				time.Sleep(option.Config.IdentityRestoreGracePeriod)
+				log.Debugf("Releasing reference counts for %d restored CIDR identities", len(d.restoredCIDRs))
+
+				d.ipcache.ReleaseCIDRIdentitiesByCIDR(d.restoredCIDRs)
+				// release the memory held by restored CIDRs
+				d.restoredCIDRs = nil
+			}
 		}()
 		d.endpointManager.Subscribe(d)
 		defer d.endpointManager.Unsubscribe(d)

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -290,7 +290,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	// Release of these identities will be tied to the corresponding policy
 	// in the policy.Repository and released upon policyDelete().
 	newlyAllocatedIdentities := make(map[string]*identity.Identity)
-	if _, err := d.ipcache.AllocateCIDRs(prefixes, newlyAllocatedIdentities); err != nil {
+	if _, err := d.ipcache.AllocateCIDRs(prefixes, nil, newlyAllocatedIdentities); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
 			"Failed to allocate identities for CIDRs during policy add")

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -276,23 +276,23 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
+	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	prodBarLbls := labels.Labels{lblBar.Key: lblBar, lblProd.Key: lblProd}
-	prodBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodBarLbls, true)
+	prodBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodBarLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), prodBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
+	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 	prodFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd}
-	prodFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodFooLbls, true)
+	prodFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodFooLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), prodFooSecLblsCtx, false)
 	prodFooJoeLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd, lblJoe.Key: lblJoe}
-	prodFooJoeSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodFooJoeLbls, true)
+	prodFooJoeSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), prodFooJoeLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), prodFooJoeSecLblsCtx, false)
 
@@ -409,11 +409,11 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 func (ds *DaemonSuite) TestL4_L7_Shadowing(c *C) {
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
+	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
+	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 
@@ -493,11 +493,11 @@ func (ds *DaemonSuite) TestL4_L7_Shadowing(c *C) {
 func (ds *DaemonSuite) TestL4_L7_ShadowingShortCircuit(c *C) {
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
+	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
+	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 
@@ -571,15 +571,15 @@ func (ds *DaemonSuite) TestL3_dependent_L7(c *C) {
 
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
+	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
+	qaFooSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 	qaJoeLbls := labels.Labels{lblJoe.Key: lblJoe, lblQA.Key: lblQA}
-	qaJoeSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaJoeLbls, true)
+	qaJoeSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaJoeLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaJoeSecLblsCtx, false)
 
@@ -733,7 +733,7 @@ func (ds *DaemonSuite) TestReplacePolicy(c *C) {
 
 func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
+	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 
@@ -818,7 +818,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 
 func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true)
+	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 
@@ -907,7 +907,7 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 
 	// Allocate identities needed for this test
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooID, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true)
+	qaFooID, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
 	c.Assert(err, Equals, nil)
 	defer ds.d.identityAllocator.Release(context.Background(), qaFooID, false)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -139,6 +139,10 @@ const (
 	// option.IdentityChangeGracePeriod
 	IdentityChangeGracePeriod = 5 * time.Second
 
+	// IdentityRestoreGracePeriod is the default value for
+	// option.IdentityRestoreGracePeriod
+	IdentityRestoreGracePeriod = 10 * time.Minute
+
 	// ExecTimeout is a timeout for executing commands.
 	ExecTimeout = 300 * time.Second
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1875,7 +1875,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 	// identity is new, then this will start updating the policy for other
 	// co-located endpoints without having to wait for that RTT.
 	notifySelectorCache := true
-	allocatedIdentity, _, err := e.allocator.AllocateIdentity(allocateCtx, newLabels, notifySelectorCache)
+	allocatedIdentity, _, err := e.allocator.AllocateIdentity(allocateCtx, newLabels, notifySelectorCache, identity.InvalidIdentity)
 	if err != nil {
 		err = fmt.Errorf("unable to resolve identity: %s", err)
 		e.LogStatus(Other, Warning, fmt.Sprintf("%s (will retry)", err.Error()))

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -261,7 +261,7 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 	c.Assert(apiPolicy.Egress.Allowed, checker.DeepEquals, allowAllIdentityList)
 
 	fooLbls := labels.Labels{"": labels.ParseLabel("foo")}
-	fooIdentity, _, err := e.allocator.AllocateIdentity(context.Background(), fooLbls, false)
+	fooIdentity, _, err := e.allocator.AllocateIdentity(context.Background(), fooLbls, false, identity.InvalidIdentity)
 	c.Assert(err, check.Equals, nil)
 	defer s.mgr.Release(context.Background(), fooIdentity, false)
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -166,7 +166,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(nil), rsp, mgr, 12345, StateRegenerating)
 
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	epIdentity, _, err := mgr.AllocateIdentity(context.Background(), qaBarLbls, true)
+	epIdentity, _, err := mgr.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	c.Assert(err, check.IsNil)
 	ep.SetIdentity(epIdentity, true)
 

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -263,7 +263,7 @@ func filterCIDRLabels(log logrus.FieldLogger, labels []string) []string {
 }
 
 func sortAndFilterLabels(log logrus.FieldLogger, labels []string, securityIdentity uint32) []string {
-	if securityIdentity&uint32(identity.LocalIdentityFlag) != 0 {
+	if identity.NumericIdentity(securityIdentity).HasLocalScope() {
 		labels = filterCIDRLabels(log, labels)
 	}
 	sort.Strings(labels)

--- a/pkg/identity/cache/local_test.go
+++ b/pkg/identity/cache/local_test.go
@@ -37,7 +37,7 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	// allocate identities for all available numeric identities with a
 	// unique label
 	for i := minID; i <= maxID; i++ {
-		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}))
+		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity)
 		c.Assert(err, IsNil)
 		c.Assert(isNew, Equals, true)
 		identities[id.ID] = id
@@ -46,7 +46,7 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	// allocate the same labels again. This must be successful and the same
 	// identities must be returned.
 	for i := minID; i <= maxID; i++ {
-		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}))
+		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity)
 		c.Assert(isNew, Equals, false)
 		c.Assert(err, IsNil)
 
@@ -55,7 +55,7 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	}
 
 	// Allocation must fail as we are out of IDs
-	_, _, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}))
+	_, _, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity)
 	c.Assert(err, Not(IsNil))
 
 	// release all identities, this must decrement the reference count but not release the identities yet
@@ -77,7 +77,7 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 
 	// allocate all identities again
 	for i := minID; i <= maxID; i++ {
-		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}))
+		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity)
 		c.Assert(err, IsNil)
 		c.Assert(isNew, Equals, true)
 		identities[id.ID] = id
@@ -87,7 +87,7 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	randomID := identity.NumericIdentity(3) | identity.LocalIdentityFlag
 	c.Assert(cache.release(identities[randomID]), Equals, true)
 
-	id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}))
+	id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity)
 	c.Assert(err, IsNil)
 	c.Assert(isNew, Equals, true)
 	// the selected numeric identity must be the one released before

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -268,7 +268,7 @@ func (ipc *IPCache) injectLabels(prefix string, lbls labels.Labels) (*identity.I
 		return ipc.injectLabelsForCIDR(prefix, lbls)
 	}
 
-	return ipc.IdentityAllocator.AllocateIdentity(ctx, lbls, false)
+	return ipc.IdentityAllocator.AllocateIdentity(ctx, lbls, false, identity.InvalidIdentity)
 }
 
 // injectLabelsForCIDR will allocate a CIDR identity for the given prefix. The
@@ -300,7 +300,7 @@ func (ipc *IPCache) injectLabelsForCIDR(p string, lbls labels.Labels) (*identity
 		"Injecting CIDR labels for prefix",
 	)
 
-	return ipc.allocate(cidr, allLbls)
+	return ipc.allocate(cidr, allLbls, identity.InvalidIdentity)
 }
 
 // RemoveLabelsExcluded removes the given labels from all IPs inside the IDMD
@@ -392,7 +392,7 @@ func (ipc *IPCache) removeLabelsFromIPs(
 				identity.AddReservedIdentityWithLabels(id.ID, l)
 			}
 
-			newID, _, err := ipc.IdentityAllocator.AllocateIdentity(context.TODO(), l, false)
+			newID, _, err := ipc.IdentityAllocator.AllocateIdentity(context.TODO(), l, false, identity.InvalidIdentity)
 			if err != nil {
 				log.WithError(err).WithFields(logrus.Fields{
 					logfields.IPAddr:         prefix,

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -121,7 +121,7 @@ func (k RuleTranslator) generateToCidrFromEndpoint(
 		// policy would be first pushed to the endpoint policies and then to the ipcache to
 		// avoid traffic mapping to an ID that the endpoint policy maps do not know about
 		// yet.
-		if _, err := k.ipcache.AllocateCIDRs(prefixes, nil); err != nil {
+		if _, err := k.ipcache.AllocateCIDRs(prefixes, nil, nil); err != nil {
 			return err
 		}
 	}

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -83,6 +83,20 @@ func (k Key) String() string {
 	return "<unknown>"
 }
 
+func (k Key) IPNet() *net.IPNet {
+	cidr := &net.IPNet{}
+	prefixLen := k.Prefixlen - getStaticPrefixBits()
+	switch k.Family {
+	case bpf.EndpointKeyIPv4:
+		cidr.IP = net.IP(k.IP[:net.IPv4len])
+		cidr.Mask = net.CIDRMask(int(prefixLen), 32)
+	case bpf.EndpointKeyIPv6:
+		cidr.IP = net.IP(k.IP[:net.IPv6len])
+		cidr.Mask = net.CIDRMask(int(prefixLen), 128)
+	}
+	return cidr
+}
+
 // getPrefixLen determines the length that should be set inside the Key so that
 // the lookup prefix is correct in the BPF map key. The specified 'prefixBits'
 // indicates the number of bits in the IP that must match to match the entry in

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -718,6 +718,10 @@ const (
 	// IdentityChangeGracePeriod option
 	IdentityChangeGracePeriod = "identity-change-grace-period"
 
+	// IdentityRestoreGracePeriod is the name of the
+	// IdentityRestoreGracePeriod option
+	IdentityRestoreGracePeriod = "identity-restore-grace-period"
+
 	// EnableHealthChecking is the name of the EnableHealthChecking option
 	EnableHealthChecking = "enable-health-checking"
 
@@ -1675,6 +1679,13 @@ type DaemonConfig struct {
 	// to whitelist the new upcoming identity of the endpoint.
 	IdentityChangeGracePeriod time.Duration
 
+	// IdentityRestoreGracePeriod is the grace period that needs to pass before CIDR identities
+	// restored during agent restart are released. If any of the restored identities remains
+	// unused after this time, they will be removed from the IP cache. Any of the restored
+	// identities that are used in network policies will remain in the IP cache until all such
+	// policies are removed.
+	IdentityRestoreGracePeriod time.Duration
+
 	// PolicyQueueSize is the size of the queues for the policy repository.
 	// A larger queue means that more events related to policy can be buffered.
 	PolicyQueueSize int
@@ -2148,6 +2159,7 @@ var (
 		KVstoreConnectivityTimeout:   defaults.KVstoreConnectivityTimeout,
 		IPAllocationTimeout:          defaults.IPAllocationTimeout,
 		IdentityChangeGracePeriod:    defaults.IdentityChangeGracePeriod,
+		IdentityRestoreGracePeriod:   defaults.IdentityRestoreGracePeriod,
 		FixedIdentityMapping:         make(map[string]string),
 		KVStoreOpt:                   make(map[string]string),
 		LogOpt:                       make(map[string]string),
@@ -2677,6 +2689,7 @@ func (c *DaemonConfig) Populate() {
 	c.HTTPRetryCount = viper.GetInt(HTTPRetryCount)
 	c.HTTPRetryTimeout = viper.GetInt(HTTPRetryTimeout)
 	c.IdentityChangeGracePeriod = viper.GetDuration(IdentityChangeGracePeriod)
+	c.IdentityRestoreGracePeriod = viper.GetDuration(IdentityRestoreGracePeriod)
 	c.IPAM = viper.GetString(IPAM)
 	c.IPv4Range = viper.GetString(IPv4Range)
 	c.IPv4NodeAddr = viper.GetString(IPv4NodeAddr)

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -67,7 +67,7 @@ func (f *MockIdentityAllocator) GetIdentities() cache.IdentitiesModel {
 
 // AllocateIdentity allocates a fake identity. It is meant to generally mock
 // the canonical identity allocator logic.
-func (f *MockIdentityAllocator) AllocateIdentity(_ context.Context, lbls labels.Labels, _ bool) (*identity.Identity, bool, error) {
+func (f *MockIdentityAllocator) AllocateIdentity(_ context.Context, lbls labels.Labels, _ bool, _ identity.NumericIdentity) (*identity.Identity, bool, error) {
 	if reservedIdentity := identity.LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
 		return reservedIdentity, false, nil
 	}

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -10,12 +10,14 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/test/config"
@@ -64,6 +66,66 @@ func (s *SSHMeta) BpfLBList(noDuplicates bool) (map[string][]string, error) {
 	}
 
 	return result, nil
+}
+
+// BpfIPCacheList returns the output of `cilium bpf ipcache list -o json` as a map
+// Key will be the CIDR (address with mask) and the value is the associated numeric security identity
+func (s *SSHMeta) BpfIPCacheList(localScopeOnly bool) (map[string]uint32, error) {
+	var (
+		dump   map[string][]string
+		result map[string]uint32
+		res    *CmdRes
+	)
+
+	res = s.ExecCilium("bpf ipcache list -o json")
+
+	if !res.WasSuccessful() {
+		return nil, fmt.Errorf("cannot get bpf ipcache list: %s", res.CombineOutput())
+	}
+	err := res.Unmarshal(&dump)
+	if err != nil {
+		return nil, err
+	}
+
+	result = make(map[string]uint32, len(dump))
+	for k, v := range dump {
+		var nid uint32
+		for _, s := range v {
+			idWord := "identity="
+			idIdx := strings.Index(s, idWord)
+			if idIdx >= 0 {
+				idIdx += len(idWord)
+				endIdx := strings.Index(s[idIdx:], " ")
+				if endIdx >= 0 {
+					endIdx += idIdx
+				} else {
+					endIdx = len(s)
+				}
+				nid64, err := strconv.ParseUint(s[idIdx:endIdx], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("cannot parse identity from: %s (%s): %s", s, s[idIdx:endIdx], err)
+				}
+				nid = uint32(nid64)
+				if localScopeOnly && !identity.NumericIdentity(nid).HasLocalScope() {
+					nid = 0
+					continue
+				}
+			}
+		}
+		if nid != 0 {
+			result[k] = nid
+		}
+	}
+
+	return result, nil
+}
+
+// SelectedIdentities returns filtered identities from the output of `cilium policy selectors list
+// -o json` as a string
+func (s *SSHMeta) SelectedIdentities(match string) string {
+	res := s.Exec(fmt.Sprintf(`cilium policy selectors list -o json | jq '.[] | select(.selector | test("%s")) | .identities[] | .'`, match))
+	res.ExpectSuccess("Failed getting identities for %s selectors", match)
+	return res.Stdout()
 }
 
 // ExecCilium runs a Cilium CLI command and returns the resultant cmdRes.


### PR DESCRIPTION
Dump old bpf IP cache on daemon startup and restore all locally allocated (CIDR) identities with the same numeric security identity as before. This helps avoid transient drops during restart due to identity changes.

Any restored identities that remain unused after 10 minutes are removed from the IP cache. This grace period is configurable with a new agent command line option `--identity-restore-grace-period` that takes a duration, e.g., `identity-restore-grace-period=5m` for 5 minutes.

Note that this feature requires support from the LInux kernel. Kernels from 4.11 to 4.15 inclusive do not support this feature.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
Locally allocated identities are now restored during restart, helping avoid transient drops due to identity changes in policies.
```
