### PR TITLE
vagrant: Don't recreate natnetworks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,6 +46,11 @@ end
 
 $cleanup = <<SCRIPT
 i=1
+while [ "$i" -le "$((num_workers+1))" ]; do
+    VBoxManage natnetwork add --netname natnet$i --network fd08::/64 --ipv6 on --enable
+    i=$((i+1))
+done 2>/dev/null
+
 res=0
 while [ "$res" == "0" ]; do
     VBoxManage natnetwork remove --netname natnet$i
@@ -217,7 +222,6 @@ Vagrant.configure(2) do |config|
         cm.vm.network "private_network",
             ip: "192.168.59.15"
         cm.vm.provider "virtualbox" do |vb|
-            vb.customize ["natnetwork", "add", "--netname", "natnet1", "--network", "fd08::/64", "--ipv6", "on", "--enable"]
             vb.customize ["modifyvm", :id, "--nic4", "natnetwork"]
             vb.customize ["modifyvm", :id, "--nat-network4", "natnet1"]
         end
@@ -280,7 +284,6 @@ Vagrant.configure(2) do |config|
             node.vm.network "private_network",
                 ip: "192.168.59.15"
             node.vm.provider "virtualbox" do |vb|
-                vb.customize ["natnetwork", "add", "--netname", "natnet#{n+2}", "--network", "fd08::/64", "--ipv6", "on", "--enable"]
                 vb.customize ["modifyvm", :id, "--nic4", "natnetwork"]
                 vb.customize ["modifyvm", :id, "--nat-network4", "natnet#{n+2}"]
             end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -59,6 +59,11 @@ end
 
 $cleanup = <<SCRIPT
 i=1
+while [ "$i" -le "$K8S_NODES" ]; do
+    VBoxManage natnetwork add --netname natnet$i --network fd08::/64 --ipv6 on --enable
+    i=$((i+1))
+done 2>/dev/null
+
 res=0
 while [ "$res" == "0" ]; do
     VBoxManage natnetwork remove --netname natnet$i
@@ -218,7 +223,6 @@ Vagrant.configure("2") do |config|
             server.vm.network "private_network",
                 ip: "192.168.59.15"
             server.vm.provider "virtualbox" do |vb|
-                vb.customize ["natnetwork", "add", "--netname", "natnet#{i}", "--network", "fd08::/64", "--ipv6", "on", "--enable"]
                 vb.customize ["modifyvm", :id, "--nic5", "natnetwork"]
                 vb.customize ["modifyvm", :id, "--nat-network5", "natnet#{i}"]
             end


### PR DESCRIPTION
We are hitting issues with the natnetwork creations, both in CI and in the dev. VM setup. In both cases, it fails to create because the natnetwork apparently already exists. For the dev. VM, that happens because the removal of natnetworks sometimes fail, maybe because it's still in use while being removed. For the CI, it's unclear why it fails as a previous listing of natnetworks shows nothing.

In any case, one way to work around this is to avoid recreating the natnetworks each time the VMs are booted. Instead, we can create only the natnetworks we need and delete the rest. If the creations fail, we assume it's because they already exist and ignore the failure.

To be able to ignore the creation failures, we must move them outside of the Vagrant interface configuration and into a proper Shell script, which we run in a pre-provisioning step.