### PR TITLE
Restructure IPCache to handle metadata merging

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -5,6 +5,7 @@ package ipcache
 
 import (
 	"net"
+	"net/netip"
 
 	"github.com/sirupsen/logrus"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -422,6 +424,42 @@ func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
 	ipc.RLock()
 	ipc.DumpToListenerLocked(listener)
 	ipc.RUnlock()
+}
+
+// UpsertMetadata upserts a given IP and some corresponding information into
+// the ipcache metadata map. See IPMetadata for a list of types that are valid
+// to pass into this function. This will trigger asynchronous calculation of
+// any datapath updates necessary to implement the logic associated with the
+// specified metadata.
+func (ipc *IPCache) UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID, aux ...IPMetadata) {
+	ipc.metadata.Lock()
+	ipc.metadata.upsertLocked(prefix, src, resource, aux...)
+	ipc.metadata.Unlock()
+	ipc.metadata.enqueuePrefixUpdates(prefix)
+	ipc.TriggerLabelInjection()
+}
+
+func (ipc *IPCache) RemoveMetadata(prefix netip.Prefix, resource ipcacheTypes.ResourceID, aux ...IPMetadata) {
+	ipc.metadata.Lock()
+	ipc.metadata.remove(prefix, resource, aux...)
+	ipc.metadata.Unlock()
+	ipc.metadata.enqueuePrefixUpdates(prefix)
+	ipc.TriggerLabelInjection()
+}
+
+// UpsertLabels upserts a given IP and its corresponding labels associated
+// with it into the ipcache metadata map. The given labels are not modified nor
+// is its reference saved, as they're copied when inserting into the map.
+// This will trigger asynchronous calculation of any local identity changes
+// that must occur to associate the specified labels with the prefix, and push
+// any datapath updates necessary to implement the logic associated with the
+// metadata currently associated with the 'prefix'.
+func (ipc *IPCache) UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
+	ipc.UpsertMetadata(prefix, src, resource, lbls)
+}
+
+func (ipc *IPCache) RemoveLabels(cidr netip.Prefix, lbls labels.Labels, resource ipcacheTypes.ResourceID) {
+	ipc.RemoveMetadata(cidr, resource, lbls)
 }
 
 // DumpToListenerLocked dumps the entire contents of the IPCache by triggering

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -71,11 +71,41 @@ type metadata struct {
 	// applyChangesMU protects InjectLabels and RemoveLabelsExcluded from being
 	// run in parallel
 	applyChangesMU lock.Mutex
+
+	// queued* handle updates into the IPCache. Whenever a label is added
+	// or removed from a specific IP prefix, that prefix is added into
+	// 'queuedPrefixes'. Each time label injection is triggered, it will
+	// process the metadata changes for these prefixes and potentially
+	// generate updates into the ipcache, policy engine and datapath.
+	queuedChangesMU lock.Mutex
+	queuedPrefixes  map[string]struct{}
 }
 
 func newMetadata() *metadata {
 	return &metadata{
-		m: make(map[string]prefixInfo),
+		m:              make(map[string]prefixInfo),
+		queuedPrefixes: make(map[string]struct{}),
+	}
+}
+
+func (m *metadata) dequeuePrefixUpdates() (modifiedPrefixes []string) {
+	m.queuedChangesMU.Lock()
+	modifiedPrefixes = make([]string, 0, len(m.queuedPrefixes))
+	for p := range m.queuedPrefixes {
+		modifiedPrefixes = append(modifiedPrefixes, p)
+	}
+	m.queuedPrefixes = make(map[string]struct{})
+	m.queuedChangesMU.Unlock()
+
+	return
+}
+
+func (m *metadata) enqueuePrefixUpdates(prefixes ...string) {
+	m.queuedChangesMU.Lock()
+	defer m.queuedChangesMU.Unlock()
+
+	for _, prefix := range prefixes {
+		m.queuedPrefixes[prefix] = struct{}{}
 	}
 }
 

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -521,12 +521,13 @@ func (ipc *IPCache) removeLabels(prefix string, lbls labels.Labels, resource typ
 //	      | (2)    +------+--------+   (2) |
 //	      +------->|Label Injector |<------+
 //	     Trigger   +-------+-------+ Trigger
-//	                   (4) |W
-//	                       |
-//	                       v
-//	                     +---+
-//	                     |IPC|
-//	                     +---+
+//		      (4) |W    (5) |W
+//		          |         |
+//		          v         v
+//		     +--------+   +---+
+//		     |Policy &|   |IPC|
+//		     |datapath|   +---+
+//		     +--------+
 //	legend:
 //	* W means write
 //	* R means read

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -20,7 +20,6 @@ import (
 	cidrlabels "github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -169,7 +168,7 @@ func (m *metadata) getLocked(prefix string) prefixInfo {
 // Returns the CIDRs that were not yet processed, for example due to an
 // unexpected error while processing the identity updates for those CIDRs
 // The caller should attempt to retry injecting labels for those CIDRs.
-func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []string, err error) {
+func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedCIDRs []string) (remainingCIDRs []string, err error) {
 	if ipc.IdentityAllocator == nil {
 		return modifiedCIDRs, ErrLocalIdentityAllocatorUninitialized
 	}
@@ -208,7 +207,7 @@ func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []strin
 			lbls := prefixInfo.ToLabels()
 
 			// Insert to propagate the updated set of labels after removal.
-			newID, _, err = ipc.injectLabels(prefix, lbls)
+			newID, _, err = ipc.injectLabels(ctx, prefix, lbls)
 			if err != nil {
 				// NOTE: This may fail during a 2nd or later
 				// iteration of the loop. To handle this, break
@@ -276,7 +275,7 @@ func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []strin
 
 	// Recalculate policy first before upserting into the ipcache.
 	if len(idsToAdd) > 0 {
-		ipc.UpdatePolicyMaps(context.TODO(), idsToAdd, nil)
+		ipc.UpdatePolicyMaps(ctx, idsToAdd, idsToDelete)
 	}
 
 	ipc.mutex.Lock()
@@ -300,11 +299,11 @@ func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []strin
 	}
 
 	for prefix, id := range previouslyAllocatedIdentities {
-		realID := ipc.IdentityAllocator.LookupIdentityByID(context.TODO(), id.ID)
+		realID := ipc.IdentityAllocator.LookupIdentityByID(ctx, id.ID)
 		if realID == nil {
 			continue
 		}
-		released, err := ipc.IdentityAllocator.Release(context.TODO(), realID, false)
+		released, err := ipc.IdentityAllocator.Release(ctx, realID, false)
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				logfields.Identity:       realID,
@@ -329,7 +328,7 @@ func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []strin
 		}
 	}
 	if len(idsToDelete) > 0 {
-		ipc.UpdatePolicyMaps(context.TODO(), nil, idsToDelete)
+		ipc.UpdatePolicyMaps(ctx, nil, idsToDelete)
 	}
 	for ip, id := range entriesToDelete {
 		ipc.deleteLocked(ip, id.Source)
@@ -372,10 +371,7 @@ func (ipc *IPCache) UpdatePolicyMaps(ctx context.Context, addedIdentities, delet
 // policy is applied will need to be converted (released and re-allocated) to
 // account for the new kube-apiserver label that will be attached to them. This
 // is a known issue, see GH-17962 below.
-func (ipc *IPCache) injectLabels(prefix string, lbls labels.Labels) (*identity.Identity, bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), option.Config.IPAllocationTimeout)
-	defer cancel()
-
+func (ipc *IPCache) injectLabels(ctx context.Context, prefix string, lbls labels.Labels) (*identity.Identity, bool, error) {
 	if lbls.Has(labels.LabelHost[labels.IDNameHost]) {
 		// Associate any new labels with the host identity.
 		//
@@ -410,7 +406,7 @@ func (ipc *IPCache) injectLabels(prefix string, lbls labels.Labels) (*identity.I
 		//   need to remove old entries from ipcache because the caller will
 		//   overwrite the ipcache entry anyway.
 
-		return ipc.injectLabelsForCIDR(prefix, lbls)
+		return ipc.injectLabelsForCIDR(ctx, prefix, lbls)
 	}
 
 	return ipc.IdentityAllocator.AllocateIdentity(ctx, lbls, false, identity.InvalidIdentity)
@@ -418,7 +414,7 @@ func (ipc *IPCache) injectLabels(prefix string, lbls labels.Labels) (*identity.I
 
 // injectLabelsForCIDR will allocate a CIDR identity for the given prefix. The
 // release of the identity must be managed by the caller.
-func (ipc *IPCache) injectLabelsForCIDR(p string, lbls labels.Labels) (*identity.Identity, bool, error) {
+func (ipc *IPCache) injectLabelsForCIDR(ctx context.Context, p string, lbls labels.Labels) (*identity.Identity, bool, error) {
 	var prefix string
 
 	ip := net.ParseIP(p)
@@ -445,7 +441,7 @@ func (ipc *IPCache) injectLabelsForCIDR(p string, lbls labels.Labels) (*identity
 		"Injecting CIDR labels for prefix",
 	)
 
-	return ipc.allocate(cidr, allLbls, identity.InvalidIdentity)
+	return ipc.allocate(ctx, cidr, allLbls, identity.InvalidIdentity)
 }
 
 // RemoveLabelsExcluded removes the given labels from all IPs inside the IDMD
@@ -548,7 +544,7 @@ func (ipc *IPCache) TriggerLabelInjection() {
 				var err error
 
 				idsToModify := ipc.metadata.dequeuePrefixUpdates()
-				idsToModify, err = ipc.InjectLabels(idsToModify)
+				idsToModify, err = ipc.InjectLabels(ctx, idsToModify)
 				ipc.metadata.enqueuePrefixUpdates(idsToModify...)
 
 				return err

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -131,7 +131,7 @@ func (m *metadata) get(prefix string) prefixInfo {
 // prefix was previously associated with an identity, it will get deallocated,
 // so a balance is kept, ensuring a one-to-one mapping between prefix and
 // identity.
-func (ipc *IPCache) InjectLabels(src source.Source) error {
+func (ipc *IPCache) InjectLabels() error {
 	if ipc.IdentityAllocator == nil {
 		return ErrLocalIdentityAllocatorUninitialized
 	}
@@ -174,7 +174,7 @@ func (ipc *IPCache) InjectLabels(src source.Source) error {
 		// cluster.
 		// Also, any new identity should be upserted, regardless.
 		if hasKubeAPIServerLabel || isNew {
-			tmpSrc := src
+			tmpSrc := info.Source()
 			if hasKubeAPIServerLabel {
 				// Overwrite the source because any IP associated with the
 				// kube-apiserver takes the strongest precedence. This is
@@ -592,7 +592,7 @@ func sourceByLabels(d source.Source, lbls labels.Labels) source.Source {
 //	legend:
 //	* W means write
 //	* R means read
-func (ipc *IPCache) TriggerLabelInjection(src source.Source) {
+func (ipc *IPCache) TriggerLabelInjection() {
 	// GH-17829: Would also be nice to have an end-to-end test to validate
 	//           on upgrade that there are no connectivity drops when this
 	//           channel is preventing transient BPF entries.
@@ -603,7 +603,7 @@ func (ipc *IPCache) TriggerLabelInjection(src source.Source) {
 		"ipcache-inject-labels",
 		controller.ControllerParams{
 			DoFunc: func(context.Context) error {
-				if err := ipc.InjectLabels(src); err != nil {
+				if err := ipc.InjectLabels(); err != nil {
 					return fmt.Errorf("failed to inject labels into ipcache: %w", err)
 				}
 				return nil

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -68,10 +68,6 @@ type metadata struct {
 	// m is the actual map containing the mappings.
 	m map[string]prefixInfo
 
-	// applyChangesMU protects InjectLabels and RemoveLabelsExcluded from being
-	// run in parallel
-	applyChangesMU lock.Mutex
-
 	// queued* handle updates into the IPCache. Whenever a label is added
 	// or removed from a specific IP prefix, that prefix is added into
 	// 'queuedPrefixes'. Each time label injection is triggered, it will
@@ -191,24 +187,21 @@ func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []strin
 		idsToAdd    = make(map[identity.NumericIdentity]labels.LabelArray)
 		idsToDelete = make(map[identity.NumericIdentity]labels.LabelArray)
 		// entriesToReplace stores the identity to replace in the ipcache.
-		entriesToReplace = make(map[string]Identity)
+		entriesToReplace   = make(map[string]Identity)
+		entriesToDelete    = make(map[string]Identity)
+		forceIPCacheUpdate = make(map[string]bool) // prefix => force
 	)
 
-	ipc.metadata.applyChangesMU.Lock()
-	defer ipc.metadata.applyChangesMU.Unlock()
-
-	ipc.metadata.Lock()
+	ipc.metadata.RLock()
 
 	for i, prefix := range modifiedCIDRs {
 		id, entryExists := ipc.LookupByIP(prefix)
 		prefixInfo := ipc.metadata.getLocked(prefix)
 		if prefixInfo == nil {
-			log.WithFields(logrus.Fields{
-				logfields.IPAddr:   prefix,
-				logfields.Identity: id,
-			}).Warning(
-				"IPCache metadata unexpectedly removed before handling metadata update",
-			)
+			if !entryExists {
+				// Already deleted, no new metadata to associate
+				continue
+			} // else continue below to remove the old entry
 		} else {
 			var newID *identity.Identity
 
@@ -254,6 +247,15 @@ func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []strin
 				ID:     newID.ID,
 				Source: prefixInfo.Source(),
 			}
+			// IPCache.Upsert() and friends currently require a
+			// Source to be provided during upsert. If the old
+			// Source was higher precedence due to labels that
+			// have now been removed, then we need to explicitly
+			// work around that to remove the old higher-priority
+			// identity and replace it with this new identity.
+			if entryExists && prefixInfo.Source() != id.Source {
+				forceIPCacheUpdate[prefix] = true
+			}
 		}
 	releaseIdentity:
 		if entryExists {
@@ -270,7 +272,7 @@ func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []strin
 		}
 	}
 	// Don't hold lock while calling UpdateIdentities, as it will otherwise run into a deadlock
-	ipc.metadata.Unlock()
+	ipc.metadata.RUnlock()
 
 	// Recalculate policy first before upserting into the ipcache.
 	if len(idsToAdd) > 0 {
@@ -288,7 +290,7 @@ func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []strin
 			key,
 			meta,
 			id,
-			true,
+			forceIPCacheUpdate[ip],
 		); err2 != nil {
 			log.WithError(err2).WithFields(logrus.Fields{
 				logfields.IPAddr:   ip,
@@ -297,7 +299,7 @@ func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []strin
 		}
 	}
 
-	for _, id := range previouslyAllocatedIdentities {
+	for prefix, id := range previouslyAllocatedIdentities {
 		realID := ipc.IdentityAllocator.LookupIdentityByID(context.TODO(), id.ID)
 		if realID == nil {
 			continue
@@ -321,10 +323,16 @@ func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []strin
 		// logic for handling the removal of these identities.
 		if released {
 			idsToDelete[id.ID] = nil // SelectorCache removal
+			if _, ok := entriesToReplace[prefix]; !ok {
+				entriesToDelete[prefix] = id // IPCache removal
+			}
 		}
 	}
 	if len(idsToDelete) > 0 {
 		ipc.UpdatePolicyMaps(context.TODO(), nil, idsToDelete)
+	}
+	for ip, id := range entriesToDelete {
+		ipc.deleteLocked(ip, id.Source)
 	}
 
 	return remainingCIDRs, err
@@ -441,30 +449,24 @@ func (ipc *IPCache) injectLabelsForCIDR(p string, lbls labels.Labels) (*identity
 }
 
 // RemoveLabelsExcluded removes the given labels from all IPs inside the IDMD
-// except for the IPs / prefixes inside the given excluded set. This may cause
-// updates to the ipcache, as well as to the identity and policy logic via
-// 'updater' and 'triggerer'.
+// except for the IPs / prefixes inside the given excluded set.
+//
+// The caller must subsequently call IPCache.TriggerLabelInjection() to push
+// these changes down into the policy engine and ipcache datapath maps.
 func (ipc *IPCache) RemoveLabelsExcluded(
 	lbls labels.Labels,
 	toExclude map[string]struct{},
-	src source.Source,
 	rid types.ResourceID,
 ) {
-	ipc.metadata.applyChangesMU.Lock()
-	defer ipc.metadata.applyChangesMU.Unlock()
-
 	ipc.metadata.Lock()
 	defer ipc.metadata.Unlock()
 
 	oldSet := ipc.metadata.filterByLabels(lbls)
-	toRemove := make(map[string]labels.Labels)
 	for _, ip := range oldSet {
 		if _, ok := toExclude[ip]; !ok {
-			toRemove[ip] = lbls
+			ipc.removeLabels(ip, lbls, rid)
 		}
 	}
-
-	ipc.removeLabelsFromIPs(toRemove, src, rid)
 }
 
 // filterByLabels returns all the prefixes inside the ipcache metadata map
@@ -484,192 +486,22 @@ func (m *metadata) filterByLabels(filter labels.Labels) []string {
 	return matching
 }
 
-// removeLabelsFromIPs removes all given prefixes at once. This function will
-// trigger policy update and recalculation if necessary on behalf of the
-// caller.
+// removeLabels asynchronously removes the labels association for a prefix.
 //
-// A prefix will only be removed from the IDMD if the set of labels becomes
-// empty.
-//
-// Assumes that the ipcache metadata lock is taken!
-func (ipc *IPCache) removeLabelsFromIPs(
-	m map[string]labels.Labels,
-	src source.Source,
-	rid types.ResourceID,
-) {
-	var (
-		idsToAdd    = make(map[identity.NumericIdentity]labels.LabelArray)
-		idsToDelete = make(map[identity.NumericIdentity]labels.LabelArray)
-		// toReplace stores the identity to replace in the ipcache.
-		toReplace = make(map[string]Identity)
-	)
-
-	ipc.Lock()
-	defer ipc.Unlock()
-
-	for prefix, lbls := range m {
-		id, exists := ipc.LookupByIPRLocked(prefix)
-		if !exists {
-			continue
-		}
-
-		idsToDelete[id.ID] = nil // labels for deletion don't matter to UpdateIdentities()
-
-		// Insert to propagate the updated set of labels after removal.
-		l := ipc.removeLabels(prefix, lbls, src, rid)
-		if len(l) > 0 {
-			// If for example kube-apiserver label is removed from the local
-			// host identity (when the kube-apiserver is running within the
-			// cluster and it is no longer running on the current local host),
-			// then removeLabels() will return a non-empty set representing the
-			// new full set of labels to associate with the node (in this
-			// example, just the local host label). In order to propagate the
-			// new identity, we must emit a delete event for the old identity
-			// and then an add event for the new identity.
-
-			// If host identity has changed, update its labels.
-			if id.ID == identity.ReservedIdentityHost {
-				identity.AddReservedIdentityWithLabels(id.ID, l)
-			}
-
-			newID, _, err := ipc.IdentityAllocator.AllocateIdentity(context.TODO(), l, false, identity.InvalidIdentity)
-			if err != nil {
-				log.WithError(err).WithFields(logrus.Fields{
-					logfields.IPAddr:         prefix,
-					logfields.Identity:       id,
-					logfields.IdentityLabels: l,    // new labels
-					logfields.Labels:         lbls, // removed labels
-				}).Error(
-					"Failed to allocate new identity after dissociating labels from existing identity. Traffic may be disrupted.",
-				)
-				continue
-			}
-			idsToAdd[newID.ID] = l.LabelArray()
-			toReplace[prefix] = Identity{
-				ID:     newID.ID,
-				Source: sourceByLabels(src, l),
-			}
-		}
-	}
-	if len(idsToDelete) > 0 {
-		ipc.UpdatePolicyMaps(context.TODO(), idsToAdd, idsToDelete)
-	}
-	for ip, id := range toReplace {
-		hIP, key := ipc.getHostIPCache(ip)
-		meta := ipc.getK8sMetadata(ip)
-		if _, err := ipc.upsertLocked(
-			ip,
-			hIP,
-			key,
-			meta,
-			id,
-			true, /* force upsert */
-		); err != nil {
-			log.WithError(err).WithFields(logrus.Fields{
-				logfields.IPAddr:   ip,
-				logfields.Identity: id,
-			}).Error("Failed to replace ipcache entry with new identity after label removal. Traffic may be disrupted.")
-		}
-	}
-}
-
-// removeLabels removes the given labels association with the given prefix. The
-// leftover labels are returned, if any. If there are leftover labels, the
-// caller must allocate a new identity and do the following *in order* to avoid
-// drops:
-//  1. policy recalculation must be implemented into the datapath and
-//  2. new identity must have a new entry upserted into the IPCache
-//
-// Note: GH-17962, triggering policy recalculation doesn't actually *implement*
-// the changes into datapath (because it's an async call), this is a known
-// issue. There's a very small window for drops when two policies select the
-// same traffic and the identity changes. For example, this is possible if an
-// IP is associated with the kube-apiserver and referenced inside a ToCIDR
-// policy, and then the IP is no longer associated with the kube-apiserver.
-//
-// Identities are deallocated and their subequent entry in the IPCache is
-// removed if the prefix is no longer associated with any labels.
-//
-// This function assumes that the ipcache metadata and the IPIdentityCache
-// locks are taken!
-func (ipc *IPCache) removeLabels(prefix string, lbls labels.Labels, src source.Source, resource types.ResourceID) labels.Labels {
+// This function assumes that the ipcache metadata lock is held for writing.
+func (ipc *IPCache) removeLabels(prefix string, lbls labels.Labels, resource types.ResourceID) {
 	info, ok := ipc.metadata.m[prefix]
 	if !ok {
-		return nil
+		return
 	}
 	info[resource].unmerge(lbls)
 	if !info[resource].isValid() {
 		delete(info, resource)
 	}
-	allLbls := info.ToLabels() // to return at the end of the function
-	if !info.isValid() {       // Labels empty, delete
-		// No labels left. Example case: when the kube-apiserver is running
-		// outside of the cluster, meaning that the IDMD only ever had the
-		// kube-apiserver label (CIDR labels are not added) and it's now being
-		// removed.
+	if !info.isValid() { // Labels empty, delete
 		delete(ipc.metadata.m, prefix)
 	}
-
-	id, exists := ipc.LookupByIPRLocked(prefix)
-	if !exists {
-		log.WithFields(logrus.Fields{
-			logfields.CIDR:   prefix,
-			logfields.Labels: lbls,
-		}).Warn(
-			"Identity for prefix was unexpectedly not found in ipcache, unable " +
-				"to remove labels from prefix. If a network policy is applied, check " +
-				"for any drops. It's possible that insertion or removal from " +
-				"the ipcache failed.",
-		)
-		return nil
-	}
-
-	realID := ipc.IdentityAllocator.LookupIdentityByID(context.TODO(), id.ID)
-	if realID == nil {
-		log.WithFields(logrus.Fields{
-			logfields.CIDR:     prefix,
-			logfields.Labels:   lbls,
-			logfields.Identity: id,
-		}).Warn(
-			"Identity unexpectedly not found within the identity allocator, " +
-				"unable to remove labels from prefix. It's possible that insertion " +
-				"or removal from the ipcache failed.",
-		)
-		return nil
-	}
-	released, err := ipc.IdentityAllocator.Release(context.TODO(), realID, false)
-	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
-			logfields.IPAddr:         prefix,
-			logfields.Labels:         lbls,
-			logfields.Identity:       realID,
-			logfields.IdentityLabels: realID.Labels,
-		}).Error(
-			"Failed to release assigned identity to IP while removing label association, this might be a leak.",
-		)
-		return nil
-	}
-	if released {
-		ipc.deleteLocked(prefix, sourceByLabels(src, lbls))
-		return nil
-	}
-
-	// Generate new identity with the label removed. This should be the case
-	// where the existing identity had >1 refcount, meaning that something was
-	// referring to it.
-	//
-	// If kube-apiserver is inside the cluster, this path is always hit
-	// (because even if we remove the kube-apiserver from that node, we
-	// need to inject the identity corresponding to "host" or "remote-node"
-	// (without apiserver label)
-	return allLbls
-}
-
-func sourceByLabels(d source.Source, lbls labels.Labels) source.Source {
-	if lbls.Has(labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer]) {
-		return source.KubeAPIServer
-	}
-	return d
+	ipc.metadata.enqueuePrefixUpdates(prefix)
 }
 
 // TriggerLabelInjection triggers the label injection controller to iterate

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	cidrlabels "github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/lock"
@@ -30,7 +31,7 @@ var (
 )
 
 // metadata contains the ipcache metadata. Mainily it holds a map which maps IP
-// prefixes (x.x.x.x/32) to their labels.
+// prefixes (x.x.x.x/32) to a set of information (prefixInfo).
 //
 // When allocating an identity to associate with each prefix, the
 // identity allocation routines will merge this set of labels into the
@@ -38,6 +39,24 @@ var (
 // thereby associating these labels with each prefix that is 'covered'
 // by this prefix. Subsequently these labels may be matched by network
 // policy and propagated in monitor output.
+//
+// ```mermaid
+// flowchart
+//
+//	subgraph resourceInfo
+//	labels.Labels
+//	source.Source
+//	end
+//	subgraph prefixInfo
+//	UA[ResourceID]-->LA[resourceInfo]
+//	UB[ResourceID]-->LB[resourceInfo]
+//	...
+//	end
+//	subgraph identityMetadata
+//	IP_Prefix-->prefixInfo
+//	end
+//
+// ```
 type metadata struct {
 	// Protects the m map.
 	//
@@ -47,7 +66,7 @@ type metadata struct {
 	lock.RWMutex
 
 	// m is the actual map containing the mappings.
-	m map[string]labels.Labels
+	m map[string]prefixInfo
 
 	// applyChangesMU protects InjectLabels and RemoveLabelsExcluded from being
 	// run in parallel
@@ -56,37 +75,45 @@ type metadata struct {
 
 func newMetadata() *metadata {
 	return &metadata{
-		m: make(map[string]labels.Labels),
+		m: make(map[string]prefixInfo),
 	}
 }
 
 // UpsertMetadata upserts a given IP and its corresponding labels associated
 // with it into the ipcache metadata map. The given labels are not modified nor
 // is its reference saved, as they're copied when inserting into the map.
-func (ipc *IPCache) UpsertMetadata(prefix string, lbls labels.Labels) {
-	ipc.metadata.upsert(prefix, lbls)
+func (ipc *IPCache) UpsertMetadata(prefix string, lbls labels.Labels, src source.Source, rid types.ResourceID) {
+	ipc.metadata.Lock()
+	ipc.metadata.upsertLocked(prefix, src, rid, lbls)
+	ipc.metadata.Unlock()
 }
 
-func (m *metadata) upsert(prefix string, lbls labels.Labels) {
-	l := labels.NewLabelsFromModel(nil)
-	l.MergeLabels(lbls)
-
-	m.Lock()
-	if cur, ok := m.m[prefix]; ok {
-		l.MergeLabels(cur)
+func (m *metadata) upsertLocked(prefix string, src source.Source, resource types.ResourceID, info ...IPMetadata) {
+	if _, ok := m.m[prefix]; !ok {
+		m.m[prefix] = make(prefixInfo)
 	}
-	m.m[prefix] = l
-	m.Unlock()
+	if _, ok := m.m[prefix][resource]; !ok {
+		m.m[prefix][resource] = &resourceInfo{
+			source: src,
+		}
+	}
+
+	for _, i := range info {
+		m.m[prefix][resource].merge(i, src)
+	}
 }
 
 // GetIDMetadataByIP returns the associated labels with an IP. The caller must
 // not modifying the returned object as it's a live reference to the underlying
 // map.
 func (ipc *IPCache) GetIDMetadataByIP(prefix string) labels.Labels {
-	return ipc.metadata.get(prefix)
+	if info := ipc.metadata.get(prefix); info != nil {
+		return info.ToLabels()
+	}
+	return nil
 }
 
-func (m *metadata) get(prefix string) labels.Labels {
+func (m *metadata) get(prefix string) prefixInfo {
 	m.RLock()
 	defer m.RUnlock()
 	return m.m[prefix]
@@ -128,7 +155,8 @@ func (ipc *IPCache) InjectLabels(src source.Source) error {
 
 	ipc.metadata.Lock()
 
-	for prefix, lbls := range ipc.metadata.m {
+	for prefix, info := range ipc.metadata.m {
+		lbls := info.ToLabels()
 		id, isNew, err := ipc.injectLabels(prefix, lbls)
 		if err != nil {
 			ipc.metadata.Unlock()
@@ -310,6 +338,7 @@ func (ipc *IPCache) RemoveLabelsExcluded(
 	lbls labels.Labels,
 	toExclude map[string]struct{},
 	src source.Source,
+	rid types.ResourceID,
 ) {
 	ipc.metadata.applyChangesMU.Lock()
 	defer ipc.metadata.applyChangesMU.Unlock()
@@ -325,7 +354,7 @@ func (ipc *IPCache) RemoveLabelsExcluded(
 		}
 	}
 
-	ipc.removeLabelsFromIPs(toRemove, src)
+	ipc.removeLabelsFromIPs(toRemove, src, rid)
 }
 
 // filterByLabels returns all the prefixes inside the ipcache metadata map
@@ -336,7 +365,8 @@ func (ipc *IPCache) RemoveLabelsExcluded(
 func (m *metadata) filterByLabels(filter labels.Labels) []string {
 	var matching []string
 	sortedFilter := filter.SortedList()
-	for prefix, lbls := range m.m {
+	for prefix, info := range m.m {
+		lbls := info.ToLabels()
 		if bytes.Contains(lbls.SortedList(), sortedFilter) {
 			matching = append(matching, prefix)
 		}
@@ -355,6 +385,7 @@ func (m *metadata) filterByLabels(filter labels.Labels) []string {
 func (ipc *IPCache) removeLabelsFromIPs(
 	m map[string]labels.Labels,
 	src source.Source,
+	rid types.ResourceID,
 ) {
 	var (
 		idsToAdd    = make(map[identity.NumericIdentity]labels.LabelArray)
@@ -375,7 +406,7 @@ func (ipc *IPCache) removeLabelsFromIPs(
 		idsToDelete[id.ID] = nil // labels for deletion don't matter to UpdateIdentities()
 
 		// Insert to propagate the updated set of labels after removal.
-		l := ipc.removeLabels(prefix, lbls, src)
+		l := ipc.removeLabels(prefix, lbls, src, rid)
 		if len(l) > 0 {
 			// If for example kube-apiserver label is removed from the local
 			// host identity (when the kube-apiserver is running within the
@@ -451,26 +482,22 @@ func (ipc *IPCache) removeLabelsFromIPs(
 //
 // This function assumes that the ipcache metadata and the IPIdentityCache
 // locks are taken!
-func (ipc *IPCache) removeLabels(prefix string, lbls labels.Labels, src source.Source) labels.Labels {
-	l, ok := ipc.metadata.m[prefix]
+func (ipc *IPCache) removeLabels(prefix string, lbls labels.Labels, src source.Source, resource types.ResourceID) labels.Labels {
+	info, ok := ipc.metadata.m[prefix]
 	if !ok {
 		return nil
 	}
-
-	l = l.Remove(lbls)
-	if len(l) == 0 { // Labels empty, delete
+	info[resource].unmerge(lbls)
+	if !info[resource].isValid() {
+		delete(info, resource)
+	}
+	allLbls := info.ToLabels() // to return at the end of the function
+	if !info.isValid() {       // Labels empty, delete
 		// No labels left. Example case: when the kube-apiserver is running
 		// outside of the cluster, meaning that the IDMD only ever had the
 		// kube-apiserver label (CIDR labels are not added) and it's now being
 		// removed.
 		delete(ipc.metadata.m, prefix)
-	} else {
-		// This case is only hit if the prefix for the kube-apiserver is
-		// running within the cluster. Therefore, the IDMD can only ever has
-		// the following labels:
-		//   * kube-apiserver + remote-node
-		//   * kube-apiserver + host
-		ipc.metadata.m[prefix] = l
 	}
 
 	id, exists := ipc.LookupByIPRLocked(prefix)
@@ -520,10 +547,11 @@ func (ipc *IPCache) removeLabels(prefix string, lbls labels.Labels, src source.S
 	// Generate new identity with the label removed. This should be the case
 	// where the existing identity had >1 refcount, meaning that something was
 	// referring to it.
-	allLbls := labels.NewLabelsFromModel(nil)
-	allLbls.MergeLabels(realID.Labels)
-	allLbls = allLbls.Remove(lbls)
-
+	//
+	// If kube-apiserver is inside the cluster, this path is always hit
+	// (because even if we remove the kube-apiserver from that node, we
+	// need to inject the identity corresponding to "host" or "remote-node"
+	// (without apiserver label)
 	return allLbls
 }
 

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -112,10 +112,14 @@ func (m *metadata) enqueuePrefixUpdates(prefixes ...string) {
 // UpsertMetadata upserts a given IP and its corresponding labels associated
 // with it into the ipcache metadata map. The given labels are not modified nor
 // is its reference saved, as they're copied when inserting into the map.
+//
+// The caller must subsequently call ipc.TriggerLabelInjection() to implement
+// these metadata updates into the datapath.
 func (ipc *IPCache) UpsertMetadata(prefix string, lbls labels.Labels, src source.Source, rid types.ResourceID) {
 	ipc.metadata.Lock()
 	ipc.metadata.upsertLocked(prefix, src, rid, lbls)
 	ipc.metadata.Unlock()
+	ipc.metadata.enqueuePrefixUpdates(prefix)
 }
 
 func (m *metadata) upsertLocked(prefix string, src source.Source, resource types.ResourceID, info ...IPMetadata) {
@@ -146,6 +150,10 @@ func (ipc *IPCache) GetIDMetadataByIP(prefix string) labels.Labels {
 func (m *metadata) get(prefix string) prefixInfo {
 	m.RLock()
 	defer m.RUnlock()
+	return m.getLocked(prefix)
+}
+
+func (m *metadata) getLocked(prefix string) prefixInfo {
 	return m.m[prefix]
 }
 
@@ -161,23 +169,29 @@ func (m *metadata) get(prefix string) prefixInfo {
 // prefix was previously associated with an identity, it will get deallocated,
 // so a balance is kept, ensuring a one-to-one mapping between prefix and
 // identity.
-func (ipc *IPCache) InjectLabels() error {
+//
+// Returns the CIDRs that were not yet processed, for example due to an
+// unexpected error while processing the identity updates for those CIDRs
+// The caller should attempt to retry injecting labels for those CIDRs.
+func (ipc *IPCache) InjectLabels(modifiedCIDRs []string) (remainingCIDRs []string, err error) {
 	if ipc.IdentityAllocator == nil {
-		return ErrLocalIdentityAllocatorUninitialized
+		return modifiedCIDRs, ErrLocalIdentityAllocatorUninitialized
 	}
 
 	if ipc.k8sSyncedChecker == nil || !ipc.k8sSyncedChecker.K8sCacheIsSynced() {
-		return errors.New("k8s cache not fully synced")
+		return modifiedCIDRs, errors.New("k8s cache not fully synced")
 	}
 
 	var (
-		// trigger is true when we need to trigger policy recalculations.
-		trigger bool
-		// toUpsert stores IPKeyPairs to upsert into the ipcache.
-		toUpsert = make(map[string]Identity)
-		// idsToPropagate stores the identities that must be updated via the
+		// previouslyAllocatedIdentities maps IP Prefix -> Identity for
+		// old identities where the prefix will now map to a new identity
+		previouslyAllocatedIdentities = make(map[string]Identity)
+		// idsToAdd stores the identities that must be updated via the
 		// selector cache.
-		idsToPropagate = make(map[identity.NumericIdentity]labels.LabelArray)
+		idsToAdd    = make(map[identity.NumericIdentity]labels.LabelArray)
+		idsToDelete = make(map[identity.NumericIdentity]labels.LabelArray)
+		// entriesToReplace stores the identity to replace in the ipcache.
+		entriesToReplace = make(map[string]Identity)
 	)
 
 	ipc.metadata.applyChangesMU.Lock()
@@ -185,62 +199,73 @@ func (ipc *IPCache) InjectLabels() error {
 
 	ipc.metadata.Lock()
 
-	for prefix, info := range ipc.metadata.m {
-		lbls := info.ToLabels()
-		id, isNew, err := ipc.injectLabels(prefix, lbls)
-		if err != nil {
-			ipc.metadata.Unlock()
-			return fmt.Errorf("failed to allocate new identity for IP %v: %w", prefix, err)
-		}
-
-		hasKubeAPIServerLabel := lbls.Has(
-			labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer],
-		)
-		// Identities with the kube-apiserver label should always be upserted
-		// if there was a change in their labels. This is especially important
-		// for IDs such as kube-apiserver or host (which can have the
-		// kube-apiserver label when the kube-apiserver is deployed within the
-		// cluster), or CIDR IDs for kube-apiservers deployed outside of the
-		// cluster.
-		// Also, any new identity should be upserted, regardless.
-		if hasKubeAPIServerLabel || isNew {
-			tmpSrc := info.Source()
-			if hasKubeAPIServerLabel {
-				// Overwrite the source because any IP associated with the
-				// kube-apiserver takes the strongest precedence. This is
-				// because we need to overwrite Local if only the local node IP
-				// has been upserted into the ipcache first.
-				//
-				// Also, trigger policy recalculations to update kube-apiserver
-				// identity.
-				newLbls := id.Labels
-				tmpSrc = source.KubeAPIServer
-				trigger = true
-				idsToPropagate[id.ID] = newLbls.LabelArray()
-			}
-
-			toUpsert[prefix] = Identity{
-				ID:     id.ID,
-				Source: tmpSrc,
-			}
+	for i, prefix := range modifiedCIDRs {
+		id, entryExists := ipc.LookupByIP(prefix)
+		prefixInfo := ipc.metadata.getLocked(prefix)
+		if prefixInfo == nil {
+			log.WithFields(logrus.Fields{
+				logfields.IPAddr:   prefix,
+				logfields.Identity: id,
+			}).Warning(
+				"IPCache metadata unexpectedly removed before handling metadata update",
+			)
 		} else {
-			// Unlikely, but to balance the allocation / release
-			// we must either add the identity to `toUpsert`, or
-			// immediately release it again. Otherwise it will leak.
-			if _, err := ipc.IdentityAllocator.Release(context.TODO(), id, false); err != nil {
+			var newID *identity.Identity
+
+			lbls := prefixInfo.ToLabels()
+
+			// Insert to propagate the updated set of labels after removal.
+			newID, _, err = ipc.injectLabels(prefix, lbls)
+			if err != nil {
+				// NOTE: This may fail during a 2nd or later
+				// iteration of the loop. To handle this, break
+				// the loop here and continue executing the set
+				// of changes for the prefixes that were
+				// already processed.
+				//
+				// Old identities corresponding to earlier
+				// prefixes may be released as part of this,
+				// so hopefully this forward progress will
+				// unblock subsequent calls into this function.
 				log.WithError(err).WithFields(logrus.Fields{
-					logfields.IPAddr: prefix,
-					logfields.Labels: lbls,
-				}).Error(
-					"Failed to release assigned identity during label injection, this might be a leak.",
-				)
-			} else {
-				log.WithFields(logrus.Fields{
 					logfields.IPAddr:   prefix,
 					logfields.Identity: id,
-				}).Debug(
-					"Released identity to balance reference counts",
+					logfields.Labels:   lbls, // new labels
+				}).Warning(
+					"Failed to allocate new identity while handling change in labels associated with a prefix.",
 				)
+				remainingCIDRs = modifiedCIDRs[i:]
+				err = fmt.Errorf("failed to allocate new identity during label injection: %w", err)
+				break
+			}
+
+			// It's plausible to pull the same information twice
+			// from different sources, for instance in etcd mode
+			// where node information is propagated both via the
+			// kvstore and via the k8s control plane. If the new
+			// security identity is the same as the one currently
+			// being used, then no need to update it.
+			if id.ID == newID.ID {
+				goto releaseIdentity
+			}
+
+			idsToAdd[newID.ID] = lbls.LabelArray()
+			entriesToReplace[prefix] = Identity{
+				ID:     newID.ID,
+				Source: prefixInfo.Source(),
+			}
+		}
+	releaseIdentity:
+		if entryExists {
+			// 'prefix' is being removed or modified, so some prior
+			// iteration of this loop hit the 'injectLabels' case
+			// above, thereby allocating a (new) identity. If we
+			// delete or update the identity for 'prefix' in this
+			// iteration of the loop, then we must balance the
+			// allocation from the prior InjectLabels() call by
+			// releasing the previous reference.
+			if _, ok := idsToAdd[id.ID]; !ok {
+				previouslyAllocatedIdentities[prefix] = id
 			}
 		}
 	}
@@ -248,24 +273,61 @@ func (ipc *IPCache) InjectLabels() error {
 	ipc.metadata.Unlock()
 
 	// Recalculate policy first before upserting into the ipcache.
-	if trigger {
-		ipc.UpdatePolicyMaps(context.TODO(), idsToPropagate, nil)
+	if len(idsToAdd) > 0 {
+		ipc.UpdatePolicyMaps(context.TODO(), idsToAdd, nil)
 	}
 
 	ipc.mutex.Lock()
 	defer ipc.mutex.Unlock()
-	for ip, id := range toUpsert {
+	for ip, id := range entriesToReplace {
 		hIP, key := ipc.getHostIPCache(ip)
 		meta := ipc.getK8sMetadata(ip)
-		if _, err := ipc.upsertLocked(ip, hIP, key, meta, Identity{
-			ID:     id.ID,
-			Source: id.Source,
-		}, false /* !force */); err != nil {
-			return fmt.Errorf("failed to upsert %s into ipcache with identity %d: %w", ip, id.ID, err)
+		if _, err2 := ipc.upsertLocked(
+			ip,
+			hIP,
+			key,
+			meta,
+			id,
+			true,
+		); err2 != nil {
+			log.WithError(err2).WithFields(logrus.Fields{
+				logfields.IPAddr:   ip,
+				logfields.Identity: id,
+			}).Error("Failed to replace ipcache entry with new identity after label removal. Traffic may be disrupted.")
 		}
 	}
 
-	return nil
+	for _, id := range previouslyAllocatedIdentities {
+		realID := ipc.IdentityAllocator.LookupIdentityByID(context.TODO(), id.ID)
+		if realID == nil {
+			continue
+		}
+		released, err := ipc.IdentityAllocator.Release(context.TODO(), realID, false)
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.Identity:       realID,
+				logfields.IdentityLabels: realID.Labels,
+			}).Warning(
+				"Failed to release previously allocated identity during ipcache metadata injection.",
+			)
+		}
+		// Note that not all subsystems currently funnel their
+		// IP prefix => metadata mappings through this code. Notably,
+		// CIDR policy currently allocates its own identities.
+		// Therefore it's possible that the identity that was
+		// previously allocated is still in use or referred in that
+		// policy. Avoid removing references in the policy engine
+		// since those other subsystems should have their own cleanup
+		// logic for handling the removal of these identities.
+		if released {
+			idsToDelete[id.ID] = nil // SelectorCache removal
+		}
+	}
+	if len(idsToDelete) > 0 {
+		ipc.UpdatePolicyMaps(context.TODO(), nil, idsToDelete)
+	}
+
+	return remainingCIDRs, err
 }
 
 // UpdatePolicyMaps pushes updates for the specified identities into the policy
@@ -276,15 +338,17 @@ func (ipc *IPCache) UpdatePolicyMaps(ctx context.Context, addedIdentities, delet
 	// dependencies that are passed into this function.
 
 	var wg sync.WaitGroup
+	// SelectorCache.UpdateIdentities() asks for callers to avoid
+	// handing the same identity in both 'adds' and 'deletes'
+	// parameters here, so make two calls. These changes will not
+	// be propagated to the datapath until the UpdatePolicyMaps
+	// call below.
 	if deletedIdentities != nil {
-		// SelectorCache.UpdateIdentities() asks for callers to avoid
-		// handing the same identity in both 'adds' and 'deletes'
-		// parameters here, so make two calls. These changes will not
-		// be propagated to the datapath until the UpdatePolicyMaps
-		// call below.
 		ipc.PolicyHandler.UpdateIdentities(nil, deletedIdentities, &wg)
 	}
-	ipc.PolicyHandler.UpdateIdentities(addedIdentities, nil, &wg)
+	if addedIdentities != nil {
+		ipc.PolicyHandler.UpdateIdentities(addedIdentities, nil, &wg)
+	}
 	policyImplementedWG := ipc.DatapathHandler.UpdatePolicyMaps(ctx, &wg)
 	policyImplementedWG.Wait()
 }
@@ -648,11 +712,14 @@ func (ipc *IPCache) TriggerLabelInjection() {
 	ipc.UpdateController(
 		"ipcache-inject-labels",
 		controller.ControllerParams{
-			DoFunc: func(context.Context) error {
-				if err := ipc.InjectLabels(); err != nil {
-					return fmt.Errorf("failed to inject labels into ipcache: %w", err)
-				}
-				return nil
+			DoFunc: func(ctx context.Context) error {
+				var err error
+
+				idsToModify := ipc.metadata.dequeuePrefixUpdates()
+				idsToModify, err = ipc.InjectLabels(idsToModify)
+				ipc.metadata.enqueuePrefixUpdates(idsToModify...)
+
+				return err
 			},
 		},
 	)

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -216,10 +216,6 @@ func (ipc *IPCache) InjectLabels() error {
 				newLbls := id.Labels
 				tmpSrc = source.KubeAPIServer
 				trigger = true
-				// If host identity has changed, update its labels.
-				if id.ID == identity.ReservedIdentityHost {
-					identity.AddReservedIdentityWithLabels(id.ID, newLbls)
-				}
 				idsToPropagate[id.ID] = newLbls.LabelArray()
 			}
 
@@ -308,9 +304,29 @@ func (ipc *IPCache) injectLabels(prefix string, lbls labels.Labels) (*identity.I
 	ctx, cancel := context.WithTimeout(context.Background(), option.Config.IPAllocationTimeout)
 	defer cancel()
 
+	if lbls.Has(labels.LabelHost[labels.IDNameHost]) {
+		// Associate any new labels with the host identity.
+		//
+		// This case is a bit special, because other parts of Cilium
+		// have hardcoded assumptions around the host identity and
+		// that it corresponds to identity.ReservedIdentityHost.
+		// If additional labels are associated with the IPs of the
+		// host, add those extra labels into the host identity here
+		// so that policy will match on the identity correctly.
+		//
+		// We can get away with this because the host identity is only
+		// significant within the current agent's view (ie each agent
+		// will calculate its own host identity labels independently
+		// for itself). For all other identities, we avoid modifying
+		// the labels at runtime and instead opt to allocate new
+		// identities below.
+		identity.AddReservedIdentityWithLabels(identity.ReservedIdentityHost, lbls)
+		return identity.LookupReservedIdentity(identity.ReservedIdentityHost), false, nil
+	}
+
 	// If no other labels are associated with this IP, we assume that it's
 	// outside of the cluster and hence needs a CIDR identity.
-	if lbls.Equals(labels.LabelKubeAPIServer) {
+	if !(lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode])) {
 		// GH-17962: Handle the following case:
 		//   1) Apply ToCIDR policy (matching IPs of kube-apiserver)
 		//   2) Apply kube-apiserver policy

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -105,19 +105,6 @@ func (m *metadata) enqueuePrefixUpdates(prefixes ...netip.Prefix) {
 	}
 }
 
-// UpsertMetadata upserts a given IP and its corresponding labels associated
-// with it into the ipcache metadata map. The given labels are not modified nor
-// is its reference saved, as they're copied when inserting into the map.
-//
-// The caller must subsequently call ipc.TriggerLabelInjection() to implement
-// these metadata updates into the datapath.
-func (ipc *IPCache) UpsertMetadata(prefix netip.Prefix, lbls labels.Labels, src source.Source, rid types.ResourceID) {
-	ipc.metadata.Lock()
-	ipc.metadata.upsertLocked(prefix, src, rid, lbls)
-	ipc.metadata.Unlock()
-	ipc.metadata.enqueuePrefixUpdates(prefix)
-}
-
 func (m *metadata) upsertLocked(prefix netip.Prefix, src source.Source, resource types.ResourceID, info ...IPMetadata) {
 	if _, ok := m.m[prefix]; !ok {
 		m.m[prefix] = make(prefixInfo)

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -24,14 +24,17 @@ func TestInjectLabels(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.NoError(t, IPIdentityCache.InjectLabels())
+	remAdd, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	assert.Len(t, remAdd, 0)
+	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	// Insert kube-apiserver IP from outside of the cluster. This should create
 	// a CIDR ID for this IP.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer, source.KubeAPIServer, "kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	assert.NoError(t, IPIdentityCache.InjectLabels())
+	_, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
+	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.True(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
 
@@ -40,7 +43,8 @@ func TestInjectLabels(t *testing.T) {
 	// IP now.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelRemoteNode, source.CustomResource, "node-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	assert.NoError(t, IPIdentityCache.InjectLabels())
+	_, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
+	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.False(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
 }
@@ -59,7 +63,8 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.NoError(t, IPIdentityCache.InjectLabels())
+	_, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	IPIdentityCache.removeLabelsFromIPs(map[string]labels.Labels{
@@ -77,7 +82,8 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
 	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
-	assert.NoError(t, IPIdentityCache.InjectLabels())
+	_, err = IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	assert.NoError(t, err)
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
 		context.TODO(),
 		identity.LocalIdentityFlag, // we assume first local ID

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -24,14 +24,14 @@ func TestInjectLabels(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.CustomResource))
+	assert.NoError(t, IPIdentityCache.InjectLabels())
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	// Insert kube-apiserver IP from outside of the cluster. This should create
 	// a CIDR ID for this IP.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer, source.KubeAPIServer, "kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
+	assert.NoError(t, IPIdentityCache.InjectLabels())
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.True(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
 
@@ -40,7 +40,7 @@ func TestInjectLabels(t *testing.T) {
 	// IP now.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelRemoteNode, source.CustomResource, "node-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
+	assert.NoError(t, IPIdentityCache.InjectLabels())
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.False(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
 }
@@ -59,7 +59,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	setupTest(t)
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.CustomResource))
+	assert.NoError(t, IPIdentityCache.InjectLabels())
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	IPIdentityCache.removeLabelsFromIPs(map[string]labels.Labels{
@@ -77,7 +77,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
 	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
-	assert.NoError(t, IPIdentityCache.InjectLabels(source.Local))
+	assert.NoError(t, IPIdentityCache.InjectLabels())
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
 		context.TODO(),
 		identity.LocalIdentityFlag, // we assume first local ID

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -8,6 +8,7 @@ package ipcache
 import (
 	"context"
 	"net"
+	"net/netip"
 	"sync"
 	"testing"
 
@@ -20,43 +21,48 @@ import (
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
+var (
+	worldPrefix     = netip.MustParsePrefix("1.1.1.1/32")
+	inClusterPrefix = netip.MustParsePrefix("10.0.0.4/32")
+)
+
 func TestInjectLabels(t *testing.T) {
 	setupTest(t)
 	ctx := context.Background()
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, err := IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
+	remaining, err := IPIdentityCache.InjectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.Len(t, remaining, 0)
 	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	// Insert kube-apiserver IP from outside of the cluster. This should create
 	// a CIDR ID for this IP.
-	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer, source.KubeAPIServer, "kube-uid")
+	IPIdentityCache.UpsertMetadata(inClusterPrefix, labels.LabelKubeAPIServer, source.KubeAPIServer, "kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"10.0.0.4"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
-	assert.True(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
+	assert.True(t, IPIdentityCache.ipToIdentityCache["10.0.0.4/32"].ID.HasLocalScope())
 
 	// Upsert node labels to the kube-apiserver to validate that the CIDR ID is
 	// deallocated and the kube-apiserver reserved ID is associated with this
 	// IP now.
-	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelRemoteNode, source.CustomResource, "node-uid")
+	IPIdentityCache.UpsertMetadata(inClusterPrefix, labels.LabelRemoteNode, source.CustomResource, "node-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"10.0.0.4"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
-	assert.False(t, IPIdentityCache.ipToIdentityCache["10.0.0.4"].ID.HasLocalScope())
+	assert.False(t, IPIdentityCache.ipToIdentityCache["10.0.0.4/32"].ID.HasLocalScope())
 }
 
 func TestFilterMetadataByLabels(t *testing.T) {
 	setupTest(t)
 
-	IPIdentityCache.UpsertMetadata("2.1.1.1", labels.LabelWorld, source.Generated, "gen-uid")
-	IPIdentityCache.UpsertMetadata("3.1.1.1", labels.LabelWorld, source.Generated, "gen-uid-2")
+	IPIdentityCache.UpsertMetadata(netip.MustParsePrefix("2.1.1.1/32"), labels.LabelWorld, source.Generated, "gen-uid")
+	IPIdentityCache.UpsertMetadata(netip.MustParsePrefix("3.1.1.1/32"), labels.LabelWorld, source.Generated, "gen-uid-2")
 
 	assert.Len(t, IPIdentityCache.metadata.filterByLabels(labels.LabelKubeAPIServer), 1)
 	assert.Len(t, IPIdentityCache.metadata.filterByLabels(labels.LabelWorld), 2)
@@ -67,27 +73,27 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	ctx := context.Background()
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, err := IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
+	remaining, err := IPIdentityCache.InjectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	IPIdentityCache.RemoveLabelsExcluded(
-		labels.LabelKubeAPIServer, map[string]struct{}{},
+		labels.LabelKubeAPIServer, map[netip.Prefix]struct{}{},
 		"kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	assert.Equal(t, labels.LabelHost, IPIdentityCache.metadata.m["1.1.1.1"].ToLabels())
+	assert.Equal(t, labels.LabelHost, IPIdentityCache.metadata.m[worldPrefix].ToLabels())
 
 	// Simulate kube-apiserver policy + CIDR policy on same prefix. Validate
 	// that removing the kube-apiserver policy will result in a new CIDR
 	// identity for the CIDR policy.
 
-	delete(IPIdentityCache.metadata.m, "1.1.1.1") // clean slate first
+	delete(IPIdentityCache.metadata.m, worldPrefix) // clean slate first
 	// Entry with only kube-apiserver labels means kube-apiserver is outside of
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
-	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
+	IPIdentityCache.UpsertMetadata(worldPrefix, labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
@@ -102,12 +108,12 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.Len(t, ids, 1)
 	assert.Equal(t, 2, id.ReferenceCount)
 	IPIdentityCache.RemoveLabelsExcluded(
-		labels.LabelKubeAPIServer, map[string]struct{}{},
+		labels.LabelKubeAPIServer, map[netip.Prefix]struct{}{},
 		"kube-uid")
-	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
-	assert.NotContains(t, IPIdentityCache.metadata.m["1.1.1.1"].ToLabels(), labels.LabelKubeAPIServer)
+	assert.NotContains(t, IPIdentityCache.metadata.m[worldPrefix].ToLabels(), labels.LabelKubeAPIServer)
 	assert.Equal(t, 1, id.ReferenceCount) // CIDR policy is left
 }
 
@@ -122,8 +128,8 @@ func setupTest(t *testing.T) {
 	})
 	IPIdentityCache.k8sSyncedChecker = &mockK8sSyncedChecker{}
 
-	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
-	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelHost, source.Local, "host-uid")
+	IPIdentityCache.UpsertMetadata(worldPrefix, labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
+	IPIdentityCache.UpsertMetadata(worldPrefix, labels.LabelHost, source.Local, "host-uid")
 }
 
 type mockK8sSyncedChecker struct{}

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -22,9 +22,10 @@ import (
 
 func TestInjectLabels(t *testing.T) {
 	setupTest(t)
+	ctx := context.Background()
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	remaining, err := IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
 	assert.Len(t, remaining, 0)
 	assert.NoError(t, err)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
@@ -33,7 +34,7 @@ func TestInjectLabels(t *testing.T) {
 	// a CIDR ID for this IP.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelKubeAPIServer, source.KubeAPIServer, "kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"10.0.0.4"})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
@@ -44,7 +45,7 @@ func TestInjectLabels(t *testing.T) {
 	// IP now.
 	IPIdentityCache.UpsertMetadata("10.0.0.4", labels.LabelRemoteNode, source.CustomResource, "node-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, err = IPIdentityCache.InjectLabels([]string{"10.0.0.4"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"10.0.0.4"})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
@@ -63,9 +64,10 @@ func TestFilterMetadataByLabels(t *testing.T) {
 
 func TestRemoveLabelsFromIPs(t *testing.T) {
 	setupTest(t)
+	ctx := context.Background()
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, err := IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	remaining, err := IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
@@ -85,7 +87,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
 	IPIdentityCache.UpsertMetadata("1.1.1.1", labels.LabelKubeAPIServer, source.CustomResource, "kube-uid")
-	remaining, err = IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
@@ -102,7 +104,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	IPIdentityCache.RemoveLabelsExcluded(
 		labels.LabelKubeAPIServer, map[string]struct{}{},
 		"kube-uid")
-	remaining, err = IPIdentityCache.InjectLabels([]string{"1.1.1.1"})
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []string{"1.1.1.1"})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
 	assert.NotContains(t, IPIdentityCache.metadata.m["1.1.1.1"].ToLabels(), labels.LabelKubeAPIServer)

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -81,3 +81,13 @@ func (s prefixInfo) ToLabels() labels.Labels {
 	}
 	return l
 }
+
+func (s prefixInfo) Source() source.Source {
+	src := source.Unspec
+	for _, v := range s {
+		if source.AllowOverwrite(src, v.source) {
+			src = v.source
+		}
+	}
+	return src
+}

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+// prefixInfo holds all of the information (labels, etc.) about a given prefix
+// independently based on the ResourceID of the origin of that information, and
+// provides convenient accessors to consistently merge the stored information
+// to generate ipcache output based on a range of inputs.
+type prefixInfo map[types.ResourceID]*resourceInfo
+
+// resourceInfo is all of the information that has been collected from a given
+// resource (types.ResourceID) about this IP. Each field must have a 'zero'
+// value that indicates that it should be ignored for purposes of merging
+// multiple resourceInfo across multiple ResourceIDs together.
+type resourceInfo struct {
+	labels labels.Labels
+	source source.Source
+}
+
+// IPMetadata is an empty interface intended to inform developers using the
+// IPCache interface about which types are valid to be injected, and how to
+// update this code, in particular the merge(),unmerge(),isValid() methods
+// below.
+//
+// In an ideal world, we would use Constraints here but as of Go 1.18, these
+// cannot be used in conjunction with methods, which is how the information
+// gets injected into the IPCache.
+type IPMetadata any
+
+// merge overwrites the field in 'resourceInfo' corresponding to 'info'. This
+// associates the new information with the prefix and ResourceID that this
+// 'resourceInfo' resides under in the outer metadata map.
+func (m *resourceInfo) merge(info IPMetadata, src source.Source) {
+	switch info := info.(type) {
+	case labels.Labels:
+		l := labels.NewLabelsFromModel(nil)
+		l.MergeLabels(info)
+		m.labels = l
+	default:
+		log.Errorf("BUG: Invalid IPMetadata passed to ipinfo.merge(): %+v", info)
+		return
+	}
+	m.source = src
+}
+
+// unmerge removes the info of the specified type from 'resourceInfo'.
+func (m *resourceInfo) unmerge(info IPMetadata) {
+	switch info.(type) {
+	case labels.Labels:
+		m.labels = nil
+	default:
+		log.Errorf("BUG: Invalid IPMetadata passed to ipinfo.unmerge(): %+v", info)
+		return
+	}
+}
+
+func (m *resourceInfo) isValid() bool {
+	return m.labels != nil
+}
+
+func (s prefixInfo) isValid() bool {
+	for _, v := range s {
+		if v.isValid() {
+			return true
+		}
+	}
+	return false
+}
+
+func (s prefixInfo) ToLabels() labels.Labels {
+	l := labels.NewLabelsFromModel(nil)
+	for _, v := range s {
+		l.MergeLabels(v.labels)
+	}
+	return l
+}

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -25,4 +26,32 @@ type PolicyHandler interface {
 // before updating the datapath's IPCache maps.
 type DatapathHandler interface {
 	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
+}
+
+// ResourceID identifies a unique copy of a resource that provides a source for
+// information tied to an IP address in the IPCache.
+type ResourceID string
+
+// ResourceKind determines the source of the ResourceID. Typically this is the
+// short name for the k8s resource.
+type ResourceKind string
+
+var (
+	ResourceKindEndpoint             = ResourceKind("ep")
+	ResourceKindEndpointSlice        = ResourceKind("endpointslices")
+	ResourceKindEndpointSlicev1beta1 = ResourceKind("endpointslices_v1beta1")
+	ResourceKindNode                 = ResourceKind("node")
+)
+
+// NewResourceID returns a ResourceID populated with the standard fields for
+// uniquely identifying a source of IPCache information.
+func NewResourceID(kind ResourceKind, namespace, name string) ResourceID {
+	str := strings.Builder{}
+	str.Grow(len(kind) + 1 + len(namespace) + 1 + len(name))
+	str.WriteString(string(kind))
+	str.WriteRune('/')
+	str.WriteString(namespace)
+	str.WriteRune('/')
+	str.WriteString(name)
+	return ResourceID(str.String())
 }

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -137,10 +137,8 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[netip.Pr
 	)
 
 	for ip := range desiredIPs {
-		k.ipcache.UpsertMetadata(ip, labels.LabelKubeAPIServer, src, rid)
+		k.ipcache.UpsertLabels(ip, labels.LabelKubeAPIServer, src, rid)
 	}
-
-	k.ipcache.TriggerLabelInjection()
 }
 
 func insertK8sPrefix(desiredIPs map[netip.Prefix]struct{}, addr string, resource ipcacheTypes.ResourceID) {

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -143,7 +143,7 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 		k.ipcache.UpsertMetadata(ip, labels.LabelKubeAPIServer, src, rid)
 	}
 
-	k.ipcache.TriggerLabelInjection(src)
+	k.ipcache.TriggerLabelInjection()
 }
 
 // TODO(christarazi): Convert to subscriber model along with the corresponding

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -109,13 +109,7 @@ func (k *K8sWatcher) deleteK8sEndpointV1(ep *slim_corev1.Endpoints, swg *lock.St
 // The actual implementation of this logic down to the datapath is handled
 // asynchronously.
 func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]struct{}, rid ipcacheTypes.ResourceID) {
-	// Use CustomResource as the source similar to the way the CiliumNode
-	// (pkg/node/manager.Manager) handler does because the ipcache entry needs
-	// to be overwrite-able by this handler and the CiliumNode handler. If we
-	// used Kubernetes as the source, then the ipcache entries inserted (first)
-	// by the CN handler wouldn't be overwrite-able by the entries inserted
-	// from this handler.
-	src := source.CustomResource
+	src := source.KubeAPIServer
 
 	// We must perform a diff on the ipcache.identityMetadata map in order to
 	// figure out which IPs are stale and should be removed, before we inject
@@ -135,7 +129,6 @@ func (k *K8sWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[string]s
 	k.ipcache.RemoveLabelsExcluded(
 		labels.LabelKubeAPIServer,
 		desiredIPs,
-		src,
 		rid,
 	)
 

--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_discover_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
@@ -201,7 +202,12 @@ func (k *K8sWatcher) addKubeAPIServerServiceEPSliceV1(eps *slim_discover_v1.Endp
 		}
 	}
 
-	k.handleKubeAPIServerServiceEPChanges(desiredIPs)
+	resource := ipcacheTypes.NewResourceID(
+		ipcacheTypes.ResourceKindEndpointSlice,
+		eps.ObjectMeta.GetNamespace(),
+		eps.ObjectMeta.GetName(),
+	)
+	k.handleKubeAPIServerServiceEPChanges(desiredIPs, resource)
 }
 
 func (k *K8sWatcher) addKubeAPIServerServiceEPSliceV1Beta1(eps *slim_discover_v1beta1.EndpointSlice) {
@@ -218,7 +224,12 @@ func (k *K8sWatcher) addKubeAPIServerServiceEPSliceV1Beta1(eps *slim_discover_v1
 		}
 	}
 
-	k.handleKubeAPIServerServiceEPChanges(desiredIPs)
+	resource := ipcacheTypes.NewResourceID(
+		ipcacheTypes.ResourceKindEndpointSlicev1beta1,
+		eps.ObjectMeta.GetNamespace(),
+		eps.ObjectMeta.GetName(),
+	)
+	k.handleKubeAPIServerServiceEPChanges(desiredIPs, resource)
 }
 
 // initEndpointsOrSlices initializes either the "Endpoints" or "EndpointSlice"

--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -4,6 +4,7 @@
 package watchers
 
 import (
+	"net/netip"
 	"sync"
 
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -195,18 +196,17 @@ func (k *K8sWatcher) addKubeAPIServerServiceEPSliceV1(eps *slim_discover_v1.Endp
 		return
 	}
 
-	desiredIPs := make(map[string]struct{})
-	for _, e := range eps.Endpoints {
-		for _, addr := range e.Addresses {
-			desiredIPs[addr] = struct{}{}
-		}
-	}
-
 	resource := ipcacheTypes.NewResourceID(
 		ipcacheTypes.ResourceKindEndpointSlice,
 		eps.ObjectMeta.GetNamespace(),
 		eps.ObjectMeta.GetName(),
 	)
+	desiredIPs := make(map[netip.Prefix]struct{})
+	for _, e := range eps.Endpoints {
+		for _, addr := range e.Addresses {
+			insertK8sPrefix(desiredIPs, addr, resource)
+		}
+	}
 	k.handleKubeAPIServerServiceEPChanges(desiredIPs, resource)
 }
 
@@ -217,18 +217,17 @@ func (k *K8sWatcher) addKubeAPIServerServiceEPSliceV1Beta1(eps *slim_discover_v1
 		return
 	}
 
-	desiredIPs := make(map[string]struct{})
-	for _, e := range eps.Endpoints {
-		for _, addr := range e.Addresses {
-			desiredIPs[addr] = struct{}{}
-		}
-	}
-
 	resource := ipcacheTypes.NewResourceID(
 		ipcacheTypes.ResourceKindEndpointSlicev1beta1,
 		eps.ObjectMeta.GetNamespace(),
 		eps.ObjectMeta.GetName(),
 	)
+	desiredIPs := make(map[netip.Prefix]struct{})
+	for _, e := range eps.Endpoints {
+		for _, addr := range e.Addresses {
+			insertK8sPrefix(desiredIPs, addr, resource)
+		}
+	}
 	k.handleKubeAPIServerServiceEPChanges(desiredIPs, resource)
 }
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -53,7 +53,7 @@ type nodeEntry struct {
 type IPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error)
 	Delete(IP string, source source.Source) bool
-	TriggerLabelInjection(source source.Source)
+	TriggerLabelInjection()
 	UpsertMetadata(prefix string, lbls labels.Labels, src source.Source, rid ipcacheTypes.ResourceID)
 }
 
@@ -555,7 +555,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		entry.mutex.Unlock()
 	}
 
-	m.ipcache.TriggerLabelInjection(n.Source)
+	m.ipcache.TriggerLabelInjection()
 }
 
 // upsertIntoIDMD upserts the given CIDR into the ipcache.identityMetadata

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -55,8 +55,7 @@ type nodeEntry struct {
 type IPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error)
 	Delete(IP string, source source.Source) bool
-	TriggerLabelInjection()
-	UpsertMetadata(prefix netip.Prefix, lbls labels.Labels, src source.Source, rid ipcacheTypes.ResourceID)
+	UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, rid ipcacheTypes.ResourceID)
 }
 
 // Configuration is the set of configuration options the node manager depends
@@ -561,8 +560,6 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		}
 		entry.mutex.Unlock()
 	}
-
-	m.ipcache.TriggerLabelInjection()
 }
 
 // upsertIntoIDMD upserts the given CIDR into the ipcache.identityMetadata
@@ -570,9 +567,9 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 // with the CIDR.
 func (m *Manager) upsertIntoIDMD(prefix netip.Prefix, id identity.NumericIdentity, rid ipcacheTypes.ResourceID) {
 	if id == identity.ReservedIdentityHost {
-		m.ipcache.UpsertMetadata(prefix, labels.LabelHost, source.Local, rid)
+		m.ipcache.UpsertLabels(prefix, labels.LabelHost, source.Local, rid)
 	} else {
-		m.ipcache.UpsertMetadata(prefix, labels.LabelRemoteNode, source.CustomResource, rid)
+		m.ipcache.UpsertLabels(prefix, labels.LabelRemoteNode, source.CustomResource, rid)
 	}
 }
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"math"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -54,7 +56,7 @@ type IPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error)
 	Delete(IP string, source source.Source) bool
 	TriggerLabelInjection()
-	UpsertMetadata(prefix string, lbls labels.Labels, src source.Source, rid ipcacheTypes.ResourceID)
+	UpsertMetadata(prefix netip.Prefix, lbls labels.Labels, src source.Source, rid ipcacheTypes.ResourceID)
 }
 
 // Configuration is the set of configuration options the node manager depends
@@ -440,14 +442,19 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			key = 0
 		}
 
-		ipAddrStr := address.IP.String()
+		var prefix netip.Prefix
+		if v4 := address.IP.To4(); v4 != nil {
+			prefix = ip.IPToNetPrefix(v4)
+		} else {
+			prefix = ip.IPToNetPrefix(address.IP.To16())
+		}
+		ipAddrStr := prefix.String()
 		_, err := m.ipcache.Upsert(ipAddrStr, tunnelIP, key, nil, ipcache.Identity{
 			ID:     remoteHostIdentity,
 			Source: n.Source,
 		})
-
 		resource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name)
-		m.upsertIntoIDMD(ipAddrStr, remoteHostIdentity, resource)
+		m.upsertIntoIDMD(prefix, remoteHostIdentity, resource)
 
 		// Upsert() will return true if the ipcache entry is owned by
 		// the source of the node update that triggered this node
@@ -561,7 +568,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 // upsertIntoIDMD upserts the given CIDR into the ipcache.identityMetadata
 // (IDMD) map. The given node identity determines which labels are associated
 // with the CIDR.
-func (m *Manager) upsertIntoIDMD(prefix string, id identity.NumericIdentity, rid ipcacheTypes.ResourceID) {
+func (m *Manager) upsertIntoIDMD(prefix netip.Prefix, id identity.NumericIdentity, rid ipcacheTypes.ResourceID) {
 	if id == identity.ReservedIdentityHost {
 		m.ipcache.UpsertMetadata(prefix, labels.LabelHost, source.Local, rid)
 	} else {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -83,7 +83,7 @@ func (i *ipcacheMock) Delete(IP string, source source.Source) bool {
 	return false
 }
 
-func (i *ipcacheMock) TriggerLabelInjection(s source.Source) {
+func (i *ipcacheMock) TriggerLabelInjection() {
 }
 
 func (i *ipcacheMock) UpsertMetadata(string, labels.Labels, source.Source, ipcacheTypes.ResourceID) {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -85,7 +86,7 @@ func (i *ipcacheMock) Delete(IP string, source source.Source) bool {
 func (i *ipcacheMock) TriggerLabelInjection(s source.Source) {
 }
 
-func (i *ipcacheMock) UpsertMetadata(string, labels.Labels) {
+func (i *ipcacheMock) UpsertMetadata(string, labels.Labels, source.Source, ipcacheTypes.ResourceID) {
 }
 
 type signalNodeHandler struct {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -107,10 +107,7 @@ func (i *ipcacheMock) Delete(ip string, source source.Source) bool {
 	return false
 }
 
-func (i *ipcacheMock) TriggerLabelInjection() {
-}
-
-func (i *ipcacheMock) UpsertMetadata(netip.Prefix, labels.Labels, source.Source, ipcacheTypes.ResourceID) {
+func (i *ipcacheMock) UpsertLabels(netip.Prefix, labels.Labels, source.Source, ipcacheTypes.ResourceID) {
 }
 
 type signalNodeHandler struct {


### PR DESCRIPTION
Meta: https://github.com/cilium/cilium/issues/21142

IPCache has historically been based around a concept of associating IP prefixes with a certain _Identity_, where each caller independently determines the exact identity that a IP Prefix should have. Each of these callers has a corresponding `source.Source` which decides the priority between these different sources of Identity.

More recently however, features like #14724 have driven the need to combine multiple sources of information, such as associating both the `remote-node` labels (from k8s `CiliumNode` resources) and `kube-apiserver` labels (from k8s `Endpoints` / `EndpointSlices` resources). Having an exclusionary policy where only one source of information can be correct can have implications like causing conflicts between policies that match on information from each source. Up until now, we've resolved these conflicts somewhat manually by forcing the callers to handle the merging of this information. For most callers, they're independent enough that users would only encounter bugs in rare conditions of using two features together in an unexpected way. We have made some attempts in certain paths to resolve these conflicts where necessary, including the example above. However, over time this code becomes more and more :spaghetti: with each caller attempting to resolve conflicts with the other callers.

This PR reworks the metadata map inside the IPCache to handle multiple sources of information at once, keying them in the map first by IP prefix, then by a `{resourceType, resourceNamespace, resourceName}` tuple (`ResourceID`). When merging the information, a new `prefixInfo` structure provides convenient merging of the labels from all of the sources of information. In effect, this introduced one additional layer of indirection with a series of chained structures represented in the mermaid chart below:

```mermaid
flowchart
  subgraph resourceInfo
  labels.Labels
  source.Source
  end
  subgraph prefixInfo
  UA[ResourceID]-->LA[resourceInfo]
  UB[ResourceID]-->LB[resourceInfo]
  ...
  end
  subgraph identityMetadata
  IP_Prefix-->prefixInfo
  end
```

Furthemore, rather than the previous implementation where _adds_ into the metadata map were asynchronous and _deletes_ were synchronous, this PR refactors the code to force both paths to be asynchronous. The first step which is synchronous is to update the desired state of the IPCache metadata, ie upserting the labels into the metadata map. This is called directly from various watchers like k8s resource watchers or the node manager. These callers then `TriggerLabelInjection()` to apply the changes out-of-band. This causes a goroutine to separately iterate through the changes that need to be made, then ensure that the control plane policy engine (in the `SelectorCache`) to be updated, followed by the dataplane policy maps, then finally followed by the dataplane ipcache. This ensures that policy transitions for newly allocated identities will occur in the correct order to prevent packet drops when different labels are associated with (or removed from) IP prefixes.

By making the deletes also asynchronous and combining the core logic, we are able to also delete a bunch of code, and more consistently handle the various cases of changing the sets of labels associated with prefixes.

See the individual commits for more details.

Combined design and implementation with @christarazi .

Supersedes: https://github.com/cilium/cilium/pull/19758
Related: https://github.com/cilium/cilium/issues/18301
