### PR TITLE
Revert "build(deps): bump google.golang.org/protobuf from 1.27.1 to 1…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20211027115401-c9b1ec1aa6d8
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
 	google.golang.org/grpc v1.45.0
-	google.golang.org/protobuf v1.28.0
+	google.golang.org/protobuf v1.27.1
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/ini.v1 v1.66.4
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1922,9 +1922,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/vendor/google.golang.org/protobuf/internal/encoding/text/decode.go
+++ b/vendor/google.golang.org/protobuf/internal/encoding/text/decode.go
@@ -381,7 +381,7 @@ func (d *Decoder) currentOpenKind() (Kind, byte) {
 	case '[':
 		return ListOpen, ']'
 	}
-	panic(fmt.Sprintf("Decoder: openStack contains invalid byte %c", openCh))
+	panic(fmt.Sprintf("Decoder: openStack contains invalid byte %s", string(openCh)))
 }
 
 func (d *Decoder) pushOpenStack(ch byte) {

--- a/vendor/google.golang.org/protobuf/internal/errors/is_go112.go
+++ b/vendor/google.golang.org/protobuf/internal/errors/is_go112.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !go1.13
 // +build !go1.13
 
 package errors

--- a/vendor/google.golang.org/protobuf/internal/errors/is_go113.go
+++ b/vendor/google.golang.org/protobuf/internal/errors/is_go113.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build go1.13
 // +build go1.13
 
 package errors

--- a/vendor/google.golang.org/protobuf/internal/flags/proto_legacy_disable.go
+++ b/vendor/google.golang.org/protobuf/internal/flags/proto_legacy_disable.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !protolegacy
 // +build !protolegacy
 
 package flags

--- a/vendor/google.golang.org/protobuf/internal/flags/proto_legacy_enable.go
+++ b/vendor/google.golang.org/protobuf/internal/flags/proto_legacy_enable.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build protolegacy
 // +build protolegacy
 
 package flags

--- a/vendor/google.golang.org/protobuf/internal/impl/codec_map_go111.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/codec_map_go111.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !go1.12
 // +build !go1.12
 
 package impl

--- a/vendor/google.golang.org/protobuf/internal/impl/codec_map_go112.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/codec_map_go112.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build go1.12
 // +build go1.12
 
 package impl

--- a/vendor/google.golang.org/protobuf/internal/impl/codec_reflect.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/codec_reflect.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build purego || appengine
 // +build purego appengine
 
 package impl

--- a/vendor/google.golang.org/protobuf/internal/impl/codec_unsafe.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/codec_unsafe.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !purego && !appengine
 // +build !purego,!appengine
 
 package impl

--- a/vendor/google.golang.org/protobuf/internal/impl/decode.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/decode.go
@@ -18,7 +18,6 @@ import (
 )
 
 var errDecode = errors.New("cannot parse invalid wire-format data")
-var errRecursionDepth = errors.New("exceeded maximum recursion depth")
 
 type unmarshalOptions struct {
 	flags    protoiface.UnmarshalInputFlags
@@ -26,7 +25,6 @@ type unmarshalOptions struct {
 		FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error)
 		FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error)
 	}
-	depth int
 }
 
 func (o unmarshalOptions) Options() proto.UnmarshalOptions {
@@ -46,7 +44,6 @@ func (o unmarshalOptions) IsDefault() bool {
 
 var lazyUnmarshalOptions = unmarshalOptions{
 	resolver: preg.GlobalTypes,
-	depth:    protowire.DefaultRecursionLimit,
 }
 
 type unmarshalOutput struct {
@@ -65,7 +62,6 @@ func (mi *MessageInfo) unmarshal(in piface.UnmarshalInput) (piface.UnmarshalOutp
 	out, err := mi.unmarshalPointer(in.Buf, p, 0, unmarshalOptions{
 		flags:    in.Flags,
 		resolver: in.Resolver,
-		depth:    in.Depth,
 	})
 	var flags piface.UnmarshalOutputFlags
 	if out.initialized {
@@ -86,10 +82,6 @@ var errUnknown = errors.New("unknown")
 
 func (mi *MessageInfo) unmarshalPointer(b []byte, p pointer, groupTag protowire.Number, opts unmarshalOptions) (out unmarshalOutput, err error) {
 	mi.init()
-	opts.depth--
-	if opts.depth < 0 {
-		return out, errRecursionDepth
-	}
 	if flags.ProtoLegacy && mi.isMessageSet {
 		return unmarshalMessageSet(mi, b, p, opts)
 	}

--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_reflect.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build purego || appengine
 // +build purego appengine
 
 package impl

--- a/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/pointer_unsafe.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !purego && !appengine
 // +build !purego,!appengine
 
 package impl

--- a/vendor/google.golang.org/protobuf/internal/strs/strings_pure.go
+++ b/vendor/google.golang.org/protobuf/internal/strs/strings_pure.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build purego || appengine
 // +build purego appengine
 
 package strs

--- a/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
+++ b/vendor/google.golang.org/protobuf/internal/strs/strings_unsafe.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !purego && !appengine
 // +build !purego,!appengine
 
 package strs

--- a/vendor/google.golang.org/protobuf/internal/version/version.go
+++ b/vendor/google.golang.org/protobuf/internal/version/version.go
@@ -52,8 +52,8 @@ import (
 //	10. Send out the CL for review and submit it.
 const (
 	Major      = 1
-	Minor      = 28
-	Patch      = 0
+	Minor      = 27
+	Patch      = 1
 	PreRelease = ""
 )
 

--- a/vendor/google.golang.org/protobuf/proto/decode.go
+++ b/vendor/google.golang.org/protobuf/proto/decode.go
@@ -42,25 +42,18 @@ type UnmarshalOptions struct {
 		FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error)
 		FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error)
 	}
-
-	// RecursionLimit limits how deeply messages may be nested.
-	// If zero, a default limit is applied.
-	RecursionLimit int
 }
 
 // Unmarshal parses the wire-format message in b and places the result in m.
 // The provided message must be mutable (e.g., a non-nil pointer to a message).
 func Unmarshal(b []byte, m Message) error {
-	_, err := UnmarshalOptions{RecursionLimit: protowire.DefaultRecursionLimit}.unmarshal(b, m.ProtoReflect())
+	_, err := UnmarshalOptions{}.unmarshal(b, m.ProtoReflect())
 	return err
 }
 
 // Unmarshal parses the wire-format message in b and places the result in m.
 // The provided message must be mutable (e.g., a non-nil pointer to a message).
 func (o UnmarshalOptions) Unmarshal(b []byte, m Message) error {
-	if o.RecursionLimit == 0 {
-		o.RecursionLimit = protowire.DefaultRecursionLimit
-	}
 	_, err := o.unmarshal(b, m.ProtoReflect())
 	return err
 }
@@ -70,9 +63,6 @@ func (o UnmarshalOptions) Unmarshal(b []byte, m Message) error {
 // This method permits fine-grained control over the unmarshaler.
 // Most users should use Unmarshal instead.
 func (o UnmarshalOptions) UnmarshalState(in protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
-	if o.RecursionLimit == 0 {
-		o.RecursionLimit = protowire.DefaultRecursionLimit
-	}
 	return o.unmarshal(in.Buf, in.Message)
 }
 
@@ -96,17 +86,12 @@ func (o UnmarshalOptions) unmarshal(b []byte, m protoreflect.Message) (out proto
 			Message:  m,
 			Buf:      b,
 			Resolver: o.Resolver,
-			Depth:    o.RecursionLimit,
 		}
 		if o.DiscardUnknown {
 			in.Flags |= protoiface.UnmarshalDiscardUnknown
 		}
 		out, err = methods.Unmarshal(in)
 	} else {
-		o.RecursionLimit--
-		if o.RecursionLimit < 0 {
-			return out, errors.New("exceeded max recursion depth")
-		}
 		err = o.unmarshalMessageSlow(b, m)
 	}
 	if err != nil {

--- a/vendor/google.golang.org/protobuf/proto/proto_methods.go
+++ b/vendor/google.golang.org/protobuf/proto/proto_methods.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 // The protoreflect build tag disables use of fast-path methods.
-//go:build !protoreflect
 // +build !protoreflect
 
 package proto

--- a/vendor/google.golang.org/protobuf/proto/proto_reflect.go
+++ b/vendor/google.golang.org/protobuf/proto/proto_reflect.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 // The protoreflect build tag disables use of fast-path methods.
-//go:build protoreflect
 // +build protoreflect
 
 package proto

--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/methods.go
+++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/methods.go
@@ -53,7 +53,6 @@ type (
 			FindExtensionByName(field FullName) (ExtensionType, error)
 			FindExtensionByNumber(message FullName, field FieldNumber) (ExtensionType, error)
 		}
-		Depth int
 	}
 	unmarshalOutput = struct {
 		pragma.NoUnkeyedLiterals

--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_pure.go
+++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_pure.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build purego || appengine
 // +build purego appengine
 
 package protoreflect

--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
+++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_union.go
@@ -41,31 +41,6 @@ import (
 // Converting to/from a Value and a concrete Go value panics on type mismatch.
 // For example, ValueOf("hello").Int() panics because this attempts to
 // retrieve an int64 from a string.
-//
-// List, Map, and Message Values are called "composite" values.
-//
-// A composite Value may alias (reference) memory at some location,
-// such that changes to the Value updates the that location.
-// A composite value acquired with a Mutable method, such as Message.Mutable,
-// always references the source object.
-//
-// For example:
-//	// Append a 0 to a "repeated int32" field.
-//	// Since the Value returned by Mutable is guaranteed to alias
-//	// the source message, modifying the Value modifies the message.
-//	message.Mutable(fieldDesc).(List).Append(protoreflect.ValueOfInt32(0))
-//
-//	// Assign [0] to a "repeated int32" field by creating a new Value,
-//	// modifying it, and assigning it.
-//	list := message.NewField(fieldDesc).(List)
-//	list.Append(protoreflect.ValueOfInt32(0))
-//	message.Set(fieldDesc, list)
-//	// ERROR: Since it is not defined whether Set aliases the source,
-//	// appending to the List here may or may not modify the message.
-//	list.Append(protoreflect.ValueOfInt32(0))
-//
-// Some operations, such as Message.Get, may return an "empty, read-only"
-// composite Value. Modifying an empty, read-only value panics.
 type Value value
 
 // The protoreflect API uses a custom Value union type instead of interface{}

--- a/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
+++ b/vendor/google.golang.org/protobuf/reflect/protoreflect/value_unsafe.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !purego && !appengine
 // +build !purego,!appengine
 
 package protoreflect

--- a/vendor/google.golang.org/protobuf/runtime/protoiface/methods.go
+++ b/vendor/google.golang.org/protobuf/runtime/protoiface/methods.go
@@ -103,7 +103,6 @@ type UnmarshalInput = struct {
 		FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error)
 		FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error)
 	}
-	Depth int
 }
 
 // UnmarshalOutput is output from the Unmarshal method.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1076,8 +1076,8 @@ google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
-# google.golang.org/protobuf v1.28.0
-## explicit; go 1.11
+# google.golang.org/protobuf v1.27.1
+## explicit; go 1.9
 google.golang.org/protobuf/encoding/protojson
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire


### PR DESCRIPTION
….28.0"

The CI is currently failing with the error, reverting the dependency
update to the previous version.
```
go_gc_heap_allocs_by_size_bytes_total non-counter metrics should not have "_total" suffix
go_gc_heap_frees_by_size_bytes_total non-counter metrics should not have "_total" suffix
go_gc_pauses_seconds_total non-counter metrics should not have "_total" suffix
```

This reverts commit d30b2e505c534675332cd115b3c670037384bc81.

Signed-off-by: André Martins <andre@cilium.io>