### PR TITLE
runtime: Bump privileged test timeout

### DIFF
--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -18,7 +18,7 @@ import (
 const (
 	// The privileged unit tests can take more than 4 minutes, the default
 	// timeout for helper commands.
-	privilegedUnitTestTimeout = 16 * time.Minute
+	privilegedUnitTestTimeout = 30 * time.Minute
 )
 
 var _ = Describe("RuntimePrivilegedUnitTests", func() {


### PR DESCRIPTION
Recent test runs have taken perhaps up to five minutes just to compile
various parts of the agent code from scratch with recent compilers, in
addition to taking a further ten minutes or so to run the tests. This is
close to the timeout, which means that occasionally the test will just
fail because it hits the timeout. Bump it to mitigate the issue.

Fixes: #18958