### PR TITLE
alignchecker: fix LLVM 15 build by removing an unused variable

### DIFF
--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -33,11 +33,10 @@
  * to the var to a BPF helper function which accepts a reference as
  * an argument.
  */
-#define DECLARE(datatype, x, iter)		\
-{						\
-	datatype x s ## iter = {};		\
-	trace_printk("%p", 1, &s ## iter);	\
-	iter++;					\
+#define DECLARE(type)			\
+{					\
+	type s = {};			\
+	trace_printk("%p", 1, &s);	\
 }
 
 /* This function is a placeholder for C struct definitions shared with Go,
@@ -45,55 +44,53 @@
  */
 int main(void)
 {
-	int iter = 0;
-
-	DECLARE(struct, ipv4_ct_tuple, iter);
-	DECLARE(struct, ipv6_ct_tuple, iter);
-	DECLARE(struct, ct_entry, iter);
-	DECLARE(struct, ipcache_key, iter);
-	DECLARE(struct, remote_endpoint_info, iter);
-	DECLARE(struct, lb4_key, iter);
-	DECLARE(struct, lb4_service, iter);
-	DECLARE(struct, lb4_backend, iter);
-	DECLARE(struct, lb6_key, iter);
-	DECLARE(struct, lb6_service, iter);
-	DECLARE(struct, lb6_backend, iter);
-	DECLARE(struct, endpoint_key, iter);
-	DECLARE(struct, endpoint_info, iter);
-	DECLARE(struct, metrics_key, iter);
-	DECLARE(struct, metrics_value, iter);
-	DECLARE(struct, sock_key, iter);
-	DECLARE(struct, policy_key, iter);
-	DECLARE(struct, policy_entry, iter);
-	DECLARE(struct, ipv4_nat_entry, iter);
-	DECLARE(struct, ipv6_nat_entry, iter);
-	DECLARE(struct, trace_notify, iter);
-	DECLARE(struct, drop_notify, iter);
-	DECLARE(struct, policy_verdict_notify, iter);
-	DECLARE(struct, debug_msg, iter);
-	DECLARE(struct, debug_capture_msg, iter);
-	DECLARE(struct, ipv4_revnat_tuple, iter);
-	DECLARE(struct, ipv4_revnat_entry, iter);
-	DECLARE(struct, ipv6_revnat_tuple, iter);
-	DECLARE(struct, ipv6_revnat_entry, iter);
-	DECLARE(struct, ipv4_frag_id, iter);
-	DECLARE(struct, ipv4_frag_l4ports, iter);
-	DECLARE(union, macaddr, iter);
-	DECLARE(struct, lb4_affinity_key, iter);
-	DECLARE(struct, lb6_affinity_key, iter);
-	DECLARE(struct, lb_affinity_val, iter);
-	DECLARE(struct, lb_affinity_match, iter);
-	DECLARE(struct, lb4_src_range_key, iter);
-	DECLARE(struct, lb6_src_range_key, iter);
-	DECLARE(struct, edt_id, iter);
-	DECLARE(struct, edt_info, iter);
-	DECLARE(struct, egress_gw_policy_key, iter);
-	DECLARE(struct, egress_gw_policy_entry, iter);
-	DECLARE(struct, vtep_key, iter);
-	DECLARE(struct, vtep_value, iter);
-	DECLARE(struct, capture4_wcard, iter);
-	DECLARE(struct, capture6_wcard, iter);
-	DECLARE(struct, capture_rule, iter);
+	DECLARE(struct ipv4_ct_tuple);
+	DECLARE(struct ipv6_ct_tuple);
+	DECLARE(struct ct_entry);
+	DECLARE(struct ipcache_key);
+	DECLARE(struct remote_endpoint_info);
+	DECLARE(struct lb4_key);
+	DECLARE(struct lb4_service);
+	DECLARE(struct lb4_backend);
+	DECLARE(struct lb6_key);
+	DECLARE(struct lb6_service);
+	DECLARE(struct lb6_backend);
+	DECLARE(struct endpoint_key);
+	DECLARE(struct endpoint_info);
+	DECLARE(struct metrics_key);
+	DECLARE(struct metrics_value);
+	DECLARE(struct sock_key);
+	DECLARE(struct policy_key);
+	DECLARE(struct policy_entry);
+	DECLARE(struct ipv4_nat_entry);
+	DECLARE(struct ipv6_nat_entry);
+	DECLARE(struct trace_notify);
+	DECLARE(struct drop_notify);
+	DECLARE(struct policy_verdict_notify);
+	DECLARE(struct debug_msg);
+	DECLARE(struct debug_capture_msg);
+	DECLARE(struct ipv4_revnat_tuple);
+	DECLARE(struct ipv4_revnat_entry);
+	DECLARE(struct ipv6_revnat_tuple);
+	DECLARE(struct ipv6_revnat_entry);
+	DECLARE(struct ipv4_frag_id);
+	DECLARE(struct ipv4_frag_l4ports);
+	DECLARE(union macaddr);
+	DECLARE(struct lb4_affinity_key);
+	DECLARE(struct lb6_affinity_key);
+	DECLARE(struct lb_affinity_val);
+	DECLARE(struct lb_affinity_match);
+	DECLARE(struct lb4_src_range_key);
+	DECLARE(struct lb6_src_range_key);
+	DECLARE(struct edt_id);
+	DECLARE(struct edt_info);
+	DECLARE(struct egress_gw_policy_key);
+	DECLARE(struct egress_gw_policy_entry);
+	DECLARE(struct vtep_key);
+	DECLARE(struct vtep_value);
+	DECLARE(struct capture4_wcard);
+	DECLARE(struct capture6_wcard);
+	DECLARE(struct capture_rule);
 
 	return 0;
 }


### PR DESCRIPTION
With LLVM 15 build breaks with

    bpf_alignchecker.c:47:6: error: variable 'iter' set but not used [-Werror,-Wunused-but-set-variable]
        int iter = 0;
            ^

The iter variable was intended to help to declare structures with names s0, s1,
etc., but instead all the structures were named "siter":

    DECLARE(struct, ipv4_ct_tuple, iter)

expands to

    {
        struct ipv4_ct_tuple siter = {};
        trace_printk("%p", 1, &siter);
        iter++
    }

Remove the unused variable and simplify the DECLARE macro to take only one
argument, so a new type check can be added, e.g., in the following way:

    DECLARE(struct ipv4_ct_tuple)

Fixes: 006ebebc28e ("bpf: Adjust alignchecker to avoid stack limits")

Signed-off-by: Anton Protopopov <a.s.protopopov@gmail.com>
