### PR TITLE
endpoint: Fix packets to host dropped with the chaining mode and host firewall

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1266,7 +1266,7 @@ out:
 	return ret;
 }
 
-#if defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_ROUTING)
+#if defined(ENABLE_HOST_FIREWALL)
 #ifdef ENABLE_IPV6
 declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
 			 is_defined(DEBUG)), CILIUM_CALL_IPV6_TO_HOST_POLICY_ONLY)
@@ -1431,6 +1431,6 @@ handle_lxc_traffic(struct __ctx_buff *ctx)
 
 	return to_host_from_lxc(ctx);
 }
-#endif /* ENABLE_HOST_FIREWALL && !ENABLE_ROUTING */
+#endif /* ENABLE_HOST_FIREWALL */
 
 BPF_LICENSE("Dual BSD/GPL");

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -167,10 +167,10 @@ func elfMapSubstitutions(ep datapath.Endpoint) map[string]string {
 		}
 	}
 
-	// The policy map is only used for the host endpoint if per-endpoint
-	// routes and the host firewall are enabled.
-	if !ep.IsHost() ||
-		(option.Config.EnableEndpointRoutes && option.Config.EnableHostFirewall) {
+	// Populate the policy map if the host firewall is enabled regardless of the per-endpoint route setting
+	// because all routing is performed by the Linux stack with the chaining mode
+	// even if the per-endpoint route is disabled in the agent
+	if !ep.IsHost() || option.Config.EnableHostFirewall {
 		result[policymap.CallString(templateLxcID)] = policymap.CallString(epID)
 	}
 	// Egress policy map is only used when Envoy Config CRDs are enabled.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -615,8 +615,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 		return datapathRegenCtxt.epInfoCache.revision, compilationExecuted, err
 	}
 
-	if !datapathRegenCtxt.epInfoCache.IsHost() ||
-		(option.Config.EnableHostFirewall && option.Config.EnableEndpointRoutes) {
+	if !datapathRegenCtxt.epInfoCache.IsHost() || option.Config.EnableHostFirewall {
 		// Hook the endpoint into the endpoint and endpoint to policy tables then expose it
 		stats.mapSync.Start()
 		epErr := eppolicymap.WriteEndpoint(datapathRegenCtxt.epInfoCache, e.policyMap)


### PR DESCRIPTION
This PR fixes the issue Cilium drops packets to the host when it's configured with the chaining mode and host firewall by populating the policy map regardless of the per-endpoint routes setting. All routing is performed by the Linux stack with the chaining mode even if the per-endpoint route is disabled in the agent.


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #18942
