### PR TITLE
Upgrade to cilium/lumberjack v2.2.2 to Flush() gzip writer before Sync()ing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
 	github.com/cilium/ebpf v0.8.1
 	github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c
-	github.com/cilium/lumberjack/v2 v2.2.1
+	github.com/cilium/lumberjack/v2 v2.2.2
 	github.com/cilium/proxy v0.0.0-20220310090216-617157adcd74
 	github.com/cilium/workerpool v1.1.2
 	github.com/containernetworking/cni v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c h1:BNplQ8/gUxxF3ISPjM5
 github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c/go.mod h1:Ascfar4FtgB+K+mwqbZpSb3WVZ5sPFIarg+iAOXNZqI=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyRem1awcpz3icz/HoL8Dxg/m6a4=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
-github.com/cilium/lumberjack/v2 v2.2.1 h1:RO55E3EXM0tRI0rEnCSx7YQgG2XddTFNiwOgq6io+FU=
-github.com/cilium/lumberjack/v2 v2.2.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
+github.com/cilium/lumberjack/v2 v2.2.2 h1:RKTdhb63DY0Xu7pE1pipMj7Zq28LyvBGSrCneHiKm4A=
+github.com/cilium/lumberjack/v2 v2.2.2/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d h1:skjwi8X3DdLWRI4AFmiAn83ruNoAw4f2kvdBlM8EI8c=
 github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
 github.com/cilium/proxy v0.0.0-20220310090216-617157adcd74 h1:y6fqnpfQ4ePgJ56DztfsOUgCJTiCtY2R0gYGcbghQO4=

--- a/vendor/github.com/cilium/lumberjack/v2/lumberjack.go
+++ b/vendor/github.com/cilium/lumberjack/v2/lumberjack.go
@@ -507,18 +507,27 @@ func compressLogFile(src, dst string) (err error) {
 		return err
 	}
 
+	// Flush the gz writer before Sync()ing
+	if err := gz.Flush(); err != nil {
+		return err
+	}
+
 	// fsync is important, otherwise os.Rename could rename a zero-length file
 	if err := gzf.Sync(); err != nil {
 		return err
 	}
 
+	// Close the gzip writer
 	if err := gz.Close(); err != nil {
 		return err
 	}
+
+	// close the underlying gzip file
 	if err := gzf.Close(); err != nil {
 		return err
 	}
 
+	// close the source file we copied from
 	if err := f.Close(); err != nil {
 		return err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -181,7 +181,7 @@ github.com/cilium/ebpf/rlimit
 github.com/cilium/ipam/cidrset
 github.com/cilium/ipam/service/allocator
 github.com/cilium/ipam/service/ipallocator
-# github.com/cilium/lumberjack/v2 v2.2.1
+# github.com/cilium/lumberjack/v2 v2.2.2
 ## explicit; go 1.13
 github.com/cilium/lumberjack/v2
 # github.com/cilium/proxy v0.0.0-20220310090216-617157adcd74


### PR DESCRIPTION
Flushing the gzip writer is necessary because it may buffer writes in
the compressor, and while it flushes on close, we called Sync() on the
underlying file before close. Thus we need to Flush, Sync, then Close.

```release-note
Upgrade to cilium/lumberjack v2.2.2 to Flush() gzip writer before Sync()ing
```
