### PR TITLE
Expose hubble-ui security context in helm chart

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -945,8 +945,12 @@
      - Roll out Hubble-ui pods automatically when configmap is updated.
      - bool
      - ``false``
+   * - hubble.ui.securityContext
+     - Security context to be added to Hubble UI pods
+     - object
+     - ``{"enabled":true,"fsGroup":1001,"runAsGroup":1001,"runAsUser":1001}``
    * - hubble.ui.securityContext.enabled
-     - Whether to set the security context on the Hubble UI pods.
+     - Deprecated in favor of hubble.ui.securityContext. Whether to set the security context on the Hubble UI pods.
      - bool
      - ``true``
    * - hubble.ui.standalone.enabled

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -350,6 +350,8 @@ Helm Options
   will be removed in 1.13.
 * ``hubble.tls.ca.key`` has been deprecated in favor of ``tls.ca.key``, and will be
   removed in 1.13.
+* ``hubble.ui.securityContext.enabled`` has been deprecated in favor of
+  ``hubble.ui.securityContext``, and will be removed in 1.13.
 * ``clustermesh.apiserver.tls.ca.cert`` has been deprecated in favor of ``tls.ca.key``,
   and will be removed in 1.13.
 * ``clustermesh.apiserver.tls.ca.key`` has been deprecated in favor of ``tls.ca.key``,

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -287,7 +287,8 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.proxy.resources | object | `{}` | Resource requests and limits for the 'proxy' container of the 'hubble-ui' deployment. |
 | hubble.ui.replicas | int | `1` | The number of replicas of Hubble UI to deploy. |
 | hubble.ui.rollOutPods | bool | `false` | Roll out Hubble-ui pods automatically when configmap is updated. |
-| hubble.ui.securityContext.enabled | bool | `true` | Whether to set the security context on the Hubble UI pods. |
+| hubble.ui.securityContext | object | `{"enabled":true,"fsGroup":1001,"runAsGroup":1001,"runAsUser":1001}` | Security context to be added to Hubble UI pods |
+| hubble.ui.securityContext.enabled | bool | `true` | Deprecated in favor of hubble.ui.securityContext. Whether to set the security context on the Hubble UI pods. |
 | hubble.ui.standalone.enabled | bool | `false` | When true, it will allow installing the Hubble UI only, without checking dependencies. It is useful if a cluster already has cilium and Hubble relay installed and you just want Hubble UI to be deployed. When installed via helm, installing UI should be done via `helm upgrade` and when installed via the cilium cli, then `cilium hubble enable --ui` |
 | hubble.ui.standalone.tls.certsVolume | object | `{}` | When deploying Hubble UI in standalone, with tls enabled for Hubble relay, it is required to provide a volume for mounting the client certificates. |
 | hubble.ui.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values used to connect to hubble-relay This keypair is presented to Hubble Relay instances for mTLS authentication and is required when hubble.relay.tls.server.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false. |

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -27,11 +27,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.hubble.ui.securityContext.enabled }}
+      {{- with .Values.hubble.ui.securityContext }}
+        {{- if .enabled }}
       securityContext:
-        runAsUser: 1001
-        runAsGroup: 1001
-        fsGroup: 1001
+        {{- omit . "enabled" | toYaml | nindent 8 }}
+        {{- end}}
       {{- end }}
       priorityClassName: {{ .Values.hubble.ui.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.ui.name | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -985,9 +985,14 @@ hubble:
       rollingUpdate:
         maxUnavailable: 1
 
+    # -- Security context to be added to Hubble UI pods
     securityContext:
-      # -- Whether to set the security context on the Hubble UI pods.
+      # -- Deprecated in favor of hubble.ui.securityContext.
+      # Whether to set the security context on the Hubble UI pods.
       enabled: true
+      runAsUser: 1001
+      runAsGroup: 1001
+      fsGroup: 1001
 
     # -- hubble-ui ingress configuration.
     ingress:


### PR DESCRIPTION
This change exposes the security context for Hubble UI pods.
Backward compatibility is maintained. `enabled` is deprecated,
can be deleted once using default security context object.

Fixes: #18440

```release-note
Expose hubble-ui security context in helm chart `hubble.ui.securityContext`
```