### PR TITLE
docs: improve description for session affinity with KPR

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1224,9 +1224,9 @@ a fixed cookie value as a trade-off. This makes all applications on the host to
 select the same service endpoint for a given service with session affinity configured.
 To disable the feature, set ``config.sessionAffinity=false``.
 
-When the fixed cookie value is not used, a service affinity of a service with
+When the fixed cookie value is not used, the session affinity of a service with
 multiple ports is per service IP and port. Meaning that all requests for a
-given service sent from the same source and to the service same port will be routed
+given service sent from the same source and to the same service port will be routed
 to the same service endpoints; but two requests for the same service, sent from
 the same source but to different service ports may be routed to distinct service
 endpoints.


### PR DESCRIPTION
Use the correct terminology ('session affinity' vs 'service affinity'),
and fix a typo.

Signed-off-by: Julian Wiedmann <jwi@isovalent.com>