### PR TITLE
Use FQDN regex LRU everywhere

### DIFF
--- a/cilium/cmd/policy.go
+++ b/cilium/cmd/policy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -34,6 +35,14 @@ var (
 
 func init() {
 	rootCmd.AddCommand(policyCmd)
+
+	// Initialize LRU here because the policy subcommands (validate, import)
+	// will call down to sanitizing the FQDN rules which contains regexes.
+	// Regexes need to be compiled as part of the FQDN rule validation.
+	//
+	// It's not necessary to pass a useful size here because it's not
+	// necessary to cache regexes in a short-lived binary (CLI).
+	re.InitRegexCompileLRU(1)
 }
 
 func getContext(content []byte, offset int64) (int, string, int) {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -924,7 +924,7 @@ func initializeFlags() {
 	flags.DurationVar(&option.Config.FQDNProxyResponseMaxDelay, option.FQDNProxyResponseMaxDelay, 100*time.Millisecond, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
 	option.BindEnv(option.FQDNProxyResponseMaxDelay)
 
-	flags.Int(option.FQDNRegexCompileLRUSize, 1024, "Size of the FQDN regex compilation LRU. Useful for heavy but repeated FQDN MatchName or MatchPattern use")
+	flags.Int(option.FQDNRegexCompileLRUSize, defaults.FQDNRegexCompileLRUSize, "Size of the FQDN regex compilation LRU. Useful for heavy but repeated DNS L7 rules with MatchName or MatchPattern")
 	flags.MarkHidden(option.FQDNRegexCompileLRUSize)
 	option.BindEnv(option.FQDNRegexCompileLRUSize)
 

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -692,7 +692,7 @@ func extractDNSLookups(endpoints []*endpoint.Endpoint, CIDRStr, matchPatternStr 
 
 	nameMatcher := func(name string) bool { return true }
 	if matchPatternStr != "" {
-		matcher, err := matchpattern.Validate(matchpattern.Sanitize(matchPatternStr))
+		matcher, err := matchpattern.ValidateWithoutCache(matchpattern.Sanitize(matchPatternStr))
 		if err != nil {
 			return nil, err
 		}
@@ -754,7 +754,7 @@ func extractDNSLookups(endpoints []*endpoint.Endpoint, CIDRStr, matchPatternStr 
 func deleteDNSLookups(globalCache *fqdn.DNSCache, endpoints []*endpoint.Endpoint, expireLookupsBefore time.Time, matchPatternStr string) (namesToRegen []string, err error) {
 	var nameMatcher *regexp.Regexp // nil matches all in our implementation
 	if matchPatternStr != "" {
-		nameMatcher, err = matchpattern.Validate(matchPatternStr)
+		nameMatcher, err = matchpattern.ValidateWithoutCache(matchPatternStr)
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/counter"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
@@ -36,6 +38,10 @@ type DaemonFQDNSuite struct {
 }
 
 var _ = Suite(&DaemonFQDNSuite{})
+
+func (ds *DaemonFQDNSuite) SetUpSuite(c *C) {
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
+}
 
 type FakeRefcountingIdentityAllocator struct {
 	*testidentity.MockIdentityAllocator

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -109,6 +109,10 @@ const (
 	// for each FQDN selector in endpoint's restored DNS rules.
 	DNSMaxIPsPerRestoredRule = 1000
 
+	// FFQDNRegexCompileLRUSize defines the maximum size for the FQDN regex
+	// compilation LRU used by the DNS proxy and policy validation.
+	FQDNRegexCompileLRUSize = 1024
+
 	// ToFQDNsMinTTL is the default lower bound for TTLs used with ToFQDNs rules.
 	// This is used in DaemonConfig.Populate
 	ToFQDNsMinTTL = 3600 // 1 hour in seconds

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -8,9 +8,10 @@ package dnsproxy
 import (
 	"testing"
 
-	"github.com/golang/groupcache/lru"
 	. "gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -39,8 +40,8 @@ func (s *DNSProxyHelperTestSuite) TestGetSelectorRegexMap(c *C) {
 			}},
 		},
 	}
-	cache := &lru.Cache{}
-	m, err := GetSelectorRegexMap(l7, cache)
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
+	m, err := GetSelectorRegexMap(l7)
 
 	c.Assert(err, Equals, nil)
 

--- a/pkg/fqdn/fqdn_test.go
+++ b/pkg/fqdn/fqdn_test.go
@@ -9,11 +9,18 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 )
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) {
 	TestingT(t)
+}
+
+func (ds *FQDNTestSuite) SetUpSuite(c *C) {
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
 }
 
 type FQDNTestSuite struct{}

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/pkg/fqdn/dns"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 )
 
 const allowedDNSCharsREGroup = "[-a-zA-Z0-9_]"
@@ -24,7 +25,7 @@ func Validate(pattern string) (matcher *regexp.Regexp, err error) {
 		return nil, errors.New(`Only alphanumeric ASCII characters, the hyphen "-", underscore "_", "." and "*" are allowed in a matchPattern`)
 	}
 
-	return regexp.Compile(ToRegexp(pattern))
+	return re.CompileRegex(ToRegexp(pattern))
 }
 
 // Sanitize canonicalized the pattern for use by ToRegexp

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -17,15 +17,31 @@ const allowedDNSCharsREGroup = "[-a-zA-Z0-9_]"
 // Validate ensures that pattern is a parseable matchPattern. It returns the
 // regexp generated when validating.
 func Validate(pattern string) (matcher *regexp.Regexp, err error) {
+	if err := prevalidate(pattern); err != nil {
+		return nil, err
+	}
+	return re.CompileRegex(ToRegexp(pattern))
+}
+
+// ValidateWithoutCache is the same as Validate() but doesn't consult the regex
+// LRU.
+func ValidateWithoutCache(pattern string) (matcher *regexp.Regexp, err error) {
+	if err := prevalidate(pattern); err != nil {
+		return nil, err
+	}
+	return regexp.Compile(ToRegexp(pattern))
+}
+
+func prevalidate(pattern string) error {
 	pattern = strings.TrimSpace(pattern)
 	pattern = strings.ToLower(pattern)
 
 	// error check
 	if strings.ContainsAny(pattern, "[]+{},") {
-		return nil, errors.New(`Only alphanumeric ASCII characters, the hyphen "-", underscore "_", "." and "*" are allowed in a matchPattern`)
+		return errors.New(`Only alphanumeric ASCII characters, the hyphen "-", underscore "_", "." and "*" are allowed in a matchPattern`)
 	}
 
-	return re.CompileRegex(ToRegexp(pattern))
+	return nil
 }
 
 // Sanitize canonicalized the pattern for use by ToRegexp

--- a/pkg/fqdn/re/re.go
+++ b/pkg/fqdn/re/re.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package re provides a simple function to access compile regex objects for
+// the FQDN subsystem.
+package re
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sync/atomic"
+	"unsafe"
+
+	lru "github.com/golang/groupcache/lru"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "fqdn/re")
+)
+
+// CompileRegex compiles a pattern p into a regex and returns the regex object.
+// The regex object will be cached by an LRU. If p has already been compiled
+// and cached, this function will return the cached regex object. If not
+// already cached, it will compile p into a regex object and cache it in the
+// LRU. This function will return an error if the LRU has not already been
+// initialized.
+func CompileRegex(p string) (*regexp.Regexp, error) {
+	lru := (*RegexCompileLRU)(atomic.LoadPointer(&regexCompileLRU))
+	if lru == nil {
+		return nil, errors.New("FQDN regex compilation LRU not yet initialized")
+	}
+	lru.Lock()
+	r, ok := lru.Get(p)
+	lru.Unlock()
+	if ok {
+		return r.(*regexp.Regexp), nil
+	}
+	n, err := regexp.Compile(p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile regex: %w", err)
+	}
+	lru.Lock()
+	lru.Add(p, n)
+	lru.Unlock()
+	return n, nil
+}
+
+// InitRegexCompileLRU creates a new instance of the regex compilation LRU.
+func InitRegexCompileLRU(size int) error {
+	if size < 0 {
+		return fmt.Errorf("failed to initialize FQDN regex compilation LRU due to invalid size %d", size)
+	} else if size == 0 {
+		log.Warnf(
+			"FQDN regex compilation LRU size is unlimited, which can grow unbounded potentially consuming too much memory. Consider passing a maximum size via --%s.",
+			option.FQDNRegexCompileLRUSize)
+	}
+	atomic.StorePointer(&regexCompileLRU, unsafe.Pointer(&RegexCompileLRU{
+		Mutex: &lock.Mutex{},
+		Cache: lru.New(size),
+	}))
+	return nil
+}
+
+// regexCompileLRU is the singleton instance of the LRU that's shared
+// throughout Cilium.
+var regexCompileLRU unsafe.Pointer // *RegexCompileLRU
+
+// RegexCompileLRU is an LRU cache for storing compiled regex objects of FQDN
+// names or patterns, used in CiliumNetworkPolicy or
+// ClusterwideCiliumNetworkPolicy.
+type RegexCompileLRU struct {
+	// The lru package doesn't provide any concurrency guarantees so we must
+	// provide our own locking.
+	*lock.Mutex
+	*lru.Cache
+}

--- a/pkg/policy/api/utils_test.go
+++ b/pkg/policy/api/utils_test.go
@@ -10,12 +10,18 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/policy/api/kafka"
 )
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) {
 	TestingT(t)
+}
+
+func (s *PolicyAPITestSuite) SetUpSuite(c *C) {
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
 }
 
 type PolicyAPITestSuite struct{}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -14,6 +14,8 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -90,6 +92,7 @@ var (
 func (ds *PolicyTestSuite) SetUpSuite(c *C) {
 	cachedRemoteNodeIdentitySetting = option.Config.EnableRemoteNodeIdentity
 	option.Config.EnableRemoteNodeIdentity = true
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
 }
 
 func (ds *PolicyTestSuite) TearDownSuite(c *C) {


### PR DESCRIPTION
- defaults: Define FQDN regex compile LRU size default
- fqdn/re: Provide new package for accessing compile regex objects
- fqdn: Use new regex LRU package everywhere
- daemon, fqdn: Provide method for non-cached validation

See commit msgs.

Related: https://github.com/cilium/cilium/pull/17224
Related: https://github.com/cilium/cilium/pull/19383
