### PR TITLE
Expose metrics for active FQDN connections per endpoint

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -200,8 +200,21 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 			// Cleanup each endpoint cache, deferring deletions via DNSZombies.
 			endpoints := d.endpointManager.GetEndpoints()
 			for _, ep := range endpoints {
+				epID := ep.StringID()
+				if option.Config.MetricsConfig.FQDNActiveNames || option.Config.MetricsConfig.FQDNActiveIPs {
+					countFQDNs, countIPs := ep.DNSHistory.Count()
+					if option.Config.MetricsConfig.FQDNActiveNames {
+						metrics.FQDNActiveNames.WithLabelValues(epID).Set(float64(countFQDNs))
+					}
+					if option.Config.MetricsConfig.FQDNActiveIPs {
+						metrics.FQDNActiveIPs.WithLabelValues(epID).Set(float64(countIPs))
+					}
+				}
 				namesToClean = append(namesToClean, ep.DNSHistory.GC(GCStart, ep.DNSZombies)...)
 				alive, dead := ep.DNSZombies.GC()
+				if option.Config.MetricsConfig.FQDNActiveZombiesConnections {
+					metrics.FQDNAliveZombieConnections.WithLabelValues(epID).Set(float64(len(alive)))
+				}
 
 				// Alive zombie need to be added to the global cache as name->IP
 				// entries.

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -624,6 +624,25 @@ func (c *DNSCache) Dump() (lookups []*cacheEntry) {
 	return deduped
 }
 
+// Count returns two values, the count of still-valid FQDNs inside the DNS
+// cache and the count of the still-valid entries (IPs) in the DNS cache.
+//
+// The FQDN count returns the length of the DNS cache size.
+//
+// The IP count is not deduplicated, see Dump(). In other words, this value
+// represents an accurate tally of IPs associated with an FQDN in the DNS
+// cache.
+func (c *DNSCache) Count() (uint64, uint64) {
+	c.RLock()
+	defer c.RUnlock()
+
+	var ips uint64
+	for _, entries := range c.forward {
+		ips += uint64(len(entries))
+	}
+	return uint64(len(c.forward)), ips
+}
+
 // MarshalJSON serialises the set of DNS lookup cacheEntries needed to
 // reconstruct this cache instance.
 // Note: Expiration times are honored and the reconstructed cache instance is

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -52,6 +52,9 @@ const (
 	// SubsystemKVStore is the subsystem to scope metrics related to the kvstore.
 	SubsystemKVStore = "kvstore"
 
+	// SubsystemFQDN is the subsystem to scope metrics related to the FQDN proxy.
+	SubsystemFQDN = "fqdn"
+
 	// SubsystemNodes is the subsystem to scope metrics related to the node manager.
 	SubsystemNodes = "nodes"
 
@@ -604,7 +607,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemKVStore + "_operations_duration_seconds":          {},
 		Namespace + "_" + SubsystemKVStore + "_events_queue_seconds":                 {},
 		Namespace + "_" + SubsystemKVStore + "_quorum_errors_total":                  {},
-		Namespace + "_fqdn_gc_deletions_total":                                       {},
+		Namespace + "_" + SubsystemFQDN + "_gc_deletions_total":                      {},
 		Namespace + "_" + SubsystemBPF + "_map_ops_total":                            {},
 		Namespace + "_" + SubsystemTriggers + "_policy_update_total":                 {},
 		Namespace + "_" + SubsystemTriggers + "_policy_update_folds":                 {},
@@ -1136,10 +1139,11 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			collectors = append(collectors, KVStoreQuorumErrors)
 			c.KVStoreQuorumErrorsEnabled = true
 
-		case Namespace + "_fqdn_gc_deletions_total":
+		case Namespace + "_" + SubsystemFQDN + "_gc_deletions_total":
 			FQDNGarbageCollectorCleanedTotal = prometheus.NewCounter(prometheus.CounterOpts{
 				Namespace: Namespace,
-				Name:      "fqdn_gc_deletions_total",
+				Subsystem: SubsystemFQDN,
+				Name:      "gc_deletions_total",
 				Help:      "Number of FQDNs that have been cleaned on FQDN Garbage collector job",
 			})
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -434,6 +434,20 @@ var (
 	// GC job.
 	FQDNGarbageCollectorCleanedTotal = NoOpCounter
 
+	// FQDNActiveNames is the number of domains inside the DNS cache that have
+	// not expired (by TTL), per endpoint.
+	FQDNActiveNames = NoOpGaugeVec
+
+	// FQDNActiveIPs is the number of IPs inside the DNS cache associated with
+	// a domain that has not expired (by TTL) and are currently active, per
+	// endpoint.
+	FQDNActiveIPs = NoOpGaugeVec
+
+	// FQDNAliveZombieConnections is the number IPs associated with domains
+	// that have expired (by TTL) yet still associated with an active
+	// connection (aka zombie), per endpoint.
+	FQDNAliveZombieConnections = NoOpGaugeVec
+
 	// BPFSyscallDuration is the metric for bpf syscalls duration.
 	BPFSyscallDuration = NoOpObserverVec
 
@@ -541,6 +555,9 @@ type Configuration struct {
 	KVStoreEventsQueueDurationEnabled       bool
 	KVStoreQuorumErrorsEnabled              bool
 	FQDNGarbageCollectorCleanedTotalEnabled bool
+	FQDNActiveNames                         bool
+	FQDNActiveIPs                           bool
+	FQDNActiveZombiesConnections            bool
 	BPFSyscallDurationEnabled               bool
 	BPFMapOps                               bool
 	BPFMapPressure                          bool
@@ -1149,6 +1166,39 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, FQDNGarbageCollectorCleanedTotal)
 			c.FQDNGarbageCollectorCleanedTotalEnabled = true
+
+		case Namespace + "_" + SubsystemFQDN + "_active_names":
+			FQDNActiveNames = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemFQDN,
+				Name:      "active_names",
+				Help:      "Number of domains inside the DNS cache that have not expired (by TTL), per endpoint",
+			}, []string{LabelPeerEndpoint})
+
+			collectors = append(collectors, FQDNActiveNames)
+			c.FQDNActiveNames = true
+
+		case Namespace + "_" + SubsystemFQDN + "_active_ips":
+			FQDNActiveIPs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemFQDN,
+				Name:      "active_ips",
+				Help:      "Number of IPs inside the DNS cache associated with a domain that has not expired (by TTL), per endpoint",
+			}, []string{LabelPeerEndpoint})
+
+			collectors = append(collectors, FQDNActiveIPs)
+			c.FQDNActiveIPs = true
+
+		case Namespace + "_" + SubsystemFQDN + "_alive_zombie_connections":
+			FQDNAliveZombieConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemFQDN,
+				Name:      "alive_zombie_connections",
+				Help:      "Number of IPs associated with domains that have expired (by TTL) yet still associated with an active connection (aka zombie), per endpoint",
+			}, []string{LabelPeerEndpoint})
+
+			collectors = append(collectors, FQDNAliveZombieConnections)
+			c.FQDNActiveZombiesConnections = true
 
 		case Namespace + "_" + SubsystemBPF + "_syscall_duration_seconds":
 			BPFSyscallDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
- pkg/fqdn: Provide DNSCache count for metrics collection
- pkg/metrics: Define FQDN subsystem
- daemon, metrics: Expose active FQDN connections per endpoint

See commit msgs.
