### PR TITLE
bpf: add "cilium bpf lb list --source-ranges"

### DIFF
--- a/Documentation/cmdref/cilium_bpf_lb_list.md
+++ b/Documentation/cmdref/cilium_bpf_lb_list.md
@@ -16,6 +16,7 @@ cilium bpf lb list [flags]
   -h, --help            help for list
   -o, --output string   json| yaml| jsonpath='{}'
       --revnat          List reverse NAT entries
+      --source-ranges   List all source range entries
 ```
 
 ### Options inherited from parent commands

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -374,6 +374,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium bpf lb list --revnat",
 		"cilium bpf lb list --frontends",
 		"cilium bpf lb list --backends",
+		"cilium bpf lb list --source-ranges",
 		"cilium bpf lb maglev list",
 		"cilium bpf egress list",
 		"cilium bpf vtep list",

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -20,11 +20,21 @@ const (
 	serviceAddressTitle = "SERVICE ADDRESS"
 	backendIdTitle      = "BACKEND ID"
 	backendAddressTitle = "BACKEND ADDRESS (REVNAT_ID) (SLOT)"
+	srcRangeTitle       = "SOURCE RANGE (REVNAT_ID)"
 )
 
 var (
-	listRevNAT, listFrontends, listBackends bool
+	listRevNAT, listFrontends, listBackends, listSrcRanges bool
 )
+
+func dumpSrcRanges(serviceList map[string][]string) {
+	if err := lbmap.SourceRange4Map.DumpIfExists(serviceList); err != nil {
+		Fatalf("Unable to dump IPv4 source range table: %s", err)
+	}
+	if err := lbmap.SourceRange6Map.DumpIfExists(serviceList); err != nil {
+		Fatalf("Unable to dump IPv6 source range table: %s", err)
+	}
+}
 
 func dumpRevNat(serviceList map[string][]string) {
 	if err := lbmap.RevNat4Map.DumpIfExists(serviceList); err != nil {
@@ -138,6 +148,10 @@ var bpfLBListCmd = &cobra.Command{
 		case listBackends:
 			firstTitle = idTitle
 			dumpBackends(serviceList)
+		case listSrcRanges:
+			firstTitle = srcRangeTitle
+			secondTitle = ""
+			dumpSrcRanges(serviceList)
 		default:
 			firstTitle = serviceAddressTitle
 			dumpSVC(serviceList)
@@ -159,5 +173,6 @@ func init() {
 	bpfLBListCmd.Flags().BoolVarP(&listRevNAT, "revnat", "", false, "List reverse NAT entries")
 	bpfLBListCmd.Flags().BoolVarP(&listFrontends, "frontends", "", false, "List all service frontend entries")
 	bpfLBListCmd.Flags().BoolVarP(&listBackends, "backends", "", false, "List all service backend entries")
+	bpfLBListCmd.Flags().BoolVarP(&listSrcRanges, "source-ranges", "", false, "List all source range entries")
 	command.AddOutputOption(bpfLBListCmd)
 }

--- a/pkg/maps/lbmap/source_range.go
+++ b/pkg/maps/lbmap/source_range.go
@@ -47,7 +47,10 @@ type SourceRangeKey4 struct {
 
 func (k *SourceRangeKey4) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 func (k *SourceRangeKey4) NewValue() bpf.MapValue    { return &SourceRangeValue{} }
-func (k *SourceRangeKey4) String() string            { return fmt.Sprintf("%s", k.Address) }
+func (k *SourceRangeKey4) String() string {
+	kHost := k.ToHost().(*SourceRangeKey4)
+	return fmt.Sprintf("%s (%d)", kHost.GetCIDR().String(), kHost.GetRevNATID())
+}
 func (k *SourceRangeKey4) ToNetwork() SourceRangeKey {
 	n := *k
 	// For some reasons rev_nat_index is stored in network byte order in
@@ -88,7 +91,10 @@ type SourceRangeKey6 struct {
 
 func (k *SourceRangeKey6) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 func (k *SourceRangeKey6) NewValue() bpf.MapValue    { return &SourceRangeValue{} }
-func (k *SourceRangeKey6) String() string            { return fmt.Sprintf("%s", k.Address) }
+func (k *SourceRangeKey6) String() string {
+	kHost := k.ToHost().(*SourceRangeKey6)
+	return fmt.Sprintf("%s (%d)", kHost.GetCIDR().String(), kHost.GetRevNATID())
+}
 func (k *SourceRangeKey6) ToNetwork() SourceRangeKey {
 	n := *k
 	// For some reasons rev_nat_index is stored in network byte order in


### PR DESCRIPTION
https://github.com/cilium/cilium/issues/13303 suggested to expose the source-ranges BPF map through `cilium`, and use that in the LB test. Decided to plumb it into `cilium bpf lb list` for now, instead of having a new `cilium bpf source-ranges list`.

Not closing that issue yet, as we also want to have support in `cilium service list`.

```release-note
Add --source-ranges option to `cilium bpf lb list`
```
