### PR TITLE
docs: fix version warning URL to point to docs.cilium.io

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -70,6 +70,7 @@ author = u'Cilium Authors'
 release = open("../VERSION", "r").read().strip()
 # Used by version warning
 versionwarning_body_selector = "div.document"
+versionwarning_api_url = "docs.cilium.io"
 
 # The version of Go used to compile Cilium
 go_release = open("../GO_VERSION", "r").read().strip()


### PR DESCRIPTION
Due to some CORS policy, the requests being performed from
docs.cilium.io to readthedocs.org were being denied. This was causing
the warning banner to never show up in the documentation. To avoid this
problem a page redirect was configured in readthedocs settings to
redirect docs.cilium.io/version to readthedocs.org/api/v2/version which
will hopefully fix the issue and the API endpoint was set to
docs.cilium.io.

Signed-off-by: André Martins <andre@cilium.io>