### PR TITLE
Spell out the full term of the CRD acronym

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -14,7 +14,7 @@ Quick Installation
 
 This guide will walk you through the quick default installation. It will
 automatically detect and use the best configuration possible for the Kubernetes
-distribution you are using. All state is stored using Kubernetes CRDs.
+distribution you are using. All state is stored using Kubernetes custom resource definitions (CRDs).
 
 This is the best installation method for most use cases.  For large
 environments (> 500 nodes) or if you want to run specific datapath modes, refer


### PR DESCRIPTION
My change spells out the full term of the Kubernetes CRD acronym. 

I am not 100% sure if this will be helpful for readers of this "Quick Start Guide," considering their level of experience, but it is a good practice to spell out the full term of an acronym on initial use.

Signed-off-by: Divine Odazie <dodazie@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number