### PR TITLE
cli: cilium config --all prints masks wrong

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -132,7 +132,8 @@ func initKubeProxyReplacementOptions() (bool, error) {
 				return false, fmt.Errorf("Invalid value for --%s: %s",
 					option.LoadBalancerRSSv4CIDR, option.Config.LoadBalancerRSSv4CIDR)
 			}
-			option.Config.LoadBalancerRSSv4 = *cidr
+			option.Config.LoadBalancerRSSv4.IP = cidr.IP
+			option.Config.LoadBalancerRSSv4.Mask = "/" + strings.Split(option.Config.LoadBalancerRSSv4CIDR, "/")[1]
 		}
 
 		if option.Config.LoadBalancerRSSv6CIDR != "" {
@@ -149,7 +150,8 @@ func initKubeProxyReplacementOptions() (bool, error) {
 				return false, fmt.Errorf("Invalid value for --%s: %s",
 					option.LoadBalancerRSSv6CIDR, option.Config.LoadBalancerRSSv6CIDR)
 			}
-			option.Config.LoadBalancerRSSv6 = *cidr
+			option.Config.LoadBalancerRSSv6.IP = cidr.IP
+			option.Config.LoadBalancerRSSv6.Mask = "/" + strings.Split(option.Config.LoadBalancerRSSv6CIDR, "/")[1]
 		}
 
 		if (option.Config.LoadBalancerRSSv4CIDR != "" || option.Config.LoadBalancerRSSv6CIDR != "") &&

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -358,9 +358,8 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		if option.Config.EnableIPv4 {
 			if option.Config.LoadBalancerRSSv4CIDR != "" {
 				ipv4 := byteorder.NetIPv4ToHost32(option.Config.LoadBalancerRSSv4.IP)
-				ones, _ := option.Config.LoadBalancerRSSv4.Mask.Size()
 				cDefinesMap["IPV4_RSS_PREFIX"] = fmt.Sprintf("%d", ipv4)
-				cDefinesMap["IPV4_RSS_PREFIX_BITS"] = fmt.Sprintf("%d", ones)
+				cDefinesMap["IPV4_RSS_PREFIX_BITS"] = option.Config.LoadBalancerRSSv4.Mask
 			} else {
 				cDefinesMap["IPV4_RSS_PREFIX"] = "IPV4_DIRECT_ROUTING"
 				cDefinesMap["IPV4_RSS_PREFIX_BITS"] = "32"
@@ -369,10 +368,9 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		if option.Config.EnableIPv6 {
 			if option.Config.LoadBalancerRSSv6CIDR != "" {
 				ipv6 := option.Config.LoadBalancerRSSv6.IP
-				ones, _ := option.Config.LoadBalancerRSSv6.Mask.Size()
 				extraMacrosMap["IPV6_RSS_PREFIX"] = ipv6.String()
 				fw.WriteString(FmtDefineAddress("IPV6_RSS_PREFIX", ipv6))
-				cDefinesMap["IPV6_RSS_PREFIX_BITS"] = fmt.Sprintf("%d", ones)
+				cDefinesMap["IPV6_RSS_PREFIX_BITS"] = option.Config.LoadBalancerRSSv6.Mask
 			} else {
 				cDefinesMap["IPV6_RSS_PREFIX"] = "IPV6_DIRECT_ROUTING"
 				cDefinesMap["IPV6_RSS_PREFIX_BITS"] = "128"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1273,6 +1273,12 @@ type IpvlanConfig struct {
 	OperationMode     string
 }
 
+// IPAddrCIDR is a IP format structure used by LoadBalancerRSSv4 and LoadBalancerRSSv6.
+type IPAddrCIDR struct {
+	IP   net.IP
+	Mask string
+}
+
 // DaemonConfig is the configuration used by Daemon.
 type DaemonConfig struct {
 	CreationTime        time.Time
@@ -1819,11 +1825,11 @@ type DaemonConfig struct {
 
 	// LoadBalancerRSSv4CIDR defines the outer source IPv4 prefix for DSR/IPIP
 	LoadBalancerRSSv4CIDR string
-	LoadBalancerRSSv4     net.IPNet
+	LoadBalancerRSSv4     IPAddrCIDR
 
 	// LoadBalancerRSSv4CIDR defines the outer source IPv6 prefix for DSR/IPIP
 	LoadBalancerRSSv6CIDR string
-	LoadBalancerRSSv6     net.IPNet
+	LoadBalancerRSSv6     IPAddrCIDR
 
 	// LoadBalancerPMTUDiscovery indicates whether LB should reply with ICMP
 	// frag needed messages to client (when needed)


### PR DESCRIPTION
Description:
Issue: Cilium config prints unknown characters for Mask
Root cause: Mask type is in byte format, So dumpConfig tries to conver byte into string which results in a group of undefined characters
Fix: We have updated the Mask format to string

Fixes: #18106

Signed-off-by: Nagendra Boyina <nagendra.boyina@benisontech.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
