### PR TITLE
ipcache: Fix UpsertMetadata() locking

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -64,7 +64,9 @@ func newMetadata() *metadata {
 // with it into the ipcache metadata map. The given labels are not modified nor
 // is its reference saved, as they're copied when inserting into the map.
 func (ipc *IPCache) UpsertMetadata(prefix string, lbls labels.Labels) {
+	ipc.metadata.Lock()
 	ipc.metadata.upsert(prefix, lbls)
+	ipc.metadata.Unlock()
 }
 
 func (m *metadata) upsert(prefix string, lbls labels.Labels) {


### PR DESCRIPTION
Previously, the modification of ipcache.metadata from the node manager
and k8s watchers was not locking the map before making changes. If
two events happened at around the same time, this could cause weird
behaviour. In general, this is fairly unlikely given the relatively
static usage of the metadata map in the current case (plus that
InjectLabels() waits for k8s to be fully synced before running), however
this is a good cleanup and will be required in future when the ipcache
metadata map plays a more central role in managing IPcache label
association.
