### PR TITLE
Add counter to track all datapath timeouts due to FQDN IP updates

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -318,6 +318,7 @@ Name                                     Labels                                 
 ======================================== ================================================== ========================================================
 ``proxy_redirects``                      ``protocol``                                       Number of redirects installed for endpoints
 ``proxy_upstream_reply_seconds``                                                            Seconds waited for upstream server to reply to a request
+``proxy_datapath_update_timeout_total``                                                     Number of total datapath update timeouts due to FQDN IP updates
 ``policy_l7_total``                      ``type``                                           Number of total L7 requests/responses
 ======================================== ================================================== ========================================================
 

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -540,6 +540,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		select {
 		case <-updateCtx.Done():
 			log.Error("Timed out waiting for datapath updates of FQDN IP information; returning response")
+			metrics.ProxyDatapathUpdateTimeout.Inc()
 		case <-updateComplete:
 		}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -322,6 +322,10 @@ var (
 	// by error, protocol and span time
 	ProxyUpstreamTime = NoOpObserverVec
 
+	// ProxyDatapathUpdateTimeout is a count of all the timeouts encountered while
+	// updating the datapath due to an FQDN IP update
+	ProxyDatapathUpdateTimeout = NoOpCounter
+
 	// L3-L4 statistics
 
 	// DropCount is the total drop requests,
@@ -512,6 +516,7 @@ type Configuration struct {
 	ProxyForwardedEnabled                   bool
 	ProxyDeniedEnabled                      bool
 	ProxyReceivedEnabled                    bool
+	ProxyDatapathUpdateTimeoutEnabled       bool
 	NoOpObserverVecEnabled                  bool
 	DropCountEnabled                        bool
 	DropBytesEnabled                        bool
@@ -864,6 +869,16 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, ProxyUpstreamTime)
 			c.NoOpObserverVecEnabled = true
+
+		case Namespace + "_proxy_datapath_update_timeout_total":
+			ProxyDatapathUpdateTimeout = prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Name:      "proxy_datapath_update_timeout_total",
+				Help:      "Number of total datapath update timeouts due to FQDN IP updates",
+			})
+
+			collectors = append(collectors, ProxyDatapathUpdateTimeout)
+			c.ProxyDatapathUpdateTimeoutEnabled = true
 
 		case Namespace + "_drop_count_total":
 			DropCount = prometheus.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
The code is logging when this is happening but it would be useful to have them exposed as metrics to put them on a dashboard and to correlate with other events in the system.


```release-note
Add counter to track all datapath timeouts due to FQDN IP updates
```

Tagging @christarazi for SA.