### PR TITLE
make: fix Makefile docker pull command to cause an error when using podman

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -15,7 +15,7 @@ clean:
 
 builder-image: Dockerfile requirements.txt
 	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
-	grep "^FROM " $< | cut -d ' ' -f2 | xargs -n1 docker pull
+	grep "^FROM " $< | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
 	$(QUIET)tar c requirements.txt Dockerfile \
 	  | $(CONTAINER_ENGINE) build --tag cilium/docs-builder -
 

--- a/bpf/mock/Makefile
+++ b/bpf/mock/Makefile
@@ -6,7 +6,7 @@ include ../../Makefile.quiet
 
 builder-image: Dockerfile
 	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
-	grep "^FROM " $< | cut -d ' ' -f2 | xargs -n1 docker pull
+	grep "^FROM " $< | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
 	$(QUIET)tar c Dockerfile \
 	 | $(CONTAINER_ENGINE) build --tag cilium/bpf-mock -
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

I try executing to debug command from Makefile using podman, I execute the following command:
make debug CONTAINER_ENGINE="sudo podman"

But, This command happens below errors on the terminal:

```
make  -C Documentation check
make[1]: Entering directory '/home/kob/git/cilium/Documentation'
# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
grep "^FROM " Dockerfile | cut -d ' ' -f2 | xargs -n1 docker pull
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
make[1]: *** [Makefile:18: builder-image] Error 123
make[1]: Leaving directory '/home/kob/git/cilium/Documentation'
make: *** [Makefile:588: postcheck] Error 2
```

The cause is a Makefile calling docker pull command and causes an error when docker daemon is not running on a machine.
This patch fixes it and replaces the docker pull command with the $(CONTAINER_ENGINE) pull it supporting podman.

Signed-off-by: Yugo Kobayashi <kobdotsh@gmail.com>