### PR TITLE
ipcache/kvstore: fix panic when procesing ip=<nil> entries

### DIFF
--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -276,7 +276,9 @@ restart:
 				}
 				ip := ipIDPair.PrefixString()
 				if ip == "<nil>" {
-					scopedLog.Debug("Ignoring entry with nil IP")
+					if scopedLog != nil {
+						scopedLog.Debug("Ignoring entry with nil IP")
+					}
 					continue
 				}
 				var k8sMeta *K8sMetadata


### PR DESCRIPTION
This problem was introduced in  6cbf5da, which results in
a "nil pointer dereference" panic.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>