### PR TITLE
Change default agent health check port to avoid conflicts

### DIFF
--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -161,6 +161,7 @@ jobs:
 
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
+          ref: ${{ steps.vars.outputs.sha }}
           persist-credentials: false
 
       - name: Boot Fedora

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -11,7 +11,7 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --agent-health-port int                                   TCP port for agent health status API (default 9876)
+      --agent-health-port int                                   TCP port for agent health status API (default 9879)
       --agent-labels strings                                    Additional labels to identify this agent
       --allocator-list-timeout duration                         Timeout for listing allocator state before exiting (default 3m0s)
       --allow-icmp-frag-needed                                  Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -628,7 +628,7 @@
    * - healthPort
      - TCP port for the agent health API. This is not the port for cilium-health.
      - int
-     - ``9876``
+     - ``9879``
    * - hostAliases
      - Host aliases for cilium-agent.
      - list

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -364,9 +364,9 @@ ICMP 8/0                 egress          ``worker-sg`` (self) health checks
 
 The following ports should also be available on each node:
 
-======================== ===========================================================
+======================== ==================================================================
 Port Range / Protocol    Description
-======================== ===========================================================
+======================== ==================================================================
 4240/tcp                 cluster health checks (``cilium-health``)
 4244/tcp                 Hubble server
 4245/tcp                 Hubble Relay
@@ -375,13 +375,13 @@ Port Range / Protocol    Description
 6062/tcp                 Hubble Relay pprof server (listening on 127.0.0.1)
 6942/tcp                 operator Prometheus metrics
 9090/tcp                 cilium-agent Prometheus metrics
-9876/tcp                 cilium-agent health status API
+9876/tcp                 cilium-agent health status API (listening on 127.0.0.1 and/or ::1)
 9890/tcp                 cilium-agent gops server (listening on 127.0.0.1)
 9891/tcp                 operator gops server (listening on 127.0.0.1)
 9892/tcp                 clustermesh-apiserver gops server (listening on 127.0.0.1)
 9893/tcp                 Hubble Relay gops server (listening on 127.0.0.1)
 51871/udp                WireGuard encryption tunnel endpoint
-======================== ===========================================================
+======================== ==================================================================
 
 .. _admin_mount_bpffs:
 

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -375,7 +375,7 @@ Port Range / Protocol    Description
 6062/tcp                 Hubble Relay pprof server (listening on 127.0.0.1)
 6942/tcp                 operator Prometheus metrics
 9090/tcp                 cilium-agent Prometheus metrics
-9876/tcp                 cilium-agent health status API (listening on 127.0.0.1 and/or ::1)
+9879/tcp                 cilium-agent health status API (listening on 127.0.0.1 and/or ::1)
 9890/tcp                 cilium-agent gops server (listening on 127.0.0.1)
 9891/tcp                 operator gops server (listening on 127.0.0.1)
 9892/tcp                 clustermesh-apiserver gops server (listening on 127.0.0.1)

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -207,7 +207,7 @@ contributors across the globe, there is almost always someone available to help.
 | extraVolumes | list | `[]` | Additional agent volumes. |
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
-| healthPort | int | `9876` | TCP port for the agent health API. This is not the port for cilium-health. |
+| healthPort | int | `9879` | TCP port for the agent health API. This is not the port for cilium-health. |
 | hostAliases | list | `[]` | Host aliases for cilium-agent. |
 | hostFirewall | object | `{"enabled":false}` | Configure the host firewall. |
 | hostFirewall.enabled | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -139,7 +139,7 @@ data:
   debug-verbose: "{{ .Values.debug.verbose }}"
 {{- end }}
 
-{{- if ne (int .Values.healthPort) 9876 }}
+{{- if ne (int .Values.healthPort) 9879 }}
   # Set the TCP port for the agent health status API. This is not the port used
   # for cilium-health.
   agent-health-port: "{{ .Values.healthPort }}"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -583,7 +583,7 @@ gke:
 healthChecking: true
 
 # -- TCP port for the agent health API. This is not the port for cilium-health.
-healthPort: 9876
+healthPort: 9879
 
 # -- Configure the host firewall.
 hostFirewall:

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// AgentHealthPort is the default value for option.AgentHealthPort
-	AgentHealthPort = 9876
+	AgentHealthPort = 9879
 
 	// ClusterHealthPort is the default value for option.ClusterHealthPort
 	ClusterHealthPort = 4240


### PR DESCRIPTION
The default value 9876 for the agent health port introduced in commit
efffbdbebdbf ("daemon: expose HTTP endpoint on localhost for health
checks") conflicts with Istio's ControlZ port. The latter has been in
use for longer. Because the port is only exposed on localhost for use by
liveness/readiness probe, we can change the default value without
breaking users. Thus, change it to 9879 for which there doesn't seem to
be any documented use.

Fixes #19817
