### PR TITLE
Add optional trace events to XDP programs

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -755,6 +755,13 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 	if (svc) {
 		const bool skip_l3_xlate = DSR_ENCAP_MODE == DSR_ENCAP_IPIP;
 
+		#if defined(XDP_TRACING) && __ctx_is == __ctx_xdp
+			send_trace_notify(ctx, TRACE_FROM_NETWORK, src_identity, 0,
+					  bpf_ntohs((__u16)svc->backend_id),
+					  ctx->ingress_ifindex, TRACE_REASON_UNKNOWN,
+					  TRACE_PAYLOAD_LEN);
+		#endif
+
 		if (!lb6_src_range_ok(svc, (union v6addr *)&ip6->saddr))
 			return DROP_NOT_IN_SRC_RANGE;
 
@@ -1789,6 +1796,13 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	svc = lb4_lookup_service(&key, false);
 	if (svc) {
 		const bool skip_l3_xlate = DSR_ENCAP_MODE == DSR_ENCAP_IPIP;
+
+		#if defined(XDP_TRACING) && __ctx_is == __ctx_xdp
+			send_trace_notify(ctx, TRACE_FROM_NETWORK, src_identity, 0,
+					  bpf_ntohs((__u16)svc->backend_id),
+					  ctx->ingress_ifindex, TRACE_REASON_UNKNOWN,
+					  TRACE_PAYLOAD_LEN);
+		#endif
 
 		if (!lb4_src_range_ok(svc, ip4->saddr))
 			return DROP_NOT_IN_SRC_RANGE;

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1359,6 +1359,7 @@ func initEnv(cmd *cobra.Command) {
 
 	option.Config.Opts.SetBool(option.Debug, debugDatapath)
 	option.Config.Opts.SetBool(option.DebugLB, debugDatapath)
+	option.Config.Opts.SetBool(option.XDPTracing, debugDatapath)
 	option.Config.Opts.SetBool(option.DropNotify, true)
 	option.Config.Opts.SetBool(option.TraceNotify, true)
 	option.Config.Opts.SetBool(option.PolicyVerdictNotify, true)

--- a/pkg/option/daemon.go
+++ b/pkg/option/daemon.go
@@ -19,6 +19,7 @@ var (
 		ConntrackLocal:      &specConntrackLocal,
 		Debug:               &specDebug,
 		DebugLB:             &specDebugLB,
+		XDPTracing:          &specXDPTracing,
 		DebugPolicy:         &specDebugPolicy,
 		DropNotify:          &specDropNotify,
 		TraceNotify:         &specTraceNotify,

--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -10,6 +10,7 @@ const (
 	Debug               = "Debug"
 	DebugLB             = "DebugLB"
 	DebugPolicy         = "DebugPolicy"
+	XDPTracing          = "XDPTracing"
 	DropNotify          = "DropNotification"
 	TraceNotify         = "TraceNotification"
 	PolicyVerdictNotify = "PolicyVerdictNotification"
@@ -41,6 +42,11 @@ var (
 	specDebugLB = Option{
 		Define:      "LB_DEBUG",
 		Description: "Enable debugging trace statements for load balancer",
+	}
+
+	specXDPTracing = Option{
+		Define:      "XDP_TRACING",
+		Description: "Enable traces / flow events for XDP",
 	}
 
 	specDebugPolicy = Option{


### PR DESCRIPTION
This PR adds the ability to enable trace events for packets passing
through XDP. The feature is disabled by default and can be enabled by
setting the `--debug-verbose=datapath` flag or at runtime with `cilium
config XDPTracing=enabled`.

When enabled, we will trace packets both before and after mangling the
packets for nodeport loadbalancing. This will result in both the mangled
and unmangled flows being displayed in Hubble.

Side effect of this is that packets may appear multiple times in the
monitor feed and metrics from aggregated traces are incorrect.

Fixes: #19703
Signed-off-by: Dylan Reimerink <dylan.reimerink@isovalent.com>

```release-note
Added flow events from XDP when the optional `XDPTracing` runtime option is enabled
```
