### PR TITLE
Restructure IPCache to handle metadata merging

### DIFF
--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -47,6 +47,9 @@ func (ipc *IPCache) AllocateCIDRs(
 		newlyAllocatedIdentities = map[string]*identity.Identity{}
 	}
 
+	allocateCtx, cancel := context.WithTimeout(context.Background(), option.Config.IPAllocationTimeout)
+	defer cancel()
+
 	allocatedIdentities := make(map[string]*identity.Identity, len(prefixes))
 	for i, p := range prefixes {
 		if p == nil {
@@ -59,7 +62,7 @@ func (ipc *IPCache) AllocateCIDRs(
 		if oldNIDs != nil && len(oldNIDs) > i {
 			oldNID = oldNIDs[i]
 		}
-		id, isNew, err := ipc.allocate(p, lbls, oldNID)
+		id, isNew, err := ipc.allocate(allocateCtx, p, lbls, oldNID)
 		if err != nil {
 			ipc.IdentityAllocator.ReleaseSlice(context.Background(), nil, usedIdentities)
 			return nil, err
@@ -120,15 +123,12 @@ func (ipc *IPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[strin
 //
 // It is up to the caller to provide the full set of labels for identity
 // allocation.
-func (ipc *IPCache) allocate(prefix *net.IPNet, lbls labels.Labels, oldNID identity.NumericIdentity) (*identity.Identity, bool, error) {
+func (ipc *IPCache) allocate(ctx context.Context, prefix *net.IPNet, lbls labels.Labels, oldNID identity.NumericIdentity) (*identity.Identity, bool, error) {
 	if prefix == nil {
 		return nil, false, nil
 	}
 
-	allocateCtx, cancel := context.WithTimeout(context.Background(), option.Config.IPAllocationTimeout)
-	defer cancel()
-
-	id, isNew, err := ipc.IdentityAllocator.AllocateIdentity(allocateCtx, lbls, false, oldNID)
+	id, isNew, err := ipc.IdentityAllocator.AllocateIdentity(ctx, lbls, false, oldNID)
 	if err != nil {
 		return nil, isNew, fmt.Errorf("failed to allocate identity for cidr %s: %s", prefix, err)
 	}

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -4,6 +4,7 @@
 package ipcache
 
 import (
+	"errors"
 	"net"
 
 	"github.com/sirupsen/logrus"
@@ -11,7 +12,9 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache/types"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -410,6 +413,45 @@ func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
 	ipc.DumpToListenerLocked(listener)
 	ipc.RUnlock()
 }
+
+func (ipc *IPCache) UpsertIdentity(cidr string, id identity.Identity) error {
+	return errors.New("not implemented")
+}
+func (ipc *IPCache) UpsertEncryptKey(cidr string, key uint8) error {
+	return errors.New("not implemented")
+}
+func (ipc *IPCache) UpsertK8sMetadata(cidr string, k8sMeta *K8sMetadata) error {
+	return errors.New("not implemented")
+}
+
+// TODO: Figure out what kind of mechanism we need to report that this operation was completed
+func (ipc *IPCache) UpsertLabels(cidr string, lbls labels.Labels, src source.Source, name types.ResourceID) error {
+	ipc.UpsertMetadata(cidr, lbls, src, name)
+	ipc.TriggerLabelInjection()
+
+	return errors.New("not implemented")
+}
+
+// TODO: Figure out what kind of mechanism we need to report that this operation was completed
+func (ipc *IPCache) RemoveLabels(cidr string, lbls labels.Labels, name types.ResourceID) error {
+	ipc.metadata.Lock()
+	ipc.removeLabels(cidr, lbls, name)
+	ipc.metadata.Unlock()
+
+	ipc.TriggerLabelInjection()
+
+	return errors.New("not implemented")
+}
+
+//func (ipc *IPcache) UpsertCIDRs(cidrs []string) error {
+//	ipc.Lock()
+//	defer ipc.Unlock()
+//
+//	for c := cidrs {
+//		// insert into the tree
+//	}
+//	ipc.TriggerLabelInjection()
+//}
 
 // DumpToListenerLocked dumps the entire contents of the IPCache by triggering
 // the listener's "OnIPIdentityCacheChange" method for each entry in the cache.

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -64,7 +64,9 @@ func newMetadata() *metadata {
 // with it into the ipcache metadata map. The given labels are not modified nor
 // is its reference saved, as they're copied when inserting into the map.
 func (ipc *IPCache) UpsertMetadata(prefix string, lbls labels.Labels) {
+	ipc.metadata.Lock()
 	ipc.metadata.upsert(prefix, lbls)
+	ipc.metadata.Unlock()
 }
 
 func (m *metadata) upsert(prefix string, lbls labels.Labels) {

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -502,12 +502,13 @@ func (ipc *IPCache) removeLabels(prefix string, lbls labels.Labels, rid types.Re
 //            | (2)    +------+--------+   (2) |
 //            +------->|Label Injector |<------+
 //           Trigger   +-------+-------+ Trigger
-//                         (4) |W
-//                             |
-//                             v
-//                           +---+
-//                           |IPC|
-//                           +---+
+//                    (4) |W    (5) |W
+//                        |         |
+//                        v         v
+//                   +--------+   +---+
+//                   |Policy &|   |IPC|
+//                   |datapath|   +---+
+//                   +--------+
 //      legend:
 //      * W means write
 //      * R means read

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	cidrlabels "github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/lock"
@@ -30,7 +31,7 @@ var (
 )
 
 // metadata contains the ipcache metadata. Mainily it holds a map which maps IP
-// prefixes (x.x.x.x/32) to their labels.
+// prefixes (x.x.x.x/32) to a set of information (prefixInfo).
 //
 // When allocating an identity to associate with each prefix, the
 // identity allocation routines will merge this set of labels into the
@@ -38,6 +39,22 @@ var (
 // thereby associating these labels with each prefix that is 'covered'
 // by this prefix. Subsequently these labels may be matched by network
 // policy and propagated in monitor output.
+//
+// ```mermaid
+// flowchart
+//   subgraph labelsWithSource
+//   labels.Labels
+//   source.Feature
+//   end
+//   subgraph prefixInfo
+//   UA[ResourceID]-->LA[labelsWithSource]
+//   UB[ResourceID]-->LB[labelsWithSource]
+//   ...
+//   end
+//   subgraph identityMetadata
+//   IP_Prefix-->prefixInfo
+//   end
+// ```
 type metadata struct {
 	// Protects the m map.
 	//
@@ -47,7 +64,7 @@ type metadata struct {
 	lock.RWMutex
 
 	// m is the actual map containing the mappings.
-	m map[string]labels.Labels
+	m map[string]prefixInfo
 
 	// applyChangesMU protects InjectLabels and RemoveLabelsExcluded from being
 	// run in parallel
@@ -56,28 +73,28 @@ type metadata struct {
 
 func newMetadata() *metadata {
 	return &metadata{
-		m: make(map[string]labels.Labels),
+		m: make(map[string]prefixInfo),
 	}
 }
 
 // UpsertMetadata upserts a given IP and its corresponding labels associated
 // with it into the ipcache metadata map. The given labels are not modified nor
 // is its reference saved, as they're copied when inserting into the map.
-func (ipc *IPCache) UpsertMetadata(prefix string, lbls labels.Labels) {
+func (ipc *IPCache) UpsertMetadata(prefix string, lbls labels.Labels, src source.Source, rid types.ResourceID) {
 	ipc.metadata.Lock()
-	ipc.metadata.upsert(prefix, lbls)
+	ipc.metadata.upsert(prefix, lbls, src, rid)
 	ipc.metadata.Unlock()
 }
 
-func (m *metadata) upsert(prefix string, lbls labels.Labels) {
+func (m *metadata) upsert(prefix string, lbls labels.Labels, src source.Source, rid types.ResourceID) {
 	l := labels.NewLabelsFromModel(nil)
 	l.MergeLabels(lbls)
 
 	m.Lock()
-	if cur, ok := m.m[prefix]; ok {
-		l.MergeLabels(cur)
+	if _, ok := m.m[prefix]; !ok {
+		m.m[prefix] = make(prefixInfo)
 	}
-	m.m[prefix] = l
+	m.m[prefix][rid] = newLabelsWithSource(l, src)
 	m.Unlock()
 }
 
@@ -85,10 +102,13 @@ func (m *metadata) upsert(prefix string, lbls labels.Labels) {
 // not modifying the returned object as it's a live reference to the underlying
 // map.
 func (ipc *IPCache) GetIDMetadataByIP(prefix string) labels.Labels {
-	return ipc.metadata.get(prefix)
+	if info := ipc.metadata.get(prefix); info != nil {
+		return info.ToLabels()
+	}
+	return nil
 }
 
-func (m *metadata) get(prefix string) labels.Labels {
+func (m *metadata) get(prefix string) prefixInfo {
 	m.RLock()
 	defer m.RUnlock()
 	return m.m[prefix]
@@ -131,7 +151,8 @@ func (ipc *IPCache) InjectLabels(src source.Source) error {
 
 	ipc.metadata.Lock()
 
-	for prefix, lbls := range ipc.metadata.m {
+	for prefix, info := range ipc.metadata.m {
+		lbls := info.ToLabels()
 		id, isNew, err := ipc.injectLabels(prefix, lbls)
 		if err != nil {
 			ipc.metadata.Unlock()
@@ -313,6 +334,7 @@ func (ipc *IPCache) RemoveLabelsExcluded(
 	lbls labels.Labels,
 	toExclude map[string]struct{},
 	src source.Source,
+	rid types.ResourceID,
 ) {
 	ipc.metadata.applyChangesMU.Lock()
 	defer ipc.metadata.applyChangesMU.Unlock()
@@ -328,7 +350,7 @@ func (ipc *IPCache) RemoveLabelsExcluded(
 		}
 	}
 
-	ipc.removeLabelsFromIPs(toRemove, src)
+	ipc.removeLabelsFromIPs(toRemove, src, rid)
 }
 
 // filterByLabels returns all the prefixes inside the ipcache metadata map
@@ -339,7 +361,8 @@ func (ipc *IPCache) RemoveLabelsExcluded(
 func (m *metadata) filterByLabels(filter labels.Labels) []string {
 	var matching []string
 	sortedFilter := filter.SortedList()
-	for prefix, lbls := range m.m {
+	for prefix, info := range m.m {
+		lbls := info.ToLabels()
 		if bytes.Contains(lbls.SortedList(), sortedFilter) {
 			matching = append(matching, prefix)
 		}
@@ -358,6 +381,7 @@ func (m *metadata) filterByLabels(filter labels.Labels) []string {
 func (ipc *IPCache) removeLabelsFromIPs(
 	m map[string]labels.Labels,
 	src source.Source,
+	rid types.ResourceID,
 ) {
 	var (
 		idsToAdd    = make(map[identity.NumericIdentity]labels.LabelArray)
@@ -378,7 +402,7 @@ func (ipc *IPCache) removeLabelsFromIPs(
 		idsToDelete[id.ID] = nil // labels for deletion don't matter to UpdateIdentities()
 
 		// Insert to propagate the updated set of labels after removal.
-		l := ipc.removeLabels(prefix, lbls, src)
+		l := ipc.removeLabels(prefix, lbls, src, rid)
 		if len(l) > 0 {
 			// If for example kube-apiserver label is removed from the local
 			// host identity (when the kube-apiserver is running within the
@@ -453,26 +477,20 @@ func (ipc *IPCache) removeLabelsFromIPs(
 //
 // This function assumes that the ipcache metadata and the IPIdentityCache
 // locks are taken!
-func (ipc *IPCache) removeLabels(prefix string, lbls labels.Labels, src source.Source) labels.Labels {
-	l, ok := ipc.metadata.m[prefix]
+func (ipc *IPCache) removeLabels(prefix string, lbls labels.Labels, src source.Source, rid types.ResourceID) labels.Labels {
+	info, ok := ipc.metadata.m[prefix]
 	if !ok {
 		return nil
 	}
+	delete(info, rid)
 
-	l = l.Remove(lbls)
-	if len(l) == 0 { // Labels empty, delete
+	allLbls := info.ToLabels()
+	if len(allLbls) == 0 { // Labels empty, delete
 		// No labels left. Example case: when the kube-apiserver is running
 		// outside of the cluster, meaning that the IDMD only ever had the
 		// kube-apiserver label (CIDR labels are not added) and it's now being
 		// removed.
 		delete(ipc.metadata.m, prefix)
-	} else {
-		// This case is only hit if the prefix for the kube-apiserver is
-		// running within the cluster. Therefore, the IDMD can only ever has
-		// the following labels:
-		//   * kube-apiserver + remote-node
-		//   * kube-apiserver + host
-		ipc.metadata.m[prefix] = l
 	}
 
 	id, exists := ipc.LookupByIPRLocked(prefix)
@@ -522,10 +540,11 @@ func (ipc *IPCache) removeLabels(prefix string, lbls labels.Labels, src source.S
 	// Generate new identity with the label removed. This should be the case
 	// where the existing identity had >1 refcount, meaning that something was
 	// referring to it.
-	allLbls := labels.NewLabelsFromModel(nil)
-	allLbls.MergeLabels(realID.Labels)
-	allLbls = allLbls.Remove(lbls)
-
+	//
+	// If kube-apiserver is inside the cluster, this path is always hit
+	// (because even if we remove the kube-apiserver from that node, we
+	// need to inject the identity corresponding to "host" or "remote-node"
+	// (without apiserver label)
 	return allLbls
 }
 

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -126,7 +126,7 @@ func (m *metadata) get(prefix string) prefixInfo {
 // prefix was previously associated with an identity, it will get deallocated,
 // so a balance is kept, ensuring a one-to-one mapping between prefix and
 // identity.
-func (ipc *IPCache) InjectLabels(src source.Source) error {
+func (ipc *IPCache) InjectLabels() error {
 	if ipc.IdentityAllocator == nil {
 		return ErrLocalIdentityAllocatorUninitialized
 	}
@@ -170,7 +170,7 @@ func (ipc *IPCache) InjectLabels(src source.Source) error {
 		// cluster.
 		// Also, any new identity should be upserted, regardless.
 		if hasKubeAPIServerLabel || isNew {
-			tmpSrc := src
+			tmpSrc := info.Source()
 			if hasKubeAPIServerLabel {
 				// Overwrite the source because any IP associated with the
 				// kube-apiserver takes the strongest precedence. This is
@@ -585,7 +585,7 @@ func sourceByLabels(d source.Source, lbls labels.Labels) source.Source {
 //      legend:
 //      * W means write
 //      * R means read
-func (ipc *IPCache) TriggerLabelInjection(src source.Source) {
+func (ipc *IPCache) TriggerLabelInjection() {
 	// GH-17829: Would also be nice to have an end-to-end test to validate
 	//           on upgrade that there are no connectivity drops when this
 	//           channel is preventing transient BPF entries.
@@ -596,7 +596,7 @@ func (ipc *IPCache) TriggerLabelInjection(src source.Source) {
 		"ipcache-inject-labels",
 		controller.ControllerParams{
 			DoFunc: func(context.Context) error {
-				if err := ipc.InjectLabels(src); err != nil {
+				if err := ipc.InjectLabels(); err != nil {
 					return fmt.Errorf("failed to inject labels into ipcache: %w", err)
 				}
 				return nil

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -24,14 +24,17 @@ func TestInjectLabels(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.NoError(t, IPIdentityCache.InjectLabels())
+	remAdd, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	assert.Len(t, remAdd, 0)
+	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	// Insert kube-apiserver IP from outside of the cluster. This should create
 	// a CIDR ID for this IP.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer, source.KubeAPIServer, "kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	assert.NoError(t, IPIdentityCache.InjectLabels())
+	_, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
+	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.True(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
 
@@ -40,7 +43,8 @@ func TestInjectLabels(t *testing.T) {
 	// IP now.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelRemoteNode, source.CustomResource, "node-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	assert.NoError(t, IPIdentityCache.InjectLabels())
+	_, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
+	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.False(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
 }
@@ -59,7 +63,8 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.NoError(t, IPIdentityCache.InjectLabels())
+	_, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	IPIdentityCache.removeLabelsFromIPs(map[string]labels.Labels{
@@ -77,7 +82,8 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
 	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
-	assert.NoError(t, IPIdentityCache.InjectLabels())
+	_, err = IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	assert.NoError(t, err)
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
 		context.TODO(),
 		identity.LocalIdentityFlag, // we assume first local ID

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -24,14 +24,14 @@ func TestInjectLabels(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.CustomResource))
+	assert.NoError(t, IPIdentityCache.InjectLabels())
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	// Insert kube-apiserver IP from outside of the cluster. This should create
 	// a CIDR ID for this IP.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer, source.KubeAPIServer, "kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
+	assert.NoError(t, IPIdentityCache.InjectLabels())
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.True(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
 
@@ -40,7 +40,7 @@ func TestInjectLabels(t *testing.T) {
 	// IP now.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelRemoteNode, source.CustomResource, "node-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
+	assert.NoError(t, IPIdentityCache.InjectLabels())
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.False(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
 }
@@ -59,7 +59,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.CustomResource))
+	assert.NoError(t, IPIdentityCache.InjectLabels())
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	IPIdentityCache.removeLabelsFromIPs(map[string]labels.Labels{
@@ -77,7 +77,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
 	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
+	assert.NoError(t, IPIdentityCache.InjectLabels())
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
 		context.TODO(),
 		identity.LocalIdentityFlag, // we assume first local ID

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -22,9 +22,10 @@ import (
 
 func TestInjectLabels(t *testing.T) {
 	setupTest(t)
+	ctx := context.Background()
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	remaining, err := IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
 	assert.Len(t, remaining, 0)
 	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
@@ -33,7 +34,7 @@ func TestInjectLabels(t *testing.T) {
 	// a CIDR ID for this IP.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer, source.KubeAPIServer, "kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"10.0.0.4"})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
@@ -44,7 +45,7 @@ func TestInjectLabels(t *testing.T) {
 	// IP now.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelRemoteNode, source.CustomResource, "node-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"10.0.0.4"})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
@@ -63,9 +64,10 @@ func TestFilterMetadataByLabels(t *testing.T) {
 
 func TestRemoveLabelsFromIPs(t *testing.T) {
 	setupTest(t)
+	ctx := context.Background()
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	remaining, err := IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
@@ -85,7 +87,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
 	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
-	remaining, err = IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
@@ -102,7 +104,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	IPIdentityCache.RemoveLabelsExcluded(
 		labels.LabelKubeAPIServer, map[string]struct{}{},
 		"kube-uid")
-	remaining, err = IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.NotContains(t, IPIdentityCache.metadata.m["1.1.1.1"], labels.LabelKubeAPIServer)

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -24,12 +24,12 @@ func TestInjectLabels(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
+	assert.NoError(t, IPIdentityCache.InjectLabels(source.CustomResource))
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	// Insert kube-apiserver IP from outside of the cluster. This should create
 	// a CIDR ID for this IP.
-	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer)
+	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer, source.KubeAPIServer, "kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
 	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
@@ -38,7 +38,7 @@ func TestInjectLabels(t *testing.T) {
 	// Upsert node labels to the kube-apiserver to validate that the CIDR ID is
 	// deallocated and the kube-apiserver reserved ID is associated with this
 	// IP now.
-	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelRemoteNode)
+	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelRemoteNode, source.CustomResource, "node-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
 	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
@@ -48,8 +48,8 @@ func TestInjectLabels(t *testing.T) {
 func TestFilterMetadataByLabels(t *testing.T) {
 	setupTest(t)
 
-	IPIdentityCache.UpsertMetadata("2.1.1.1", labels.LabelWorld)
-	IPIdentityCache.UpsertMetadata("3.1.1.1", labels.LabelWorld)
+	IPIdentityCache.UpsertMetadata("2.1.1.1", labels.LabelWorld, source.Generated, "gen-uid")
+	IPIdentityCache.UpsertMetadata("3.1.1.1", labels.LabelWorld, source.Generated, "gen-uid-2")
 
 	assert.Len(t, IPIdentityCache.metadata.filterByLabels(labels.LabelKubeAPIServer), 1)
 	assert.Len(t, IPIdentityCache.metadata.filterByLabels(labels.LabelWorld), 2)
@@ -59,14 +59,14 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
+	assert.NoError(t, IPIdentityCache.InjectLabels(source.CustomResource))
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	IPIdentityCache.removeLabelsFromIPs(map[string]labels.Labels{
 		"1.1.1.1": labels.LabelKubeAPIServer,
-	}, source.Local)
+	}, source.Local, "kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.Equal(t, labels.LabelHost, IPIdentityCache.metadata.m["1.1.1.1"])
+	assert.Equal(t, labels.LabelHost, IPIdentityCache.metadata.m["1.1.1.1"].ToLabels())
 
 	// Simulate kube-apiserver policy + CIDR policy on same prefix. Validate
 	// that removing the kube-apiserver policy will result in a new CIDR
@@ -76,7 +76,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// Entry with only kube-apiserver labels means kube-apiserver is outside of
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
-	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer)
+	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
 	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
 		context.TODO(),
@@ -91,7 +91,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.Equal(t, 2, id.ReferenceCount)
 	IPIdentityCache.removeLabelsFromIPs(map[string]labels.Labels{ // remove kube-apiserver policy
 		"1.1.1.1": labels.LabelKubeAPIServer,
-	}, source.Local)
+	}, source.Local, "kube-uid")
 	assert.NotContains(t, IPIdentityCache.metadata.m["1.1.1.1"], labels.LabelKubeAPIServer)
 	assert.Equal(t, 1, id.ReferenceCount) // CIDR policy is left
 }
@@ -107,8 +107,8 @@ func setupTest(t *testing.T) {
 	})
 	IPIdentityCache.k8sSyncedChecker = &mockK8sSyncedChecker{}
 
-	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer)
-	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelHost)
+	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
+	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelHost, source.Local, "host-uid")
 }
 
 type mockK8sSyncedChecker struct{}

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -24,8 +24,8 @@ func TestInjectLabels(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remAdd, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
-	assert.Len(t, remAdd, 0)
+	remaining, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	assert.Len(t, remaining, 0)
 	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
@@ -33,8 +33,9 @@ func TestInjectLabels(t *testing.T) {
 	// a CIDR ID for this IP.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer, source.KubeAPIServer, "kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	_, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
+	remaining, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
 	assert.NoError(t, err)
+	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.True(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
 
@@ -43,8 +44,9 @@ func TestInjectLabels(t *testing.T) {
 	// IP now.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelRemoteNode, source.CustomResource, "node-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	_, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
+	remaining, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
 	assert.NoError(t, err)
+	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.False(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
 }
@@ -63,13 +65,14 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	_, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	remaining, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
 	assert.NoError(t, err)
+	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
-	IPIdentityCache.removeLabelsFromIPs(map[string]labels.Labels{
-		"1.1.1.1": labels.LabelKubeAPIServer,
-	}, source.Local, "kube-uid")
+	IPIdentityCache.RemoveLabelsExcluded(
+		labels.LabelKubeAPIServer, map[string]struct{}{},
+		"kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
 	assert.Equal(t, labels.LabelHost, IPIdentityCache.metadata.m["1.1.1.1"].ToLabels())
 
@@ -82,8 +85,9 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
 	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
-	_, err = IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	remaining, err = IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
 	assert.NoError(t, err)
+	assert.Len(t, remaining, 0)
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
 		context.TODO(),
 		identity.LocalIdentityFlag, // we assume first local ID
@@ -95,9 +99,12 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, ids, 1)
 	assert.Equal(t, 2, id.ReferenceCount)
-	IPIdentityCache.removeLabelsFromIPs(map[string]labels.Labels{ // remove kube-apiserver policy
-		"1.1.1.1": labels.LabelKubeAPIServer,
-	}, source.Local, "kube-uid")
+	IPIdentityCache.RemoveLabelsExcluded(
+		labels.LabelKubeAPIServer, map[string]struct{}{},
+		"kube-uid")
+	remaining, err = IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	assert.NoError(t, err)
+	assert.Len(t, remaining, 0)
 	assert.NotContains(t, IPIdentityCache.metadata.m["1.1.1.1"], labels.LabelKubeAPIServer)
 	assert.Equal(t, 1, id.ReferenceCount) // CIDR policy is left
 }

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+type labelsWithSource struct {
+	labels labels.Labels
+	source source.Source
+}
+
+func newLabelsWithSource(l labels.Labels, src source.Source) labelsWithSource {
+	return labelsWithSource{
+		source: src,
+		labels: l,
+	}
+}
+
+// prefixInfo holds all of the information (labels, etc.) about a given prefix
+// independently based on the ResourceID of the origin of that information, and
+// provides convenient accessors to consistently merge the stored information
+// to generate ipcache output based on a range of inputs.
+type prefixInfo map[types.ResourceID]labelsWithSource
+
+func (s prefixInfo) ToLabels() labels.Labels {
+	l := labels.NewLabelsFromModel(nil)
+	for _, v := range s {
+		l.MergeLabels(v.labels)
+	}
+	return l
+}

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -34,3 +34,13 @@ func (s prefixInfo) ToLabels() labels.Labels {
 	}
 	return l
 }
+
+func (s prefixInfo) Source() source.Source {
+	src := source.Unspec
+	for _, v := range s {
+		if source.AllowOverwrite(src, v.source) {
+			src = v.source
+		}
+	}
+	return src
+}

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -25,4 +26,21 @@ type PolicyHandler interface {
 // before updating the datapath's IPCache maps.
 type DatapathHandler interface {
 	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
+}
+
+// ResourceID identifies a unique copy of a resource that provides a source for
+// information tied to an IP address in the IPCache.
+type ResourceID string
+
+// NewResourceID returns a ResourceID populated with the standard fields for
+// uniquely identifying a source of IPCache information.
+func NewResourceID(kind, namespace, name string) ResourceID {
+	str := strings.Builder{}
+	str.Grow(len(kind) + 1 + len(namespace) + 1 + len(name))
+	str.WriteString(kind)
+	str.WriteString("/")
+	str.WriteString(namespace)
+	str.WriteString("/")
+	str.WriteString(name)
+	return ResourceID(str.String())
 }

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -113,7 +113,7 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 	// used Kubernetes as the source, then the ipcache entries inserted (first)
 	// by the CN handler wouldn't be overwrite-able by the entries inserted
 	// from this handler.
-	src := source.CustomResource
+	src := source.KubeAPIServer
 
 	// We must perform a diff on the ipcache.identityMetadata map in order to
 	// figure out which IPs are stale and should be removed, before we inject
@@ -133,7 +133,6 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 	k.ipcache.RemoveLabelsExcluded(
 		labels.LabelKubeAPIServer,
 		desiredIPs,
-		src,
 		rid,
 	)
 

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -141,7 +141,7 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 		k.ipcache.UpsertMetadata(ip, labels.LabelKubeAPIServer, src, rid)
 	}
 
-	k.ipcache.TriggerLabelInjection(src)
+	k.ipcache.TriggerLabelInjection()
 }
 
 // TODO(christarazi): Convert to subscriber model along with the corresponding

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -105,7 +106,7 @@ func (k *K8sWatcher) deleteK8sEndpointV1(ep *slim_corev1.Endpoints, swg *lock.St
 //
 // The actual implementation of this logic down to the datapath is handled
 // asynchronously.
-func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]struct{}) {
+func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]struct{}, rid ipcacheTypes.ResourceID) {
 	// Use CustomResource as the source similar to the way the CiliumNode
 	// (pkg/node/manager.Manager) handler does because the ipcache entry needs
 	// to be overwrite-able by this handler and the CiliumNode handler. If we
@@ -133,10 +134,11 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 		labels.LabelKubeAPIServer,
 		desiredIPs,
 		src,
+		rid,
 	)
 
 	for ip := range desiredIPs {
-		k.ipcache.UpsertMetadata(ip, labels.LabelKubeAPIServer)
+		k.ipcache.UpsertMetadata(ip, labels.LabelKubeAPIServer, src, rid)
 	}
 
 	k.ipcache.TriggerLabelInjection(src)
@@ -156,5 +158,6 @@ func (k *K8sWatcher) addKubeAPIServerServiceEPs(ep *slim_corev1.Endpoints) {
 		}
 	}
 
-	k.handleKubeAPIServerServiceEPChanges(desiredIPs)
+	rid := ipcacheTypes.NewResourceID("ep", ep.ObjectMeta.GetNamespace(), ep.ObjectMeta.GetName())
+	k.handleKubeAPIServerServiceEPChanges(desiredIPs, rid)
 }

--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_discover_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
@@ -188,7 +189,8 @@ func (k *K8sWatcher) addKubeAPIServerServiceEPSliceV1(eps *slim_discover_v1.Endp
 		}
 	}
 
-	k.handleKubeAPIServerServiceEPChanges(desiredIPs)
+	rid := ipcacheTypes.NewResourceID("endpointslices", eps.ObjectMeta.GetNamespace(), eps.ObjectMeta.GetName())
+	k.handleKubeAPIServerServiceEPChanges(desiredIPs, rid)
 }
 
 func (k *K8sWatcher) addKubeAPIServerServiceEPSliceV1Beta1(eps *slim_discover_v1beta1.EndpointSlice) {
@@ -205,7 +207,8 @@ func (k *K8sWatcher) addKubeAPIServerServiceEPSliceV1Beta1(eps *slim_discover_v1
 		}
 	}
 
-	k.handleKubeAPIServerServiceEPChanges(desiredIPs)
+	rid := ipcacheTypes.NewResourceID("endpointslices_v1beta1", eps.ObjectMeta.GetNamespace(), eps.ObjectMeta.GetName())
+	k.handleKubeAPIServerServiceEPChanges(desiredIPs, rid)
 }
 
 // initEndpointsOrSlices initializes either the "Endpoints" or "EndpointSlice"

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -52,7 +53,7 @@ type IPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error)
 	Delete(IP string, source source.Source) bool
 	TriggerLabelInjection(source source.Source)
-	UpsertMetadata(string, labels.Labels)
+	UpsertMetadata(prefix string, lbls labels.Labels, src source.Source, rid ipcacheTypes.ResourceID)
 }
 
 // Configuration is the set of configuration options the node manager depends
@@ -444,7 +445,8 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			Source: n.Source,
 		})
 
-		m.upsertIntoIDMD(ipAddrStr, remoteHostIdentity)
+		rid := ipcacheTypes.NewResourceID("node", "", n.Name)
+		m.upsertIntoIDMD(ipAddrStr, remoteHostIdentity, rid)
 
 		// Upsert() will return true if the ipcache entry is owned by
 		// the source of the node update that triggered this node
@@ -532,11 +534,11 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 // upsertIntoIDMD upserts the given CIDR into the ipcache.identityMetadata
 // (IDMD) map. The given node identity determines which labels are associated
 // with the CIDR.
-func (m *Manager) upsertIntoIDMD(prefix string, id identity.NumericIdentity) {
+func (m *Manager) upsertIntoIDMD(prefix string, id identity.NumericIdentity, rid ipcacheTypes.ResourceID) {
 	if id == identity.ReservedIdentityHost {
-		m.ipcache.UpsertMetadata(prefix, labels.LabelHost)
+		m.ipcache.UpsertMetadata(prefix, labels.LabelHost, source.Local, rid)
 	} else {
-		m.ipcache.UpsertMetadata(prefix, labels.LabelRemoteNode)
+		m.ipcache.UpsertMetadata(prefix, labels.LabelRemoteNode, source.CustomResource, rid)
 	}
 }
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -52,7 +52,7 @@ type nodeEntry struct {
 type IPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error)
 	Delete(IP string, source source.Source) bool
-	TriggerLabelInjection(source source.Source)
+	TriggerLabelInjection()
 	UpsertMetadata(prefix string, lbls labels.Labels, src source.Source, rid ipcacheTypes.ResourceID)
 }
 
@@ -528,7 +528,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		entry.mutex.Unlock()
 	}
 
-	m.ipcache.TriggerLabelInjection(n.Source)
+	m.ipcache.TriggerLabelInjection()
 }
 
 // upsertIntoIDMD upserts the given CIDR into the ipcache.identityMetadata

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -83,7 +83,7 @@ func (i *ipcacheMock) Delete(IP string, source source.Source) bool {
 	return false
 }
 
-func (i *ipcacheMock) TriggerLabelInjection(s source.Source) {
+func (i *ipcacheMock) TriggerLabelInjection() {
 }
 
 func (i *ipcacheMock) UpsertMetadata(string, labels.Labels, source.Source, ipcacheTypes.ResourceID) {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -85,7 +86,7 @@ func (i *ipcacheMock) Delete(IP string, source source.Source) bool {
 func (i *ipcacheMock) TriggerLabelInjection(s source.Source) {
 }
 
-func (i *ipcacheMock) UpsertMetadata(string, labels.Labels) {
+func (i *ipcacheMock) UpsertMetadata(string, labels.Labels, source.Source, ipcacheTypes.ResourceID) {
 }
 
 type signalNodeHandler struct {


### PR DESCRIPTION
WIP, also up for debate how far this refactor should go before merge.

Depends on:
* [ ] #19318 (not yet rebased against this but I think it makes sense to fix that first)

IPCache has historically been based around a concept of associating IP prefixes with a certain _Identity_, where each caller independently determines the exact identity that a IP Prefix should have. Each of these callers has a corresponding `source.Source` which decides the priority between these different sources of Identity. 

More recently however, features like #14724 have driven the need to combine multiple sources of information, such as associating both the `remote-node` labels (from k8s `CiliumNode` resources) and `kube-apiserver` labels (from k8s `Endpoints` / `EndpointSlices` resources). Having an exclusionary policy where only one source of information can be correct can have implications like causing conflicts between policies that match on information from each source. Up until now, we've resolved these conflicts somewhat manually by forcing the callers to handle the merging of this information. For most callers, they're independent enough that users would only encounter bugs in rare conditions of using two features together in an unexpected way. We have made some attempts in certain paths to resolve these conflicts where necessary, including the example above. However, over time this code becomes more and more :spaghetti: with each caller attempting to resolve conflicts with the other callers.

This PR reworks the metadata map inside the IPCache to handle multiple sources of information at once, keying them in the map first by IP prefix, then by a `{resourceType, resourceNamespace, resourceName}` tuple (`ResourceID`). When merging the information, a new `prefixInfo` structure provides convenient merging of the labels from all of the sources of information. In effect, this introduced one additional layer of indirection with a series of chained structures represented in the mermaid chart below:

```mermaid                                                                                                                                                                                                                                                                                                                                                                   
flowchart                                                                       
  subgraph labelsWithSource                                                     
  labels.Labels                                                                 
  source.Feature                                                                
  end                                                                           
  subgraph prefixInfo                                                           
  UA[ResourceID]-->LA[labelsWithSource]                                         
  UB[ResourceID]-->LB[labelsWithSource]                                         
  ...                                                                           
  end                                                                           
  subgraph identityMetadata                                                     
  IP_Prefix-->prefixInfo                                                        
  end                                                                           
```

Furthemore, rather than the previous implementation where _adds_ into the metadata map were asynchronous and _deletes_ were synchronous, this PR refactors the code to force both paths to be asynchronous. The first step which is synchronous is to update the desired state of the IPCache metadata, ie upserting the labels into the metadata map. This is called directly from various watchers like k8s resource watchers or the node manager. These callers then `TriggerLabelInjection()` to apply the changes out-of-band. This causes a goroutine to separately iterate through the changes that need to be made, then ensure that the control plane policy engine (in the `SelectorCache`) to be updated, followed by the dataplane policy maps, then finally followed by the dataplane ipcache. This ensures that policy transitions for newly allocated identities will occur in the correct order to prevent packet drops when different labels are associated with (or removed from) IP prefixes.

By making the deletes also asynchronous and combining the core logic, we are able to also delete a bunch of code, and more consistently handle the various cases of changing the sets of labels associated with prefixes.

See the individual commits for more details.

Combined design and implementation with @christarazi .

Related: https://github.com/cilium/cilium/issues/18301 