### PR TITLE
Fix comment for EndpointCreated function

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -731,7 +731,7 @@ func (d *Daemon) EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConf
 	}
 }
 
-// EndpointDeleted is a callback to satisfy EndpointManager.Subscriber,
+// EndpointCreated is a callback to satisfy EndpointManager.Subscriber,
 // allowing the EndpointManager to be the primary implementer of the core
 // endpoint management functionality while deferring other responsibilities
 // to the daemon.


### PR DESCRIPTION
The comment for EndpointCreated is still using EndpointDeleted.
Looks like a copy paste error. Fix it.

Signed-off-by: Jiang Wang <jiang.wang@bytedance.com>

