### PR TITLE
ipcache: Make SupportsDelete() more robust by using a separate map

### DIFF
--- a/pkg/maps/ipcache/ipcache_privileged_test.go
+++ b/pkg/maps/ipcache/ipcache_privileged_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build privileged_tests
+
+package ipcache
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/cilium/ebpf/rlimit"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/version"
+	"github.com/cilium/cilium/pkg/versioncheck"
+)
+
+// Hook up gocheck into the "go test" runner.
+type IPCacheMapTestSuite struct{}
+
+var _ = Suite(&IPCacheMapTestSuite{})
+
+func init() {
+}
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (k *IPCacheMapTestSuite) SetUpSuite(c *C) {
+	logging.SetLogLevelToDebug()
+	bpf.CheckOrMountFS("")
+	err := rlimit.RemoveMemlock()
+	c.Assert(err, IsNil)
+}
+
+func (k *IPCacheMapTestSuite) Test_SupportsDelete(c *C) {
+	ver, err := version.GetKernelVersion()
+	c.Assert(err, IsNil)
+	constraint, err := versioncheck.Compile(">=4.15.0")
+	c.Assert(err, IsNil)
+	c.Assert(SupportsDelete(), Equals, constraint(ver))
+}


### PR DESCRIPTION
This makes SupportsDelete() use a separate map for the probing so it'll
work even if the map hasn't been pinned yet, allowing it to be used early
in the init and hopefully preventing issues like one fixed by #19501.

Fixes: #19619
Signed-off-by: Jussi Maki <jussi@isovalent.com>