### PR TITLE
api: don't attempt to set unix domain socket group to `cilium`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,9 +122,6 @@ sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-etc
 sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium.service /lib/systemd/system
 sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-operator.service /lib/systemd/system
 sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium /etc/sysconfig
-
-getent group cilium >/dev/null || sudo groupadd -r cilium
-sudo usermod -a -G cilium vagrant
 SCRIPT
 
 $node_ip_base = ENV['IPV4_BASE_ADDR'] || ""

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -21,7 +21,6 @@ clean:
 ifeq ("$(PKG_BUILD)","")
 
 install:
-	groupadd -f cilium
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 

--- a/images/README.md
+++ b/images/README.md
@@ -125,8 +125,7 @@ COPY --from=builder /out/${TARGETPLATFORM} /
 
 WORKDIR /home/cilium
 
-RUN groupadd -f cilium \
-    && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
+RUN echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc
 
 CMD ["/usr/bin/cilium"]
 ```

--- a/pkg/api/apipanic.go
+++ b/pkg/api/apipanic.go
@@ -11,7 +11,10 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "api")
 
 // APIPanicHandler recovers from API panics and logs encountered panics
 type APIPanicHandler struct {

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -9,8 +9,6 @@ import (
 )
 
 const (
-	// CiliumGroupName is the cilium's unix group name.
-	CiliumGroupName = "cilium"
 	// SocketFileMode is the default file mode for the sockets.
 	SocketFileMode os.FileMode = 0660
 	// ClientTimeout specifies timeout to be used by clients

--- a/pkg/api/socket.go
+++ b/pkg/api/socket.go
@@ -6,44 +6,13 @@ package api
 import (
 	"fmt"
 	"os"
-	"os/user"
-	"strconv"
-
-	"github.com/sirupsen/logrus"
-
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "api")
-
-// getGroupIDByName returns the group ID for the given grpName.
-func getGroupIDByName(grpName string) (int, error) {
-	group, err := user.LookupGroup(grpName)
-	if err != nil {
-		return -1, err
-	}
-	return strconv.Atoi(group.Gid)
-}
-
-// SetDefaultPermissions sets the given socket's group to `CiliumGroupName` and
-// mode to `SocketFileMode`.
+// SetDefaultPermissions sets the given socket's mode to `SocketFileMode`.
 func SetDefaultPermissions(socketPath string) error {
-	gid, err := getGroupIDByName(CiliumGroupName)
-	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
-			logfields.Path: socketPath,
-			"group":        CiliumGroupName,
-		}).Info("Group not found")
-	} else {
-		if err := os.Chown(socketPath, 0, gid); err != nil {
-			return fmt.Errorf("failed while setting up %s's group ID"+
-				" in %q: %s", CiliumGroupName, socketPath, err)
-		}
-	}
 	if err := os.Chmod(socketPath, SocketFileMode); err != nil {
-		return fmt.Errorf("failed while setting up %s's file"+
-			" permissions in %q: %s", CiliumGroupName, socketPath, err)
+		return fmt.Errorf("failed while setting up file permissions for %q: %w",
+			socketPath, err)
 	}
 	return nil
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -308,17 +308,17 @@ var badLogMessages = map[string][]string{
 }
 
 var ciliumCLICommands = map[string]string{
-	"cilium endpoint list -o json":          "endpoint_list.txt",
-	"cilium service list -o json":           "service_list.txt",
-	"cilium config":                         "config.txt",
-	"sudo cilium bpf lb list":               "bpf_lb_list.txt",
-	"sudo cilium bpf ct list global":        "bpf_ct_list.txt",
-	"sudo cilium bpf tunnel list":           "bpf_tunnel_list.txt",
-	"cilium policy get":                     "policy_get.txt",
-	"cilium status --all-controllers":       "status.txt",
-	"cilium kvstore get cilium --recursive": "kvstore_get.txt",
+	"sudo cilium endpoint list -o json":          "endpoint_list.txt",
+	"sudo cilium service list -o json":           "service_list.txt",
+	"sudo cilium config":                         "config.txt",
+	"sudo cilium bpf lb list":                    "bpf_lb_list.txt",
+	"sudo cilium bpf ct list global":             "bpf_ct_list.txt",
+	"sudo cilium bpf tunnel list":                "bpf_tunnel_list.txt",
+	"sudo cilium policy get":                     "policy_get.txt",
+	"sudo cilium status --all-controllers":       "status.txt",
+	"sudo cilium kvstore get cilium --recursive": "kvstore_get.txt",
 
-	"hubble observe --since 4h -o jsonpb": "hubble_observe.json",
+	"sudo hubble observe --since 4h -o jsonpb": "hubble_observe.json",
 }
 
 // ciliumKubCLICommands these commands are the same as `ciliumCLICommands` but
@@ -341,7 +341,7 @@ var ciliumKubCLICommands = map[string]string{
 // of timing out in our CI, so we want to run it separately. Otherwise, we might
 // lose out on getting other critical debugging output when a test fails.
 var ciliumKubCLICommandsKVStore = map[string]string{
-	"cilium kvstore get cilium --recursive": "kvstore_get.txt",
+	"sudo cilium kvstore get cilium --recursive": "kvstore_get.txt",
 }
 
 // K8s1VMName is the name of the Kubernetes master node when running K8s tests.

--- a/test/helpers/hubble.go
+++ b/test/helpers/hubble.go
@@ -22,7 +22,7 @@ func (s *SSHMeta) HubbleObserve(args ...string) *CmdRes {
 	if len(args) > 0 {
 		argsCoalesced = strings.Join(args, " ")
 	}
-	hubbleCmd := fmt.Sprintf("hubble observe --server=%q --output=json %s",
+	hubbleCmd := fmt.Sprintf("sudo hubble observe --server=%q --output=json %s",
 		hubbleSock, argsCoalesced)
 	return s.Exec(hubbleCmd)
 }
@@ -37,7 +37,7 @@ func (s *SSHMeta) HubbleObserveFollow(ctx context.Context, args ...string) *CmdR
 	if len(args) > 0 {
 		argsCoalesced = strings.Join(args, " ")
 	}
-	hubbleCmd := fmt.Sprintf("hubble observe --server=%q --follow --output=json %s",
+	hubbleCmd := fmt.Sprintf("sudo hubble observe --server=%q --follow --output=json %s",
 		hubbleSock, argsCoalesced)
 	return s.ExecInBackground(ctx, hubbleCmd)
 }

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -143,11 +143,6 @@ else
         systemctl restart $service || echo "service $service failed to restart"
     done
 
-    echo "running \"sudo adduser ${VMUSER} cilium\" "
-    # Add group explicitly to avoid the case where the group was not added yet
-    getent group cilium >/dev/null || sudo groupadd -r cilium
-    sudo adduser ${VMUSER} cilium
-
     # Download all images needed for runtime tests.
     ./test/provision/container-images.sh test_images test/helpers
 fi

--- a/test/provision/docker-run-cilium.sh
+++ b/test/provision/docker-run-cilium.sh
@@ -52,7 +52,7 @@ if [ -n "$(${SUDO} docker ps -a -q -f label=app=cilium)" ]; then
 fi
 
 echo "Launching Cilium agent $CILIUM_IMAGE with params $CILIUM_OPTS"
-${SUDO} docker run --name cilium $DOCKER_OPTS $CILIUM_IMAGE /bin/bash -c "groupadd -f cilium && cilium-agent $CILIUM_OPTS"
+${SUDO} docker run --name cilium $DOCKER_OPTS $CILIUM_IMAGE cilium-agent $CILIUM_OPTS
 
 # Copy Cilium CLI
 ${SUDO} docker cp cilium:/usr/bin/cilium /usr/bin/

--- a/test/runtime/benchmark.go
+++ b/test/runtime/benchmark.go
@@ -86,8 +86,8 @@ var _ = Describe("BenchmarkNetperfPerformance", func() {
 
 	AfterFailed(func() {
 		vm.ReportFailed(
-			"cilium service list",
-			"cilium policy get")
+			"sudo cilium service list",
+			"sudo cilium policy get")
 	})
 
 	AfterEach(func() {

--- a/test/runtime/chaos_endpoint.go
+++ b/test/runtime/chaos_endpoint.go
@@ -52,8 +52,8 @@ var endpointChaosTest = func() {
 		// Go back and add the identity labels back into the output
 		getSortedLabels := "(.status.identity.labels | sort)"
 		jqCmd := fmt.Sprintf("jq 'map(%s) | map(%s, %s)'", filterHealthEP, filterFields, getSortedLabels)
-		endpointListCmd := fmt.Sprintf("cilium endpoint list -o json | %s", jqCmd)
-		originalEndpointList := vm.Exec(endpointListCmd)
+		endpointListCmd := fmt.Sprintf("endpoint list -o json | %s", jqCmd)
+		originalEndpointList := vm.ExecCilium(endpointListCmd)
 
 		err := vm.RestartCilium()
 		Expect(err).Should(BeNil(), "restarting Cilium failed")
@@ -63,7 +63,7 @@ var endpointChaosTest = func() {
 		http://localhost/v1beta/healthz/ | jq ".ipam.ipv4|length"`)
 		Expect(originalIps.Stdout()).To(Equal(ips.Stdout()))
 
-		EndpointList := vm.Exec(endpointListCmd)
+		EndpointList := vm.ExecCilium(endpointListCmd)
 		By("original: %s", originalEndpointList.Stdout())
 		By("new: %s", EndpointList.Stdout())
 		Expect(EndpointList.Stdout()).To(Equal(originalEndpointList.Stdout()))

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -285,7 +285,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		escapedDomain := strings.Replace(domain, `.`, `\\.`, -1)
 		jqfilter := fmt.Sprintf(`jq -c '.[] | select(.identities|length >= %d) | select(.users|length > 0) | .selector | match("^MatchName: (\\w+\\.%s|), MatchPattern: ([\\w*]+\\.%s|)$") | length > 0'`, minNumIDs, escapedDomain, escapedDomain)
 		body := func() bool {
-			res := vm.Exec(fmt.Sprintf(`cilium policy selectors -o json | %s`, jqfilter))
+			res := vm.ExecCilium(fmt.Sprintf(`policy selectors -o json | %s`, jqfilter))
 			return strings.HasPrefix(res.Stdout(), "true")
 		}
 		err := helpers.WithTimeout(
@@ -355,7 +355,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 	It("Validate dns-proxy monitor information", func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
-		monitorCMD := vm.ExecInBackground(ctx, "cilium monitor --type=l7")
+		monitorCMD := vm.ExecInBackground(ctx, "sudo cilium monitor --type=l7")
 		defer cancel()
 
 		policy := `
@@ -795,7 +795,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		})
 
 		BeforeEach(func() {
-			By("Clearing fqdn cache: %s", vm.Exec("cilium fqdn cache clean -f").CombineOutput().String())
+			By("Clearing fqdn cache: %s", vm.ExecCilium("fqdn cache clean -f").CombineOutput().String())
 		})
 
 		AfterAll(func() {
@@ -869,7 +869,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		})
 
 		BeforeEach(func() {
-			By("Clearing fqdn cache: %s", vm.Exec("cilium fqdn cache clean -f").CombineOutput().String())
+			By("Clearing fqdn cache: %s", vm.ExecCilium("fqdn cache clean -f").CombineOutput().String())
 		})
 
 		AfterAll(func() {
@@ -879,7 +879,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 
 		It("Policy addition after DNS lookup", func() {
 			ctx, cancel := context.WithCancel(context.Background())
-			monitorCMD := vm.ExecInBackground(ctx, "cilium monitor")
+			monitorCMD := vm.ExecInBackground(ctx, "sudo cilium monitor")
 			defer cancel()
 
 			policy := `
@@ -939,7 +939,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 
 		It("L3-dependent L7/HTTP with toFQDN updates proxy policy", func() {
 			ctx, cancel := context.WithCancel(context.Background())
-			monitorCMD := vm.ExecInBackground(ctx, "cilium monitor")
+			monitorCMD := vm.ExecInBackground(ctx, "sudo cilium monitor")
 			defer cancel()
 
 			policy := `

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -168,7 +168,7 @@ var kvstoreChaosTests = func() {
 		_, err := vm.PolicyRenderAndImport(policy)
 		Expect(err).To(BeNil(), "Unable to import policy: %s", err)
 
-		CIDRIdentities := vm.Exec(fmt.Sprintf(`cilium identity list -o json| %s`, jqFilter))
+		CIDRIdentities := vm.ExecCilium(fmt.Sprintf(`identity list -o json| %s`, jqFilter))
 		CIDRIdentities.ExpectSuccess("Cannot get cidr identities")
 
 		for _, identityID := range CIDRIdentities.ByLines() {
@@ -176,7 +176,7 @@ var kvstoreChaosTests = func() {
 			vm.Exec(action).ExpectSuccess("Key %s cannot be deleted correctly", identityID)
 		}
 
-		newCIDRIdentities := vm.Exec(fmt.Sprintf(`cilium identity list -o json| %s`, jqFilter))
+		newCIDRIdentities := vm.ExecCilium(fmt.Sprintf(`identity list -o json| %s`, jqFilter))
 		newCIDRIdentities.ExpectSuccess("Cannot get cidr identities")
 
 		Expect(CIDRIdentities.ByLines()).To(Equal(newCIDRIdentities.ByLines()),

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -105,7 +105,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			monitorConfig()
 
 			ctx, cancel := context.WithCancel(context.Background())
-			res := vm.ExecInBackground(ctx, "cilium monitor -vv")
+			res := vm.ExecInBackground(ctx, "sudo cilium monitor -vv")
 			defer cancel()
 
 			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
@@ -141,7 +141,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
-				res := vm.ExecInBackground(ctx, fmt.Sprintf("cilium monitor --type %s -vv", k))
+				res := vm.ExecInBackground(ctx, fmt.Sprintf("sudo cilium monitor --type %s -vv", k))
 
 				vm.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 				vm.ContainerExec(helpers.App3, helpers.Ping(helpers.Httpd1))
@@ -154,7 +154,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			}
 
 			By("all types together")
-			command := "cilium monitor -vv"
+			command := "sudo cilium monitor -vv"
 			for k := range eventTypes {
 				command = command + " --type " + k
 			}
@@ -191,7 +191,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			defer cancel()
 
 			res := vm.ExecInBackground(ctx, fmt.Sprintf(
-				"cilium monitor --type debug --from %s -vv", endpoints[helpers.App1]))
+				"sudo cilium monitor --type debug --from %s -vv", endpoints[helpers.App1]))
 			vm.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 
 			filter := fmt.Sprintf("FROM %s DEBUG:", endpoints[helpers.App1])
@@ -215,7 +215,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			res := vm.ExecInBackground(ctx, fmt.Sprintf(
-				"cilium monitor -vv --to %s", endpoints[helpers.Httpd1]))
+				"sudo cilium monitor -vv --to %s", endpoints[helpers.Httpd1]))
 
 			vm.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 			vm.ContainerExec(helpers.App2, helpers.Ping(helpers.Httpd1))
@@ -238,7 +238,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			res := vm.ExecInBackground(ctx, fmt.Sprintf(
-				"cilium monitor -vv --related-to %s", endpoints[helpers.Httpd1]))
+				"sudo cilium monitor -vv --related-to %s", endpoints[helpers.Httpd1]))
 
 			vm.WaitEndpointsReady()
 			vm.ContainerExec(helpers.App1, helpers.CurlFail("http://httpd1/public"))
@@ -259,7 +259,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			ctx, cancelfn := context.WithCancel(context.Background())
 
 			for i := 1; i <= 3; i++ {
-				monitorRes = append(monitorRes, vm.ExecInBackground(ctx, "cilium monitor"))
+				monitorRes = append(monitorRes, vm.ExecInBackground(ctx, "sudo cilium monitor"))
 			}
 
 			vm.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
@@ -316,7 +316,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			res := vm.ExecInBackground(ctx, "cilium monitor -vv")
+			res := vm.ExecInBackground(ctx, "sudo cilium monitor -vv")
 
 			vm.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 			vm.ContainerExec(helpers.Httpd1, helpers.Ping(helpers.App1))

--- a/test/runtime/net_policies.go
+++ b/test/runtime/net_policies.go
@@ -1544,7 +1544,7 @@ var _ = Describe("RuntimePolicies", func() {
 				defer cancel()
 
 				By("Starting cilium monitor in background")
-				monitorRes := vm.ExecInBackground(ctx, "cilium monitor --type policy-verdict")
+				monitorRes := vm.ExecInBackground(ctx, "sudo cilium monitor --type policy-verdict")
 
 				By("Creating an endpoint")
 				endpointID, endpointIP := createEndpoint()
@@ -1575,7 +1575,7 @@ var _ = Describe("RuntimePolicies", func() {
 				monitorRes.ExpectContains(auditVerdict, "No ingress policy log record")
 
 				By("Testing cilium endpoint list output")
-				res = vm.Exec("cilium endpoint list")
+				res = vm.ExecCilium("endpoint list")
 				res.ExpectMatchesRegexp(endpointID+"\\s*Disabled \\(Audit\\)\\s*Disabled \\(Audit\\)", "Endpoint is not in audit mode")
 			})
 
@@ -1588,7 +1588,7 @@ var _ = Describe("RuntimePolicies", func() {
 				defer cancel()
 
 				By("Starting cilium monitor in background")
-				monitorRes := vm.ExecInBackground(ctx, "cilium monitor --type policy-verdict")
+				monitorRes := vm.ExecInBackground(ctx, "sudo cilium monitor --type policy-verdict")
 
 				By("Creating an endpoint")
 				endpointID, _ := createEndpoint("ping", hostIP)
@@ -1615,7 +1615,7 @@ var _ = Describe("RuntimePolicies", func() {
 				monitorRes.ExpectContains(auditVerdict, "No egress policy log record")
 
 				By("Testing cilium endpoint list output")
-				res := vm.Exec("cilium endpoint list")
+				res := vm.ExecCilium("endpoint list")
 				res.ExpectMatchesRegexp(endpointID+"\\s*Disabled \\(Audit\\)\\s*Disabled \\(Audit\\)", "Endpoint is not in audit mode")
 			})
 		})
@@ -1900,7 +1900,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 
 		By("Verifying that trace says that %q can reach %q", httpd2Label, httpd1Label)
 
-		res := vm.Exec(fmt.Sprintf(`cilium policy trace -s %s -d %s/TCP --dport 0/ANY`, httpd2Label, httpd1Label))
+		res := vm.ExecCilium(fmt.Sprintf(`policy trace -s %s -d %s/TCP --dport 0/ANY`, httpd2Label, httpd1Label))
 		Expect(res.Stdout()).Should(ContainSubstring(allowedVerdict), "Policy trace did not contain %s", allowedVerdict)
 
 		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
@@ -1964,14 +1964,14 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 		Expect(err).Should(BeNil(), "Error importing policy: %s", err)
 
 		By("Verifying verbose trace for expected output using security identities")
-		res = vm.Exec(fmt.Sprintf(
-			`cilium policy trace --src-identity %d --dst-identity %d --dport 0/ANY`,
+		res = vm.ExecCilium(fmt.Sprintf(
+			`policy trace --src-identity %d --dst-identity %d --dport 0/ANY`,
 			httpd2SecurityIdentity, httpd1SecurityIdentity))
 		res.ExpectContains(allowedVerdict, "Policy trace did not contain %s", allowedVerdict)
 
 		By("Verifying verbose trace for expected output using endpoint IDs")
-		res = vm.Exec(fmt.Sprintf(
-			`cilium policy trace --src-endpoint %s --dst-endpoint %s --dport 0/ANY`,
+		res = vm.ExecCilium(fmt.Sprintf(
+			`policy trace --src-endpoint %s --dst-endpoint %s --dport 0/ANY`,
 			httpd2EndpointID, httpd1EndpointID))
 		res.ExpectContains(allowedVerdict, "Policy trace did not contain %s", allowedVerdict)
 
@@ -2006,7 +2006,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 
 		By("Checking that policy trace returns allowed verdict without any policies imported")
-		res = vm.Exec(fmt.Sprintf(`cilium policy trace --src-endpoint %s --dst-endpoint %s --dport 0/ANY`, httpd2EndpointID, httpd1EndpointID))
+		res = vm.ExecCilium(fmt.Sprintf(`policy trace --src-endpoint %s --dst-endpoint %s --dport 0/ANY`, httpd2EndpointID, httpd1EndpointID))
 		res.ExpectContains(allowedVerdict, "Policy trace did not contain %s", allowedVerdict)
 	})
 })


### PR DESCRIPTION
Since commit 67f74ff43201 ("images/cilium: remove cilium group from
Dockerfile") the cilium group is no longer created in the image running
the agent, resulting in the following log message on cilium-agent start:

```
level=info msg="Group not found" error="group: unknown group cilium" file-path=/var/run/cilium/cilium.sock group=cilium subsys=api
```

Setting the group is no longer necessary, so that part of
`SetDefaultPermissions`.