### PR TITLE
bpf: egressgw: fix direct routing mode detection

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1946,15 +1946,15 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 	l4_off = l3_off + ipv4_hdrlen(ip4);
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
-#if defined(ENABLE_EGRESS_GATEWAY) && !defined(TUNNEL_MODE)
-	/* Traffic from clients to egress gateway nodes reaches said gateways
-	 * by a vxlan tunnel. If we are not using TUNNEL_MODE, we need to
+#if defined(ENABLE_EGRESS_GATEWAY) && DIRECT_ROUTING_DEV_IFINDEX != 0
+	/* Traffic from clients to egress gateway nodes reaches said nodes via
+	 * a vxlan tunnel.
+	 * If the datapath is running in direct routing mode, we need to
 	 * identify reverse traffic from the gateway to clients and also steer
-	 * it via the vxlan tunnel to avoid issues with iptables dropping these
-	 * packets. We do this in the code below, by performing a lookup in the
-	 * egress gateway map using a reverse address tuple. A match means that
-	 * the corresponding forward traffic was forwarded to the egress gateway
-	 * via the tunnel.
+	 * it to the vxlan tunnel to avoid issues with iptables dropping these
+	 * packets. We do this by performing a lookup in the egress gateway map
+	 * using a reverse address tuple. A match means that the corresponding
+	 * forward traffic was forwarded to the egress gateway via the tunnel.
 	 */
 	{
 		struct egress_gw_policy_entry *egress_policy;
@@ -1970,7 +1970,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 			}
 		}
 	}
-#endif /* ENABLE_EGRESS_GATEWAY */
+#endif /* defined(ENABLE_EGRESS_GATEWAY) && DIRECT_ROUTING_DEV_IFINDEX != 0 */
 	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_INGRESS, &ct_state,
 			 &monitor);
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1961,11 +1961,11 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 
 		egress_policy = lookup_ip4_egress_gw_policy(ip4->daddr, ip4->saddr);
 		if (egress_policy) {
-			struct remote_endpoint_info *info;
+			struct remote_endpoint_info *remote_ep;
 
-			info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
-			if (info && info->tunnel_endpoint != 0) {
-				tunnel_endpoint = info->tunnel_endpoint;
+			remote_ep = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
+			if (remote_ep && remote_ep->tunnel_endpoint != 0) {
+				tunnel_endpoint = remote_ep->tunnel_endpoint;
 				goto encap_redirect;
 			}
 		}


### PR DESCRIPTION
When egress gateway is enabled, in rev_nodeport_lb4() we need to check
if the datapath is running in direct routing mode in order to correctly
forward reply traffic back to the worker node over the tunnel.

Currently this check is defined as !defined(TUNNEL_MODE), which will
always be true whenever egress gateway is enabled (as the feature
requires TUNNEL_MODE to be enabled).

The correct check should be on the ENCAP_IFINDEX macro, but to make
it more explicit, this commit switches it to use DIRECT_ROUTING_DEV_IFINDEX.