### PR TITLE
[v1.9] Add concurrency limiting for DNS message processing

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -15,210 +15,212 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --agent-health-port int                                TCP port for agent health status API (default 9876)
-      --agent-labels strings                                 Additional labels to identify this agent
-      --allow-icmp-frag-needed                               Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
-      --allow-localhost string                               Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
-      --annotate-k8s-node                                    Annotate Kubernetes node (default true)
-      --api-rate-limit map                                   API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default map[])
-      --arping-refresh-period duration                       Period for remote node ARP entry refresh (set 0 to disable) (default 5m0s)
-      --auto-create-cilium-node-resource                     Automatically create CiliumNode resource for own node on startup (default true)
-      --auto-direct-node-routes                              Enable automatic L2 routing between nodes
-      --bpf-compile-debug                                    Enable debugging of the BPF compilation process
-      --bpf-ct-global-any-max int                            Maximum number of entries in non-TCP CT table (default 262144)
-      --bpf-ct-global-tcp-max int                            Maximum number of entries in TCP CT table (default 524288)
-      --bpf-ct-timeout-regular-any duration                  Timeout for entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-regular-tcp duration                  Timeout for established entries in TCP CT table (default 6h0m0s)
-      --bpf-ct-timeout-regular-tcp-fin duration              Teardown timeout for entries in TCP CT table (default 10s)
-      --bpf-ct-timeout-regular-tcp-syn duration              Establishment timeout for entries in TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-any duration                  Timeout for service entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-tcp duration                  Timeout for established service entries in TCP CT table (default 6h0m0s)
-      --bpf-fragments-map-max int                            Maximum number of entries in fragments tracking map (default 8192)
-      --bpf-lb-acceleration string                           BPF load balancing acceleration via XDP ("native", "disabled") (default "disabled")
-      --bpf-lb-algorithm string                              BPF load balancing algorithm ("random", "maglev") (default "random")
-      --bpf-lb-maglev-hash-seed string                       Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
-      --bpf-lb-maglev-table-size uint                        Maglev per service backend table size (parameter M) (default 16381)
-      --bpf-lb-map-max int                                   Maximum number of entries in Cilium BPF lbmap (default 65536)
-      --bpf-lb-mode string                                   BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
-      --bpf-map-dynamic-size-ratio float                     Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
-      --bpf-nat-global-max int                               Maximum number of entries for the global BPF NAT table (default 524288)
-      --bpf-neigh-global-max int                             Maximum number of entries for the global BPF neighbor table (default 524288)
-      --bpf-policy-map-max int                               Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
-      --bpf-root string                                      Path to BPF filesystem
-      --bpf-sock-rev-map-max int                             Maximum number of entries for the SockRevNAT BPF map (default 262144)
-      --certificates-directory string                        Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cgroup-root string                                   Path to Cgroup2 filesystem
-      --cluster-id int                                       Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --conntrack-gc-interval duration                       Overwrite the connection-tracking garbage collection interval
-      --crd-wait-timeout duration                            Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
-      --datapath-mode string                                 Datapath mode name (default "veth")
-  -D, --debug                                                Enable debugging mode
-      --debug-verbose strings                                List of enabled verbose debug groups
-      --devices strings                                      List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall)
-      --direct-routing-device string                         Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
-      --disable-cnp-status-updates                           Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)
-      --disable-conntrack                                    Disable connection tracking
-      --disable-endpoint-crd                                 Disable use of CiliumEndpoint CRD
-      --disable-iptables-feeder-rules strings                Chains to ignore when installing feeder rules.
-      --dns-max-ips-per-restored-rule int                    Maximum number of IPs to maintain for each restored DNS rule (default 1000)
-      --egress-masquerade-interfaces string                  Limit egress masquerading to interface selector
-      --egress-multi-home-ip-rule-compat                     Use a new scheme to store rules and routes under ENI and Azure IPAM modes, if false. Otherwise, it will use the old scheme.
-      --enable-auto-protect-node-port-range                  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
-      --enable-bandwidth-manager                             Enable BPF bandwidth manager
-      --enable-bpf-clock-probe                               Enable BPF clock source probing for more efficient tick retrieval
-      --enable-bpf-masquerade                                Masquerade packets from endpoints leaving the host with BPF instead of iptables
-      --enable-bpf-tproxy                                    Enable BPF-based proxy redirection, if support available
-      --enable-endpoint-health-checking                      Enable connectivity health checking between virtual endpoints (default true)
-      --enable-endpoint-routes                               Use per endpoint routes instead of routing via cilium_host
-      --enable-external-ips                                  Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
-      --enable-health-check-nodeport                         Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
-      --enable-health-checking                               Enable connectivity health checking (default true)
-      --enable-host-firewall                                 Enable host network policies (beta)
-      --enable-host-legacy-routing                           Enable the legacy host forwarding model which does not bypass upper stack in host namespace
-      --enable-host-port                                     Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
-      --enable-host-reachable-services                       Enable reachability of services for host applications
-      --enable-hubble                                        Enable hubble server
-      --enable-identity-mark                                 Enable setting identity mark for local traffic (default true)
-      --enable-ip-masq-agent                                 Enable BPF ip-masq-agent
-      --enable-ipsec                                         Enable IPSec support
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv4-fragment-tracking                        Enable IPv4 fragments tracking for L4-based lookups (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-ipv6-ndp                                      Enable IPv6 NDP support
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-k8s-event-handover                            Enable k8s event handover to kvstore for improved scalability
-      --enable-l7-proxy                                      Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-local-node-route                              Enable installation of the route which points the allocation prefix of the local node (default true)
-      --enable-local-redirect-policy                         Enable Local Redirect Policy
-      --enable-monitor                                       Enable the monitor unix domain socket server (default true)
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enable-policy string                                 Enable policy enforcement (default "default")
-      --enable-remote-node-identity                          Enable use of remote node identity
-      --enable-session-affinity                              Enable support for service session affinity
-      --enable-svc-source-range-check                        Enable check of service source ranges (currently, only for LoadBalancer) (default true)
-      --enable-tracing                                       Enable tracing while determining policy (debugging)
-      --enable-well-known-identities                         Enable well-known identities for known Kubernetes components (default true)
-      --enable-xt-socket-fallback                            Enable fallback for missing xt_socket module (default true)
-      --encrypt-interface string                             Transparent encryption interface
-      --encrypt-node                                         Enables encrypting traffic from non-Cilium pods and host networking
-      --endpoint-interface-name-prefix string                Prefix of interface name shared by all endpoints (default "lxc+")
-      --endpoint-queue-size int                              size of EventQueue per-endpoint (default 25)
-      --endpoint-status strings                              Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
-      --envoy-log string                                     Path to a separate Envoy log file, if any
-      --exclude-local-address strings                        Exclude CIDR from being recognized as local address
-      --fixed-identity-mapping map                           Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
-      --flannel-master-device string                         Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
-      --flannel-uninstall-on-exit                            When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
-      --force-local-policy-eval-at-source                    Force policy evaluation of all local communication at the source endpoint (default true)
-      --gops-port int                                        Port for gops server to listen on (default 9890)
-  -h, --help                                                 help for cilium-agent
-      --host-reachable-services-protos strings               Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
-      --http-idle-timeout uint                               Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
-      --http-max-grpc-timeout uint                           Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
-      --http-normalize-path                                  Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution. (default true)
-      --http-request-timeout uint                            Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
-      --http-retry-count uint                                Number of retries performed after a forwarded request attempt fails (default 3)
-      --http-retry-timeout uint                              Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
-      --hubble-disable-tls                                   Allow Hubble server to run on the given listen address without TLS.
-      --hubble-event-queue-size int                          Buffer size of the channel to receive monitor events.
-      --hubble-flow-buffer-size int                          Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096 (default 4095)
-      --hubble-listen-address string                         An additional address for Hubble server to listen to, e.g. ":4244"
-      --hubble-metrics strings                               List of Hubble metrics to enable.
-      --hubble-metrics-server string                         Address to serve Hubble metrics on.
-      --hubble-socket-path string                            Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
-      --hubble-tls-cert-file string                          Path to the public key file for the Hubble server. The file must contain PEM encoded data.
-      --hubble-tls-client-ca-files strings                   Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --hubble-tls-key-file string                           Path to the private key file for the Hubble server. The file must contain PEM encoded data.
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-change-grace-period duration                Time to wait before using new identity on endpoint identity change (default 5s)
-      --install-iptables-rules                               Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
-      --ip-allocation-timeout duration                       Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
-      --ip-masq-agent-config-path string                     ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
-      --ipam string                                          Backend to use for IPAM (default "cluster-pool")
-      --ipsec-key-file string                                Path to IPSec key file
-      --iptables-lock-timeout duration                       Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
-      --iptables-random-fully                                Set iptables flag random-fully on masquerading rules
-      --ipv4-node string                                     IPv4 address of node (default "auto")
-      --ipv4-pod-subnets strings                             List of IPv4 pod subnets to preconfigure for encryption
-      --ipv4-range string                                    Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
-      --ipv4-service-loopback-address string                 IPv4 address for service loopback SNAT (default "169.254.42.1")
-      --ipv4-service-range string                            Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
-      --ipv6-cluster-alloc-cidr string                       IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
-      --ipv6-mcast-device string                             Device that joins a Solicited-Node multicast group for IPv6
-      --ipv6-node string                                     IPv6 address of node (default "auto")
-      --ipv6-pod-subnets strings                             List of IPv6 pod subnets to preconfigure for encryption
-      --ipv6-range string                                    Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
-      --ipv6-service-range string                            Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
-      --ipvlan-master-device string                          Device facing external network acting as ipvlan master (default "undefined")
-      --join-cluster                                         Join a Cilium cluster via kvstore registration
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium is deployed in
-      --k8s-require-ipv4-pod-cidr                            Require IPv4 PodCIDR to be specified in node resource
-      --k8s-require-ipv6-pod-cidr                            Require IPv6 PodCIDR to be specified in node resource
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --k8s-watcher-endpoint-selector string                 K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
-      --keep-config                                          When restoring state, keeps containers' configuration in place
-      --kube-proxy-replacement string                        auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
-      --kube-proxy-replacement-healthz-bind-address string   The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
-      --kvstore string                                       Key-value store type
-      --kvstore-connectivity-timeout duration                Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
-      --kvstore-opt map                                      Key-value store options (default map[])
-      --kvstore-periodic-sync duration                       Periodic KVstore synchronization interval (default 5m0s)
-      --label-prefix-file string                             Valid label prefixes file path
-      --labels strings                                       List of label prefixes used to determine identity of an endpoint
-      --lib-dir string                                       Directory path to store runtime build environment (default "/var/lib/cilium")
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium (default map[])
-      --log-system-load                                      Enable periodic logging of system load
-      --masquerade                                           Masquerade packets from endpoints leaving the host (default true)
-      --metrics strings                                      Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
-      --monitor-aggregation string                           Level of monitor aggregation for traces from the datapath (default "None")
-      --monitor-aggregation-flags strings                    TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
-      --monitor-aggregation-interval duration                Monitor report interval when monitor aggregation is enabled (default 5s)
-      --monitor-queue-size int                               Size of the event queue when reading monitor events
-      --mtu int                                              Overwrite auto-detected MTU of underlying network
-      --nat46-range string                                   IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
-      --native-routing-cidr string                           Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.
-      --node-port-bind-protection                            Reject application bind(2) requests to service ports in the NodePort range (default true)
-      --node-port-range strings                              Set the min/max NodePort port range (default [30000,32767])
-      --policy-audit-mode                                    Enable policy audit (non-drop) mode
-      --policy-queue-size int                                size of queues for policy-related events (default 100)
-      --pprof                                                Enable serving the pprof debugging API
-      --preallocate-bpf-maps                                 Enable BPF map pre-allocation (default true)
-      --prefilter-device string                              Device facing external network for XDP prefiltering (default "undefined")
-      --prefilter-mode string                                Prefilter mode via XDP ("native", "generic") (default "native")
-      --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
-      --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
-      --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
-      --proxy-gid uint                                       Group ID for proxy control plane sockets. (default 1337)
-      --proxy-prometheus-port int                            Port to serve Envoy metrics on. Default 0 (disabled).
-      --read-cni-conf string                                 Read to the CNI configuration at specified path to extract per node configuration
-      --restore                                              Restores state, if possible, from previous daemon (default true)
-      --sidecar-istio-proxy-image string                     Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
-      --single-cluster-route                                 Use a single cluster route instead of per node routes
-      --skip-crd-creation                                    Skip Kubernetes Custom Resource Definitions creations
-      --socket-path string                                   Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
-      --sockops-enable                                       Enable sockops when kernel supported
-      --state-dir string                                     Directory path to store runtime state (default "/var/run/cilium")
-      --tofqdns-dns-reject-response-code string              DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
-      --tofqdns-enable-dns-compression                       Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
-      --tofqdns-endpoint-max-ip-per-hostname int             Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
-      --tofqdns-idle-connection-grace-period duration        Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)
-      --tofqdns-max-deferred-connection-deletes int          Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
-      --tofqdns-min-ttl int                                  The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
-      --tofqdns-pre-cache string                             DNS cache data at this path is preloaded on agent startup
-      --tofqdns-proxy-port int                               Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
-      --tofqdns-proxy-response-max-delay duration            The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
-      --trace-payloadlen int                                 Length of payload to capture when tracing (default 128)
-  -t, --tunnel string                                        Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
-      --version                                              Print version information
-      --write-cni-conf-when-ready string                     Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
+      --agent-health-port int                                   TCP port for agent health status API (default 9876)
+      --agent-labels strings                                    Additional labels to identify this agent
+      --allow-icmp-frag-needed                                  Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
+      --allow-localhost string                                  Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
+      --annotate-k8s-node                                       Annotate Kubernetes node (default true)
+      --api-rate-limit map                                      API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default map[])
+      --arping-refresh-period duration                          Period for remote node ARP entry refresh (set 0 to disable) (default 5m0s)
+      --auto-create-cilium-node-resource                        Automatically create CiliumNode resource for own node on startup (default true)
+      --auto-direct-node-routes                                 Enable automatic L2 routing between nodes
+      --bpf-compile-debug                                       Enable debugging of the BPF compilation process
+      --bpf-ct-global-any-max int                               Maximum number of entries in non-TCP CT table (default 262144)
+      --bpf-ct-global-tcp-max int                               Maximum number of entries in TCP CT table (default 524288)
+      --bpf-ct-timeout-regular-any duration                     Timeout for entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-regular-tcp duration                     Timeout for established entries in TCP CT table (default 6h0m0s)
+      --bpf-ct-timeout-regular-tcp-fin duration                 Teardown timeout for entries in TCP CT table (default 10s)
+      --bpf-ct-timeout-regular-tcp-syn duration                 Establishment timeout for entries in TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-any duration                     Timeout for service entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-tcp duration                     Timeout for established service entries in TCP CT table (default 6h0m0s)
+      --bpf-fragments-map-max int                               Maximum number of entries in fragments tracking map (default 8192)
+      --bpf-lb-acceleration string                              BPF load balancing acceleration via XDP ("native", "disabled") (default "disabled")
+      --bpf-lb-algorithm string                                 BPF load balancing algorithm ("random", "maglev") (default "random")
+      --bpf-lb-maglev-hash-seed string                          Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
+      --bpf-lb-maglev-table-size uint                           Maglev per service backend table size (parameter M) (default 16381)
+      --bpf-lb-map-max int                                      Maximum number of entries in Cilium BPF lbmap (default 65536)
+      --bpf-lb-mode string                                      BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
+      --bpf-map-dynamic-size-ratio float                        Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
+      --bpf-nat-global-max int                                  Maximum number of entries for the global BPF NAT table (default 524288)
+      --bpf-neigh-global-max int                                Maximum number of entries for the global BPF neighbor table (default 524288)
+      --bpf-policy-map-max int                                  Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
+      --bpf-root string                                         Path to BPF filesystem
+      --bpf-sock-rev-map-max int                                Maximum number of entries for the SockRevNAT BPF map (default 262144)
+      --certificates-directory string                           Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cgroup-root string                                      Path to Cgroup2 filesystem
+      --cluster-id int                                          Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --clustermesh-config string                               Path to the ClusterMesh configuration directory
+      --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                       Configuration directory that contains a file for each option
+      --conntrack-gc-interval duration                          Overwrite the connection-tracking garbage collection interval
+      --crd-wait-timeout duration                               Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
+      --datapath-mode string                                    Datapath mode name (default "veth")
+  -D, --debug                                                   Enable debugging mode
+      --debug-verbose strings                                   List of enabled verbose debug groups
+      --devices strings                                         List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall)
+      --direct-routing-device string                            Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
+      --disable-cnp-status-updates                              Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)
+      --disable-conntrack                                       Disable connection tracking
+      --disable-endpoint-crd                                    Disable use of CiliumEndpoint CRD
+      --disable-iptables-feeder-rules strings                   Chains to ignore when installing feeder rules.
+      --dns-max-ips-per-restored-rule int                       Maximum number of IPs to maintain for each restored DNS rule (default 1000)
+      --dnsproxy-concurrency-limit int                          Limit concurrency of DNS message processing
+      --dnsproxy-concurrency-processing-grace-period duration   Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing
+      --egress-masquerade-interfaces string                     Limit egress masquerading to interface selector
+      --egress-multi-home-ip-rule-compat                        Use a new scheme to store rules and routes under ENI and Azure IPAM modes, if false. Otherwise, it will use the old scheme.
+      --enable-auto-protect-node-port-range                     Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
+      --enable-bandwidth-manager                                Enable BPF bandwidth manager
+      --enable-bpf-clock-probe                                  Enable BPF clock source probing for more efficient tick retrieval
+      --enable-bpf-masquerade                                   Masquerade packets from endpoints leaving the host with BPF instead of iptables
+      --enable-bpf-tproxy                                       Enable BPF-based proxy redirection, if support available
+      --enable-endpoint-health-checking                         Enable connectivity health checking between virtual endpoints (default true)
+      --enable-endpoint-routes                                  Use per endpoint routes instead of routing via cilium_host
+      --enable-external-ips                                     Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
+      --enable-health-check-nodeport                            Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
+      --enable-health-checking                                  Enable connectivity health checking (default true)
+      --enable-host-firewall                                    Enable host network policies (beta)
+      --enable-host-legacy-routing                              Enable the legacy host forwarding model which does not bypass upper stack in host namespace
+      --enable-host-port                                        Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
+      --enable-host-reachable-services                          Enable reachability of services for host applications
+      --enable-hubble                                           Enable hubble server
+      --enable-identity-mark                                    Enable setting identity mark for local traffic (default true)
+      --enable-ip-masq-agent                                    Enable BPF ip-masq-agent
+      --enable-ipsec                                            Enable IPSec support
+      --enable-ipv4                                             Enable IPv4 support (default true)
+      --enable-ipv4-fragment-tracking                           Enable IPv4 fragments tracking for L4-based lookups (default true)
+      --enable-ipv6                                             Enable IPv6 support (default true)
+      --enable-ipv6-ndp                                         Enable IPv6 NDP support
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                               Enable k8s event handover to kvstore for improved scalability
+      --enable-l7-proxy                                         Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-local-node-route                                 Enable installation of the route which points the allocation prefix of the local node (default true)
+      --enable-local-redirect-policy                            Enable Local Redirect Policy
+      --enable-monitor                                          Enable the monitor unix domain socket server (default true)
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enable-policy string                                    Enable policy enforcement (default "default")
+      --enable-remote-node-identity                             Enable use of remote node identity
+      --enable-session-affinity                                 Enable support for service session affinity
+      --enable-svc-source-range-check                           Enable check of service source ranges (currently, only for LoadBalancer) (default true)
+      --enable-tracing                                          Enable tracing while determining policy (debugging)
+      --enable-well-known-identities                            Enable well-known identities for known Kubernetes components (default true)
+      --enable-xt-socket-fallback                               Enable fallback for missing xt_socket module (default true)
+      --encrypt-interface string                                Transparent encryption interface
+      --encrypt-node                                            Enables encrypting traffic from non-Cilium pods and host networking
+      --endpoint-interface-name-prefix string                   Prefix of interface name shared by all endpoints (default "lxc+")
+      --endpoint-queue-size int                                 size of EventQueue per-endpoint (default 25)
+      --endpoint-status strings                                 Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
+      --envoy-log string                                        Path to a separate Envoy log file, if any
+      --exclude-local-address strings                           Exclude CIDR from being recognized as local address
+      --fixed-identity-mapping map                              Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
+      --flannel-master-device string                            Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
+      --flannel-uninstall-on-exit                               When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
+      --force-local-policy-eval-at-source                       Force policy evaluation of all local communication at the source endpoint (default true)
+      --gops-port int                                           Port for gops server to listen on (default 9890)
+  -h, --help                                                    help for cilium-agent
+      --host-reachable-services-protos strings                  Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
+      --http-idle-timeout uint                                  Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
+      --http-max-grpc-timeout uint                              Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
+      --http-normalize-path                                     Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution. (default true)
+      --http-request-timeout uint                               Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
+      --http-retry-count uint                                   Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                 Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
+      --hubble-disable-tls                                      Allow Hubble server to run on the given listen address without TLS.
+      --hubble-event-queue-size int                             Buffer size of the channel to receive monitor events.
+      --hubble-flow-buffer-size int                             Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096 (default 4095)
+      --hubble-listen-address string                            An additional address for Hubble server to listen to, e.g. ":4244"
+      --hubble-metrics strings                                  List of Hubble metrics to enable.
+      --hubble-metrics-server string                            Address to serve Hubble metrics on.
+      --hubble-socket-path string                               Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
+      --hubble-tls-cert-file string                             Path to the public key file for the Hubble server. The file must contain PEM encoded data.
+      --hubble-tls-client-ca-files strings                      Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --hubble-tls-key-file string                              Path to the private key file for the Hubble server. The file must contain PEM encoded data.
+      --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")
+      --identity-change-grace-period duration                   Time to wait before using new identity on endpoint identity change (default 5s)
+      --install-iptables-rules                                  Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
+      --ip-allocation-timeout duration                          Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
+      --ip-masq-agent-config-path string                        ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
+      --ipam string                                             Backend to use for IPAM (default "cluster-pool")
+      --ipsec-key-file string                                   Path to IPSec key file
+      --iptables-lock-timeout duration                          Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
+      --iptables-random-fully                                   Set iptables flag random-fully on masquerading rules
+      --ipv4-node string                                        IPv4 address of node (default "auto")
+      --ipv4-pod-subnets strings                                List of IPv4 pod subnets to preconfigure for encryption
+      --ipv4-range string                                       Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
+      --ipv4-service-loopback-address string                    IPv4 address for service loopback SNAT (default "169.254.42.1")
+      --ipv4-service-range string                               Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
+      --ipv6-cluster-alloc-cidr string                          IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
+      --ipv6-mcast-device string                                Device that joins a Solicited-Node multicast group for IPv6
+      --ipv6-node string                                        IPv6 address of node (default "auto")
+      --ipv6-pod-subnets strings                                List of IPv6 pod subnets to preconfigure for encryption
+      --ipv6-range string                                       Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
+      --ipv6-service-range string                               Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
+      --ipvlan-master-device string                             Device facing external network acting as ipvlan master (default "undefined")
+      --join-cluster                                            Join a Cilium cluster via kvstore registration
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                    Name of the Kubernetes namespace in which Cilium is deployed in
+      --k8s-require-ipv4-pod-cidr                               Require IPv4 PodCIDR to be specified in node resource
+      --k8s-require-ipv6-pod-cidr                               Require IPv6 PodCIDR to be specified in node resource
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --k8s-watcher-endpoint-selector string                    K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
+      --keep-config                                             When restoring state, keeps containers' configuration in place
+      --kube-proxy-replacement string                           auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
+      --kube-proxy-replacement-healthz-bind-address string      The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
+      --kvstore string                                          Key-value store type
+      --kvstore-connectivity-timeout duration                   Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
+      --kvstore-opt map                                         Key-value store options (default map[])
+      --kvstore-periodic-sync duration                          Periodic KVstore synchronization interval (default 5m0s)
+      --label-prefix-file string                                Valid label prefixes file path
+      --labels strings                                          List of label prefixes used to determine identity of an endpoint
+      --lib-dir string                                          Directory path to store runtime build environment (default "/var/lib/cilium")
+      --log-driver strings                                      Logging endpoints to use for example syslog
+      --log-opt map                                             Log driver options for cilium (default map[])
+      --log-system-load                                         Enable periodic logging of system load
+      --masquerade                                              Masquerade packets from endpoints leaving the host (default true)
+      --metrics strings                                         Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
+      --monitor-aggregation string                              Level of monitor aggregation for traces from the datapath (default "None")
+      --monitor-aggregation-flags strings                       TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
+      --monitor-aggregation-interval duration                   Monitor report interval when monitor aggregation is enabled (default 5s)
+      --monitor-queue-size int                                  Size of the event queue when reading monitor events
+      --mtu int                                                 Overwrite auto-detected MTU of underlying network
+      --nat46-range string                                      IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
+      --native-routing-cidr string                              Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.
+      --node-port-bind-protection                               Reject application bind(2) requests to service ports in the NodePort range (default true)
+      --node-port-range strings                                 Set the min/max NodePort port range (default [30000,32767])
+      --policy-audit-mode                                       Enable policy audit (non-drop) mode
+      --policy-queue-size int                                   size of queues for policy-related events (default 100)
+      --pprof                                                   Enable serving the pprof debugging API
+      --preallocate-bpf-maps                                    Enable BPF map pre-allocation (default true)
+      --prefilter-device string                                 Device facing external network for XDP prefiltering (default "undefined")
+      --prefilter-mode string                                   Prefilter mode via XDP ("native", "generic") (default "native")
+      --prepend-iptables-chains                                 Prepend custom iptables chains instead of appending (default true)
+      --prometheus-serve-addr string                            IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-connect-timeout uint                              Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-gid uint                                          Group ID for proxy control plane sockets. (default 1337)
+      --proxy-prometheus-port int                               Port to serve Envoy metrics on. Default 0 (disabled).
+      --read-cni-conf string                                    Read to the CNI configuration at specified path to extract per node configuration
+      --restore                                                 Restores state, if possible, from previous daemon (default true)
+      --sidecar-istio-proxy-image string                        Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
+      --single-cluster-route                                    Use a single cluster route instead of per node routes
+      --skip-crd-creation                                       Skip Kubernetes Custom Resource Definitions creations
+      --socket-path string                                      Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
+      --sockops-enable                                          Enable sockops when kernel supported
+      --state-dir string                                        Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdns-dns-reject-response-code string                 DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
+      --tofqdns-enable-dns-compression                          Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
+      --tofqdns-endpoint-max-ip-per-hostname int                Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
+      --tofqdns-idle-connection-grace-period duration           Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)
+      --tofqdns-max-deferred-connection-deletes int             Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
+      --tofqdns-min-ttl int                                     The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
+      --tofqdns-pre-cache string                                DNS cache data at this path is preloaded on agent startup
+      --tofqdns-proxy-port int                                  Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+      --tofqdns-proxy-response-max-delay duration               The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
+      --trace-payloadlen int                                    Length of payload to capture when tracing (default 128)
+  -t, --tunnel string                                           Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
+      --version                                                 Print version information
+      --write-cni-conf-when-ready string                        Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
 ```
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -826,6 +826,12 @@ func init() {
 	flags.Bool(option.ToFQDNsEnableDNSCompression, defaults.ToFQDNsEnableDNSCompression, "Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present")
 	option.BindEnv(option.ToFQDNsEnableDNSCompression)
 
+	flags.Int(option.DNSProxyConcurrencyLimit, 0, "Limit concurrency of DNS message processing")
+	option.BindEnv(option.DNSProxyConcurrencyLimit)
+
+	flags.Duration(option.DNSProxyConcurrencyProcessingGracePeriod, 0, "Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing")
+	option.BindEnv(option.DNSProxyConcurrencyProcessingGracePeriod)
+
 	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "size of queues for policy-related events")
 	option.BindEnv(option.PolicyQueueSize)
 

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -54,8 +54,10 @@ import (
 )
 
 const (
-	upstream       = "upstreamTime"
-	processingTime = "processingTime"
+	upstream        = "upstreamTime"
+	processingTime  = "processingTime"
+	semaphoreTime   = "semaphoreTime"
+	policyCheckTime = "policyCheckTime"
 
 	metricErrorTimeout = "timeout"
 	metricErrorProxy   = "proxyErr"
@@ -309,7 +311,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	}
 	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
 		option.Config.DNSMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
-		d.notifyOnDNSMsg)
+		d.notifyOnDNSMsg, option.Config.DNSProxyConcurrencyLimit)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
 		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.BindPort)
@@ -388,6 +390,10 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 			stat.UpstreamTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(
 			stat.ProcessingTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, semaphoreTime).Observe(
+			stat.SemaphoreAcquireTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyCheckTime).Observe(
+			stat.PolicyCheckTime.Total().Seconds())
 	}
 
 	switch {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -351,10 +351,9 @@ type ProxyRequestContext struct {
 
 // IsTimeout return true if the ProxyRequest timeout
 func (proxyStat *ProxyRequestContext) IsTimeout() bool {
-	netErr, isNetErr := proxyStat.Err.(net.Error)
-	if isNetErr && netErr.Timeout() {
-		return true
-
+	var neterr net.Error
+	if errors.As(proxyStat.Err, &neterr) {
+		return neterr.Timeout()
 	}
 	return false
 }
@@ -524,7 +523,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	addr, _, err := net.SplitHostPort(epIPPort)
 	if err != nil {
 		scopedLog.WithError(err).Error("cannot extract endpoint IP from DNS request")
-		stat.Err = fmt.Errorf("Cannot extract endpoint IP from DNS request: %s", err)
+		stat.Err = fmt.Errorf("Cannot extract endpoint IP from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, "", request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
@@ -533,7 +532,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	ep, err := p.LookupEndpointByIP(net.ParseIP(addr))
 	if err != nil {
 		scopedLog.WithError(err).Error("cannot extract endpoint ID from DNS request")
-		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %s", err)
+		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, "", request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
@@ -545,7 +544,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	targetServerIP, targetServerPort, targetServerAddr, err := p.lookupTargetDNSServer(w)
 	if err != nil {
 		log.WithError(err).Error("cannot extract destination IP:port from DNS request")
-		stat.Err = fmt.Errorf("Cannot extract destination IP:port from DNS request: %s", err)
+		stat.Err = fmt.Errorf("Cannot extract destination IP:port from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
@@ -569,7 +568,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	switch {
 	case err != nil:
 		scopedLog.WithError(err).Error("Rejecting DNS query from endpoint due to error")
-		stat.Err = fmt.Errorf("Rejecting DNS query from endpoint due to error: %s", err)
+		stat.Err = fmt.Errorf("Rejecting DNS query from endpoint due to error: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
@@ -596,7 +595,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		client = p.TCPClient
 	default:
 		scopedLog.Error("Cannot parse DNS proxy client network to select forward client")
-		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %s", err)
+		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
@@ -615,7 +614,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		} else {
 			scopedLog.WithError(err).Error("Cannot forward proxied DNS lookup")
 			p.sendRefused(scopedLog, w, request)
-			stat.Err = fmt.Errorf("Cannot forward proxied DNS lookup: %s", err)
+			stat.Err = fmt.Errorf("Cannot forward proxied DNS lookup: %w", err)
 		}
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
 		return
@@ -634,7 +633,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	err = w.WriteMsg(response)
 	if err != nil {
 		scopedLog.WithError(err).Error("Cannot forward proxied DNS response")
-		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %s", err)
+		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %w", err)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, response, protocol, true, &stat)
 	} else {
 		p.Lock()
@@ -653,7 +652,7 @@ func (p *DNSProxy) sendRefused(scopedLog *logrus.Entry, w dns.ResponseWriter, re
 
 	if err = w.WriteMsg(refused); err != nil {
 		scopedLog.WithError(err).Error("Cannot send REFUSED response")
-		err = fmt.Errorf("cannot send REFUSED response: %s", err)
+		err = fmt.Errorf("cannot send REFUSED response: %w", err)
 	}
 	return err
 }

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -41,6 +42,7 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -113,6 +115,15 @@ type DNSProxy struct {
 	// EnableDNSCompression allows the DNS proxy to compress responses to
 	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
 	EnableDNSCompression bool
+
+	// ConcurrencyLimit limits parallel goroutines number that serve DNS
+	ConcurrencyLimit *semaphore.Weighted
+	// ConcurrencyGracePeriod is the grace period for waiting on
+	// ConcurrencyLimit before timing out
+	ConcurrencyGracePeriod time.Duration
+	// logLimiter limits log msgs that could be bursty and too verbose.
+	// Currently used when ConcurrencyLimit is set.
+	logLimiter logging.Limiter
 
 	// lookupTargetDNSServer extracts the originally intended target of a DNS
 	// query. It is always set to lookupTargetDNSServer in
@@ -340,13 +351,49 @@ type LookupIPsBySecIDFunc func(nid identity.NumericIdentity) []string
 // See DNSProxy.LookupEndpointIDByIP for usage.
 type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error
 
+// errFailedAcquireSemaphore is an an error representing the DNS proxy's
+// failure to acquire the semaphore. This is error is treated like a timeout.
+type errFailedAcquireSemaphore struct {
+	parallel int
+}
+
+func (e errFailedAcquireSemaphore) Timeout() bool { return true }
+
+// Temporary is deprecated. Return false.
+func (e errFailedAcquireSemaphore) Temporary() bool { return false }
+func (e errFailedAcquireSemaphore) Error() string {
+	return fmt.Sprintf(
+		"failed to acquire DNS proxy semaphore, %d parallel requests already in-flight",
+		e.parallel,
+	)
+}
+
+// errTimedOutAcquireSemaphore is an an error representing the DNS proxy timing
+// out when acquiring the semaphore. It is treated the same as
+// errTimedOutAcquireSemaphore.
+type errTimedOutAcquireSemaphore struct {
+	errFailedAcquireSemaphore
+
+	gracePeriod time.Duration
+}
+
+func (e errTimedOutAcquireSemaphore) Error() string {
+	return fmt.Sprintf(
+		"timed out after %v acquiring DNS proxy semaphore, %d parallel requests already in-flight",
+		e.gracePeriod,
+		e.parallel,
+	)
+}
+
 // ProxyRequestContext proxy dns request context struct to send in the callback
 type ProxyRequestContext struct {
 	ProcessingTime spanstat.SpanStat // This is going to happen at the end of the second callback.
 	// Error is a enum of [timeout, allow, denied, proxyerr].
-	UpstreamTime spanstat.SpanStat
-	Success      bool
-	Err          error
+	UpstreamTime         spanstat.SpanStat
+	SemaphoreAcquireTime spanstat.SpanStat
+	PolicyCheckTime      spanstat.SpanStat
+	Success              bool
+	Err                  error
 }
 
 // IsTimeout return true if the ProxyRequest timeout
@@ -369,7 +416,7 @@ func (proxyStat *ProxyRequestContext) IsTimeout() bool {
 // notifyFunc will be called with DNS response data that is returned to a
 // requesting endpoint. Note that denied requests will not trigger this
 // callback.
-func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRestoreDNSIPs int, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc) (*DNSProxy, error) {
+func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRestoreDNSIPs int, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc, concurrencyLimit int) (*DNSProxy, error) {
 	if port == 0 {
 		log.Debug("DNS Proxy port is configured to 0. A random port will be assigned by the OS.")
 	}
@@ -383,6 +430,7 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		LookupSecIDByIP:          lookupSecIDFunc,
 		LookupIPsBySecID:         lookupIPsFunc,
 		NotifyOnDNSMsg:           notifyFunc,
+		logLimiter:               logging.NewLimiter(10*time.Second, 1),
 		lookupTargetDNSServer:    lookupTargetDNSServer,
 		usedServers:              make(map[string]struct{}),
 		allowed:                  make(perEPAllow),
@@ -390,6 +438,10 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		restoredEPs:              make(restoredEPs),
 		EnableDNSCompression:     enableDNSCompression,
 		maxIPsPerRestoredDNSRule: maxRestoreDNSIPs,
+	}
+	if concurrencyLimit > 0 {
+		p.ConcurrencyLimit = semaphore.NewWeighted(int64(concurrencyLimit))
+		p.ConcurrencyGracePeriod = option.Config.DNSProxyConcurrencyProcessingGracePeriod
 	}
 	atomic.StoreInt32(&p.rejectReply, dns.RcodeRefused)
 
@@ -508,18 +560,42 @@ func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID ident
 //  fqdn/NameManager instance).
 //  - Write the response to the endpoint.
 func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
-	stat := ProxyRequestContext{}
-	stat.ProcessingTime.Start()
 	requestID := request.Id // keep the original request ID
 	qname := string(request.Question[0].Name)
 	protocol := w.LocalAddr().Network()
+	epIPPort := w.RemoteAddr().String()
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.DNSName:      qname,
-		logfields.IPAddr:       w.RemoteAddr(),
-		logfields.DNSRequestID: request.Id})
+		logfields.IPAddr:       epIPPort,
+		logfields.DNSRequestID: requestID,
+	})
+
+	var stat ProxyRequestContext
+	if p.ConcurrencyLimit != nil {
+		// TODO: Consider plumbing the daemon context here.
+		ctx, cancel := context.WithTimeout(context.TODO(), p.ConcurrencyGracePeriod)
+		defer cancel()
+
+		stat.SemaphoreAcquireTime.Start()
+		// Enforce the concurrency limit by attempting to acquire the
+		// semaphore.
+		if err := p.enforceConcurrencyLimit(ctx); err != nil {
+			stat.SemaphoreAcquireTime.End(false)
+			if p.logLimiter.Allow() {
+				scopedLog.WithError(err).Error("Dropping DNS request due to too many DNS requests already in-flight")
+			}
+			stat.Err = err
+			p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, "", request, protocol, false, &stat)
+			p.sendRefused(scopedLog, w, request)
+			return
+		}
+		stat.SemaphoreAcquireTime.End(true)
+		defer p.ConcurrencyLimit.Release(1)
+	}
+	stat.ProcessingTime.Start()
+
 	scopedLog.Debug("Handling DNS query from endpoint")
 
-	epIPPort := w.RemoteAddr().String()
 	addr, _, err := net.SplitHostPort(epIPPort)
 	if err != nil {
 		scopedLog.WithError(err).Error("cannot extract endpoint IP from DNS request")
@@ -564,7 +640,9 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	// Note: The cache doesn't know about the source of the DNS data (yet) and so
 	// it won't enforce any separation between results from different endpoints.
 	// This isn't ideal but we are trusting the DNS responses anyway.
+	stat.PolicyCheckTime.Start()
 	allowed, err := p.CheckAllowed(uint64(ep.ID), targetServerPort, targetServerID, targetServerIP, qname)
+	stat.PolicyCheckTime.End(err == nil)
 	switch {
 	case err != nil:
 		scopedLog.WithError(err).Error("Rejecting DNS query from endpoint due to error")
@@ -642,6 +720,29 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		p.usedServers[targetServerIP.String()] = struct{}{}
 		p.Unlock()
 	}
+}
+
+func (p *DNSProxy) enforceConcurrencyLimit(ctx context.Context) error {
+	if p.ConcurrencyGracePeriod == 0 {
+		// No grace time configured. Failing to acquire semaphore means
+		// immediately give up.
+		if !p.ConcurrencyLimit.TryAcquire(1) {
+			return errFailedAcquireSemaphore{
+				parallel: option.Config.DNSProxyConcurrencyLimit,
+			}
+		}
+	} else if err := p.ConcurrencyLimit.Acquire(ctx, 1); err != nil && errors.Is(err, context.DeadlineExceeded) {
+		// We ignore err because errTimedOutAcquireSemaphore implements the
+		// net.Error interface deeming it a timeout error which will be
+		// treated the same as context.DeadlineExceeded.
+		return errTimedOutAcquireSemaphore{
+			errFailedAcquireSemaphore: errFailedAcquireSemaphore{
+				parallel: option.Config.DNSProxyConcurrencyLimit,
+			},
+			gracePeriod: p.ConcurrencyGracePeriod,
+		}
+	}
+	return nil
 }
 
 // sendRefused creates and sends a REFUSED response for request to w

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build privileged_tests
 // +build privileged_tests
 
 package dnsproxy
@@ -981,4 +982,15 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	c.Assert(exists, Equals, false)
 
 	s.restoring = false
+}
+
+func (s *DNSProxyTestSuite) TestProxyRequestContext_IsTimeout(c *C) {
+	p := new(ProxyRequestContext)
+	p.Err = fmt.Errorf("sample err: %w", context.DeadlineExceeded)
+	c.Assert(p.IsTimeout(), Equals, true)
+
+	// Assert that failing to wrap the error properly (by using '%w') causes
+	// IsTimeout() to return the wrong value.
+	p.Err = fmt.Errorf("sample err: %s", context.DeadlineExceeded)
+	c.Assert(p.IsTimeout(), Equals, false)
 }

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -236,7 +236,9 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 		// NotifyOnDNSMsg
 		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error {
 			return nil
-		})
+		},
+		0,
+	)
 	c.Assert(err, IsNil, Commentf("error starting DNS Proxy"))
 	s.proxy = proxy
 
@@ -993,4 +995,11 @@ func (s *DNSProxyTestSuite) TestProxyRequestContext_IsTimeout(c *C) {
 	// IsTimeout() to return the wrong value.
 	p.Err = fmt.Errorf("sample err: %s", context.DeadlineExceeded)
 	c.Assert(p.IsTimeout(), Equals, false)
+
+	p.Err = errFailedAcquireSemaphore{}
+	c.Assert(p.IsTimeout(), Equals, true)
+	p.Err = errTimedOutAcquireSemaphore{
+		gracePeriod: 1 * time.Second,
+	}
+	c.Assert(p.IsTimeout(), Equals, true)
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -422,6 +422,15 @@ const (
 	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
 	ToFQDNsEnableDNSCompression = "tofqdns-enable-dns-compression"
 
+	// DNSProxyConcurrencyLimit limits parallel processing of DNS messages in
+	// DNS proxy at any given point in time.
+	DNSProxyConcurrencyLimit = "dnsproxy-concurrency-limit"
+
+	// DNSProxyConcurrencyProcessingGracePeriod is the amount of grace time to
+	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
+	// been reached.
+	DNSProxyConcurrencyProcessingGracePeriod = "dnsproxy-concurrency-processing-grace-period"
+
 	// MTUName is the name of the MTU option
 	MTUName = "mtu"
 
@@ -1724,6 +1733,15 @@ type DaemonConfig struct {
 	// Cilium on all interfaces created by the flannel.
 	FlannelUninstallOnExit bool
 
+	// DNSProxyConcurrencyLimit limits parallel processing of DNS messages in
+	// DNS proxy at any given point in time.
+	DNSProxyConcurrencyLimit int
+
+	// DNSProxyConcurrencyProcessingGracePeriod is the amount of grace time to
+	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
+	// been reached.
+	DNSProxyConcurrencyProcessingGracePeriod time.Duration
+
 	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
 	// sysctl option if `xt_socket` kernel module is not available.
 	EnableXTSocketFallback bool
@@ -2690,6 +2708,8 @@ func (c *DaemonConfig) Populate() {
 	c.ToFQDNsProxyPort = viper.GetInt(ToFQDNsProxyPort)
 	c.ToFQDNsPreCache = viper.GetString(ToFQDNsPreCache)
 	c.ToFQDNsEnableDNSCompression = viper.GetBool(ToFQDNsEnableDNSCompression)
+	c.DNSProxyConcurrencyLimit = viper.GetInt(DNSProxyConcurrencyLimit)
+	c.DNSProxyConcurrencyProcessingGracePeriod = viper.GetDuration(DNSProxyConcurrencyProcessingGracePeriod)
 
 	// Convert IP strings into net.IPNet types
 	subnets, invalid := ip.ParseCIDRs(viper.GetStringSlice(IPv4PodSubnets))


### PR DESCRIPTION
This change adds a configurable semaphore to DNS proxy which controls
the limit of concurrently processed DNS messages.

Signed-off-by: Maciej Kwiek <maciej@isovalent.com>

Backport of https://github.com/cilium/cilium/pull/19592