### PR TITLE
Limit the number of active FQDNs beyond the TTL to `--tofqdns-endpoint-max-ip-per-hostname`

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -470,7 +470,7 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, nam
 		OpLabels:         labels.NewOpLabels(),
 		DNSRules:         nil,
 		DNSHistory:       fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
-		DNSZombies:       fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes),
+		DNSZombies:       fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
 		state:            "",
 		status:           NewEndpointStatus(),
 		hasBPFProgram:    make(chan struct{}, 0),

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -498,7 +498,7 @@ func (ep *Endpoint) UnmarshalJSON(raw []byte) error {
 	restoredEp := &serializableEndpoint{
 		OpLabels:   labels.NewOpLabels(),
 		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
-		DNSZombies: fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes),
+		DNSZombies: fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
 	}
 	if err := json.Unmarshal(raw, restoredEp); err != nil {
 		return fmt.Errorf("error unmarshaling serializableEndpoint from base64 representation: %s", err)


### PR DESCRIPTION
Commit f6ce522d55d5 ("FQDN: Added garbage collector functions.")                                                                                                                                                                                                                            
introduced a per-host limit on the number of IPs to be associated in the        
DNS cache, but at the time we did not support keeping FQDN entries alive        
beyond DNS TTL ("zombie entries"). These were later added in commit             
f6293725867c ("fqdn: Add and use DNSZombieMappings in Endpoint"), but at        
that time no such per-host limit was imposed on these zombie entries.           
                                                                                
Commit 5923dafd88be ("fqdn: keep IPs alive if their name is alive")             
later adjusted the zombie garbage collection to allow zombies to stay           
alive as long as any IP that shares the same FQDN is marked as alive.           
Unfortunately, this lead to situations where a very high number of DNS          
cache entries remain in the cache beyond the DNS TTL, simply because one        
IP for the given name continues to be used.                                     
                                                                                
In the case of something like Amazon S3, where DNS TTLs are known to be         
low, and IP recycling high, if an app constantly made requests via              
ToFQDNs policy towards names hosted by this service, this could lead to         
thousands of stale FQDN mappings accumulating in the cache. For each of         
these mappings, Cilium would allocate corresponding identities, and when        
this is combined with a permissive pod policy, this could lead to               
policymaps becoming full, and error messages in the logs like:                  
                                                                                
    msg="Failed to add PolicyMap key" ... error="Unable to update element for map with file descriptor 67: argument list too long"    
                                                                                
This could also prevent new pods from being scheduled on nodes, as              
Cilium would be unable to implement the full requested policy for the           
new endpoints.                                                                  
                                                                                
In order to mitigate this situation, extend the per-host limit                  
configuration to apply separately also to zombie entries. This allows up        
to 'ToFQDNsMaxIPsPerHost' FQDN entries that are alive (ie below DNS TTL)        
in addition to a further 'ToFQDNsMaxIPsPerHost' zombie entries                  
corresponding to connections which remain alive beyond the DNS TTL. 

Fixes: 5923dafd88be ("fqdn: keep IPs alive if their name is alive")
Fixes: #13914

```release-note
Improve garbage collection for resources allocated by ToFQDNs policy for services which rotate IP addresses frequently such as Amazon S3
```