### PR TITLE
bpf: do not pass 0 as a trace reason for send_trace_notify()

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1862,7 +1862,8 @@ int handle_policy_egress(struct __ctx_buff *ctx)
 
 	edt_set_aggregate(ctx, 0); /* do not count this traffic again */
 	send_trace_notify(ctx, TRACE_FROM_PROXY, SECLABEL, 0, 0,
-			  0 /*ifindex*/, 0, TRACE_PAYLOAD_LEN);
+			  0 /*ifindex*/,
+			  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);
 
 	switch (proto) {
 #ifdef ENABLE_IPV6

--- a/contrib/coccinelle/zero_trace_reason.cocci
+++ b/contrib/coccinelle/zero_trace_reason.cocci
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0
+/// Prevent passing 0 as a reason to send_trace_notify(), because 0 is a valid
+/// value corresponding to new conntrack connections, and passing it instead of
+/// TRACE_REASON_UNKNOWN may confuse Hubble.
+// Confidence: Medium
+// Copyright Authors of Cilium.
+// Comments:
+// Options: --include-headers
+
+@initialize:python@
+@@
+
+cnt = 0
+
+
+@pass_reason@
+expression e1, e2, e3, e4, e5, e6, e7, e8;
+identifier f;
+position p;
+@@
+
+(
+  send_trace_notify@f(e1, e2, e3, e4, e5, e6,
+- 0@p,
++ TRACE_REASON_UNKNOWN,
+  e7);
+|
+  \(send_trace_notify4@f\|send_trace_notify6@f\)(e1, e2, e3, e4, e5, e6, e7,
+- 0@p,
++ TRACE_REASON_UNKNOWN,
+  e8);
+|
+  update_trace_metrics@f(e1, e2,
+- 0@p
++ TRACE_REASON_UNKNOWN
+  );
+)
+
+
+@script:python@
+p << pass_reason.p;
+f << pass_reason.f;
+@@
+
+print("* file %s: %s() has '0' as trace reason on line %s, use enum trace_reason instead (TRACE_REASON_UNKNOWN if the reason is not known)" % (p[0].file, f, p[0].line))
+cnt += 1
+
+
+@declare_ctx@
+identifier tc;
+position p;
+@@
+
+(
+  struct trace_ctx tc = {
+-   .reason = 0@p,
++   .reason = TRACE_REASON_UNKNOWN,
+    ...
+  };
+|
+  struct trace_ctx tc;
+  ... when != return ...;
+- tc.reason = 0@p;
++ tc.reason = TRACE_REASON_UNKNOWN;
+|
+  struct trace_ctx *tc;
+  ... when != return ...;
+- tc->reason = 0@p;
++ tc->reason = TRACE_REASON_UNKNOWN;
+)
+
+
+@script:python@
+p << declare_ctx.p;
+tc << declare_ctx.tc;
+@@
+
+print("* file %s: '%s' gets '0' as trace reason on line %s, use enum trace_reason instead (TRACE_REASON_UNKNOWN if the reason is not known)" % (p[0].file, tc, p[0].line))
+cnt += 1
+
+
+@finalize:python@
+@@
+
+if cnt > 0:
+  print("""Use the following command to fix the above issues:
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                           \\
+    -it docker.io/cilium/coccicheck spatch --sp-file contrib/coccinelle/zero_trace_reason.cocci \\
+    --include-headers --very-quiet --in-place bpf/\n
+""")


### PR DESCRIPTION
The values in the `enum trace_reason` passed to `send_trace_notify()` [have recently been extended with `TRACE_REASON_UNKNOWN`](https://github.com/cilium/cilium/commit/a256a8459fba772f02a9fbdbe89b3feb45a44e04), in order to avoid conflicts between `0` as an “unknown reason” and `TRACE_REASON_POLICY`.

However, not all developers are aware, and it remains tempting to use `0` as a default value when the reason for the trace is not known. We can find examples of it [in open PRs](https://github.com/cilium/cilium/pull/19158#discussion_r848900397), or even [in recent code additions](https://github.com/cilium/cilium/commit/d1d8e7a35b35d3420a33251767ae2696d664da53).

This PR fixes the occurrence that made it to the code, and adds a coccinelle check to reject passing `0` directly to `send_trace_notify()` in the future.