### PR TITLE
test: Wait for pod termination in K8sServicesTest

### DIFF
--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -64,6 +64,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 	})
 
 	AfterAll(func() {
+		ExpectAllPodsTerminated(kubectl)
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
 	})


### PR DESCRIPTION
_Take No. 2 :crossed_fingers:_

Wait for pod termination before removing Cilium.

The premature removal of Cilium might cause the removal of any test pods
to fail. For example the following CI flake:

    "Pods are still terminating:
        [echo-694c58bbf4-896gh echo-694c58bbf4-fr4ck]"

This is due to the missing CNI plugin. From the kubelet logs:

    failed to "KillPodSandbox" for "..."
    with KillPodSandboxError: "rpc error: code = Unknown desc =
    networkPlugin cni failed to teardown pod
    \"echo-694c58bbf4-fr4ck_default\" network: failed to find plugin
    \"cilium-cni\" in path [/opt/cni/bin]"

The proposed change is not ideal, as the ExpectAllPodsInNsTerminated()
function is racy. If neither of pods have not entered the termination
state yet, the function will return too early (without waiting for the
termination).

The proper solution would be to use the deployment manager used by
the K8sDatapathConfig. However, the manager would require significant
changes. Considering that we are planning to completely change the
integration suite, the proper solution is not worth time.

Fix https://github.com/cilium/cilium/issues/18895