### PR TITLE
.github/workflows: install the right helm chart version for stable branches

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -213,8 +213,8 @@ jobs:
 
       - name: Install Cilium
         run: |
-          curl -LO https://github.com/cilium/cilium/archive/master.tar.gz
-          tar xzf master.tar.gz
+          curl -LO https://github.com/cilium/cilium/archive/v1.10.tar.gz
+          tar xzf v1.10.tar.gz
           cd cilium-master/install/kubernetes
           helm install cilium ./cilium \
             --namespace kube-system \

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -213,8 +213,8 @@ jobs:
 
       - name: Install Cilium
         run: |
-          curl -LO https://github.com/cilium/cilium/archive/master.tar.gz
-          tar xzf master.tar.gz
+          curl -LO https://github.com/cilium/cilium/archive/v1.11.tar.gz
+          tar xzf v1.11.tar.gz
           cd cilium-master/install/kubernetes
           helm install cilium ./cilium \
             --namespace kube-system \


### PR DESCRIPTION
In stable branches we should not use the 'master' version of the helm
charts but instead we should use the same version of the base branch
being tested.

Signed-off-by: André Martins <andre@cilium.io>