### PR TITLE
v1.10 backports 2022-04-26

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -70,6 +70,7 @@ author = u'Cilium Authors'
 release = open("../VERSION", "r").read().strip()
 # Used by version warning
 versionwarning_body_selector = "div.document"
+versionwarning_api_url = "docs.cilium.io"
 
 # The version of Go used to compile Cilium
 go_release = open("../GO_VERSION", "r").read().strip()

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ JOB_BASE_NAME ?= cilium_test
 GO_VERSION := $(shell cat GO_VERSION)
 GO_MAJOR_AND_MINOR_VERSION := $(shell sed 's/\([0-9]\+\).\([0-9]\+\)\(.[0-9]\+\)\?/\1.\2/' GO_VERSION)
 GO_IMAGE_VERSION := $(shell awk -F. '{ z=$$3; if (z == "") z=0; print $$1 "." $$2 "." z}' GO_VERSION)
+GO_INSTALLED_MAJOR_AND_MINOR_VERSION := $(shell $(GO) version | sed 's/go version go\([0-9]\+\).\([0-9]\+\)\(.[0-9]\+\)\?.*/\1.\2/')
 
 DOCKER_FLAGS ?=
 
@@ -500,7 +501,7 @@ microk8s: check-microk8s ## Build cilium-dev docker image and import to mircrok8
 kind: ## Create a kind cluster for Cilium development.
 	$(QUIET)./contrib/scripts/kind.sh
 
-precheck: logging-subsys-field ## Peform build precheck for the source code.
+precheck: check-go-version logging-subsys-field ## Peform build precheck for the source code.
 ifeq ($(SKIP_K8S_CODE_GEN_CHECK),"false")
 	@$(ECHO_CHECK) contrib/scripts/check-k8s-code-gen.sh
 	$(QUIET) contrib/scripts/check-k8s-code-gen.sh
@@ -570,6 +571,14 @@ postcheck: build ## Run Cilium build postcheck (update-cmdref, build documentati
 
 licenses-all: ## Generate file with all the License from dependencies.
 	@$(GO) run ./tools/licensegen > LICENSE.all || ( rm -f LICENSE.all ; false )
+
+check-go-version: ## Check locally install Go version against required Go version.
+ifneq ($(GO_MAJOR_AND_MINOR_VERSION),$(GO_INSTALLED_MAJOR_AND_MINOR_VERSION))
+	@echo "Installed Go version $(GO_INSTALLED_MAJOR_AND_MINOR_VERSION) does not match requested Go version $(GO_MAJOR_AND_MINOR_VERSION)"
+	@exit 1
+else
+	@$(ECHO_CHECK) "Installed Go version $(GO_INSTALLED_MAJOR_AND_MINOR_VERSION) matches required version $(GO_MAJOR_AND_MINOR_VERSION)"
+endif
 
 update-go-version: update-dev-doctor-go-version update-gh-actions-go-version update-travis-go-version update-test-go-version update-images-go-version ## Update Go version for all the components (travis, dev-doctor, gh-actions etc.).
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -465,7 +465,7 @@ func createEndpoint(owner regeneration.Owner, proxy EndpointProxy, allocator cac
 		OpLabels:        labels.NewOpLabels(),
 		DNSRules:        nil,
 		DNSHistory:      fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
-		DNSZombies:      fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes),
+		DNSZombies:      fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
 		state:           "",
 		status:          NewEndpointStatus(),
 		hasBPFProgram:   make(chan struct{}, 0),

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -524,7 +524,7 @@ func (ep *Endpoint) UnmarshalJSON(raw []byte) error {
 	restoredEp := &serializableEndpoint{
 		OpLabels:   labels.NewOpLabels(),
 		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
-		DNSZombies: fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes),
+		DNSZombies: fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
 	}
 	if err := json.Unmarshal(raw, restoredEp); err != nil {
 		return fmt.Errorf("error unmarshaling serializableEndpoint from base64 representation: %s", err)

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -25,9 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // cacheEntry objects hold data passed in via DNSCache.Update, nominally
@@ -727,13 +725,17 @@ type DNSZombieMappings struct {
 	deletes        map[string]*DNSZombieMapping // map[ip]toDelete
 	lastCTGCUpdate time.Time
 	max            int // max allowed zombies
+
+	// perHostLimit is the number of maximum number of IP per host.
+	perHostLimit int
 }
 
 // NewDNSZombieMappings constructs a DNSZombieMappings that is read to use
-func NewDNSZombieMappings(max int) *DNSZombieMappings {
+func NewDNSZombieMappings(max, perHostLimit int) *DNSZombieMappings {
 	return &DNSZombieMappings{
-		deletes: make(map[string]*DNSZombieMapping),
-		max:     max,
+		deletes:      make(map[string]*DNSZombieMapping),
+		max:          max,
+		perHostLimit: perHostLimit,
 	}
 }
 
@@ -773,12 +775,16 @@ func (zombies *DNSZombieMappings) isConnectionAlive(zombie *DNSZombieMapping) bo
 
 // getAliveNames returns all the names that are alive
 //   a name is alive if at least one of the IPs that resolve to it is alive
-func (zombies *DNSZombieMappings) getAliveNames() map[string]struct{} {
-	var aliveNames map[string]struct{} = map[string]struct{}{}
+func (zombies *DNSZombieMappings) getAliveNames() map[string][]*DNSZombieMapping {
+	aliveNames := make(map[string][]*DNSZombieMapping)
+
 	for _, z := range zombies.deletes {
 		if zombies.isConnectionAlive(z) {
 			for _, name := range z.Names {
-				aliveNames[name] = struct{}{}
+				if _, ok := aliveNames[name]; !ok {
+					aliveNames[name] = make([]*DNSZombieMapping, 0, 5)
+				}
+				aliveNames[name] = append(aliveNames[name], z)
 			}
 		}
 	}
@@ -791,22 +797,27 @@ func (zombies *DNSZombieMappings) getAliveNames() map[string]struct{} {
 // A zombie is alive if its connection is alive or if one of its names is
 // alive. The function takes an argument that contains the aliveNames (can be
 // obtained via getAliveNames())
-func (zombies *DNSZombieMappings) isZombieAlive(zombie *DNSZombieMapping, aliveNames map[string]struct{}) bool {
+func (zombies *DNSZombieMappings) isZombieAlive(zombie *DNSZombieMapping, aliveNames map[string][]*DNSZombieMapping) (alive, overLimit bool) {
 	if zombies.isConnectionAlive(zombie) {
-		return true
-	}
-
-	for _, name := range zombie.Names {
-		if _, ok := aliveNames[name]; ok {
-			log.WithFields(logrus.Fields{
-				logfields.DNSName: name,
-				logfields.IPAddr:  zombie.IP,
-			}).Debug("FQDN has multiple IPs. One IP has an expired TTL.")
-			return true
+		alive = true
+		if zombies.perHostLimit == 0 {
+			return alive, overLimit
 		}
 	}
 
-	return false
+	for _, name := range zombie.Names {
+		if z, ok := aliveNames[name]; ok {
+			alive = true
+			if zombies.perHostLimit == 0 {
+				return alive, overLimit
+			} else if len(z) > zombies.perHostLimit {
+				overLimit = true
+				return alive, overLimit
+			}
+		}
+	}
+
+	return alive, overLimit
 }
 
 // sortZombieMappingSlice sorts the provided slice by whether the connection is
@@ -834,15 +845,66 @@ func (zombies *DNSZombieMappings) GC() (alive, dead []*DNSZombieMapping) {
 	zombies.Lock()
 	defer zombies.Unlock()
 
-	var aliveNames map[string]struct{} = zombies.getAliveNames()
+	aliveNames := zombies.getAliveNames()
 
 	// Collect zombies we can delete
 	for _, zombie := range zombies.deletes {
-		if zombies.isZombieAlive(zombie, aliveNames) {
+		zombieAlive, overLimit := zombies.isZombieAlive(zombie, aliveNames)
+		if overLimit {
+			// No-op: This zombie is part of a name in 'aliveNames'
+			// that needs to impose a per-host IP limit. Decide
+			// whether to add to alive or dead in the next loop.
+		} else if zombieAlive {
 			alive = append(alive, zombie.DeepCopy())
 		} else {
 			// Emit the actual object here since we will no longer update it
 			dead = append(dead, zombie)
+		}
+	}
+
+	if zombies.perHostLimit > 0 {
+		warnActiveDNSEntries := false
+		deadIdx := len(dead)
+
+		// Find names which have too many IPs associated mark them dead.
+		//
+		// Multiple names can refer to the same IP, so if we expire the
+		// zombie by IP then we need to ensure that it doesn't get
+		// added to both 'alive' and 'dead'.
+		//
+		// 1) Assemble all of the 'dead', starting from 'deadIdx'.
+		//    Assemble alive candidates in 'possibleAlive'.
+		// 2) Ensure that 'possibleAlive' doesn't contain any of the
+		//    entries in 'dead[deadIdx:]'.
+		// 3) Add the remaining 'possibleAlive' to 'alive'.
+		possibleAlive := make(map[*DNSZombieMapping]struct{})
+		for _, aliveIPsForName := range aliveNames {
+			if len(aliveIPsForName) <= zombies.perHostLimit {
+				// Already handled in the loop above.
+				continue
+			}
+			overLimit := len(aliveIPsForName) - zombies.perHostLimit
+			sortZombieMappingSlice(aliveIPsForName)
+			dead = append(dead, aliveIPsForName[:overLimit]...)
+			for _, z := range aliveIPsForName[overLimit:] {
+				possibleAlive[z] = struct{}{}
+			}
+			if dead[len(dead)-1].AliveAt.IsZero() {
+				warnActiveDNSEntries = true
+			}
+		}
+		if warnActiveDNSEntries {
+			log.Warningf("Evicting expired DNS cache entries that may be in-use due to per-host limits. This may cause recently created connections to be disconnected. Raise %s to mitigate this.", option.ToFQDNsMaxIPsPerHost)
+		}
+
+		for _, dead := range dead[deadIdx:] {
+			if _, ok := possibleAlive[dead]; ok {
+				delete(possibleAlive, dead)
+			}
+		}
+
+		for zombie := range possibleAlive {
+			alive = append(alive, zombie.DeepCopy())
 		}
 	}
 
@@ -988,7 +1050,7 @@ func (zombies *DNSZombieMappings) DumpAlive(cidrMatcher CIDRMatcherFunc) (alive 
 
 	aliveNames := zombies.getAliveNames()
 	for _, zombie := range zombies.deletes {
-		if !zombies.isZombieAlive(zombie, aliveNames) {
+		if alive, _ := zombies.isZombieAlive(zombie, aliveNames); !alive {
 			continue
 		}
 		// only proceed if zombie is alive and the IP matches the CIDR selector

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -809,6 +809,19 @@ func (zombies *DNSZombieMappings) isZombieAlive(zombie *DNSZombieMapping, aliveN
 	return false
 }
 
+// sortZombieMappingSlice sorts the provided slice by whether the connection is
+// marked alive or not, the oldest created connections, and tie-break by the
+// number of DNS names for that IP.
+//
+// Important zombies shuffle to the end of the slice.
+func sortZombieMappingSlice(alive []*DNSZombieMapping) {
+	sort.Slice(alive, func(i, j int) bool {
+		return alive[i].AliveAt.Before(alive[j].AliveAt) ||
+			alive[i].DeletePendingAt.Before(alive[j].DeletePendingAt) ||
+			len(alive[i].Names) < len(alive[j].Names)
+	})
+}
+
 // GC returns alive and dead DNSZombieMapping entries. This removes dead
 // zombies interally, and repeated calls will return different data.
 // Zombies are alive if they have been marked alive (with MarkAlive). When
@@ -839,11 +852,7 @@ func (zombies *DNSZombieMappings) GC() (alive, dead []*DNSZombieMapping) {
 	// that IP.
 	overLimit := len(alive) - zombies.max
 	if overLimit > 0 {
-		sort.Slice(alive, func(i, j int) bool {
-			return alive[i].AliveAt.Before(alive[j].AliveAt) ||
-				alive[i].DeletePendingAt.Before(alive[j].DeletePendingAt) ||
-				len(alive[i].Names) < len(alive[j].Names)
-		})
+		sortZombieMappingSlice(alive)
 		dead = append(dead, alive[:overLimit]...)
 		alive = alive[overLimit:]
 		if dead[len(dead)-1].AliveAt.IsZero() {

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -625,7 +625,7 @@ func assertZombiesContain(c *C, zombies []*DNSZombieMapping, mappings map[string
 
 func (ds *DNSCacheTestSuite) TestZombiesSiblingsGC(c *C) {
 	now := time.Now()
-	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes)
+	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
 
 	// Siblings are IPs that resolve to the same name.
 	zombies.Upsert(now, "1.1.1.1", "test.com")
@@ -650,7 +650,7 @@ func (ds *DNSCacheTestSuite) TestZombiesSiblingsGC(c *C) {
 
 func (ds *DNSCacheTestSuite) TestZombiesGC(c *C) {
 	now := time.Now()
-	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes)
+	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
 
 	zombies.Upsert(now, "1.1.1.1", "test.com")
 	zombies.Upsert(now, "2.2.2.2", "somethingelse.com")
@@ -729,9 +729,33 @@ func (ds *DNSCacheTestSuite) TestZombiesGC(c *C) {
 	})
 }
 
+func (ds *DNSCacheTestSuite) TestZombiesGCOverLimit(c *C) {
+	now := time.Now()
+	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes, 1)
+
+	// Limit the total number of IPs to be associated with a specific host
+	// to 1, but associate 'test.com' with multiple IPs.
+	zombies.Upsert(now, "1.1.1.1", "test.com")
+	zombies.Upsert(now, "2.2.2.2", "somethingelse.com", "test.com")
+	zombies.Upsert(now, "3.3.3.3", "anothertest.com")
+
+	// Based on the zombie liveness sorting, the '2.2.2.2' entry is more
+	// important (as it could potentially impact multiple apps connecting
+	// to different domains), so it should be kept alive when sweeping to
+	// enforce the max per-host IP limit for names.
+	alive, dead := zombies.GC()
+	assertZombiesContain(c, dead, map[string][]string{
+		"1.1.1.1": {"test.com"},
+	})
+	assertZombiesContain(c, alive, map[string][]string{
+		"2.2.2.2": {"somethingelse.com", "test.com"},
+		"3.3.3.3": {"anothertest.com"},
+	})
+}
+
 func (ds *DNSCacheTestSuite) TestZombiesGCDeferredDeletes(c *C) {
 	now := time.Now()
-	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes)
+	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
 
 	zombies.Upsert(now.Add(0*time.Second), "1.1.1.1", "test.com")
 	zombies.Upsert(now.Add(1*time.Second), "2.2.2.2", "somethingelse.com")
@@ -746,7 +770,7 @@ func (ds *DNSCacheTestSuite) TestZombiesGCDeferredDeletes(c *C) {
 		"3.3.3.3": {"onemorething.com"},
 	})
 
-	zombies = NewDNSZombieMappings(2)
+	zombies = NewDNSZombieMappings(2, defaults.ToFQDNsMaxIPsPerHost)
 	zombies.Upsert(now.Add(0*time.Second), "1.1.1.1", "test.com")
 
 	// No zombies should be evicted because we are below the limit
@@ -789,7 +813,7 @@ func (ds *DNSCacheTestSuite) TestZombiesGCDeferredDeletes(c *C) {
 
 func (ds *DNSCacheTestSuite) TestZombiesForceExpire(c *C) {
 	now := time.Now()
-	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes)
+	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
 
 	zombies.Upsert(now, "1.1.1.1", "test.com", "anothertest.com")
 	zombies.Upsert(now, "2.2.2.2", "somethingelse.com")
@@ -864,7 +888,7 @@ func (ds *DNSCacheTestSuite) TestZombiesForceExpire(c *C) {
 func (ds *DNSCacheTestSuite) TestCacheToZombiesGCCascade(c *C) {
 	now := time.Now()
 	cache := NewDNSCache(0)
-	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes)
+	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
 
 	// Add entries that should expire at different times
 	cache.Update(now, "test.com", []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}, 3)
@@ -895,7 +919,7 @@ func (ds *DNSCacheTestSuite) TestCacheToZombiesGCCascade(c *C) {
 
 func (ds *DNSCacheTestSuite) TestZombiesDumpAlive(c *C) {
 	now := time.Now()
-	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes)
+	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
 
 	alive := zombies.DumpAlive(nil)
 	c.Assert(alive, HasLen, 0)


### PR DESCRIPTION
 * ~#19153 -- metrics: Add go_* metrics (@chancez)~
   * Skipped due to vendor breakage
 * #19528 -- make: check that Go major/minor version matches required version (@tklauser)
   * Makefile conflicts, I think we just need to add the new target & hook it in like I've done here.
 * #19452 -- Limit the number of active FQDNs beyond the TTL to `--tofqdns-endpoint-max-ip-per-hostname` (@joestringer)
   * Minor conflicts in `pkg/endpoint/endpoint.go`, `pkg/fqdn/cache.go`.
 * #19563 -- docs: fix version warning URL to point to docs.cilium.io (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19528 19452 19563; do contrib/backporting/set-labels.py $pr done 1.10; done
```