### PR TITLE
feat(helm): allow to set Hubble Relay and UI service type and nodePort

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -965,6 +965,18 @@
      - Deprecated in favor of hubble.ui.securityContext. Whether to set the security context on the Hubble UI pods.
      - bool
      - ``true``
+   * - hubble.ui.service
+     - hubble-ui service configuration.
+     - object
+     - ``{"nodePort":31235,"type":"ClusterIP"}``
+   * - hubble.ui.service.nodePort
+     - - The port to use when the service type is set to NodePort.
+     - int
+     - ``31235``
+   * - hubble.ui.service.type
+     - - The type of service used for Hubble UI access, either ClusterIP or NodePort.
+     - string
+     - ``"ClusterIP"``
    * - hubble.ui.standalone.enabled
      - When true, it will allow installing the Hubble UI only, without checking dependencies. It is useful if a cluster already has cilium and Hubble relay installed and you just want Hubble UI to be deployed. When installed via helm, installing UI should be done via ``helm upgrade`` and when installed via the cilium cli, then ``cilium hubble enable --ui``
      - bool

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -785,6 +785,18 @@
      - hubble-relay security context
      - object
      - ``{}``
+   * - hubble.relay.service
+     - hubble-relay service configuration.
+     - object
+     - ``{"nodePort":31234,"type":"ClusterIP"}``
+   * - hubble.relay.service.nodePort
+     - - The port to use when the service type is set to NodePort.
+     - int
+     - ``31234``
+   * - hubble.relay.service.type
+     - - The type of service used for Hubble Relay access, either ClusterIP or NodePort.
+     - string
+     - ``"ClusterIP"``
    * - hubble.relay.sortBufferDrainTimeout
      - When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s").
      - string

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -292,6 +292,9 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.rollOutPods | bool | `false` | Roll out Hubble-ui pods automatically when configmap is updated. |
 | hubble.ui.securityContext | object | `{"enabled":true,"fsGroup":1001,"runAsGroup":1001,"runAsUser":1001}` | Security context to be added to Hubble UI pods |
 | hubble.ui.securityContext.enabled | bool | `true` | Deprecated in favor of hubble.ui.securityContext. Whether to set the security context on the Hubble UI pods. |
+| hubble.ui.service | object | `{"nodePort":31235,"type":"ClusterIP"}` | hubble-ui service configuration. |
+| hubble.ui.service.nodePort | int | `31235` | - The port to use when the service type is set to NodePort. |
+| hubble.ui.service.type | string | `"ClusterIP"` | - The type of service used for Hubble UI access, either ClusterIP or NodePort.  |
 | hubble.ui.standalone.enabled | bool | `false` | When true, it will allow installing the Hubble UI only, without checking dependencies. It is useful if a cluster already has cilium and Hubble relay installed and you just want Hubble UI to be deployed. When installed via helm, installing UI should be done via `helm upgrade` and when installed via the cilium cli, then `cilium hubble enable --ui` |
 | hubble.ui.standalone.tls.certsVolume | object | `{}` | When deploying Hubble UI in standalone, with tls enabled for Hubble relay, it is required to provide a volume for mounting the client certificates. |
 | hubble.ui.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values used to connect to hubble-relay This keypair is presented to Hubble Relay instances for mTLS authentication and is required when hubble.relay.tls.server.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -247,6 +247,9 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.retryTimeout | string | `nil` | Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s"). |
 | hubble.relay.rollOutPods | bool | `false` | Roll out Hubble Relay pods automatically when configmap is updated. |
 | hubble.relay.securityContext | object | `{}` | hubble-relay security context |
+| hubble.relay.service | object | `{"nodePort":31234,"type":"ClusterIP"}` | hubble-relay service configuration. |
+| hubble.relay.service.nodePort | int | `31234` | - The port to use when the service type is set to NodePort. |
+| hubble.relay.service.type | string | `"ClusterIP"` | - The type of service used for Hubble Relay access, either ClusterIP or NodePort.  |
 | hubble.relay.sortBufferDrainTimeout | string | `nil` | When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s"). |
 | hubble.relay.sortBufferLenMax | string | `nil` | Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100). |
 | hubble.relay.terminationGracePeriodSeconds | int | `1` | Configure termination grace period for hubble relay Deployment. |

--- a/install/kubernetes/cilium/templates/hubble-relay/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     k8s-app: hubble-relay
 spec:
-  type: ClusterIP
+  type: {{ .Values.hubble.relay.service.type | quote }}
   selector:
     k8s-app: hubble-relay
   ports:
@@ -18,4 +18,7 @@ spec:
     port: {{ .Values.hubble.relay.tls.server.enabled | ternary 443 80 }}
   {{- end }}
     targetPort: {{ .Values.hubble.relay.listenPort }}
+    {{- if and (eq "NodePort" .Values.hubble.relay.service.type) .Values.hubble.relay.service.nodePort }}
+    nodePort: {{ .Values.hubble.relay.service.nodePort }}
+    {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/service.yaml
@@ -7,11 +7,14 @@ metadata:
   labels:
     k8s-app: hubble-ui
 spec:
-  type: ClusterIP
+  type: {{ .Values.hubble.ui.service.type | quote }}
   selector:
     k8s-app: hubble-ui
   ports:
     - name: http
       port: 80
       targetPort: 8081
+      {{- if and (eq "NodePort" .Values.hubble.ui.service.type) .Values.hubble.ui.service.nodePort }}
+      nodePort: {{ .Values.hubble.ui.service.nodePort }}
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1014,6 +1014,13 @@ hubble:
       runAsGroup: 1001
       fsGroup: 1001
 
+    # -- hubble-ui service configuration.
+    service:
+      # --- The type of service used for Hubble UI access, either ClusterIP or NodePort. 
+      type: ClusterIP
+      # --- The port to use when the service type is set to NodePort.
+      nodePort: 31235
+
     # -- hubble-ui ingress configuration.
     ingress:
       enabled: false

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -837,6 +837,13 @@ hubble:
     # -- hubble-relay security context
     securityContext: {}
 
+    # -- hubble-relay service configuration.
+    service:
+      # --- The type of service used for Hubble Relay access, either ClusterIP or NodePort. 
+      type: ClusterIP
+      # --- The port to use when the service type is set to NodePort.
+      nodePort: 31234
+
     # -- Host to listen to. Specify an empty string to bind to all the interfaces.
     listenHost: ""
 


### PR DESCRIPTION
This allows to tune the Hubble UI service type and optional nodePort.

Signed-off-by: Raphaël Pinson <raphael@isovalent.com>