### PR TITLE
bpf: fix selection of Nodeport XDP accel for IPv6

### DIFF
--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -182,7 +182,7 @@ static __always_inline int check_v4(struct __ctx_buff *ctx)
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPV6
-#ifdef ENABLE_NODEPORT
+#ifdef ENABLE_NODEPORT_ACCELERATION
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_LXC)
 int tail_lb_ipv6(struct __ctx_buff *ctx)
 {
@@ -209,7 +209,7 @@ static __always_inline int check_v6_lb(struct __ctx_buff *ctx __maybe_unused)
 {
 	return CTX_ACT_OK;
 }
-#endif /* ENABLE_NODEPORT */
+#endif /* ENABLE_NODEPORT_ACCELERATION */
 
 #ifdef ENABLE_PREFILTER
 static __always_inline int check_v6(struct __ctx_buff *ctx)


### PR DESCRIPTION
Fix a s/ENABLE_NODEPORT/ENABLE_NODEPORT_ACCELERATION typo, so that the
XDP-based acceleration for IPv6 Nodeport only gets compiled when selected.
This matches the IPv4 path.

Only makes a difference if the XDP program gets loaded for some other
feature. Right now that would only be XDP-based CIDR filtering.

Fixes: 964c3fb9e609 ("bpf: initial datapath acceleration for nodeport in xdp")
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>

```release-note
Only apply XDP acceleration for IPv6 Nodeport when enabled (with --bpf-lb-acceleration=native).
```