### PR TITLE
clustermesh: Add support for service-affinity

### DIFF
--- a/Documentation/cmdref/cilium_service_list.md
+++ b/Documentation/cmdref/cilium_service_list.md
@@ -11,8 +11,9 @@ cilium service list [flags]
 ### Options
 
 ```
-  -h, --help            help for list
-  -o, --output string   json| yaml| jsonpath='{}'
+      --clustermesh-affinity   Print clustermesh affinity if available
+  -h, --help                   help for list
+  -o, --output string          json| yaml| jsonpath='{}'
 ```
 
 ### Options inherited from parent commands

--- a/api/v1/models/backend_address.go
+++ b/api/v1/models/backend_address.go
@@ -32,6 +32,10 @@ type BackendAddress struct {
 	// Layer 4 port number
 	Port uint16 `json:"port,omitempty"`
 
+	// Indicator if this backend is preferred in the context of clustermesh service affinity. The value is set based
+	// on related annotation of global service. Applicable for active state only.
+	Preferred bool `json:"preferred,omitempty"`
+
 	// State of the backend for load-balancing service traffic
 	// Enum: [active terminating quarantined maintenance]
 	State string `json:"state,omitempty"`

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2494,6 +2494,11 @@ definitions:
           - terminating
           - quarantined
           - maintenance
+      preferred:
+        description: |-
+          Indicator if this backend is preferred in the context of clustermesh service affinity. The value is set based
+          on related annotation of global service. Applicable for active state only.
+        type: boolean
   LRPBackend:
     description: Pod backend of an LRP
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1606,6 +1606,10 @@ func init() {
           "type": "integer",
           "format": "uint16"
         },
+        "preferred": {
+          "description": "Indicator if this backend is preferred in the context of clustermesh service affinity. The value is set based\non related annotation of global service. Applicable for active state only.",
+          "type": "boolean"
+        },
         "state": {
           "description": "State of the backend for load-balancing service traffic",
           "type": "string",
@@ -6060,6 +6064,10 @@ func init() {
           "description": "Layer 4 port number",
           "type": "integer",
           "format": "uint16"
+        },
+        "preferred": {
+          "description": "Indicator if this backend is preferred in the context of clustermesh service affinity. The value is set based\non related annotation of global service. Applicable for active state only.",
+          "type": "boolean"
         },
         "state": {
           "description": "State of the backend for load-balancing service traffic",

--- a/cilium/cmd/service_list.go
+++ b/cilium/cmd/service_list.go
@@ -26,8 +26,11 @@ var serviceListCmd = &cobra.Command{
 	},
 }
 
+var clustermeshAffinity bool
+
 func init() {
 	serviceCmd.AddCommand(serviceListCmd)
+	serviceListCmd.Flags().BoolVar(&clustermeshAffinity, "clustermesh-affinity", false, "Print clustermesh affinity if available")
 	command.AddOutputOption(serviceListCmd)
 }
 
@@ -78,7 +81,12 @@ func printServiceList(w *tabwriter.Writer, list []*models.Service) {
 				fmt.Fprintf(os.Stderr, "error parsing backend %+v", be)
 				continue
 			}
-			str := fmt.Sprintf("%d => %s (%s)", i+1, beA.String(), be.State)
+			var str string
+			if clustermeshAffinity && be.Preferred {
+				str = fmt.Sprintf("%d => %s (%s) (preferred)", i+1, beA.String(), be.State)
+			} else {
+				str = fmt.Sprintf("%d => %s (%s)", i+1, beA.String(), be.State)
+			}
 			backendAddresses = append(backendAddresses, str)
 		}
 

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -56,6 +56,16 @@ const (
 	// sharing local endpoints.
 	SharedService = Prefix + "/shared-service"
 
+	// ServiceAffinity annotations determines the preferred endpoint destination
+	// Allowed values:
+	//  - local
+	//		preferred endpoints from local cluster if available
+	//  - remote
+	// 		preferred endpoints from remote cluster if available
+	//  - none (default)
+	//		no preference. Default behavior if this annotation does not exist
+	ServiceAffinity = Prefix + "/service-affinity"
+
 	// ProxyVisibility is the annotation name used to indicate whether proxy
 	// visibility should be enabled for a given pod (i.e., all traffic for the
 	// pod is redirected to the proxy for the given port / protocol in the

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -58,6 +58,7 @@ type Backend struct {
 	NodeName      string
 	Terminating   bool
 	HintsForZones []string
+	Preferred     bool
 }
 
 // String returns the string representation of an endpoints resource, with

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -491,6 +491,7 @@ func (s *ServiceCache) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 		localEndpoints = s.filterEndpoints(localEndpoints, svc)
 
 		for ip, e := range localEndpoints.Backends {
+			e.Preferred = svcFound && svc.IncludeExternal && svc.ServiceAffinity == serviceAffinityLocal
 			endpoints.Backends[ip] = e
 		}
 	}
@@ -511,6 +512,7 @@ func (s *ServiceCache) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 							"cluster":              clusterName,
 						}).Warning("Conflicting service backend IP")
 					} else {
+						e.Preferred = svc.ServiceAffinity == serviceAffinityRemote
 						endpoints.Backends[ip] = e
 					}
 				}

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -65,6 +65,23 @@ func (s *K8sSuite) TestGetAnnotationShared(c *check.C) {
 	c.Assert(getAnnotationShared(svc), check.Equals, false)
 }
 
+func (s *K8sSuite) TestGetAnnotationServiceAffinity(c *check.C) {
+	svc := &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/service-affinity": "local"},
+	}}
+	c.Assert(getAnnotationServiceAffinity(svc), check.Equals, serviceAffinityLocal)
+
+	svc = &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/service-affinity": "remote"},
+	}}
+	c.Assert(getAnnotationServiceAffinity(svc), check.Equals, serviceAffinityRemote)
+
+	svc = &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
+		Annotations: map[string]string{},
+	}}
+	c.Assert(getAnnotationServiceAffinity(svc), check.Equals, serviceAffinityNone)
+}
+
 func (s *K8sSuite) TestParseServiceID(c *check.C) {
 	svc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -742,7 +742,8 @@ func genCartesianProduct(
 						IP:     parsedIP,
 						L4Addr: *backendPort,
 					},
-					State: backendState,
+					State:     backendState,
+					Preferred: loadbalancer.Preferred(backend.Preferred),
 				})
 			}
 		}

--- a/pkg/k8s/zz_generated.deepequal.go
+++ b/pkg/k8s/zz_generated.deepequal.go
@@ -164,6 +164,9 @@ func (in *Service) deepEqual(other *Service) bool {
 	if in.Shared != other.Shared {
 		return false
 	}
+	if in.ServiceAffinity != other.ServiceAffinity {
+		return false
+	}
 	if in.TrafficPolicy != other.TrafficPolicy {
 		return false
 	}

--- a/pkg/k8s/zz_generated.deepequal.go
+++ b/pkg/k8s/zz_generated.deepequal.go
@@ -59,6 +59,10 @@ func (in *Backend) DeepEqual(other *Backend) bool {
 		}
 	}
 
+	if in.Preferred != other.Preferred {
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -303,6 +303,9 @@ type ID uint32
 // BackendState is the state of a backend for load-balancing service traffic.
 type BackendState uint8
 
+// Preferred indicates if this backend is preferred to be load balanced.
+type Preferred bool
+
 // Backend represents load balancer backend.
 type Backend struct {
 	// FEPortName is the frontend port name. This is used to filter backends sending to EDS.
@@ -315,6 +318,10 @@ type Backend struct {
 	L3n4Addr
 	// State of the backend for load-balancing service traffic
 	State BackendState
+
+	// Preferred indicates if the healthy backend is preferred
+	Preferred Preferred
+
 	// RestoredFromDatapath indicates whether the backend was restored from BPF maps
 	RestoredFromDatapath bool
 }
@@ -556,9 +563,10 @@ func NewL3n4AddrFromModel(base *models.FrontendAddress) (*L3n4Addr, error) {
 func NewBackend(id BackendID, protocol L4Type, ip net.IP, portNumber uint16) *Backend {
 	lbport := NewL4Addr(protocol, portNumber)
 	b := Backend{
-		ID:       BackendID(id),
-		L3n4Addr: L3n4Addr{IP: ip, L4Addr: *lbport},
-		State:    BackendStateActive,
+		ID:        BackendID(id),
+		L3n4Addr:  L3n4Addr{IP: ip, L4Addr: *lbport},
+		State:     BackendStateActive,
+		Preferred: Preferred(false),
 	}
 
 	return &b
@@ -595,7 +603,12 @@ func NewBackendFromBackendModel(base *models.BackendAddress) (*Backend, error) {
 		return nil, fmt.Errorf("invalid backend state [%s]", base.State)
 	}
 
-	return &Backend{NodeName: base.NodeName, L3n4Addr: L3n4Addr{IP: ip, L4Addr: *l4addr}, State: state}, nil
+	return &Backend{
+		NodeName:  base.NodeName,
+		L3n4Addr:  L3n4Addr{IP: ip, L4Addr: *l4addr},
+		State:     state,
+		Preferred: Preferred(base.Preferred),
+	}, nil
 }
 
 func NewL3n4AddrFromBackendModel(base *models.BackendAddress) (*L3n4Addr, error) {
@@ -636,10 +649,11 @@ func (b *Backend) GetBackendModel() *models.BackendAddress {
 	ip := b.IP.String()
 	stateStr, _ := b.State.String()
 	return &models.BackendAddress{
-		IP:       &ip,
-		Port:     b.Port,
-		NodeName: b.NodeName,
-		State:    stateStr,
+		IP:        &ip,
+		Port:      b.Port,
+		NodeName:  b.NodeName,
+		State:     stateStr,
+		Preferred: bool(b.Preferred),
 	}
 }
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -286,6 +286,9 @@ const (
 	// BackendState is the state of the backend
 	BackendState = "backendState"
 
+	// BackendPreferred is the indicator if this backend is preferred if active.
+	BackendPreferred = "backendPreferred"
+
 	// CiliumNetworkPolicy is a cilium specific NetworkPolicy
 	CiliumNetworkPolicy = "ciliumNetworkPolicy"
 

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -41,8 +41,12 @@ func (m *LBMockMap) UpsertService(p *lbmap.UpsertServiceParams) error {
 		}
 		backendsList = append(backendsList, *b)
 	}
-	if p.UseMaglev && len(p.ActiveBackends) != 0 {
-		if err := m.UpsertMaglevLookupTable(p.ID, p.ActiveBackends, p.IPv6); err != nil {
+	backends := p.ActiveBackends
+	if len(p.PreferredBackends) > 0 {
+		backends = p.PreferredBackends
+	}
+	if p.UseMaglev && len(backends) != 0 {
+		if err := m.UpsertMaglevLookupTable(p.ID, backends, p.IPv6); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
### Description 

This is to add service-annotation for global service in clustermesh

### Changes

Please refer the individual commit for more details.

### TODO

- [ ] Update the docs later, I will either update docs after first round of review, or in separate PR.
- [x] Confirm if backport to 1.11 is required. Updated: backport is not required. 
   - [x] If yes, backport should be done manually + separately due to conflict with quanrantine backend service feature. 

### Testing

Testing was done for locally with 2 kind clusters

- [x] Service Affinity set as Local
    - [x] Local endpoints are healthy, responses must be from these local endpoints only
    - [x] Local endpoints are not healthy, responses can be from remote clusters
        - [x] scale down local pods to 0
        - [x] mark local endpoint as not Active (e.g. Quarantine)
- [x] Service Affinity set as Remote
    - [x] Remote endpoints are healthy, responses must be from these remote endpoints only
    - [x] Remote endpoints are not healthy, responses should fall back to local endpoints
        - [x] scale down remote pods to 0
        - [x] mark remote endpoint as not Active (e.g. Quarantine)
- [x] Toggle service affinity 
   - [x] From none to local
   - [x] From none to remote
   - [x] From remote to local
   - [x] From local to remote
   - [x] Remove service affinity
   

<details>
<summary>One case with local service affinity</summary>
   
```
# Starting with no service affinity
$ ./local/clustermesh_check.sh
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}

# Set service affinity to local for cluster 2 service
$ k annotate service rebel-base io.cilium/service-affinity="local" --context kind-kind-2 --overwrite
service/rebel-base annotated

# Check the preferred endpoints, which should match local endpoints
$ ksysex ds/cilium -c cilium-agent -- cilium service list                                           
ID   Frontend            Service Type   Backend                                     
1    10.96.0.1:443       ClusterIP      1 => 172.18.0.5:6443 (active)               
2    10.96.0.10:53       ClusterIP      1 => 10.244.1.249:53 (active)               
                                        2 => 10.244.1.170:53 (active)               
3    10.96.0.10:9153     ClusterIP      1 => 10.244.1.249:9153 (active)             
                                        2 => 10.244.1.170:9153 (active)             
11   10.96.198.86:2379   ClusterIP      1 => 10.244.1.111:2379 (active)             
12   10.96.178.32:80     ClusterIP      1 => 10.244.1.71:80 (active) (preferred)    
                                        2 => 10.244.0.123:80 (active) (preferred)   
                                        3 => 10.244.1.105:80 (active)               
                                        4 => 10.244.1.49:80 (active)   

$ kg endpoints                                           
NAME         ENDPOINTS                        AGE
kubernetes   172.18.0.5:6443                  3h19m
rebel-base   10.244.0.123:80,10.244.1.71:80   39m

# Run the test again
$ ./local/clustermesh_check.sh
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-2"}
```

</details>

<details>
<summary>Scale down the local service</summary>

```
$ kubectl scale --replicas=0 deployment/rebel-base --context kind-kind-2
deployment.apps/rebel-base scaled

# Check preferred service list again
$ ksysex ds/cilium -c cilium-agent -- cilium service list               
ID   Frontend            Service Type   Backend                           
1    10.96.0.1:443       ClusterIP      1 => 172.18.0.5:6443 (active)     
2    10.96.0.10:53       ClusterIP      1 => 10.244.1.249:53 (active)     
                                        2 => 10.244.1.170:53 (active)     
3    10.96.0.10:9153     ClusterIP      1 => 10.244.1.249:9153 (active)   
                                        2 => 10.244.1.170:9153 (active)   
11   10.96.198.86:2379   ClusterIP      1 => 10.244.1.111:2379 (active)   
12   10.96.178.32:80     ClusterIP      1 => 10.244.1.105:80 (active)     
                                        2 => 10.244.1.49:80 (active)   
                                        
# Run the check again
$ ./local/clustermesh_check.sh
Checking in cluster 1
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
Checking in cluster 2
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}

```

</details>