### PR TITLE
cli: Update regex for key value validation

### DIFF
--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var keyValueRegex = regexp.MustCompile(`([\w-:./]+=[\w-:./]+,)*([\w-:./]+=[\w-:./]+)$`)
+var keyValueRegex = regexp.MustCompile(`([\w-:./@]+=[\w-:./@]*,)*([\w-:./@]+=[\w-:./@]*)$`)
 
 // GetStringMapString contains one enhancement to support k1=v2,k2=v2 compared to original
 // implementation of GetStringMapString function

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -74,6 +74,30 @@ func TestGetStringMapString(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "valid kv format with @",
+			args: args{
+				key:   "FOO_BAR",
+				value: "k1=v1,k2=test@test.com",
+			},
+			want: map[string]string{
+				"k1": "v1",
+				"k2": "test@test.com",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "valid kv format with empty value",
+			args: args{
+				key:   "FOO_BAR",
+				value: "k1=,k2=v2",
+			},
+			want: map[string]string{
+				"k1": "",
+				"k2": "v2",
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "valid kv format with forward slash",
 			args: args{
 				key:   "FOO_BAR",


### PR DESCRIPTION
This commit is to allow empty value, as well as @ character in value for
key value pair validation.

Fixes: #19793
Signed-off-by: Tam Mach <tam.mach@cilium.io>