### PR TITLE
Exclude interface's primary address from IP pool by default in Azure

### DIFF
--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -13,7 +13,7 @@ cilium-operator-azure [flags]
 ```
       --azure-resource-group string               Resource group to use for Azure IPAM
       --azure-subscription-id string              Subscription ID to access Azure API
-      --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations (default true)
+      --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string    ID of the user assigned identity used to auth with the Azure API
       --bgp-announce-lb-ip                        Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                    Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -18,7 +18,7 @@ cilium-operator [flags]
       --aws-use-primary-address                   Allows for using primary address of the ENI for allocations on the node
       --azure-resource-group string               Resource group to use for Azure IPAM
       --azure-subscription-id string              Subscription ID to access Azure API
-      --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations (default true)
+      --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string    ID of the user assigned identity used to auth with the Azure API
       --bgp-announce-lb-ip                        Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                    Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -337,7 +337,14 @@ Annotations:
   +-----------------------+-----------------------+-------------------------+
   | Hubble                |  9091                 | 9965                    |
   +-----------------------+-----------------------+-------------------------+
-  
+
+* In Azure IPAM mode, the default for ``--azure-use-primary-address`` has changed from
+  true to false. With this change pod interface's primary IP is no longer included in the
+  node's IP pool by default. The previous default required users to disable DHCP on the
+  pod's interface to avoid primary IP from interfering with host networking. Unless the
+  flag is explicitly set to true, ``--bypass-ip-availability-upon-restore`` also needs
+  to be set to ensure that pods using primary IP get a new IP address. This flag can be
+  removed once the upgrade is complete.
 
 New Options
 ~~~~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -344,7 +344,8 @@ Annotations:
   pod's interface to avoid primary IP from interfering with host networking. Unless the
   flag is explicitly set to true, ``--bypass-ip-availability-upon-restore`` also needs
   to be set to ensure that pods using primary IP get a new IP address. This flag can be
-  removed once the upgrade is complete.
+  removed once the upgrade is complete. Backward compatibility will be maintained when
+  ``upgradeCompatibility`` is set on the helm chart.
 
 New Options
 ~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1590,7 +1590,7 @@ func initEnv(cmd *cobra.Command) {
 	// mode which support the bypass.
 	if option.Config.BypassIPAvailabilityUponRestore {
 		switch option.Config.IPAMMode() {
-		case ipamOption.IPAMENI:
+		case ipamOption.IPAMENI, ipamOption.IPAMAzure:
 			log.Info(
 				"Running with bypass of IP not available errors upon endpoint " +
 					"restore. Be advised that this mode is intended to be " +

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -14,6 +14,7 @@
 {{- $fragmentTracking := "true" -}}
 {{- $crdWaitTimeout := "5m" -}}
 {{- $defaultKubeProxyReplacement := "probe" -}}
+{{- $azureUsePrimaryAddress := "true" -}}
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
@@ -39,10 +40,18 @@
   {{- $defaultBpfMasquerade = "false" -}}
 {{- end -}}
 
+{{- /* Default values when 1.12 was initially deployed */ -}}
+{{- if semverCompare ">=1.12" (default "1.12" .Values.upgradeCompatibility) -}}
+  {{- if .Values.azure.enabled }}
+      {{- $azureUsePrimaryAddress = "false" -}}
+  {{- end }}
+{{- end -}}
+
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}
 {{- $bpfCtTcpMax := (coalesce .Values.bpf.ctTcpMax $defaultBpfCtTcpMax) -}}
 {{- $bpfCtAnyMax := (coalesce .Values.bpf.ctAnyMax $defaultBpfCtAnyMax) -}}
 {{- $kubeProxyReplacement := (coalesce .Values.kubeProxyReplacement $defaultKubeProxyReplacement) -}}
+{{- $azureUsePrimaryAddress := (coalesce .Values.azure.usePrimaryAddress $azureUsePrimaryAddress) -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -407,6 +416,7 @@ data:
 {{- if .Values.azure.userAssignedIdentityID }}
   azure-user-assigned-identity-id: {{ .Values.azure.userAssignedIdentityID | quote }}
 {{- end }}
+  azure-use-primary-address: {{ $azureUsePrimaryAddress | quote }}
 {{- end }}
 
 {{- if .Values.alibabacloud.enabled }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -212,6 +212,7 @@ azure:
   # Note that this is incompatible with AKS clusters created in BYOCNI mode: use
   # AKS BYOCNI integration (`aksbyocni.enabled`) instead.
   enabled: false
+  # usePrimaryAddress: false
   # resourceGroup: group1
   # subscriptionID: 00000000-0000-0000-0000-000000000000
   # tenantID: 00000000-0000-0000-0000-000000000000

--- a/operator/provider_azure_flags.go
+++ b/operator/provider_azure_flags.go
@@ -24,7 +24,7 @@ func init() {
 	flags.String(operatorOption.AzureUserAssignedIdentityID, "", "ID of the user assigned identity used to auth with the Azure API")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureUserAssignedIdentityID, "AZURE_USER_ASSIGNED_IDENTITY_ID")
 
-	flags.Bool(operatorOption.AzureUsePrimaryAddress, true, "Use Azure IP address from interface's primary IPConfigurations")
+	flags.Bool(operatorOption.AzureUsePrimaryAddress, false, "Use Azure IP address from interface's primary IPConfigurations")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureUsePrimaryAddress, "AZURE_USE_PRIMARY_ADDRESS")
 
 	viper.BindPFlags(flags)


### PR DESCRIPTION
Currently `--azure-use-primary-address` defaults to true and this can lead
to connectivity issues in host networked pods unless users explicitly
disable DHCP on the interface.

See https://github.com/cilium/cilium/pull/13415 for more details on connectivity issues. 
Defaulting to false also makes the behavior consistent with ENI mode.

Signed-off-by: Hemanth Malla <hemanth.malla@datadoghq.com>

Open questions  : 
- [ ] How do i make sure this change shows up in upgrade guides ?
- [ ] What happens to existing pods using the primary IP for users upgrading from prior versions ?
- [ ] Is this too late for `1.12` ?