### PR TITLE
identity: Initialize local identity allocator early

### DIFF
--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -174,12 +174,10 @@ func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 	owner := newDummyOwner()
 	events := make(allocator.AllocatorEventChan, 1024)
 	watcher := identityWatcher{
-		stopChan: make(chan struct{}),
-		owner:    owner,
+		owner: owner,
 	}
 
 	watcher.watch(events)
-	defer close(watcher.stopChan)
 
 	lbls := labels.NewLabelsFromSortedList("id=foo")
 	key := GlobalIdentity{lbls.LabelArray()}

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -29,6 +29,7 @@ import (
 //
 // Previously used numeric identities for the given prefixes may be passed in as the
 // 'oldNIDs' parameter; nil slice must be passed if no previous numeric identities exist.
+// Previously used NID is allocated if still available. Non-availability is not an error.
 //
 // Upon success, the caller must also arrange for the resulting identities to
 // be released via a subsequent call to ReleaseCIDRIdentitiesByCIDR().

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -105,7 +105,7 @@ func (m *metadata) get(prefix string) labels.Labels {
 // so a balance is kept, ensuring a one-to-one mapping between prefix and
 // identity.
 func (ipc *IPCache) InjectLabels(src source.Source) error {
-	if ipc.IdentityAllocator == nil || !ipc.IdentityAllocator.IsLocalIdentityAllocatorInitialized() {
+	if ipc.IdentityAllocator == nil {
 		return ErrLocalIdentityAllocatorUninitialized
 	}
 

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -54,11 +54,6 @@ func (f *MockIdentityAllocator) WaitForInitialGlobalIdentities(context.Context) 
 	return nil
 }
 
-// IsLocalIdentityAllocatorInitialized returns true.
-func (f *MockIdentityAllocator) IsLocalIdentityAllocatorInitialized() bool {
-	return true
-}
-
 // GetIdentities returns the identities from the identity cache.
 func (f *MockIdentityAllocator) GetIdentities() cache.IdentitiesModel {
 	result := cache.IdentitiesModel{}

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -228,6 +228,7 @@ const (
 	unstableStat        = "BUG: stat() has unstable behavior"                        // from https://github.com/cilium/cilium/pull/11028
 	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
 	missingIptablesWait = "Missing iptables wait arg (-w):"
+	localIDRestoreFail  = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
 
 	// ...and their exceptions.
 	lrpExists                = "local-redirect service exists for frontend"                         // cf. https://github.com/cilium/cilium/issues/16400
@@ -299,6 +300,7 @@ var badLogMessages = map[string][]string{
 	unstableStat:        nil,
 	removeTransientRule: nil,
 	missingIptablesWait: nil,
+	localIDRestoreFail:  nil,
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -1124,9 +1124,9 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		By("Dumping IP cache after Cilium is restarted")
 		ipcacheAfter, err := vm.BpfIPCacheList(true)
 		Expect(err).To(BeNil(), "ipcache can not be dumped")
+		GinkgoPrint(fmt.Sprintf("Local scope identities in IP cache after Cilium restart: %v", ipcacheAfter))
 		equal, diff := checker.DeepEqual(ipcacheBefore, ipcacheAfter)
 		Expect(equal).To(BeTrue(), "CIDR identities were not restored correctly: %s", diff)
-		GinkgoPrint(fmt.Sprintf("Local scope identities in IP cache after Cilium restart: %v", ipcacheAfter))
 
 		// Reapply FQDN policy and check that selectors still have same ids
 		_, err = vm.PolicyRenderAndImport(policy)


### PR DESCRIPTION
Move local identity allocator initialization to
NewCachingIdentityAllocator() so that it is initialized when the
allocator is returned to the caller. Also make the events channel and
start the watcher in NewCachingIdentityAllocator(). Close() will no
longer GC the local identity allocator or stop the watcher. Now that the
locally allocated identities are persisted via the bpf ipcache map across
restarts, recycling them at runtime via Close() would be inappropriate.

This is then used in daemon bootstrap to restore locally allocated
identities before new policies can be received via Cilium API or k8s API.

This fixes the issue where CIDR policies were received from k8s before
locally allocated (CIDR) identities were restored, causing the identities
derived from the received policy to be newly allocated with different
numeric identity values, ultimately causing policy drops during Cilium
restart.

Fixes: #19360
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
