### PR TITLE
v1.10 backports 2022-05-02

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -70,7 +70,7 @@ author = u'Cilium Authors'
 release = open("../VERSION", "r").read().strip()
 # Used by version warning
 versionwarning_body_selector = "div.document"
-versionwarning_api_url = "docs.cilium.io"
+versionwarning_api_url = "https://docs.cilium.io/"
 
 # The version of Go used to compile Cilium
 go_release = open("../GO_VERSION", "r").read().strip()

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -698,7 +698,7 @@ with XDP, and number of combined channels need to be adapted.
 The default MTU is set to 9001 on the ena driver. Given XDP buffers are linear, they
 operate on a single page. A driver typically reserves some headroom for XDP as well
 (e.g. for encapsulation purpose), therefore, the highest possible MTU for XDP would
-be 3818.
+be 3498.
 
 In terms of ena channels, the settings can be gathered via ``ethtool -l eth0``. For the
 ``m5n.xlarge`` instance, the default output should look like::
@@ -720,7 +720,7 @@ In order to use XDP the channels must be set to at most 1/2 of the value from
 
 .. code-block:: shell-session
 
-  $ for ip in $IPS ; do ssh ec2-user@$ip "sudo ip link set dev eth0 mtu 3818"; done
+  $ for ip in $IPS ; do ssh ec2-user@$ip "sudo ip link set dev eth0 mtu 3498"; done
   $ for ip in $IPS ; do ssh ec2-user@$ip "sudo ethtool -L eth0 combined 2"; done
 
 In order to deploy Cilium, the Kubernetes API server IP and port is needed:


### PR DESCRIPTION
* #19593 -- docs: Update max MTU value for Nodeport XDP on AWS (@qmonnet)
* #19610 -- docs: set the right url for API version check (@aanm)
* ~#19626 -- daemon: Initialize k8sCachesSynced channel before calling Initk8sSubsystem() (@jrajahalme) --
                      **Resolved conflicts (please check)~** 

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19593 19610; do contrib/backporting/set-labels.py $pr done 1.10; done
```