### PR TITLE
v1.9 backports 2022-04-26

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -70,6 +70,7 @@ author = u'Cilium Authors'
 release = open("../VERSION", "r").read().strip()
 # Used by version warning
 versionwarning_body_selector = "div.document"
+versionwarning_api_url = "docs.cilium.io"
 
 # The version of Go used to compile Cilium
 go_release = open("../GO_VERSION", "r").read().strip()

--- a/Documentation/gettingstarted/local-redirect-policy.rst
+++ b/Documentation/gettingstarted/local-redirect-policy.rst
@@ -33,8 +33,8 @@ the redirection.
 
 .. include:: ../beta.rst
 
-Deploy Cilium
-===============
+Prerequisites
+=============
 
 .. note::
 

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -172,7 +172,7 @@ pipeline {
         }
         stage ("Copy code and boot vms"){
             options {
-                timeout(time: 50, unit: 'MINUTES')
+                timeout(time: 30, unit: 'MINUTES')
             }
 
             environment {
@@ -205,10 +205,8 @@ pipeline {
             }
             steps {
                 withCredentials([usernamePassword(credentialsId: 'CILIUM_BOT_DUMMY', usernameVariable: 'DOCKER_LOGIN', passwordVariable: 'DOCKER_PASSWORD')]) {
-                    retry(3) {
-                        dir("${TESTDIR}") {
-                            sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 15m ./vagrant-ci-start.sh'
-                        }
+                    dir("${TESTDIR}") {
+                        sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" timeout 25m ./vagrant-ci-start.sh'
                     }
                 }
             }

--- a/pkg/k8s/apis/cilium.io/v2/clrp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/clrp_types.go
@@ -228,8 +228,14 @@ func (pInfo *PortInfo) SanitizePortInfo(checkNamedPort bool) (uint16, string, lb
 	}
 	// Sanitize name
 	if checkNamedPort {
+		if pInfo.Name == "" {
+			return pInt, pName, protocol, fmt.Errorf("port %s in the local "+
+				"redirect policy spec must have a valid IANA_SVC_NAME, as there are multiple ports", pInfo.Port)
+
+		}
 		if !iana.IsSvcName(pInfo.Name) {
-			return pInt, pName, protocol, fmt.Errorf("valid port name is not present")
+			return pInt, pName, protocol, fmt.Errorf("port name %s isn't a "+
+				"valid IANA_SVC_NAME", pInfo.Name)
 		}
 	}
 	pName = strings.ToLower(pInfo.Name) // Normalize for case insensitive comparison


### PR DESCRIPTION
* #19458 -- jenkinsfiles: Increase VM boot timeout (@pchaigno)
   * The whole patch conflicted, so I attempted to apply the same changes
     directly against the v1.9 tree: Lower overall timeout, increase bootstrap
     timeout, remove the loop to try provisioning 3 times.
 * #19489 -- LRP minor improvements (@aditighag)
 * #19563 -- docs: fix version warning URL to point to docs.cilium.io (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19458 19489 19563; do contrib/backporting/set-labels.py $pr done 1.9; done
```