### PR TITLE
test: Fix directory name for source archive

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  cilium_base_version: "1.10"
   cilium_cli_version: v0.10.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.94.0
@@ -214,16 +215,18 @@ jobs:
 
       - name: Install Cilium
         run: |
-          curl -LO https://github.com/cilium/cilium/archive/v1.10.tar.gz
-          tar xzf v1.10.tar.gz
-          cd cilium-master/install/kubernetes
+          curl -LO https://github.com/cilium/cilium/archive/v${{ env.cilium_base_version }}.tar.gz
+          tar xzf v${{ env.cilium_base_version }}.tar.gz
+          cd cilium-${{ env.cilium_base_version }}/install/kubernetes
           helm install cilium ./cilium \
             --namespace kube-system \
             --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
             --set image.tag=${{ steps.vars.outputs.sha }} \
+            --set image.useDigest=false \
             --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
             --set operator.image.suffix="-ci" \
             --set operator.image.tag=${{ steps.vars.outputs.sha }} \
+            --set operator.image.useDigest=false \
             --set cni.chainingMode=aws-cni \
             --set enableIPv4Masquerade=false \
             --set tunnel=disabled \
@@ -233,13 +236,14 @@ jobs:
 
       - name: Enable Relay
         run: |
-          cd cilium-master/install/kubernetes
+          cd cilium-${{ env.cilium_base_version }}/install/kubernetes
           helm upgrade cilium ./cilium \
             --namespace kube-system \
             --reuse-values \
             --set hubble.relay.enabled=true \
             --set hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
-            --set hubble.relay.image.tag=${{ steps.vars.outputs.sha }}
+            --set hubble.relay.image.tag=${{ steps.vars.outputs.sha }} \
+            --set hubble.relay.image.useDigest=false
 
       - name: Wait for Cilium status to be ready
         run: |
@@ -254,7 +258,7 @@ jobs:
       - name: Run connectivity test
         run: |
           cilium connectivity test \
-            --base-version=v1.10 \
+            --base-version=v${{ env.cilium_base_version }} \
             --flow-validation=disabled \
             --test '!fqdn,!l7' # L7 policies are not supported in chaining mode.
 

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  cilium_base_version: "1.11"
   cilium_cli_version: v0.10.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.94.0
@@ -214,16 +215,18 @@ jobs:
 
       - name: Install Cilium
         run: |
-          curl -LO https://github.com/cilium/cilium/archive/v1.11.tar.gz
-          tar xzf v1.11.tar.gz
-          cd cilium-master/install/kubernetes
+          curl -LO https://github.com/cilium/cilium/archive/v${{ env.cilium_base_version }}.tar.gz
+          tar xzf v${{ env.cilium_base_version }}.tar.gz
+          cd cilium-${{ env.cilium_base_version }}/install/kubernetes
           helm install cilium ./cilium \
             --namespace kube-system \
             --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
             --set image.tag=${{ steps.vars.outputs.sha }} \
+            --set image.useDigest=false \
             --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
             --set operator.image.suffix="-ci" \
             --set operator.image.tag=${{ steps.vars.outputs.sha }} \
+            --set operator.image.useDigest=false \
             --set cni.chainingMode=aws-cni \
             --set enableIPv4Masquerade=false \
             --set tunnel=disabled \
@@ -233,13 +236,14 @@ jobs:
 
       - name: Enable Relay
         run: |
-          cd cilium-master/install/kubernetes
+          cd cilium-${{ env.cilium_base_version }}/install/kubernetes
           helm upgrade cilium ./cilium \
             --namespace kube-system \
             --reuse-values \
             --set hubble.relay.enabled=true \
             --set hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
-            --set hubble.relay.image.tag=${{ steps.vars.outputs.sha }}
+            --set hubble.relay.image.tag=${{ steps.vars.outputs.sha }} \
+            --set hubble.relay.image.useDigest=false
 
       - name: Wait for Cilium status to be ready
         run: |
@@ -254,7 +258,7 @@ jobs:
       - name: Run connectivity test
         run: |
           cilium connectivity test \
-            --base-version=v1.11 \
+            --base-version=v${{ env.cilium_base_version }} \
             --flow-validation=disabled \
             --test '!fqdn,!l7' # L7 policies are not supported in chaining mode.
 


### PR DESCRIPTION
- Define cilium_base_version as an environment variable so that there
  is a single place to update for each feature branch.
- Set useDigest to false for all the images since the image digests
  in values.yaml do not match the ones for the CI images.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>