### PR TITLE
v1.9 backports 2022-05-06

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -41,7 +41,6 @@ COPY --from=builder /out/${TARGETOS}/${TARGETARCH} /
 
 WORKDIR /home/cilium
 
-RUN groupadd -f cilium \
-  && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
+RUN echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
 
 CMD ["/usr/bin/cilium"]

--- a/test/provision/docker-run-cilium.sh
+++ b/test/provision/docker-run-cilium.sh
@@ -52,7 +52,7 @@ if [ -n "$(${SUDO} docker ps -a -q -f label=app=cilium)" ]; then
 fi
 
 echo "Launching Cilium agent $CILIUM_IMAGE with params $CILIUM_OPTS"
-${SUDO} docker run --name cilium $DOCKER_OPTS $CILIUM_IMAGE cilium-agent $CILIUM_OPTS
+${SUDO} docker run --name cilium $DOCKER_OPTS $CILIUM_IMAGE /bin/bash -c "groupadd -f cilium && cilium-agent $CILIUM_OPTS"
 
 # Copy Cilium CLI
 ${SUDO} docker cp cilium:/usr/bin/cilium /usr/bin/


### PR DESCRIPTION
 * #19711 -- images/cilium: remove cilium group from Dockerfile (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19711; do contrib/backporting/set-labels.py $pr done 1.9; done
```
or with
```
$ make add-label BRANCH=v1.9 ISSUES=19711
```