### PR TITLE
make: remove deprecated test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,12 +285,6 @@ build-deb: ## Build deb package of cilium.
 build-rpm: ## Build rpm package of cilium.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C ./contrib/packaging/rpm
 
-runtime-tests: ## Run runtime-tests for Cilium.
-	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C tests runtime-tests
-
-k8s-tests:
-	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C tests k8s-tests
-
 -include Makefile.docker
 
 ##@ API targets

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -117,10 +117,6 @@ getent group cilium >/dev/null || sudo groupadd -r cilium
 sudo usermod -a -G cilium vagrant
 SCRIPT
 
-$testsuite = <<SCRIPT
-sudo -E env PATH="${PATH}" make -C ~/go/src/github.com/cilium/cilium/ runtime-tests
-SCRIPT
-
 $node_ip_base = ENV['IPV4_BASE_ADDR'] || ""
 $node_nfs_base_ip = ENV['IPV4_BASE_ADDR_NFS'] || ""
 $num_workers = (ENV['NWORKERS'] || 0).to_i
@@ -251,9 +247,6 @@ Vagrant.configure(2) do |config|
                    privileged: true,
                    path: k8sinstall
            end
-        end
-        if ENV['RUN_TEST_SUITE'] then
-           cm.vm.provision "testsuite", run: "always", type: "shell", privileged: false, inline: $testsuite
         end
     end
 


### PR DESCRIPTION
The respective tests were removed by commit ef3768af8c6f ("test: Remove
tests/ dir") and the targets are no longer functional:

    % make runtime-tests
    make  -C tests runtime-tests
    make[1]: *** tests: No such file or directory. Stop.
    make: *** [Makefile:289: runtime-tests] Error 2
    % make k8s-tests
    make  -C tests k8s-tests
    make[1]: *** tests: No such file or directory. Stop.
    make: *** [Makefile:292: k8s-tests] Error 2

Also remove the integration of these tests from Vagrantfile via
RUN_TEST_SUITE.
