### PR TITLE
[BPF/SNAT] Improve code readability and complexity of the datapath

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1137,7 +1137,6 @@ snat_v6_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target)
 		__be16 sport;
 		__be16 dport;
 	} l4hdr;
-	__u8 nexthdr;
 	__u32 off;
 	bool icmp_echoreply = false;
 
@@ -1146,8 +1145,7 @@ snat_v6_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target)
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &ip6->nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
@@ -1212,7 +1210,6 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target)
 		__be16 sport;
 		__be16 dport;
 	} l4hdr;
-	__u8 nexthdr;
 	__u32 off;
 
 	build_bug_on(sizeof(struct ipv6_nat_entry) > 64);
@@ -1220,8 +1217,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target)
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, &ip6->nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1645,7 +1645,7 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 	 */
 	target.addr = IPV4_DIRECT_ROUTING;
 
-	ret = snat_v4_rev_nat(ctx, &target, false);
+	ret = snat_v4_rev_nat(ctx, &target);
 	if (IS_ERR(ret)) {
 		/* In case of no mapping, recircle back to main path. SNAT is very
 		 * expensive in terms of instructions (since we don't have BPF to

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1277,8 +1277,7 @@ static __always_inline int nodeport_nat_ipv4_fwd(struct __ctx_buff *ctx)
 	int ret = CTX_ACT_OK;
 
 	if (snat_v4_needed(ctx, &target.addr, &from_endpoint))
-		ret = snat_v4_process(ctx, NAT_DIR_EGRESS, &target,
-				      from_endpoint);
+		ret = snat_v4_nat(ctx, &target, from_endpoint);
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
 
@@ -1646,7 +1645,7 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 	 */
 	target.addr = IPV4_DIRECT_ROUTING;
 
-	ret = snat_v4_process(ctx, NAT_DIR_INGRESS, &target, false);
+	ret = snat_v4_rev_nat(ctx, &target, false);
 	if (IS_ERR(ret)) {
 		/* In case of no mapping, recircle back to main path. SNAT is very
 		 * expensive in terms of instructions (since we don't have BPF to
@@ -1738,7 +1737,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 		use_tunnel = true;
 	}
 #endif
-	ret = snat_v4_process(ctx, NAT_DIR_EGRESS, &target, false);
+	ret = snat_v4_nat(ctx, &target, false);
 	if (IS_ERR(ret) && ret != NAT_PUNT_TO_STACK)
 		goto drop_err;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -214,7 +214,7 @@ static __always_inline int nodeport_nat_ipv6_fwd(struct __ctx_buff *ctx,
 	ipv6_addr_copy(&target.addr, addr);
 
 	ret = snat_v6_needed(ctx, addr) ?
-	      snat_v6_process(ctx, NAT_DIR_EGRESS, &target) : CTX_ACT_OK;
+	      snat_v6_nat(ctx, &target) : CTX_ACT_OK;
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
 	return ret;
@@ -587,7 +587,7 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 		build_v4_in_v6(&tmp, IPV4_DIRECT_ROUTING);
 	target.addr = tmp;
 
-	ret = snat_v6_process(ctx, NAT_DIR_INGRESS, &target);
+	ret = snat_v6_rev_nat(ctx, &target);
 	if (IS_ERR(ret)) {
 		/* In case of no mapping, recircle back to main path. SNAT is very
 		 * expensive in terms of instructions (since we don't have BPF to
@@ -664,7 +664,7 @@ int tail_nodeport_nat_ipv6_egress(struct __ctx_buff *ctx)
 		use_tunnel = true;
 	}
 #endif
-	ret = snat_v6_process(ctx, NAT_DIR_EGRESS, &target);
+	ret = snat_v6_nat(ctx, &target);
 	if (IS_ERR(ret) && ret != NAT_PUNT_TO_STACK)
 		goto drop_err;
 


### PR DESCRIPTION
This is addressing issue  #19660.

> Split the snat_v{4,6}_process() functions into nat_snat_v{4,6}() and nat_rev_snat_v{4,6}().
> 
> The proposed change would not only improve the readability of the datapath code, but also should reduce the verifier complexity of the code path which is responsible for doing the rev-SNAT translations, as no new SNAT mapping needs to be find for this code path (only the lookup in the BPF SNAT map).

Fixes: #19660 

```release-note
Masquerading bpf mode -  Improve code readability and comlexity of the datapath.
```
