### PR TITLE
v1.10 backports 2022-05-16

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -331,6 +331,14 @@ Annotations:
 
 .. _1.10_upgrade_notes:
 
+1.10.11 Upgrade Notes
+---------------------
+
+* ``operator.unmanagedPodWatcher.restart`` has been introduced to govern
+  whether the cilium-operator will attempt to restart pods that are not
+  managed by Cilium. To retain consistency with earlier releases, this setting
+  is enabled by default.
+
 1.10.6 Upgrade Notes
 --------------------
 


### PR DESCRIPTION
* #19820 -- docs: Document operator.unmanagedPodWatcher (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19820; do contrib/backporting/set-labels.py $pr done 1.10; done
```