### PR TITLE
Use '.Values.enableIPv4Masquerade' in 'node-init'

### DIFF
--- a/install/kubernetes/cilium/files/nodeinit/prestop.bash
+++ b/install/kubernetes/cilium/files/nodeinit/prestop.bash
@@ -46,7 +46,7 @@ echo "Restarting the kubelet"
 systemctl restart kubelet
 {{- end }}
 
-{{- if (and .Values.gke.enabled (or .Values.masquerade .Values.gke.disableDefaultSnat))}}
+{{- if (and .Values.gke.enabled (or .Values.enableIPv4Masquerade .Values.gke.disableDefaultSnat))}}
 # If the IP-MASQ chain exists, add back default jump rule from the GKE instance configure script
 if iptables -w -t nat -L IP-MASQ > /dev/null; then
   iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ

--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -106,7 +106,7 @@ echo "Restarting the kubelet..."
 systemctl restart kubelet
 {{- end }}
 
-{{- if (and .Values.gke.enabled (or .Values.masquerade .Values.gke.disableDefaultSnat))}}
+{{- if (and .Values.gke.enabled (or .Values.enableIPv4Masquerade .Values.gke.disableDefaultSnat))}}
 # If Cilium is configured to manage masquerading of traffic leaving the node,
 # we need to disable the IP-MASQ chain because even if ip-masq-agent
 # is not installed, the node init script installs some default rules into


### PR DESCRIPTION
I'm not 100% sure if this was overlooked during the
`masquerade` → `enableIPv4Masquerade` renaming
(https://github.com/cilium/cilium/pull/14124), but assuming that was
the case, this commit changes the reference from the old value to the
new one so the value of `enableIPv4Masquerade` is actually taken into
account in `node-init`.

```release-note
`node-init` now takes `enableIPv4Masquerade` into account on GKE.
```