### PR TITLE
bgp-cp: fix taking address of of loop variable

### DIFF
--- a/pkg/bgpv1/gobgp/workdiff.go
+++ b/pkg/bgpv1/gobgp/workdiff.go
@@ -88,9 +88,9 @@ func (wd *reconcileDiff) empty() bool {
 // since registerOrReconcileDiff populates the `seen` field of a diff, this method should always
 // be called first when computing a reconcileDiff.
 func (wd *reconcileDiff) registerOrReconcileDiff(m LocalASNMap, policy *v2alpha1api.CiliumBGPPeeringPolicy) error {
-	for _, config := range policy.Spec.VirtualRouters {
+	for i, config := range policy.Spec.VirtualRouters {
 		if _, ok := wd.seen[config.LocalASN]; !ok {
-			wd.seen[config.LocalASN] = &config
+			wd.seen[config.LocalASN] = &policy.Spec.VirtualRouters[i]
 		} else {
 			return fmt.Errorf("encountered duplicate local ASNs")
 		}


### PR DESCRIPTION
this commit fixes a bug in computing a work diff when reconciliating BGP
virtual routers.

this bug would take an address of the the loop variable and store this
which is not the correct reference when utilized later.

to fix this, just take the address of the slice's index.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>

```release-note
Fixes a bug in the BGP control plane which causes the wrong BGP virtual servers to be selected for reconciliation or removal
```
