### PR TITLE
v1.10 backports 2022-04-26

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -464,7 +464,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	// Collect old CIDR identities
 	var oldNIDs []identity.NumericIdentity
-	if option.Config.RestoreState && !option.Config.DryMode && ipcachemap.SupportsDump() {
+	if option.Config.RestoreState && !option.Config.DryMode {
 		if err := ipcachemap.IPCache.DumpWithCallback(func(key bpf.MapKey, value bpf.MapValue) {
 			k := key.(*ipcachemap.Key)
 			v := value.(*ipcachemap.RemoteEndpointInfo)
@@ -474,8 +474,10 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 				oldNIDs = append(oldNIDs, nid)
 			}
 		}); err != nil && !os.IsNotExist(err) {
-			log.WithError(err).Warning("Error dumping ipcache")
+			log.WithError(err).Debug("Error dumping ipcache")
 		}
+		// DumpWithCallback() leaves the ipcache map open, must close before opened for
+		// parallel mode in Daemon.initMaps()
 		ipcachemap.IPCache.Close()
 	}
 

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -81,6 +81,11 @@ func (d *Daemon) policyUpdateTrigger(reasons []string) {
 // in agent configuration, changes in endpoint labels, and change of security
 // identities.
 func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) {
+	// CIDR identity restoration may trigger early when endpoints can not yet be regenerated
+	if d.policyTrigger == nil {
+		return
+	}
+
 	if force {
 		log.Debugf("Artificially increasing policy revision to enforce policy recalculation")
 		d.policy.BumpRevision()

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -185,12 +185,10 @@ func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 	owner := newDummyOwner()
 	events := make(allocator.AllocatorEventChan, 1024)
 	watcher := identityWatcher{
-		stopChan: make(chan struct{}),
-		owner:    owner,
+		owner: owner,
 	}
 
 	watcher.watch(events)
-	defer close(watcher.stopChan)
 
 	lbls := labels.NewLabelsFromSortedList("id=foo")
 	key := GlobalIdentity{lbls.LabelArray()}

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -86,18 +86,15 @@ type CachingIdentityAllocator struct {
 	// allocator is initialized.
 	globalIdentityAllocatorInitialized chan struct{}
 
-	// localIdentityAllocatorInitialized is closed whenever the local identity
-	// allocator is initialized.
-	localIdentityAllocatorInitialized chan struct{}
-
 	localIdentities *localIdentityCache
 
 	identitiesPath string
 
+	events  allocator.AllocatorEventChan
+	watcher identityWatcher
+
 	// setupMutex synchronizes InitIdentityAllocator() and Close()
 	setupMutex lock.Mutex
-
-	watcher identityWatcher
 
 	owner IdentityAllocatorOwner
 }
@@ -172,7 +169,7 @@ type IdentityAllocator interface {
 	ReleaseCIDRIdentitiesByID(context.Context, []identity.NumericIdentity)
 }
 
-// InitIdentityAllocator creates the the identity allocator. Only the first
+// InitIdentityAllocator creates the global identity allocator. Only the first
 // invocation of this function will have an effect. The Caller must have
 // initialized well known identities before calling this (by calling
 // identity.InitWellKnownIdentities()).
@@ -193,23 +190,12 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 
 	log.Info("Initializing identity allocator")
 
-	// Local identity cache can be created synchronously since it doesn't
-	// rely upon any external resources (e.g., external kvstore).
-	events := make(allocator.AllocatorEventChan, 1024)
-	m.localIdentities = newLocalIdentityCache(1, 0xFFFFFF, events)
-	close(m.localIdentityAllocatorInitialized)
-
 	minID := idpool.ID(identity.MinimalAllocationIdentity)
 	maxID := idpool.ID(identity.MaximumAllocationIdentity)
 
-	// It is important to start listening for events before calling
-	// NewAllocator() as it will emit events while filling the
-	// initial cache
-	m.watcher.watch(events)
-
 	// Asynchronously set up the global identity allocator since it connects
 	// to the kvstore.
-	go func(owner IdentityAllocatorOwner, evs allocator.AllocatorEventChan, minID, maxID idpool.ID) {
+	go func(owner IdentityAllocatorOwner, events allocator.AllocatorEventChan, minID, maxID idpool.ID) {
 		m.setupMutex.Lock()
 		defer m.setupMutex.Unlock()
 
@@ -253,7 +239,7 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 
 		m.IdentityAllocator = a
 		close(m.globalIdentityAllocatorInitialized)
-	}(m.owner, events, minID, maxID)
+	}(m.owner, m.events, minID, maxID)
 
 	return m.globalIdentityAllocatorInitialized
 }
@@ -274,18 +260,23 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 // CachingIdentityAllocator.
 func NewCachingIdentityAllocator(owner IdentityAllocatorOwner) *CachingIdentityAllocator {
 	watcher := identityWatcher{
-		stopChan: make(chan struct{}),
-		owner:    owner,
+		owner: owner,
 	}
 
-	mgr := &CachingIdentityAllocator{
+	m := &CachingIdentityAllocator{
 		globalIdentityAllocatorInitialized: make(chan struct{}),
-		localIdentityAllocatorInitialized:  make(chan struct{}),
 		owner:                              owner,
 		identitiesPath:                     IdentitiesPath,
 		watcher:                            watcher,
+		events:                             make(allocator.AllocatorEventChan, 1024),
 	}
-	return mgr
+	m.watcher.watch(m.events)
+
+	// Local identity cache can be created synchronously since it doesn't
+	// rely upon any external resources (e.g., external kvstore).
+	m.localIdentities = newLocalIdentityCache(1, 0xFFFFFF, m.events)
+
+	return m
 }
 
 // Close closes the identity allocator and allows to call
@@ -303,21 +294,9 @@ func (m *CachingIdentityAllocator) Close() {
 		}
 	}
 
-	select {
-	case <-m.localIdentityAllocatorInitialized:
-		// This means the channel was closed and therefore the IdentityAllocator == nil will never be true
-	default:
-		if m.IdentityAllocator == nil {
-			log.Panic("Close() called without calling InitIdentityAllocator() first")
-		}
-	}
-
 	m.IdentityAllocator.Delete()
-	m.watcher.stop()
 	m.IdentityAllocator = nil
 	m.globalIdentityAllocatorInitialized = make(chan struct{})
-	m.localIdentityAllocatorInitialized = make(chan struct{})
-	m.localIdentities = nil
 }
 
 // WaitForInitialGlobalIdentities waits for the initial set of global security
@@ -379,7 +358,6 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 	}
 
 	if !identity.RequiresGlobalIdentity(lbls) {
-		<-m.localIdentityAllocatorInitialized
 		return m.localIdentities.lookupOrCreate(lbls, oldNID)
 	}
 
@@ -433,7 +411,6 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 	}
 
 	if !identity.RequiresGlobalIdentity(id.Labels) {
-		<-m.localIdentityAllocatorInitialized
 		return m.localIdentities.release(id), nil
 	}
 

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -49,6 +49,7 @@ var (
 //
 // Previously used numeric identities for the given prefixes may be passed in as the
 // 'oldNIDs' parameter; nil slice must be passed if no previous numeric identities exist.
+// Previously used NID is allocated if still available. Non-availability is not an error.
 //
 // Upon success, the caller must also arrange for the resulting identities to
 // be released via a subsequent call to ReleaseCIDRIdentitiesByCIDR().

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -169,11 +169,6 @@ type Map struct {
 	// whether the underlying kernel supports delete operations on the map
 	// the first time that supportsDelete() is called.
 	deleteSupport bool
-
-	// dumpSupport is set to 'true' initially, then is updated to set
-	// whether the underlying kernel supports dump operations on the map
-	// the first time that supportsDelete() or supportsDump() is called.
-	dumpSupport bool
 }
 
 // NewMap instantiates a Map.
@@ -191,7 +186,6 @@ func NewMap(name string) *Map {
 			bpf.ConvertKeyValue,
 		).WithCache().WithPressureMetric(),
 		deleteSupport: true,
-		dumpSupport:   true,
 	}
 }
 
@@ -241,14 +235,14 @@ func (m *Map) supportsDelete() bool {
 
 		// Detect dump support
 		err := m.Dump(map[string][]string{})
-		m.dumpSupport = err == nil
-		log.Debugf("Detected IPCache dump operation support: %t", m.dumpSupport)
+		dumpSupport := err == nil
+		log.Debugf("Detected IPCache dump operation support: %t", dumpSupport)
 
 		// In addition to delete support, ability to dump the map is
 		// also required in order to run the garbage collector which
 		// will iterate over the map and delete entries.
 		if m.deleteSupport {
-			m.deleteSupport = m.dumpSupport
+			m.deleteSupport = dumpSupport
 		}
 
 		if !m.deleteSupport {
@@ -258,21 +252,10 @@ func (m *Map) supportsDelete() bool {
 	return m.deleteSupport
 }
 
-func (m *Map) supportsDump() bool {
-	m.supportsDelete()
-	return m.dumpSupport
-}
-
 // SupportsDelete determines whether the underlying kernel map type supports
 // the delete operation.
 func SupportsDelete() bool {
 	return IPCache.supportsDelete()
-}
-
-// SupportsDump determines whether the underlying kernel map type supports
-// the dump operation.
-func SupportsDump() bool {
-	return IPCache.supportsDump()
 }
 
 // BackedByLPM returns true if the IPCache is backed by a proper LPM

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -240,6 +240,7 @@ const (
 	uninitializedRegen  = "Uninitialized regeneration level"                         // from https://github.com/cilium/cilium/pull/10949
 	unstableStat        = "BUG: stat() has unstable behavior"                        // from https://github.com/cilium/cilium/pull/11028
 	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
+	localIDRestoreFail  = "Could not restore all CIDR identities"                    // from https://github.com/cilium/cilium/pull/19556
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -304,6 +305,7 @@ var badLogMessages = map[string][]string{
 	uninitializedRegen:  nil,
 	unstableStat:        nil,
 	removeTransientRule: nil,
+	localIDRestoreFail:  nil,
 	"DATA RACE":         nil,
 }
 

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -1127,9 +1127,9 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		By("Dumping IP cache after Cilium is restarted")
 		ipcacheAfter, err := vm.BpfIPCacheList(true)
 		Expect(err).To(BeNil(), "ipcache can not be dumped")
+		GinkgoPrint(fmt.Sprintf("Local scope identities in IP cache after Cilium restart: %v", ipcacheAfter))
 		equal, diff := checker.DeepEqual(ipcacheBefore, ipcacheAfter)
 		Expect(equal).To(BeTrue(), "CIDR identities were not restored correctly: %s", diff)
-		GinkgoPrint(fmt.Sprintf("Local scope identities in IP cache after Cilium restart: %v", ipcacheAfter))
 
 		// Reapply FQDN policy and check that selectors still have same ids
 		_, err = vm.PolicyRenderAndImport(policy)


### PR DESCRIPTION
 * #19501 -- daemon: Dump ipcache without probing for support (@jrajahalme)
 * #19556 -- identity: Initialize local identity allocator early (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19501 19556; do contrib/backporting/set-labels.py $pr done 1.10; done
```
