### PR TITLE
.github: add dependabot for docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,402 @@ updates:
     - kind/enhancement
     - release-note/misc
 
+# # # # # # # # # # # # # # # #
+# Docker images master branch #
+# # # # # # # # # # # # # # # #
+
+  - package-ecosystem: docker
+    directory: ./images/builder
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cache
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium-docker-plugin
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium-test
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/clustermesh-apiserver
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/hubble-relay
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/operator
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/runtime
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+# # # # # # # # # # # # # # # #
+# Docker images v1.11 branch  #
+# # # # # # # # # # # # # # # #
+
+  - package-ecosystem: docker
+    directory: ./images/builder
+    schedule:
+      interval: daily
+    target-branch: "v1.11"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cache
+    schedule:
+      interval: daily
+    target-branch: "v1.11"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium
+    schedule:
+      interval: daily
+    target-branch: "v1.11"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium-docker-plugin
+    schedule:
+      interval: daily
+    target-branch: "v1.11"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium-test
+    schedule:
+      interval: daily
+    target-branch: "v1.11"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/clustermesh-apiserver
+    schedule:
+      interval: daily
+    target-branch: "v1.11"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/hubble-relay
+    schedule:
+      interval: daily
+    target-branch: "v1.11"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/operator
+    schedule:
+      interval: daily
+    target-branch: "v1.11"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/runtime
+    schedule:
+      interval: daily
+    target-branch: "v1.11"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+# # # # # # # # # # # # # # # #
+# Docker images v1.10 branch  #
+# # # # # # # # # # # # # # # #
+
+  - package-ecosystem: docker
+    directory: ./images/builder
+    schedule:
+      interval: daily
+    target-branch: "v1.10"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cache
+    schedule:
+      interval: daily
+    target-branch: "v1.10"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium
+    schedule:
+      interval: daily
+    target-branch: "v1.10"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium-docker-plugin
+    schedule:
+      interval: daily
+    target-branch: "v1.10"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium-test
+    schedule:
+      interval: daily
+    target-branch: "v1.10"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/clustermesh-apiserver
+    schedule:
+      interval: daily
+    target-branch: "v1.10"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/hubble-relay
+    schedule:
+      interval: daily
+    target-branch: "v1.10"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/operator
+    schedule:
+      interval: daily
+    target-branch: "v1.10"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/runtime
+    schedule:
+      interval: daily
+    target-branch: "v1.10"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+# # # # # # # # # # # # # # # #
+#  Docker images v1.9 branch  #
+# # # # # # # # # # # # # # # #
+
+  - package-ecosystem: docker
+    directory: ./images/builder
+    schedule:
+      interval: daily
+    target-branch: "v1.9"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cache
+    schedule:
+      interval: daily
+    target-branch: "v1.9"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium
+    schedule:
+      interval: daily
+    target-branch: "v1.9"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium-docker-plugin
+    schedule:
+      interval: daily
+    target-branch: "v1.9"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/cilium-test
+    schedule:
+      interval: daily
+    target-branch: "v1.9"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/hubble-relay
+    schedule:
+      interval: daily
+    target-branch: "v1.9"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/operator
+    schedule:
+      interval: daily
+    target-branch: "v1.9"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+  - package-ecosystem: docker
+    directory: ./images/runtime
+    schedule:
+      interval: daily
+    target-branch: "v1.9"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - kind/enhancement
+      - release-note/misc
+
+# # # # # # # # # # # # # # # #
+#        GitHub Actions       #
+# # # # # # # # # # # # # # # #
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
With this commit, dependabot will be able to update docker images from
cilium repository as well.

Signed-off-by: André Martins <andre@cilium.io>