### PR TITLE
docs: Fix display of misspelled words

### DIFF
--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -36,7 +36,7 @@ has_spelling_errors() {
 describe_spelling_errors() {
     printf "\nPlease fix the following spelling mistakes:\n"
     # show file paths relative to repo root
-    sed 's/^/* Documentation\//' "${spelldir}"/*
+    find "${spelldir}" -type f -print0 | xargs -0 sed 's/^/* Documentation\//'
 }
 
 hint_about_wordlist_update() {


### PR DESCRIPTION
Recent changes to the build framework for the documentation have brought some updates to the way spelling errors are reported and displayed. A bug may occur when trying to display the misspelled words reported by Sphinx: The current code in the script attempts to process all files directly under _build/spelling/, but some reports may be located under _subdirectories_ of this folder, and check-build.sh fails to process them (trying to apply the sed expression on directories) and to print the misspelled words. [One example here](https://github.com/cilium/cilium/runs/6130586687?check_suite_focus=true).

Let's fix this by retrieving properly all files under _build/spelling/ and passing them to the sed expression.
