### PR TITLE
daemon, option: remove deprecated native-routing-cidr option

### DIFF
--- a/.github/workflows/tests-nightly.yaml
+++ b/.github/workflows/tests-nightly.yaml
@@ -49,7 +49,7 @@ jobs:
             --set prometheus.enabled=true \
             --set operator.prometheus.enabled=true \
             --set hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}" \
-            --set nativeRoutingCIDR=NATIVE_CIDR_PLACEHOLDER \
+            --set ipv4NativeRoutingCIDR=NATIVE_CIDR_PLACEHOLDER \
             | tee -a cilium.yaml
       - name: Request GKE test cluster
         uses: docker://quay.io/isovalent/gke-test-cluster-requester:fe34abda190c31680968ba62634c788428d91706@sha256:5f4345487870e0447afa150d2b12741ac8734c36ae13a46a13b80c7129da9b4b

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -338,6 +338,8 @@ Removed Options
   in version 1.13.
 * The ``host-reachable-services-protos`` option (``.hostServices.protocols`` in
   Helm) was deprecated, and it will be removed in version 1.13.
+* The ``native-routing-cidr`` option deprecated in 1.11 in favor of
+  ``ipv4-native-routing-cidr`` has been removed.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -95,7 +95,6 @@ MiB
 Minikube
 Monnet
 Mythbusters
-NativeRoutingCIDR
 NeighDiscovery
 Netronome
 NewProto

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -675,15 +675,6 @@ func initializeFlags() {
 	flags.Bool(option.EnableHostFirewall, false, "Enable host network policies")
 	option.BindEnv(option.EnableHostFirewall)
 
-	flags.String(option.NativeRoutingCIDR, "",
-		fmt.Sprintf("Allows to explicitly specify the IPv4 CIDR for native routing. "+
-			"When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. "+
-			"Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. "+
-			"To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag. "+
-			"Deprecated in favor of --%s", option.IPv4NativeRoutingCIDR))
-	option.BindEnv(option.NativeRoutingCIDR)
-	flags.MarkDeprecated(option.NativeRoutingCIDR, "This option will be removed in v1.12")
-
 	flags.String(option.IPv4NativeRoutingCIDR, "", "Allows to explicitly specify the IPv4 CIDR for native routing. "+
 		"When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. "+
 		"Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. "+

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1073,10 +1073,6 @@ func initializeFlags() {
 		"Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.")
 	option.BindEnv(option.EgressMultiHomeIPRuleCompat)
 
-	flags.Bool(option.EnableBPFBypassFIBLookup, false, "Enable FIB lookup bypass optimization for nodeport reverse NAT handling")
-	option.BindEnv(option.EnableBPFBypassFIBLookup)
-	flags.MarkDeprecated(option.EnableBPFBypassFIBLookup, fmt.Sprintf("This option will be removed in v1.12."))
-
 	flags.Bool(option.InstallNoConntrackIptRules, defaults.InstallNoConntrackIptRules, "Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.")
 	option.BindEnv(option.InstallNoConntrackIptRules)
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -519,9 +519,7 @@ data:
   enable-local-redirect-policy: {{ .Values.localRedirectPolicy | quote }}
 {{- end }}
 
-{{- if hasKey .Values "nativeRoutingCIDR" }}
-  ipv4-native-routing-cidr: {{ .Values.nativeRoutingCIDR }}
-{{- else if hasKey .Values "ipv4NativeRoutingCIDR" }}
+{{- if hasKey .Values "ipv4NativeRoutingCIDR" }}
   ipv4-native-routing-cidr: {{ .Values.ipv4NativeRoutingCIDR }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1202,20 +1202,6 @@ vtep:
 # direct routing and the Kubernetes CIDR is included in the native routing CIDR,
 # the user must configure the routes to reach pods, either manually or by
 # setting the auto-direct-node-routes flag.
-#
-# Deprecated in favor of ipv4NativeRoutingCIDR, will be removed in 1.12.
-# nativeRoutingCIDR:
-
-# -- Allows to explicitly specify the IPv4 CIDR for native routing.
-# When specified, Cilium assumes networking for this CIDR is preconfigured and
-# hands traffic destined for that range to the Linux network stack without
-# applying any SNAT.
-# Generally speaking, specifying a native routing CIDR implies that Cilium can
-# depend on the underlying networking stack to route packets to their
-# destination. To offer a concrete example, if Cilium is configured to use
-# direct routing and the Kubernetes CIDR is included in the native routing CIDR,
-# the user must configure the routes to reach pods, either manually or by
-# setting the auto-direct-node-routes flag.
 # ipv4NativeRoutingCIDR:
 
 # -- Allows to explicitly specify the IPv6 CIDR for native routing.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1019,10 +1019,6 @@ const (
 	// Otherwise, it will use the old scheme.
 	EgressMultiHomeIPRuleCompat = "egress-multi-home-ip-rule-compat"
 
-	// EnableBPFBypassFIBLookup instructs Cilium to enable the FIB lookup bypass
-	// optimization for nodeport reverse NAT handling (DEPRECATED).
-	EnableBPFBypassFIBLookup = "bpf-lb-bypass-fib-lookup"
-
 	// EnableCustomCallsName is the name of the option to enable tail calls
 	// for user-defined custom eBPF programs.
 	EnableCustomCallsName = "enable-custom-calls"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -838,9 +838,6 @@ const (
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource = "auto-create-cilium-node-resource"
 
-	// NativeRoutingCIDR describes a v4 CIDR in which pod IPs are routable
-	NativeRoutingCIDR = "native-routing-cidr"
-
 	// IPv4NativeRoutingCIDR describes a v4 CIDR in which pod IPs are routable
 	IPv4NativeRoutingCIDR = "ipv4-native-routing-cidr"
 
@@ -2912,20 +2909,9 @@ func (c *DaemonConfig) Populate() {
 		c.AddressScopeMax = defaults.AddressScopeMax
 	}
 
-	nativeRoutingCIDR := viper.GetString(NativeRoutingCIDR)
 	ipv4NativeRoutingCIDR := viper.GetString(IPv4NativeRoutingCIDR)
 
-	if nativeRoutingCIDR != "" && ipv4NativeRoutingCIDR != "" {
-		log.Fatalf("Cannot specify both %s and %s", NativeRoutingCIDR, IPv4NativeRoutingCIDR)
-	}
-
-	if nativeRoutingCIDR != "" {
-		c.IPv4NativeRoutingCIDR = cidr.MustParseCIDR(nativeRoutingCIDR)
-
-		if len(c.IPv4NativeRoutingCIDR.IP) != net.IPv4len {
-			log.Fatalf("%s must be an IPv4 CIDR", NativeRoutingCIDR)
-		}
-	} else if ipv4NativeRoutingCIDR != "" {
+	if ipv4NativeRoutingCIDR != "" {
 		c.IPv4NativeRoutingCIDR = cidr.MustParseCIDR(ipv4NativeRoutingCIDR)
 
 		if len(c.IPv4NativeRoutingCIDR.IP) != net.IPv4len {
@@ -2933,7 +2919,7 @@ func (c *DaemonConfig) Populate() {
 		}
 	}
 
-	if c.EnableIPv4 && nativeRoutingCIDR == "" && ipv4NativeRoutingCIDR == "" && c.EnableAutoDirectRouting {
+	if c.EnableIPv4 && ipv4NativeRoutingCIDR == "" && c.EnableAutoDirectRouting {
 		log.Warnf("If %s is enabled, then you are recommended to also configure %s. If %s is not configured, this may lead to pod to pod traffic being masqueraded, "+
 			"which can cause problems with performance, observability and policy", EnableAutoDirectRoutingName, IPv4NativeRoutingCIDR, IPv4NativeRoutingCIDR)
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -147,7 +147,7 @@ var (
 		"cni.binPath":                 "/home/kubernetes/bin",
 		"gke.enabled":                 "true",
 		"loadBalancer.mode":           "snat",
-		"nativeRoutingCIDR":           GKENativeRoutingCIDR(),
+		"ipv4NativeRoutingCIDR":       GKENativeRoutingCIDR(),
 		"hostFirewall.enabled":        "false",
 		"ipam.mode":                   "kubernetes",
 		"devices":                     "", // Override "eth0 eth0\neth0"


### PR DESCRIPTION
The native-routing-cidr option was deprecated in Cilium v1.11 in favor
of ipv4-native-routing-cidr. Remove the option for the upcoming v1.12
release.
