### PR TITLE
pkg/bpf: add map name in error message for OpenParallel

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -440,7 +440,7 @@ func (m *Map) OpenParallel() (bool, error) {
 	defer m.lock.Unlock()
 
 	if m.fd != 0 {
-		return false, fmt.Errorf("OpenParallel() called on already open map")
+		return false, fmt.Errorf("OpenParallel() called on already open map: %s", m.name)
 	}
 
 	if err := m.setPathIfUnset(); err != nil {


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>
