### PR TITLE
vtep: VTEP redirection in bpf_host  from-host  to support  L7 policy

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -182,6 +182,11 @@ MAX_HOST_OPTIONS = $(MAX_BASE_OPTIONS) -DENCAP_IFINDEX=1 -DTUNNEL_MODE=1
 ifneq (,$(filter $(KERNEL),"54" "netnext"))
 MAX_HOST_OPTIONS += -DENABLE_EGRESS_GATEWAY=1
 endif
+ifeq ("$(KERNEL)","54")
+MAX_HOST_OPTIONS+= -DENABLE_VTEP=1
+else ifeq ("$(KERNEL)","netnext")
+MAX_HOST_OPTIONS+= -DENABLE_VTEP=1
+endif
 endif
 
 bpf_host.ll: bpf_host.c $(LIB)

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -895,7 +895,12 @@ ct_recreate4:
 skip_egress_gateway:
 #endif
 
-#ifdef ENABLE_VTEP
+	/* L7 proxy result in VTEP redirection in bpf_host, but when L7 proxy disabled
+	 * We want VTEP redirection handled earlier here to avoid packets passing to
+	 * stack to bpf_host for VTEP redirection. When L7 proxy enabled, but no
+	 * L7 policy applied to pod, VTEP redirection also happen here.
+	 */
+#if defined(ENABLE_VTEP)
 	{
 		struct vtep_key vkey = {};
 		struct vtep_value *vtep;

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -571,6 +571,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_ICMP_RULE"] = "1"
 	}
 
+	if option.Config.EnableL7Proxy {
+		cDefinesMap["ENABLE_L7_PROXY"] = "1"
+	}
+
 	// Since golang maps are unordered, we sort the keys in the map
 	// to get a consistent written format to the writer. This maintains
 	// the consistency when we try to calculate hash for a datapath after

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -16,6 +16,9 @@ const (
 	// rules
 	RouteTableWireguard = 201
 
+	// RouteTableVtep is the default table ID to use for VTEP routing rules
+	RouteTableVtep = 202
+
 	// RouteTableEgressGatewayInterfacesOffset is the offset for the per-ENI
 	// egress gateway routing tables.
 	// Each ENI interface will have its own table starting with this offset. It
@@ -93,6 +96,9 @@ const (
 	// associated, but from the main routing table instead.
 	// This priority is before the egress priority.
 	RulePriorityNodeport = RulePriorityEgress - 1
+
+	// RulePriorityVtep is the priority of the rule used for routing packets to VTEP device
+	RulePriorityVtep = 112
 
 	// TunnelDeviceName the default name of the tunnel device when using vxlan
 	TunnelDeviceName = "cilium_vxlan"


### PR DESCRIPTION
    L7 policies redirect packets on egress of bpf_lxc to userspace
    proxy. When packets leave the proxy, they don't go back through
    bpf_lxc again, so the VTEP redirectons won't be enforced. Add
    the VTEP redirection in bpf_host. This also requires route to
    VTEP CIDR setup like:
    
    <VTEP CIDR> dev cilium_host scope link
    
    Reason is when packets are passed to host stack with destination
    ip in VTEP CIDR, host stack needs to know where to route the
    packets to, and __section("from-host") is attached to cilium_host,
    so we setup route on cilium_host with scope link.
 
    we still keep the VTEP redirection in bpf_lxc when L7 proxy is disabled
    VTEP redirection would happen earlier to avoid packets passing to
    host stack to be handled in bpf_host.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Add support for L7 policies with VTEP integration
```
