### PR TITLE
workflows: Pin the kubectl version used with EKS workflows

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -67,6 +67,7 @@ env:
   cilium_cli_version: v0.10.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.94.0
+  kubectl_version: v1.23.6
 
 jobs:
   check_changes:
@@ -121,6 +122,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Install pinned kubectl version
+        uses: azure/setup-kubectl@v2.0
+        id: kubectl-install
+        with:
+          version: ${{ env.kubectl_version }}
       - name: Set up job variables
         id: vars
         run: |

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -67,6 +67,7 @@ env:
   cilium_cli_version: v0.10.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.94.0
+  kubectl_version: v1.23.6
 
 jobs:
   check_changes:
@@ -121,6 +122,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Install pinned kubectl version
+        uses: azure/setup-kubectl@v2.0
+        id: kubectl-install
+        with:
+          version: ${{ env.kubectl_version }}
       - name: Set up job variables
         id: vars
         run: |

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -69,6 +69,7 @@ env:
   cilium_cli_version: v0.11.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.94.0
+  kubectl_version: v1.23.6
 
 jobs:
   check_changes:
@@ -123,6 +124,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Install pinned kubectl version
+        uses: azure/setup-kubectl@v2.0
+        id: kubectl-install
+        with:
+          version: ${{ env.kubectl_version }}
       - name: Set up job variables
         id: vars
         run: |

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -66,6 +66,7 @@ env:
   cilium_cli_version: v0.10.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.94.0
+  kubectl_version: v1.23.6
 
 jobs:
   check_changes:
@@ -120,6 +121,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Install pinned kubectl version
+        uses: azure/setup-kubectl@v2.0
+        id: kubectl-install
+        with:
+          version: ${{ env.kubectl_version }}
       - name: Set up job variables
         id: vars
         run: |

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -66,6 +66,7 @@ env:
   cilium_cli_version: v0.10.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.94.0
+  kubectl_version: v1.23.6
 
 jobs:
   check_changes:
@@ -120,6 +121,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Install pinned kubectl version
+        uses: azure/setup-kubectl@v2.0
+        id: kubectl-install
+        with:
+          version: ${{ env.kubectl_version }}
       - name: Set up job variables
         id: vars
         run: |

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -69,6 +69,7 @@ env:
   cilium_cli_version: v0.11.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.94.0
+  kubectl_version: v1.23.6
 
 jobs:
   check_changes:
@@ -123,6 +124,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Install pinned kubectl version
+        uses: azure/setup-kubectl@v2.0
+        id: kubectl-install
+        with:
+          version: ${{ env.kubectl_version }}
       - name: Set up job variables
         id: vars
         run: |


### PR DESCRIPTION
The new kubectl version v1.24.0 started causing issues with the aws-cli
tooling:
  error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"

This fixes the problem by downgrading kubectl to pinned version v1.23.6 until
the issue has been fixed upstream.

Upstream issue: https://github.com/aws/aws-cli/issues/6920