### PR TITLE
operator: Add cilium node garbage collector

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -60,6 +60,7 @@ cilium-operator-alibabacloud [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -65,6 +65,7 @@ cilium-operator-aws [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -63,6 +63,7 @@ cilium-operator-azure [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -59,6 +59,7 @@ cilium-operator-generic [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -70,6 +70,7 @@ cilium-operator [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1257,6 +1257,10 @@
      - cilium-operator image.
      - object
      - ``{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/operator","suffix":"","tag":"latest","useDigest":false}``
+   * - operator.nodeGCInterval
+     - Interval for cilium node garbage collection.
+     - string
+     - ``"5m0s"``
    * - operator.nodeSelector
      - Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -326,6 +326,9 @@ New Options
   for EC2 instances (and existing ENIs). EC2 Instances tags is in the form of k1=v1,k2=v2
   (multiple k/v pairs can also be passed by repeating the CLI flag")
   Use ``instanceTagsFilter`` in Helm chart.
+* ``nodes-gc-interval``: This option was marked as deprecated and has no effect
+  in 1.11. Cilium Node Garbage collector is added back in 1.12 (but for k8s GC instead
+  of kvstore), so this flag is moved out of deprecated list.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -675,6 +675,7 @@ nfsd
 nftables
 nginx
 nodeEncryption
+nodeGCInterval
 nodePort
 nodeSelector
 nodeX

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -365,6 +365,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
 | operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/operator","suffix":"","tag":"latest","useDigest":false}` | cilium-operator image. |
+| operator.nodeGCInterval | string | `"5m0s"` | Interval for cilium node garbage collection. |
 | operator.nodeSelector | object | `{}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
 | operator.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -109,6 +109,10 @@ data:
   cilium-endpoint-gc-interval: "{{ .Values.operator.endpointGCInterval }}"
 {{- end }}
 
+{{- if hasKey .Values.operator "nodeGCInterval" }}
+  nodes-gc-interval: "{{ .Values.operator.nodeGCInterval | default "0s" }}"
+{{- end }}
+
 {{- if hasKey .Values "disableEndpointCRD" }}
   # Disable the usage of CiliumEndpoint CRD
   disable-endpoint-crd: "{{ .Values.disableEndpointCRD }}"

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus }}
+{{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus .Values.operator.endpointGCInterval }}
 - apiGroups:
   - ""
   resources:
@@ -29,6 +29,8 @@ rules:
   verbs:
   - list
   - watch
+{{- end }}
+{{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus }}
 - apiGroups:
   - ""
   resources:
@@ -128,6 +130,12 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.operator.nodeGCInterval }}
+{{- if ne .Values.operator.nodeGCInterval "0s" }}
+    # To perform CiliumNode garbage collector
+  - delete
+{{- end }}
+{{- end }}
 - apiGroups:
   - cilium.io
   resources:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1599,6 +1599,9 @@ operator:
   # -- Interval for endpoint garbage collection.
   endpointGCInterval: "5m0s"
 
+  # -- Interval for cilium node garbage collection.
+  nodeGCInterval: "5m0s"
+
   # -- Interval for identity garbage collection.
   identityGCInterval: "15m0s"
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -249,10 +249,8 @@ func init() {
 	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
 	option.BindEnv(option.K8sKubeConfigPath)
 
-	// To be removed in Cilium 1.12
-	flags.Duration(operatorOption.NodesGCInterval, 2*time.Minute, "GC interval for nodes store in the kvstore")
+	flags.Duration(operatorOption.NodesGCInterval, 0*time.Second, "GC interval for CiliumNodes")
 	option.BindEnv(operatorOption.NodesGCInterval)
-	flags.MarkDeprecated(operatorOption.NodesGCInterval, "Unused flag, will be removed in future Cilium releases")
 
 	flags.String(operatorOption.OperatorPrometheusServeAddr, operatorOption.PrometheusServeAddr, "Address to serve Prometheus metrics")
 	option.BindEnv(operatorOption.OperatorPrometheusServeAddr)

--- a/operator/main.go
+++ b/operator/main.go
@@ -512,6 +512,10 @@ func onOperatorStartLeading(ctx context.Context) {
 		RunCNPNodeStatusGC(ciliumNodeStore)
 	}
 
+	if operatorOption.Config.NodeGCInterval != 0 {
+		operatorWatchers.RunCiliumNodeGC(ctx, ciliumNodeStore, operatorOption.Config.NodeGCInterval)
+	}
+
 	if option.Config.IPAM == ipamOption.IPAMClusterPool || option.Config.IPAM == ipamOption.IPAMClusterPoolV2 {
 		// We will use CiliumNodes as the source of truth for the podCIDRs.
 		// Once the CiliumNodes are synchronized with the operator we will

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -76,7 +76,7 @@ const (
 	// IdentityHeartbeatTimeout is the timeout used to GC identities from k8s
 	IdentityHeartbeatTimeout = "identity-heartbeat-timeout"
 
-	// NodesGCInterval is the duration for which the nodes are GC in the KVStore.
+	// NodesGCInterval is the duration for which the cilium nodes are GC.
 	NodesGCInterval = "nodes-gc-interval"
 
 	// OperatorAPIServeAddr IP:Port on which to serve api requests in
@@ -258,6 +258,9 @@ type OperatorConfig struct {
 	// CNPStatusUpdateInterval is the interval between status updates
 	// being sent to the K8s apiserver for a given CNP.
 	CNPStatusUpdateInterval time.Duration
+
+	// NodeGCInterval is the GC interval for CiliumNodes
+	NodeGCInterval time.Duration
 
 	// EnableMetrics enables prometheus metrics.
 	EnableMetrics bool
@@ -461,6 +464,7 @@ type OperatorConfig struct {
 func (c *OperatorConfig) Populate() {
 	c.CNPNodeStatusGCInterval = viper.GetDuration(CNPNodeStatusGCInterval)
 	c.CNPStatusUpdateInterval = viper.GetDuration(CNPStatusUpdateInterval)
+	c.NodeGCInterval = viper.GetDuration(NodesGCInterval)
 	c.EnableMetrics = viper.GetBool(EnableMetrics)
 	c.EndpointGCInterval = viper.GetDuration(EndpointGCInterval)
 	c.IdentityGCInterval = viper.GetDuration(IdentityGCInterval)

--- a/operator/watchers/cilium_node_gc.go
+++ b/operator/watchers/cilium_node_gc.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers
+
+import (
+	"context"
+	"time"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/k8s"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// ciliumNodeGCCandidate keeps track of cilium nodes, which are candidate for GC.
+// Underlying there is a map with node name as key, and last marked timestamp as value.
+type ciliumNodeGCCandidate struct {
+	lock          lock.RWMutex
+	nodesToRemove map[string]time.Time
+}
+
+func newCiliumNodeGCCandidate() *ciliumNodeGCCandidate {
+	return &ciliumNodeGCCandidate{
+		nodesToRemove: map[string]time.Time{},
+	}
+}
+
+func (c *ciliumNodeGCCandidate) Get(nodeName string) (time.Time, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	val, exists := c.nodesToRemove[nodeName]
+	return val, exists
+}
+
+func (c *ciliumNodeGCCandidate) Add(nodeName string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.nodesToRemove[nodeName] = time.Now()
+}
+
+func (c *ciliumNodeGCCandidate) Delete(nodeName string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.nodesToRemove, nodeName)
+}
+
+// RunCiliumNodeGC performs garbage collector for cilium node resource
+func RunCiliumNodeGC(ctx context.Context, ciliumNodeStore cache.Store, interval time.Duration) {
+	nodesInit(k8s.WatcherClient(), ctx.Done())
+
+	// wait for k8s nodes synced is done
+	select {
+	case <-slimNodeStoreSynced:
+	case <-ctx.Done():
+		return
+	}
+
+	log.Info("Starting to garbage collect stale CiliumNode custom resources")
+
+	candidateStore := newCiliumNodeGCCandidate()
+	// create the controller to perform mark and sweep operation for cilium nodes
+	ctrlMgr.UpdateController("cilium-node-gc",
+		controller.ControllerParams{
+			Context: ctx,
+			DoFunc: func(ctx context.Context) error {
+				return performCiliumNodeGC(ctx, k8s.CiliumClient().CiliumV2().CiliumNodes(), ciliumNodeStore,
+					nodeGetter{}, interval, candidateStore)
+			},
+			RunInterval: interval,
+		},
+	)
+}
+
+func performCiliumNodeGC(ctx context.Context, client ciliumv2.CiliumNodeInterface, ciliumNodeStore cache.Store,
+	nodeGetter slimNodeGetter, interval time.Duration, candidateStore *ciliumNodeGCCandidate) error {
+	for _, nodeName := range ciliumNodeStore.ListKeys() {
+		scopedLog := log.WithField(logfields.NodeName, nodeName)
+		_, err := nodeGetter.GetK8sSlimNode(nodeName)
+		if err == nil {
+			scopedLog.Debugf("CiliumNode is valid, no gargage collection required")
+			continue
+		}
+
+		if !k8serrors.IsNotFound(err) {
+			scopedLog.WithError(err).Error("Unable to fetch k8s node from store")
+			return err
+		}
+
+		obj, _, err := ciliumNodeStore.GetByKey(nodeName)
+		if err != nil {
+			scopedLog.WithError(err).Error("Unable to fetch CiliumNode from store")
+			return err
+		}
+
+		cn, ok := obj.(*cilium_v2.CiliumNode)
+		if !ok {
+			scopedLog.Errorf("Object stored in store is not *cilium_v2.CiliumNode but %T", obj)
+			return err
+		}
+
+		// if there is owner references, let k8s handle garbage collection
+		if len(cn.GetOwnerReferences()) > 0 {
+			continue
+		}
+
+		lastMarkedTime, exists := candidateStore.Get(nodeName)
+		if !exists {
+			scopedLog.Info("Add CiliumNode to garbage collector candidates")
+			candidateStore.Add(nodeName)
+			continue
+		}
+
+		// only remove the node if last marked time is more than running interval
+		if lastMarkedTime.Before(time.Now().Add(-interval)) {
+			scopedLog.Info("Perform GC for invalid CiliumNode")
+			err = client.Delete(ctx, nodeName, metav1.DeleteOptions{})
+			if err != nil && !k8serrors.IsNotFound(err) {
+				scopedLog.WithError(err).Error("Failed to delete invalid CiliumNode")
+				return err
+			}
+			scopedLog.Info("CiliumNode is garbage collected successfully")
+			candidateStore.Delete(nodeName)
+		}
+	}
+	return nil
+}

--- a/operator/watchers/cilium_node_gc_test.go
+++ b/operator/watchers/cilium_node_gc_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+// +build !privileged_tests
+
+package watchers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+)
+
+func Test_performCiliumNodeGC(t *testing.T) {
+	validCN := &v2.CiliumNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-node",
+		},
+	}
+	invalidCN := &v2.CiliumNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "invalid-node",
+		},
+	}
+	invalidCNWithOwnerRef := &v2.CiliumNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "invalid-node-with-owner-ref",
+			OwnerReferences: []metav1.OwnerReference{
+				{},
+			},
+		},
+	}
+
+	fcn := fake.NewSimpleClientset(validCN, invalidCN, invalidCNWithOwnerRef).CiliumV2().CiliumNodes()
+
+	fCNStore := &cache.FakeCustomStore{
+		ListKeysFunc: func() []string {
+			return []string{"valid-node", "invalid-node"}
+		},
+		GetByKeyFunc: func(key string) (interface{}, bool, error) {
+			return &v2.CiliumNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: key,
+				},
+			}, true, nil
+		},
+	}
+
+	interval := time.Nanosecond
+	fng := &fakeNodeGetter{
+		OnGetK8sSlimNode: func(nodeName string) (*slim_corev1.Node, error) {
+			if nodeName == "valid-node" {
+				return &slim_corev1.Node{}, nil
+			}
+			return nil, k8serrors.NewNotFound(schema.GroupResource{}, "invalid-node")
+		},
+	}
+
+	candidateStore := newCiliumNodeGCCandidate()
+
+	// check if the invalid node is added to GC candidate
+	err := performCiliumNodeGC(context.TODO(), fcn, fCNStore, fng, interval, candidateStore)
+	assert.NoError(t, err)
+	assert.Len(t, candidateStore.nodesToRemove, 1)
+	_, exists := candidateStore.nodesToRemove["invalid-node"]
+	assert.True(t, exists)
+
+	// check if the invalid node is actually GC-ed
+	time.Sleep(interval)
+	err = performCiliumNodeGC(context.TODO(), fcn, fCNStore, fng, interval, candidateStore)
+	assert.NoError(t, err)
+	assert.Len(t, candidateStore.nodesToRemove, 0)
+	_, exists = candidateStore.nodesToRemove["invalid-node"]
+	assert.False(t, exists)
+}

--- a/operator/watchers/node.go
+++ b/operator/watchers/node.go
@@ -1,0 +1,116 @@
+package watchers
+
+import (
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/cilium/cilium/pkg/k8s/informer"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+var (
+	// slimNodeStore contains all cluster nodes store as slim_core.Node
+	slimNodeStore cache.Store
+
+	nodeController cache.Controller
+
+	nodeQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "node-queue")
+)
+
+type slimNodeGetter interface {
+	GetK8sSlimNode(nodeName string) (*slim_corev1.Node, error)
+}
+
+type nodeGetter struct{}
+
+// GetK8sSlimNode returns a slim_corev1.Node from the local store.
+// The return structure should only be used for read purposes and should never
+// be written into it.
+func (nodeGetter) GetK8sSlimNode(nodeName string) (*slim_corev1.Node, error) {
+	nodeInterface, exists, err := slimNodeStore.GetByKey(nodeName)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, k8sErrors.NewNotFound(schema.GroupResource{
+			Group:    "core",
+			Resource: "Node",
+		}, nodeName)
+	}
+	return nodeInterface.(*slim_corev1.Node), nil
+}
+
+// nodesInit starts up a node watcher to handle node events.
+func nodesInit(k8sClient kubernetes.Interface, stopCh <-chan struct{}) {
+	slimNodeStore, nodeController = informer.NewInformer(
+		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
+			"nodes", metav1.NamespaceAll, fields.Everything()),
+		&slim_corev1.Node{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				key, _ := queueKeyFunc(obj)
+				nodeQueue.Add(key)
+			},
+			UpdateFunc: func(_, newObj interface{}) {
+				key, _ := queueKeyFunc(newObj)
+				nodeQueue.Add(key)
+			},
+		},
+		convertToNode,
+	)
+	go nodeController.Run(stopCh)
+}
+
+func convertToNode(obj interface{}) interface{} {
+	switch concreteObj := obj.(type) {
+	case *slim_corev1.Node:
+		n := &slim_corev1.Node{
+			TypeMeta: concreteObj.TypeMeta,
+			ObjectMeta: slim_metav1.ObjectMeta{
+				Name:            concreteObj.Name,
+				ResourceVersion: concreteObj.ResourceVersion,
+			},
+			Spec: slim_corev1.NodeSpec{
+				Taints: concreteObj.Spec.Taints,
+			},
+			Status: slim_corev1.NodeStatus{
+				Conditions: concreteObj.Status.Conditions,
+			},
+		}
+		*concreteObj = slim_corev1.Node{}
+		return n
+	case cache.DeletedFinalStateUnknown:
+		node, ok := concreteObj.Obj.(*slim_corev1.Node)
+		if !ok {
+			return obj
+		}
+		dfsu := cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &slim_corev1.Node{
+				TypeMeta: node.TypeMeta,
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            node.Name,
+					ResourceVersion: node.ResourceVersion,
+				},
+				Spec: slim_corev1.NodeSpec{
+					Taints: node.Spec.Taints,
+				},
+				Status: slim_corev1.NodeStatus{
+					Conditions: node.Status.Conditions,
+				},
+			},
+		}
+		// Small GC optimization
+		*node = slim_corev1.Node{}
+		return dfsu
+	default:
+		return obj
+	}
+}

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -21,11 +21,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -40,14 +37,7 @@ const (
 	ciliumNodeConditionReason = "CiliumIsUp"
 )
 
-type slimNodeGetter interface {
-	GetK8sSlimNode(nodeName string) (*slim_corev1.Node, error)
-}
-
 var (
-	// slimNodeStore contains all cluster nodes store as slim_core.Node
-	slimNodeStore cache.Store
-
 	// ciliumPodsStore contains all Cilium pods running in the cluster
 	ciliumPodsStore = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, ciliumIndexers)
 
@@ -66,110 +56,7 @@ var (
 	mno markNodeOptions
 )
 
-type nodeGetter struct{}
-
-// GetK8sSlimNode returns a slim_corev1.Node from the local store.
-// The return structure should only be used for read purposes and should never
-// be written into it.
-func (nodeGetter) GetK8sSlimNode(nodeName string) (*slim_corev1.Node, error) {
-	nodeInterface, exists, err := slimNodeStore.GetByKey(nodeName)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, k8sErrors.NewNotFound(schema.GroupResource{
-			Group:    "core",
-			Resource: "Node",
-		}, nodeName)
-	}
-	return nodeInterface.(*slim_corev1.Node), nil
-}
-
-// nodesInit starts up a node watcher to handle node events.
-func nodesInit(k8sClient kubernetes.Interface, stopCh <-chan struct{}) {
-	var (
-		nodeController cache.Controller
-	)
-	nodeQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "node-queue")
-
-	slimNodeStore, nodeController = informer.NewInformer(
-		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
-			"nodes", v1.NamespaceAll, fields.Everything()),
-		&slim_corev1.Node{},
-		0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				key, _ := queueKeyFunc(obj)
-				nodeQueue.Add(key)
-			},
-			UpdateFunc: func(_, newObj interface{}) {
-				key, _ := queueKeyFunc(newObj)
-				nodeQueue.Add(key)
-			},
-		},
-		convertToNode,
-	)
-
-	nodeGetter := &nodeGetter{}
-
-	go func() {
-		// Do not use the k8sClient provided by the nodesInit function since we
-		// need a k8s client that can update node structures and not simply
-		// watch for node events.
-		for processNextNodeItem(k8s.Client(), nodeGetter, nodeQueue) {
-		}
-	}()
-	go nodeController.Run(stopCh)
-}
-
-func convertToNode(obj interface{}) interface{} {
-	switch concreteObj := obj.(type) {
-	case *slim_corev1.Node:
-		n := &slim_corev1.Node{
-			TypeMeta: concreteObj.TypeMeta,
-			ObjectMeta: slim_metav1.ObjectMeta{
-				Name:            concreteObj.Name,
-				ResourceVersion: concreteObj.ResourceVersion,
-			},
-			Spec: slim_corev1.NodeSpec{
-				Taints: concreteObj.Spec.Taints,
-			},
-			Status: slim_corev1.NodeStatus{
-				Conditions: concreteObj.Status.Conditions,
-			},
-		}
-		*concreteObj = slim_corev1.Node{}
-		return n
-	case cache.DeletedFinalStateUnknown:
-		node, ok := concreteObj.Obj.(*slim_corev1.Node)
-		if !ok {
-			return obj
-		}
-		dfsu := cache.DeletedFinalStateUnknown{
-			Key: concreteObj.Key,
-			Obj: &slim_corev1.Node{
-				TypeMeta: node.TypeMeta,
-				ObjectMeta: slim_metav1.ObjectMeta{
-					Name:            node.Name,
-					ResourceVersion: node.ResourceVersion,
-				},
-				Spec: slim_corev1.NodeSpec{
-					Taints: node.Spec.Taints,
-				},
-				Status: slim_corev1.NodeStatus{
-					Conditions: node.Status.Conditions,
-				},
-			},
-		}
-		// Small GC optimization
-		*node = slim_corev1.Node{}
-		return dfsu
-	default:
-		return obj
-	}
-}
-
-func processNextNodeItem(c kubernetes.Interface, nodeGetter slimNodeGetter, workQueue workqueue.RateLimitingInterface) bool {
+func checkTaintForNextNodeItem(c kubernetes.Interface, nodeGetter slimNodeGetter, workQueue workqueue.RateLimitingInterface) bool {
 	// Get the next 'key' from the queue.
 	key, quit := workQueue.Get()
 	if quit {
@@ -519,5 +406,14 @@ func HandleNodeTolerationAndTaints(stopCh <-chan struct{}) {
 		SetCiliumIsUpCondition: option.Config.SetCiliumIsUpCondition,
 	}
 	nodesInit(k8s.WatcherClient(), stopCh)
+
+	go func() {
+		// Do not use the k8sClient provided by the nodesInit function since we
+		// need a k8s client that can update node structures and not simply
+		// watch for node events.
+		for checkTaintForNextNodeItem(k8s.Client(), &nodeGetter{}, nodeQueue) {
+		}
+	}()
+
 	ciliumPodsWatcher(k8s.WatcherClient(), stopCh)
 }

--- a/operator/watchers/node_taint_test.go
+++ b/operator/watchers/node_taint_test.go
@@ -145,7 +145,7 @@ func (n *NodeTaintSuite) TestNodeTaintWithoutCondition(c *check.C) {
 
 	nodeQueue.Add(key)
 
-	continueProcess := processNextNodeItem(fakeClient, fng, nodeQueue)
+	continueProcess := checkTaintForNextNodeItem(fakeClient, fng, nodeQueue)
 	c.Assert(continueProcess, check.Equals, true)
 
 	err = testutils.WaitUntil(func() bool {
@@ -278,7 +278,7 @@ func (n *NodeTaintSuite) TestNodeCondition(c *check.C) {
 
 	nodeQueue.Add(key)
 
-	continueProcess := processNextNodeItem(fakeClient, fng, nodeQueue)
+	continueProcess := checkTaintForNextNodeItem(fakeClient, fng, nodeQueue)
 	c.Assert(continueProcess, check.Equals, true)
 
 	err = testutils.WaitUntil(func() bool {
@@ -384,7 +384,7 @@ func (n *NodeTaintSuite) TestNodeConditionIfCiliumIsNotReady(c *check.C) {
 
 	nodeQueue.Add(key)
 
-	continueProcess := processNextNodeItem(fakeClient, fng, nodeQueue)
+	continueProcess := checkTaintForNextNodeItem(fakeClient, fng, nodeQueue)
 	c.Assert(continueProcess, check.Equals, true)
 
 	err = testutils.WaitUntil(func() bool {
@@ -490,7 +490,7 @@ func (n *NodeTaintSuite) TestNodeConditionIfCiliumAndNodeAreReady(c *check.C) {
 
 	nodeQueue.Add(key)
 
-	continueProcess := processNextNodeItem(fakeClient, fng, nodeQueue)
+	continueProcess := checkTaintForNextNodeItem(fakeClient, fng, nodeQueue)
 	c.Assert(continueProcess, check.Equals, true)
 
 	err = testutils.WaitUntil(func() bool {


### PR DESCRIPTION
### Description

In the normal scenario, CiliumNode is created by agent with owner
references attached all time time in below PR[0]. However, there could
be the case that CiliumNode is created by IPAM module[1], which
didn't have any ownerReferences at all. For this case, if the
corresponding node got terminated and never came back with same
name, the CiliumNode resource is still dangling, and needs to be
garbage collected.

This commit is to add garbage collector for CiliumNode, with below
logic:

- Gargage collector will run every predefined interval (e.g. specify
  by flag --nodes-gc-interval)
- Each run will check if CiliumNode is having a counterpart k8s node
  resource. Also, remove this node from GC candidate if required.
- If yes, CiliumNode is considered as valid, happy day.
- If no, check if ownerReferences are set.
  - If yes, let k8s perform garbage collection.
  - If no, mark the node as GC candidate. If in the next run, this
    node is still in GC candidate, remove it.

### Testing

Testing was done locally with kind cluster

<details>
<summary>Create one dummy ciliumnode and check gc </summary>

```
$ ksyslo deployment/cilium-operator --timestamps | grep kind-worker-dummy
2022-04-26T10:59:22.106774489Z level=debug msg="UpdatedStatus Node" error="<nil>" node-name=kind-worker-dummy subsys=pod-cidr
2022-04-26T10:59:23.087007602Z level=debug msg="UpdatedStatus Node" error="<nil>" node-name=kind-worker-dummy subsys=pod-cidr
2022-04-26T10:59:51.977272944Z level=info msg="Add CiliumNode to garbage collector candidates" nodeName=kind-worker-dummy subsys=watchers
2022-04-26T11:00:21.978387751Z level=info msg="Perform GC for invalid CiliumNode" nodeName=kind-worker-dummy subsys=watchers

$ kg ciliumnodes
NAME                 AGE
kind-control-plane   156m
kind-worker          156m
```

</details>