### PR TITLE
vtep: Remove UpdateIPCacheVTEPMapping()

### DIFF
--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/types"
@@ -283,22 +282,4 @@ var (
 // on the filesystem.
 func Reopen() error {
 	return IPCache.Map.Reopen()
-}
-
-// Function to update IPCache map with VTEP CIDR
-func UpdateIPCacheVTEPMapping(newCIDR *cidr.CIDR, newTunnelEndpoint net.IP,
-	securityIdentity uint32, encryptKey uint8) error {
-
-	key := NewKey(newCIDR.IP, newCIDR.Mask)
-
-	value := RemoteEndpointInfo{
-		SecurityIdentity: securityIdentity,
-		Key:              encryptKey,
-	}
-	if ip4 := newTunnelEndpoint.To4(); ip4 != nil {
-		copy(value.TunnelEndpoint[:], ip4)
-	}
-
-	return IPCache.Update(&key, &value)
-
 }


### PR DESCRIPTION
UpdateIPCacheVTEPMapping() is not needed and replaced by vtep
hash map impelmentation

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Clean up UpdateIPCacheVTEPMapping()
```
