### PR TITLE
install/kubernetes: Add CAP_IPC_LOCK for mmap

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -256,6 +256,8 @@ spec:
               - KILL
               # Used since cilium modifies routing tables, etc...
               - NET_ADMIN
+              # Used since cilium monitor uses mmap
+              - IPC_LOCK
               # Used in iptables. Consider removing once we are iptables-free
               - SYS_MODULE
               # We need it for now but might not need it for >= 5.11 specially


### PR DESCRIPTION
### Description

This commit is to add IPC_LOCK cap for cilium agent, as mmap is triggered as
part of monitor-agent.

```
level=fatal msg="Cannot initialise BPF perf ring buffer sockets" error="failed to create perf ring for CPU 0: can't mmap: operation not permitted" startTime="2022-05-12 21:57:54.463823399 +0000 UTC m=+3.211794063" subsys=monitor-agent
```

Related docs:
https://man7.org/linux/man-pages/man7/capabilities.7.html

Relates 28bffa6d4b11936f9c2dc94a68dec0ecd4d3f745
Fixes #19808

Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

I was able to simulate the issue locally with normal `cilium install --version v1.12.0-rc2`, and then just test it out by modify cilium daemonset directly.

<details>
<summary>Before</summary>

```
$ ksysgpo
NAME                               READY   STATUS             RESTARTS      AGE
cilium-operator-688b75db67-28tj4   1/1     Running            0             38m
cilium-t72pb                       0/1     CrashLoopBackOff   4 (52s ago)   2m40s

$ ksysg daemonsets.apps cilium -o json | jq '.spec.template.spec.containers[0].securityContext'
{
  "capabilities": {
    "add": [
      "KILL",
      "NET_ADMIN",
      "SYS_MODULE",
      "SYS_ADMIN",
      "SYS_RESOURCE"
    ]
  }
}

$ ksyslo ds/cilium | grep "level=fatal"
level=fatal msg="Cannot initialise BPF perf ring buffer sockets" error="failed to create perf ring for CPU 30: can't mmap: operation not permitted" startTime="2022-05-13 12:07:42.393208179 +0000 UTC m=+2.609485545" subsys=monitor-agent

```

</details>


<details>
<summary>After</summary>

```
$ ksysg daemonsets.apps cilium -o json | jq '.spec.template.spec.containers[0].securityContext'
{
  "capabilities": {
    "add": [
      "KILL",
      "NET_ADMIN",
      "IPC_LOCK",
      "SYS_MODULE",
      "SYS_ADMIN",
      "SYS_RESOURCE"
    ]
  }
}

$ kgpo -A
NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
kube-system   cilium-9fl7v                       1/1     Running   0             18s
kube-system   cilium-operator-688b75db67-28tj4   1/1     Running   0             42m
kube-system   coredns-64897985d-vbtzt            1/1     Running   0             43m
kube-system   etcd-minikube                      1/1     Running   0             43m
kube-system   kube-apiserver-minikube            1/1     Running   0             43m
kube-system   kube-controller-manager-minikube   1/1     Running   0             43m
kube-system   kube-proxy-pns5t                   1/1     Running   0             43m
kube-system   kube-scheduler-minikube            1/1     Running   0             43m
kube-system   storage-provisioner                1/1     Running   1 (42m ago)   43m

$ cilium status
    /¯¯\
 /¯¯\__/¯¯\    Cilium:         OK
 \__/¯¯\__/    Operator:       OK
 /¯¯\__/¯¯\    Hubble:         disabled
 \__/¯¯\__/    ClusterMesh:    disabled
    \__/

Deployment        cilium-operator    Desired: 1, Ready: 1/1, Available: 1/1
DaemonSet         cilium             Desired: 1, Ready: 1/1, Available: 1/1
Containers:       cilium             Running: 1
                  cilium-operator    Running: 1
Cluster Pods:     1/1 managed by Cilium
Image versions    cilium             quay.io/cilium/cilium:v1.12.0-rc2: 1
                  cilium-operator    quay.io/cilium/operator-generic:v1.12.0-rc2: 1
```

</details>