### PR TITLE
daemon, fqdn: Implement semaphore around DNS proxy

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -119,6 +119,7 @@ type Daemon struct {
 
 	deviceManager *DeviceManager
 
+	dnsProxySemaphore *semaphore.Weighted
 	// dnsNameManager tracks which api.FQDNSelector are present in policy which
 	// apply to locally running endpoints.
 	dnsNameManager *fqdn.NameManager
@@ -484,6 +485,9 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		nodeDiscovery:     nd,
 		endpointCreations: newEndpointCreationManager(),
 		apiLimiterSet:     apiLimiterSet,
+		// TODO: Make this configurable? After implementing DNS proxy latency +
+		// throughput metrics, can be pick an optimal value?
+		dnsProxySemaphore: semaphore.NewWeighted(int64(runtime.NumCPU() * 2)),
 	}
 
 	if option.Config.RunMonitorAgent {

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -395,6 +395,12 @@ func (d *Daemon) lookupIPsBySecID(nid identity.NumericIdentity) []string {
 // the source for egress (the only case current).
 // serverID is the destination server security identity at the time of the DNS event.
 func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
+	// TODO: At this point, a goroutine has already spun off and starts
+	// executing this function. Is this too late in the flow in acquire the
+	// semaphore? Do we need deeper integration with the miekg DNS library?
+	d.dnsProxySemaphore.Acquire(context.TODO(), 1)
+	defer d.dnsProxySemaphore.Release(1)
+
 	var protoID = u8proto.ProtoIDs[strings.ToLower(protocol)]
 	var verdict accesslog.FlowVerdict
 	var reason string


### PR DESCRIPTION
Signed-off-by: Chris Tarazi <chris@isovalent.com>
