### PR TITLE
docs: set right path for robots.txt

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -192,7 +192,7 @@ html_static_path = ['images', '_static']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-html_extra_path = ['robots']
+html_extra_path = ['robots/robots.txt']
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
Accordingly to some examples found on google the path pointed by
html_extra_path should contain the direct path for the robots.txt file.

Signed-off-by: André Martins <andre@cilium.io>

@qmonnet I hope this is the last PR...