### PR TITLE
HostCope: Add Customer IP and MAC Annotation (PoC)

### DIFF
--- a/api/v1/models/ip_a_m_response.go
+++ b/api/v1/models/ip_a_m_response.go
@@ -33,6 +33,9 @@ type IPAMResponse struct {
 
 	// ipv6
 	IPV6 *IPAMAddressResponse `json:"ipv6,omitempty"`
+
+	// MAC address
+	MAC string `json:"mac,omitempty"`
 }
 
 // Validate validates this IP a m response

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -64,6 +64,7 @@ func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 			ExpirationUUID:  ipv4Result.ExpirationUUID,
 			InterfaceNumber: ipv4Result.InterfaceNumber,
 		}
+		resp.MAC = ipv4Result.MAC.String()
 	}
 
 	if ipv6Result != nil {
@@ -76,6 +77,7 @@ func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 			ExpirationUUID:  ipv6Result.ExpirationUUID,
 			InterfaceNumber: ipv6Result.InterfaceNumber,
 		}
+		resp.MAC = ipv6Result.MAC.String()
 	}
 
 	return ipamapi.NewPostIpamCreated().WithPayload(resp)

--- a/pkg/datapath/connector/veth.go
+++ b/pkg/datapath/connector/veth.go
@@ -65,9 +65,16 @@ func SetupVethWithNames(lxcIfName, tmpIfName string, mtu int, ep *models.Endpoin
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to generate rnd mac addr: %s", err)
 	}
-	epLXCMAC, err = mac.GenerateRandMAC()
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to generate rnd mac addr: %s", err)
+	if ep.Mac != "" {
+		epLXCMAC, err = mac.ParseMAC(ep.Mac)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to parse peer mac addr: %s", err)
+		}
+	} else {
+		epLXCMAC, err = mac.GenerateRandMAC()
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to generate rnd mac addr: %s", err)
+		}
 	}
 
 	veth := &netlink.Veth{

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -69,10 +69,10 @@ func (h *hostScopeAllocator) AllocateNext(owner string) (*AllocationResult, erro
 			if ip == nil {
 				return nil, fmt.Errorf("customer invalid ip: %s. ", pod.Annotations[customPodIpAddr])
 			}
-			err = h.allocator.Allocate(ip)
-			if err != nil {
-				return nil, fmt.Errorf("customer ip is not avaliable %s: %w", ip.String(), err)
-			}
+			//err = h.allocator.Allocate(ip)
+			//if err != nil {
+			//	return nil, fmt.Errorf("customer ip is not avaliable %s: %w", ip.String(), err)
+			//}
 			return &AllocationResult{IP: ip}, nil
 		}
 	}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -118,11 +118,11 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 		}).Infof("Initializing %s IPAM", c.IPAMMode())
 
 		if c.IPv6Enabled() {
-			ipam.IPv6Allocator = newHostScopeAllocator(nodeAddressing.IPv6().AllocationCIDR().IPNet)
+			ipam.IPv6Allocator = newHostScopeAllocator(nodeAddressing.IPv6().AllocationCIDR().IPNet, k8sEventReg)
 		}
 
 		if c.IPv4Enabled() {
-			ipam.IPv4Allocator = newHostScopeAllocator(nodeAddressing.IPv4().AllocationCIDR().IPNet)
+			ipam.IPv4Allocator = newHostScopeAllocator(nodeAddressing.IPv4().AllocationCIDR().IPNet, k8sEventReg)
 		}
 	case ipamOption.IPAMClusterPoolV2:
 		log.Info("Initializing ClusterPool v2 IPAM")

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -13,6 +13,10 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 )
 
+const (
+	customPodIpAddr = "cni.cilium.io/ipAddrs"
+)
+
 // AllocationResult is the result of an allocation
 type AllocationResult struct {
 	// IP is the allocated IP

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	customPodIpAddr = "cni.cilium.io/ipAddrs"
+	customPodIpAddr  = "cni.cilium.io/ipAddrs"
+	customPodMacAddr = "cni.cilium.io/macAddrs"
 )
 
 // AllocationResult is the result of an allocation
@@ -46,6 +47,9 @@ type AllocationResult struct {
 	// InterfaceNumber is a field for generically identifying an interface.
 	// This is only useful in ENI mode.
 	InterfaceNumber string
+
+	// MAC is the MAC address of the container interface.
+	MAC net.HardwareAddr
 }
 
 // Allocator is the interface for an IP allocator implementation

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -289,7 +289,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		netNs    ns.NetNS
 	)
 
-	n, err = types.LoadNetConf(args.StdinData)
+	n, err = types.LoadNetConf(args.StdinData, args.Args)
 	if err != nil {
 		err = fmt.Errorf("unable to parse CNI configuration \"%s\": %s", args.StdinData, err)
 		return
@@ -416,6 +416,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		Addressing:   &models.AddressPair{},
 		K8sPodName:   string(cniArgs.K8S_POD_NAME),
 		K8sNamespace: string(cniArgs.K8S_POD_NAMESPACE),
+		Mac:          ipam.MAC,
 	}
 
 	switch conf.DatapathMode {
@@ -559,7 +560,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	// Note about when to return errors: kubelet will retry the deletion
 	// for a long time. Therefore, only return an error for errors which
 	// are guaranteed to be recoverable.
-	n, err := types.LoadNetConf(args.StdinData)
+	n, err := types.LoadNetConf(args.StdinData, args.Args)
 	if err != nil {
 		err = fmt.Errorf("unable to parse CNI configuration \"%s\": %s", args.StdinData, err)
 		return err

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -231,6 +231,9 @@ EOF
 {
   "cniVersion": "0.3.1",
   "name": "cilium",
+  "capabilities": {
+    "mac": true
+  },
   "type": "cilium-cni",
   "enable-debug": ${ENABLE_DEBUG},
   "log-file": "${LOG_FILE}"


### PR DESCRIPTION
Not intended to be merged.
Add the oportunity to request specific MAC- and IP-address using annotations:

```yaml
cni.cilium.io/ipAddrs: 10.10.10.10
cni.cilium.io/macAddrs: f6:e1:74:94:b8:1d
```


We develop the opportunity to live-migrate KubeVirt VMs connected to cilium.
To bind cilium to VM the [macvtap binding mode](https://github.com/kubevirt/kubevirt/pull/7648) is used.
To make VM migratable across the hosts, the pods should be created with the same IP- and MAC-address.

*Another branch [`kvaps:customer-ip-and-mac-old`](https://github.com/kvaps/cilium/tree/customer-ip-and-mac-old) is based on `v1.11.4`*

---

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/17026

kind/feature
