### PR TITLE
v1.9 backports 2022-04-12

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
-      - uses: docker://cilium/docs-builder:latest
+      - uses: docker://cilium/docs-builder:2021-06-09@sha256:7126ea9182667ab1961bd8bb71265cbd3ec951e412910a116e24e0e74d7fc653
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -197,6 +197,7 @@ cilium-agent [flags]
       --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
       --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-gid uint                                       Group ID for proxy control plane sockets. (default 1337)
       --proxy-prometheus-port int                            Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                                 Read to the CNI configuration at specified path to extract per node configuration
       --restore                                              Restores state, if possible, from previous daemon (default true)

--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -130,8 +130,8 @@ interface as follows:
 
 .. _node_to_node_encryption:
 
-Node to node encryption
------------------------
+Node-to-node encryption (beta)
+------------------------------
 
 In order to enable node-to-node encryption, add:
 
@@ -144,8 +144,11 @@ In order to enable node-to-node encryption, add:
 
 .. note::
 
-    Node to node encryption feature is tested and supported with direct routing
-    modes. Using with encapsulation/tunneling is not currently tested or supported.
+    Node-to-node encryption is a beta feature. Please provide feedback and file
+    a GitHub issue if you experience any problems.
+
+    Node-to-node encryption is tested and supported with direct routing modes.
+    Using with encapsulation/tunneling is not currently tested or supported.
 
     Support with tunneling mode is tracked at `#13663 <https://github.com/cilium/cilium/issues/13663>`_.
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -424,6 +424,9 @@ func init() {
 	flags.Uint(option.ProxyConnectTimeout, 1, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
 	option.BindEnv(option.ProxyConnectTimeout)
 
+	flags.Uint(option.ProxyGID, 1337, "Group ID for proxy control plane sockets.")
+	option.BindEnv(option.ProxyGID)
+
 	flags.Int(option.ProxyPrometheusPort, 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
 	option.BindEnv(option.ProxyPrometheusPort)
 

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/flowdebug"
+	"github.com/cilium/cilium/pkg/option"
 	kafka_api "github.com/cilium/cilium/pkg/policy/api/kafka"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -54,10 +55,14 @@ func StartAccessLogServer(stateDir string, xdsServer *XDSServer, endpointInfoReg
 	}
 	accessLogListener.SetUnlinkOnClose(true)
 
-	// Make the socket accessible by non-root Envoy proxies, e.g. running in
-	// sidecar containers.
-	if err = os.Chmod(accessLogPath, 0777); err != nil {
+	// Make the socket accessible by owner and group only. Group access is needed for Istio
+	// sidecar proxies.
+	if err = os.Chmod(accessLogPath, 0660); err != nil {
 		log.WithError(err).Fatalf("Envoy: Failed to change mode of access log listen socket at %s", accessLogPath)
+	}
+	// Change the group to ProxyGID allowing access from any process from that group.
+	if err = os.Chown(accessLogPath, -1, option.Config.ProxyGID); err != nil {
+		log.WithError(err).Warningf("Envoy: Failed to change the group of access log listen socket at %s, sidecar proxies may not work", accessLogPath)
 	}
 
 	server := accessLogServer{

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -161,10 +161,14 @@ func StartXDSServer(stateDir string) *XDSServer {
 		log.WithError(err).Fatalf("Envoy: Failed to open xDS listen socket at %s", xdsPath)
 	}
 
-	// Make the socket accessible by non-root Envoy proxies, e.g. running in
-	// sidecar containers.
-	if err = os.Chmod(xdsPath, 0777); err != nil {
+	// Make the socket accessible by owner and group only. Group access is needed for Istio
+	// sidecar proxies.
+	if err = os.Chmod(xdsPath, 0660); err != nil {
 		log.WithError(err).Fatalf("Envoy: Failed to change mode of xDS listen socket at %s", xdsPath)
+	}
+	// Change the group to ProxyGID allowing access from any process from that group.
+	if err = os.Chown(xdsPath, -1, option.Config.ProxyGID); err != nil {
+		log.WithError(err).Warningf("Envoy: Failed to change the group of xDS listen socket at %s, sidecar proxies may not work", xdsPath)
 	}
 
 	ldsCache := xds.NewCache()

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -134,8 +134,8 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(len(IPIdentityCache.ipToK8sMetadata), Equals, 0)
 
 	// Test mapping of multiple IPs to same identity.
-	endpointIPs := []string{"192.168.0.1", "20.3.75.3", "27.2.2.2", "127.0.0.1", "127.0.0.1"}
-	identities := []identityPkg.NumericIdentity{5, 67, 29, 29, 29}
+	endpointIPs := []string{"192.168.0.1", "20.3.75.3", "27.2.2.2", "127.0.0.1", "127.0.0.1", "10.1.1.250"}
+	identities := []identityPkg.NumericIdentity{5, 67, 29, 29, 29, 42}
 
 	for index := range endpointIPs {
 		IPIdentityCache.Upsert(endpointIPs[index], nil, 0, nil, Identity{
@@ -175,6 +175,36 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	_, exists = IPIdentityCache.LookupByPrefix("127.0.0.1/32")
 	c.Assert(exists, Equals, false)
 
+	// Assert IPCache entry is overwritten when a different pod (different
+	// k8sMeta) with the same IP as what's already inside the IPCache is
+	// inserted.
+	updated, _ = IPIdentityCache.Upsert("10.1.1.250", net.ParseIP("10.0.0.1"), 0, &K8sMetadata{
+		Namespace: "ns-1",
+		PodName:   "pod1",
+	}, Identity{
+		ID:     42,
+		Source: source.KVStore,
+	})
+	c.Assert(updated, Equals, true)
+	_, exists = IPIdentityCache.LookupByPrefix("10.1.1.250/32")
+	c.Assert(exists, Equals, true)
+	// Insert different pod now.
+	updated, _ = IPIdentityCache.Upsert("10.1.1.250", net.ParseIP("10.0.0.2"), 0, &K8sMetadata{
+		Namespace: "ns-1",
+		PodName:   "pod2",
+	}, Identity{
+		ID:     43,
+		Source: source.KVStore,
+	})
+	c.Assert(updated, Equals, true)
+	cachedIdentity, _ = IPIdentityCache.LookupByPrefix("10.1.1.250/32")
+	c.Assert(cachedIdentity.ID, Equals, identityPkg.NumericIdentity(43)) // Assert entry overwritten.
+	// Assuming different pod with same IP 10.1.1.250 as a previous pod was
+	// deleted, assert IPCache entry is deleted is still deleted.
+	IPIdentityCache.Delete("10.1.1.250", source.KVStore)
+	_, exists = IPIdentityCache.LookupByPrefix("10.1.1.250/32")
+	c.Assert(exists, Equals, false) // Assert entry deleted.
+
 	// Clean up.
 	for index := range endpointIPs {
 		IPIdentityCache.Delete(endpointIPs[index], source.KVStore)
@@ -187,7 +217,6 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
 	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 0)
-
 }
 
 func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1224,6 +1224,10 @@ const (
 	// is considered timed out
 	ProxyConnectTimeout = "proxy-connect-timeout"
 
+	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
+	// agent for proxy configuration and access logging.
+	ProxyGID = "proxy-gid"
+
 	// ReadCNIConfiguration reads the CNI configuration file and extracts
 	// Cilium relevant information. This can be used to pass per node
 	// configuration to Cilium.
@@ -1548,6 +1552,10 @@ type DaemonConfig struct {
 	// ProxyConnectTimeout is the time in seconds after which Envoy considers a TCP
 	// connection attempt to have timed out.
 	ProxyConnectTimeout int
+
+	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
+	// agent for proxy configuration and access logging.
+	ProxyGID int
 
 	// ProxyPrometheusPort specifies the port to serve Envoy metrics on.
 	ProxyPrometheusPort int
@@ -2624,6 +2632,7 @@ func (c *DaemonConfig) Populate() {
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
 	c.PrometheusServeAddr = viper.GetString(PrometheusServeAddr)
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
+	c.ProxyGID = viper.GetInt(ProxyGID)
 	c.ProxyPrometheusPort = viper.GetInt(ProxyPrometheusPort)
 	c.ReadCNIConfiguration = viper.GetString(ReadCNIConfiguration)
 	c.RestoreState = viper.GetBool(Restore)


### PR DESCRIPTION
* #16200 -- docs: mark node-to-node IPSec encryption as beta (@qmonnet)
 * #19258 -- ipcache: Add test asserting out-of-order Kubernetes events (@christarazi)
 * #19356 -- ci: Pin down image for the documentation workflow (@qmonnet)
 * #19190 -- envoy: Limit accesslog socket permissions (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16200 19258 19356 19190; do contrib/backporting/set-labels.py $pr done 1.9; done
```