### PR TITLE
pkg/policy/api: Optimize Decision MarshalJSON()

### DIFF
--- a/pkg/policy/api/decision.go
+++ b/pkg/policy/api/decision.go
@@ -58,5 +58,11 @@ func (d *Decision) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON returns the decision as JSON formatted buffer
 func (d Decision) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, d)), nil
+	s := d.String()
+	// length of decision string plus two `"`
+	b := make([]byte, len(s)+2)
+	b[0] = '"'
+	copy(b[1:], s)
+	b[len(b)-1] = '"'
+	return b, nil
 }

--- a/pkg/policy/api/decision_test.go
+++ b/pkg/policy/api/decision_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package api
+
+import (
+	"testing"
+)
+
+func BenchmarkDecisionMarshalJSON(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, d := range []Decision{
+			Undecided,
+			Allowed,
+			Denied,
+		} {
+			_, _ = d.MarshalJSON()
+		}
+	}
+}


### PR DESCRIPTION
Use strings.Builder instead of fmt.Sprintf() and preallocate the size of
the string so that Go doesn't need to over-allocate if the string ends
up longer than what the buffer growth algorithm predicts.

Result:
```
$ go test -benchmem -run=^$ -bench ^BenchmarkDecisionMarshalJSON$ ./pkg/policy/api > BenchmarkDecisionMarshalJSON_old.txt
$ go test -benchmem -run=^$ -bench ^BenchmarkDecisionMarshalJSON$ ./pkg/policy/api > BenchmarkDecisionMarshalJSON_new.txt
$ benchcmp BenchmarkDecisionMarshalJSON_old.txt BenchmarkDecisionMarshalJSON_new.txt
benchmark                          old ns/op     new ns/op     delta
BenchmarkDecisionMarshalJSON-4     751           157           -79.13%

benchmark                          old allocs     new allocs     delta
BenchmarkDecisionMarshalJSON-4     3              3              +0.00%

benchmark                          old bytes     new bytes     delta
BenchmarkDecisionMarshalJSON-4     40            40            +0.00%
```

issue reference : https://github.com/cilium/cilium/issues/19571

Signed-off-by: MikeLing <sabergeass@gmail.com>