### PR TITLE
egressgw: emit a warning rather than a fatal error when L7 proxy is enabled

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -899,8 +899,9 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		}
 
 		if option.Config.EnableL7Proxy {
-			return nil, nil, fmt.Errorf("egress gateway requires L7 proxy to be disabled (--%s=\"false\").",
-				option.EnableL7Proxy)
+			log.WithField(logfields.URL, "https://github.com/cilium/cilium/issues/19642").
+				Warningf("both egress gateway and L7 proxy (--%s) are enabled. This is currently not fully supported: "+
+					"if the same endpoint is selected both by an egress gateway and a L7 policy, endpoint traffic will not go through egress gateway.", option.EnableL7Proxy)
 		}
 	}
 	if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {


### PR DESCRIPTION
The egress gateway feature is only partially incompatible with
--enable-l7-proxy as traffic will not be forwarded to an egress gateway
only if there's an L7 policy selecting the same endpoint selected by an
egress gateway policy.

Because of this, just logging a warning should be sufficient as in most
cases both features can be enabled and used at the same time.