### PR TITLE
operator: Remove deprecated nodes-gc-interval flag

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -338,6 +338,7 @@ Removed Options
   in version 1.13.
 * The ``host-reachable-services-protos`` option (``.hostServices.protocols`` in
   Helm) was deprecated, and it will be removed in version 1.13.
+* The deprecated ``nodes-gc-interval`` option was removed.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -248,11 +248,6 @@ func init() {
 	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
 	option.BindEnv(option.K8sKubeConfigPath)
 
-	// To be removed in Cilium 1.12
-	flags.Duration(operatorOption.NodesGCInterval, 2*time.Minute, "GC interval for nodes store in the kvstore")
-	option.BindEnv(operatorOption.NodesGCInterval)
-	flags.MarkDeprecated(operatorOption.NodesGCInterval, "Unused flag, will be removed in future Cilium releases")
-
 	flags.String(operatorOption.OperatorPrometheusServeAddr, operatorOption.PrometheusServeAddr, "Address to serve Prometheus metrics")
 	option.BindEnv(operatorOption.OperatorPrometheusServeAddr)
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -74,9 +74,6 @@ const (
 	// IdentityHeartbeatTimeout is the timeout used to GC identities from k8s
 	IdentityHeartbeatTimeout = "identity-heartbeat-timeout"
 
-	// NodesGCInterval is the duration for which the nodes are GC in the KVStore.
-	NodesGCInterval = "nodes-gc-interval"
-
 	// OperatorAPIServeAddr IP:Port on which to serve api requests in
 	// operator (pass ":Port" to bind on all interfaces, "" is off)
 	OperatorAPIServeAddr = "operator-api-serve-addr"


### PR DESCRIPTION
This flag is deprecated in 1.11, so remove it for 1.12 now.

Relates to https://github.com/cilium/cilium/pull/17873

