### PR TITLE
Add a 'Limitations' section to 'External Workloads'.

### DIFF
--- a/Documentation/gettingstarted/external-workloads.rst
+++ b/Documentation/gettingstarted/external-workloads.rst
@@ -54,6 +54,12 @@ Prerequisites
 * So far this functionality is only tested with the vxlan tunneling
   datapath mode (default for most installations).
 
+Limitations
+###########
+
+* Transparent encryption of traffic to/from external workloads is currently not
+  supported.
+
 Prepare your cluster
 ####################
 


### PR DESCRIPTION
This commit adds a 'Limitations' section to the 'External Workloads' page, initially referring to the fact that transparent encryption to/from external workloads is currently not supported.