### PR TITLE
ingress: Set max stream duration as 0

### DIFF
--- a/operator/pkg/ingress/envoy_config.go
+++ b/operator/pkg/ingress/envoy_config.go
@@ -477,6 +477,11 @@ func getVirtualHost(ingress *slim_networkingv1.Ingress, rule slim_networkingv1.I
 					ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
 						Cluster: fmt.Sprintf("%s/%s", ingress.Namespace, path.Backend.Service.Name),
 					},
+					MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+						MaxStreamDuration: &durationpb.Duration{
+							Seconds: 0,
+						},
+					},
 				},
 			},
 		}


### PR DESCRIPTION
### Description

This commit is to set maxStreamOption for both http and http2 in route
level, mainly for gRPC API.

Signed-off-by: Tam Mach <tam.mach@isovalent.com>

### Testing

Testing was done locally with hubble-ui ingress, connection drop was no longer
happening.

- [x] Conformance test was also done locally.
