### PR TITLE
Clean up IP rules when router IP restoration fails

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -163,9 +163,11 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing types.NodeAddressi
 		Mask: net.CIDRMask(32, 32),
 	}
 
-	for _, cidr := range cidrs {
-		if err = linuxrouting.SetupRules(&routerIP, &cidr, info.GetMac().String(), info.GetInterfaceNumber()); err != nil {
-			return nil, fmt.Errorf("unable to install ip rule for cilium_host: %w", err)
+	if option.Config.EnableIPSec {
+		for _, cidr := range cidrs {
+			if err = linuxrouting.SetupRule(&routerIP, &cidr, info.GetMac().String(), info.GetInterfaceNumber()); err != nil {
+				return nil, fmt.Errorf("unable to install ip rule for cilium_host: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently IP rules needed for encryption in ENI mode are not gated
behind IPSec flag. When router IP restoration fails, these rules are
leaked. This commit extends removeOldRouterState() to clean up stale IP
rules ans also gates installation of these rules behind IPSec flag.

Signed-off-by: Hemanth Malla <hemanth.malla@datadoghq.com>
