### PR TITLE
Update to CNI spec version 1.0.0

### DIFF
--- a/plugins/cilium-cni/chaining/api/api.go
+++ b/plugins/cilium-cni/chaining/api/api.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	cniTypesVer "github.com/containernetworking/cni/pkg/types/040"
+	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/client"

--- a/plugins/cilium-cni/chaining/api/api_test.go
+++ b/plugins/cilium-cni/chaining/api/api_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	cniTypesVer "github.com/containernetworking/cni/pkg/types/040"
+	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
 	"gopkg.in/check.v1"
 )
 

--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	cniTypesVer "github.com/containernetworking/cni/pkg/types/040"
+	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
 	cniVersion "github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/sirupsen/logrus"

--- a/plugins/cilium-cni/chaining/portmap/portmap.go
+++ b/plugins/cilium-cni/chaining/portmap/portmap.go
@@ -6,7 +6,7 @@ package portmap
 import (
 	"context"
 
-	cniTypesVer "github.com/containernetworking/cni/pkg/types/040"
+	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
 
 	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
 )

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/containernetworking/cni/pkg/skel"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
-	cniTypesVer "github.com/containernetworking/cni/pkg/types/040"
+	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
 	cniVersion "github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ns"
 	gops "github.com/google/gops/agent"
@@ -79,7 +79,7 @@ func main() {
 	skel.PluginMain(cmdAdd,
 		nil,
 		cmdDel,
-		cniVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1"),
+		cniVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0"),
 		"Cilium CNI plugin "+version.Version)
 }
 
@@ -212,11 +212,10 @@ func newCNIRoute(r route.Route) *cniTypes.Route {
 
 func prepareIP(ipAddr string, isIPv6 bool, state *CmdState, mtu int) (*cniTypesVer.IPConfig, []*cniTypes.Route, error) {
 	var (
-		routes    []route.Route
-		err       error
-		gw        string
-		ipVersion string
-		ip        addressing.CiliumIP
+		routes []route.Route
+		err    error
+		gw     string
+		ip     addressing.CiliumIP
 	)
 
 	if isIPv6 {
@@ -229,7 +228,6 @@ func prepareIP(ipAddr string, isIPv6 bool, state *CmdState, mtu int) (*cniTypesV
 		routes = state.IP6routes
 		ip = state.IP6
 		gw = connector.IPv6Gateway(state.HostAddr)
-		ipVersion = "6"
 	} else {
 		if state.IP4, err = addressing.NewCiliumIPv4(ipAddr); err != nil {
 			return nil, nil, err
@@ -240,7 +238,6 @@ func prepareIP(ipAddr string, isIPv6 bool, state *CmdState, mtu int) (*cniTypesV
 		routes = state.IP4routes
 		ip = state.IP4
 		gw = connector.IPv4Gateway(state.HostAddr)
-		ipVersion = "4"
 	}
 
 	rt := []*cniTypes.Route{}
@@ -256,7 +253,6 @@ func prepareIP(ipAddr string, isIPv6 bool, state *CmdState, mtu int) (*cniTypesV
 	return &cniTypesVer.IPConfig{
 		Address: *ip.EndpointPrefix(),
 		Gateway: gwIP,
-		Version: ipVersion,
 	}, rt, nil
 }
 

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net"
 
-	current "github.com/containernetworking/cni/pkg/types/040"
+	current "github.com/containernetworking/cni/pkg/types/100"
 
 	"github.com/cilium/cilium/api/v1/models"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
@@ -21,12 +21,10 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 	}
 
 	var masq bool
-	if ipConfig.Version == "4" {
+	if ipConfig.Address.IP.To4() != nil {
 		masq = conf.MasqueradeProtocols.IPV4
-	} else if ipConfig.Version == "6" {
-		masq = conf.MasqueradeProtocols.IPV6
 	} else {
-		return fmt.Errorf("Invalid IPConfig version: %s", ipConfig.Version)
+		masq = conf.MasqueradeProtocols.IPV6
 	}
 
 	allCIDRs := make([]*net.IPNet, 0, len(ipam.Cidrs))

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -10,7 +10,7 @@ import (
 	"os"
 
 	cniTypes "github.com/containernetworking/cni/pkg/types"
-	current "github.com/containernetworking/cni/pkg/types/040"
+	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/cni/pkg/version"
 
 	alibabaCloudTypes "github.com/cilium/cilium/pkg/alibabacloud/eni/types"


### PR DESCRIPTION
The only change relevant for the Cilium CNI is the removal of the
version field in the interfaces array, see [1]. Instead, the IP version
can be derived from the specified address.

[1] https://github.com/containernetworking/cni/blob/master/SPEC.md#version
