### PR TITLE
v1.9 backports 2022-04-08

### DIFF
--- a/contrib/systemd/cilium
+++ b/contrib/systemd/cilium
@@ -21,7 +21,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
 #
 # Note: A key-value store is require for cilium to function.
 # Check more cli options using cilium-agent -h
-
+CILIUM_IMAGE=cilium/cilium:latest
 CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500
 CILIUM_OPERATOR_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --k8s-kubeconfig-path=/home/vagrant/.kube/config
 

--- a/contrib/systemd/cilium.service-with-docker
+++ b/contrib/systemd/cilium.service-with-docker
@@ -1,0 +1,16 @@
+[Unit]
+Description=cilium
+Documentation=http://docs.cilium.io
+Requires=docker.service cilium-consul.service cilium-docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+TimeoutStartSec=0
+LimitCORE=infinity
+EnvironmentFile=-/etc/sysconfig/cilium
+ExecStart=/usr/bin/docker-run-cilium $CILIUM_OPTS
+ExecStop=-/usr/bin/docker-run-cilium uninstall
+
+[Install]
+WantedBy=multi-user.target

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -125,7 +125,8 @@ Vagrant.configure("2") do |config|
               "RACE" => "#{$RACE}",
               "LOCKDEBUG" => "#{$LOCKDEBUG}",
               "BASE_IMAGE" => "#{$BASE_IMAGE}",
-              "PROVISION_EXTERNAL_WORKLOAD" => "#{$PROVISION_EXTERNAL_WORKLOAD}"
+              "PROVISION_EXTERNAL_WORKLOAD" => "#{$PROVISION_EXTERNAL_WORKLOAD}",
+              "CILIUM_IMAGE" => "#{$CILIUM_IMAGE}"
             }
         end
     end

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -181,6 +181,34 @@ func (s *SSHMeta) WaitEndpointsDeleted() bool {
 
 }
 
+// WaitDockerPluginReady waits up until timeout reached for Cilium docker plugin to be ready
+func (s *SSHMeta) WaitDockerPluginReady() bool {
+	logger := s.logger.WithFields(logrus.Fields{"functionName": "WaitDockerPluginReady"})
+
+	body := func() bool {
+		// check that docker plugin socket exists
+		cmd := `stat /run/docker/plugins/cilium.sock`
+		res := s.ExecWithSudo(cmd)
+		if !res.WasSuccessful() {
+			return false
+		}
+		// check that connect works
+		cmd = `nc -U -z /run/docker/plugins/cilium.sock`
+		res = s.ExecWithSudo(cmd)
+		if !res.WasSuccessful() {
+			return false
+		}
+		return true
+	}
+	err := WithTimeout(body, "Docker plugin is not ready after timeout", &TimeoutConfig{Timeout: HelperTimeout})
+	if err != nil {
+		logger.WithError(err).Warn("Docker plugin is not ready after timeout")
+		s.ExecWithSudo("ls -l /run/docker/plugins/cilium.sock") // This function is only for debugginag.
+		return false
+	}
+	return true
+}
+
 func (s *SSHMeta) MonitorDebug(on bool, epID string) bool {
 	logger := s.logger.WithFields(logrus.Fields{"functionName": "MonitorDebug"})
 	dbg := "Disabled"
@@ -895,13 +923,18 @@ func (s *SSHMeta) SetUpCilium() error {
 // SetUpCiliumWithOptions sets up Cilium as a systemd service with a given set of options. It
 // returns an error if any of the operations needed to start Cilium fail.
 func (s *SSHMeta) SetUpCiliumWithOptions(ciliumOpts string) error {
+	// Default kvstore options
+	if !strings.Contains(ciliumOpts, "--kvstore") {
+		ciliumOpts += " --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500"
+	}
+
 	ciliumOpts += " --exclude-local-address=" + DockerBridgeIP + "/32"
 	ciliumOpts += " --exclude-local-address=" + FakeIPv4WorldAddress + "/32"
 	ciliumOpts += " --exclude-local-address=" + FakeIPv6WorldAddress + "/128"
 
 	systemdTemplate := `
 PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load %s
+CILIUM_OPTS=--debug --pprof=true --log-system-load %s
 INITSYSTEM=SYSTEMD`
 
 	ciliumConfig := "cilium.conf.ginkgo"

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -235,7 +235,7 @@ func (s *SSHMeta) WaitEndpointsReady() bool {
 	logger := s.logger.WithFields(logrus.Fields{"functionName": "WaitEndpointsReady"})
 	desiredState := string(models.EndpointStateReady)
 	body := func() bool {
-		filter := `{range [*]}{@.status.external-identifiers.container-name}{"="}{@.status.state},{@.status.identity.id}{"\n"}{end}`
+		filter := `{range [*]}{@.id}{"="}{@.status.state},{@.status.identity.id}{"\n"}{end}`
 		cmd := fmt.Sprintf(`cilium endpoint list -o jsonpath='%s'`, filter)
 
 		res := s.Exec(cmd)

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -932,19 +932,27 @@ func (s *SSHMeta) SetUpCiliumWithOptions(ciliumOpts string) error {
 	ciliumOpts += " --exclude-local-address=" + FakeIPv4WorldAddress + "/32"
 	ciliumOpts += " --exclude-local-address=" + FakeIPv6WorldAddress + "/128"
 
+	// Get the current CILIUM_IMAGE from the service definition
+	res := s.Exec("grep CILIUM_IMAGE= /etc/sysconfig/cilium")
+	if !res.WasSuccessful() {
+		return fmt.Errorf("Could not find CILIUM_IMAGE from /etc/sysconfig/cilium: %s", res.CombineOutput())
+	}
+	ciliumImage := res.Stdout()
+
 	systemdTemplate := `
 PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+%s
 CILIUM_OPTS=--debug --pprof=true --log-system-load %s
 INITSYSTEM=SYSTEMD`
 
 	ciliumConfig := "cilium.conf.ginkgo"
-	err := s.RenderTemplateToFile(ciliumConfig, fmt.Sprintf(systemdTemplate, ciliumOpts), os.ModePerm)
+	err := s.RenderTemplateToFile(ciliumConfig, fmt.Sprintf(systemdTemplate, ciliumImage, ciliumOpts), os.ModePerm)
 	if err != nil {
 		return err
 	}
 
 	confPath := filepath.Join("/home/vagrant/go/src/github.com/cilium/cilium/test", ciliumConfig)
-	res := s.Exec(fmt.Sprintf("sudo cp %s /etc/sysconfig/cilium", confPath))
+	res = s.Exec(fmt.Sprintf("sudo cp %s /etc/sysconfig/cilium", confPath))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("%s", res.CombineOutput())
 	}

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 set -e
 
-CILIUM_DS_TAG="k8s-app=cilium"
-KUBE_SYSTEM_NAMESPACE="kube-system"
-KUBECTL="/usr/bin/kubectl"
-PROVISIONSRC="/tmp/provision"
-GOPATH="/home/vagrant/go"
-REGISTRY="k8s1:5000"
-CILIUM_TAG="cilium/cilium-dev"
-CILIUM_OPERATOR_TAG="cilium/operator"
-CILIUM_OPERATOR_GENERIC_TAG="cilium/operator-generic"
-CILIUM_OPERATOR_AWS_TAG="cilium/operator-aws"
-CILIUM_OPERATOR_AZURE_TAG="cilium/operator-azure"
-HUBBLE_RELAY_TAG="cilium/hubble-relay"
+export CILIUM_DS_TAG="k8s-app=cilium"
+export KUBE_SYSTEM_NAMESPACE="kube-system"
+export KUBECTL="/usr/bin/kubectl"
+export VMUSER=${VMUSER:-vagrant}
+export PROVISIONSRC="/tmp/provision"
+export GOPATH="/home/${VMUSER}/go"
+export REGISTRY="k8s1:5000"
+export DOCKER_REGISTRY="docker.io"
+export CILIUM_TAG="cilium/cilium-dev"
+export CILIUM_OPERATOR_TAG="cilium/operator"
+export CILIUM_OPERATOR_GENERIC_TAG="cilium/operator-generic"
+export CILIUM_OPERATOR_AWS_TAG="cilium/operator-aws"
+export CILIUM_OPERATOR_AZURE_TAG="cilium/operator-azure"
+export HUBBLE_RELAY_TAG="cilium/hubble-relay"
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
@@ -138,10 +140,11 @@ else
         systemctl enable $service || echo "service $service failed"
         systemctl restart $service || echo "service $service failed to restart"
     done
-    echo "running \"sudo adduser vagrant cilium\" "
+
+    echo "running \"sudo adduser ${VMUSER} cilium\" "
     # Add group explicitly to avoid the case where the group was not added yet
     getent group cilium >/dev/null || sudo groupadd -r cilium
-    sudo adduser vagrant cilium
+    sudo adduser ${VMUSER} cilium
 
     # Download all images needed for runtime tests.
     ./test/provision/container-images.sh test_images test/helpers

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -108,6 +108,9 @@ then
     else
         echo "Not on master K8S node; no need to compile Cilium container"
     fi
+
+    # Download all images needed for k8s tests.
+    ./test/provision/container-images.sh test_images test/k8s
 else
     echo "compiling cilium..."
     sudo -u vagrant -H -E make SKIP_CUSTOMVET_CHECK=true LOCKDEBUG=1 SKIP_K8S_CODE_GEN_CHECK=false SKIP_DOCS=true
@@ -129,7 +132,7 @@ else
     done
     echo "running \"sudo adduser vagrant cilium\" "
     sudo adduser vagrant cilium
-fi
 
-# Download all images needed for tests.
-./test/provision/container-images.sh test_images .
+    # Download all images needed for runtime tests.
+    ./test/provision/container-images.sh test_images test/helpers
+fi

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -112,25 +112,32 @@ then
     # Download all images needed for k8s tests.
     ./test/provision/container-images.sh test_images test/k8s
 else
-    echo "compiling cilium..."
-    sudo -u vagrant -H -E make SKIP_CUSTOMVET_CHECK=true LOCKDEBUG=1 SKIP_K8S_CODE_GEN_CHECK=false SKIP_DOCS=true
-    echo "installing cilium..."
-    make install
+    echo "Installing docker-plugin..."
+    make -C plugins/cilium-docker
+    make -C plugins/cilium-docker install
+    
+    echo "Building Cilium..."
+    make docker-cilium-image SKIP_CUSTOMVET_CHECK=true LOCKDEBUG=1 SKIP_K8S_CODE_GEN_CHECK=false SKIP_DOCS=true
+    sudo cp ${PROVISIONSRC}/docker-run-cilium.sh /usr/bin/docker-run-cilium
+
     mkdir -p /etc/sysconfig/
-    cp -f contrib/systemd/cilium /etc/sysconfig/cilium
-    services=$(ls -1 ./contrib/systemd/*.*)
-    for svc in ${services}; do
-        cp -f "${svc}" /etc/systemd/system/
-    done
-    for svc in ${services}; do
-        service=$(echo "$svc" | sed -E -n 's/.*\/(.*?).(service|mount)/\1.\2/p')
-        if [ -n "$service" ] ; then
-          echo "installing service $service"
-          systemctl enable $service || echo "service $service failed"
-          systemctl restart $service || echo "service $service failed to restart"
-        fi
+    cp contrib/systemd/cilium /etc/sysconfig/cilium
+
+    cp -f contrib/systemd/*.* /etc/systemd/system/
+    # Use dockerized Cilium with runtime tests
+    cp -f contrib/systemd/cilium.service-with-docker /etc/systemd/system/cilium.service
+    # Do not run cilium-operator with runtime tests, as it fails to connect to k8s api-server
+    rm -f /etc/systemd/system/cilium-operator.service
+
+    services=$(cd /etc/systemd/system; ls -1 cilium*.service sys-fs-bpf.mount)
+    for service in ${services}; do
+        echo "installing service $service"
+        systemctl enable $service || echo "service $service failed"
+        systemctl restart $service || echo "service $service failed to restart"
     done
     echo "running \"sudo adduser vagrant cilium\" "
+    # Add group explicitly to avoid the case where the group was not added yet
+    getent group cilium >/dev/null || sudo groupadd -r cilium
     sudo adduser vagrant cilium
 
     # Download all images needed for runtime tests.

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -116,12 +116,15 @@ else
     make -C plugins/cilium-docker
     make -C plugins/cilium-docker install
     
-    echo "Building Cilium..."
-    make docker-cilium-image SKIP_CUSTOMVET_CHECK=true LOCKDEBUG=1 SKIP_K8S_CODE_GEN_CHECK=false SKIP_DOCS=true
+    if [[ "${CILIUM_IMAGE}" == "" ]]; then
+	export CILIUM_IMAGE=cilium/cilium:latest
+	echo "Building Cilium..."
+	make docker-cilium-image SKIP_CUSTOMVET_CHECK=true LOCKDEBUG=1 SKIP_K8S_CODE_GEN_CHECK=false SKIP_DOCS=true
+    fi
     sudo cp ${PROVISIONSRC}/docker-run-cilium.sh /usr/bin/docker-run-cilium
 
     mkdir -p /etc/sysconfig/
-    cp contrib/systemd/cilium /etc/sysconfig/cilium
+    sed "s|CILIUM_IMAGE[^[:space:]]*$|CILIUM_IMAGE=${CILIUM_IMAGE}|" contrib/systemd/cilium > /etc/sysconfig/cilium
 
     cp -f contrib/systemd/*.* /etc/systemd/system/
     # Use dockerized Cilium with runtime tests

--- a/test/provision/container-images.sh
+++ b/test/provision/container-images.sh
@@ -26,10 +26,8 @@ function test_images {
   # sed's -n does not print non-matching lines and the `#p` prints only
   # matching groups. `#` is used as the sed delimiter to avoid escaping `/` in
   # the regex.
-  # Narrow down the directories to avoid pulling images from random yamls or test_result logs.
-  TEST_DIRS="test/helpers test/k8sT test/provision"
-  DOCKER_IMAGES=$(grep -rI --no-filename "docker.io" $TEST_DIRS | sed -nEe 's#.*(docker.io/[-_a-zA-Z0-9]+/[-_a-zA-Z0-9]+:[-_.a-zA-Z0-9]+)[^-_.a-zA-Z0-9].*#\1#p' | sort | uniq)
-  QUAY_IMAGES=$(grep -rI --no-filename "quay.io" $TEST_DIRS     | sed -nEe   's#.*(quay.io/[-_a-zA-Z0-9]+/[-_a-zA-Z0-9]+:[-_.a-zA-Z0-9]+)[^-_.a-zA-Z0-9].*#\1#p' | sort | uniq)
+  DOCKER_IMAGES=$(grep -rI --no-filename "docker.io" . | sed -nEe 's#.*(docker.io/[-_a-zA-Z0-9]+/[-_a-zA-Z0-9]+:[-_.a-zA-Z0-9]+)[^-_.a-zA-Z0-9].*#\1#p' | sort | uniq)
+  QUAY_IMAGES=$(grep -rI --no-filename "quay.io" .     | sed -nEe   's#.*(quay.io/[-_a-zA-Z0-9]+/[-_a-zA-Z0-9]+:[-_.a-zA-Z0-9]+)[^-_.a-zA-Z0-9].*#\1#p' | sort | uniq)
 
   check_img_list $DOCKER_IMAGES
   check_img_list $QUAY_IMAGES

--- a/test/provision/docker-run-cilium.sh
+++ b/test/provision/docker-run-cilium.sh
@@ -4,7 +4,7 @@
 CILIUM_OPTS=$@
 # Default kvstore to consul
 if [[ "${CILIUM_OPTS}" != *--kvstore* ]]; then
-    CILIUM_OPTS+="--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500"
+    CILIUM_OPTS+=" --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500"
 fi
 
 CILIUM_IMAGE=${CILIUM_IMAGE:-cilium/cilium:latest}

--- a/test/provision/docker-run-cilium.sh
+++ b/test/provision/docker-run-cilium.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# all args are passed as cilium-agent options (except for "uninstall" below)
+CILIUM_OPTS=$@
+# Default kvstore to consul
+if [[ "${CILIUM_OPTS}" != *--kvstore* ]]; then
+    CILIUM_OPTS+="--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500"
+fi
+
+CILIUM_IMAGE=${CILIUM_IMAGE:-cilium/cilium:latest}
+
+set -e
+shopt -s extglob
+
+# Run without sudo if not available (e.g., running as root)
+SUDO=
+if [ ! "$(whoami)" = "root" ] ; then
+    SUDO=sudo
+fi
+
+if [ "$1" = "uninstall" ] ; then
+    if [ -n "$(${SUDO} docker ps -a -q -f label=app=cilium)" ]; then
+        echo "Shutting down running Cilium agent"
+        ${SUDO} docker rm -f cilium || true
+    fi
+    if [ -f /usr/bin/cilium ] ; then
+        echo "Removing /usr/bin/cilium"
+        ${SUDO} rm /usr/bin/cilium
+        echo "Removing /usr/bin/cilium-bugtool"
+        ${SUDO} rm /usr/bin/cilium-bugtool
+    fi
+    exit 0
+fi
+
+DOCKER_OPTS=" -d --log-driver local --restart always"
+DOCKER_OPTS+=" --privileged --network host --cap-add NET_ADMIN --cap-add SYS_MODULE"
+# Run cilium agent in the host's cgroup namespace so that
+# socket-based load balancing works as expected.
+# See https://github.com/cilium/cilium/pull/16259 for more details.
+DOCKER_OPTS+=" --cgroupns=host"
+DOCKER_OPTS+=" --volume /var/lib/cilium/etcd:/var/lib/cilium/etcd"
+DOCKER_OPTS+=" --volume /var/run/cilium:/var/run/cilium"
+DOCKER_OPTS+=" --volume /boot:/boot"
+DOCKER_OPTS+=" --volume /lib/modules:/lib/modules"
+DOCKER_OPTS+=" --volume /sys/fs/bpf:/sys/fs/bpf"
+DOCKER_OPTS+=" --volume /run/xtables.lock:/run/xtables.lock"
+DOCKER_OPTS+=" --label app=cilium"
+
+if [ -n "$(${SUDO} docker ps -a -q -f label=app=cilium)" ]; then
+    echo "Shutting down running Cilium agent"
+    ${SUDO} docker rm -f cilium || true
+fi
+
+echo "Launching Cilium agent $CILIUM_IMAGE with params $CILIUM_OPTS"
+${SUDO} docker run --name cilium $DOCKER_OPTS $CILIUM_IMAGE cilium-agent $CILIUM_OPTS
+
+# Copy Cilium CLI
+${SUDO} docker cp cilium:/usr/bin/cilium /usr/bin/
+${SUDO} docker cp cilium:/usr/bin/cilium-bugtool /usr/bin/

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -19,7 +19,7 @@ sudo systemctl restart ssh
 
 if [[ "${PROVISION_EXTERNAL_WORKLOAD}" == "false" ]]; then
     "${PROVISIONSRC}"/compile.sh
-    "${PROVISIONSRC}"/wait-cilium.sh
+    "${PROVISIONSRC}"/wait-cilium-in-docker.sh
 else
     "${PROVISIONSRC}"/externalworkload_install.sh
 fi

--- a/test/provision/wait-cilium-in-docker.sh
+++ b/test/provision/wait-cilium-in-docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Wait for cilium agent to become available
+for ((i = 0 ; i < 12; i++)); do
+    if cilium status --brief > /dev/null 2>&1; then
+        break
+    fi
+    sleep 5s
+    echo "Waiting for Cilium daemon to come up..."
+done
+
+echo "Cilium status:"
+cilium status || true

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -851,13 +851,8 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 	})
 
 	Context("toFQDNs populates toCIDRSet (data from proxy)", func() {
-		var config = `
-PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load
-INITSYSTEM=SYSTEMD`
 		BeforeAll(func() {
-			vm.SetUpCiliumWithOptions(config)
-
+			vm.SetUpCilium()
 			ExpectCiliumReady(vm)
 			areEndpointsReady := vm.WaitEndpointsReady()
 			Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -15,7 +15,6 @@
 package RuntimeTest
 
 import (
-	"context"
 	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -31,7 +30,8 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 
 	BeforeAll(func() {
 		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
-		ExpectCiliumReady(vm)
+		vm.ExecWithSudo("systemctl stop cilium")
+		ExpectCiliumNotRunning(vm)
 	})
 
 	containers := func(option string) {
@@ -45,20 +45,12 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		}
 	}
 
-	BeforeEach(func() {
-		res := vm.ExecWithSudo("systemctl stop cilium")
-		res.ExpectSuccess("Failed trying to stop cilium via systemctl")
-		ExpectCiliumNotRunning(vm)
-	}, 150)
-
 	JustBeforeEach(func() {
 		testStartTime = time.Now()
 	})
 
 	AfterEach(func() {
 		containers(helpers.Delete)
-		err := vm.RestartCilium()
-		Expect(err).Should(BeNil(), "restarting Cilium failed")
 	})
 
 	JustAfterEach(func() {
@@ -70,23 +62,25 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 	})
 
 	AfterAll(func() {
+		// Other runtime tests fail if using etcd, as cilium-operator is not functional
+		// without k8s.
+		err := vm.SetUpCilium()
+		Expect(err).Should(BeNil(), "Cilium failed to start")
+		ExpectCiliumReady(vm)
 		vm.CloseSSHClient()
 	})
 
 	Context("KVStore tests", func() {
 		It("Consul KVStore", func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			By("Starting Cilium with consul as kvstore")
-			vm.ExecInBackground(
-				ctx,
-				"sudo cilium-agent --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug 2>&1 | logger -t cilium")
-			err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
-			Expect(err).Should(BeNil())
+			err := vm.SetUpCiliumWithOptions("--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500")
+			Expect(err).Should(BeNil(), "Cilium failed to start")
 
 			By("Restarting cilium-docker service")
 			vm.Exec("sudo systemctl restart cilium-docker")
-			helpers.Sleep(2)
+			Expect(vm.WaitDockerPluginReady()).Should(BeTrue(), "Docker plugin is not ready after timeout")
+			ExpectCiliumReady(vm)
+
 			containers(helpers.Create)
 			vm.WaitEndpointsReady()
 			eps, err := vm.GetEndpointsNames()
@@ -95,18 +89,15 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		})
 
 		It("Etcd KVStore", func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			By("Starting Cilium with etcd as kvstore")
-			vm.ExecInBackground(
-				ctx,
-				"sudo cilium-agent --kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001 --debug 2>&1 | logger -t cilium")
-			err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
-			Expect(err).Should(BeNil(), "Timed out waiting for VM to be ready after restarting Cilium")
+			err := vm.SetUpCiliumWithOptions("--kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001")
+			Expect(err).Should(BeNil(), "Cilium failed to start")
 
 			By("Restarting cilium-docker service")
 			vm.Exec("sudo systemctl restart cilium-docker")
-			helpers.Sleep(2)
+			Expect(vm.WaitDockerPluginReady()).Should(BeTrue(), "Docker plugin is not ready after timeout")
+			ExpectCiliumReady(vm)
+
 			containers(helpers.Create)
 
 			vm.WaitEndpointsReady()


### PR DESCRIPTION
 * #16437 -- test/helpers: Fix incorrect count of endpoints (@pchaigno)
 * #19310 -- Test runtime cilium in container (take two) (@jrajahalme)
 * #19358 -- test: Fix whitespace in docker-run-cilium (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16437 19310 19358; do contrib/backporting/set-labels.py $pr done 1.9; done
```
