### PR TITLE
docs: update copybutton.css following the docutils update

### DIFF
--- a/Documentation/_static/copybutton.css
+++ b/Documentation/_static/copybutton.css
@@ -2,7 +2,7 @@ div.code-wrapper {
   position: relative !important;
 }
 
-.section > div.code-wrapper {
+section > div.code-wrapper {
   margin-bottom: 24px !important;
 }
 


### PR DESCRIPTION
We recently updated the version of Sphinx that we use to build the docs, and with it the version of docutils (from 0.14 to 0.17). This version of docutils introduce some changes in the generated HTML ([commit](https://sourceforge.net/p/docutils/code/8472/)): in particular, the `<div id="..." class="section">` nodes are replaced with `<section id="...">`. We need to adjust a rule based on the class name `.section` in copybutton.css accordingly, to restore the padding below the code wrappers.
