### PR TITLE
v1.11 backports 2022-04-12

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           persist-credentials: false
-      - uses: docker://cilium/docs-builder:latest
+      - uses: docker://cilium/docs-builder:2021-06-09@sha256:7126ea9182667ab1961bd8bb71265cbd3ec951e412910a116e24e0e74d7fc653
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           filters: |
             src:
+              - .github/workflows/documentation.yaml
               - 'Documentation/**'
               - 'bugtool/cmd/**'
               - 'cilium/cmd/**'

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -223,6 +223,7 @@ cilium-agent [flags]
       --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
       --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-gid uint                                       Group ID for proxy control plane sockets. (default 1337)
       --proxy-prometheus-port int                            Port to serve Envoy metrics on. Default 0 (disabled).
       --read-cni-conf string                                 Read to the CNI configuration at specified path to extract per node configuration
       --restore                                              Restores state, if possible, from previous daemon (default true)

--- a/Documentation/gettingstarted/clustermesh/services.rst
+++ b/Documentation/gettingstarted/clustermesh/services.rst
@@ -24,14 +24,12 @@ Cilium will automatically perform load-balancing to pods in both clusters.
 .. literalinclude:: ../../../examples/kubernetes/clustermesh/global-service-example/rebel-base-global-shared.yaml
   :language: YAML
 
-Load-balancing Only to a Remote Cluster
-#######################################
+Disabling Global Service Sharing
+################################
 
 By default, a Global Service will load-balance across backends in multiple clusters.
 This implicitly configures ``io.cilium/shared-service: "true"``. To prevent service
-backends from being shared to other clusters, and to ensure that the service
-will only load-balance to backends in remote clusters, this option should be
-disabled.
+backends from being shared to other clusters, this option should be disabled.
 
 Below example will expose remote endpoint without sharing local endpoints.
 
@@ -76,3 +74,39 @@ Deploying a Simple Example Service
       kubectl exec -ti deployment/x-wing -- curl rebel-base
 
    You will see replies from pods in both clusters.
+
+4. In cluster 1, add ``io.cilium/shared-service="false"`` to existing global service
+
+   .. code-block:: shell-session
+
+      kubectl annotate service rebel-base io.cilium/shared-service="false" --overwrite
+
+5. From cluster 1, access the global service one more time:
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+   You will still see replies from pods in both clusters.
+
+6. From cluster 2, access the global service again:
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+   You will see replies from pods only from cluster 2, as the global service in cluster 1 is no longer shared.
+
+7. In cluster 1, remove ``io.cilium/shared-service`` annotation of existing global service
+
+   .. code-block:: shell-session
+
+      kubectl annotate service rebel-base io.cilium/shared-service-
+
+8. From either cluster, access the global service:
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+   You will see replies from pods in both clusters again.

--- a/Documentation/gettingstarted/external-workloads.rst
+++ b/Documentation/gettingstarted/external-workloads.rst
@@ -54,6 +54,12 @@ Prerequisites
 * So far this functionality is only tested with the vxlan tunneling
   datapath mode (default for most installations).
 
+Limitations
+###########
+
+* Transparent encryption of traffic to/from external workloads is currently not
+  supported.
+
 Prepare your cluster
 ####################
 

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -996,7 +996,7 @@
    * - nodeinit.bootstrapFile
      - bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet
      - string
-     - ``"/tmp/cilium-bootstrap-time"``
+     - ``"/tmp/cilium-bootstrap.d/cilium-bootstrap-time"``
    * - nodeinit.enabled
      - Enable the node initialization DaemonSet
      - bool

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -929,14 +929,14 @@
      - healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled.
      - string
      - ``""``
-   * - l2NeighDiscovery.arping-refresh-period
-     - Override the agent's default neighbor resolution refresh period.
-     - string
-     - ``"30s"``
    * - l2NeighDiscovery.enabled
      - Enable L2 neighbor discovery in the agent
      - bool
      - ``true``
+   * - l2NeighDiscovery.refreshPeriod
+     - Override the agent's default neighbor resolution refresh period.
+     - string
+     - ``"30s"``
    * - l7Proxy
      - Enable Layer 7 network policy.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -736,6 +736,7 @@ recompiles
 recv
 recvmsg
 refactoring
+refreshPeriod
 regenerations
 regex
 regexes

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -441,6 +441,9 @@ func initializeFlags() {
 	flags.Uint(option.ProxyConnectTimeout, 1, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
 	option.BindEnv(option.ProxyConnectTimeout)
 
+	flags.Uint(option.ProxyGID, 1337, "Group ID for proxy control plane sockets.")
+	option.BindEnv(option.ProxyGID)
+
 	flags.Int(option.ProxyPrometheusPort, 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
 	option.BindEnv(option.ProxyPrometheusPort)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -299,7 +299,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodePort.bindProtection | bool | `true` | Set to true to prevent applications binding to service ports. |
 | nodePort.enableHealthCheck | bool | `true` | Enable healthcheck nodePort server for NodePort services |
 | nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
-| nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
+| nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap.d/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraConfigmapMounts | list | `[]` | Additional nodeinit ConfigMap mounts. |
 | nodeinit.extraEnv | object | `{}` | Additional nodeinit environment variables. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -283,8 +283,8 @@ contributors across the globe, there is almost always someone available to help.
 | keepDeprecatedLabels | bool | `false` | Keep the deprecated selector labels when deploying Cilium DaemonSet. |
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |
 | kubeProxyReplacementHealthzBindAddr | string | `""` | healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
-| l2NeighDiscovery.arping-refresh-period | string | `"30s"` | Override the agent's default neighbor resolution refresh period. |
 | l2NeighDiscovery.enabled | bool | `true` | Enable L2 neighbor discovery in the agent |
+| l2NeighDiscovery.refreshPeriod | string | `"30s"` | Override the agent's default neighbor resolution refresh period. |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/files/nodeinit/prestop.bash
+++ b/install/kubernetes/cilium/files/nodeinit/prestop.bash
@@ -23,7 +23,7 @@ if ip link show cilium_host; then
 fi
 
 {{- if not (eq .Values.nodeinit.bootstrapFile "") }}
-rm -f {{ .Values.nodeinit.bootstrapFile }}
+rm -f {{ .Values.nodeinit.bootstrapFile | quote }}
 {{- end }}
 
 rm -f /tmp/node-init.cilium.io

--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -120,7 +120,8 @@ iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq: ensure nat POST
 {{- end }}
 
 {{- if not (eq .Values.nodeinit.bootstrapFile "") }}
-date > {{ .Values.nodeinit.bootstrapFile }}
+mkdir -p {{ .Values.nodeinit.bootstrapFile | dir | quote }}
+date > {{ .Values.nodeinit.bootstrapFile | quote }}
 {{- end }}
 
 {{- if .Values.azure.enabled }}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -383,13 +383,13 @@ spec:
         - sh
         - -c
         - |
-          until test -s {{ .Values.nodeinit.bootstrapFile | quote }}; do
+          until test -s {{ (print "/tmp/cilium-bootstrap.d/" (.Values.nodeinit.bootstrapFile | base)) | quote }}; do
             echo "Waiting on node-init to run...";
             sleep 1;
           done
         volumeMounts:
-        - name: cilium-bootstrap-file
-          mountPath: {{ .Values.nodeinit.bootstrapFile }}
+        - name: cilium-bootstrap-file-dir
+          mountPath: "/tmp/cilium-bootstrap.d"
       {{- end }}
       - name: clean-cilium-state
         image: {{ include "cilium.image" .Values.image | quote }}
@@ -508,10 +508,10 @@ spec:
           type: FileOrCreate
       {{- end }}
       {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
-      - name: cilium-bootstrap-file
+      - name: cilium-bootstrap-file-dir
         hostPath:
-          path: {{ .Values.nodeinit.bootstrapFile }}
-          type: FileOrCreate
+          path: {{ .Values.nodeinit.bootstrapFile | dir | quote }}
+          type: DirectoryOrCreate
       {{- end }}
       {{- range .Values.extraHostPathMounts }}
       - name: {{ .name }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -74,8 +74,6 @@ spec:
                     {{- tpl (.Files.Get "files/nodeinit/prestop.bash") . | nindent 20 }}
           {{- end }}
           env:
-          - name: CHECKPOINT_PATH
-            value: /tmp/node-init.cilium.io
           # STARTUP_SCRIPT is the script run on node bootstrap. Node
           # bootstrapping can be customized in this script. This script is invoked
           # using nsenter, so it runs in the host's network and mount namespace using

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -30,6 +30,8 @@ spec:
       {{- if .Values.hubble.ui.securityContext.enabled }}
       securityContext:
         runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
       {{- end }}
       priorityClassName: {{ .Values.hubble.ui.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.ui.name | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1537,7 +1537,7 @@ nodeinit:
 
   # -- bootstrapFile is the location of the file where the bootstrap timestamp is
   # written by the node-init DaemonSet
-  bootstrapFile: "/tmp/cilium-bootstrap-time"
+  bootstrapFile: "/tmp/cilium-bootstrap.d/cilium-bootstrap-time"
 
 preflight:
   # -- Enable Cilium pre-flight resources (required for upgrade)

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1027,7 +1027,7 @@ l2NeighDiscovery:
   # -- Enable L2 neighbor discovery in the agent
   enabled: true
   # -- Override the agent's default neighbor resolution refresh period.
-  arping-refresh-period: "30s"
+  refreshPeriod: "30s"
 
 # -- Enable Layer 7 network policy.
 l7Proxy: true

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -141,9 +141,9 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	return fw.Flush()
 }
 
-// writeHeaderfile writes the lxc_config.h header file of an endpoint
+// writeHeaderfile writes the lxc_config.h header file of an endpoint.
 //
-// e.mutex must be RLock()ed.
+// e.mutex must be write-locked.
 func (e *Endpoint) writeHeaderfile(prefix string) error {
 	headerPath := filepath.Join(prefix, common.CHeaderFileName)
 	e.getLogger().WithFields(logrus.Fields{

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -474,6 +474,8 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, pro
 		noTrackPort:     0,
 	}
 
+	ep.initDNSHistoryTrigger()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	ep.aliveCancel = cancel
 	ep.aliveCtx = ctx
@@ -483,6 +485,19 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, pro
 	ep.SetDefaultOpts(option.Config.Opts)
 
 	return ep
+}
+
+func (e *Endpoint) initDNSHistoryTrigger() {
+	// Note: This can only fail if the trigger func is nil.
+	var err error
+	e.dnsHistoryTrigger, err = trigger.NewTrigger(trigger.Parameters{
+		Name:        "sync_endpoint_header_file",
+		MinInterval: 5 * time.Second,
+		TriggerFunc: e.syncEndpointHeaderFile,
+	})
+	if err != nil {
+		log.WithField(logfields.EndpointID, e.ID).WithError(err).Error("Failed to create the endpoint header file sync trigger")
+	}
 }
 
 // CreateHostEndpoint creates the endpoint corresponding to the host.
@@ -816,6 +831,8 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter p
 	if err := parseBase64ToEndpoint(epSlice[1], &ep); err != nil {
 		return nil, fmt.Errorf("failed to parse restored endpoint: %s", err)
 	}
+
+	ep.initDNSHistoryTrigger()
 
 	// Validate the options that were parsed
 	ep.SetDefaultOpts(ep.Options)
@@ -2147,30 +2164,12 @@ func (e *Endpoint) syncEndpointHeaderFile(reasons []string) {
 	}
 }
 
-// SyncEndpointHeaderFile it bumps the current DNS History information for the
-// endpoint in the ep_config.h file.
-func (e *Endpoint) SyncEndpointHeaderFile() error {
-	if err := e.lockAlive(); err != nil {
-		// endpoint was removed in the meanwhile, return
-		return nil
+// SyncEndpointHeaderFile triggers the header file sync to the ep_config.h
+// file. This includes updating the current DNS History information.
+func (e *Endpoint) SyncEndpointHeaderFile() {
+	if e.dnsHistoryTrigger != nil {
+		e.dnsHistoryTrigger.Trigger()
 	}
-	defer e.unlock()
-
-	if e.dnsHistoryTrigger == nil {
-		t, err := trigger.NewTrigger(trigger.Parameters{
-			Name:        "sync_endpoint_header_file",
-			MinInterval: 5 * time.Second,
-			TriggerFunc: func(reasons []string) { e.syncEndpointHeaderFile(reasons) },
-		})
-		if err != nil {
-			return fmt.Errorf(
-				"Sync Endpoint header file trigger for endpoint cannot be activated: %s",
-				err)
-		}
-		e.dnsHistoryTrigger = t
-	}
-	e.dnsHistoryTrigger.Trigger()
-	return nil
 }
 
 // Delete cleans up all resources associated with this endpoint, including the

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/option"
 	kafka_api "github.com/cilium/cilium/pkg/policy/api/kafka"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -44,10 +45,14 @@ func StartAccessLogServer(stateDir string, xdsServer *XDSServer) {
 	}
 	accessLogListener.SetUnlinkOnClose(true)
 
-	// Make the socket accessible by non-root Envoy proxies, e.g. running in
-	// sidecar containers.
-	if err = os.Chmod(accessLogPath, 0777); err != nil {
+	// Make the socket accessible by owner and group only. Group access is needed for Istio
+	// sidecar proxies.
+	if err = os.Chmod(accessLogPath, 0660); err != nil {
 		log.WithError(err).Fatalf("Envoy: Failed to change mode of access log listen socket at %s", accessLogPath)
+	}
+	// Change the group to ProxyGID allowing access from any process from that group.
+	if err = os.Chown(accessLogPath, -1, option.Config.ProxyGID); err != nil {
+		log.WithError(err).Warningf("Envoy: Failed to change the group of access log listen socket at %s, sidecar proxies may not work", accessLogPath)
 	}
 
 	server := accessLogServer{

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -152,10 +152,14 @@ func StartXDSServer(stateDir string) *XDSServer {
 		log.WithError(err).Fatalf("Envoy: Failed to open xDS listen socket at %s", xdsPath)
 	}
 
-	// Make the socket accessible by non-root Envoy proxies, e.g. running in
-	// sidecar containers.
-	if err = os.Chmod(xdsPath, 0777); err != nil {
+	// Make the socket accessible by owner and group only. Group access is needed for Istio
+	// sidecar proxies.
+	if err = os.Chmod(xdsPath, 0660); err != nil {
 		log.WithError(err).Fatalf("Envoy: Failed to change mode of xDS listen socket at %s", xdsPath)
+	}
+	// Change the group to ProxyGID allowing access from any process from that group.
+	if err = os.Chown(xdsPath, -1, option.Config.ProxyGID); err != nil {
+		log.WithError(err).Warningf("Envoy: Failed to change the group of xDS listen socket at %s, sidecar proxies may not work", xdsPath)
 	}
 
 	ldsCache := xds.NewCache()

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -114,7 +114,7 @@ type DNSProxy struct {
 	maxIPsPerRestoredDNSRule int
 
 	// this mutex protects variables below this point
-	lock.Mutex
+	lock.RWMutex
 
 	// usedServers is the set of DNS servers that have been allowed and used successfully.
 	// This is used to limit the number of IPs we store for restored DNS rules.
@@ -180,8 +180,8 @@ func (p *DNSProxy) checkRestored(endpointID uint64, destPort uint16, destIP stri
 // GetRules creates a fresh copy of EP's DNS rules to be stored
 // for later restoration.
 func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
-	p.Lock()
-	defer p.Unlock()
+	p.RLock()
+	defer p.RUnlock()
 
 	restored := make(restore.DNSRules)
 	for port, entries := range p.allowed[uint64(endpointID)] {
@@ -491,8 +491,8 @@ func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort 
 // something that was added (via UpdateAllowed or RestoreRules) previously.
 func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID identity.NumericIdentity, destIP net.IP, name string) (allowed bool, err error) {
 	name = strings.ToLower(dns.Fqdn(name))
-	p.Lock()
-	defer p.Unlock()
+	p.RLock()
+	defer p.RUnlock()
 
 	epAllow, exists := p.allowed.getPortRulesForID(endpointID, destPort)
 	if !exists {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1055,6 +1055,10 @@ const (
 	// is considered timed out
 	ProxyConnectTimeout = "proxy-connect-timeout"
 
+	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
+	// agent for proxy configuration and access logging.
+	ProxyGID = "proxy-gid"
+
 	// ReadCNIConfiguration reads the CNI configuration file and extracts
 	// Cilium relevant information. This can be used to pass per node
 	// configuration to Cilium.
@@ -1398,6 +1402,10 @@ type DaemonConfig struct {
 	// ProxyConnectTimeout is the time in seconds after which Envoy considers a TCP
 	// connection attempt to have timed out.
 	ProxyConnectTimeout int
+
+	// ProxyGID specifies the group ID that has access to unix domain sockets opened by Cilium
+	// agent for proxy configuration and access logging.
+	ProxyGID int
 
 	// ProxyPrometheusPort specifies the port to serve Envoy metrics on.
 	ProxyPrometheusPort int
@@ -2629,6 +2637,7 @@ func (c *DaemonConfig) Populate() {
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
 	c.PrometheusServeAddr = viper.GetString(PrometheusServeAddr)
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
+	c.ProxyGID = viper.GetInt(ProxyGID)
 	c.ProxyPrometheusPort = viper.GetInt(ProxyPrometheusPort)
 	c.ReadCNIConfiguration = viper.GetString(ReadCNIConfiguration)
 	c.RestoreState = viper.GetBool(Restore)

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -67,6 +67,7 @@ type Agent struct {
 	privKey          wgtypes.Key
 	peerByNodeName   map[string]*peerConfig
 	nodeNameByNodeIP map[string]string
+	nodeNameByPubKey map[wgtypes.Key]string
 	restoredPubKeys  map[wgtypes.Key]struct{}
 	cleanup          []func()
 }
@@ -92,6 +93,7 @@ func NewAgent(privKeyPath string) (*Agent, error) {
 		listenPort:       listenPort,
 		peerByNodeName:   map[string]*peerConfig{},
 		nodeNameByNodeIP: map[string]string{},
+		nodeNameByPubKey: map[wgtypes.Key]string{},
 		restoredPubKeys:  map[wgtypes.Key]struct{}{},
 		cleanup:          []func(){},
 	}, nil
@@ -320,10 +322,22 @@ func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 	a.Lock()
 	defer a.Unlock()
 
+	pubKey, err := wgtypes.ParseKey(pubKeyHex)
+	if err != nil {
+		return err
+	}
+
+	if prevNodeName, ok := a.nodeNameByPubKey[pubKey]; ok {
+		if nodeName != prevNodeName {
+			return fmt.Errorf("detected duplicate public key. "+
+				"node %q uses same key as existing node %q", nodeName, prevNodeName)
+		}
+	}
+
 	var allowedIPs []net.IPNet = nil
 	if prev := a.peerByNodeName[nodeName]; prev != nil {
 		// Handle pubKey change
-		if prev.pubKey.String() != pubKeyHex {
+		if prev.pubKey != pubKey {
 			log.WithField(logfields.NodeName, nodeName).Debug("Pubkey has changed")
 			// pubKeys differ, so delete old peer
 			if err := a.deletePeerByPubKey(prev.pubKey); err != nil {
@@ -357,11 +371,6 @@ func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 			lookupIPv6 = nodeIPv6
 		}
 		allowedIPs = append(allowedIPs, a.ipCache.LookupByHostRLocked(lookupIPv4, lookupIPv6)...)
-	}
-
-	pubKey, err := wgtypes.ParseKey(pubKeyHex)
-	if err != nil {
-		return err
 	}
 
 	ep := ""
@@ -398,6 +407,7 @@ func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 	}
 
 	a.peerByNodeName[nodeName] = peer
+	a.nodeNameByPubKey[pubKey] = nodeName
 	if nodeIPv4 != nil {
 		a.nodeNameByNodeIP[nodeIPv4.String()] = nodeName
 	}
@@ -422,6 +432,8 @@ func (a *Agent) DeletePeer(nodeName string) error {
 	}
 
 	delete(a.peerByNodeName, nodeName)
+	delete(a.nodeNameByPubKey, peer.pubKey)
+
 	if peer.nodeIPv4 != nil {
 		delete(a.nodeNameByNodeIP, peer.nodeIPv4.String())
 	}

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -89,6 +89,7 @@ func (a *AgentSuite) TestAgent_PeerConfig(c *C) {
 		listenPort:       listenPort,
 		peerByNodeName:   map[string]*peerConfig{},
 		nodeNameByNodeIP: map[string]string{},
+		nodeNameByPubKey: map[wgtypes.Key]string{},
 	}
 	ipCache.AddListener(wgAgent)
 
@@ -185,8 +186,14 @@ func (a *AgentSuite) TestAgent_PeerConfig(c *C) {
 	c.Assert(containsIP(k8s2.allowedIPs, pod3IPv4), Equals, true)
 	c.Assert(containsIP(k8s2.allowedIPs, pod3IPv6), Equals, true)
 
+	// Tests that duplicate public keys are rejected (k8s2 imitates k8s1)
+	err = wgAgent.UpdatePeer(k8s2NodeName, k8s1PubKey, k8s2NodeIPv4, k8s2NodeIPv6)
+	c.Assert(err, ErrorMatches, "detected duplicate public key.*")
+
 	// Node Deletion
 	wgAgent.DeletePeer(k8s1NodeName)
 	wgAgent.DeletePeer(k8s2NodeName)
 	c.Assert(wgAgent.peerByNodeName, HasLen, 0)
+	c.Assert(wgAgent.nodeNameByNodeIP, HasLen, 0)
+	c.Assert(wgAgent.nodeNameByPubKey, HasLen, 0)
 }


### PR DESCRIPTION
* #19286 -- fix(helm): use a directory to store bootstrap time (@raphink)
 * #19338 -- install/kubernetes: fix hubble-ui with TLS (@aanm)
 * #19313 -- docs: Update shared service annotation docs (@sayboras)
 * #19344 -- wireguard: Reject duplicate public keys (@gandro)
 * #19336 -- Use RLock while reading data in DNS proxy (@nebril)
 * #19356 -- ci: Pin down image for the documentation workflow (@qmonnet)
 * #19366 -- Add a 'Limitations' section to 'External Workloads'. (@bmcustodio)
 * #19190 -- envoy: Limit accesslog socket permissions (@jrajahalme)
 * #19205 -- Update the 'refresh period' formatting in readme and doc (@dongwangdw)
 * #19347 -- Improve endpoint and DNS proxy lock contention during bursty DNS traffic (@christarazi)
 * #19394 -- add 'refreshPeriod' to spelling wordlist (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19286 19338 19313 19344 19336 19356 19366 19190 19205 19347 19394; do contrib/backporting/set-labels.py $pr done 1.11; done
```