### PR TITLE
v1.11 backports 2022-04-19

### DIFF
--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -174,10 +174,20 @@ Install Cilium
           Kubernetes worker node than the ENI limit, but means that pod
           connectivity to resources outside the cluster (e.g., VMs in the VPC
           or AWS managed services) is masqueraded (i.e., SNAT) by Cilium to use
-          the VPC IP address of the Kubernetes worker node.  Excluding the
-          lines for ``eni.enabled=true``, ``ipam.mode=eni`` and
-          ``tunnel=disabled`` from the helm command will configure Cilium to
-          use overlay routing mode (which is the helm default).
+          the VPC IP address of the Kubernetes worker node. To set up Cilium 
+          overlay mode, follow the steps below:
+
+            1. Excluding the lines for ``eni.enabled=true``, ``ipam.mode=eni`` and 
+               ``tunnel=disabled`` from the helm command will configure Cilium to use 
+               overlay routing mode (which is the helm default).
+            2. Flush iptables rules added by VPC CNI
+
+               .. code-block:: shell-session
+               
+                  iptables -t nat -F AWS-SNAT-CHAIN-0 \\
+                     && iptables -t nat -F AWS-SNAT-CHAIN-1 \\
+                     && iptables -t nat -F AWS-CONNMARK-CHAIN-0 \\
+                     && iptables -t nat -F AWS-CONNMARK-CHAIN-1
 
          Some Linux distributions use a different interface naming convention.
          If you use masquerading with the option ``egressMasqueradeInterfaces=eth0``,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -474,7 +474,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx, __u32 *dst_id)
 	struct ipv6hdr *ip6;
 	int ret;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	/* Handle special ICMPv6 messages. This includes echo requests to the
@@ -544,7 +544,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 	bool has_l4_header = false;
 	bool __maybe_unused dst_remote_ep = false;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 /* If IPv4 fragmentation is disabled

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -506,7 +506,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	if option.Config.EnableIPv4EgressGateway {
-		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(&d)
+		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(&d, d.identityAllocator)
 	}
 
 	d.k8sWatcher = watchers.NewK8sWatcher(

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -534,7 +534,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		d.k8sWatcher.NodeChain.Register(&d.k8sWatcher.K8sSvcCache)
 	}
 
-	d.k8sWatcher.NodeChain.Register(watchers.NewCiliumNodeUpdater(d.k8sWatcher))
+	d.k8sWatcher.NodeChain.Register(watchers.NewCiliumNodeUpdater(d.k8sWatcher, d.nodeDiscovery))
 
 	d.redirectPolicyManager.RegisterSvcCache(&d.k8sWatcher.K8sSvcCache)
 	d.redirectPolicyManager.RegisterGetStores(d.k8sWatcher)

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
             parallel {
                 stage ("Copy code and boot vms"){
                     options {
-                        timeout(time: 50, unit: 'MINUTES')
+                        timeout(time: 30, unit: 'MINUTES')
                     }
 
                     environment {
@@ -156,10 +156,8 @@ pipeline {
                     }
                     steps {
                         withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                            retry(3) {
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 15m ./vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 25m ./vagrant-ci-start.sh'
                             }
                         }
                     }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -428,8 +428,8 @@ func (m *IptablesManager) Init() {
 	if err := modulesManager.FindOrLoadModules(
 		"ip6_tables", "ip6table_mangle", "ip6table_raw", "ip6table_filter"); err != nil {
 		if option.Config.EnableIPv6 {
-			log.WithError(err).Warning(
-				"IPv6 is enabled and ip6tables modules could not be initialized (try loading ip6_tables, ip6table_mangle, ip6table_raw and ip6table_filter modules)")
+			log.WithError(err).Fatal(
+				"IPv6 is enabled and ip6tables modules could not be initialized (try disabling IPv6 in Cilium or loading ip6_tables, ip6table_mangle, ip6table_raw and ip6table_filter kernel modules)")
 		}
 		log.WithError(err).Debug(
 			"ip6tables kernel modules could not be loaded, so IPv6 cannot be used")

--- a/pkg/egressgateway/endpoint.go
+++ b/pkg/egressgateway/endpoint.go
@@ -27,7 +27,7 @@ type endpointMetadata struct {
 // endpointID includes endpoint name and namespace
 type endpointID = types.NamespacedName
 
-func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint) (*endpointMetadata, error) {
+func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels labels.Labels) (*endpointMetadata, error) {
 	var ipv4s []net.IP
 	id := types.NamespacedName{
 		Name:      endpoint.GetName(),
@@ -50,7 +50,7 @@ func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint) (*endpointMetadata, 
 
 	data := &endpointMetadata{
 		ips:    ipv4s,
-		labels: labels.NewLabelsFromModel(endpoint.Identity.Labels).K8sStringMap(),
+		labels: identityLabels.K8sStringMap(),
 		id:     id,
 	}
 

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -4,13 +4,19 @@
 package egressgateway
 
 import (
+	"context"
+	"fmt"
 	"time"
 
+	"github.com/cilium/cilium/pkg/identity"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
@@ -39,19 +45,39 @@ type Manager struct {
 
 	// epDataStore stores endpointId to endpoint metadata mapping
 	epDataStore map[endpointID]*endpointMetadata
+
+	// identityAllocator is used to fetch identity labels for endpoint updates
+	identityAllocator identityCache.IdentityAllocator
 }
 
 // NewEgressGatewayManager returns a new Egress Gateway Manager.
-func NewEgressGatewayManager(k8sCacheSyncedChecker k8sCacheSyncedChecker) *Manager {
+func NewEgressGatewayManager(k8sCacheSyncedChecker k8sCacheSyncedChecker, identityAlocator identityCache.IdentityAllocator) *Manager {
 	manager := &Manager{
 		k8sCacheSyncedChecker: k8sCacheSyncedChecker,
 		policyConfigs:         make(map[policyID]*PolicyConfig),
 		epDataStore:           make(map[endpointID]*endpointMetadata),
+		identityAllocator:     identityAlocator,
 	}
 
 	manager.runReconciliationAfterK8sSync()
 
 	return manager
+}
+
+// getIdentityLabels waits for the global identities to be populated to the cache,
+// then looks up identity by ID from the cached identity allocator and return its labels.
+func (manager *Manager) getIdentityLabels(securityIdentity uint32) (labels.Labels, error) {
+	identityCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
+	defer cancel()
+	if err := manager.identityAllocator.WaitForInitialGlobalIdentities(identityCtx); err != nil {
+		return nil, fmt.Errorf("failed to wait for initial global identities: %v", err)
+	}
+
+	identity := manager.identityAllocator.LookupIdentityByID(identityCtx, identity.NumericIdentity(securityIdentity))
+	if identity == nil {
+		return nil, fmt.Errorf("identity %d not found", securityIdentity)
+	}
+	return identity.Labels, nil
 }
 
 // runReconciliationAfterK8sSync spawns a goroutine that waits for the agent to
@@ -118,6 +144,7 @@ func (manager *Manager) OnDeleteEgressPolicy(configID policyID) {
 func (manager *Manager) OnUpdateEndpoint(endpoint *k8sTypes.CiliumEndpoint) {
 	var epData *endpointMetadata
 	var err error
+	var identityLabels labels.Labels
 
 	manager.mutex.Lock()
 	defer manager.mutex.Unlock()
@@ -133,7 +160,13 @@ func (manager *Manager) OnUpdateEndpoint(endpoint *k8sTypes.CiliumEndpoint) {
 		return
 	}
 
-	if epData, err = getEndpointMetadata(endpoint); err != nil {
+	if identityLabels, err = manager.getIdentityLabels(uint32(endpoint.Identity.ID)); err != nil {
+		logger.WithError(err).
+			Error("Failed to get idenity labels for endpoint, skipping update to egress policy.")
+		return
+	}
+
+	if epData, err = getEndpointMetadata(endpoint, identityLabels); err != nil {
 		logger.WithError(err).
 			Error("Failed to get valid endpoint metadata, skipping update to egress policy.")
 		return

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -7,17 +7,20 @@
 package egressgateway
 
 import (
-	"fmt"
+	"context"
 	"net"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/identity"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
 	. "gopkg.in/check.v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,6 +46,8 @@ const (
 var (
 	ep1Labels = map[string]string{"test-key": "test-value-1"}
 	ep2Labels = map[string]string{"test-key": "test-value-2"}
+
+	identityAllocator = testidentity.NewMockIdentityAllocator(nil)
 )
 
 type egressRule struct {
@@ -91,7 +96,7 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 
 	k8sCacheSyncedChecker := &k8sCacheSyncedCheckerMock{}
 
-	egressGatewayManager := NewEgressGatewayManager(k8sCacheSyncedChecker)
+	egressGatewayManager := NewEgressGatewayManager(k8sCacheSyncedChecker, identityAllocator)
 	c.Assert(egressGatewayManager, NotNil)
 
 	k8sCacheSyncedChecker.synced = true
@@ -102,23 +107,22 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 
 	assertEgressRules(c, []egressRule{})
 
-	// Add a new endpoint which matches policy-1
-	ep1 := newEndpoint("ep-1", ep1IP, ep1Labels)
+	// Add a new endpoint & ID which matches policy-1
+	ep1, id1 := newEndpointAndIdentity("ep-1", ep1IP, ep1Labels)
 	egressGatewayManager.OnUpdateEndpoint(&ep1)
 
 	assertEgressRules(c, []egressRule{
 		{ep1IP, destCIDR, egressIP1, egressIP1},
 	})
 
-	// Update the endpoint labels in order for it to not be a match
-	oldEp1Labels := ep1.Identity.Labels
-	ep1.Identity.Labels = []string{}
+	// Update the labels for ep1 in order for it to NOT be a match
+	id1 = updateEndpointAndIdentity(&ep1, id1, map[string]string{})
 	egressGatewayManager.OnUpdateEndpoint(&ep1)
 
 	assertEgressRules(c, []egressRule{})
 
-	// Restore the old endpoint lables in order for it to be a match
-	ep1.Identity.Labels = oldEp1Labels
+	// Restore the old ep1 lables in order for it to be a match
+	id1 = updateEndpointAndIdentity(&ep1, id1, ep1Labels)
 	egressGatewayManager.OnUpdateEndpoint(&ep1)
 
 	assertEgressRules(c, []egressRule{
@@ -133,8 +137,8 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 		{ep1IP, destCIDR, egressIP1, egressIP1},
 	})
 
-	// Add a new endpoint which matches policy-2
-	ep2 := newEndpoint("ep-2", ep2IP, ep2Labels)
+	// Add a new endpoint and ID which matches policy-2
+	ep2, _ := newEndpointAndIdentity("ep-2", ep2IP, ep2Labels)
 	egressGatewayManager.OnUpdateEndpoint(&ep2)
 
 	assertEgressRules(c, []egressRule{
@@ -142,9 +146,8 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 		{ep2IP, destCIDR, egressIP2, egressIP2},
 	})
 
-	// Update the endpoint labels for policy-1 in order for it to not be a match
-	oldEp1Labels = ep1.Identity.Labels
-	ep1.Identity.Labels = []string{}
+	// Update the endpoint labels for policy-1 in order for it to NOT be a match
+	updateEndpointAndIdentity(&ep1, id1, map[string]string{})
 	egressGatewayManager.OnUpdateEndpoint(&ep1)
 
 	assertEgressRules(c, []egressRule{
@@ -178,18 +181,16 @@ func newEgressPolicyConfig(policyName string, labels map[string]string, destinat
 	}
 }
 
-func newEndpoint(name, ip string, labels map[string]string) k8sTypes.CiliumEndpoint {
-	epLabels := []string{}
-	for k, v := range labels {
-		epLabels = append(epLabels, fmt.Sprintf("k8s:%s=%s", k, v))
-	}
+// Mock the creation of endpoint and its corresponding identity, returns endpoint and ID.
+func newEndpointAndIdentity(name, ip string, epLabels map[string]string) (k8sTypes.CiliumEndpoint, *identity.Identity) {
+	id, _, _ := identityAllocator.AllocateIdentity(context.Background(), labels.Map2Labels(epLabels, labels.LabelSourceK8s), true, identity.InvalidIdentity)
 
 	return k8sTypes.CiliumEndpoint{
 		ObjectMeta: slimv1.ObjectMeta{
 			Name: name,
 		},
 		Identity: &v2.EndpointIdentity{
-			Labels: epLabels,
+			ID: int64(id.ID),
 		},
 		Networking: &v2.EndpointNetworking{
 			Addressing: v2.AddressPairList{
@@ -198,7 +199,17 @@ func newEndpoint(name, ip string, labels map[string]string) k8sTypes.CiliumEndpo
 				},
 			},
 		},
-	}
+	}, id
+}
+
+// Mock the update of endpoint and its corresponding identity, with new labels. Returns new ID.
+func updateEndpointAndIdentity(endpoint *k8sTypes.CiliumEndpoint, oldID *identity.Identity, newEpLabels map[string]string) *identity.Identity {
+	ctx := context.Background()
+
+	identityAllocator.Release(ctx, oldID, true)
+	newID, _, _ := identityAllocator.AllocateIdentity(ctx, labels.Map2Labels(newEpLabels, labels.LabelSourceK8s), true, identity.InvalidIdentity)
+	endpoint.Identity.ID = int64(newID.ID)
+	return newID
 }
 
 func parseEgressRule(sourceIP, destCIDR, egressIP, gatewayIP string) parsedEgressRule {

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -37,6 +37,13 @@ var (
 	onceNodeInitStart sync.Once
 )
 
+// The KVStoreNodeUpdater interface is used to provide an abstraction for the
+// nodediscovery.NodeDiscovery object logic used to update a node entry in the
+// KV store.
+type KVStoreNodeUpdater interface {
+	UpdateKVNodeEntry(node *nodeTypes.Node) error
+}
+
 func nodeEventsAreEqual(oldNode, newNode *v1.Node) bool {
 	if !comparator.MapStringEquals(oldNode.GetLabels(), newNode.GetLabels()) {
 		return false
@@ -134,23 +141,25 @@ func (k *K8sWatcher) GetK8sNode(_ context.Context, nodeName string) (*v1.Node, e
 // ciliumNodeUpdater implements the subscriber.Node interface and is used
 // to keep CiliumNode objects in sync with the node ones.
 type ciliumNodeUpdater struct {
-	k8sWatcher *K8sWatcher
+	k8sWatcher         *K8sWatcher
+	kvStoreNodeUpdater KVStoreNodeUpdater
 }
 
-func NewCiliumNodeUpdater(k8sWatcher *K8sWatcher) *ciliumNodeUpdater {
+func NewCiliumNodeUpdater(k8sWatcher *K8sWatcher, kvStoreNodeUpdater KVStoreNodeUpdater) *ciliumNodeUpdater {
 	return &ciliumNodeUpdater{
-		k8sWatcher: k8sWatcher,
+		k8sWatcher:         k8sWatcher,
+		kvStoreNodeUpdater: kvStoreNodeUpdater,
 	}
 }
 
 func (u *ciliumNodeUpdater) OnAddNode(newNode *v1.Node, swg *lock.StoppableWaitGroup) error {
-	u.updateCiliumNode(newNode)
+	u.updateCiliumNode(u.kvStoreNodeUpdater, newNode)
 
 	return nil
 }
 
 func (u *ciliumNodeUpdater) OnUpdateNode(oldNode, newNode *v1.Node, swg *lock.StoppableWaitGroup) error {
-	u.updateCiliumNode(newNode)
+	u.updateCiliumNode(u.kvStoreNodeUpdater, newNode)
 
 	return nil
 }
@@ -159,7 +168,7 @@ func (u *ciliumNodeUpdater) OnDeleteNode(*v1.Node, *lock.StoppableWaitGroup) err
 	return nil
 }
 
-func (u *ciliumNodeUpdater) updateCiliumNode(node *v1.Node) {
+func (u *ciliumNodeUpdater) updateCiliumNode(kvStoreNodeUpdater KVStoreNodeUpdater, node *v1.Node) {
 	var (
 		controllerName = fmt.Sprintf("sync-node-with-ciliumnode (%v)", node.Name)
 
@@ -171,8 +180,7 @@ func (u *ciliumNodeUpdater) updateCiliumNode(node *v1.Node) {
 
 	doFunc := func(ctx context.Context) (err error) {
 		if option.Config.KVStore != "" && !option.Config.JoinCluster {
-			// TODO(jibi) handle the KV store case
-			return nil
+			return kvStoreNodeUpdater.UpdateKVNodeEntry(k8sNodeParsed)
 		} else {
 			u.k8sWatcher.ciliumNodeStoreMU.RLock()
 			defer u.k8sWatcher.ciliumNodeStoreMU.RUnlock()

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -57,6 +57,12 @@ type k8sNodeGetter interface {
 	GetK8sNode(ctx context.Context, nodeName string) (*corev1.Node, error)
 }
 
+// The KVStoreNodeUpdater interface is used to provide an abstraction for the
+// NodeStore object logic used to update a node entry in the KV store.
+type KVStoreNodeUpdater interface {
+	UpdateKVNodeEntry(node *nodeTypes.Node) error
+}
+
 // NodeDiscovery represents a node discovery action
 type NodeDiscovery struct {
 	Manager               *nodemanager.Manager
@@ -619,4 +625,20 @@ func (n *NodeDiscovery) RegisterK8sNodeGetter(k8sNodeGetter k8sNodeGetter) {
 
 func getInt(i int) *int {
 	return &i
+}
+
+func (nodeDiscovery *NodeDiscovery) UpdateKVNodeEntry(node *nodeTypes.Node) error {
+	if nodeDiscovery.Registrar.SharedStore == nil {
+		return nil
+	}
+
+	if err := nodeDiscovery.Registrar.UpdateLocalKeySync(node); err != nil {
+		return fmt.Errorf("failed to update KV node store entry: %w", err)
+	}
+
+	if err := nodeDiscovery.mutateNodeResource(node.ToCiliumNode()); err != nil {
+		return fmt.Errorf("failed to mutate node resource: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
* #19308 -- pull skb data at the entrance of from-containter (@liuyuan10)
   - Merge conflicts resolved according to
     https://github.com/cilium/cilium/pull/19308#issuecomment-1099573718
 * #19207 -- docs: improve guide to setup Cilium overlay on EKS (@oliwave)
 * #19375 -- k8s: keep KVStore CiliumNode labels synced with Node object (@jibi)
   - Had to resolve a merge conflict, please review carefully.
 * #19458 -- jenkinsfiles: Increase VM boot timeout (@pchaigno)
 * #18941 -- iptables: Fatal when IPv6 is enabled but corresponding kernel modules are missing (@vadorovsky)
 * #19194 -- Use identity labels for selector matching for Egress NAT Gateway (@blzhao-0)
   - Had to resolve a merge conflict due to different import group ordering in `v1.11` vs. `master`.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19308 19207 19375 19458 18941 19194; do contrib/backporting/set-labels.py $pr done 1.11; done
```