### PR TITLE
redirectpolicy: Fix panic in service matcher LPR processing

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -328,7 +328,7 @@ const (
 	// Devices is the devices name
 	Devices = "devices"
 
-	//DirectRoutingDevice is the name of the direct routing device
+	// DirectRoutingDevice is the name of the direct routing device
 	DirectRoutingDevice = "directRoutingDevice"
 
 	// IpvlanMasterDevice is the ipvlan master device name
@@ -544,6 +544,12 @@ const (
 
 	// LRPBackendPorts are the parsed backend ports of the Local Redirect Policy.
 	LRPBackendPorts = "lrpBackendPorts"
+
+	// LRPType is the type of the Local Redirect Policy.
+	LRPType = "lrpType"
+
+	// LRPFrontendType is the parsed frontend type of the Local Redirect Policy.
+	LRPFrontendType = "lrpFrontendType"
 
 	// ENPName is the name of the egress nat policy
 	ENPName = "enpName"


### PR DESCRIPTION
When a service matcher LRP and the selected backend pods
are deployed first, we previously didn't check if the LRP
frontend information (aka clusterIP) is available. This led to agent panic.
The frontend information is populated only when the LRP selected
service event is received. 
This issue won't be hit when the selected service was deployed
prior to the LRP or backend pod.

Reported-by: Karsten Nielsen
Signed-off-by: Aditi Ghag <aditi@cilium.io>

```release-note
Fix agent panic in some cases when service matcher local redirect policy was deployed prior to the selected service. 
```
