### PR TITLE
fix bug:when using k8s L4 networkpolicy without filling in protocol p…

### DIFF
--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -186,6 +186,18 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 				return DROP_POLICY_DENY;
 			return policy->proxy_port;
 		}
+		
+		/* L4-only lookup, If not fill out port*/
+		key.dport = 0;
+		policy = map_lookup_elem(map, &key);
+		if (likely(policy)) {
+			account(ctx, policy);
+			*match_type = POLICY_MATCH_L4_ONLY;
+			if (unlikely(policy->deny))
+				return DROP_POLICY_DENY;
+			return policy->proxy_port;
+		}
+		
 		key.sec_label = remote_id;
 	}
 

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -187,7 +187,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 			return policy->proxy_port;
 		}
 		
-		/* L4-only lookup, If not fill out port*/
+		/* L4-only lookup, If not fill out port, podSelector and namespaceSelector */
 		key.dport = 0;
 		policy = map_lookup_elem(map, &key);
 		if (likely(policy)) {
@@ -198,7 +198,16 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 			return policy->proxy_port;
 		}
 		
+		/* L4-only lookup, If not fill out port ,but use podSelector and namespaceSelector */
 		key.sec_label = remote_id;
+		policy = map_lookup_elem(map, &key);
+		if (likely(policy)) {
+			account(ctx, policy);
+			*match_type = POLICY_MATCH_L4_ONLY;
+			if (unlikely(policy->deny))
+				return DROP_POLICY_DENY;
+			return policy->proxy_port;
+		}
 	}
 
 	/* If L4 policy check misses, fall back to L3. */

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -176,6 +176,17 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 			return policy->proxy_port;
 		}
 
+		/* L3/L4 lookup, If not fill out port, podSelector and namespaceSelector */
+		key.dport = 0;
+		policy = map_lookup_elem(map, &key);
+		if (likely(policy)) {
+			account(ctx, policy);
+			*match_type = POLICY_MATCH_L4_ONLY;
+			if (unlikely(policy->deny))
+				return DROP_POLICY_DENY;
+			return policy->proxy_port;
+		}
+
 		/* L4-only lookup. */
 		key.sec_label = 0;
 		policy = map_lookup_elem(map, &key);
@@ -187,27 +198,6 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 			return policy->proxy_port;
 		}
 		
-		/* L4-only lookup, If not fill out port, podSelector and namespaceSelector */
-		key.dport = 0;
-		policy = map_lookup_elem(map, &key);
-		if (likely(policy)) {
-			account(ctx, policy);
-			*match_type = POLICY_MATCH_L4_ONLY;
-			if (unlikely(policy->deny))
-				return DROP_POLICY_DENY;
-			return policy->proxy_port;
-		}
-		
-		/* L4-only lookup, If not fill out port ,but use podSelector and namespaceSelector */
-		key.sec_label = remote_id;
-		policy = map_lookup_elem(map, &key);
-		if (likely(policy)) {
-			account(ctx, policy);
-			*match_type = POLICY_MATCH_L4_ONLY;
-			if (unlikely(policy->deny))
-				return DROP_POLICY_DENY;
-			return policy->proxy_port;
-		}
 	}
 
 	/* If L4 policy check misses, fall back to L3. */

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -176,7 +176,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 			return policy->proxy_port;
 		}
 
-		/* L3/L4 lookup, If not fill out port, podSelector and namespaceSelector */
+		/* L3/L4 lookup, If not fill out port, but fill podSelector and namespaceSelector */
 		key.dport = 0;
 		policy = map_lookup_elem(map, &key);
 		if (likely(policy)) {
@@ -188,6 +188,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 		}
 
 		/* L4-only lookup. */
+		key.dport = dport;
 		key.sec_label = 0;
 		policy = map_lookup_elem(map, &key);
 		if (likely(policy)) {
@@ -197,7 +198,8 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 				return DROP_POLICY_DENY;
 			return policy->proxy_port;
 		}
-		
+
+		key.sec_label = remote_id;
 	}
 
 	/* If L4 policy check misses, fall back to L3. */

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -181,7 +181,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 		policy = map_lookup_elem(map, &key);
 		if (likely(policy)) {
 			account(ctx, policy);
-			*match_type = POLICY_MATCH_L4_ONLY;
+			*match_type = POLICY_MATCH_L3_L4;
 			if (unlikely(policy->deny))
 				return DROP_POLICY_DENY;
 			return policy->proxy_port;


### PR DESCRIPTION
…ort，the L4 protocol packet will be denied

### Description
This commit is to fix bug:when using k8s L4 networkpolicy without filling in protocol port，the L4 protocol packet will be denied

**according to kubernetes explanation，all packet that matched the protool no matter which port will be allow**
![image](https://user-images.githubusercontent.com/42599177/165009241-5ac3edc2-c535-424e-a04c-43fc67d5c205.png)

example networkpolicy spec:
```
spec:
  egress:
  - ports:
    - protocol: TCP
  ingress:
  - ports:
    - protocol: TCP
  podSelector: {}
  policyTypes:
  - Ingress
  - Egress
```


Signed-off-by: Liang Ma (ma77045728@gmail.com)

