### PR TITLE
test/upgrade: use the unreleased helm chart of stable branches

### DIFF
--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -22,6 +22,7 @@ var (
 	l7Policy         string
 	migrateSVCClient string
 	migrateSVCServer string
+	stableChartPath  string
 )
 
 var _ = Describe("K8sUpdates", func() {
@@ -77,6 +78,20 @@ var _ = Describe("K8sUpdates", func() {
 
 		By("Waiting for pods to be terminated")
 		ExpectAllPodsTerminated(kubectl)
+
+		// Download the stable helm chart from GitHub
+		versionPath := filepath.Join(kubectl.BasePath(), "../old-charts/%s", helpers.CiliumStableVersion)
+		stableChartPath = filepath.Join(versionPath, fmt.Sprintf("cilium-%s/install/kubernetes/cilium", helpers.CiliumStableHelmChartVersion))
+
+		cmd := kubectl.ExecMiddle(fmt.Sprintf("mkdir -p %s && "+
+			"cd %s &&"+
+			"wget https://github.com/cilium/cilium/archive/refs/heads/%s.zip &&"+
+			"unzip %s.zip",
+			versionPath,
+			versionPath,
+			helpers.CiliumStableVersion,
+			helpers.CiliumStableVersion))
+		ExpectWithOffset(1, cmd).To(helpers.CMDSuccess(), "Unable to download helm chart %s from GitHub", helpers.CiliumStableVersion)
 	})
 
 	AfterAll(func() {
@@ -212,7 +227,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		cleanupCiliumState(filepath.Join(kubectl.BasePath(), helpers.HelmTemplate), newHelmChartVersion, "", newImageVersion, "")
 
 		By("Cleaning Cilium state (%s)", oldImageVersion)
-		cleanupCiliumState("cilium/cilium", oldHelmChartVersion, "quay.io/cilium/cilium-ci", oldImageVersion, "")
+		cleanupCiliumState(stableChartPath, oldHelmChartVersion, "quay.io/cilium/cilium-ci", oldImageVersion, "")
 
 		By("Deploying Cilium %s", oldHelmChartVersion)
 
@@ -233,7 +248,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		EventuallyWithOffset(1, func() (*helpers.CmdRes, error) {
 			return kubectl.RunHelm(
 				"install",
-				"cilium/cilium",
+				stableChartPath,
 				"cilium",
 				oldHelmChartVersion,
 				helpers.CiliumNamespace,


### PR DESCRIPTION
The upgrade tests are using the official helm charts with unreleased
Cilium images. This can might cause the upgrade tests to fail in case
the changes done in the unreleased Cilium versions require a new helm
chart release. To fix this problem the upgrade tests will now use the
unreleased helm charts as well.

Signed-off-by: André Martins <andre@cilium.io>