### PR TITLE
testutils/mockmaps: Bring duplicate backend calls check back

### DIFF
--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -95,10 +95,9 @@ func (m *LBMockMap) AddBackend(b lb.Backend, ipv6 bool) error {
 	ip := b.IP
 	port := b.Port
 
-	if be, found := m.BackendByID[id]; found {
-		if be.L3n4Addr.IP.Equal(ip) && be.L4Addr.Port == port {
-			return nil
-		}
+	// Backends can be added to both v4 and v6 lb maps (when nat64 policies
+	// are enabled).
+	if _, found := m.BackendByID[id]; found && !b.L3n4Addr.IsIPv6() && !ipv6 {
 		return fmt.Errorf("Backend %d already exists", id)
 	}
 


### PR DESCRIPTION
Commit d7bcc0aac9 rendered the duplicate calls to add a backend
check ineffective. Until we have a better mock code
to differentiate between v4 and v6 backend maps, let's
bring back the original check with some special checks
with respect to NAT46/64 policies.

Fixes: d7bcc0aac9 ("cilium, tests: Add NAT46 and NAT64 upsert test cases")
Signed-off-by: Aditi Ghag <aditi@cilium.io>
