### PR TITLE
install/cilium-operator: fix clusterrole rules

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -25,6 +25,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
 {{- if .Values.operator.removeNodeTaints }}
   # To remove node taints
   - nodes
@@ -34,8 +41,6 @@ rules:
   - nodes/status
 {{- end }}
   verbs:
-  - list
-  - watch
   - patch
 {{- end }}
 - apiGroups:


### PR DESCRIPTION
The clusterrole rules would be incorrect if the user would install
Cilium with --set operator.removeNodeTaints=false as it would lose the
permissions to list and watch k8s nodes.

Signed-off-by: André Martins <andre@cilium.io>

cc @sayboras maybe worth holding https://github.com/cilium/cilium/pull/19576 until this PR is merged?

The backport of this PR is already being done in https://github.com/cilium/cilium/pull/19673 https://github.com/cilium/cilium/pull/19674 and https://github.com/cilium/cilium/pull/19675