### PR TITLE
bgpv1: Set nexthop of locally originated routes to 0.0.0.0 (or ::)

### DIFF
--- a/pkg/bgpv1/gobgp/reconcile.go
+++ b/pkg/bgpv1/gobgp/reconcile.go
@@ -405,7 +405,7 @@ func exportPodCIDRReconciler(ctx context.Context, _ *BGPRouterManager, sc *Serve
 	// create new adverts
 	for _, advrt := range toAdvertise {
 		l.Debugf("Advertising pod CIDR %v for policy with local ASN: %v", advrt.Net.String(), newc.LocalASN)
-		advrt, err := sc.AdvertisePath(ctx, advrt.Net, cstate)
+		advrt, err := sc.AdvertisePath(ctx, advrt.Net)
 		if err != nil {
 			return fmt.Errorf("failed to advertise pod cidr prefix %v: %w", advrt.Net, err)
 		}

--- a/pkg/bgpv1/gobgp/reconcile_test.go
+++ b/pkg/bgpv1/gobgp/reconcile_test.go
@@ -393,9 +393,6 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 					ListenPort: -1,
 				},
 			}
-			oldcstate := agent.ControlPlaneState{
-				IPv4: net.ParseIP("127.0.0.1"),
-			}
 			oldc := &v2alpha1api.CiliumBGPVirtualRouter{
 				LocalASN:      64125,
 				ExportPodCIDR: tt.enabled,
@@ -407,7 +404,7 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 			}
 			testSC.Config = oldc
 			for _, cidr := range tt.advertised {
-				advrt, err := testSC.AdvertisePath(context.Background(), cidr, &oldcstate)
+				advrt, err := testSC.AdvertisePath(context.Background(), cidr)
 				if err != nil {
 					t.Fatalf("failed to advertise initial pod cidr routes: %v", err)
 				}

--- a/pkg/bgpv1/gobgp/server.go
+++ b/pkg/bgpv1/gobgp/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/osrg/gobgp/v3/pkg/server"
 	apb "google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
@@ -165,15 +164,15 @@ func (sc *ServerWithConfig) RemoveNeighbor(ctx context.Context, n *v2alpha1api.C
 // `ip` can be an ipv4 or ipv6 and this method will handle the differences
 // between MP BGP and BGP.
 //
-// `cstate` provides the IPv6 and IPv4 next host addresses which `must` be
-// Cilium's externally reachable IPv6 or IPv4 address.
-//
 // It is an error to advertise an IPv6 path when no IPv6 address is configured
 // on this Cilium node, selfsame for IPv4.
 //
+// Nexthop of the path will always set to "0.0.0.0" in IPv4 and "::" in IPv6, so
+// that GoBGP selects appropriate actual nexthop address and advertise it.
+//
 // An Advertisement is returned which may be passed to WithdrawPath to remove
 // this Advertisement.
-func (sc *ServerWithConfig) AdvertisePath(ctx context.Context, ip *net.IPNet, cstate *agent.ControlPlaneState) (Advertisement, error) {
+func (sc *ServerWithConfig) AdvertisePath(ctx context.Context, ip *net.IPNet) (Advertisement, error) {
 	var err error
 	var path *gobgp.Path
 	origin, _ := apb.New(&gobgp.OriginAttribute{
@@ -181,16 +180,28 @@ func (sc *ServerWithConfig) AdvertisePath(ctx context.Context, ip *net.IPNet, cs
 	})
 	switch {
 	case ip.IP.To4() != nil:
-		if cstate.IPv4.IsUnspecified() {
-			return Advertisement{}, fmt.Errorf("cannot advertise IPv4 path %v, control plane has no configured IPv4 address for next hop", ip.String())
-		}
 		prefixLen, _ := ip.Mask.Size()
 		nlri, _ := apb.New(&gobgp.IPAddressPrefix{
 			PrefixLen: uint32(prefixLen),
 			Prefix:    ip.IP.String(),
 		})
+		// Currently, we only support advertising locally originated paths (the paths generated in Cilium
+		// node itself, not the paths received from another BGP Peer or redistributed from another routing
+		// protocol. In this case, the nexthop address should be the address used for peering. That means
+		// the nexthop address can be changed depending on the neighbor.
+		//
+		// For example, when the Cilium node is connected to two subnets 10.0.0.0/24 and 10.0.1.0/24 with
+		// local address 10.0.0.1 and 10.0.1.1 respectively, the nexthop should be advertised for 10.0.0.0/24
+		// peers is 10.0.0.1. On the other hand, we should advertise 10.0.1.1 as a nexthop for 10.0.1.0/24.
+		//
+		// Fortunately, GoBGP takes care of resolving appropriate nexthop address for each peers when we
+		// specify an zero IP address (0.0.0.0 for IPv4 and :: for IPv6). So, we can just rely on that.
+		//
+		// References:
+		// - RFC4271 Section 5.1.3 (NEXT_HOP)
+		// - RFC4760 Section 3 (Multiprotocol Reachable NLRI - MP_REACH_NLRI (Type Code 14))
 		nextHop, _ := apb.New(&gobgp.NextHopAttribute{
-			NextHop: cstate.IPv4.String(),
+			NextHop: "0.0.0.0",
 		})
 		path = &gobgp.Path{
 			Family: GoBGPIPv4Family,
@@ -201,17 +212,15 @@ func (sc *ServerWithConfig) AdvertisePath(ctx context.Context, ip *net.IPNet, cs
 			Path: path,
 		})
 	case ip.IP.To16() != nil:
-		if cstate.IPv6.IsUnspecified() {
-			return Advertisement{}, fmt.Errorf("cannot advertise IPv6 path %v, control plane has no configured IPv6 address for next hop", ip.String())
-		}
 		prefixLen, _ := ip.Mask.Size()
 		nlri, _ := apb.New(&gobgp.IPAddressPrefix{
 			PrefixLen: uint32(prefixLen),
 			Prefix:    ip.IP.String(),
 		})
 		nlriAttrs, _ := apb.New(&gobgp.MpReachNLRIAttribute{ // MP BGP NLRI
-			Family:   GoBGPIPv6Family,
-			NextHops: []string{cstate.IPv6.String()},
+			Family: GoBGPIPv6Family,
+			// See the above explanation for IPv4
+			NextHops: []string{"::"},
 			Nlris:    []*apb.Any{nlri},
 		})
 		path = &gobgp.Path{


### PR DESCRIPTION
Please see the commit message and comments on the code for more details.

```release-note
bgpv1: Use IP address used for peering as a nexthop
```
