### PR TITLE
datapath: Allow egress GW with XDP

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -337,16 +337,11 @@ func initKubeProxyReplacementOptions() (bool, error) {
 			option.Config.NodePortMode = option.NodePortModeSNAT
 		}
 
-		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
-			if option.Config.TunnelingEnabled() {
-				return false, fmt.Errorf("Cannot use NodePort acceleration with tunneling. Either run cilium-agent with --%s=%s or --%s=%s",
-					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.TunnelName, option.TunnelDisabled)
-			}
+		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled &&
+			option.Config.TunnelingEnabled() {
 
-			if option.Config.EnableIPv4EgressGateway {
-				return false, fmt.Errorf("Cannot use NodePort acceleration with the egress gateway. Run cilium-agent with either --%s=%s or %s=false",
-					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.EnableIPv4EgressGateway)
-			}
+			return false, fmt.Errorf("Cannot use NodePort acceleration with tunneling. Either run cilium-agent with --%s=%s or --%s=%s",
+				option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.TunnelName, option.TunnelDisabled)
 		}
 
 		if option.Config.NodePortMode == option.NodePortModeDSR &&


### PR DESCRIPTION
This commit allows a user to use the egress GW feature with XDP
(--bpf-lb-acceleration != disabled). However, a support for the
redirection from the reverse egress GW traffic to a tunnel netdev from
bpf_xdp is still missing \[1\].

With the current approach, when enabling the egress GW together with XDP
a reply packets might be dropped if the iptables' default policy for the
FORWARD chain is DROP.

The egress GW reply packet will be handled by the bpf_xdp which will do
the reverse SNAT translation. Also, it will set XFER_PKT_NO_SVC to
prevent the bpf_host (attached to the same netdev as the bpf_xdp) to
call nodeport_lb4() (perf optimization). The latter function is the
entry point not only for the NodePort BPF, but also for the egress GW.
Therefore, due to XFER_PKT_NO_SVC, the reply won't be handled by the
bpf_host. As a consequence, it won't be redirected to the tunnel netdev
and it will be passed to the stack. Instead of redirecting the reply to
the tunnel netdev, the stack might drop the packet if the FORWARD policy
is set to DROP.

This will be fixed in \[1\] once we do the encap from bpf_xdp.

\[1\]: https://github.com/cilium/cilium/issues/17770

Related #17770 (it does NOT close it though).