### PR TITLE
maps/lbmap: fix maglev test suite build

### DIFF
--- a/pkg/maps/lbmap/maglev_test.go
+++ b/pkg/maps/lbmap/maglev_test.go
@@ -47,12 +47,15 @@ func (s *MaglevSuite) SetUpSuite(c *C) {
 	err = rlimit.RemoveMemlock()
 	c.Assert(err, IsNil)
 
+	option.Config.LBMapEntries = DefaultMaxEntries
+
 	Init(InitParams{
 		IPv4: option.Config.EnableIPv4,
 		IPv6: option.Config.EnableIPv6,
 
-		MaxSockRevNatMapEntries: option.Config.SockRevNatEntries,
-		MaxEntries:              option.Config.LBMapEntries,
+		ServiceMapMaxEntries: option.Config.LBMapEntries,
+		RevNatMapMaxEntries:  option.Config.LBMapEntries,
+		MaglevMapMaxEntries:  option.Config.LBMapEntries,
 	})
 }
 


### PR DESCRIPTION
Building the tests of this package currently fails with:

    # github.com/cilium/cilium/pkg/maps/lbmap [github.com/cilium/cilium/pkg/maps/lbmap.test]
    pkg/maps/lbmap/maglev_test.go:55:3: unknown field 'MaxEntries' in struct literal of type InitParams

Fix this by adjusting to the new InitParams member name for the maglev
map.

Fixes: 3798f32d8b2f ("daemon: Split --bpf-lb-map-max into multiple options")
