### PR TITLE
pkg/policy/api: Optimize FQDNSelector String()

### DIFF
--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -6,6 +6,7 @@ package api
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
@@ -61,7 +62,15 @@ type FQDNSelector struct {
 }
 
 func (s *FQDNSelector) String() string {
-	return fmt.Sprintf("MatchName: %s, MatchPattern: %s", s.MatchName, s.MatchPattern)
+	const m = "MatchName: "
+	const mm = ", MatchPattern: "
+	var str strings.Builder
+	str.Grow(len(m) + len(mm) + len(s.MatchName) + len(s.MatchPattern))
+	str.WriteString(m)
+	str.WriteString(s.MatchName)
+	str.WriteString(mm)
+	str.WriteString(s.MatchPattern)
+	return str.String()
 }
 
 // sanitize for FQDNSelector is a little wonky. While we do more processing

--- a/pkg/policy/api/fqdn_test.go
+++ b/pkg/policy/api/fqdn_test.go
@@ -2,10 +2,13 @@
 // Copyright Authors of Cilium
 
 //go:build !privileged_tests
+// +build !privileged_tests
 
 package api
 
 import (
+	"testing"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -62,5 +65,22 @@ func (s *PolicyAPITestSuite) TestPortRuleDNSSanitize(c *C) {
 	} {
 		err := reject.Sanitize()
 		c.Assert(err, Not(IsNil), Commentf("PortRuleDNS %+v was accepted but it should be invalid", reject))
+	}
+}
+
+// TestPortRuleDNSSanitize tests that the sanitizer correctly catches bad
+// cases, and allows good ones.
+func BenchmarkFQDNSelectorString(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, s := range []FQDNSelector{
+			{MatchName: "cilium.io"},
+			{MatchPattern: "[a-z]*.cilium.io"},
+			{MatchName: "a{1,2}.cilium.io", MatchPattern: "[a-z]*.cilium.io"},
+			{MatchPattern: "*.cilium.io"},
+		} {
+			_ = s.String()
+		}
 	}
 }


### PR DESCRIPTION
Use strings.Builder instead of fmt.Sprintf() and preallocate the size of
the string so that Go doesn't need to over-allocate if the string ends
up longer than what the buffer growth algorithm predicts.

Results:

```
$ go test -v -run '^$' -bench 'BenchmarkFQDNSelectorString' -benchmem ./pkg/policy/api > old.txt
$ go test -v -run '^$' -bench 'BenchmarkFQDNSelectorString' -benchmem ./pkg/policy/api > new.txt
$ benchcmp old.txt new.txt
benchmark                         old ns/op     new ns/op     delta
BenchmarkFQDNSelectorString-8     690           180           -73.97%

benchmark                         old allocs     new allocs     delta
BenchmarkFQDNSelectorString-8     9              4              -55.56%

benchmark                         old bytes     new bytes     delta
BenchmarkFQDNSelectorString-8     288           208           -27.78%
```

Signed-off-by: Chris Tarazi <chris@isovalent.com>

Related: https://github.com/cilium/cilium/issues/19571