### PR TITLE
Helm Chart loop monitor sidecar

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -318,11 +318,18 @@ spec:
       - name: cilium-monitor
         image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["cilium"]
+        command:
+        - /bin/bash
+        - -c
+        - --
         args:
-        - monitor
-        {{- range $type := .Values.monitor.eventTypes }}
-        - --type={{ $type }}
+        - |-
+          for i in {1..5}; do \
+            [ -S /var/run/cilium/monitor1_2.sock ] && break || sleep 10;\
+            done; \
+          cilium monitor
+        {{- range $type := .Values.monitor.eventTypes -}} 
+          {{ " " }}--type={{ $type }}
         {{- end }}
         volumeMounts:
         - name: cilium-run


### PR DESCRIPTION
Added loop inside sidecar `cilium-monitor` DeamonSet. It's necessary because when cilium agent is starting it takes some time to create socket and sidecar is exit with error
```
$ kubectl logs cilium-smjv6 cilium-monitor
Press Ctrl-C to quit
time="2022-04-08T07:40:37Z" level=error msg="Cannot open monitor socket" error="Cannot find or open a supported node-monitor socket. /var/run/cilium/monitor1_2.sock: dial unix /var/run/cilium/monitor1_2.sock: connect: no such file or directory"
```
And the status of cilium-agent is the following:
```
cilium-smjv6   0/2     CrashLoopBackOff   1 (10s ago)   13s
cilium-smjv6   0/2     Completed          2 (16s ago)   19s
cilium-smjv6   0/2     CrashLoopBackOff   2 (12s ago)   30s
cilium-smjv6   0/2     CrashLoopBackOff   2 (22s ago)   40s
cilium-smjv6   1/2     CrashLoopBackOff   2 (22s ago)   40s
cilium-smjv6   2/2     Running            3             41s
```
It spent 3th restart sidecar until the socket is up and running


