### PR TITLE
daemon: Dump ipcache without probing for support

### DIFF
--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -160,11 +160,6 @@ type Map struct {
 	// whether the underlying kernel supports delete operations on the map
 	// the first time that supportsDelete() is called.
 	deleteSupport bool
-
-	// dumpSupport is set to 'true' initially, then is updated to set
-	// whether the underlying kernel supports dump operations on the map
-	// the first time that supportsDelete() or supportsDump() is called.
-	dumpSupport bool
 }
 
 // NewMap instantiates a Map.
@@ -182,7 +177,6 @@ func NewMap(name string) *Map {
 			bpf.ConvertKeyValue,
 		).WithCache().WithPressureMetric(),
 		deleteSupport: true,
-		dumpSupport:   true,
 	}
 }
 
@@ -232,14 +226,14 @@ func (m *Map) supportsDelete() bool {
 
 		// Detect dump support
 		err := m.Dump(map[string][]string{})
-		m.dumpSupport = err == nil
-		log.Debugf("Detected IPCache dump operation support: %t", m.dumpSupport)
+		dumpSupport := err == nil
+		log.Debugf("Detected IPCache dump operation support: %t", dumpSupport)
 
 		// In addition to delete support, ability to dump the map is
 		// also required in order to run the garbage collector which
 		// will iterate over the map and delete entries.
 		if m.deleteSupport {
-			m.deleteSupport = m.dumpSupport
+			m.deleteSupport = dumpSupport
 		}
 
 		if !m.deleteSupport {
@@ -249,21 +243,10 @@ func (m *Map) supportsDelete() bool {
 	return m.deleteSupport
 }
 
-func (m *Map) supportsDump() bool {
-	m.supportsDelete()
-	return m.dumpSupport
-}
-
 // SupportsDelete determines whether the underlying kernel map type supports
 // the delete operation.
 func SupportsDelete() bool {
 	return IPCache.supportsDelete()
-}
-
-// SupportsDump determines whether the underlying kernel map type supports
-// the dump operation.
-func SupportsDump() bool {
-	return IPCache.supportsDump()
 }
 
 // BackedByLPM returns true if the IPCache is backed by a proper LPM


### PR DESCRIPTION
Ipcache SupportDump() and SupportsDelete() open the map to probe for the
support if the map is not already open and also schedule the
bpf-map-sync-cilium_ipcache controller. If the controller is run before
initMaps(), initMaps will fail as the controller will leave the map open
and initMaps() assumes this not be the case.

Solve this by not trying to detect dump support, but try dump and see if
it succeeds. This is exactly the same logic dump support detection would
have used anyway, and this fixes Cilium Agent crash on kernels that do not
support ipcache dump operations and when certain Cilium features are
enabled on slow machines that caused the scheduled controller to run too
soon.

Fixes: #19360
Fixes: #19495
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
Fixed Cilium agent regression causing a crash due to ipcache controller being scheduled too soon.
```
