### PR TITLE
add support for AKS BYOCNI

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -177,12 +177,9 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_PR_SP_CREDS }}
 
-      - name: Display Azure CLI info
-        uses: azure/CLI@7378ce2ca3c38b4b063feb7a4cbe384fef978055
-        with:
-          azcliversion: 2.0.72
-          inlineScript: |
-            az account show
+      - name: Display az version
+        run: |
+            az version
 
       - name: Create AKS cluster
         run: |
@@ -198,39 +195,9 @@ jobs:
             --name ${{ env.name }} \
             --location ${{ env.location }} \
             --network-plugin azure \
-            --node-count 1 \
+            --node-count 2 \
             ${{ env.cost_reduction }} \
             --generate-ssh-keys
-
-          # Get name of initial system node pool
-          nodepool_to_delete=$(az aks nodepool list --resource-group ${{ env.name }} --cluster-name ${{ env.name }} --output tsv --query "[0].name")
-
-          # Create system node pool tainted with `CriticalAddonsOnly=true:NoSchedule`
-          az aks nodepool add \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name systempool \
-            --mode system \
-            --node-count 1 \
-            --node-taints "CriticalAddonsOnly=true:NoSchedule" \
-            ${{ env.cost_reduction }} \
-            --no-wait
-
-          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoExecute`
-          az aks nodepool add \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name userpool \
-            --mode user \
-            --node-count 2 \
-            --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
-            ${{ env.cost_reduction }}
-
-          # Delete the initial system node pool
-          az aks nodepool delete \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name "${nodepool_to_delete}"
 
       - name: Get cluster credentials
         run: |

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -187,12 +187,9 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_PR_SP_CREDS }}
 
-      - name: Display Azure CLI info
-        uses: azure/CLI@7378ce2ca3c38b4b063feb7a4cbe384fef978055
-        with:
-          azcliversion: 2.0.72
-          inlineScript: |
-            az account show
+      - name: Display az version
+        run: |
+            az version
 
       - name: Create AKS cluster
         run: |
@@ -208,39 +205,9 @@ jobs:
             --name ${{ env.name }} \
             --location ${{ env.location }} \
             --network-plugin azure \
-            --node-count 1 \
+            --node-count 2 \
             ${{ env.cost_reduction }} \
             --generate-ssh-keys
-
-          # Get name of initial system node pool
-          nodepool_to_delete=$(az aks nodepool list --resource-group ${{ env.name }} --cluster-name ${{ env.name }} --output tsv --query "[0].name")
-
-          # Create system node pool tainted with `CriticalAddonsOnly=true:NoSchedule`
-          az aks nodepool add \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name systempool \
-            --mode system \
-            --node-count 1 \
-            --node-taints "CriticalAddonsOnly=true:NoSchedule" \
-            ${{ env.cost_reduction }} \
-            --no-wait
-
-          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoExecute`
-          az aks nodepool add \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name userpool \
-            --mode user \
-            --node-count 2 \
-            --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
-            ${{ env.cost_reduction }}
-
-          # Delete the initial system node pool
-          az aks nodepool delete \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name "${nodepool_to_delete}"
 
       - name: Get cluster credentials
         run: |

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -193,12 +193,11 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_PR_SP_CREDS }}
 
-      - name: Display Azure CLI info
-        uses: azure/CLI@7378ce2ca3c38b4b063feb7a4cbe384fef978055
-        with:
-          azcliversion: 2.0.72
-          inlineScript: |
-            az account show
+      - name: Install aks-preview CLI extension
+        run: |
+            az extension add --name aks-preview
+            az extension update --name aks-preview
+            az version
 
       - name: Create AKS cluster
         run: |
@@ -213,40 +212,10 @@ jobs:
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
-            --network-plugin azure \
-            --node-count 1 \
+            --network-plugin none \
+            --node-count 2 \
             ${{ env.cost_reduction }} \
             --generate-ssh-keys
-
-          # Get name of initial system node pool
-          nodepool_to_delete=$(az aks nodepool list --resource-group ${{ env.name }} --cluster-name ${{ env.name }} --output tsv --query "[0].name")
-
-          # Create system node pool tainted with `CriticalAddonsOnly=true:NoSchedule`
-          az aks nodepool add \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name systempool \
-            --mode system \
-            --node-count 1 \
-            --node-taints "CriticalAddonsOnly=true:NoSchedule" \
-            ${{ env.cost_reduction }} \
-            --no-wait
-
-          # Create user node pool tainted with `node.cilium.io/agent-not-ready=true:NoExecute`
-          az aks nodepool add \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name userpool \
-            --mode user \
-            --node-count 2 \
-            --node-taints "node.cilium.io/agent-not-ready=true:NoExecute" \
-            ${{ env.cost_reduction }}
-
-          # Delete the initial system node pool
-          az aks nodepool delete \
-            --resource-group ${{ env.name }} \
-            --cluster-name ${{ env.name }} \
-            --name "${nodepool_to_delete}"
 
       - name: Get cluster credentials
         run: |

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -156,11 +156,14 @@ jobs:
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
+            --base-version=v1.12 \
             --version="
-          HUBBLE_ENABLE_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          HUBBLE_ENABLE_DEFAULTS=" --chart-directory=install/kubernetes/cilium \
             --relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci:${SHA} \
+            --base-version=v1.12 \
             --relay-version=${SHA}"
-          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled"
+          CONNECTIVITY_TEST_DEFAULTS="--base-version=v1.12 \
+            --flow-validation=disabled"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
           echo ::set-output name=connectivity_test_defaults::${CONNECTIVITY_TEST_DEFAULTS}

--- a/Documentation/concepts/networking/ipam/azure.rst
+++ b/Documentation/concepts/networking/ipam/azure.rst
@@ -10,6 +10,10 @@
 Azure IPAM
 ##########
 
+.. note::
+
+   Azure IPAM is not compatible with AKS clusters created in BYOCNI mode.
+
 The Azure IPAM allocator is specific to Cilium deployments running in the Azure
 cloud and performs IP allocation based on `Azure Private IP addresses
 <https://docs.microsoft.com/en-us/azure/virtual-network/private-ip-addresses>`__.

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -56,7 +56,52 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
           Please make sure to read and understand the documentation page on :ref:`taint effects and unmanaged pods<taint_effects>`.
 
-    .. group-tab:: AKS
+    .. group-tab:: AKS (BYOCNI)
+
+       .. note::
+
+          BYOCNI is the preferred way to run Cilium on AKS, however integration
+          with the Azure stack via the :ref:`Azure IPAM<ipam_azure>` is not
+          available. If you require Azure IPAM, refer to the AKS (Azure IPAM)
+          installation.
+
+       The following commands create a Kubernetes cluster using `Azure
+       Kubernetes Service <https://docs.microsoft.com/en-us/azure/aks/>`_ with
+       no CNI plugin pre-installed (BYOCNI). See `Azure Cloud CLI
+       <https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest>`_
+       for instructions on how to install ``az`` and prepare your account, and
+       the `Bring your own CNI documentation
+       <https://docs.microsoft.com/en-us/azure/aks/use-byo-cni?tabs=azure-cli>`_
+       for more details about BYOCNI prerequisites / implications.
+
+       .. note::
+
+          BYOCNI requires the ``aks-preview`` CLI extension with version >=
+          0.5.55, which itself requires an ``az`` CLI version >= 2.32.0 .
+
+       .. code-block:: bash
+
+           export NAME="$(whoami)-$RANDOM"
+           export AZURE_RESOURCE_GROUP="${NAME}-group"
+           az group create --name "${AZURE_RESOURCE_GROUP}" -l westus2
+
+           # Create AKS cluster
+           az aks create \
+             --resource-group "${AZURE_RESOURCE_GROUP}" \
+             --name "${NAME}" \
+             --network-plugin none
+
+           # Get the credentials to access the cluster with kubectl
+           az aks get-credentials --resource-group "${AZURE_RESOURCE_GROUP}" --name "${NAME}"
+
+    .. group-tab:: AKS (Azure IPAM)
+
+       .. note::
+
+          :ref:`Azure IPAM<ipam_azure>` offers integration with the Azure stack
+          but is not the preferred way to run Cilium on AKS. If you do not
+          require Azure IPAM, we recommend you to switch to the AKS (BYOCNI)
+          installation.
 
        The following commands create a Kubernetes cluster using `Azure
        Kubernetes Service <https://docs.microsoft.com/en-us/azure/aks/>`_. See
@@ -264,9 +309,21 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
            cilium install
 
-    .. group-tab:: AKS
+    .. group-tab:: AKS (BYOCNI)
 
-       .. include:: requirements-aks.rst
+       .. include:: requirements-aks-byocni.rst
+
+       **Install Cilium:**
+
+       Install Cilium into the AKS cluster:
+
+       .. code-block:: shell-session
+
+           cilium install --azure-resource-group "${AZURE_RESOURCE_GROUP}"
+
+    .. group-tab:: AKS (Azure IPAM)
+
+       .. include:: requirements-aks-azure-ipam.rst
 
        **Install Cilium:**
 

--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -81,9 +81,24 @@ Install Cilium
        * Reconfigure kubelet to run in CNI mode
        * Mount the eBPF filesystem
 
-    .. group-tab:: AKS
+    .. group-tab:: AKS (BYOCNI)
 
-       .. include:: requirements-aks.rst
+       .. include:: requirements-aks-byocni.rst
+
+       **Install Cilium:**
+
+       Deploy Cilium release via Helm:
+
+       .. parsed-literal::
+
+          helm install cilium |CHART_RELEASE| \\
+            --namespace kube-system \\
+            --set aksbyocni.enabled=true \\
+            --set nodeinit.enabled=true
+
+    .. group-tab:: AKS (Azure IPAM)
+
+       .. include:: requirements-aks-azure-ipam.rst
 
        **Create a Service Principal:**
 

--- a/Documentation/gettingstarted/requirements-aks-azure-ipam.rst
+++ b/Documentation/gettingstarted/requirements-aks-azure-ipam.rst
@@ -1,5 +1,6 @@
-To install Cilium on `Azure Kubernetes Service (AKS) <https://docs.microsoft.com/en-us/azure/aks/>`_,
-perform the following steps:
+To install Cilium on `Azure Kubernetes Service (AKS) <https://docs.microsoft.com/en-us/azure/aks/>`_
+with Azure integration via :ref:`Azure IPAM<ipam_azure>`, perform the following
+steps:
 
 **Default Configuration:**
 
@@ -8,6 +9,12 @@ Datapath        IPAM                Datastore
 =============== =================== ==============
 Direct Routing  Azure IPAM          Kubernetes CRD
 =============== =================== ==============
+
+.. note::
+
+   :ref:`Azure IPAM<ipam_azure>` offers integration with the Azure stack but is
+   not the preferred way to run Cilium on AKS. If you do not require Azure IPAM,
+   we recommend you to switch to the AKS (BYOCNI) installation.
 
 .. tip::
 

--- a/Documentation/gettingstarted/requirements-aks-azure-ipam.rst
+++ b/Documentation/gettingstarted/requirements-aks-azure-ipam.rst
@@ -27,24 +27,39 @@ Direct Routing  Azure IPAM          Kubernetes CRD
   compatibility with Cilium. The Azure network plugin will be replaced with
   Cilium by the installer.
 
-* Node pools must be properly tainted to ensure applications pods are properly
-  managed by Cilium:
-
-  * User node pools should be tainted with ``node.cilium.io/agent-not-ready=true:NoExecute``
-    to ensure application pods will only be scheduled/executed once Cilium is ready to
-    manage them. However, there are other options. Please make sure to
-    read and understand the documentation page on :ref:`taint effects and unmanaged pods<taint_effects>`.
-
-  * System node pools must be tainted with ``CriticalAddonsOnly=true:NoSchedule``,
-    preventing application pods from being scheduled on them. This is necessary
-    because it is not possible to assign custom node taints such as ``node.cilium.io/agent-not-ready=true:NoExecute``
-    to system node pools, cf. `Azure/AKS#2578 <https://github.com/Azure/AKS/issues/2578>`_.
-    
-    * The initial node pool must be replaced with a new system node pool since
-      it is not possible to assign taints to the initial node pool at this time,
-      cf. `Azure/AKS#1402 <https://github.com/Azure/AKS/issues/1402>`_.
-
 **Limitations:**
 
 * All VMs and VM scale sets used in a cluster must belong to the same resource
   group.
+
+* Adding new nodes to node pools might result in application pods being
+  scheduled on the new nodes before Cilium is ready to properly manage them.
+  The only way to fix this is either by making sure application pods are not
+  scheduled on new nodes before Cilium is ready, or by restarting any unmanaged
+  pods on the nodes once Cilium is ready.
+
+  Ideally we would recommend node pools should be tainted with
+  ``node.cilium.io/agent-not-ready=true:NoExecute`` to ensure application pods
+  will only be scheduled/executed once Cilium is ready to manage them (see
+  :ref:`Considerations on node pool taints and unmanaged pods <taint_effects>`
+  for more details), however this is not an option on AKS clusters:
+
+  * It is not possible to assign custom node taints such as
+    ``node.cilium.io/agent-not-ready=true:NoExecute`` to system node pools,
+    cf. `Azure/AKS#2578 <https://github.com/Azure/AKS/issues/2578>`_: only
+    ``CriticalAddonsOnly=true:NoSchedule`` is available for our use case. To
+    make matters worse, it is not possible to assign taints to the initial node
+    pool created for new AKS clusters, cf.
+    `Azure/AKS#1402 <https://github.com/Azure/AKS/issues/1402>`_.
+
+  * Custom node taints on user node pools cannot be properly managed at will
+    anymore, cf. `Azure/AKS#2934 <https://github.com/Azure/AKS/issues/2934>`_.
+
+  * These issues prevent usage of our previously recommended scenario via
+    replacement of initial system node pool with
+    ``CriticalAddonsOnly=true:NoSchedule`` and usage of additional user
+    node pools with ``node.cilium.io/agent-not-ready=true:NoExecute``.
+
+  We do not have a standard and foolproof alternative to recommend, hence the
+  only solution is to craft a custom mechanism that will work in your
+  environment to handle this scenario when adding new nodes to AKS clusters.

--- a/Documentation/gettingstarted/requirements-aks-byocni.rst
+++ b/Documentation/gettingstarted/requirements-aks-byocni.rst
@@ -1,0 +1,23 @@
+To install Cilium on `Azure Kubernetes Service (AKS) <https://docs.microsoft.com/en-us/azure/aks/>`_
+in `Bring your own CNI <https://docs.microsoft.com/en-us/azure/aks/use-byo-cni?tabs=azure-cli>`_
+mode, perform the following steps:
+
+**Default Configuration:**
+
+=============== =================== ==============
+Datapath        IPAM                Datastore
+=============== =================== ==============
+Encapsulation   Cluster Pool        Kubernetes CRD
+=============== =================== ==============
+
+.. note::
+
+   BYOCNI is the preferred way to run Cilium on AKS, however integration with
+   the Azure stack via the :ref:`Azure IPAM<ipam_azure>` is not available. If
+   you require Azure IPAM, refer to the AKS (Azure IPAM) installation.
+
+**Requirements:**
+
+* The AKS cluster must be created with ``--network-plugin none`` (BYOCNI). See
+  the `Bring your own CNI documentation <https://docs.microsoft.com/en-us/azure/aks/use-byo-cni?tabs=azure-cli>`_
+  for more details about BYOCNI prerequisites / implications.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -21,6 +21,10 @@
      - Configure the key of the taint indicating that Cilium is not ready on the node. When set to a value starting with ``ignore-taint.cluster-autoscaler.kubernetes.io/``\ , the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up.
      - string
      - ``"node.cilium.io/agent-not-ready"``
+   * - aksbyocni.enabled
+     - Enable AKS BYOCNI integration. Note that this is incompatible with AKS clusters not created in BYOCNI mode: use Azure integration (\ ``azure.enabled``\ ) instead.
+     - bool
+     - ``false``
    * - alibabacloud.enabled
      - Enable AlibabaCloud ENI integration
      - bool
@@ -34,7 +38,7 @@
      - bool
      - ``false``
    * - azure.enabled
-     - Enable Azure integration
+     - Enable Azure integration. Note that this is incompatible with AKS clusters created in BYOCNI mode: use AKS BYOCNI integration (\ ``aksbyocni.enabled``\ ) instead.
      - bool
      - ``false``
    * - bandwidthManager

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -147,6 +147,7 @@ Zookeeper
 aarch
 admin
 agentNotReadyTaintKey
+aksbyocni
 alibabacloud
 allocator
 allocators

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -56,10 +56,11 @@ contributors across the globe, there is almost always someone available to help.
 | affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-agent. |
 | agent | bool | `true` | Install the cilium agent resources. |
 | agentNotReadyTaintKey | string | `"node.cilium.io/agent-not-ready"` | Configure the key of the taint indicating that Cilium is not ready on the node. When set to a value starting with `ignore-taint.cluster-autoscaler.kubernetes.io/`, the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up. |
+| aksbyocni.enabled | bool | `false` | Enable AKS BYOCNI integration. Note that this is incompatible with AKS clusters not created in BYOCNI mode: use Azure integration (`azure.enabled`) instead. |
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |
-| azure.enabled | bool | `false` | Enable Azure integration |
+| azure.enabled | bool | `false` | Enable Azure integration. Note that this is incompatible with AKS clusters created in BYOCNI mode: use AKS BYOCNI integration (`aksbyocni.enabled`) instead. |
 | bandwidthManager | object | `{"bbr":false,"enabled":false}` | Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
 | bandwidthManager.bbr | bool | `false` | Activate BBR TCP congestion control for Pods |
 | bandwidthManager.enabled | bool | `false` | Enable bandwidth manager infrastructure (also prerequirement for BBR) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -371,8 +371,10 @@ data:
   tunnel: "disabled"
   enable-endpoint-routes: "true"
   enable-local-node-route: "false"
+{{- else if .Values.aksbyocni.enabled }}
+  tunnel: "vxlan"
 {{- else }}
-  tunnel: {{ .Values.tunnel }}
+  tunnel: {{ .Values.tunnel | quote }}
 {{- end }}
 
 {{- if hasKey .Values "tunnelPort" }}
@@ -746,7 +748,11 @@ data:
   # A space separated list of iptables chains to disable when installing feeder rules.
   disable-iptables-feeder-rules: {{ .Values.disableIptablesFeederRules | join " " | quote }}
 {{- end }}
+{{- if .Values.aksbyocni.enabled }}
+  ipam: "cluster-pool"
+{{- else }}
   ipam: {{ $ipam | quote }}
+{{- end }}
 
 {{- if or (eq $ipam "cluster-pool") (eq $ipam "cluster-pool-v2beta") }}
 {{- if .Values.ipv4.enabled }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -194,6 +194,12 @@ updateStrategy:
 
 # Configuration Values for cilium-agent
 
+aksbyocni:
+  # -- Enable AKS BYOCNI integration.
+  # Note that this is incompatible with AKS clusters not created in BYOCNI mode:
+  # use Azure integration (`azure.enabled`) instead.
+  enabled: false
+
 # -- Enable installation of PodCIDR routes between worker
 # nodes if worker nodes share a common L2 network segment.
 autoDirectNodeRoutes: false
@@ -202,7 +208,9 @@ autoDirectNodeRoutes: false
 annotateK8sNode: false
 
 azure:
-  # -- Enable Azure integration
+  # -- Enable Azure integration.
+  # Note that this is incompatible with AKS clusters created in BYOCNI mode: use
+  # AKS BYOCNI integration (`aksbyocni.enabled`) instead.
   enabled: false
   # resourceGroup: group1
   # subscriptionID: 00000000-0000-0000-0000-000000000000

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -191,6 +191,12 @@ updateStrategy:
 
 # Configuration Values for cilium-agent
 
+aksbyocni:
+  # -- Enable AKS BYOCNI integration.
+  # Note that this is incompatible with AKS clusters not created in BYOCNI mode:
+  # use Azure integration (`azure.enabled`) instead.
+  enabled: false
+
 # -- Enable installation of PodCIDR routes between worker
 # nodes if worker nodes share a common L2 network segment.
 autoDirectNodeRoutes: false
@@ -199,7 +205,9 @@ autoDirectNodeRoutes: false
 annotateK8sNode: false
 
 azure:
-  # -- Enable Azure integration
+  # -- Enable Azure integration.
+  # Note that this is incompatible with AKS clusters created in BYOCNI mode: use
+  # AKS BYOCNI integration (`aksbyocni.enabled`) instead.
   enabled: false
   # resourceGroup: group1
   # subscriptionID: 00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
Microsoft has recently released support for "Bring your own CNI" when creating AKS clusters, allowing users to create clusters with no CNI plugin pre-installed.

This is extremely useful for Cilium as previously setting up an AKS cluster and installing Cilium was very complicated, due to the need to use multiple nodepools with a complex taint system in order to ensure applications pods would not get scheduled before Cilium agents were ready to manage connectivity in the cluster.

The BYOCNI feature has been available in preview as an `az` CLI extension for some time now, and Microsoft has published a dedicated documentation page outlining the prequisites and implications (notably in terms of support policy) of BYOCNI: https://docs.microsoft.com/en-us/azure/aks/use-byo-cni?tabs=azure-cli

BYOCNI in its current state is a strong enough proposal to warrant a change to the recommendations we make to our users for newly created AKS clusters.

Here are the changes necessary to run Cilium on an AKS cluster in BYOCNI mode:

- Azure IPAM does not work in BYOCNI mode as the Azure API is not available. Instead of using the Azure operator, we must use the generic operator with Cluster Pool IPAM.
- Direct routing does not work in BYOCNI mode. Instead, we must use VXLAN encapsulation.

See per commit for a more thorough description of the implementation.

### ⚠️ Additional notes for reviewers

- See [this comment](https://github.com/cilium/cilium/pull/19379#issuecomment-1156611493) for example of working workflow run with temporary commit.

### ⚠️ Checklist

- [x] ~~We are currently not making any changes to the old Azure IPAM-based installation method, however it is currently unusable due to the taints not working on AKS (see https://github.com/Azure/AKS/issues/2934).~~ Instructions for Azure IPAM have been updated.
- [x] This PR depends on https://github.com/cilium/cilium-cli/pull/899 being merged and released, at which point we can add a commit in this PR to update the CLI version used in the AKS workflows.

### ⚠️ After merge

- [ ] Re-enable AKS CI workflows.