### PR TITLE
v1.10 backports 2022-05-06

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -59,7 +59,7 @@ cilium-operator-alibabacloud [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -62,7 +62,7 @@ cilium-operator-aws [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -63,7 +63,7 @@ cilium-operator-azure [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -58,7 +58,7 @@ cilium-operator-generic [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -68,7 +68,7 @@ cilium-operator [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --nodes-gc-interval duration                GC interval for nodes store in the kvstore (default 2m0s)
+      --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1025,6 +1025,10 @@
      - cilium-operator image.
      - object
      - ``{"alibabacloudDigest":"sha256:6154fcc069700cca6754cff0ee7bf6990bbf4a2865076b5358cb0c70c0043d52","awsDigest":"sha256:9bc04377606cb57c16f699a5b34dcdd6b6ffc1c4f43f5e6da81015fc16c10edc","azureDigest":"sha256:6973d45f7255c1791c0502339675a42105b8cbeca1a98634362623433674efe1","genericDigest":"sha256:8a317287b6ac8fe0ba4999342c9627dc913e0c1591552164f96d0aadf5d1a740","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.10.10","useDigest":true}``
+   * - operator.nodeGCInterval
+     - Interval for cilium node garbage collection.
+     - string
+     - ``"5m0s"``
    * - operator.nodeSelector
      - Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -585,6 +585,18 @@
      - Labels to add to ServiceMonitor hubble
      - object
      - ``{}``
+   * - hubble.peerService.clusterDomain
+     - The cluster domain to use to query the Hubble Peer service. It should be the local cluster.
+     - string
+     - ``"cluster.local"``
+   * - hubble.peerService.enabled
+     - Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client
+     - bool
+     - ``true``
+   * - hubble.peerService.servicePort
+     - Service Port for the Peer service.
+     - int
+     - ``4254``
    * - hubble.relay.dialTimeout
      - Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
      - string

--- a/Documentation/internals/hubble.rst
+++ b/Documentation/internals/hubble.rst
@@ -46,8 +46,8 @@ Hubble server
 
 The Hubble server component implements two gRPC services. The **Observer
 service** which may optionally be exposed via a TCP socket in addition to a
-local Unix domain socket and the  **Peer service**, which is only served on a
-local Unix domain socket.
+local Unix domain socket and the  **Peer service**, which is served on both
+as well as a Kubernetes Service.
 
 The Observer service
 ^^^^^^^^^^^^^^^^^^^^
@@ -95,9 +95,9 @@ the peers in the cluster and subsequently sends information about peers that
 are updated, added or removed from the cluster. Thus, it allows the caller to
 keep track of all Hubble instances and query their respective gRPC services.
 
-This service is typically only exposed on a local Unix domain socket and is
-primarily used by Hubble Relay in order to have a cluster-wide view of all
-Hubble instances.
+This service is typically only exposed on a local Unix domain socket and a
+Kubernetes Service and is primarily used by Hubble Relay in order to have
+a cluster-wide view of all Hubble instances.
 
 The Peer service obtains peer change notifications by subscribing to Cilium's
 node manager. To this end, it internally defines a handler that implements

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -661,6 +661,7 @@ parserfactory
 parsers
 pc
 pcap
+peerService
 perf
 periodSeconds
 pipelining

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -637,6 +637,7 @@ nfsd
 nftables
 nginx
 nodeEncryption
+nodeGCInterval
 nodePort
 nodeSelector
 nodeX

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -171,12 +171,12 @@ func (d *Daemon) launchHubble() {
 	if option.Config.HubbleTLSDisabled {
 		peerServiceOptions = append(peerServiceOptions, serviceoption.WithoutTLSInfo())
 	}
-
+	peerSvc := peer.NewService(d.nodeDiscovery.Manager, peerServiceOptions...)
 	localSrvOpts := []serveroption.Option{
 		serveroption.WithUnixSocketListener(sockPath),
 		serveroption.WithHealthService(),
 		serveroption.WithObserverService(d.hubbleObserver),
-		serveroption.WithPeerService(peer.NewService(d.nodeDiscovery.Manager, peerServiceOptions...)),
+		serveroption.WithPeerService(peerSvc),
 		serveroption.WithInsecure(),
 	}
 
@@ -209,6 +209,7 @@ func (d *Daemon) launchHubble() {
 	go func() {
 		<-d.ctx.Done()
 		localSrv.Stop()
+		peerSvc.Close()
 	}()
 
 	// configure another hubble instance that serve fewer gRPC services
@@ -220,6 +221,7 @@ func (d *Daemon) launchHubble() {
 		options := []serveroption.Option{
 			serveroption.WithTCPListener(address),
 			serveroption.WithHealthService(),
+			serveroption.WithPeerService(peerSvc),
 			serveroption.WithObserverService(d.hubbleObserver),
 		}
 

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -33,6 +33,7 @@ import (
 )
 
 const (
+	keyClusterName            = "cluster-name"
 	keyPprof                  = "pprof"
 	keyPprofPort              = "pprof-port"
 	keyGops                   = "gops"
@@ -63,6 +64,10 @@ func New(vp *viper.Viper) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
+	flags.String(
+		keyClusterName,
+		defaults.ClusterName,
+		"Name of the current cluster")
 	flags.Bool(
 		keyPprof, false, "Enable serving the pprof debugging API",
 	)
@@ -90,7 +95,7 @@ func New(vp *viper.Viper) *cobra.Command {
 		"Address on which to listen")
 	flags.String(
 		keyPeerService,
-		defaults.HubbleTarget,
+		defaults.PeerTarget,
 		"Address of the server that implements the peer gRPC service")
 	flags.Int(
 		keySortBufferMaxLen,
@@ -145,8 +150,9 @@ func runServe(vp *viper.Viper) error {
 	logger := logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay")
 
 	opts := []server.Option{
+		server.WithLocalClusterName(vp.GetString(keyClusterName)),
 		server.WithDialTimeout(vp.GetDuration(keyDialTimeout)),
-		server.WithHubbleTarget(vp.GetString(keyPeerService)),
+		server.WithPeerTarget(vp.GetString(keyPeerService)),
 		server.WithListenAddress(vp.GetString(keyListenAddress)),
 		server.WithRetryTimeout(vp.GetDuration(keyRetryTimeout)),
 		server.WithSortBufferMaxLen(vp.GetInt(keySortBufferMaxLen)),

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -79,8 +79,7 @@ ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETARCH
 LABEL maintainer="maintainer@cilium.io"
-RUN groupadd -f cilium \
-    && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
+RUN echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
 COPY --from=cilium-envoy / /
 # When used within the Cilium container, Hubble CLI should target the
 # local unix domain socket instead of Hubble Relay.

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -307,6 +307,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
 | operator.image | object | `{"alibabacloudDigest":"sha256:6154fcc069700cca6754cff0ee7bf6990bbf4a2865076b5358cb0c70c0043d52","awsDigest":"sha256:9bc04377606cb57c16f699a5b34dcdd6b6ffc1c4f43f5e6da81015fc16c10edc","azureDigest":"sha256:6973d45f7255c1791c0502339675a42105b8cbeca1a98634362623433674efe1","genericDigest":"sha256:8a317287b6ac8fe0ba4999342c9627dc913e0c1591552164f96d0aadf5d1a740","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.10.10","useDigest":true}` | cilium-operator image. |
+| operator.nodeGCInterval | string | `"5m0s"` | Interval for cilium node garbage collection. |
 | operator.nodeSelector | object | `{}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
 | operator.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":1}` | PodDisruptionBudget settings ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -197,6 +197,9 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble |
 | hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | hubble.metrics.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor hubble |
+| hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
+| hubble.peerService.enabled | bool | `true` | Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client |
+| hubble.peerService.servicePort | int | `4254` | Service Port for the Peer service. |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
 | hubble.relay.image | object | `{"digest":"sha256:a0769e44299bba301dee08d489f4e2d3b3924916bed985346dcf9fcf10861c8a","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.10.10","useDigest":true}` | Hubble-relay container image. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -109,6 +109,10 @@ data:
   cilium-endpoint-gc-interval: "{{ .Values.operator.endpointGCInterval }}"
 {{- end }}
 
+{{- if hasKey .Values.operator "nodeGCInterval" }}
+  nodes-gc-interval: "{{ .Values.operator.nodeGCInterval | default "0s" }}"
+{{- end }}
+
 {{- if hasKey .Values "identityChangeGracePeriod" }}
   # identity-change-grace-period is the grace period that needs to pass
   # before an endpoint that has changed its identity will start using

--- a/install/kubernetes/cilium/templates/cilium-operator-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-clusterrole.yaml
@@ -41,7 +41,7 @@ rules:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus }}
+{{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus .Values.operator.endpointGCInterval }}
 - apiGroups:
   - ""
   resources:
@@ -49,6 +49,8 @@ rules:
   verbs:
   - list
   - watch
+{{- end }}
+{{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus }}
 - apiGroups:
   - ""
   resources:

--- a/install/kubernetes/cilium/templates/hubble-relay-configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-configmap.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.hubble.relay.enabled }}
+{{- $peerSvcPort := .Values.hubble.peerService.servicePort -}}
+{{- if not .Values.hubble.peerService.servicePort }}
+{{- $peerSvcPort = (.Values.hubble.tls.enabled | ternary 443 80) -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -7,7 +11,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |
+    cluster-name: {{ .Values.cluster.name }}
+    {{- if and .Values.hubble.enabled .Values.hubble.peerService.enabled }}
+    peer-service: "hubble-peer.{{ .Release.Namespace }}.svc.{{ .Values.hubble.peerService.clusterDomain }}:{{ $peerSvcPort }}"
+    {{- else }}
     peer-service: unix://{{ .Values.hubble.socketPath }}
+    {{- end }}
     listen-address: {{ .Values.hubble.relay.listenHost }}:{{ .Values.hubble.relay.listenPort }}
     dial-timeout: {{ .Values.hubble.relay.dialTimeout }}
     retry-timeout: {{ .Values.hubble.relay.retryTimeout }}

--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.hubble.relay.enabled }}
+{{- $mountSocket := not .Values.hubble.peerService.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,9 +72,11 @@ spec:
             {{- toYaml . | trim | nindent 12 }}
 {{- end }}
           volumeMounts:
+          {{- if $mountSocket }}
           - mountPath: {{ dir .Values.hubble.socketPath }}
             name: hubble-sock-dir
             readOnly: true
+          {{- end }}
           - mountPath: /etc/hubble-relay
             name: config
             readOnly: true
@@ -102,10 +105,12 @@ spec:
           - key: config.yaml
             path: config.yaml
         name: config
+      {{- if $mountSocket }}
       - hostPath:
           path: {{ dir .Values.hubble.socketPath }}
           type: Directory
         name: hubble-sock-dir
+      {{- end }}
 {{- if .Values.hubble.tls.enabled }}
       - projected:
           sources:

--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.hubble.enabled .Values.hubble.listenAddress .Values.hubble.peerService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-peer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: cilium
+spec:
+  selector:
+    k8s-app: cilium
+  ports:
+  - name: peer-service
+    {{- if .Values.hubble.peerService.servicePort }}
+    port: {{ .Values.hubble.peerService.servicePort }}
+    {{- else }}
+    port: {{ .Values.hubble.tls.enabled | ternary 443 80 }}
+    {{- end }}
+    protocol: TCP
+    targetPort: {{ splitList ":" .Values.hubble.listenAddress | last }}
+{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
+  internalTrafficPolicy: Local
+{{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -608,7 +608,15 @@ hubble:
   # Set this field ":4244" if you are enabling Hubble Relay, as it assumes that
   # Hubble is listening on port 4244.
   listenAddress: ":4244"
-
+  peerService:
+    # -- Enable a K8s Service for the Peer service, so that it can be accessed
+    # by a non-local client
+    enabled: true
+    # -- Service Port for the Peer service.
+    servicePort: 4254
+    # -- The cluster domain to use to query the Hubble Peer service. It should
+    # be the local cluster.
+    clusterDomain: cluster.local
   # -- TLS configuration for Hubble
   tls:
     # -- Enable mutual TLS for listenAddress. Setting this value to false is

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1363,6 +1363,9 @@ operator:
   # -- Interval for endpoint garbage collection.
   endpointGCInterval: "5m0s"
 
+  # -- Interval for cilium node garbage collection.
+  nodeGCInterval: "5m0s"
+
   # -- Interval for identity garbage collection.
   identityGCInterval: "15m0s"
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -259,7 +259,7 @@ func init() {
 	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
 	option.BindEnv(option.K8sKubeConfigPath)
 
-	flags.Duration(operatorOption.NodesGCInterval, 2*time.Minute, "GC interval for nodes store in the kvstore")
+	flags.Duration(operatorOption.NodesGCInterval, 0*time.Second, "GC interval for CiliumNodes")
 	option.BindEnv(operatorOption.NodesGCInterval)
 
 	flags.String(operatorOption.OperatorPrometheusServeAddr, operatorOption.PrometheusServeAddr, "Address to serve Prometheus metrics")

--- a/operator/main.go
+++ b/operator/main.go
@@ -516,6 +516,10 @@ func onOperatorStartLeading(ctx context.Context) {
 		operatorWatchers.HandleNodeTolerationAndTaints(stopCh)
 	}
 
+	if operatorOption.Config.NodeGCInterval != 0 {
+		operatorWatchers.RunCiliumNodeGC(ctx, ciliumNodeStore, operatorOption.Config.NodeGCInterval)
+	}
+
 	if operatorOption.Config.IdentityGCInterval != 0 {
 		identityRateLimiter = rate.NewLimiter(
 			operatorOption.Config.IdentityGCRateInterval,

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -81,7 +81,7 @@ const (
 	// IdentityHeartbeatTimeout is the timeout used to GC identities from k8s
 	IdentityHeartbeatTimeout = "identity-heartbeat-timeout"
 
-	// NodesGCInterval is the duration for which the nodes are GC in the KVStore.
+	// NodesGCInterval is the duration for which the cilium nodes are GC.
 	NodesGCInterval = "nodes-gc-interval"
 
 	// OperatorAPIServeAddr IP:Port on which to serve api requests in
@@ -231,6 +231,9 @@ type OperatorConfig struct {
 	// CNPStatusUpdateInterval is the interval between status updates
 	// being sent to the K8s apiserver for a given CNP.
 	CNPStatusUpdateInterval time.Duration
+
+	// NodeGCInterval is the GC interval for CiliumNodes
+	NodeGCInterval time.Duration
 
 	// EnableMetrics enables prometheus metrics.
 	EnableMetrics bool
@@ -413,6 +416,7 @@ func (c *OperatorConfig) Populate() {
 	c.IdentityGCRateInterval = viper.GetDuration(IdentityGCRateInterval)
 	c.IdentityGCRateLimit = viper.GetInt64(IdentityGCRateLimit)
 	c.IdentityHeartbeatTimeout = viper.GetDuration(IdentityHeartbeatTimeout)
+	c.NodeGCInterval = viper.GetDuration(NodesGCInterval)
 	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
 	c.OperatorAPIServeAddr = viper.GetString(OperatorAPIServeAddr)
 	c.OperatorPrometheusServeAddr = viper.GetString(OperatorPrometheusServeAddr)

--- a/operator/watchers/cilium_node_gc.go
+++ b/operator/watchers/cilium_node_gc.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers
+
+import (
+	"context"
+	"time"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/k8s"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// ciliumNodeGCCandidate keeps track of cilium nodes, which are candidate for GC.
+// Underlying there is a map with node name as key, and last marked timestamp as value.
+type ciliumNodeGCCandidate struct {
+	lock          lock.RWMutex
+	nodesToRemove map[string]time.Time
+}
+
+func newCiliumNodeGCCandidate() *ciliumNodeGCCandidate {
+	return &ciliumNodeGCCandidate{
+		nodesToRemove: map[string]time.Time{},
+	}
+}
+
+func (c *ciliumNodeGCCandidate) Get(nodeName string) (time.Time, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	val, exists := c.nodesToRemove[nodeName]
+	return val, exists
+}
+
+func (c *ciliumNodeGCCandidate) Add(nodeName string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.nodesToRemove[nodeName] = time.Now()
+}
+
+func (c *ciliumNodeGCCandidate) Delete(nodeName string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.nodesToRemove, nodeName)
+}
+
+// RunCiliumNodeGC performs garbage collector for cilium node resource
+func RunCiliumNodeGC(ctx context.Context, ciliumNodeStore cache.Store, interval time.Duration) {
+	nodesInit(k8s.WatcherClient(), ctx.Done())
+
+	// wait for k8s nodes synced is done
+	select {
+	case <-slimNodeStoreSynced:
+	case <-ctx.Done():
+		return
+	}
+
+	log.Info("Starting to garbage collect stale CiliumNode custom resources")
+
+	candidateStore := newCiliumNodeGCCandidate()
+	// create the controller to perform mark and sweep operation for cilium nodes
+	ctrlMgr.UpdateController("cilium-node-gc",
+		controller.ControllerParams{
+			Context: ctx,
+			DoFunc: func(ctx context.Context) error {
+				return performCiliumNodeGC(ctx, k8s.CiliumClient().CiliumV2().CiliumNodes(), ciliumNodeStore,
+					nodeGetter{}, interval, candidateStore)
+			},
+			RunInterval: interval,
+		},
+	)
+}
+
+func performCiliumNodeGC(ctx context.Context, client ciliumv2.CiliumNodeInterface, ciliumNodeStore cache.Store,
+	nodeGetter slimNodeGetter, interval time.Duration, candidateStore *ciliumNodeGCCandidate) error {
+	for _, nodeName := range ciliumNodeStore.ListKeys() {
+		scopedLog := log.WithField(logfields.NodeName, nodeName)
+		_, err := nodeGetter.GetK8sSlimNode(nodeName)
+		if err == nil {
+			scopedLog.Debugf("CiliumNode is valid, no gargage collection required")
+			continue
+		}
+
+		if !k8serrors.IsNotFound(err) {
+			scopedLog.WithError(err).Error("Unable to fetch k8s node from store")
+			return err
+		}
+
+		obj, _, err := ciliumNodeStore.GetByKey(nodeName)
+		if err != nil {
+			scopedLog.WithError(err).Error("Unable to fetch CiliumNode from store")
+			return err
+		}
+
+		cn, ok := obj.(*cilium_v2.CiliumNode)
+		if !ok {
+			scopedLog.Errorf("Object stored in store is not *cilium_v2.CiliumNode but %T", obj)
+			return err
+		}
+
+		// if there is owner references, let k8s handle garbage collection
+		if len(cn.GetOwnerReferences()) > 0 {
+			continue
+		}
+
+		lastMarkedTime, exists := candidateStore.Get(nodeName)
+		if !exists {
+			scopedLog.Info("Add CiliumNode to garbage collector candidates")
+			candidateStore.Add(nodeName)
+			continue
+		}
+
+		// only remove the node if last marked time is more than running interval
+		if lastMarkedTime.Before(time.Now().Add(-interval)) {
+			scopedLog.Info("Perform GC for invalid CiliumNode")
+			err = client.Delete(ctx, nodeName, metav1.DeleteOptions{})
+			if err != nil && !k8serrors.IsNotFound(err) {
+				scopedLog.WithError(err).Error("Failed to delete invalid CiliumNode")
+				return err
+			}
+			scopedLog.Info("CiliumNode is garbage collected successfully")
+			candidateStore.Delete(nodeName)
+		}
+	}
+	return nil
+}

--- a/operator/watchers/cilium_node_gc_test.go
+++ b/operator/watchers/cilium_node_gc_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+// +build !privileged_tests
+
+package watchers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+)
+
+func Test_performCiliumNodeGC(t *testing.T) {
+	validCN := &v2.CiliumNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-node",
+		},
+	}
+	invalidCN := &v2.CiliumNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "invalid-node",
+		},
+	}
+	invalidCNWithOwnerRef := &v2.CiliumNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "invalid-node-with-owner-ref",
+			OwnerReferences: []metav1.OwnerReference{
+				{},
+			},
+		},
+	}
+
+	fcn := fake.NewSimpleClientset(validCN, invalidCN, invalidCNWithOwnerRef).CiliumV2().CiliumNodes()
+
+	fCNStore := &cache.FakeCustomStore{
+		ListKeysFunc: func() []string {
+			return []string{"valid-node", "invalid-node"}
+		},
+		GetByKeyFunc: func(key string) (interface{}, bool, error) {
+			return &v2.CiliumNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: key,
+				},
+			}, true, nil
+		},
+	}
+
+	interval := time.Nanosecond
+	fng := &fakeNodeGetter{
+		OnGetK8sSlimNode: func(nodeName string) (*slim_corev1.Node, error) {
+			if nodeName == "valid-node" {
+				return &slim_corev1.Node{}, nil
+			}
+			return nil, k8serrors.NewNotFound(schema.GroupResource{}, "invalid-node")
+		},
+	}
+
+	candidateStore := newCiliumNodeGCCandidate()
+
+	// check if the invalid node is added to GC candidate
+	err := performCiliumNodeGC(context.TODO(), fcn, fCNStore, fng, interval, candidateStore)
+	assert.NoError(t, err)
+	assert.Len(t, candidateStore.nodesToRemove, 1)
+	_, exists := candidateStore.nodesToRemove["invalid-node"]
+	assert.True(t, exists)
+
+	// check if the invalid node is actually GC-ed
+	time.Sleep(interval)
+	err = performCiliumNodeGC(context.TODO(), fcn, fCNStore, fng, interval, candidateStore)
+	assert.NoError(t, err)
+	assert.Len(t, candidateStore.nodesToRemove, 0)
+	_, exists = candidateStore.nodesToRemove["invalid-node"]
+	assert.False(t, exists)
+}

--- a/operator/watchers/node.go
+++ b/operator/watchers/node.go
@@ -1,0 +1,116 @@
+package watchers
+
+import (
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/cilium/cilium/pkg/k8s/informer"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+var (
+	// slimNodeStore contains all cluster nodes store as slim_core.Node
+	slimNodeStore cache.Store
+
+	nodeController cache.Controller
+
+	nodeQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "node-queue")
+)
+
+type slimNodeGetter interface {
+	GetK8sSlimNode(nodeName string) (*slim_corev1.Node, error)
+}
+
+type nodeGetter struct{}
+
+// GetK8sSlimNode returns a slim_corev1.Node from the local store.
+// The return structure should only be used for read purposes and should never
+// be written into it.
+func (nodeGetter) GetK8sSlimNode(nodeName string) (*slim_corev1.Node, error) {
+	nodeInterface, exists, err := slimNodeStore.GetByKey(nodeName)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, k8sErrors.NewNotFound(schema.GroupResource{
+			Group:    "core",
+			Resource: "Node",
+		}, nodeName)
+	}
+	return nodeInterface.(*slim_corev1.Node), nil
+}
+
+// nodesInit starts up a node watcher to handle node events.
+func nodesInit(k8sClient kubernetes.Interface, stopCh <-chan struct{}) {
+	slimNodeStore, nodeController = informer.NewInformer(
+		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
+			"nodes", metav1.NamespaceAll, fields.Everything()),
+		&slim_corev1.Node{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				key, _ := queueKeyFunc(obj)
+				nodeQueue.Add(key)
+			},
+			UpdateFunc: func(_, newObj interface{}) {
+				key, _ := queueKeyFunc(newObj)
+				nodeQueue.Add(key)
+			},
+		},
+		convertToNode,
+	)
+	go nodeController.Run(stopCh)
+}
+
+func convertToNode(obj interface{}) interface{} {
+	switch concreteObj := obj.(type) {
+	case *slim_corev1.Node:
+		n := &slim_corev1.Node{
+			TypeMeta: concreteObj.TypeMeta,
+			ObjectMeta: slim_metav1.ObjectMeta{
+				Name:            concreteObj.Name,
+				ResourceVersion: concreteObj.ResourceVersion,
+			},
+			Spec: slim_corev1.NodeSpec{
+				Taints: concreteObj.Spec.Taints,
+			},
+			Status: slim_corev1.NodeStatus{
+				Conditions: concreteObj.Status.Conditions,
+			},
+		}
+		*concreteObj = slim_corev1.Node{}
+		return n
+	case cache.DeletedFinalStateUnknown:
+		node, ok := concreteObj.Obj.(*slim_corev1.Node)
+		if !ok {
+			return obj
+		}
+		dfsu := cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &slim_corev1.Node{
+				TypeMeta: node.TypeMeta,
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            node.Name,
+					ResourceVersion: node.ResourceVersion,
+				},
+				Spec: slim_corev1.NodeSpec{
+					Taints: node.Spec.Taints,
+				},
+				Status: slim_corev1.NodeStatus{
+					Conditions: node.Status.Conditions,
+				},
+			},
+		}
+		// Small GC optimization
+		*node = slim_corev1.Node{}
+		return dfsu
+	default:
+		return obj
+	}
+}

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -21,11 +21,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -40,14 +37,7 @@ const (
 	ciliumNodeConditionReason = "CiliumIsUp"
 )
 
-type slimNodeGetter interface {
-	GetK8sSlimNode(nodeName string) (*slim_corev1.Node, error)
-}
-
 var (
-	// slimNodeStore contains all cluster nodes store as slim_core.Node
-	slimNodeStore cache.Store
-
 	// ciliumPodsStore contains all Cilium pods running in the cluster
 	ciliumPodsStore = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, ciliumIndexers)
 
@@ -66,110 +56,7 @@ var (
 	mno markNodeOptions
 )
 
-type nodeGetter struct{}
-
-// GetK8sSlimNode returns a slim_corev1.Node from the local store.
-// The return structure should only be used for read purposes and should never
-// be written into it.
-func (nodeGetter) GetK8sSlimNode(nodeName string) (*slim_corev1.Node, error) {
-	nodeInterface, exists, err := slimNodeStore.GetByKey(nodeName)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, k8sErrors.NewNotFound(schema.GroupResource{
-			Group:    "core",
-			Resource: "Node",
-		}, nodeName)
-	}
-	return nodeInterface.(*slim_corev1.Node), nil
-}
-
-// nodesInit starts up a node watcher to handle node events.
-func nodesInit(k8sClient kubernetes.Interface, stopCh <-chan struct{}) {
-	var (
-		nodeController cache.Controller
-	)
-	nodeQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "node-queue")
-
-	slimNodeStore, nodeController = informer.NewInformer(
-		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
-			"nodes", v1.NamespaceAll, fields.Everything()),
-		&slim_corev1.Node{},
-		0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				key, _ := queueKeyFunc(obj)
-				nodeQueue.Add(key)
-			},
-			UpdateFunc: func(_, newObj interface{}) {
-				key, _ := queueKeyFunc(newObj)
-				nodeQueue.Add(key)
-			},
-		},
-		convertToNode,
-	)
-
-	nodeGetter := &nodeGetter{}
-
-	go func() {
-		// Do not use the k8sClient provided by the nodesInit function since we
-		// need a k8s client that can update node structures and not simply
-		// watch for node events.
-		for processNextNodeItem(k8s.Client(), nodeGetter, nodeQueue) {
-		}
-	}()
-	go nodeController.Run(stopCh)
-}
-
-func convertToNode(obj interface{}) interface{} {
-	switch concreteObj := obj.(type) {
-	case *slim_corev1.Node:
-		n := &slim_corev1.Node{
-			TypeMeta: concreteObj.TypeMeta,
-			ObjectMeta: slim_metav1.ObjectMeta{
-				Name:            concreteObj.Name,
-				ResourceVersion: concreteObj.ResourceVersion,
-			},
-			Spec: slim_corev1.NodeSpec{
-				Taints: concreteObj.Spec.Taints,
-			},
-			Status: slim_corev1.NodeStatus{
-				Conditions: concreteObj.Status.Conditions,
-			},
-		}
-		*concreteObj = slim_corev1.Node{}
-		return n
-	case cache.DeletedFinalStateUnknown:
-		node, ok := concreteObj.Obj.(*slim_corev1.Node)
-		if !ok {
-			return obj
-		}
-		dfsu := cache.DeletedFinalStateUnknown{
-			Key: concreteObj.Key,
-			Obj: &slim_corev1.Node{
-				TypeMeta: node.TypeMeta,
-				ObjectMeta: slim_metav1.ObjectMeta{
-					Name:            node.Name,
-					ResourceVersion: node.ResourceVersion,
-				},
-				Spec: slim_corev1.NodeSpec{
-					Taints: node.Spec.Taints,
-				},
-				Status: slim_corev1.NodeStatus{
-					Conditions: node.Status.Conditions,
-				},
-			},
-		}
-		// Small GC optimization
-		*node = slim_corev1.Node{}
-		return dfsu
-	default:
-		return obj
-	}
-}
-
-func processNextNodeItem(c kubernetes.Interface, nodeGetter slimNodeGetter, workQueue workqueue.RateLimitingInterface) bool {
+func checkTaintForNextNodeItem(c kubernetes.Interface, nodeGetter slimNodeGetter, workQueue workqueue.RateLimitingInterface) bool {
 	// Get the next 'key' from the queue.
 	key, quit := workQueue.Get()
 	if quit {
@@ -519,5 +406,14 @@ func HandleNodeTolerationAndTaints(stopCh <-chan struct{}) {
 		SetCiliumIsUpCondition: option.Config.SetCiliumIsUpCondition,
 	}
 	nodesInit(k8s.WatcherClient(), stopCh)
+
+	go func() {
+		// Do not use the k8sClient provided by the nodesInit function since we
+		// need a k8s client that can update node structures and not simply
+		// watch for node events.
+		for checkTaintForNextNodeItem(k8s.Client(), &nodeGetter{}, nodeQueue) {
+		}
+	}()
+
 	ciliumPodsWatcher(k8s.WatcherClient(), stopCh)
 }

--- a/operator/watchers/node_taint_test.go
+++ b/operator/watchers/node_taint_test.go
@@ -145,7 +145,7 @@ func (n *NodeTaintSuite) TestNodeTaintWithoutCondition(c *check.C) {
 
 	nodeQueue.Add(key)
 
-	continueProcess := processNextNodeItem(fakeClient, fng, nodeQueue)
+	continueProcess := checkTaintForNextNodeItem(fakeClient, fng, nodeQueue)
 	c.Assert(continueProcess, check.Equals, true)
 
 	err = testutils.WaitUntil(func() bool {
@@ -278,7 +278,7 @@ func (n *NodeTaintSuite) TestNodeCondition(c *check.C) {
 
 	nodeQueue.Add(key)
 
-	continueProcess := processNextNodeItem(fakeClient, fng, nodeQueue)
+	continueProcess := checkTaintForNextNodeItem(fakeClient, fng, nodeQueue)
 	c.Assert(continueProcess, check.Equals, true)
 
 	err = testutils.WaitUntil(func() bool {
@@ -384,7 +384,7 @@ func (n *NodeTaintSuite) TestNodeConditionIfCiliumIsNotReady(c *check.C) {
 
 	nodeQueue.Add(key)
 
-	continueProcess := processNextNodeItem(fakeClient, fng, nodeQueue)
+	continueProcess := checkTaintForNextNodeItem(fakeClient, fng, nodeQueue)
 	c.Assert(continueProcess, check.Equals, true)
 
 	err = testutils.WaitUntil(func() bool {
@@ -490,7 +490,7 @@ func (n *NodeTaintSuite) TestNodeConditionIfCiliumAndNodeAreReady(c *check.C) {
 
 	nodeQueue.Add(key)
 
-	continueProcess := processNextNodeItem(fakeClient, fng, nodeQueue)
+	continueProcess := checkTaintForNextNodeItem(fakeClient, fng, nodeQueue)
 	c.Assert(continueProcess, check.Equals, true)
 
 	err = testutils.WaitUntil(func() bool {

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -148,7 +148,7 @@ func newChangeNotification(n types.Node, t peerpb.ChangeNotificationType, withTL
 	var tls *peerpb.TLS
 	if withTLS {
 		tls = &peerpb.TLS{
-			ServerName: tlsServerName(n.Name, n.Cluster),
+			ServerName: TLSServerName(n.Name, n.Cluster),
 		}
 	}
 	return &peerpb.ChangeNotification{
@@ -173,7 +173,7 @@ func nodeAddress(n types.Node) string {
 	return addr.String()
 }
 
-// tlsServerName constructs a server name to be used as the TLS server name.
+// TLSServerName constructs a server name to be used as the TLS server name.
 // The server name is of the following form:
 //
 //     <nodeName>.<clusterName>.<hubble-grpc-svc-name>.<domain>
@@ -187,7 +187,7 @@ func nodeAddress(n types.Node) string {
 // nodeName are replaced by Hyphen (-). When clusterName is not provided, it
 // defaults to the default cluster name. All Dot (.) in clusterName are
 // replaced by Hypen (-).
-func tlsServerName(nodeName, clusterName string) string {
+func TLSServerName(nodeName, clusterName string) string {
 	if nodeName == "" {
 		return ""
 	}

--- a/pkg/hubble/peer/types/client.go
+++ b/pkg/hubble/peer/types/client.go
@@ -16,12 +16,16 @@ package types
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"time"
 
 	peerpb "github.com/cilium/cilium/api/v1/peer"
+	"github.com/cilium/cilium/pkg/crypto/certloader"
+	hubbleopts "github.com/cilium/cilium/pkg/hubble/server/serveroption"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // Client defines an interface that Peer service client should implement.
@@ -60,6 +64,35 @@ func (b LocalClientBuilder) Client(target string) (Client, error) {
 	defer cancel()
 	// the connection is local so we assume WithInsecure() is safe in this context
 	conn, err := grpc.DialContext(ctx, target, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return nil, err
+	}
+	return &client{conn, peerpb.NewPeerClient(conn)}, nil
+}
+
+// RemoteClientBuilder is a ClientBuilder that is suitable when the gRPC
+// connection to the Peer service is remote (typically a K8s Service).
+type RemoteClientBuilder struct {
+	DialTimeout   time.Duration
+	TLSConfig     certloader.ClientConfigBuilder
+	TLSServerName string
+}
+
+// Client implements ClientBuilder.Client.
+func (b RemoteClientBuilder) Client(target string) (Client, error) {
+	opts := []grpc.DialOption{grpc.WithBlock()}
+	if b.TLSConfig == nil {
+		opts = append(opts, grpc.WithInsecure())
+	} else {
+		tlsConfig := b.TLSConfig.ClientConfig(&tls.Config{
+			ServerName: b.TLSServerName,
+			MinVersion: hubbleopts.MinTLSVersion,
+		})
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), b.DialTimeout)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, target, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -23,6 +23,8 @@ import (
 )
 
 const (
+	// ClusterName is the default cluster name
+	ClusterName = ciliumDefaults.ClusterName
 	// DialTimeout is the timeout that is used when establishing a new
 	// connection.
 	DialTimeout = 5 * time.Second
@@ -32,8 +34,10 @@ const (
 	PprofPort = 6062
 	// RetryTimeout is the duration to wait between reconnection attempts.
 	RetryTimeout = 30 * time.Second
-	// HubbleTarget is the address of the local Hubble instance.
-	HubbleTarget = "unix://" + ciliumDefaults.HubbleSockPath
+	// PeerTarget is the address of the peer service.
+	PeerTarget = "unix://" + ciliumDefaults.HubbleSockPath
+	// PeerServiceName is the name of the peer service, should it exist.
+	PeerServiceName = "hubble-peer"
 
 	// SortBufferMaxLen is the max number of flows that can be buffered for
 	// sorting before being sen to the client.

--- a/pkg/hubble/relay/pool/option.go
+++ b/pkg/hubble/relay/pool/option.go
@@ -30,7 +30,7 @@ import (
 
 // defaultOptions is the reference point for default values.
 var defaultOptions = options{
-	peerServiceAddress: defaults.HubbleTarget,
+	peerServiceAddress: defaults.PeerTarget,
 	peerClientBuilder: peerTypes.LocalClientBuilder{
 		DialTimeout: defaults.DialTimeout,
 	},

--- a/pkg/hubble/relay/server/option.go
+++ b/pkg/hubble/relay/server/option.go
@@ -16,7 +16,6 @@ package server
 
 import (
 	"crypto/tls"
-	"strings"
 	"time"
 
 	"github.com/cilium/cilium/pkg/crypto/certloader"
@@ -34,7 +33,7 @@ const MinTLSVersion = tls.VersionTLS13
 
 // options stores all the configuration values for the hubble-relay server.
 type options struct {
-	hubbleTarget    string
+	peerTarget      string
 	dialTimeout     time.Duration
 	retryTimeout    time.Duration
 	listenAddress   string
@@ -42,13 +41,14 @@ type options struct {
 	serverTLSConfig certloader.ServerConfigBuilder
 	insecureServer  bool
 	clientTLSConfig certloader.ClientConfigBuilder
+	clusterName     string
 	insecureClient  bool
 	observerOptions []observer.Option
 }
 
 // defaultOptions is the reference point for default values.
 var defaultOptions = options{
-	hubbleTarget:  defaults.HubbleTarget,
+	peerTarget:    defaults.PeerTarget,
 	dialTimeout:   defaults.DialTimeout,
 	retryTimeout:  defaults.RetryTimeout,
 	listenAddress: defaults.ListenAddress,
@@ -58,14 +58,10 @@ var defaultOptions = options{
 // Option customizes the configuration of the hubble-relay server.
 type Option func(o *options) error
 
-// WithHubbleTarget sets the URL of the local hubble instance to connect to.
-// This target MUST implement the Peer service.
-func WithHubbleTarget(t string) Option {
+// WithPeerTarget sets the URL of the hubble peer service to connect to.
+func WithPeerTarget(t string) Option {
 	return func(o *options) error {
-		if !strings.HasPrefix(t, "unix://") {
-			t = "unix://" + t
-		}
-		o.hubbleTarget = t
+		o.peerTarget = t
 		return nil
 	}
 }
@@ -173,6 +169,16 @@ func WithClientTLS(cfg certloader.ClientConfigBuilder) Option {
 func WithInsecureClient() Option {
 	return func(o *options) error {
 		o.insecureClient = true
+		return nil
+	}
+}
+
+// WithLocalClusterName sets the cluster name for the peer service
+// so that it knows how to construct the proper TLSServerName
+// to validate mTLS in the K8s Peer service.
+func WithLocalClusterName(clusterName string) Option {
+	return func(o *options) error {
+		o.clusterName = clusterName
 		return nil
 	}
 }

--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -19,10 +19,13 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/peer"
 	peerTypes "github.com/cilium/cilium/pkg/hubble/peer/types"
+	"github.com/cilium/cilium/pkg/hubble/relay/defaults"
 	"github.com/cilium/cilium/pkg/hubble/relay/observer"
 	"github.com/cilium/cilium/pkg/hubble/relay/pool"
 
@@ -66,13 +69,20 @@ func New(options ...Option) (*Server, error) {
 		return nil, ErrNoServerTLSConfig
 	}
 
+	var peerClientBuilder peerTypes.ClientBuilder = &peerTypes.LocalClientBuilder{
+		DialTimeout: opts.dialTimeout,
+	}
+	if !strings.HasPrefix(opts.peerTarget, "unix://") {
+		peerClientBuilder = &peerTypes.RemoteClientBuilder{
+			DialTimeout:   opts.dialTimeout,
+			TLSConfig:     opts.clientTLSConfig,
+			TLSServerName: peer.TLSServerName(defaults.PeerServiceName, opts.clusterName),
+		}
+	}
+
 	pm, err := pool.NewPeerManager(
-		pool.WithPeerServiceAddress(opts.hubbleTarget),
-		pool.WithPeerClientBuilder(
-			&peerTypes.LocalClientBuilder{
-				DialTimeout: opts.dialTimeout,
-			},
-		),
+		pool.WithPeerServiceAddress(opts.peerTarget),
+		pool.WithPeerClientBuilder(peerClientBuilder),
 		pool.WithClientConnBuilder(pool.GRPCClientConnBuilder{
 			DialTimeout: opts.dialTimeout,
 			Options: []grpc.DialOption{

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -187,7 +187,7 @@ const (
 
 	// CiliumStableHelmChartVersion should be the chart version that points
 	// to the v1.X branch
-	CiliumStableHelmChartVersion = "1.9-dev"
+	CiliumStableHelmChartVersion = "1.9"
 	CiliumStableVersion          = "v1.9"
 	CiliumLatestHelmChartVersion = "1.9.90"
 

--- a/test/provision/docker-run-cilium.sh
+++ b/test/provision/docker-run-cilium.sh
@@ -52,7 +52,7 @@ if [ -n "$(${SUDO} docker ps -a -q -f label=app=cilium)" ]; then
 fi
 
 echo "Launching Cilium agent $CILIUM_IMAGE with params $CILIUM_OPTS"
-${SUDO} docker run --name cilium $DOCKER_OPTS $CILIUM_IMAGE cilium-agent $CILIUM_OPTS
+${SUDO} docker run --name cilium $DOCKER_OPTS $CILIUM_IMAGE /bin/bash -c "groupadd -f cilium && cilium-agent $CILIUM_OPTS"
 
 # Copy Cilium CLI
 ${SUDO} docker cp cilium:/usr/bin/cilium /usr/bin/


### PR DESCRIPTION
 * #18620 -- hubble/relay: Make Peer Service a K8s Service (@nathanjsweet)
 * #19710 -- test/upgrade: use the unreleased helm chart of stable branches (@aanm)
 * #19711 -- images/cilium: remove cilium group from Dockerfile (@aanm)
 * #19576 -- operator: Add cilium node garbage collector (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 18620 19710 19711 19576; do contrib/backporting/set-labels.py $pr done 1.10; done
```
or with
```
$ make add-label BRANCH=v1.10 ISSUES=18620,19710,19711,19576
```