### PR TITLE
pkg/policy/rule: Optimize rule String()

### DIFF
--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -44,7 +44,7 @@ func (m *ruleMetadata) delete(identity *identity.Identity) {
 }
 
 func (r *rule) String() string {
-	return fmt.Sprintf("%v", r.EndpointSelector)
+	return r.EndpointSelector.String()
 }
 
 func (r *rule) getSelector() *api.EndpointSelector {


### PR DESCRIPTION
Avoiding to use  fmt.Sprintf() so that Go won't over-allocate the memory.

issue reference : cilium#19571

Result:

```
$ go test -v -run '^$' -bench 'BenchmarkRuleString' -benchmem ./pkg/policy > BenchmarkRuleString_old.txt
$ go test -v -run '^$' -bench 'BenchmarkRuleString' -benchmem ./pkg/policy > BenchmarkRuleString_new.txt
$ benchcmp BenchmarkRuleString_old.txt BenchmarkRuleString_new.txt
benchmark                 old ns/op     new ns/op     delta
BenchmarkRuleString-4     1929          1514          -21.51%

benchmark                 old allocs     new allocs     delta
BenchmarkRuleString-4     13             10             -23.08%

benchmark                 old bytes     new bytes     delta
BenchmarkRuleString-4     752           656           -12.77%
```

Signed-off-by: MikeLing <sabergeass@gmail.com>
