### PR TITLE
pkg/policy/policy: Optimize SearchContext String()

### DIFF
--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/labels"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -19,3 +22,101 @@ func Test(t *testing.T) {
 type PolicyTestSuite struct{}
 
 var _ = Suite(&PolicyTestSuite{})
+
+func (ds *PolicyTestSuite) TestSearchContextString(c *C) {
+	for expected, sc := range map[string]SearchContext{
+		"From: [unspec:a, unspec:b, unspec:c] => To: [unspec:d, unspec:e, unspec:f] Ports: [HTTP/TCP, HTTPs/TCP]": {
+			Trace: 1,
+			Depth: 0,
+			From:  labels.ParseLabelArray("a", "c", "b"),
+			To:    labels.ParseLabelArray("d", "e", "f"),
+			DPorts: []*models.Port{
+				{
+					Name:     "HTTP",
+					Port:     80,
+					Protocol: "TCP",
+				},
+				{
+					Name:     "HTTPs",
+					Port:     442,
+					Protocol: "TCP",
+				},
+			},
+			rulesSelect: false,
+		},
+		"From: [unspec:a, unspec:b, unspec:c] => To: [unspec:d, unspec:e, unspec:f] Ports: [80/TCP, 442/TCP]": {
+			Trace: 1,
+			Depth: 0,
+			From:  labels.ParseLabelArray("a", "c", "b"),
+			To:    labels.ParseLabelArray("d", "e", "f"),
+			DPorts: []*models.Port{
+				{
+					Port:     80,
+					Protocol: "TCP",
+				},
+				{
+					Port:     442,
+					Protocol: "TCP",
+				},
+			},
+			rulesSelect: false,
+		},
+		"From: [k8s:a, local:b, unspec:c] => To: [unspec:d, unspec:e, unspec:f]": {
+			Trace:       1,
+			Depth:       0,
+			From:        labels.ParseLabelArray("k8s:a", "unspec:c", "local:b"),
+			To:          labels.ParseLabelArray("d", "e", "f"),
+			rulesSelect: false,
+		},
+	} {
+		str := sc.String()
+		c.Assert(str, Equals, expected)
+	}
+}
+
+func BenchmarkSearchContextString(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, sc := range []SearchContext{
+			{
+				Trace: 1,
+				Depth: 0,
+				From:  labels.ParseLabelArray("a", "c", "b"),
+				To:    labels.ParseLabelArray("d", "e", "f"),
+				DPorts: []*models.Port{
+					{
+						Name:     "HTTP",
+						Port:     80,
+						Protocol: "TCP",
+					},
+					{
+						Name:     "HTTPs",
+						Port:     442,
+						Protocol: "TCP",
+					},
+				},
+				rulesSelect: false,
+			},
+			{
+				Trace: 1,
+				Depth: 0,
+				From:  labels.ParseLabelArray("a", "c", "b"),
+				To:    labels.ParseLabelArray("d", "e", "f"),
+				DPorts: []*models.Port{
+					{
+						Port:     80,
+						Protocol: "TCP",
+					},
+					{
+						Port:     442,
+						Protocol: "TCP",
+					},
+				},
+				rulesSelect: false,
+			},
+		} {
+			_ = sc.String()
+		}
+	}
+}


### PR DESCRIPTION
Use strings.Builder instead of fmt.Sprintf() and preallocate the size of
the string so that Go doesn't need to over-allocate if the string ends
up longer than what the buffer growth algorithm predicts.

issue reference : https://github.com/cilium/cilium/issues/19571

Result:

```
$ go test -v -run '^$' -bench 'BenchmarkSearchContextString' -benchmem ./pkg/policy > BenchmarkSearchContextString_old.txt
$ go test -v -run '^$' -bench 'BenchmarkSearchContextString' -benchmem ./pkg/policy > BenchmarkSearchContextString_new.txt
$ benchcmp BenchmarkSearchContextString_old.txt BenchmarkSearchContextString_new.txt
benchmark                          old ns/op     new ns/op     delta
BenchmarkSearchContextString-2     9336          5106          -45.31%

benchmark                          old allocs     new allocs     delta
BenchmarkSearchContextString-2     77             47             -38.96%

benchmark                          old bytes     new bytes     delta
BenchmarkSearchContextString-2     2736          1848          -32.46%
```

Signed-off-by: MikeLing <sabergeass@gmail.com>