### PR TITLE
helm: Create cilium IngressClass

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-ingress-class.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-class.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.ingressController.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: cilium
+spec:
+  controller: cilium.io/ingress-controller
+{{- end}}


### PR DESCRIPTION
### Description

Some environments might already have another ingress controllers such as
nginx, we need to create dedicated IngressClass for cilium, otherwise
IngressClass webhook validation might fail.

Signed-off-by: Tam Mach <tam.mach@isovalent.com>
