### PR TITLE
gha: Add retry options for ingress sanity check

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -110,6 +110,8 @@ jobs:
             --set operator.image.tag=${{ steps.vars.outputs.sha }} \
             --set operator.image.pullPolicy=IfNotPresent \
             --set operator.image.useDigest=false \
+            --set debug.enabled=true \
+            --set debug.verbose=flow \
             --set securityContext.privileged=true \
             --set ingressController.enabled=true
 

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -127,8 +127,8 @@ jobs:
           kubectl wait -n default --for=condition=Ready --all pod --timeout=${{ env.timeout }}
 
           lb=$(kubectl get ingress basic-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-          curl --fail -- http://"$lb"
-          curl --fail -- http://"$lb"/details/1
+          curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail -- http://"$lb"
+          curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail -- http://"$lb"/details/1
 
       - name: Run Ingress conformance test
         timeout-minutes: 30

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -52,6 +52,7 @@ jobs:
             --helm-set=clustermesh.apiserver.image.useDigest=false \
             --helm-set=hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${SHA} \
+            --helm-set=debug.enabled=true \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \


### PR DESCRIPTION
This commit is to add curl options for retries to mitigate potential timing
issue, which could happen in envoy proxy and xDS.,

```
curl: (22) The requested URL returned error: 503 Service Unavailable
```

Signed-off-by: Tam Mach <tam.mach@cilium.io>

