### PR TITLE
pkg/k8s: use subresource "nodes/status" to update node annotations

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -39,10 +39,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - nodes/status
   verbs:
   # To annotate the k8s node with Cilium's metadata
-  - update
+  - patch
 {{- end }}
 - apiGroups:
   - apiextensions.k8s.io

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -39,10 +39,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - nodes/status
   verbs:
   # To annotate the k8s node with Cilium's metadata
-  - update
+  - patch
 {{- end }}
 - apiGroups:
   - apiextensions.k8s.io

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -80,7 +80,7 @@ func updateNodeAnnotation(c kubernetes.Interface, nodeName string, encryptKey ui
 	}
 	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":%s}}`, raw))
 
-	_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.StrategicMergePatchType, patch, v1.PatchOptions{})
+	_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.StrategicMergePatchType, patch, v1.PatchOptions{}, "status")
 
 	return err
 }

--- a/pkg/k8s/init_test.go
+++ b/pkg/k8s/init_test.go
@@ -47,12 +47,6 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	k8sCLI.Interface = fakeK8sClient
 	fakeK8sClient.AddReactor("patch", "nodes",
 		func(action testing.Action) (bool, runtime.Object, error) {
-			// If subresource is empty it means we are patching status and not
-			// patching annotations
-			if action.GetSubresource() != "" {
-				return true, nil, nil
-			}
-
 			n1copy := node1.DeepCopy()
 			n1copy.Annotations[annotation.V4CIDRName] = "10.2.0.0/16"
 			raw, err := json.Marshal(n1copy.Annotations)
@@ -112,11 +106,6 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	k8sCLI.Interface = fakeK8sClient
 	fakeK8sClient.AddReactor("patch", "nodes",
 		func(action testing.Action) (bool, runtime.Object, error) {
-			// If subresource is empty it means we are patching status and not
-			// patching annotations
-			if action.GetSubresource() != "" {
-				return true, nil, nil
-			}
 			// first call will be a patch for annotations
 			if failAttempts == 0 {
 				failAttempts++


### PR DESCRIPTION
We can use the "status" subresource to update node annotations which
also allow us to reduce the clusterrole's permissions of the cilium
DaemonSet even further.

Signed-off-by: André Martins <andre@cilium.io>