### PR TITLE
docs: Fix incorrect command in IPsec GSG

### DIFF
--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -113,7 +113,7 @@ interface as follows:
 
        .. code-block:: shell-session
 
-          cilium install --encryption ipsec --config encryption-interface=ethX
+          cilium install --encryption ipsec --config encrypt-interface=ethX
 
     .. group-tab:: Helm
 


### PR DESCRIPTION
The `encryption-interface` flag doesn't exist. It is called `encrypt-interface`.

Fixes: https://github.com/cilium/cilium/pull/15695.