### PR TITLE
Fix smoke tests by filtering out go_* metrics from metrics linting

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -195,7 +195,9 @@ jobs:
           tar xzvf prometheus-${PROM_VERSION}.linux-amd64.tar.gz prometheus-${PROM_VERSION}.linux-amd64/promtool
           rm -f prometheus-${PROM_VERSION}.linux-amd64.tar.gz
           sudo mv prometheus-${PROM_VERSION}.linux-amd64/promtool /usr/bin
-          cat metrics.prom | promtool check metrics
+          # filter go_ metrics which do not conform to the _total convention with gauges
+          # See https://github.com/prometheus/prometheus/issues/10574
+          cat metrics.prom | grep -v 'go_' | promtool check metrics
 
       - name: Capture cilium-sysdump
         if: ${{ failure() }}


### PR DESCRIPTION
See https://github.com/cilium/cilium/pull/19398/ and https://github.com/prometheus/prometheus/issues/10574 for the original issue this aims to work-around.