### PR TITLE
updating code of conduct email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -38,8 +38,8 @@ This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project maintainers or our mediator, Beatriz
-Martinez <beatriz@cilium.io>.
+reported by contacting the code of conduct team via 
+[conduct@cilium.io](mailto:conduct@cilium.io).
 
 This Code of Conduct is adapted from the Contributor Covenant
 (http://contributor-covenant.org), version 1.2.0, available at


### PR DESCRIPTION
Signed-off-by: Bill Mulligan <bill@isovalent.com>


```release-note
Code of conduct email updated to conduct@cilium.io
```
