### PR TITLE
vtep: VTEP integration pod src identity set to WORLD_ID

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -609,7 +609,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 			if (eth_store_daddr(ctx, (__u8 *)&vtep->vtep_mac, 0) < 0)
 				return DROP_WRITE_ERROR;
 			return __encap_and_redirect_with_nodeid(ctx, vtep->tunnel_endpoint,
-								WORLD_ID, &trace);
+								secctx, WORLD_ID, &trace);
 		}
 	}
 skip_vtep:
@@ -898,7 +898,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 
 	bpf_clear_meta(ctx);
 	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, src_id,
-						&trace);
+						NOT_VTEP_DST, &trace);
 }
 
 static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto __maybe_unused,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1062,7 +1062,7 @@ skip_egress_gateway:
 			if (eth_store_daddr(ctx, (__u8 *)&vtep->vtep_mac, 0) < 0)
 				return DROP_WRITE_ERROR;
 			return __encap_and_redirect_with_nodeid(ctx, vtep->tunnel_endpoint,
-								WORLD_ID, &trace);
+								SECLABEL, WORLD_ID, &trace);
 		}
 	}
 skip_vtep:

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -382,6 +382,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 	if (info->tunnel_endpoint)
 		return __encap_and_redirect_with_nodeid(ctx,
 							info->tunnel_endpoint,
+							SECLABEL,
 							WORLD_ID,
 							&trace);
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -611,6 +611,7 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 		if (info != NULL && info->tunnel_endpoint != 0) {
 			ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 						  WORLD_ID,
+						  NOT_VTEP_DST,
 						  (enum trace_reason)CT_NEW,
 						  TRACE_PAYLOAD_LEN);
 			if (ret)
@@ -931,6 +932,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex
 			if (info != NULL && info->tunnel_endpoint != 0) {
 				ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 							  SECLABEL,
+							  NOT_VTEP_DST,
 							  TRACE_REASON_CT_REPLY,
 							  TRACE_PAYLOAD_LEN);
 				if (ret)
@@ -1667,6 +1669,7 @@ int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 			 */
 			ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 						  WORLD_ID,
+						  NOT_VTEP_DST,
 						  (enum trace_reason)CT_NEW,
 						  TRACE_PAYLOAD_LEN);
 			if (ret)
@@ -2105,7 +2108,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 #if (defined(ENABLE_EGRESS_GATEWAY) || defined(TUNNEL_MODE)) && \
 	__ctx_is != __ctx_xdp
 encap_redirect:
-	ret = __encap_with_nodeid(ctx, tunnel_endpoint, SECLABEL,
+	ret = __encap_with_nodeid(ctx, tunnel_endpoint, SECLABEL, NOT_VTEP_DST,
 				  reason, monitor);
 	if (ret)
 		return ret;


### PR DESCRIPTION
When pod send traffic to VTEP devices, pod src identity
is set to WORLD_ID in send_trace_notify, this could
confuse hubble output, this is observed in issues/18459

before fix:

to-overlay: 98 bytes (98 captured), state established,
interface cilium_vxlan, , identity world->unknown

after fix:

to-overlay: 98 bytes (98 captured), state established,
interface cilium_vxlan, , identity 4352->unknown

Fix: issues/18459

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #18459

```release-note
vtep: fix pod src identity in send_trace_notify

```
