### PR TITLE
hubble/filters: strict number check for full HTTP status code

### DIFF
--- a/pkg/hubble/filters/http.go
+++ b/pkg/hubble/filters/http.go
@@ -31,8 +31,8 @@ func httpMatchCompatibleEventFilter(types []*flowpb.EventTypeFilter) bool {
 }
 
 var (
-	httpStatusCodeFull   = regexp.MustCompile(`[1-5][0-9]{2}`)
-	httpStatusCodePrefix = regexp.MustCompile(`^([1-5][0-9]?\+)$`)
+	httpStatusCodeFull   = regexp.MustCompile(`^[1-5][0-9]{2}$`)
+	httpStatusCodePrefix = regexp.MustCompile(`^[1-5][0-9]?\+$`)
 )
 
 func filterByHTTPStatusCode(statusCodePrefixes []string) (FilterFunc, error) {

--- a/pkg/hubble/filters/http_test.go
+++ b/pkg/hubble/filters/http_test.go
@@ -160,6 +160,18 @@ func TestHTTPFilters(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid status code text",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						HttpStatusCode: []string{"HTTP 200 OK"},
+						EventType:      []*flowpb.EventTypeFilter{{Type: api.MessageTypeAccessLog}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "invalid status code prefix",
 			args: args{
 				f: []*flowpb.FlowFilter{


### PR DESCRIPTION
Before this patch, the Hubble HTTP status code filter would accept any string containing a HTTP status code.
