### PR TITLE
add 'refreshPeriod' to spelling wordlist

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -751,6 +751,7 @@ recompiles
 recv
 recvmsg
 refactoring
+refreshPeriod
 regenerations
 regex
 regexes


### PR DESCRIPTION
Fixes: c12f2ac1c8a4 ("docs: the 'refresh period' formatting in readme and doc")
Signed-off-by: André Martins <andre@cilium.io>