### PR TITLE
v1.10 backports 2022-04-19

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1191,9 +1191,9 @@ a fixed cookie value as a trade-off. This makes all applications on the host to
 select the same service endpoint for a given service with session affinity configured.
 To disable the feature, set ``config.sessionAffinity=false``.
 
-When the fixed cookie value is not used, a service affinity of a service with
+When the fixed cookie value is not used, the session affinity of a service with
 multiple ports is per service IP and port. Meaning that all requests for a
-given service sent from the same source and to the service same port will be routed
+given service sent from the same source and to the same service port will be routed
 to the same service endpoints; but two requests for the same service, sent from
 the same source but to different service ports may be routed to distinct service
 endpoints.

--- a/Documentation/gettingstarted/local-redirect-policy.rst
+++ b/Documentation/gettingstarted/local-redirect-policy.rst
@@ -33,8 +33,8 @@ the redirection.
 
 .. include:: ../beta.rst
 
-Deploy Cilium
-===============
+Prerequisites
+=============
 
 .. note::
 

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
             parallel {
                 stage ("Copy code and boot vms"){
                     options {
-                        timeout(time: 50, unit: 'MINUTES')
+                        timeout(time: 30, unit: 'MINUTES')
                     }
 
                     environment {
@@ -156,10 +156,8 @@ pipeline {
                     }
                     steps {
                         withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                            retry(3) {
-                                dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 15m ./vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 25m ./vagrant-ci-start.sh'
                             }
                         }
                     }

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -478,7 +478,7 @@ func (m *Map) OpenParallel() (bool, error) {
 	defer m.lock.Unlock()
 
 	if m.fd != 0 {
-		return false, fmt.Errorf("OpenParallel() called on already open map")
+		return false, fmt.Errorf("OpenParallel() called on already open map: %s", m.name)
 	}
 
 	if err := m.setPathIfUnset(); err != nil {

--- a/pkg/k8s/apis/cilium.io/v2/clrp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/clrp_types.go
@@ -228,8 +228,14 @@ func (pInfo *PortInfo) SanitizePortInfo(checkNamedPort bool) (uint16, string, lb
 	}
 	// Sanitize name
 	if checkNamedPort {
+		if pInfo.Name == "" {
+			return pInt, pName, protocol, fmt.Errorf("port %s in the local "+
+				"redirect policy spec must have a valid IANA_SVC_NAME, as there are multiple ports", pInfo.Port)
+
+		}
 		if !iana.IsSvcName(pInfo.Name) {
-			return pInt, pName, protocol, fmt.Errorf("valid port name is not present")
+			return pInt, pName, protocol, fmt.Errorf("port name %s isn't a "+
+				"valid IANA_SVC_NAME", pInfo.Name)
 		}
 	}
 	pName = strings.ToLower(pInfo.Name) // Normalize for case insensitive comparison


### PR DESCRIPTION
 * ~#19308 -- pull skb data at the entrance of from-containter (@liuyuan10)~
   - Merge conflicts resolved according to
     https://github.com/cilium/cilium/pull/19308#issuecomment-1099573718
   - Dropped for now due to https://github.com/cilium/cilium/pull/19482#issuecomment-1105117347
 * #19458 -- jenkinsfiles: Increase VM boot timeout (@pchaigno)
 * #19491 -- pkg/bpf: add map name in error message for OpenParallel (@aanm)
 * #19478 -- docs: improve description for session affinity with KPR (@julianwiedmann)
 * #19489 -- LRP minor improvements (@aditighag)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19458 19491 19478 19489; do contrib/backporting/set-labels.py $pr done 1.10; done
```