### PR TITLE
checkpatch: Update image for "checkpatch" target, reuse target in CI

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -47,7 +47,8 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Run checkpatch.pl
-        uses: docker://quay.io/cilium/cilium-checkpatch:2f0f4f512e795d5668ea4e7ef0ba85abc75eb225@sha256:f307bf0315954e8b8c31edc1864d949bf211b0c6522346359317d757b5a6cea0
+        run: |
+          make -C bpf checkpatch || (echo "Run 'make -C bpf checkpatch' locally to investigate reports"; exit 1)
       - name: Send slack notification
         if: ${{ !success() && (github.event_name == 'schedule' || github.event_name == 'push') }}
         uses: 8398a7/action-slack@a74b761b4089b5d730d813fbedcd2ec5d394f3af

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -76,6 +76,7 @@ checkpatch:
 		--workdir /workspace \
 		--volume $(CURDIR)/..:/workspace \
 		--user "$(shell id -u):$(shell id -g)" \
+		-e GITHUB_REF=$(GITHUB_REF) -e GITHUB_REPOSITORY=$(GITHUB_REPOSITORY) \
 		$(CHECKPATCH_IMAGE_AND_ENTRY) $(CHECKPATCH_ARGS)
 
 coccicheck:

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -61,13 +61,22 @@ force:
 	@$(ECHO_CC)
 	$(QUIET) ${LLC} $(LLC_FLAGS) -filetype=asm -o $@ $(patsubst %.s,%.ll,$@)
 
+CHECKPATCH_IMAGE := quay.io/cilium/cilium-checkpatch:2f0f4f512e795d5668ea4e7ef0ba85abc75eb225@sha256:f307bf0315954e8b8c31edc1864d949bf211b0c6522346359317d757b5a6cea0
+ifneq ($(CHECKPATCH_DEBUG),)
+  # Run script with "bash -x"
+  CHECKPATCH_IMAGE_AND_ENTRY := \
+	--entrypoint /bin/bash $(CHECKPATCH_IMAGE) -x /checkpatch/checkpatch.sh
+else
+  # Use default entrypoint
+  CHECKPATCH_IMAGE_AND_ENTRY := $(CHECKPATCH_IMAGE)
+endif
 checkpatch:
 	@$(ECHO_CHECK) "(checkpatch)"
 	$(QUIET) $(CONTAINER_ENGINE) container run --rm \
 		--workdir /workspace \
 		--volume $(CURDIR)/..:/workspace \
 		--user "$(shell id -u):$(shell id -g)" \
-		cilium/cilium-checkpatch:e6a6843cef50a43c38819badb55a21061967ce64
+		$(CHECKPATCH_IMAGE_AND_ENTRY) $(CHECKPATCH_ARGS)
 
 coccicheck:
 	$(QUIET) $(foreach TARGET,$(shell find $(ROOT_DIR)/contrib/coccinelle/ -name '*.cocci'), \


### PR DESCRIPTION
Some minor adjustements to the way we run checkpatch:

- Update the image for the `checkpatch` target in bpf/Makefile.bpf, so that running `make -C bpf checkpatch` uses the same image as CI.
- Update CI action to use this `checkpatch` target. This is so that we only keep one reference to the Docker image instead of having it at two distinct locations.