### PR TITLE
vtep: Documents VTEP redirection and L7 policy partial incompatibility

### DIFF
--- a/Documentation/gettingstarted/vtep.rst
+++ b/Documentation/gettingstarted/vtep.rst
@@ -32,10 +32,9 @@ endpoint IPs, CIDRs, and MAC addresses.
 
 .. warning::
 
-   This feature is in beta, and is currently incompatible with network policy.
-   The instructions below will specify to disable network policy in order to enable
-   the feature for getting started. This restriction will be lifted when the feature
-   graduates from beta. This work is tracked in :gh-issue:`17694`.
+   This feature is in beta, and currently, it is partially incompatible the L7 policy.
+   When a pod with an egress L7 policy sends a request to VTEP devices, the VTEP redirection
+   is bypassed. The improvement is tracked in :gh-issue:`19699`.
 
 
 Enable VXLAN Tunnel Endpoint (VTEP) integration

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -275,6 +275,12 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 		if err != nil {
 			return err
 		}
+		if option.Config.EnableL7Proxy {
+			log.WithField(logfields.URL, "https://github.com/cilium/cilium/issues/19699").
+				Warningf("Both VTEP redirection (%s) and L7 proxy (--%s) are enabled. This is currently not fully supported: "+
+					"if the endpoint has a L7 policy and send request to VTEP devices , endpoint traffic will not go through VTEP devices.", option.EnableVTEP, option.EnableL7Proxy)
+
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Update the VTEP redirection and L7 policy partial incompatibility
documentation, log warnings when both VTEP rediretion and L7 policy
enabled

Reported-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
doc: VTEP redirection and L7 policy partially incompatible
```
