### PR TITLE
Document that clustermesh cluster-id range is 1-255

### DIFF
--- a/Documentation/gettingstarted/clustermesh/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh/clustermesh.rst
@@ -43,7 +43,7 @@ Specify the Cluster Name and ID
 ===============================
 
 Each cluster must be assigned a unique human-readable name as well as a numeric
-cluster ID (0-255). It is best to assign both these attributes at installation
+cluster ID (1-255). It is best to assign both these attributes at installation
 time of Cilium:
 
  * ConfigMap options ``cluster-name`` and ``cluster-id``


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

The documented clustermesh cluster-id range is 0-255 but actually seems to be 1-255 as per https://github.com/cilium/cilium/blob/master/daemon/cmd/daemon.go#L1188-L1190
