### PR TITLE
Add concurrency limiting for DNS message processing

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -11,254 +11,256 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --agent-health-port int                                TCP port for agent health status API (default 9876)
-      --agent-labels strings                                 Additional labels to identify this agent
-      --allocator-list-timeout duration                      Timeout for listing allocator state before exiting (default 3m0s)
-      --allow-icmp-frag-needed                               Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
-      --allow-localhost string                               Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
-      --annotate-k8s-node                                    Annotate Kubernetes node
-      --api-rate-limit map                                   API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
-      --arping-refresh-period duration                       Period for remote node ARP entry refresh (set 0 to disable) (default 30s)
-      --auto-create-cilium-node-resource                     Automatically create CiliumNode resource for own node on startup (default true)
-      --auto-direct-node-routes                              Enable automatic L2 routing between nodes
-      --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
-      --bgp-announce-pod-cidr                                Announces the node's pod CIDR via BGP
-      --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bpf-ct-global-any-max int                            Maximum number of entries in non-TCP CT table (default 262144)
-      --bpf-ct-global-tcp-max int                            Maximum number of entries in TCP CT table (default 524288)
-      --bpf-ct-timeout-regular-any duration                  Timeout for entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-regular-tcp duration                  Timeout for established entries in TCP CT table (default 6h0m0s)
-      --bpf-ct-timeout-regular-tcp-fin duration              Teardown timeout for entries in TCP CT table (default 10s)
-      --bpf-ct-timeout-regular-tcp-syn duration              Establishment timeout for entries in TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-any duration                  Timeout for service entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-tcp duration                  Timeout for established service entries in TCP CT table (default 6h0m0s)
-      --bpf-fragments-map-max int                            Maximum number of entries in fragments tracking map (default 8192)
-      --bpf-lb-acceleration string                           BPF load balancing acceleration via XDP ("native", "disabled") (default "disabled")
-      --bpf-lb-algorithm string                              BPF load balancing algorithm ("random", "maglev") (default "random")
-      --bpf-lb-dev-ip-addr-inherit string                    Device name which IP addr is inherited by devices running LB BPF program (--devices)
-      --bpf-lb-dsr-dispatch string                           BPF load balancing DSR dispatch method ("opt", "ipip") (default "opt")
-      --bpf-lb-dsr-l4-xlate string                           BPF load balancing DSR L4 DNAT method for IPIP ("frontend", "backend") (default "frontend")
-      --bpf-lb-external-clusterip                            Enable external access to ClusterIP services (default false)
-      --bpf-lb-maglev-hash-seed string                       Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
-      --bpf-lb-maglev-table-size uint                        Maglev per service backend table size (parameter M) (default 16381)
-      --bpf-lb-map-max int                                   Maximum number of entries in Cilium BPF lbmap (default 65536)
-      --bpf-lb-mode string                                   BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
-      --bpf-lb-rss-ipv4-src-cidr string                      BPF load balancing RSS outer source IPv4 CIDR prefix for IPIP
-      --bpf-lb-rss-ipv6-src-cidr string                      BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP
-      --bpf-lb-sock-hostns-only                              Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).
-      --bpf-map-dynamic-size-ratio float                     Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
-      --bpf-nat-global-max int                               Maximum number of entries for the global BPF NAT table (default 524288)
-      --bpf-neigh-global-max int                             Maximum number of entries for the global BPF neighbor table (default 524288)
-      --bpf-policy-map-max int                               Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
-      --bpf-root string                                      Path to BPF filesystem
-      --bpf-sock-rev-map-max int                             Maximum number of entries for the SockRevNAT BPF map (default 262144)
-      --certificates-directory string                        Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cgroup-root string                                   Path to Cgroup2 filesystem
-      --cluster-health-port int                              TCP port for cluster-wide network connectivity health API (default 4240)
-      --cluster-id int                                       Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --conntrack-gc-interval duration                       Overwrite the connection-tracking garbage collection interval
-      --crd-wait-timeout duration                            Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
-      --datapath-mode string                                 Datapath mode name (default "veth")
-  -D, --debug                                                Enable debugging mode
-      --debug-verbose strings                                List of enabled verbose debug groups
-      --devices strings                                      List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
-      --direct-routing-device string                         Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
-      --disable-cnp-status-updates                           Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)
-      --disable-endpoint-crd                                 Disable use of CiliumEndpoint CRD
-      --disable-iptables-feeder-rules strings                Chains to ignore when installing feeder rules.
-      --dns-max-ips-per-restored-rule int                    Maximum number of IPs to maintain for each restored DNS rule (default 1000)
-      --dns-policy-unload-on-shutdown                        Unload DNS policy rules on graceful shutdown
-      --egress-masquerade-interfaces string                  Limit egress masquerading to interface selector
-      --egress-multi-home-ip-rule-compat                     Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
-      --enable-auto-protect-node-port-range                  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
-      --enable-bandwidth-manager                             Enable BPF bandwidth manager
-      --enable-bbr                                           Enable BBR for the bandwidth manager
-      --enable-bgp-control-plane                             Enable the BGP control plane.
-      --enable-bpf-clock-probe                               Enable BPF clock source probing for more efficient tick retrieval
-      --enable-bpf-masquerade                                Masquerade packets from endpoints leaving the host with BPF instead of iptables
-      --enable-bpf-tproxy                                    Enable BPF-based proxy redirection, if support available
-      --enable-cilium-endpoint-slice                         If set to true, CiliumEndpointSlice feature is enabled and cilium agent watch for CiliumEndpointSlice instead of CiliumEndpoint to update the IPCache.
-      --enable-custom-calls                                  Enable tail call hooks for custom eBPF programs
-      --enable-endpoint-health-checking                      Enable connectivity health checking between virtual endpoints (default true)
-      --enable-endpoint-routes                               Use per endpoint routes instead of routing via cilium_host
-      --enable-envoy-config                                  Enable Envoy Config CRDs
-      --enable-external-ips                                  Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
-      --enable-health-check-nodeport                         Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
-      --enable-health-checking                               Enable connectivity health checking (default true)
-      --enable-host-firewall                                 Enable host network policies
-      --enable-host-legacy-routing                           Enable the legacy host forwarding model which does not bypass upper stack in host namespace
-      --enable-host-port                                     Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
-      --enable-host-reachable-services                       Enable reachability of services for host applications
-      --enable-hubble                                        Enable hubble server
-      --enable-hubble-recorder-api                           Enable the Hubble recorder API (default true)
-      --enable-identity-mark                                 Enable setting identity mark for local traffic (default true)
-      --enable-ip-masq-agent                                 Enable BPF ip-masq-agent
-      --enable-ipsec                                         Enable IPSec support
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv4-egress-gateway                           Enable egress gateway for IPv4
-      --enable-ipv4-fragment-tracking                        Enable IPv4 fragments tracking for L4-based lookups (default true)
-      --enable-ipv4-masquerade                               Masquerade IPv4 traffic from endpoints leaving the host (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-ipv6-masquerade                               Masquerade IPv6 traffic from endpoints leaving the host (default true)
-      --enable-ipv6-ndp                                      Enable IPv6 NDP support
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-k8s-event-handover                            Enable k8s event handover to kvstore for improved scalability
-      --enable-k8s-terminating-endpoint                      Enable auto-detect of terminating endpoint condition (default true)
-      --enable-l2-neigh-discovery                            Enables L2 neighbor discovery used by kube-proxy-replacement and IPsec (default true)
-      --enable-l7-proxy                                      Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-local-node-route                              Enable installation of the route which points the allocation prefix of the local node (default true)
-      --enable-local-redirect-policy                         Enable Local Redirect Policy
-      --enable-monitor                                       Enable the monitor unix domain socket server (default true)
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enable-policy string                                 Enable policy enforcement (default "default")
-      --enable-recorder                                      Enable BPF datapath pcap recorder
-      --enable-remote-node-identity                          Enable use of remote node identity
-      --enable-service-topology                              Enable support for service topology aware hints
-      --enable-session-affinity                              Enable support for service session affinity
-      --enable-svc-source-range-check                        Enable check of service source ranges (currently, only for LoadBalancer) (default true)
-      --enable-tracing                                       Enable tracing while determining policy (debugging)
-      --enable-unreachable-routes                            Add unreachable routes on pod deletion
-      --enable-vtep                                          Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)
-      --enable-well-known-identities                         Enable well-known identities for known Kubernetes components (default true)
-      --enable-wireguard                                     Enable wireguard
-      --enable-wireguard-userspace-fallback                  Enables the fallback to the wireguard userspace implementation
-      --enable-xdp-prefilter                                 Enable XDP prefiltering
-      --enable-xt-socket-fallback                            Enable fallback for missing xt_socket module (default true)
-      --encrypt-interface string                             Transparent encryption interface
-      --encrypt-node                                         Enables encrypting traffic from non-Cilium pods and host networking
-      --endpoint-queue-size int                              size of EventQueue per-endpoint (default 25)
-      --endpoint-status strings                              Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
-      --envoy-config-timeout duration                        Timeout duration for Envoy Config acknowledgements (default 2m0s)
-      --envoy-log string                                     Path to a separate Envoy log file, if any
-      --exclude-local-address strings                        Exclude CIDR from being recognized as local address
-      --fixed-identity-mapping map                           Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns
-      --force-local-policy-eval-at-source                    Force policy evaluation of all local communication at the source endpoint (default true)
-      --gops-port int                                        Port for gops server to listen on (default 9890)
-  -h, --help                                                 help for cilium-agent
-      --http-idle-timeout uint                               Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
-      --http-max-grpc-timeout uint                           Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
-      --http-normalize-path                                  Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution. (default true)
-      --http-request-timeout uint                            Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
-      --http-retry-count uint                                Number of retries performed after a forwarded request attempt fails (default 3)
-      --http-retry-timeout uint                              Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
-      --hubble-disable-tls                                   Allow Hubble server to run on the given listen address without TLS.
-      --hubble-event-buffer-capacity int                     Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
-      --hubble-event-queue-size int                          Buffer size of the channel to receive monitor events.
-      --hubble-export-file-compress                          Compress rotated Hubble export files.
-      --hubble-export-file-max-backups int                   Number of rotated Hubble export files to keep. (default 5)
-      --hubble-export-file-max-size-mb int                   Size in MB at which to rotate Hubble export file. (default 10)
-      --hubble-export-file-path string                       Filepath to write Hubble events to.
-      --hubble-listen-address string                         An additional address for Hubble server to listen to, e.g. ":4244"
-      --hubble-metrics strings                               List of Hubble metrics to enable.
-      --hubble-metrics-server string                         Address to serve Hubble metrics on.
-      --hubble-recorder-sink-queue-size int                  Queue size of each Hubble recorder sink (default 1024)
-      --hubble-recorder-storage-path string                  Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")
-      --hubble-socket-path string                            Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
-      --hubble-tls-cert-file string                          Path to the public key file for the Hubble server. The file must contain PEM encoded data.
-      --hubble-tls-client-ca-files strings                   Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --hubble-tls-key-file string                           Path to the private key file for the Hubble server. The file must contain PEM encoded data.
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-change-grace-period duration                Time to wait before using new identity on endpoint identity change (default 5s)
-      --identity-restore-grace-period duration               Time to wait before releasing unused restored CIDR identities during agent restart (default 10m0s)
-      --install-egress-gateway-routes                        Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
-      --install-iptables-rules                               Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
-      --install-no-conntrack-iptables-rules                  Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
-      --ip-allocation-timeout duration                       Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
-      --ip-masq-agent-config-path string                     ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
-      --ipam string                                          Backend to use for IPAM (default "cluster-pool")
-      --ipsec-key-file string                                Path to IPSec key file
-      --iptables-lock-timeout duration                       Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
-      --iptables-random-fully                                Set iptables flag random-fully on masquerading rules
-      --ipv4-native-routing-cidr string                      Allows to explicitly specify the IPv4 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag.
-      --ipv4-node string                                     IPv4 address of node (default "auto")
-      --ipv4-pod-subnets strings                             List of IPv4 pod subnets to preconfigure for encryption
-      --ipv4-range string                                    Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
-      --ipv4-service-loopback-address string                 IPv4 address for service loopback SNAT (default "169.254.42.1")
-      --ipv4-service-range string                            Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
-      --ipv6-cluster-alloc-cidr string                       IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
-      --ipv6-mcast-device string                             Device that joins a Solicited-Node multicast group for IPv6
-      --ipv6-native-routing-cidr string                      Allows to explicitly specify the IPv6 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag.
-      --ipv6-node string                                     IPv6 address of node (default "auto")
-      --ipv6-pod-subnets strings                             List of IPv6 pod subnets to preconfigure for encryption
-      --ipv6-range string                                    Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
-      --ipv6-service-range string                            Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
-      --join-cluster                                         Join a Cilium cluster via kvstore registration
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium is deployed in
-      --k8s-require-ipv4-pod-cidr                            Require IPv4 PodCIDR to be specified in node resource
-      --k8s-require-ipv6-pod-cidr                            Require IPv6 PodCIDR to be specified in node resource
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --k8s-watcher-endpoint-selector string                 K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
-      --keep-config                                          When restoring state, keeps containers' configuration in place
-      --kube-proxy-replacement string                        auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
-      --kube-proxy-replacement-healthz-bind-address string   The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
-      --kvstore string                                       Key-value store type
-      --kvstore-connectivity-timeout duration                Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
-      --kvstore-max-consecutive-quorum-errors int            Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure (default 2)
-      --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --kvstore-periodic-sync duration                       Periodic KVstore synchronization interval (default 5m0s)
-      --label-prefix-file string                             Valid label prefixes file path
-      --labels strings                                       List of label prefixes used to determine identity of an endpoint
-      --lib-dir string                                       Directory path to store runtime build environment (default "/var/lib/cilium")
-      --local-router-ipv4 string                             Link-local IPv4 used for Cilium's router devices
-      --local-router-ipv6 string                             Link-local IPv6 used for Cilium's router devices
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
-      --log-system-load                                      Enable periodic logging of system load
-      --metrics strings                                      Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
-      --monitor-aggregation string                           Level of monitor aggregation for traces from the datapath (default "None")
-      --monitor-aggregation-flags strings                    TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
-      --monitor-aggregation-interval duration                Monitor report interval when monitor aggregation is enabled (default 5s)
-      --monitor-queue-size int                               Size of the event queue when reading monitor events
-      --mtu int                                              Overwrite auto-detected MTU of underlying network
-      --node-port-bind-protection                            Reject application bind(2) requests to service ports in the NodePort range (default true)
-      --node-port-range strings                              Set the min/max NodePort port range (default [30000,32767])
-      --policy-audit-mode                                    Enable policy audit (non-drop) mode
-      --policy-queue-size int                                size of queues for policy-related events (default 100)
-      --pprof                                                Enable serving the pprof debugging API
-      --pprof-port int                                       Port that the pprof listens on (default 6060)
-      --preallocate-bpf-maps                                 Enable BPF map pre-allocation (default true)
-      --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
-      --procfs string                                        Root's proc filesystem path (default "/proc")
-      --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
-      --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
-      --proxy-gid uint                                       Group ID for proxy control plane sockets. (default 1337)
-      --proxy-max-connection-duration-seconds int            Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
-      --proxy-max-requests-per-connection int                Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
-      --proxy-prometheus-port int                            Port to serve Envoy metrics on. Default 0 (disabled).
-      --read-cni-conf string                                 Read to the CNI configuration at specified path to extract per node configuration
-      --restore                                              Restores state, if possible, from previous daemon (default true)
-      --route-metric int                                     Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
-      --sidecar-istio-proxy-image string                     Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
-      --single-cluster-route                                 Use a single cluster route instead of per node routes
-      --socket-path string                                   Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
-      --sockops-enable                                       Enable sockops when kernel supported
-      --state-dir string                                     Directory path to store runtime state (default "/var/run/cilium")
-      --tofqdns-dns-reject-response-code string              DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
-      --tofqdns-enable-dns-compression                       Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
-      --tofqdns-endpoint-max-ip-per-hostname int             Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
-      --tofqdns-idle-connection-grace-period duration        Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)
-      --tofqdns-max-deferred-connection-deletes int          Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
-      --tofqdns-min-ttl int                                  The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
-      --tofqdns-pre-cache string                             DNS cache data at this path is preloaded on agent startup
-      --tofqdns-proxy-port int                               Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
-      --tofqdns-proxy-response-max-delay duration            The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
-      --trace-payloadlen int                                 Length of payload to capture when tracing (default 128)
-  -t, --tunnel string                                        Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
-      --tunnel-port int                                      Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
-      --version                                              Print version information
-      --vlan-bpf-bypass ints                                 List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs
-      --vtep-cidr strings                                    List of VTEP CIDRs that will be routed towards VTEPs for traffic cluster egress
-      --vtep-endpoint strings                                List of VTEP IP addresses
-      --vtep-mac strings                                     List of VTEP MAC addresses for forwarding traffic outside the cluster
-      --vtep-mask string                                     VTEP CIDR Mask for all VTEP CIDRs (default "255.255.255.0")
-      --write-cni-conf-when-ready string                     Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
+      --agent-health-port int                                   TCP port for agent health status API (default 9876)
+      --agent-labels strings                                    Additional labels to identify this agent
+      --allocator-list-timeout duration                         Timeout for listing allocator state before exiting (default 3m0s)
+      --allow-icmp-frag-needed                                  Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
+      --allow-localhost string                                  Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
+      --annotate-k8s-node                                       Annotate Kubernetes node
+      --api-rate-limit map                                      API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
+      --arping-refresh-period duration                          Period for remote node ARP entry refresh (set 0 to disable) (default 30s)
+      --auto-create-cilium-node-resource                        Automatically create CiliumNode resource for own node on startup (default true)
+      --auto-direct-node-routes                                 Enable automatic L2 routing between nodes
+      --bgp-announce-lb-ip                                      Announces service IPs of type LoadBalancer via BGP
+      --bgp-announce-pod-cidr                                   Announces the node's pod CIDR via BGP
+      --bgp-config-path string                                  Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --bpf-ct-global-any-max int                               Maximum number of entries in non-TCP CT table (default 262144)
+      --bpf-ct-global-tcp-max int                               Maximum number of entries in TCP CT table (default 524288)
+      --bpf-ct-timeout-regular-any duration                     Timeout for entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-regular-tcp duration                     Timeout for established entries in TCP CT table (default 6h0m0s)
+      --bpf-ct-timeout-regular-tcp-fin duration                 Teardown timeout for entries in TCP CT table (default 10s)
+      --bpf-ct-timeout-regular-tcp-syn duration                 Establishment timeout for entries in TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-any duration                     Timeout for service entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-tcp duration                     Timeout for established service entries in TCP CT table (default 6h0m0s)
+      --bpf-fragments-map-max int                               Maximum number of entries in fragments tracking map (default 8192)
+      --bpf-lb-acceleration string                              BPF load balancing acceleration via XDP ("native", "disabled") (default "disabled")
+      --bpf-lb-algorithm string                                 BPF load balancing algorithm ("random", "maglev") (default "random")
+      --bpf-lb-dev-ip-addr-inherit string                       Device name which IP addr is inherited by devices running LB BPF program (--devices)
+      --bpf-lb-dsr-dispatch string                              BPF load balancing DSR dispatch method ("opt", "ipip") (default "opt")
+      --bpf-lb-dsr-l4-xlate string                              BPF load balancing DSR L4 DNAT method for IPIP ("frontend", "backend") (default "frontend")
+      --bpf-lb-external-clusterip                               Enable external access to ClusterIP services (default false)
+      --bpf-lb-maglev-hash-seed string                          Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
+      --bpf-lb-maglev-table-size uint                           Maglev per service backend table size (parameter M) (default 16381)
+      --bpf-lb-map-max int                                      Maximum number of entries in Cilium BPF lbmap (default 65536)
+      --bpf-lb-mode string                                      BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
+      --bpf-lb-rss-ipv4-src-cidr string                         BPF load balancing RSS outer source IPv4 CIDR prefix for IPIP
+      --bpf-lb-rss-ipv6-src-cidr string                         BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP
+      --bpf-lb-sock-hostns-only                                 Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).
+      --bpf-map-dynamic-size-ratio float                        Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
+      --bpf-nat-global-max int                                  Maximum number of entries for the global BPF NAT table (default 524288)
+      --bpf-neigh-global-max int                                Maximum number of entries for the global BPF neighbor table (default 524288)
+      --bpf-policy-map-max int                                  Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
+      --bpf-root string                                         Path to BPF filesystem
+      --bpf-sock-rev-map-max int                                Maximum number of entries for the SockRevNAT BPF map (default 262144)
+      --certificates-directory string                           Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cgroup-root string                                      Path to Cgroup2 filesystem
+      --cluster-health-port int                                 TCP port for cluster-wide network connectivity health API (default 4240)
+      --cluster-id int                                          Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --clustermesh-config string                               Path to the ClusterMesh configuration directory
+      --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                       Configuration directory that contains a file for each option
+      --conntrack-gc-interval duration                          Overwrite the connection-tracking garbage collection interval
+      --crd-wait-timeout duration                               Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
+      --datapath-mode string                                    Datapath mode name (default "veth")
+  -D, --debug                                                   Enable debugging mode
+      --debug-verbose strings                                   List of enabled verbose debug groups
+      --devices strings                                         List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
+      --direct-routing-device string                            Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
+      --disable-cnp-status-updates                              Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)
+      --disable-endpoint-crd                                    Disable use of CiliumEndpoint CRD
+      --disable-iptables-feeder-rules strings                   Chains to ignore when installing feeder rules.
+      --dns-max-ips-per-restored-rule int                       Maximum number of IPs to maintain for each restored DNS rule (default 1000)
+      --dns-policy-unload-on-shutdown                           Unload DNS policy rules on graceful shutdown
+      --dnsproxy-concurrency-limit int                          Limit concurrency of DNS message processing
+      --dnsproxy-concurrency-processing-grace-period duration   Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing
+      --egress-masquerade-interfaces string                     Limit egress masquerading to interface selector
+      --egress-multi-home-ip-rule-compat                        Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
+      --enable-auto-protect-node-port-range                     Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
+      --enable-bandwidth-manager                                Enable BPF bandwidth manager
+      --enable-bbr                                              Enable BBR for the bandwidth manager
+      --enable-bgp-control-plane                                Enable the BGP control plane.
+      --enable-bpf-clock-probe                                  Enable BPF clock source probing for more efficient tick retrieval
+      --enable-bpf-masquerade                                   Masquerade packets from endpoints leaving the host with BPF instead of iptables
+      --enable-bpf-tproxy                                       Enable BPF-based proxy redirection, if support available
+      --enable-cilium-endpoint-slice                            If set to true, CiliumEndpointSlice feature is enabled and cilium agent watch for CiliumEndpointSlice instead of CiliumEndpoint to update the IPCache.
+      --enable-custom-calls                                     Enable tail call hooks for custom eBPF programs
+      --enable-endpoint-health-checking                         Enable connectivity health checking between virtual endpoints (default true)
+      --enable-endpoint-routes                                  Use per endpoint routes instead of routing via cilium_host
+      --enable-envoy-config                                     Enable Envoy Config CRDs
+      --enable-external-ips                                     Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
+      --enable-health-check-nodeport                            Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
+      --enable-health-checking                                  Enable connectivity health checking (default true)
+      --enable-host-firewall                                    Enable host network policies
+      --enable-host-legacy-routing                              Enable the legacy host forwarding model which does not bypass upper stack in host namespace
+      --enable-host-port                                        Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
+      --enable-host-reachable-services                          Enable reachability of services for host applications
+      --enable-hubble                                           Enable hubble server
+      --enable-hubble-recorder-api                              Enable the Hubble recorder API (default true)
+      --enable-identity-mark                                    Enable setting identity mark for local traffic (default true)
+      --enable-ip-masq-agent                                    Enable BPF ip-masq-agent
+      --enable-ipsec                                            Enable IPSec support
+      --enable-ipv4                                             Enable IPv4 support (default true)
+      --enable-ipv4-egress-gateway                              Enable egress gateway for IPv4
+      --enable-ipv4-fragment-tracking                           Enable IPv4 fragments tracking for L4-based lookups (default true)
+      --enable-ipv4-masquerade                                  Masquerade IPv4 traffic from endpoints leaving the host (default true)
+      --enable-ipv6                                             Enable IPv6 support (default true)
+      --enable-ipv6-masquerade                                  Masquerade IPv6 traffic from endpoints leaving the host (default true)
+      --enable-ipv6-ndp                                         Enable IPv6 NDP support
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                               Enable k8s event handover to kvstore for improved scalability
+      --enable-k8s-terminating-endpoint                         Enable auto-detect of terminating endpoint condition (default true)
+      --enable-l2-neigh-discovery                               Enables L2 neighbor discovery used by kube-proxy-replacement and IPsec (default true)
+      --enable-l7-proxy                                         Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-local-node-route                                 Enable installation of the route which points the allocation prefix of the local node (default true)
+      --enable-local-redirect-policy                            Enable Local Redirect Policy
+      --enable-monitor                                          Enable the monitor unix domain socket server (default true)
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enable-policy string                                    Enable policy enforcement (default "default")
+      --enable-recorder                                         Enable BPF datapath pcap recorder
+      --enable-remote-node-identity                             Enable use of remote node identity
+      --enable-service-topology                                 Enable support for service topology aware hints
+      --enable-session-affinity                                 Enable support for service session affinity
+      --enable-svc-source-range-check                           Enable check of service source ranges (currently, only for LoadBalancer) (default true)
+      --enable-tracing                                          Enable tracing while determining policy (debugging)
+      --enable-unreachable-routes                               Add unreachable routes on pod deletion
+      --enable-vtep                                             Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)
+      --enable-well-known-identities                            Enable well-known identities for known Kubernetes components (default true)
+      --enable-wireguard                                        Enable wireguard
+      --enable-wireguard-userspace-fallback                     Enables the fallback to the wireguard userspace implementation
+      --enable-xdp-prefilter                                    Enable XDP prefiltering
+      --enable-xt-socket-fallback                               Enable fallback for missing xt_socket module (default true)
+      --encrypt-interface string                                Transparent encryption interface
+      --encrypt-node                                            Enables encrypting traffic from non-Cilium pods and host networking
+      --endpoint-queue-size int                                 size of EventQueue per-endpoint (default 25)
+      --endpoint-status strings                                 Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
+      --envoy-config-timeout duration                           Timeout duration for Envoy Config acknowledgements (default 2m0s)
+      --envoy-log string                                        Path to a separate Envoy log file, if any
+      --exclude-local-address strings                           Exclude CIDR from being recognized as local address
+      --fixed-identity-mapping map                              Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns
+      --force-local-policy-eval-at-source                       Force policy evaluation of all local communication at the source endpoint (default true)
+      --gops-port int                                           Port for gops server to listen on (default 9890)
+  -h, --help                                                    help for cilium-agent
+      --http-idle-timeout uint                                  Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
+      --http-max-grpc-timeout uint                              Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
+      --http-normalize-path                                     Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution. (default true)
+      --http-request-timeout uint                               Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
+      --http-retry-count uint                                   Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                 Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
+      --hubble-disable-tls                                      Allow Hubble server to run on the given listen address without TLS.
+      --hubble-event-buffer-capacity int                        Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
+      --hubble-event-queue-size int                             Buffer size of the channel to receive monitor events.
+      --hubble-export-file-compress                             Compress rotated Hubble export files.
+      --hubble-export-file-max-backups int                      Number of rotated Hubble export files to keep. (default 5)
+      --hubble-export-file-max-size-mb int                      Size in MB at which to rotate Hubble export file. (default 10)
+      --hubble-export-file-path string                          Filepath to write Hubble events to.
+      --hubble-listen-address string                            An additional address for Hubble server to listen to, e.g. ":4244"
+      --hubble-metrics strings                                  List of Hubble metrics to enable.
+      --hubble-metrics-server string                            Address to serve Hubble metrics on.
+      --hubble-recorder-sink-queue-size int                     Queue size of each Hubble recorder sink (default 1024)
+      --hubble-recorder-storage-path string                     Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")
+      --hubble-socket-path string                               Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
+      --hubble-tls-cert-file string                             Path to the public key file for the Hubble server. The file must contain PEM encoded data.
+      --hubble-tls-client-ca-files strings                      Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --hubble-tls-key-file string                              Path to the private key file for the Hubble server. The file must contain PEM encoded data.
+      --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")
+      --identity-change-grace-period duration                   Time to wait before using new identity on endpoint identity change (default 5s)
+      --identity-restore-grace-period duration                  Time to wait before releasing unused restored CIDR identities during agent restart (default 10m0s)
+      --install-egress-gateway-routes                           Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
+      --install-iptables-rules                                  Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
+      --install-no-conntrack-iptables-rules                     Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
+      --ip-allocation-timeout duration                          Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
+      --ip-masq-agent-config-path string                        ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
+      --ipam string                                             Backend to use for IPAM (default "cluster-pool")
+      --ipsec-key-file string                                   Path to IPSec key file
+      --iptables-lock-timeout duration                          Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
+      --iptables-random-fully                                   Set iptables flag random-fully on masquerading rules
+      --ipv4-native-routing-cidr string                         Allows to explicitly specify the IPv4 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag.
+      --ipv4-node string                                        IPv4 address of node (default "auto")
+      --ipv4-pod-subnets strings                                List of IPv4 pod subnets to preconfigure for encryption
+      --ipv4-range string                                       Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
+      --ipv4-service-loopback-address string                    IPv4 address for service loopback SNAT (default "169.254.42.1")
+      --ipv4-service-range string                               Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
+      --ipv6-cluster-alloc-cidr string                          IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
+      --ipv6-mcast-device string                                Device that joins a Solicited-Node multicast group for IPv6
+      --ipv6-native-routing-cidr string                         Allows to explicitly specify the IPv6 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag.
+      --ipv6-node string                                        IPv6 address of node (default "auto")
+      --ipv6-pod-subnets strings                                List of IPv6 pod subnets to preconfigure for encryption
+      --ipv6-range string                                       Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
+      --ipv6-service-range string                               Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
+      --join-cluster                                            Join a Cilium cluster via kvstore registration
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                    Name of the Kubernetes namespace in which Cilium is deployed in
+      --k8s-require-ipv4-pod-cidr                               Require IPv4 PodCIDR to be specified in node resource
+      --k8s-require-ipv6-pod-cidr                               Require IPv6 PodCIDR to be specified in node resource
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --k8s-watcher-endpoint-selector string                    K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
+      --keep-config                                             When restoring state, keeps containers' configuration in place
+      --kube-proxy-replacement string                           auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
+      --kube-proxy-replacement-healthz-bind-address string      The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
+      --kvstore string                                          Key-value store type
+      --kvstore-connectivity-timeout duration                   Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
+      --kvstore-max-consecutive-quorum-errors int               Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure (default 2)
+      --kvstore-opt map                                         Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --kvstore-periodic-sync duration                          Periodic KVstore synchronization interval (default 5m0s)
+      --label-prefix-file string                                Valid label prefixes file path
+      --labels strings                                          List of label prefixes used to determine identity of an endpoint
+      --lib-dir string                                          Directory path to store runtime build environment (default "/var/lib/cilium")
+      --local-router-ipv4 string                                Link-local IPv4 used for Cilium's router devices
+      --local-router-ipv6 string                                Link-local IPv6 used for Cilium's router devices
+      --log-driver strings                                      Logging endpoints to use for example syslog
+      --log-opt map                                             Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
+      --log-system-load                                         Enable periodic logging of system load
+      --metrics strings                                         Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
+      --monitor-aggregation string                              Level of monitor aggregation for traces from the datapath (default "None")
+      --monitor-aggregation-flags strings                       TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
+      --monitor-aggregation-interval duration                   Monitor report interval when monitor aggregation is enabled (default 5s)
+      --monitor-queue-size int                                  Size of the event queue when reading monitor events
+      --mtu int                                                 Overwrite auto-detected MTU of underlying network
+      --node-port-bind-protection                               Reject application bind(2) requests to service ports in the NodePort range (default true)
+      --node-port-range strings                                 Set the min/max NodePort port range (default [30000,32767])
+      --policy-audit-mode                                       Enable policy audit (non-drop) mode
+      --policy-queue-size int                                   size of queues for policy-related events (default 100)
+      --pprof                                                   Enable serving the pprof debugging API
+      --pprof-port int                                          Port that the pprof listens on (default 6060)
+      --preallocate-bpf-maps                                    Enable BPF map pre-allocation (default true)
+      --prepend-iptables-chains                                 Prepend custom iptables chains instead of appending (default true)
+      --procfs string                                           Root's proc filesystem path (default "/proc")
+      --prometheus-serve-addr string                            IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-connect-timeout uint                              Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-gid uint                                          Group ID for proxy control plane sockets. (default 1337)
+      --proxy-max-connection-duration-seconds int               Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
+      --proxy-max-requests-per-connection int                   Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
+      --proxy-prometheus-port int                               Port to serve Envoy metrics on. Default 0 (disabled).
+      --read-cni-conf string                                    Read to the CNI configuration at specified path to extract per node configuration
+      --restore                                                 Restores state, if possible, from previous daemon (default true)
+      --route-metric int                                        Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
+      --sidecar-istio-proxy-image string                        Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
+      --single-cluster-route                                    Use a single cluster route instead of per node routes
+      --socket-path string                                      Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
+      --sockops-enable                                          Enable sockops when kernel supported
+      --state-dir string                                        Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdns-dns-reject-response-code string                 DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
+      --tofqdns-enable-dns-compression                          Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
+      --tofqdns-endpoint-max-ip-per-hostname int                Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
+      --tofqdns-idle-connection-grace-period duration           Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)
+      --tofqdns-max-deferred-connection-deletes int             Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
+      --tofqdns-min-ttl int                                     The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
+      --tofqdns-pre-cache string                                DNS cache data at this path is preloaded on agent startup
+      --tofqdns-proxy-port int                                  Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+      --tofqdns-proxy-response-max-delay duration               The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
+      --trace-payloadlen int                                    Length of payload to capture when tracing (default 128)
+  -t, --tunnel string                                           Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
+      --tunnel-port int                                         Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
+      --version                                                 Print version information
+      --vlan-bpf-bypass ints                                    List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs
+      --vtep-cidr strings                                       List of VTEP CIDRs that will be routed towards VTEPs for traffic cluster egress
+      --vtep-endpoint strings                                   List of VTEP IP addresses
+      --vtep-mac strings                                        List of VTEP MAC addresses for forwarding traffic outside the cluster
+      --vtep-mask string                                        VTEP CIDR Mask for all VTEP CIDRs (default "255.255.255.0")
+      --write-cni-conf-when-ready string                        Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
 ```
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -934,6 +934,12 @@ func initializeFlags() {
 	flags.Bool(option.ToFQDNsEnableDNSCompression, defaults.ToFQDNsEnableDNSCompression, "Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present")
 	option.BindEnv(option.ToFQDNsEnableDNSCompression)
 
+	flags.Int(option.DNSProxyConcurrencyLimit, 0, "Limit concurrency of DNS message processing")
+	option.BindEnv(option.DNSProxyConcurrencyLimit)
+
+	flags.Duration(option.DNSProxyConcurrencyProcessingGracePeriod, 0, "Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing")
+	option.BindEnv(option.DNSProxyConcurrencyProcessingGracePeriod)
+
 	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "size of queues for policy-related events")
 	option.BindEnv(option.PolicyQueueSize)
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -231,7 +231,9 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 		// NotifyOnDNSMsg
 		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error {
 			return nil
-		})
+		},
+		0,
+	)
 	c.Assert(err, IsNil, Commentf("error starting DNS Proxy"))
 	s.proxy = proxy
 
@@ -993,6 +995,13 @@ func (s *DNSProxyTestSuite) TestProxyRequestContext_IsTimeout(c *C) {
 	// IsTimeout() to return the wrong value.
 	p.Err = fmt.Errorf("sample err: %s", context.DeadlineExceeded)
 	c.Assert(p.IsTimeout(), Equals, false)
+
+	p.Err = errFailedAcquireSemaphore{}
+	c.Assert(p.IsTimeout(), Equals, true)
+	p.Err = errTimedOutAcquireSemaphore{
+		gracePeriod: 1 * time.Second,
+	}
+	c.Assert(p.IsTimeout(), Equals, true)
 }
 
 type selectorMock struct {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -479,6 +479,15 @@ const (
 	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
 	ToFQDNsEnableDNSCompression = "tofqdns-enable-dns-compression"
 
+	// DNSProxyConcurrencyLimit limits parallel processing of DNS messages in
+	// DNS proxy at any given point in time.
+	DNSProxyConcurrencyLimit = "dnsproxy-concurrency-limit"
+
+	// DNSProxyConcurrencyProcessingGracePeriod is the amount of grace time to
+	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
+	// been reached.
+	DNSProxyConcurrencyProcessingGracePeriod = "dnsproxy-concurrency-processing-grace-period"
+
 	// MTUName is the name of the MTU option
 	MTUName = "mtu"
 
@@ -1670,6 +1679,15 @@ type DaemonConfig struct {
 	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
 	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
 	ToFQDNsEnableDNSCompression bool
+
+	// DNSProxyConcurrencyLimit limits parallel processing of DNS messages in
+	// DNS proxy at any given point in time.
+	DNSProxyConcurrencyLimit int
+
+	// DNSProxyConcurrencyProcessingGracePeriod is the amount of grace time to
+	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
+	// been reached.
+	DNSProxyConcurrencyProcessingGracePeriod time.Duration
 
 	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
 	// sysctl option if `xt_socket` kernel module is not available.
@@ -2962,6 +2980,8 @@ func (c *DaemonConfig) Populate() {
 	c.ToFQDNsProxyPort = viper.GetInt(ToFQDNsProxyPort)
 	c.ToFQDNsPreCache = viper.GetString(ToFQDNsPreCache)
 	c.ToFQDNsEnableDNSCompression = viper.GetBool(ToFQDNsEnableDNSCompression)
+	c.DNSProxyConcurrencyLimit = viper.GetInt(DNSProxyConcurrencyLimit)
+	c.DNSProxyConcurrencyProcessingGracePeriod = viper.GetDuration(DNSProxyConcurrencyProcessingGracePeriod)
 
 	// Convert IP strings into net.IPNet types
 	subnets, invalid := ip.ParseCIDRs(viper.GetStringSlice(IPv4PodSubnets))


### PR DESCRIPTION
This commit does the following:

* Adds a configuration option for controlling the concurrency of the DNS
  proxy
* Adds a configuration option for the semaphore (from above) timeout
* Exposes an additional metric for the time taken to perform the policy
  check on a DNS request within the DNS proxy

The concurrency limitation is done by introducing a semaphore to DNS
proxy. By default, no such limit is imposed.

Users are advised to take into account the number of DNS requests[1] and
how many CPUs on each node in their cluster in order to come up with an
appropriate concurrency limit.

In addition, we expose the semaphore grace period as a configurable
option. Assuming the "right" for this timeout is a tradeoff that we
shouldn't really assume for the user.

The semaphore grace period is to prevent the situation where Cilium
deadlocks or consistently high rate of DNS traffic causing Cilium to be
unable to keep up.

See https://github.com/cilium/cilium/pull/19543#discussion_r862136748 by
<joe@cilium.io>.

The user can take into account the rate that they expect DNS requests to
be following into Cilium and how many of those requests should be
processed without retrying. If retrying isn't an issue then keeping the
grace period at 0 (default) will immediately free the goroutine handling
the DNS request if the semaphore acquire fails. Conversely, if a backlog
of "unproductive" goroutines is acceptable (and DNS request retries are
not), then setting the grace period is advisable. This gives the
goroutines some time to acquire the semaphore. Goroutines could pile up
if the grace period is too high and there's a consistently high rate of
DNS requests.

It's worth noting that blindly increasing the concurrency limit will not
linearly improve performance. It might actually degrade instead due to
internal downstream lock contention (as seen by the recent commits to
move Endpoint-related functions to use read-locks).

Ultimately, it becomes a tradeoff between high number of semaphore
timeouts (dropped DNS requests that must be retried) or high number of
(unproductive) goroutines, which can consume system resources.

[1]: The metric to monitor is

```
cilium_policy_l7_total{rule="received"}
```

Co-authored-by: Chris Tarazi <chris@isovalent.com>
Signed-off-by: Maciej Kwiek <maciej@isovalent.com>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
