### PR TITLE
docs: set the right url for API version check

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -70,7 +70,7 @@ author = u'Cilium Authors'
 release = open("../VERSION", "r").read().strip()
 # Used by version warning
 versionwarning_body_selector = "div.document"
-versionwarning_api_url = "docs.cilium.io"
+versionwarning_api_url = "https://docs.cilium.io/"
 
 # The version of Go used to compile Cilium
 go_release = open("../GO_VERSION", "r").read().strip()


### PR DESCRIPTION
The right format for this field should contain the protocol and a
trailing "/" to work properly.

Fixes: b3b05029e4c9 ("docs: fix version warning URL to point to docs.cilium.io")
Signed-off-by: André Martins <andre@cilium.io>