### PR TITLE
bpf/nat: fix current behavior that is silently ignoring errors in a revSNAT context

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1194,7 +1194,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __
 			}
 			break;
 		default:
-			return DROP_NAT_UNSUPP_PROTO;
+			return NAT_PUNT_TO_STACK;
 		}
 		break;
 	default:
@@ -1960,7 +1960,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target, __
 			goto rewrite_ingress;
 		}
 		default:
-			return DROP_NAT_UNSUPP_PROTO;
+			return NAT_PUNT_TO_STACK;
 		}
 		break;
 	default:

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -780,10 +780,12 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 		     * needed.
 		     */
 		    ret == DROP_NAT_NO_MAPPING) {
-			/* In case of no mapping, recircle back to main path. SNAT
-			 * is very expensive in terms of instructions (since we
-			 * don't have BPF to BPF calls as we use tail calls) and
-			 * complexity, hence this is done inside a tail call here.
+			/* In case of no mapping, recircle back to
+			 * main path. SNAT is very expensive in terms
+			 * of instructions and
+			 * complexity. Consequently, this is done
+			 * inside a tail call here (because we don't
+			 * have BPF to BPF calls).
 			 */
 			ctx_skip_nodeport_set(ctx);
 			ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
@@ -1991,10 +1993,12 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 		     * needed.
 		     */
 		    ret == DROP_NAT_NO_MAPPING) {
-			/* In case of no mapping, recircle back to main path. SNAT
-			 * is very expensive in terms of instructions (since we
-			 * don't have BPF to BPF calls as we use tail calls) and
-			 * complexity, hence this is done inside a tail call here.
+			/* In case of no mapping, recircle back to
+			 * main path. SNAT is very expensive in terms
+			 * of instructions and
+			 * complexity. Consequently, this is done
+			 * inside a tail call here (because we don't
+			 * have BPF to BPF calls).
 			 */
 			ctx_skip_nodeport_set(ctx);
 			ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -773,14 +773,22 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 	/* ext_err is NULL because errors don't survive the tailcall anyway. */
 	ret = snat_v6_rev_nat(ctx, &target, NULL);
 	if (IS_ERR(ret)) {
-		/* In case of no mapping, recircle back to main path. SNAT is very
-		 * expensive in terms of instructions (since we don't have BPF to
-		 * BPF calls as we use tail calls) and complexity, hence this is
-		 * done inside a tail call here.
-		 */
-		ctx_skip_nodeport_set(ctx);
-		ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
-		ret = DROP_MISSED_TAIL_CALL;
+		if (ret == NAT_PUNT_TO_STACK ||
+		    /* DROP_NAT_NO_MAPPING is unwanted behavior in a
+		     * rev-SNAT context. Let's continue to passing it
+		     * up to the host and revisiting this later if
+		     * needed.
+		     */
+		    ret == DROP_NAT_NO_MAPPING) {
+			/* In case of no mapping, recircle back to main path. SNAT
+			 * is very expensive in terms of instructions (since we
+			 * don't have BPF to BPF calls as we use tail calls) and
+			 * complexity, hence this is done inside a tail call here.
+			 */
+			ctx_skip_nodeport_set(ctx);
+			ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
+			ret = DROP_MISSED_TAIL_CALL;
+		}
 		goto drop_err;
 	}
 
@@ -1976,14 +1984,22 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 	/* ext_err is NULL because errors don't survive the tailcall anyway. */
 	ret = snat_v4_rev_nat(ctx, &target, NULL);
 	if (IS_ERR(ret)) {
-		/* In case of no mapping, recircle back to main path. SNAT is very
-		 * expensive in terms of instructions (since we don't have BPF to
-		 * BPF calls as we use tail calls) and complexity, hence this is
-		 * done inside a tail call here.
-		 */
-		ctx_skip_nodeport_set(ctx);
-		ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);
-		ret = DROP_MISSED_TAIL_CALL;
+		if (ret == NAT_PUNT_TO_STACK ||
+		    /* DROP_NAT_NO_MAPPING is unwanted behavior in a
+		     * rev-SNAT context. Let's continue to passing it up
+		     * to the host and revisiting this later if
+		     * needed.
+		     */
+		    ret == DROP_NAT_NO_MAPPING) {
+			/* In case of no mapping, recircle back to main path. SNAT
+			 * is very expensive in terms of instructions (since we
+			 * don't have BPF to BPF calls as we use tail calls) and
+			 * complexity, hence this is done inside a tail call here.
+			 */
+			ctx_skip_nodeport_set(ctx);
+			ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);
+			ret = DROP_MISSED_TAIL_CALL;
+		}
 		goto drop_err;
 	}
 


### PR DESCRIPTION
The PR is fixing current behavior of nodeport in context of a revSNAT that is silently ignoring errors to process them to the main path anyway.

- In the first patch we remove usage of DROP_NAT_UNSUPP_PROTO in favor of NAT_PUNT_TO_STACK considering that we want to be conservative in such situation.
- In the second patch we we have determined errors that can happen from a revSNAT
point of view to only accept those that are legitimate.
- The last one clarify comment.