### PR TITLE
jenkinsfiles: Increase VM boot timeout

### DIFF
--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
             parallel {
                 stage ("Copy code and boot vms"){
                     options {
-                        timeout(time: 50, unit: 'MINUTES')
+                        timeout(time: 30, unit: 'MINUTES')
                     }
 
                     environment {
@@ -156,10 +156,8 @@ pipeline {
                     }
                     steps {
                         withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                            retry(3) {
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 15m ./vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 25m ./vagrant-ci-start.sh'
                             }
                         }
                     }


### PR DESCRIPTION
This pull request increases the VM boot timeout while decreasing the overall timeout :mindblown:

We currently run the `vagrant-ci-start.sh` script with a 15m timeout and retry twice if it fails. That takes up to 45m in total if all attempts fail, as in frequently happening in CI right now. In particular, if the script simply fails because it's taking on average more than 15m then it is likely to fail all three times.

This pull request instead increases the timeout from 15m to 25m and removes the retries. The goal is obviously to succeed on the first try :p

Ideally, we would investigate why it is now taking longer to start the VM. But this issue has been happening for a long time. And because of the retries, we probably didn't even notice the increase at the beginning: if it takes on average 15min, it might fail half the time and the test might still succeed most of the time. That is, the retries participate to hide the increase.
