### PR TITLE
v1.10 backports 2022-04-12

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           persist-credentials: false
-      - uses: docker://cilium/docs-builder:latest
+      - uses: docker://cilium/docs-builder:2021-06-09@sha256:7126ea9182667ab1961bd8bb71265cbd3ec951e412910a116e24e0e74d7fc653
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           filters: |
             src:
+              - .github/workflows/documentation.yaml
               - 'Documentation/**'
               - 'bugtool/cmd/**'
               - 'cilium/cmd/**'

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -218,6 +218,7 @@ cilium-agent [flags]
       --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
       --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-gid uint                                       Group ID for proxy control plane sockets. (default 1337)
       --proxy-prometheus-port int                            Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                                 Read to the CNI configuration at specified path to extract per node configuration
       --restore                                              Restores state, if possible, from previous daemon (default true)

--- a/Documentation/gettingstarted/external-workloads.rst
+++ b/Documentation/gettingstarted/external-workloads.rst
@@ -51,6 +51,12 @@ Prerequisites
 * So far this functionality is only tested with the vxlan tunneling
   datapath mode (default for most installations).
 
+Limitations
+###########
+
+* Transparent encryption of traffic to/from external workloads is currently not
+  supported.
+
 Prepare your cluster
 ####################
 

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -904,7 +904,7 @@
    * - nodeinit.bootstrapFile
      - bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet
      - string
-     - ``"/tmp/cilium-bootstrap-time"``
+     - ``"/tmp/cilium-bootstrap.d/cilium-bootstrap-time"``
    * - nodeinit.enabled
      - Enable the node initialization DaemonSet
      - bool

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -449,6 +449,9 @@ func initializeFlags() {
 	flags.Uint(option.ProxyConnectTimeout, 1, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
 	option.BindEnv(option.ProxyConnectTimeout)
 
+	flags.Uint(option.ProxyGID, 1337, "Group ID for proxy control plane sockets.")
+	option.BindEnv(option.ProxyGID)
+
 	flags.Int(option.ProxyPrometheusPort, 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
 	option.BindEnv(option.ProxyPrometheusPort)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -276,7 +276,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodePort.bindProtection | bool | `true` | Set to true to prevent applications binding to service ports. |
 | nodePort.enableHealthCheck | bool | `true` | Enable healthcheck nodePort server for NodePort services |
 | nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
-| nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
+| nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap.d/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraConfigmapMounts | list | `[]` | Additional nodeinit ConfigMap mounts. |
 | nodeinit.extraEnv | object | `{}` | Additional nodeinit environment variables. |

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -406,12 +406,12 @@ spec:
 {{- end }}
 {{- if and .Values.nodeinit.enabled (not (eq .Values.nodeinit.bootstrapFile "")) }}
       - name: wait-for-node-init
-        command: ['sh', '-c', 'until test -s {{ .Values.nodeinit.bootstrapFile | quote }}; do echo "Waiting on node-init to run..."; sleep 1; done']
+        command: ['sh', '-c', 'until test -s {{ (print "/tmp/cilium-bootstrap.d/" (.Values.nodeinit.bootstrapFile | base)) | quote }}; do echo "Waiting on node-init to run..."; sleep 1; done']
         image: "{{ if .Values.image.override }}{{ .Values.image.override }}{{ else }}{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}{{ end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
-        - mountPath: {{ .Values.nodeinit.bootstrapFile }}
-          name: cilium-bootstrap-file
+        - mountPath: "/tmp/cilium-bootstrap.d"
+          name: cilium-bootstrap-file-dir
 {{- end }}
       - command:
         - /init-container.sh
@@ -543,9 +543,9 @@ spec:
 {{- end }}
 {{- if and .Values.nodeinit.enabled (not (eq .Values.nodeinit.bootstrapFile "")) }}
       - hostPath:
-          path: {{ .Values.nodeinit.bootstrapFile }}
-          type: FileOrCreate
-        name: cilium-bootstrap-file
+          path: {{ .Values.nodeinit.bootstrapFile | dir | quote }}
+          type: DirectoryOrCreate
+        name: cilium-bootstrap-file-dir
 {{- end }}
 {{- range .Values.extraHostPathMounts }}
       - name: {{ .name }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -138,7 +138,7 @@ spec:
                     fi
 
 {{- if not (eq .Values.nodeinit.bootstrapFile "") }}
-                    rm -f {{ .Values.nodeinit.bootstrapFile }}
+                    rm -f {{ .Values.nodeinit.bootstrapFile | quote }}
 {{- end }}
 
                     rm -f /tmp/node-init.cilium.io
@@ -294,7 +294,8 @@ spec:
 {{- end }}
 
 {{- if not (eq .Values.nodeinit.bootstrapFile "") }}
-              date > {{ .Values.nodeinit.bootstrapFile }}
+              mkdir -p {{ .Values.nodeinit.bootstrapFile | dir | quote }}
+              date > {{ .Values.nodeinit.bootstrapFile | quote }}
 {{- end }}
 
 {{- if .Values.nodeinit.restartPods }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -173,8 +173,6 @@ spec:
                     echo "Node de-initialization complete"
 {{- end }}
           env:
-          - name: CHECKPOINT_PATH
-            value: /tmp/node-init.cilium.io
           # STARTUP_SCRIPT is the script run on node bootstrap. Node
           # bootstrapping can be customized in this script. This script is invoked
           # using nsenter, so it runs in the host's network and mount namespace using

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1459,7 +1459,7 @@ nodeinit:
 
   # -- bootstrapFile is the location of the file where the bootstrap timestamp is
   # written by the node-init DaemonSet
-  bootstrapFile: "/tmp/cilium-bootstrap-time"
+  bootstrapFile: "/tmp/cilium-bootstrap.d/cilium-bootstrap-time"
 
 preflight:
   # -- Enable Cilium pre-flight resources (required for upgrade)

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/flowdebug"
+	"github.com/cilium/cilium/pkg/option"
 	kafka_api "github.com/cilium/cilium/pkg/policy/api/kafka"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -55,10 +56,14 @@ func StartAccessLogServer(stateDir string, xdsServer *XDSServer, endpointInfoReg
 	}
 	accessLogListener.SetUnlinkOnClose(true)
 
-	// Make the socket accessible by non-root Envoy proxies, e.g. running in
-	// sidecar containers.
-	if err = os.Chmod(accessLogPath, 0777); err != nil {
+	// Make the socket accessible by owner and group only. Group access is needed for Istio
+	// sidecar proxies.
+	if err = os.Chmod(accessLogPath, 0660); err != nil {
 		log.WithError(err).Fatalf("Envoy: Failed to change mode of access log listen socket at %s", accessLogPath)
+	}
+	// Change the group to ProxyGID allowing access from any process from that group.
+	if err = os.Chown(accessLogPath, -1, option.Config.ProxyGID); err != nil {
+		log.WithError(err).Warningf("Envoy: Failed to change the group of access log listen socket at %s, sidecar proxies may not work", accessLogPath)
 	}
 
 	server := accessLogServer{

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -160,10 +160,14 @@ func StartXDSServer(stateDir string) *XDSServer {
 		log.WithError(err).Fatalf("Envoy: Failed to open xDS listen socket at %s", xdsPath)
 	}
 
-	// Make the socket accessible by non-root Envoy proxies, e.g. running in
-	// sidecar containers.
-	if err = os.Chmod(xdsPath, 0777); err != nil {
+	// Make the socket accessible by owner and group only. Group access is needed for Istio
+	// sidecar proxies.
+	if err = os.Chmod(xdsPath, 0660); err != nil {
 		log.WithError(err).Fatalf("Envoy: Failed to change mode of xDS listen socket at %s", xdsPath)
+	}
+	// Change the group to ProxyGID allowing access from any process from that group.
+	if err = os.Chown(xdsPath, -1, option.Config.ProxyGID); err != nil {
+		log.WithError(err).Warningf("Envoy: Failed to change the group of xDS listen socket at %s, sidecar proxies may not work", xdsPath)
 	}
 
 	ldsCache := xds.NewCache()

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -125,7 +125,7 @@ type DNSProxy struct {
 	maxIPsPerRestoredDNSRule int
 
 	// this mutex protects variables below this point
-	lock.Mutex
+	lock.RWMutex
 
 	// usedServers is the set of DNS servers that have been allowed and used successfully.
 	// This is used to limit the number of IPs we store for restored DNS rules.
@@ -191,8 +191,8 @@ func (p *DNSProxy) checkRestored(endpointID uint64, destPort uint16, destIP stri
 // GetRules creates a fresh copy of EP's DNS rules to be stored
 // for later restoration.
 func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
-	p.Lock()
-	defer p.Unlock()
+	p.RLock()
+	defer p.RUnlock()
 
 	restored := make(restore.DNSRules)
 	for port, entries := range p.allowed[uint64(endpointID)] {
@@ -502,8 +502,8 @@ func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort 
 // something that was added (via UpdateAllowed or RestoreRules) previously.
 func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID identity.NumericIdentity, destIP net.IP, name string) (allowed bool, err error) {
 	name = strings.ToLower(dns.Fqdn(name))
-	p.Lock()
-	defer p.Unlock()
+	p.RLock()
+	defer p.RUnlock()
 
 	epAllow, exists := p.allowed.getPortRulesForID(endpointID, destPort)
 	if !exists {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1045,6 +1045,10 @@ const (
 	// is considered timed out
 	ProxyConnectTimeout = "proxy-connect-timeout"
 
+	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
+	// agent for proxy configuration and access logging.
+	ProxyGID = "proxy-gid"
+
 	// ReadCNIConfiguration reads the CNI configuration file and extracts
 	// Cilium relevant information. This can be used to pass per node
 	// configuration to Cilium.
@@ -1382,6 +1386,10 @@ type DaemonConfig struct {
 	// ProxyConnectTimeout is the time in seconds after which Envoy considers a TCP
 	// connection attempt to have timed out.
 	ProxyConnectTimeout int
+
+	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
+	// agent for proxy configuration and access logging.
+	ProxyGID int
 
 	// ProxyPrometheusPort specifies the port to serve Envoy metrics on.
 	ProxyPrometheusPort int
@@ -2563,6 +2571,7 @@ func (c *DaemonConfig) Populate() {
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
 	c.PrometheusServeAddr = viper.GetString(PrometheusServeAddr)
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
+	c.ProxyGID = viper.GetInt(ProxyGID)
 	c.ProxyPrometheusPort = viper.GetInt(ProxyPrometheusPort)
 	c.ReadCNIConfiguration = viper.GetString(ReadCNIConfiguration)
 	c.RestoreState = viper.GetBool(Restore)

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -99,6 +99,7 @@ func (a *AgentSuite) TestAgent_PeerConfig(c *C) {
 		listenPort:       listenPort,
 		peerByNodeName:   map[string]*peerConfig{},
 		nodeNameByNodeIP: map[string]string{},
+		nodeNameByPubKey: map[wgtypes.Key]string{},
 	}
 	ipCache.AddListener(wgAgent)
 
@@ -195,8 +196,14 @@ func (a *AgentSuite) TestAgent_PeerConfig(c *C) {
 	c.Assert(containsIP(k8s2.allowedIPs, pod3IPv4), Equals, true)
 	c.Assert(containsIP(k8s2.allowedIPs, pod3IPv6), Equals, true)
 
+	// Tests that duplicate public keys are rejected (k8s2 imitates k8s1)
+	err = wgAgent.UpdatePeer(k8s2NodeName, k8s1PubKey, k8s2NodeIPv4, k8s2NodeIPv6)
+	c.Assert(err, ErrorMatches, "detected duplicate public key.*")
+
 	// Node Deletion
 	wgAgent.DeletePeer(k8s1NodeName)
 	wgAgent.DeletePeer(k8s2NodeName)
 	c.Assert(wgAgent.peerByNodeName, HasLen, 0)
+	c.Assert(wgAgent.nodeNameByNodeIP, HasLen, 0)
+	c.Assert(wgAgent.nodeNameByPubKey, HasLen, 0)
 }


### PR DESCRIPTION
* #19286 -- fix(helm): use a directory to store bootstrap time (@raphink)
 * #19344 -- wireguard: Reject duplicate public keys (@gandro)
 * #19336 -- Use RLock while reading data in DNS proxy (@nebril)
 * #19356 -- ci: Pin down image for the documentation workflow (@qmonnet)
 * #19366 -- Add a 'Limitations' section to 'External Workloads'. (@bmcustodio)
 * #19190 -- envoy: Limit accesslog socket permissions (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19286 19344 19336 19356 19366 19190; do contrib/backporting/set-labels.py $pr done 1.10; done
```