### PR TITLE
github: Backport DNS fix for external workloads 1.10 and 1.11 tests

### DIFF
--- a/.github/workflows/conformance-externalworkloads-v1.10.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yml
@@ -265,9 +265,10 @@ jobs:
             --command "cilium status"
 
       - name: Verify cluster DNS on VM
+        # Limit nslookup to the first (global) DNS server setting
         run: |
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} \
-            --command "nslookup -norecurse clustermesh-apiserver.kube-system.svc.cluster.local"
+            --command "nslookup -d2 -retry=10 -timeout=5 -norecurse clustermesh-apiserver.kube-system.svc.cluster.local \$(systemd-resolve --status | grep -m 1 \"Current DNS Server:\" | cut -d':' -f2)"
 
       - name: Ping clustermesh-apiserver from VM
         run: |

--- a/.github/workflows/conformance-externalworkloads-v1.11.yml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yml
@@ -265,9 +265,10 @@ jobs:
             --command "cilium status"
 
       - name: Verify cluster DNS on VM
+        # Limit nslookup to the first (global) DNS server setting
         run: |
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} \
-            --command "nslookup -norecurse clustermesh-apiserver.kube-system.svc.cluster.local"
+            --command "nslookup -d2 -retry=10 -timeout=5 -norecurse clustermesh-apiserver.kube-system.svc.cluster.local \$(systemd-resolve --status | grep -m 1 \"Current DNS Server:\" | cut -d':' -f2)"
 
       - name: Ping clustermesh-apiserver from VM
         run: |


### PR DESCRIPTION
Backport the DNS verification fix to 1.10 and 1.11 versions of the
external workloads conformance test.

These workflows need to be merged to master before they can be run for actual v1.10 and v1.11 backports.

Reviewers should compare these changes to the ones made to `.github/workflows/conformance-externalworkloads.yml` in #19483.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
