### PR TITLE
Partially revert ".github: enable cilium-cli helm based installation"

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -63,7 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
-  cilium_cli_version: v0.11.1
+  cilium_cli_version: v0.10.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -146,12 +146,6 @@ jobs:
           description: Connectivity test in progress...
           state: pending
           target_url: ${{ env.check_url }}
-
-      - name: Checkout code
-        uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
-        with:
-          ref: ${{ steps.vars.outputs.sha }}
-          persist-credentials: false
 
       - name: Install Cilium CLI
         run: |

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -63,7 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
-  cilium_cli_version: v0.11.1
+  cilium_cli_version: v0.10.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -146,12 +146,6 @@ jobs:
           description: Connectivity test in progress...
           state: pending
           target_url: ${{ env.check_url }}
-
-      - name: Checkout code
-        uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
-        with:
-          ref: ${{ steps.vars.outputs.sha }}
-          persist-credentials: false
 
       - name: Install Cilium CLI
         run: |

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -66,7 +66,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
-  cilium_cli_version: v0.11.1
+  cilium_cli_version: v0.10.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -149,12 +149,6 @@ jobs:
           description: Connectivity test in progress...
           state: pending
           target_url: ${{ env.check_url }}
-
-      - name: Checkout code
-        uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
-        with:
-          ref: ${{ steps.vars.outputs.sha }}
-          persist-credentials: false
 
       - name: Install Cilium CLI
         run: |


### PR DESCRIPTION
This reverts commit 27590a95dc26685fe10c86eb478e6d52a72881b9.

Signed-off-by: André Martins <andre@cilium.io>
