### PR TITLE
operator: fix identity GC collection

### DIFF
--- a/operator/identity_gc.go
+++ b/operator/identity_gc.go
@@ -11,7 +11,9 @@ import (
 	"github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/allocator"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
@@ -24,7 +26,9 @@ func startKvstoreIdentityGC() {
 	if err != nil {
 		log.WithError(err).Fatal("Unable to initialize kvstore backend for identity allocation")
 	}
-	a := allocator.NewAllocatorForGC(backend)
+	minID := idpool.ID(identity.MinimalAllocationIdentity)
+	maxID := idpool.ID(identity.MaximumAllocationIdentity)
+	a := allocator.NewAllocatorForGC(backend, allocator.WithMin(minID), allocator.WithMax(maxID))
 
 	successfulRuns := 0
 	failedRuns := 0

--- a/operator/kvstore_watchdog.go
+++ b/operator/kvstore_watchdog.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
@@ -61,7 +63,10 @@ func startKvstoreWatchdog() {
 	if err != nil {
 		log.WithError(err).Fatal("Unable to initialize kvstore backend for identity garbage collection")
 	}
-	a := allocator.NewAllocatorForGC(backend)
+
+	minID := idpool.ID(identity.MinimalAllocationIdentity)
+	maxID := idpool.ID(identity.MaximumAllocationIdentity)
+	a := allocator.NewAllocatorForGC(backend, allocator.WithMin(minID), allocator.WithMax(maxID))
 
 	keysToDelete := map[string]kvstore.Value{}
 	go func() {

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -155,7 +155,21 @@ type Allocator struct {
 type AllocatorOption func(*Allocator)
 
 // NewAllocatorForGC returns an allocator that can be used to run RunGC()
-func NewAllocatorForGC(backend Backend) *Allocator {
+//
+// The allocator can be configured by passing in additional options:
+//  - WithMin(id) - minimum ID to allocate (default: 1)
+//  - WithMax(id) - maximum ID to allocate (default max(uint64))
+func NewAllocatorForGC(backend Backend, opts ...AllocatorOption) *Allocator {
+	a := &Allocator{
+		backend: backend,
+		min:     idpool.ID(1),
+		max:     idpool.ID(^uint64(0)),
+	}
+
+	for _, fn := range opts {
+		fn(a)
+	}
+
 	return &Allocator{backend: backend}
 }
 


### PR DESCRIPTION
As the operator uses a different constructor for the GC of the
allocator, this constructor was not being initialized with the min and
max values of the identities that it should be GC. This commit adds
those options making it possible for the Operator to GC those
identities.

Fixes: 0c0f96531286 ("operator: only GC identity keys of its own cluster")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/19648