### PR TITLE
preallocate memory before looping over it

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -135,12 +135,12 @@ func (d *Daemon) DumpIPAM() *models.IPAMStatus {
 		Status: st,
 	}
 
-	v4 := []string{}
+	v4 := make([]string, 0, len(allocv4))
 	for ip := range allocv4 {
 		v4 = append(v4, ip)
 	}
 
-	v6 := []string{}
+	v6 := make([]string, 0, len(allocv6))
 	if allocv4 == nil {
 		allocv4 = map[string]string{}
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -355,7 +355,7 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 		fmt.Fprintf(w, "IPAM:\t%s\n", sr.Ipam.Status)
 		if sd.AllAddresses {
 			fmt.Fprintf(w, "Allocated addresses:\n")
-			out := []string{}
+			out := make([]string, 0, len(sr.Ipam.Allocations))
 			for ip, owner := range sr.Ipam.Allocations {
 				out = append(out, fmt.Sprintf("  %s (%s)", ip, owner))
 			}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -574,7 +574,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	// to get a consistent written format to the writer. This maintains
 	// the consistency when we try to calculate hash for a datapath after
 	// writing the config.
-	keys := []string{}
+	keys := make([]string, 0, len(cDefinesMap))
 	for key := range cDefinesMap {
 		keys = append(keys, key)
 	}

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -288,7 +288,7 @@ func (c *DNSCache) cleanupOverLimitEntries() (affectedNames []string, removed ma
 		if overlimit <= 0 {
 			continue
 		}
-		sortedEntries := []IPEntry{}
+		sortedEntries := make([]IPEntry, 0, len(entries))
 		for ip, entry := range entries {
 			sortedEntries = append(sortedEntries, IPEntry{ip, entry})
 		}

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -480,7 +480,7 @@ func (r *Recorder) RetrieveRecorder(id ID) (*RecInfo, error) {
 
 // RetrieveRecorderSet will return a list of all existing recorder objects.
 func (r *Recorder) RetrieveRecorderSet() []*RecInfo {
-	recList := []*RecInfo{}
+	recList := make([]*RecInfo, 0, len(r.recByID))
 	r.RLock()
 	defer r.RUnlock()
 	for id := range r.recByID {
@@ -492,7 +492,7 @@ func (r *Recorder) RetrieveRecorderSet() []*RecInfo {
 
 // RetrieveRecorderMaskSet will return a list of all existing recorder masks.
 func (r *Recorder) RetrieveRecorderMaskSet() []*RecMask {
-	recMaskList := []*RecMask{}
+	recMaskList := make([]*RecMask, 0, len(r.recMask))
 	r.RLock()
 	defer r.RUnlock()
 	for _, mask := range r.recMask {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Looping over an array to append something can put high preasure on the garbage collector and cause memory relocations. If the destination is properly allocated in advance, it reduces the work that is needed to be done by GC.

This is not a enduser visible change so I did not add something for the release notes.