### PR TITLE
helm: don't generate the hubble-peer svc during preflight checks

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.listenAddress .Values.hubble.peerService.enabled }}
+{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.listenAddress .Values.hubble.peerService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Before this patch, the hubble-peer Service would be deployed during preflight check, which will in turn prevent Cilium to be installed as it would attempt to install it again.

Hit by https://github.com/cilium/cilium/pull/19750 ([CI build link](https://jenkins.cilium.io/job/Cilium-PR-K8s-1.22-kernel-4.19/1318/)):
```
00:45:35.626  	 Error: INSTALLATION FAILED: rendered manifests contain a resource that already exists. Unable to continue with install: Service "hubble-peer" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "cilium-preflight": current value is "cilium"
```