### PR TITLE
v1.11 backports 2022-05-02

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -191,7 +191,7 @@ html_static_path = ['images', '_static']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-html_extra_path = ['robots']
+html_extra_path = ['robots/robots.txt']
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -72,7 +72,7 @@ author = u'Cilium Authors'
 release = open("../VERSION", "r").read().strip()
 # Used by version warning
 versionwarning_body_selector = "div.document"
-versionwarning_api_url = "docs.cilium.io"
+versionwarning_api_url = "https://docs.cilium.io/"
 
 # The version of Go used to compile Cilium
 go_release = open("../GO_VERSION", "r").read().strip()

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -699,7 +699,7 @@ with XDP, and number of combined channels need to be adapted.
 The default MTU is set to 9001 on the ena driver. Given XDP buffers are linear, they
 operate on a single page. A driver typically reserves some headroom for XDP as well
 (e.g. for encapsulation purpose), therefore, the highest possible MTU for XDP would
-be 3818.
+be 3498.
 
 In terms of ena channels, the settings can be gathered via ``ethtool -l eth0``. For the
 ``m5n.xlarge`` instance, the default output should look like::
@@ -721,7 +721,7 @@ In order to use XDP the channels must be set to at most 1/2 of the value from
 
 .. code-block:: shell-session
 
-  $ for ip in $IPS ; do ssh ec2-user@$ip "sudo ip link set dev eth0 mtu 3818"; done
+  $ for ip in $IPS ; do ssh ec2-user@$ip "sudo ip link set dev eth0 mtu 3498"; done
   $ for ip in $IPS ; do ssh ec2-user@$ip "sudo ethtool -L eth0 combined 2"; done
 
 In order to deploy Cilium, the Kubernetes API server IP and port is needed:

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1898,7 +1898,8 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 	l4_off = l3_off + ipv4_hdrlen(ip4);
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
-#if defined(ENABLE_EGRESS_GATEWAY) && !defined(TUNNEL_MODE)
+#if defined(ENABLE_EGRESS_GATEWAY) && !defined(TUNNEL_MODE) && \
+	__ctx_is != __ctx_xdp
 	/* Traffic from clients to egress gateway nodes reaches said gateways
 	 * by a vxlan tunnel. If we are not using TUNNEL_MODE, we need to
 	 * identify reverse traffic from the gateway to clients and also steer
@@ -1907,6 +1908,10 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 	 * egress gateway map using a reverse address tuple. A match means that
 	 * the corresponding forward traffic was forwarded to the egress gateway
 	 * via the tunnel.
+	 *
+	 * Currently, we don't support redirect to a tunnel netdev / encap on
+	 * XDP. Thus, the problem mentioned above is present when using the
+	 * egress gw feature with bpf_xdp.
 	 */
 	{
 		struct egress_gw_policy_entry *egress_policy;
@@ -1939,7 +1944,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 		bpf_mark_snat_done(ctx);
 
 		*ifindex = ct_state.ifindex;
-#ifdef TUNNEL_MODE
+#if defined(TUNNEL_MODE) && __ctx_is != __ctx_xdp
 		{
 			struct remote_endpoint_info *info;
 
@@ -2016,7 +2021,8 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 
 	return CTX_ACT_OK;
 
-#if defined(ENABLE_EGRESS_GATEWAY) || defined(TUNNEL_MODE)
+#if (defined(ENABLE_EGRESS_GATEWAY) || defined(TUNNEL_MODE)) && \
+	__ctx_is != __ctx_xdp
 encap_redirect:
 	ret = __encap_with_nodeid(ctx, tunnel_endpoint, SECLABEL, TRACE_PAYLOAD_LEN);
 	if (ret)

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -303,7 +303,7 @@ func updateIdentity(obj interface{}) {
 
 	var key []byte
 	for _, l := range labelArray {
-		key = append(key, []byte(l.FormatForKVStore())...)
+		key = append(key, l.FormatForKVStore()...)
 	}
 
 	if len(key) == 0 {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -224,7 +224,7 @@ func (d *Daemon) init() error {
 		bandwidth.InitBandwidthManager()
 
 		if err := d.createNodeConfigHeaderfile(); err != nil {
-			return err
+			return fmt.Errorf("failed while creating node config header file: %w", err)
 		}
 
 		if option.Config.SockopsEnable {
@@ -239,7 +239,7 @@ func (d *Daemon) init() error {
 		}
 
 		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
-			return err
+			return fmt.Errorf("failed while reinitializing datapath: %w", err)
 		}
 	}
 
@@ -347,6 +347,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	if option.Config.ReadCNIConfiguration != "" {
 		netConf, err = cnitypes.ReadNetConf(option.Config.ReadCNIConfiguration)
 		if err != nil {
+			log.WithError(err).Error("Unable to read CNI configuration")
 			return nil, nil, fmt.Errorf("unable to read CNI configuration: %w", err)
 		}
 
@@ -358,6 +359,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	apiLimiterSet, err := rate.NewAPILimiterSet(option.Config.APIRateLimit, apiRateLimitDefaults, &apiRateLimitingMetrics{})
 	if err != nil {
+		log.WithError(err).Error("unable to configure API rate limiting")
 		return nil, nil, fmt.Errorf("unable to configure API rate limiting: %w", err)
 	}
 
@@ -373,6 +375,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// created.
 	isKubeProxyReplacementStrict, err := initKubeProxyReplacementOptions()
 	if err != nil {
+		log.WithError(err).Error("unable to initialize Kube proxy replacement options")
 		return nil, nil, fmt.Errorf("unable to initialize Kube proxy replacement options: %w", err)
 	}
 
@@ -389,7 +392,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	if option.Config.DryMode == false {
 		if err := bpf.ConfigureResourceLimits(); err != nil {
-			return nil, nil, fmt.Errorf("unable to set memory resource limits: %w", err)
+			log.WithError(err).Error("unable to set memory resource limits")
 		}
 	}
 
@@ -455,6 +458,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	d.rec, err = recorder.NewRecorder(d.ctx, &d)
 	if err != nil {
+		log.WithError(err).Error("error while initializing BPF pcap recorder")
 		return nil, nil, fmt.Errorf("error while initializing BPF pcap recorder: %w", err)
 	}
 
@@ -568,6 +572,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	err = d.initMaps()
 	bootstrapStats.mapsInit.EndError(err)
 	if err != nil {
+		log.WithError(err).Error("error while opening/creating BPF maps")
 		return nil, nil, fmt.Errorf("error while opening/creating BPF maps: %w", err)
 	}
 
@@ -644,6 +649,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		}
 
 		if err := k8s.WaitForNodeInformation(d.ctx, d.k8sWatcher); err != nil {
+			log.WithError(err).Error("unable to connect to get node spec from apiserver")
 			return nil, nil, fmt.Errorf("unable to connect to get node spec from apiserver: %w", err)
 		}
 
@@ -661,7 +667,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	if wgAgent := dp.WireguardAgent(); option.Config.EnableWireguard {
 		if err := wgAgent.Init(mtuConfig); err != nil {
-			return nil, nil, fmt.Errorf("failed to initialize wireguard agent: %w", err)
+			log.WithError(err).Error("failed to initialize wireguard agent")
 		}
 	}
 
@@ -684,6 +690,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		disableNodePort()
 	}
 	if err := finishKubeProxyReplacementInit(isKubeProxyReplacementStrict); err != nil {
+		log.WithError(err).Error("failed to finalise LB initialization")
 		return nil, nil, fmt.Errorf("failed to finalise LB initialization: %w", err)
 	}
 
@@ -720,12 +727,15 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 	if option.Config.EnableIPv4EgressGateway {
 		if !probes.NewProbeManager().GetMisc().HaveLargeInsnLimit {
+			log.WithError(err).Error("egress gateway needs kernel 5.2 or newer")
 			return nil, nil, fmt.Errorf("egress gateway needs kernel 5.2 or newer")
 		}
 
 		// datapath code depends on remote node identities to distinguish between cluser-local and
 		// cluster-egress traffic
 		if !option.Config.EnableRemoteNodeIdentity {
+			log.WithError(err).Errorf("egress gateway requires remote node identities (--%s=\"true\").",
+				option.EnableRemoteNodeIdentity)
 			return nil, nil, fmt.Errorf("egress gateway requires remote node identities (--%s=\"true\").",
 				option.EnableRemoteNodeIdentity)
 		}
@@ -733,14 +743,18 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {
 		// TODO(brb) nodeport + ipvlan constraints will be lifted once the SNAT BPF code has been refactored
 		if option.Config.DatapathMode == datapathOption.DatapathModeIpvlan {
+			log.WithError(err).Errorf("BPF masquerade works only in veth mode (--%s=\"%s\"", option.DatapathMode, datapathOption.DatapathModeVeth)
 			return nil, nil, fmt.Errorf("BPF masquerade works only in veth mode (--%s=\"%s\"", option.DatapathMode, datapathOption.DatapathModeVeth)
 		}
 		if err := node.InitBPFMasqueradeAddrs(option.Config.Devices); err != nil {
+			log.WithError(err).Error("failed to determine BPF masquerade IPv4 addrs")
 			return nil, nil, fmt.Errorf("failed to determine BPF masquerade IPv4 addrs: %w", err)
 		}
 	} else if option.Config.EnableIPMasqAgent {
+		log.WithError(err).Errorf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
 		return nil, nil, fmt.Errorf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
 	} else if option.Config.EnableIPv4EgressGateway {
+		log.WithError(err).Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
 		return nil, nil, fmt.Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
 	} else if !option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade {
 		// There is not yet support for option.Config.EnableIPv6Masquerade
@@ -750,14 +764,17 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 	if option.Config.EnableIPMasqAgent {
 		if !option.Config.EnableIPv4 {
+			log.WithError(err).Errorf("BPF ip-masq-agent requires IPv4 support (--%s=\"true\")", option.EnableIPv4Name)
 			return nil, nil, fmt.Errorf("BPF ip-masq-agent requires IPv4 support (--%s=\"true\")", option.EnableIPv4Name)
 		}
 		if !probe.HaveFullLPM() {
+			log.WithError(err).Error("BPF ip-masq-agent needs kernel 4.16 or newer")
 			return nil, nil, fmt.Errorf("BPF ip-masq-agent needs kernel 4.16 or newer")
 		}
 	}
 	if option.Config.EnableHostFirewall && len(option.Config.Devices) == 0 {
 		msg := "host firewall's external facing device could not be determined. Use --%s to specify."
+		log.WithError(err).Errorf(msg, option.Devices)
 		return nil, nil, fmt.Errorf(msg, option.Devices)
 	}
 
@@ -800,9 +817,11 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	if option.Config.JoinCluster {
 		if k8s.IsEnabled() {
+			log.WithError(err).Errorf("cannot join a Cilium cluster (--%s) when configured as a Kubernetes node", option.JoinClusterName)
 			return nil, nil, fmt.Errorf("cannot join a Cilium cluster (--%s) when configured as a Kubernetes node", option.JoinClusterName)
 		}
 		if option.Config.KVStore == "" {
+			log.WithError(err).Errorf("joining a Cilium cluster (--%s) requires kvstore (--%s) be set", option.JoinClusterName, option.KVStore)
 			return nil, nil, fmt.Errorf("joining a Cilium cluster (--%s) requires kvstore (--%s) be set", option.JoinClusterName, option.KVStore)
 		}
 		agentLabels := labels.NewLabelsFromModel(option.Config.AgentLabels).K8sStringMap()
@@ -846,7 +865,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 	bootstrapStats.restore.End(true)
 
-	if err := d.allocateIPs(); err != nil {
+	if err := d.allocateIPs(); err != nil { // will log errors/fatal internally
 		return nil, nil, err
 	}
 
@@ -924,25 +943,28 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	// iptables rules can be updated only after d.init() intializes the iptables above.
 	err = d.updateDNSDatapathRules()
 	if err != nil {
-		return nil, restoredEndpoints, err
+		log.WithError(err).Error("error encountered while updating DNS datapath rules.")
+		return nil, restoredEndpoints, fmt.Errorf("error encountered while updating DNS datapath rules: %w", err)
 	}
 
 	// We can only attach the monitor agent once cilium_event has been set up.
 	if option.Config.RunMonitorAgent {
 		err = d.monitorAgent.AttachToEventsMap(defaults.MonitorBufferPages)
 		if err != nil {
-			return nil, nil, err
+			log.WithError(err).Error("encountered error configuring run monitor agent")
+			return nil, nil, fmt.Errorf("encountered error configuring run monitor agent: %w", err)
 		}
 
 		if option.Config.EnableMonitor {
 			err = monitoragent.ServeMonitorAPI(d.monitorAgent)
 			if err != nil {
-				return nil, nil, err
+				log.WithError(err).Error("encountered error configuring run monitor agent")
+				return nil, nil, fmt.Errorf("encountered error configuring run monitor agent: %w", err)
 			}
 		}
 	}
 
-	if err := d.syncEndpointsAndHostIPs(); err != nil {
+	if err := d.syncEndpointsAndHostIPs(); err != nil { // logs errors/fatal internally
 		return nil, nil, err
 	}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -890,6 +890,10 @@ func initializeFlags() {
 	flags.DurationVar(&option.Config.FQDNProxyResponseMaxDelay, option.FQDNProxyResponseMaxDelay, 100*time.Millisecond, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
 	option.BindEnv(option.FQDNProxyResponseMaxDelay)
 
+	flags.Int(option.FQDNRegexCompileLRUSize, 128, "Size of the FQDN regex compilation LRU. Useful for heavy but repeated FQDN MatchName or MatchPattern use")
+	flags.MarkHidden(option.FQDNRegexCompileLRUSize)
+	option.BindEnv(option.FQDNRegexCompileLRUSize)
+
 	flags.String(option.ToFQDNsPreCache, defaults.ToFQDNsPreCache, "DNS cache data at this path is preloaded on agent startup")
 	option.BindEnv(option.ToFQDNsPreCache)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -890,7 +890,7 @@ func initializeFlags() {
 	flags.DurationVar(&option.Config.FQDNProxyResponseMaxDelay, option.FQDNProxyResponseMaxDelay, 100*time.Millisecond, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
 	option.BindEnv(option.FQDNProxyResponseMaxDelay)
 
-	flags.Int(option.FQDNRegexCompileLRUSize, 128, "Size of the FQDN regex compilation LRU. Useful for heavy but repeated FQDN MatchName or MatchPattern use")
+	flags.Int(option.FQDNRegexCompileLRUSize, 1024, "Size of the FQDN regex compilation LRU. Useful for heavy but repeated FQDN MatchName or MatchPattern use")
 	flags.MarkHidden(option.FQDNRegexCompileLRUSize)
 	option.BindEnv(option.FQDNRegexCompileLRUSize)
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -336,16 +336,11 @@ func initKubeProxyReplacementOptions() (bool, error) {
 			option.Config.NodePortMode = option.NodePortModeSNAT
 		}
 
-		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
-			if option.Config.TunnelingEnabled() {
-				return false, fmt.Errorf("Cannot use NodePort acceleration with tunneling. Either run cilium-agent with --%s=%s or --%s=%s",
-					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.TunnelName, option.TunnelDisabled)
-			}
+		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled &&
+			option.Config.TunnelingEnabled() {
 
-			if option.Config.EnableIPv4EgressGateway {
-				return false, fmt.Errorf("Cannot use NodePort acceleration with the egress gateway. Run cilium-agent with either --%s=%s or %s=false",
-					option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.EnableIPv4EgressGateway)
-			}
+			return false, fmt.Errorf("Cannot use NodePort acceleration with tunneling. Either run cilium-agent with --%s=%s or --%s=%s",
+				option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.TunnelName, option.TunnelDisabled)
 		}
 
 		if option.Config.NodePortMode == option.NodePortModeDSR &&

--- a/operator/identity_gc.go
+++ b/operator/identity_gc.go
@@ -9,7 +9,9 @@ import (
 	"github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/allocator"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
@@ -24,7 +26,9 @@ func startKvstoreIdentityGC() {
 	if err != nil {
 		log.WithError(err).Fatal("Unable to initialize kvstore backend for identity allocation")
 	}
-	a := allocator.NewAllocatorForGC(backend)
+	minID := idpool.ID(identity.MinimalAllocationIdentity)
+	maxID := idpool.ID(identity.MaximumAllocationIdentity)
+	a := allocator.NewAllocatorForGC(backend, allocator.WithMin(minID), allocator.WithMax(maxID))
 
 	successfulRuns := 0
 	failedRuns := 0

--- a/operator/kvstore_watchdog.go
+++ b/operator/kvstore_watchdog.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
@@ -61,7 +63,10 @@ func startKvstoreWatchdog() {
 	if err != nil {
 		log.WithError(err).Fatal("Unable to initialize kvstore backend for identity garbage collection")
 	}
-	a := allocator.NewAllocatorForGC(backend)
+
+	minID := idpool.ID(identity.MinimalAllocationIdentity)
+	maxID := idpool.ID(identity.MaximumAllocationIdentity)
+	a := allocator.NewAllocatorForGC(backend, allocator.WithMin(minID), allocator.WithMax(maxID))
 
 	keysToDelete := map[string]kvstore.Value{}
 	go func() {

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -155,7 +155,21 @@ type Allocator struct {
 type AllocatorOption func(*Allocator)
 
 // NewAllocatorForGC returns an allocator that can be used to run RunGC()
-func NewAllocatorForGC(backend Backend) *Allocator {
+//
+// The allocator can be configured by passing in additional options:
+//  - WithMin(id) - minimum ID to allocate (default: 1)
+//  - WithMax(id) - maximum ID to allocate (default max(uint64))
+func NewAllocatorForGC(backend Backend, opts ...AllocatorOption) *Allocator {
+	a := &Allocator{
+		backend: backend,
+		min:     idpool.ID(1),
+		max:     idpool.ID(^uint64(0)),
+	}
+
+	for _, fn := range opts {
+		fn(a)
+	}
+
 	return &Allocator{backend: backend}
 }
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -389,7 +389,7 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		restoredEPs:              make(restoredEPs),
 		EnableDNSCompression:     enableDNSCompression,
 		maxIPsPerRestoredDNSRule: maxRestoreDNSIPs,
-		regexCompileLRU:          lru.New(128),
+		regexCompileLRU:          lru.New(option.Config.FQDNRegexCompileLRUSize),
 	}
 	atomic.StoreInt32(&p.rejectReply, dns.RcodeRefused)
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -11,7 +11,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -26,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -39,6 +42,7 @@ import (
 	"github.com/golang/groupcache/lru"
 	"github.com/miekg/dns"
 	. "gopkg.in/check.v1"
+	"sigs.k8s.io/yaml"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -981,6 +985,7 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 }
 
 type selectorMock struct {
+	key string
 }
 
 func (t selectorMock) GetSelections() []identity.NumericIdentity {
@@ -1000,7 +1005,7 @@ func (t selectorMock) IsNone() bool {
 }
 
 func (t selectorMock) String() string {
-	panic("implement me")
+	return t.key
 }
 
 func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
@@ -1028,8 +1033,8 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 			},
 		}
 	}
-	pea := perEPAllow{}
 
+	pea := perEPAllow{}
 	lru := lru.New(128)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -1038,4 +1043,104 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 			pea.setPortRulesForID(lru, epID, 8053, newRules)
 		}
 	}
+}
+
+func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
+	b.Skip()
+
+	bb, err := ioutil.ReadFile("testdata/cnps-large.yaml")
+	if err != nil {
+		b.Fatal(err)
+	}
+	var cnpList v2.CiliumNetworkPolicyList
+	if err := yaml.Unmarshal(bb, &cnpList); err != nil {
+		b.Fatal(err)
+	}
+
+	rules := policy.L7DataMap{}
+
+	addEgress := func(e []api.EgressRule) {
+		var (
+			portRuleDNS []api.PortRuleDNS
+		)
+		for _, egress := range e {
+			if egress.ToPorts != nil {
+				for _, ports := range egress.ToPorts {
+					if ports.Rules != nil {
+						for _, dns := range ports.Rules.DNS {
+							if len(dns.MatchPattern) > 0 {
+								portRuleDNS = append(portRuleDNS, api.PortRuleDNS{
+									MatchPattern: dns.MatchPattern,
+								})
+							}
+							if len(dns.MatchName) > 0 {
+								portRuleDNS = append(portRuleDNS, api.PortRuleDNS{
+									MatchName: dns.MatchName,
+								})
+							}
+						}
+					}
+				}
+			}
+		}
+		rules[new(selectorMock)] = &policy.PerSelectorPolicy{
+			L7Rules: api.L7Rules{
+				DNS: portRuleDNS,
+			},
+		}
+	}
+
+	for _, cnp := range cnpList.Items {
+		if cnp.Specs != nil {
+			for _, spec := range cnp.Specs {
+				if spec.Egress != nil {
+					addEgress(spec.Egress)
+				}
+			}
+		}
+		if cnp.Spec != nil {
+			if cnp.Spec.Egress != nil {
+				addEgress(cnp.Spec.Egress)
+			}
+		}
+	}
+
+	fmt.Printf("Before (N=%v)\n", b.N)
+
+	runtime.GC()
+
+	m := getMemStats()
+	fmt.Printf("Alloc = %v MiB", bToMb(m.Alloc))
+	fmt.Printf("\tHeapInuse = %v MiB", bToMb(m.HeapInuse))
+	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
+	fmt.Printf("\tNumGC = %v\n", m.NumGC)
+
+	pea := perEPAllow{}
+	lru := lru.New(128) // modify to 1024 and compare results
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for epID := uint64(0); epID < 20; epID++ {
+			pea.setPortRulesForID(lru, epID, 8053, rules)
+		}
+	}
+	b.StopTimer()
+
+	fmt.Printf("After (N=%v)\n", b.N)
+
+	m = getMemStats()
+	fmt.Printf("Alloc = %v MiB", bToMb(m.Alloc))
+	fmt.Printf("\tHeapInuse = %v MiB", bToMb(m.HeapInuse))
+	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
+	fmt.Printf("\tNumGC = %v\n", m.NumGC)
+}
+
+func getMemStats() runtime.MemStats {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m
+}
+
+func bToMb(b uint64) uint64 {
+	return b / 1024 / 1024
 }

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"path"
+	"strings"
 
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/identity"
@@ -38,11 +39,12 @@ type GlobalIdentity struct {
 }
 
 // GetKey encodes an Identity as string
-func (gi GlobalIdentity) GetKey() (str string) {
+func (gi GlobalIdentity) GetKey() string {
+	var str strings.Builder
 	for _, l := range gi.LabelArray {
-		str += l.FormatForKVStore()
+		str.Write(l.FormatForKVStore())
 	}
-	return
+	return str.String()
 }
 
 // GetAsMap encodes a GlobalIdentity a map of keys to values. The keys will

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -4,6 +4,7 @@
 package labels
 
 import (
+	"bytes"
 	"crypto/sha512"
 	"encoding/json"
 	"fmt"
@@ -454,14 +455,22 @@ func (l Labels) SHA256Sum() string {
 // PART OF THE KEY IN THE KEY-VALUE STORE.
 //
 // Non-pointer receiver allows this to be called on a value in a map.
-func (l Label) FormatForKVStore() string {
+func (l Label) FormatForKVStore() []byte {
 	// We don't care if the values already have a '=' since this method is
 	// only used to calculate a SHA256Sum
 	//
 	// We absolutely care that the final character is a semi-colon.
 	// Identity allocation in the kvstore depends on this (see
 	// kvstore.prefixMatchesKey())
-	return fmt.Sprintf(`%s:%s=%s;`, l.Source, l.Key, l.Value)
+	b := make([]byte, 0, len(l.Source)+len(l.Key)+len(l.Value)+3)
+	buf := bytes.NewBuffer(b)
+	buf.WriteString(l.Source)
+	buf.WriteRune(':')
+	buf.WriteString(l.Key)
+	buf.WriteRune('=')
+	buf.WriteString(l.Value)
+	buf.WriteRune(';')
+	return buf.Bytes()
 }
 
 // SortedList returns the labels as a sorted list, separated by semicolon
@@ -475,12 +484,13 @@ func (l Labels) SortedList() []byte {
 	}
 	sort.Strings(keys)
 
-	result := ""
+	b := make([]byte, 0, len(keys)*2)
+	buf := bytes.NewBuffer(b)
 	for _, k := range keys {
-		result += l[k].FormatForKVStore()
+		buf.Write(l[k].FormatForKVStore())
 	}
 
-	return []byte(result)
+	return buf.Bytes()
 }
 
 // ToSlice returns a slice of label with the values of the given

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -403,6 +403,23 @@ func TestLabels_GetFromSource(t *testing.T) {
 	}
 }
 
+func BenchmarkLabels_SortedList(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = lbls.SortedList()
+	}
+}
+
+func BenchmarkLabel_FormatForKVStore(b *testing.B) {
+	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", "k8s")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = l.FormatForKVStore()
+	}
+}
+
 func BenchmarkLabel_String(b *testing.B) {
 	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", "k8s")
 	b.ReportAllocs()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -651,6 +651,10 @@ const (
 	// FQDNProxyResponseMaxDelay is the maximum time the proxy holds back a response
 	FQDNProxyResponseMaxDelay = "tofqdns-proxy-response-max-delay"
 
+	// FQDNRegexCompileLRUSize is the size of the FQDN regex compilation LRU.
+	// Useful for heavy but repeated FQDN MatchName or MatchPattern use.
+	FQDNRegexCompileLRUSize = "fqdn-regex-compile-lru-size"
+
 	// PreAllocateMapsName is the name of the option PreAllocateMaps
 	PreAllocateMapsName = "preallocate-bpf-maps"
 
@@ -1565,6 +1569,10 @@ type DaemonConfig struct {
 	// DNS response before sending it along. Responses are sent as soon as the
 	// datapath is updated with the new IP information.
 	FQDNProxyResponseMaxDelay time.Duration
+
+	// FQDNRegexCompileLRUSize is the size of the FQDN regex compilation LRU.
+	// Useful for heavy but repeated FQDN MatchName or MatchPattern use.
+	FQDNRegexCompileLRUSize int
 
 	// Path to a file with DNS cache data to preload on startup
 	ToFQDNsPreCache string
@@ -2726,6 +2734,7 @@ func (c *DaemonConfig) Populate() {
 
 	// toFQDNs options
 	c.DNSMaxIPsPerRestoredRule = viper.GetInt(DNSMaxIPsPerRestoredRule)
+	c.FQDNRegexCompileLRUSize = viper.GetInt(FQDNRegexCompileLRUSize)
 	c.ToFQDNsMaxIPsPerHost = viper.GetInt(ToFQDNsMaxIPsPerHost)
 	if maxZombies := viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes); maxZombies >= 0 {
 		c.ToFQDNsMaxDeferredConnectionDeletes = viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes)

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -6,6 +6,7 @@ package api
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
@@ -61,7 +62,15 @@ type FQDNSelector struct {
 }
 
 func (s *FQDNSelector) String() string {
-	return fmt.Sprintf("MatchName: %s, MatchPattern: %s", s.MatchName, s.MatchPattern)
+	const m = "MatchName: "
+	const mm = ", MatchPattern: "
+	var str strings.Builder
+	str.Grow(len(m) + len(mm) + len(s.MatchName) + len(s.MatchPattern))
+	str.WriteString(m)
+	str.WriteString(s.MatchName)
+	str.WriteString(mm)
+	str.WriteString(s.MatchPattern)
+	return str.String()
 }
 
 // sanitize for FQDNSelector is a little wonky. While we do more processing

--- a/pkg/policy/api/fqdn_test.go
+++ b/pkg/policy/api/fqdn_test.go
@@ -7,6 +7,8 @@
 package api
 
 import (
+	"testing"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -63,5 +65,22 @@ func (s *PolicyAPITestSuite) TestPortRuleDNSSanitize(c *C) {
 	} {
 		err := reject.Sanitize()
 		c.Assert(err, Not(IsNil), Commentf("PortRuleDNS %+v was accepted but it should be invalid", reject))
+	}
+}
+
+// TestPortRuleDNSSanitize tests that the sanitizer correctly catches bad
+// cases, and allows good ones.
+func BenchmarkFQDNSelectorString(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, s := range []FQDNSelector{
+			{MatchName: "cilium.io"},
+			{MatchPattern: "[a-z]*.cilium.io"},
+			{MatchName: "a{1,2}.cilium.io", MatchPattern: "[a-z]*.cilium.io"},
+			{MatchPattern: "*.cilium.io"},
+		} {
+			_ = s.String()
+		}
 	}
 }


### PR DESCRIPTION
* #19570 -- pkg/policy/api: Optimize FQDNSelector String() (@christarazi)
 * #19593 -- docs: Update max MTU value for Nodeport XDP on AWS (@qmonnet)
 * #19610 -- docs: set the right url for API version check (@aanm)
 * #19423 -- pkg/labels: Optimize SortedList() and FormatForKVStore() (@christarazi)
 * #19587 -- datapath: Allow egress GW with XDP (@brb)
 * #19638 -- docs: set right path for robots.txt (@aanm)
 * #19383 -- daemon, fqdn: Add flag to control FQDN regex LRU size (@christarazi) --
                      **Resolved conflicts (please check)**
 * #19649 -- operator: fix identity GC collection (@aanm)
 * #19188 -- logging: do not swallow subsystem logs (@ldelossa) --
                     **Resolved conflicts (please check)**

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19570 19593 19610 19423 19587 19638 19383 19649 19188; do contrib/backporting/set-labels.py $pr done 1.11; done
```