### PR TITLE
make: grep for new go:build tags in PRIV_TEST_PKGS_EVAL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ build-container: ## Builds components required for cilium-agent container.
 $(SUBDIRS): force ## Execute default make target(make all) for the provided subdirectory.
 	@ $(MAKE) $(SUBMAKEOPTS) -C $@ all
 
-PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $$pkg; done | xargs grep --include='*.go' -ril '+build [^!]*privileged_tests' | xargs dirname | sort | uniq)
+PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $$pkg; done | xargs grep --include='*.go' -ril 'go:build [^!]*privileged_tests' | xargs dirname | sort | uniq)
 PRIV_TEST_PKGS ?= $(PRIV_TEST_PKGS_EVAL)
 tests-privileged: GO_TAGS_FLAGS+=privileged_tests ## Run integration-tests for Cilium that requires elevated privileges.
 tests-privileged:


### PR DESCRIPTION
Updating to Go 1.18 and removing all +build tags in commit 1108684e354d
("Update Go to 1.18") lead to any make target reporting the following
error as reported by Quentin in [1]:

    $  make help > /dev/null
    dirname: missing operand
    Try 'dirname --help' for more information.

Fix this by instead grep'ing for the new go:build tags in
PRIV_TEST_PKGS_EVAL.

[1] https://github.com/cilium/cilium/pull/19169#issuecomment-1096858549

Fixes: 1108684e354d ("Update Go to 1.18")