### PR TITLE
v1.9 backports 2022-05-16

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -308,6 +308,14 @@ Annotations:
 
 .. _1.9_upgrade_notes:
 
+1.9.16 Upgrade Notes
+--------------------
+
+* ``operator.unmanagedPodWatcher.restart`` has been introduced to govern
+  whether the cilium-operator will attempt to restart pods that are not
+  managed by Cilium. To retain consistency with earlier releases, this setting
+  is enabled by default.
+
 1.9.1 Upgrade Notes
 -------------------
 


### PR DESCRIPTION
* #19820 -- docs: Document operator.unmanagedPodWatcher (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19820; do contrib/backporting/set-labels.py $pr done 1.9; done
```