### PR TITLE
test: Fix waiting for pod termination in K8sServices suite

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -22,7 +22,7 @@ IPFAMILY="${6:-${default_ipfamily}}"
 CILIUM_ROOT="$(realpath $(dirname $(readlink -ne $BASH_SOURCE))/../..)"
 
 usage() {
-  echo "Usage: ${PROG} [control-plane node count] [worker node count] [cluster-name] [node image] [kube-proxy mode]"
+  echo "Usage: ${PROG} [control-plane node count] [worker node count] [cluster-name] [node image] [kube-proxy mode] [ip-family]"
 }
 
 have_kind() {
@@ -34,12 +34,12 @@ if ! have_kind; then
     echo "  https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
 fi
 
-if [[ "${#}" -gt 5 ]]; then
+if [[ "${#}" -gt 6 ]]; then
   usage
   exit 1
 fi
 
-if [[ "${#}" -gt 5 ]] ||
+if [[ "${#}" -gt 6 ]] ||
    [[ "${CONTROLPLANES}" == "-h" ||
       "${CONTROLPLANES}" == "--help" ]]; then
   usage

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4699,3 +4699,13 @@ func (kub *Kubectl) WaitForServiceBackend(node, ipAddr string) error {
 		fmt.Sprintf("backend entry for %s was not found in time", ipAddr),
 		&TimeoutConfig{Timeout: HelperTimeout})
 }
+
+// WaitForDelete waits until resources in the given manifest file have been
+// removed.
+func (kub *Kubectl) WaitForDelete(manifestPath string) *CmdRes {
+	cmd := fmt.Sprintf("%s wait -f %s --for=delete", KubectlCmd, manifestPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), MidCommandTimeout*2)
+	defer cancel()
+	return kub.ExecContext(ctx, cmd)
+}

--- a/test/k8s/assertion_helpers.go
+++ b/test/k8s/assertion_helpers.go
@@ -75,6 +75,9 @@ func ExpectHubbleRelayReady(vm *helpers.Kubectl, ns string) {
 
 // ExpectAllPodsTerminated is a wrapper around helpers/WaitTerminatingPods.
 // It asserts that the error returned by that function is nil.
+//
+// The function is flaky - if all pods are not in terminating state yet, then
+// the function will prematurely return. Use `kubectl.WaitForDelete(...) instead.
 func ExpectAllPodsTerminated(vm *helpers.Kubectl) {
 	err := vm.WaitTerminatingPods(helpers.HelperTimeout)
 	ExpectWithOffset(1, err).To(BeNil(), "terminating containers are not deleted after timeout")

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -98,8 +98,9 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		AfterAll(func() {
 			for _, yaml := range yamls {
 				kubectl.Delete(yaml)
+				kubectl.WaitForDelete(yaml).
+					ExpectSuccess("Resources %s haven't been deleted in time", yaml)
 			}
-			ExpectAllPodsTerminated(kubectl)
 		})
 
 		// This is testing bpf_lxc LB (= KPR=disabled) when both client and
@@ -282,8 +283,9 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 				for _, yaml := range yamls {
 					path := helpers.ManifestGet(kubectl.BasePath(), yaml)
 					kubectl.Delete(path)
+					kubectl.WaitForDelete(path).
+						ExpectSuccess("Resources %s haven't been deleted in time", path)
 				}
-				ExpectAllPodsTerminated(kubectl)
 			})
 
 			// In adition to the bpf_sock bypass, this test is testing whether bpf_lxc
@@ -538,8 +540,9 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 		AfterAll(func() {
 			for _, yaml := range yamls {
 				kubectl.Delete(yaml)
+				kubectl.WaitForDelete(yaml).
+					ExpectSuccess("Resources %s haven't been deleted in time", yaml)
 			}
-			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("Tests NodePort with sessionAffinity from outside", func() {
@@ -901,7 +904,8 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 		AfterEach(func() {
 			wg.Wait()
 			kubectl.Delete(gracefulTermYAML)
-			ExpectAllPodsTerminated(kubectl)
+			kubectl.WaitForDelete(gracefulTermYAML).
+				ExpectSuccess("Resources %s haven't been deleted in time", gracefulTermYAML)
 		})
 
 		It("Checks client terminates gracefully on service endpoint deletion", func() {


### PR DESCRIPTION

This commit changes the way how we wait for the pods to be deleted in the K8sServices suite.

Previously, `ExpectAllPodsInNsTerminated()` was used to wait. The problem with the function is that it might prematurely return if all pods haven't entered a termination states yet.

This became visible when the CI started hitting the following flake:

    "Pods are still terminating:
        [echo-694c58bbf4-896gh echo-694c58bbf4-fr4ck]"

Further inspection showed that the kubelet was failing to remove the pods due to the CNI plugin being already gone:

    failed to "KillPodSandbox" for "..."
    with KillPodSandboxError: "rpc error: code = Unknown desc =
    networkPlugin cni failed to teardown pod
    \"echo-694c58bbf4-fr4ck_default\" network: failed to find plugin
    \"cilium-cni\" in path [/opt/cni/bin]"

This hinted that the wait for the deletion might be not working as expected.

This commit fixes the waiting by relying on `kubectl wait --for=deletion -f manifest.yaml` which we wrapped into the `WaitForDelete()` function.

Also, fix the kind.sh script bug.

Related #13909
Fix #18895 