### PR TITLE
.github: Fix external workloads workflow for master

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yml
+++ b/.github/workflows/conformance-externalworkloads.yml
@@ -264,9 +264,10 @@ jobs:
             --command "cilium status"
 
       - name: Verify cluster DNS on VM
+        # Limit nslookup to the first (global) DNS server setting
         run: |
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} \
-            --command "nslookup -norecurse clustermesh-apiserver.kube-system.svc.cluster.local"
+            --command "nslookup -d2 -retry=10 -timeout=5 -norecurse clustermesh-apiserver.kube-system.svc.cluster.local \$(systemd-resolve --status | grep -m 1 \"Current DNS Server:\" | cut -d':' -f2)"
 
       - name: Ping clustermesh-apiserver from VM
         run: |


### PR DESCRIPTION
Only use the first configured DNS server (the global one) in the
test. Also add nslookup debug and retry options in case they are needed
for further debugging and troubleshooting.

This fixes external workload CI test on master that failed like this:
```
Server:		169.254.169.254
Address:	169.254.169.254#53

** server can't find clustermesh-apiserver.kube-system.svc.cluster.local: NXDOMAIN
```

Here an incorrect nameserver is being used by `nslookup`. This `169.254.169.254` is configured (now) in GKE as a nameserver for some local names. Don't know why `nslookup` sometimes chooses it if no server address is given as a parameter.
