### PR TITLE
Simpler more precise way to do the same thing using generic unix tooling

### DIFF
--- a/contrib/k8s/k8s-unmanaged.sh
+++ b/contrib/k8s/k8s-unmanaged.sh
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 
-ALL_CEPS=$(kubectl get cep --all-namespaces -o json | jq -r '.items[].metadata | .namespace + "/" + .name')
-ALL_PODS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.spec.hostNetwork==true | not) | .metadata | .namespace + "/" + .name')
-
+function all_ceps { kubectl get cep --all-namespaces -o json | jq -r '.items[].metadata | .namespace + "/" + .name'; }
+function all_pods { kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.spec.hostNetwork==true | not) | .metadata | .namespace + "/" + .name'; }
+ 
 echo "Skipping pods with host networking enabled..."
-for pod in $ALL_PODS; do
-	if ! echo "$ALL_CEPS" | grep -q "$pod"; then
-		echo $pod
-	fi
-done
+
+sort <(all_ceps) <(all_pods) | uniq -u


### PR DESCRIPTION
Just a simple refactor of something which is overcomplicated using generic UNIX tooling.

Its quicker too!

```release-note
Improve the efficiency of the `k8s-unmanaged.sh` script
```