### PR TITLE
daemon: Initialize k8sCachesSynced channel before calling Initk8sSubsystem()

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -939,9 +939,15 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// are set.
 	if k8s.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
+
+		// Initialize d.k8sCachesSynced before any k8s watchers are alive, as they may
+		// access it to check the status of k8s initialization
+		cachesSynced := make(chan struct{})
+		d.k8sCachesSynced = cachesSynced
+
 		// Launch the K8s watchers in parallel as we continue to process other
 		// daemon options.
-		d.k8sCachesSynced = d.k8sWatcher.InitK8sSubsystem(d.ctx)
+		d.k8sWatcher.InitK8sSubsystem(d.ctx, cachesSynced)
 		bootstrapStats.k8sInit.End(true)
 	}
 


### PR DESCRIPTION
InitK8sSubsystem() starts all k8s watchers concurrently, some of which do
call into K8sCacheIsSynced() via ipcache/metadata.InjectLabels(), and
possibly also from elsewhere. Initialize k8sCachesSynced before any
watchers are started to make this access safe. This fixes data race
detected by race detection builds.

Fixes: #19614
Fixes: #19556
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>