### PR TITLE
v1.11 backports 2022-04-26

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -460,7 +460,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	// Collect old CIDR identities
 	var oldNIDs []identity.NumericIdentity
-	if option.Config.RestoreState && !option.Config.DryMode && ipcachemap.SupportsDump() {
+	if option.Config.RestoreState && !option.Config.DryMode {
 		if err := ipcachemap.IPCache.DumpWithCallback(func(key bpf.MapKey, value bpf.MapValue) {
 			k := key.(*ipcachemap.Key)
 			v := value.(*ipcachemap.RemoteEndpointInfo)
@@ -470,8 +470,10 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 				oldNIDs = append(oldNIDs, nid)
 			}
 		}); err != nil && !os.IsNotExist(err) {
-			log.WithError(err).Warning("Error dumping ipcache")
+			log.WithError(err).Debug("Error dumping ipcache")
 		}
+		// DumpWithCallback() leaves the ipcache map open, must close before opened for
+		// parallel mode in Daemon.initMaps()
 		ipcachemap.IPCache.Close()
 	}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -800,9 +800,15 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// are set.
 	if k8s.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
+
+		// Initialize d.k8sCachesSynced before any k8s watchers are alive, as they may
+		// access it to check the status of k8s initialization
+		cachesSynced := make(chan struct{})
+		d.k8sCachesSynced = cachesSynced
+
 		// Launch the K8s watchers in parallel as we continue to process other
 		// daemon options.
-		d.k8sCachesSynced = d.k8sWatcher.InitK8sSubsystem(d.ctx)
+		d.k8sWatcher.InitK8sSubsystem(d.ctx, cachesSynced)
 		bootstrapStats.k8sInit.End(true)
 	}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -492,6 +492,34 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	ipcache.IdentityAllocator = d.identityAllocator
 	proxy.Allocator = d.identityAllocator
 
+	// Preallocate IDs for old CIDRs. This must be done before any Identity allocations are
+	// possible so that the old IDs are still available. That is why we do this ASAP after the
+	// new (userspace) ipcache is created above.
+	//
+	// CIDRs were dumped from the old ipcache, they are re-allocated here, hopefully with the
+	// same numeric IDs as before, but the restored identities are to be upsterted to the new
+	// (datapath) ipcache after it has been initialized below. This is accomplished by passing
+	// 'restoredCIDRidentities' to AllocateCIDRs() and then calling
+	// UpsertGeneratedIdentities(restoredCIDRidentities) after initMaps() below.
+	restoredCIDRidentities := make(map[string]*identity.Identity)
+	if len(d.restoredCIDRs) > 0 {
+		log.Infof("Restoring %d old CIDR identities", len(d.restoredCIDRs))
+		_, err = ipcache.AllocateCIDRs(d.restoredCIDRs, oldNIDs, restoredCIDRidentities)
+		if err != nil {
+			log.WithError(err).Error("Error allocating old CIDR identities")
+		}
+		// Log a warning for the first CIDR identity than could not be restored with the
+		// same numeric identity as before the restart. This can only happen if we have
+		// re-introduced bugs into this agent bootstrap order, so we want to surface this.
+		for i, prefix := range d.restoredCIDRs {
+			id, exists := restoredCIDRidentities[prefix.String()]
+			if !exists || id.ID != oldNIDs[i] {
+				log.WithField(logfields.Identity, oldNIDs[i]).Warn("Could not restore all CIDR identities")
+				break
+			}
+		}
+	}
+
 	d.endpointManager = epMgr
 	d.endpointManager.InitMetrics()
 
@@ -571,6 +599,10 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	bootstrapStats.mapsInit.EndError(err)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error while opening/creating BPF maps: %w", err)
+	}
+	// Upsert restored CIDRs after the new ipcache has been opened above
+	if len(restoredCIDRidentities) > 0 {
+		ipcache.UpsertGeneratedIdentities(restoredCIDRidentities)
 	}
 
 	// Read the service IDs of existing services from the BPF map and
@@ -901,15 +933,6 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		// identity allocator to run asynchronously.
 		realIdentityAllocator := d.identityAllocator
 		realIdentityAllocator.InitIdentityAllocator(k8s.CiliumClient(), nil)
-
-		// Preallocate IDs for old CIDRs, must be called after InitIdentityAllocator
-		if len(d.restoredCIDRs) > 0 {
-			log.Infof("Restoring %d old CIDR identities", len(d.restoredCIDRs))
-			_, err = ipcache.AllocateCIDRs(d.restoredCIDRs, oldNIDs, nil)
-			if err != nil {
-				log.WithError(err).Error("Error allocating old CIDR identities")
-			}
-		}
 
 		d.bootstrapClusterMesh(nodeMngr)
 	}

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -175,12 +175,10 @@ func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 	owner := newDummyOwner()
 	events := make(allocator.AllocatorEventChan, 1024)
 	watcher := identityWatcher{
-		stopChan: make(chan struct{}),
-		owner:    owner,
+		owner: owner,
 	}
 
 	watcher.watch(events)
-	defer close(watcher.stopChan)
 
 	lbls := labels.NewLabelsFromSortedList("id=foo")
 	key := GlobalIdentity{lbls.LabelArray()}

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -38,6 +38,7 @@ var (
 //
 // Previously used numeric identities for the given prefixes may be passed in as the
 // 'oldNIDs' parameter; nil slice must be passed if no previous numeric identities exist.
+// Previously used NID is allocated if still available. Non-availability is not an error.
 //
 // Upon success, the caller must also arrange for the resulting identities to
 // be released via a subsequent call to ReleaseCIDRIdentitiesByCIDR().

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -86,7 +86,7 @@ func GetIDMetadataByIP(prefix string) labels.Labels {
 // so a balance is kept, ensuring a one-to-one mapping between prefix and
 // identity.
 func InjectLabels(src source.Source, updater identityUpdater, triggerer policyTriggerer) error {
-	if IdentityAllocator == nil || !IdentityAllocator.IsLocalIdentityAllocatorInitialized() {
+	if IdentityAllocator == nil {
 		return ErrLocalIdentityAllocatorUninitialized
 	}
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -361,21 +361,18 @@ func (k *K8sWatcher) resourceGroups() []string {
 	return append(k8sGroups, ciliumGroups...)
 }
 
-// InitK8sSubsystem returns a channel for which it will be closed when all
+// InitK8sSubsystem takes a channel for which it will be closed when all
 // caches essential for daemon are synchronized.
 // To be called after WaitForCRDsToRegister() so that all needed CRDs have
 // already been registered.
-func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context) <-chan struct{} {
-	cachesSynced := make(chan struct{})
-
+func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context, cachesSynced chan struct{}) {
 	resources := k.resourceGroups()
 	if err := k.EnableK8sWatcher(ctx, resources); err != nil {
 		if !errors.Is(err, context.Canceled) {
 			log.WithError(err).Fatal("Unable to start K8s watchers for Cilium")
 		}
 		// If the context was canceled it means the daemon is being stopped
-		// so we can return a non-closed channel.
-		return cachesSynced
+		return
 	}
 
 	go func() {
@@ -392,8 +389,6 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context) <-chan struct{} {
 			log.Fatal("Timed out waiting for pre-existing resources to be received; exiting")
 		}
 	}()
-
-	return cachesSynced
 }
 
 // WatcherConfiguration is the required configuration for EnableK8sWatcher

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -158,11 +158,6 @@ type Map struct {
 	// whether the underlying kernel supports delete operations on the map
 	// the first time that supportsDelete() is called.
 	deleteSupport bool
-
-	// dumpSupport is set to 'true' initially, then is updated to set
-	// whether the underlying kernel supports dump operations on the map
-	// the first time that supportsDelete() or supportsDump() is called.
-	dumpSupport bool
 }
 
 // NewMap instantiates a Map.
@@ -180,7 +175,6 @@ func NewMap(name string) *Map {
 			bpf.ConvertKeyValue,
 		).WithCache().WithPressureMetric(),
 		deleteSupport: true,
-		dumpSupport:   true,
 	}
 }
 
@@ -230,14 +224,14 @@ func (m *Map) supportsDelete() bool {
 
 		// Detect dump support
 		err := m.Dump(map[string][]string{})
-		m.dumpSupport = err == nil
-		log.Debugf("Detected IPCache dump operation support: %t", m.dumpSupport)
+		dumpSupport := err == nil
+		log.Debugf("Detected IPCache dump operation support: %t", dumpSupport)
 
 		// In addition to delete support, ability to dump the map is
 		// also required in order to run the garbage collector which
 		// will iterate over the map and delete entries.
 		if m.deleteSupport {
-			m.deleteSupport = m.dumpSupport
+			m.deleteSupport = dumpSupport
 		}
 
 		if !m.deleteSupport {
@@ -247,21 +241,10 @@ func (m *Map) supportsDelete() bool {
 	return m.deleteSupport
 }
 
-func (m *Map) supportsDump() bool {
-	m.supportsDelete()
-	return m.dumpSupport
-}
-
 // SupportsDelete determines whether the underlying kernel map type supports
 // the delete operation.
 func SupportsDelete() bool {
 	return IPCache.supportsDelete()
-}
-
-// SupportsDump determines whether the underlying kernel map type supports
-// the dump operation.
-func SupportsDump() bool {
-	return IPCache.supportsDump()
 }
 
 // BackedByLPM returns true if the IPCache is backed by a proper LPM

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -54,11 +54,6 @@ func (f *MockIdentityAllocator) WaitForInitialGlobalIdentities(context.Context) 
 	return nil
 }
 
-// IsLocalIdentityAllocatorInitialized returns true.
-func (f *MockIdentityAllocator) IsLocalIdentityAllocatorInitialized() bool {
-	return true
-}
-
 // GetIdentities returns the identities from the identity cache.
 func (f *MockIdentityAllocator) GetIdentities() cache.IdentitiesModel {
 	result := cache.IdentitiesModel{}

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -230,6 +230,7 @@ const (
 	unstableStat        = "BUG: stat() has unstable behavior"                        // from https://github.com/cilium/cilium/pull/11028
 	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
 	missingIptablesWait = "Missing iptables wait arg (-w):"
+	localIDRestoreFail  = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
 
 	// ...and their exceptions.
 	lrpExists                = "local-redirect service exists for frontend"                         // cf. https://github.com/cilium/cilium/issues/16400
@@ -302,6 +303,7 @@ var badLogMessages = map[string][]string{
 	unstableStat:        nil,
 	removeTransientRule: nil,
 	missingIptablesWait: nil,
+	localIDRestoreFail:  nil,
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -1120,9 +1120,9 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		By("Dumping IP cache after Cilium is restarted")
 		ipcacheAfter, err := vm.BpfIPCacheList(true)
 		Expect(err).To(BeNil(), "ipcache can not be dumped")
+		GinkgoPrint(fmt.Sprintf("Local scope identities in IP cache after Cilium restart: %v", ipcacheAfter))
 		equal, diff := checker.DeepEqual(ipcacheBefore, ipcacheAfter)
 		Expect(equal).To(BeTrue(), "CIDR identities were not restored correctly: %s", diff)
-		GinkgoPrint(fmt.Sprintf("Local scope identities in IP cache after Cilium restart: %v", ipcacheAfter))
 
 		// Reapply FQDN policy and check that selectors still have same ids
 		_, err = vm.PolicyRenderAndImport(policy)


### PR DESCRIPTION
 * #19501 -- daemon: Dump ipcache without probing for support (@jrajahalme)
 * #19556 -- identity: Initialize local identity allocator early (@jrajahalme)
 * #19626 -- daemon: Initialize k8sCachesSynced channel before calling Initk8sSubsystem() (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19501 19556 19626; do contrib/backporting/set-labels.py $pr done 1.11; done
```
