### PR TITLE
added NYT to the Cilium Users list

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -189,6 +189,12 @@ Users (Alphabetically)
       U: Networking (CNI, Maglev, kube-proxy replacement, local redirect policy),  Observability (Network metrics with Hubble, DNS proxy, service maps, policy troubleshooting) and Security (Network Policy)
       L: https://www.myfitnesspal.com
 
+    * N: New York Times (the)
+      D: The New York Times is using Cilium on EKS to build multi-region multi-tenant shared clusters
+      U: Networking (CNI, EKS IPAM, Maglev, kube-proxy replacement, Direct Routing),  Observability (Network metrics with Hubble, policy troubleshooting) and Security (Network Policy)
+      L: https://www.nytimes.com/
+      Q: @prune
+
     * N: Nexxiot
       D: Nexxiot is an IoT SaaS provider using Cilium as the main CNI plugin on AWS EKS clusters
       U: Networking (IPAM, CNI), Security (Network Policies), Visibility (hubble)


### PR DESCRIPTION
This PR adds The New York Times to the list of Cilium users.

Signed-off-by: Sebastien Prune THOMAS <prune@lecentre.net>