### PR TITLE
v1.11 backports 2022-05-17

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -11,7 +11,7 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --agent-health-port int                                   TCP port for agent health status API (default 9876)
+      --agent-health-port int                                   TCP port for agent health status API (default 9879)
       --agent-labels strings                                    Additional labels to identify this agent
       --allocator-list-timeout duration                         Timeout for listing allocator state before exiting (default 3m0s)
       --allow-icmp-frag-needed                                  Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -11,242 +11,244 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --agent-health-port int                                TCP port for agent health status API (default 9876)
-      --agent-labels strings                                 Additional labels to identify this agent
-      --allocator-list-timeout duration                      Timeout for listing allocator state before exiting (default 3m0s)
-      --allow-icmp-frag-needed                               Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
-      --allow-localhost string                               Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
-      --annotate-k8s-node                                    Annotate Kubernetes node (default true)
-      --api-rate-limit map                                   API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
-      --arping-refresh-period duration                       Period for remote node ARP entry refresh (set 0 to disable) (default 30s)
-      --auto-create-cilium-node-resource                     Automatically create CiliumNode resource for own node on startup (default true)
-      --auto-direct-node-routes                              Enable automatic L2 routing between nodes
-      --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
-      --bgp-announce-pod-cidr                                Announces the node's pod CIDR via BGP
-      --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
-      --bpf-ct-global-any-max int                            Maximum number of entries in non-TCP CT table (default 262144)
-      --bpf-ct-global-tcp-max int                            Maximum number of entries in TCP CT table (default 524288)
-      --bpf-ct-timeout-regular-any duration                  Timeout for entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-regular-tcp duration                  Timeout for established entries in TCP CT table (default 6h0m0s)
-      --bpf-ct-timeout-regular-tcp-fin duration              Teardown timeout for entries in TCP CT table (default 10s)
-      --bpf-ct-timeout-regular-tcp-syn duration              Establishment timeout for entries in TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-any duration                  Timeout for service entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-tcp duration                  Timeout for established service entries in TCP CT table (default 6h0m0s)
-      --bpf-fragments-map-max int                            Maximum number of entries in fragments tracking map (default 8192)
-      --bpf-lb-acceleration string                           BPF load balancing acceleration via XDP ("native", "disabled") (default "disabled")
-      --bpf-lb-algorithm string                              BPF load balancing algorithm ("random", "maglev") (default "random")
-      --bpf-lb-dev-ip-addr-inherit string                    Device name which IP addr is inherited by devices running LB BPF program (--devices)
-      --bpf-lb-dsr-dispatch string                           BPF load balancing DSR dispatch method ("opt", "ipip") (default "opt")
-      --bpf-lb-dsr-l4-xlate string                           BPF load balancing DSR L4 DNAT method for IPIP ("frontend", "backend") (default "frontend")
-      --bpf-lb-external-clusterip                            Enable external access to ClusterIP services (default false)
-      --bpf-lb-maglev-hash-seed string                       Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
-      --bpf-lb-maglev-table-size uint                        Maglev per service backend table size (parameter M) (default 16381)
-      --bpf-lb-map-max int                                   Maximum number of entries in Cilium BPF lbmap (default 65536)
-      --bpf-lb-mode string                                   BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
-      --bpf-lb-rss-ipv4-src-cidr string                      BPF load balancing RSS outer source IPv4 CIDR prefix for IPIP
-      --bpf-lb-rss-ipv6-src-cidr string                      BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP
-      --bpf-lb-sock-hostns-only                              Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).
-      --bpf-map-dynamic-size-ratio float                     Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
-      --bpf-nat-global-max int                               Maximum number of entries for the global BPF NAT table (default 524288)
-      --bpf-neigh-global-max int                             Maximum number of entries for the global BPF neighbor table (default 524288)
-      --bpf-policy-map-max int                               Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
-      --bpf-root string                                      Path to BPF filesystem
-      --bpf-sock-rev-map-max int                             Maximum number of entries for the SockRevNAT BPF map (default 262144)
-      --certificates-directory string                        Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cgroup-root string                                   Path to Cgroup2 filesystem
-      --cluster-health-port int                              TCP port for cluster-wide network connectivity health API (default 4240)
-      --cluster-id int                                       Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster (default "default")
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --conntrack-gc-interval duration                       Overwrite the connection-tracking garbage collection interval
-      --crd-wait-timeout duration                            Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
-      --datapath-mode string                                 Datapath mode name (default "veth")
-  -D, --debug                                                Enable debugging mode
-      --debug-verbose strings                                List of enabled verbose debug groups
-      --devices strings                                      List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
-      --direct-routing-device string                         Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF fast redirect; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
-      --disable-cnp-status-updates                           Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)
-      --disable-conntrack                                    Disable connection tracking
-      --disable-endpoint-crd                                 Disable use of CiliumEndpoint CRD
-      --disable-iptables-feeder-rules strings                Chains to ignore when installing feeder rules.
-      --dns-max-ips-per-restored-rule int                    Maximum number of IPs to maintain for each restored DNS rule (default 1000)
-      --egress-masquerade-interfaces string                  Limit egress masquerading to interface selector
-      --egress-multi-home-ip-rule-compat                     Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
-      --enable-auto-protect-node-port-range                  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
-      --enable-bandwidth-manager                             Enable BPF bandwidth manager
-      --enable-bpf-clock-probe                               Enable BPF clock source probing for more efficient tick retrieval
-      --enable-bpf-masquerade                                Masquerade packets from endpoints leaving the host with BPF instead of iptables
-      --enable-bpf-tproxy                                    Enable BPF-based proxy redirection, if support available
-      --enable-cilium-endpoint-slice                         If set to true, CiliumEndpointSlice feature is enabled and cilium agent watch for CiliumEndpointSlice instead of CiliumEndpoint to update the IPCache.
-      --enable-custom-calls                                  Enable tail call hooks for custom eBPF programs
-      --enable-endpoint-health-checking                      Enable connectivity health checking between virtual endpoints (default true)
-      --enable-endpoint-routes                               Use per endpoint routes instead of routing via cilium_host
-      --enable-external-ips                                  Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
-      --enable-health-check-nodeport                         Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
-      --enable-health-checking                               Enable connectivity health checking (default true)
-      --enable-host-firewall                                 Enable host network policies
-      --enable-host-legacy-routing                           Enable the legacy host forwarding model which does not bypass upper stack in host namespace
-      --enable-host-port                                     Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
-      --enable-host-reachable-services                       Enable reachability of services for host applications
-      --enable-hubble                                        Enable hubble server
-      --enable-hubble-recorder-api                           Enable the Hubble recorder API (default true)
-      --enable-identity-mark                                 Enable setting identity mark for local traffic (default true)
-      --enable-ip-masq-agent                                 Enable BPF ip-masq-agent
-      --enable-ipsec                                         Enable IPSec support
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv4-egress-gateway                           Enable egress gateway for IPv4
-      --enable-ipv4-fragment-tracking                        Enable IPv4 fragments tracking for L4-based lookups (default true)
-      --enable-ipv4-masquerade                               Masquerade IPv4 traffic from endpoints leaving the host (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-ipv6-masquerade                               Masquerade IPv6 traffic from endpoints leaving the host (default true)
-      --enable-ipv6-ndp                                      Enable IPv6 NDP support
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-k8s-event-handover                            Enable k8s event handover to kvstore for improved scalability
-      --enable-k8s-terminating-endpoint                      Enable auto-detect of terminating endpoint condition (default true)
-      --enable-l2-neigh-discovery                            Enables L2 neighbor discovery used by kube-proxy-replacement and IPsec (default true)
-      --enable-l7-proxy                                      Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-local-node-route                              Enable installation of the route which points the allocation prefix of the local node (default true)
-      --enable-local-redirect-policy                         Enable Local Redirect Policy
-      --enable-monitor                                       Enable the monitor unix domain socket server (default true)
-      --enable-node-port                                     Enable NodePort type services by Cilium
-      --enable-policy string                                 Enable policy enforcement (default "default")
-      --enable-recorder                                      Enable BPF datapath pcap recorder
-      --enable-remote-node-identity                          Enable use of remote node identity
-      --enable-service-topology                              Enable support for service topology aware hints
-      --enable-session-affinity                              Enable support for service session affinity
-      --enable-svc-source-range-check                        Enable check of service source ranges (currently, only for LoadBalancer) (default true)
-      --enable-tracing                                       Enable tracing while determining policy (debugging)
-      --enable-well-known-identities                         Enable well-known identities for known Kubernetes components (default true)
-      --enable-wireguard                                     Enable wireguard
-      --enable-wireguard-userspace-fallback                  Enables the fallback to the wireguard userspace implementation
-      --enable-xdp-prefilter                                 Enable XDP prefiltering
-      --enable-xt-socket-fallback                            Enable fallback for missing xt_socket module (default true)
-      --encrypt-interface string                             Transparent encryption interface
-      --encrypt-node                                         Enables encrypting traffic from non-Cilium pods and host networking
-      --endpoint-interface-name-prefix string                Prefix of interface name shared by all endpoints (default "lxc+")
-      --endpoint-queue-size int                              size of EventQueue per-endpoint (default 25)
-      --endpoint-status strings                              Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
-      --envoy-log string                                     Path to a separate Envoy log file, if any
-      --exclude-local-address strings                        Exclude CIDR from being recognized as local address
-      --fixed-identity-mapping map                           Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns
-      --force-local-policy-eval-at-source                    Force policy evaluation of all local communication at the source endpoint (default true)
-      --gops-port int                                        Port for gops server to listen on (default 9890)
-  -h, --help                                                 help for cilium-agent
-      --host-reachable-services-protos strings               Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
-      --http-idle-timeout uint                               Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
-      --http-max-grpc-timeout uint                           Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
-      --http-normalize-path                                  Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution. (default true)
-      --http-request-timeout uint                            Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
-      --http-retry-count uint                                Number of retries performed after a forwarded request attempt fails (default 3)
-      --http-retry-timeout uint                              Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
-      --hubble-disable-tls                                   Allow Hubble server to run on the given listen address without TLS.
-      --hubble-event-buffer-capacity int                     Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
-      --hubble-event-queue-size int                          Buffer size of the channel to receive monitor events.
-      --hubble-export-file-compress                          Compress rotated Hubble export files.
-      --hubble-export-file-max-backups int                   Number of rotated Hubble export files to keep. (default 5)
-      --hubble-export-file-max-size-mb int                   Size in MB at which to rotate Hubble export file. (default 10)
-      --hubble-export-file-path string                       Filepath to write Hubble events to.
-      --hubble-listen-address string                         An additional address for Hubble server to listen to, e.g. ":4244"
-      --hubble-metrics strings                               List of Hubble metrics to enable.
-      --hubble-metrics-server string                         Address to serve Hubble metrics on.
-      --hubble-recorder-sink-queue-size int                  Queue size of each Hubble recorder sink (default 1024)
-      --hubble-recorder-storage-path string                  Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")
-      --hubble-socket-path string                            Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
-      --hubble-tls-cert-file string                          Path to the public key file for the Hubble server. The file must contain PEM encoded data.
-      --hubble-tls-client-ca-files strings                   Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --hubble-tls-key-file string                           Path to the private key file for the Hubble server. The file must contain PEM encoded data.
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-change-grace-period duration                Time to wait before using new identity on endpoint identity change (default 5s)
-      --identity-restore-grace-period duration               Time to wait before releasing unused restored CIDR identities during agent restart (default 10m0s)
-      --install-iptables-rules                               Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
-      --install-no-conntrack-iptables-rules                  Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
-      --ip-allocation-timeout duration                       Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
-      --ip-masq-agent-config-path string                     ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
-      --ipam string                                          Backend to use for IPAM (default "cluster-pool")
-      --ipsec-key-file string                                Path to IPSec key file
-      --iptables-lock-timeout duration                       Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
-      --iptables-random-fully                                Set iptables flag random-fully on masquerading rules
-      --ipv4-native-routing-cidr string                      Allows to explicitly specify the IPv4 CIDR for native routing. This value corresponds to the configured cluster-cidr.
-      --ipv4-node string                                     IPv4 address of node (default "auto")
-      --ipv4-pod-subnets strings                             List of IPv4 pod subnets to preconfigure for encryption
-      --ipv4-range string                                    Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
-      --ipv4-service-loopback-address string                 IPv4 address for service loopback SNAT (default "169.254.42.1")
-      --ipv4-service-range string                            Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
-      --ipv6-cluster-alloc-cidr string                       IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
-      --ipv6-mcast-device string                             Device that joins a Solicited-Node multicast group for IPv6
-      --ipv6-node string                                     IPv6 address of node (default "auto")
-      --ipv6-pod-subnets strings                             List of IPv6 pod subnets to preconfigure for encryption
-      --ipv6-range string                                    Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
-      --ipv6-service-range string                            Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
-      --join-cluster                                         Join a Cilium cluster via kvstore registration
-      --k8s-api-server string                                Kubernetes API server URL
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium is deployed in
-      --k8s-require-ipv4-pod-cidr                            Require IPv4 PodCIDR to be specified in node resource
-      --k8s-require-ipv6-pod-cidr                            Require IPv6 PodCIDR to be specified in node resource
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --k8s-watcher-endpoint-selector string                 K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
-      --keep-config                                          When restoring state, keeps containers' configuration in place
-      --kube-proxy-replacement string                        auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
-      --kube-proxy-replacement-healthz-bind-address string   The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
-      --kvstore string                                       Key-value store type
-      --kvstore-connectivity-timeout duration                Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
-      --kvstore-max-consecutive-quorum-errors int            Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure (default 2)
-      --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --kvstore-periodic-sync duration                       Periodic KVstore synchronization interval (default 5m0s)
-      --label-prefix-file string                             Valid label prefixes file path
-      --labels strings                                       List of label prefixes used to determine identity of an endpoint
-      --lib-dir string                                       Directory path to store runtime build environment (default "/var/lib/cilium")
-      --local-router-ipv4 string                             Link-local IPv4 used for Cilium's router devices
-      --local-router-ipv6 string                             Link-local IPv6 used for Cilium's router devices
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
-      --log-system-load                                      Enable periodic logging of system load
-      --metrics strings                                      Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
-      --monitor-aggregation string                           Level of monitor aggregation for traces from the datapath (default "None")
-      --monitor-aggregation-flags strings                    TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
-      --monitor-aggregation-interval duration                Monitor report interval when monitor aggregation is enabled (default 5s)
-      --monitor-queue-size int                               Size of the event queue when reading monitor events
-      --mtu int                                              Overwrite auto-detected MTU of underlying network
-      --nat46-range string                                   IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
-      --node-port-bind-protection                            Reject application bind(2) requests to service ports in the NodePort range (default true)
-      --node-port-range strings                              Set the min/max NodePort port range (default [30000,32767])
-      --policy-audit-mode                                    Enable policy audit (non-drop) mode
-      --policy-queue-size int                                size of queues for policy-related events (default 100)
-      --pprof                                                Enable serving the pprof debugging API
-      --pprof-port int                                       Port that the pprof listens on (default 6060)
-      --preallocate-bpf-maps                                 Enable BPF map pre-allocation (default true)
-      --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
-      --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
-      --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
-      --proxy-gid uint                                       Group ID for proxy control plane sockets. (default 1337)
-      --proxy-prometheus-port int                            Port to serve Envoy metrics on. Default 0 (disabled).
-      --read-cni-conf string                                 Read to the CNI configuration at specified path to extract per node configuration
-      --restore                                              Restores state, if possible, from previous daemon (default true)
-      --route-metric int                                     Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
-      --sidecar-istio-proxy-image string                     Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
-      --single-cluster-route                                 Use a single cluster route instead of per node routes
-      --socket-path string                                   Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
-      --sockops-enable                                       Enable sockops when kernel supported
-      --state-dir string                                     Directory path to store runtime state (default "/var/run/cilium")
-      --tofqdns-dns-reject-response-code string              DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
-      --tofqdns-enable-dns-compression                       Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
-      --tofqdns-endpoint-max-ip-per-hostname int             Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
-      --tofqdns-idle-connection-grace-period duration        Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)
-      --tofqdns-max-deferred-connection-deletes int          Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
-      --tofqdns-min-ttl int                                  The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
-      --tofqdns-pre-cache string                             DNS cache data at this path is preloaded on agent startup
-      --tofqdns-proxy-port int                               Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
-      --tofqdns-proxy-response-max-delay duration            The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
-      --trace-payloadlen int                                 Length of payload to capture when tracing (default 128)
-  -t, --tunnel string                                        Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
-      --tunnel-port int                                      Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
-      --version                                              Print version information
-      --vlan-bpf-bypass ints                                 List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs
-      --write-cni-conf-when-ready string                     Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
+      --agent-health-port int                                   TCP port for agent health status API (default 9876)
+      --agent-labels strings                                    Additional labels to identify this agent
+      --allocator-list-timeout duration                         Timeout for listing allocator state before exiting (default 3m0s)
+      --allow-icmp-frag-needed                                  Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
+      --allow-localhost string                                  Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
+      --annotate-k8s-node                                       Annotate Kubernetes node (default true)
+      --api-rate-limit map                                      API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
+      --arping-refresh-period duration                          Period for remote node ARP entry refresh (set 0 to disable) (default 30s)
+      --auto-create-cilium-node-resource                        Automatically create CiliumNode resource for own node on startup (default true)
+      --auto-direct-node-routes                                 Enable automatic L2 routing between nodes
+      --bgp-announce-lb-ip                                      Announces service IPs of type LoadBalancer via BGP
+      --bgp-announce-pod-cidr                                   Announces the node's pod CIDR via BGP
+      --bgp-config-path string                                  Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --bpf-ct-global-any-max int                               Maximum number of entries in non-TCP CT table (default 262144)
+      --bpf-ct-global-tcp-max int                               Maximum number of entries in TCP CT table (default 524288)
+      --bpf-ct-timeout-regular-any duration                     Timeout for entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-regular-tcp duration                     Timeout for established entries in TCP CT table (default 6h0m0s)
+      --bpf-ct-timeout-regular-tcp-fin duration                 Teardown timeout for entries in TCP CT table (default 10s)
+      --bpf-ct-timeout-regular-tcp-syn duration                 Establishment timeout for entries in TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-any duration                     Timeout for service entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-tcp duration                     Timeout for established service entries in TCP CT table (default 6h0m0s)
+      --bpf-fragments-map-max int                               Maximum number of entries in fragments tracking map (default 8192)
+      --bpf-lb-acceleration string                              BPF load balancing acceleration via XDP ("native", "disabled") (default "disabled")
+      --bpf-lb-algorithm string                                 BPF load balancing algorithm ("random", "maglev") (default "random")
+      --bpf-lb-dev-ip-addr-inherit string                       Device name which IP addr is inherited by devices running LB BPF program (--devices)
+      --bpf-lb-dsr-dispatch string                              BPF load balancing DSR dispatch method ("opt", "ipip") (default "opt")
+      --bpf-lb-dsr-l4-xlate string                              BPF load balancing DSR L4 DNAT method for IPIP ("frontend", "backend") (default "frontend")
+      --bpf-lb-external-clusterip                               Enable external access to ClusterIP services (default false)
+      --bpf-lb-maglev-hash-seed string                          Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
+      --bpf-lb-maglev-table-size uint                           Maglev per service backend table size (parameter M) (default 16381)
+      --bpf-lb-map-max int                                      Maximum number of entries in Cilium BPF lbmap (default 65536)
+      --bpf-lb-mode string                                      BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
+      --bpf-lb-rss-ipv4-src-cidr string                         BPF load balancing RSS outer source IPv4 CIDR prefix for IPIP
+      --bpf-lb-rss-ipv6-src-cidr string                         BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP
+      --bpf-lb-sock-hostns-only                                 Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).
+      --bpf-map-dynamic-size-ratio float                        Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
+      --bpf-nat-global-max int                                  Maximum number of entries for the global BPF NAT table (default 524288)
+      --bpf-neigh-global-max int                                Maximum number of entries for the global BPF neighbor table (default 524288)
+      --bpf-policy-map-max int                                  Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
+      --bpf-root string                                         Path to BPF filesystem
+      --bpf-sock-rev-map-max int                                Maximum number of entries for the SockRevNAT BPF map (default 262144)
+      --certificates-directory string                           Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cgroup-root string                                      Path to Cgroup2 filesystem
+      --cluster-health-port int                                 TCP port for cluster-wide network connectivity health API (default 4240)
+      --cluster-id int                                          Unique identifier of the cluster
+      --cluster-name string                                     Name of the cluster (default "default")
+      --clustermesh-config string                               Path to the ClusterMesh configuration directory
+      --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                       Configuration directory that contains a file for each option
+      --conntrack-gc-interval duration                          Overwrite the connection-tracking garbage collection interval
+      --crd-wait-timeout duration                               Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
+      --datapath-mode string                                    Datapath mode name (default "veth")
+  -D, --debug                                                   Enable debugging mode
+      --debug-verbose strings                                   List of enabled verbose debug groups
+      --devices strings                                         List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
+      --direct-routing-device string                            Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF fast redirect; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
+      --disable-cnp-status-updates                              Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)
+      --disable-conntrack                                       Disable connection tracking
+      --disable-endpoint-crd                                    Disable use of CiliumEndpoint CRD
+      --disable-iptables-feeder-rules strings                   Chains to ignore when installing feeder rules.
+      --dns-max-ips-per-restored-rule int                       Maximum number of IPs to maintain for each restored DNS rule (default 1000)
+      --dnsproxy-concurrency-limit int                          Limit concurrency of DNS message processing
+      --dnsproxy-concurrency-processing-grace-period duration   Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing
+      --egress-masquerade-interfaces string                     Limit egress masquerading to interface selector
+      --egress-multi-home-ip-rule-compat                        Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
+      --enable-auto-protect-node-port-range                     Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
+      --enable-bandwidth-manager                                Enable BPF bandwidth manager
+      --enable-bpf-clock-probe                                  Enable BPF clock source probing for more efficient tick retrieval
+      --enable-bpf-masquerade                                   Masquerade packets from endpoints leaving the host with BPF instead of iptables
+      --enable-bpf-tproxy                                       Enable BPF-based proxy redirection, if support available
+      --enable-cilium-endpoint-slice                            If set to true, CiliumEndpointSlice feature is enabled and cilium agent watch for CiliumEndpointSlice instead of CiliumEndpoint to update the IPCache.
+      --enable-custom-calls                                     Enable tail call hooks for custom eBPF programs
+      --enable-endpoint-health-checking                         Enable connectivity health checking between virtual endpoints (default true)
+      --enable-endpoint-routes                                  Use per endpoint routes instead of routing via cilium_host
+      --enable-external-ips                                     Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
+      --enable-health-check-nodeport                            Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
+      --enable-health-checking                                  Enable connectivity health checking (default true)
+      --enable-host-firewall                                    Enable host network policies
+      --enable-host-legacy-routing                              Enable the legacy host forwarding model which does not bypass upper stack in host namespace
+      --enable-host-port                                        Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
+      --enable-host-reachable-services                          Enable reachability of services for host applications
+      --enable-hubble                                           Enable hubble server
+      --enable-hubble-recorder-api                              Enable the Hubble recorder API (default true)
+      --enable-identity-mark                                    Enable setting identity mark for local traffic (default true)
+      --enable-ip-masq-agent                                    Enable BPF ip-masq-agent
+      --enable-ipsec                                            Enable IPSec support
+      --enable-ipv4                                             Enable IPv4 support (default true)
+      --enable-ipv4-egress-gateway                              Enable egress gateway for IPv4
+      --enable-ipv4-fragment-tracking                           Enable IPv4 fragments tracking for L4-based lookups (default true)
+      --enable-ipv4-masquerade                                  Masquerade IPv4 traffic from endpoints leaving the host (default true)
+      --enable-ipv6                                             Enable IPv6 support (default true)
+      --enable-ipv6-masquerade                                  Masquerade IPv6 traffic from endpoints leaving the host (default true)
+      --enable-ipv6-ndp                                         Enable IPv6 NDP support
+      --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                               Enable k8s event handover to kvstore for improved scalability
+      --enable-k8s-terminating-endpoint                         Enable auto-detect of terminating endpoint condition (default true)
+      --enable-l2-neigh-discovery                               Enables L2 neighbor discovery used by kube-proxy-replacement and IPsec (default true)
+      --enable-l7-proxy                                         Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-local-node-route                                 Enable installation of the route which points the allocation prefix of the local node (default true)
+      --enable-local-redirect-policy                            Enable Local Redirect Policy
+      --enable-monitor                                          Enable the monitor unix domain socket server (default true)
+      --enable-node-port                                        Enable NodePort type services by Cilium
+      --enable-policy string                                    Enable policy enforcement (default "default")
+      --enable-recorder                                         Enable BPF datapath pcap recorder
+      --enable-remote-node-identity                             Enable use of remote node identity
+      --enable-service-topology                                 Enable support for service topology aware hints
+      --enable-session-affinity                                 Enable support for service session affinity
+      --enable-svc-source-range-check                           Enable check of service source ranges (currently, only for LoadBalancer) (default true)
+      --enable-tracing                                          Enable tracing while determining policy (debugging)
+      --enable-well-known-identities                            Enable well-known identities for known Kubernetes components (default true)
+      --enable-wireguard                                        Enable wireguard
+      --enable-wireguard-userspace-fallback                     Enables the fallback to the wireguard userspace implementation
+      --enable-xdp-prefilter                                    Enable XDP prefiltering
+      --enable-xt-socket-fallback                               Enable fallback for missing xt_socket module (default true)
+      --encrypt-interface string                                Transparent encryption interface
+      --encrypt-node                                            Enables encrypting traffic from non-Cilium pods and host networking
+      --endpoint-interface-name-prefix string                   Prefix of interface name shared by all endpoints (default "lxc+")
+      --endpoint-queue-size int                                 size of EventQueue per-endpoint (default 25)
+      --endpoint-status strings                                 Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
+      --envoy-log string                                        Path to a separate Envoy log file, if any
+      --exclude-local-address strings                           Exclude CIDR from being recognized as local address
+      --fixed-identity-mapping map                              Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns
+      --force-local-policy-eval-at-source                       Force policy evaluation of all local communication at the source endpoint (default true)
+      --gops-port int                                           Port for gops server to listen on (default 9890)
+  -h, --help                                                    help for cilium-agent
+      --host-reachable-services-protos strings                  Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
+      --http-idle-timeout uint                                  Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
+      --http-max-grpc-timeout uint                              Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
+      --http-normalize-path                                     Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution. (default true)
+      --http-request-timeout uint                               Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
+      --http-retry-count uint                                   Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                 Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
+      --hubble-disable-tls                                      Allow Hubble server to run on the given listen address without TLS.
+      --hubble-event-buffer-capacity int                        Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
+      --hubble-event-queue-size int                             Buffer size of the channel to receive monitor events.
+      --hubble-export-file-compress                             Compress rotated Hubble export files.
+      --hubble-export-file-max-backups int                      Number of rotated Hubble export files to keep. (default 5)
+      --hubble-export-file-max-size-mb int                      Size in MB at which to rotate Hubble export file. (default 10)
+      --hubble-export-file-path string                          Filepath to write Hubble events to.
+      --hubble-listen-address string                            An additional address for Hubble server to listen to, e.g. ":4244"
+      --hubble-metrics strings                                  List of Hubble metrics to enable.
+      --hubble-metrics-server string                            Address to serve Hubble metrics on.
+      --hubble-recorder-sink-queue-size int                     Queue size of each Hubble recorder sink (default 1024)
+      --hubble-recorder-storage-path string                     Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")
+      --hubble-socket-path string                               Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
+      --hubble-tls-cert-file string                             Path to the public key file for the Hubble server. The file must contain PEM encoded data.
+      --hubble-tls-client-ca-files strings                      Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --hubble-tls-key-file string                              Path to the private key file for the Hubble server. The file must contain PEM encoded data.
+      --identity-allocation-mode string                         Method to use for identity allocation (default "kvstore")
+      --identity-change-grace-period duration                   Time to wait before using new identity on endpoint identity change (default 5s)
+      --identity-restore-grace-period duration                  Time to wait before releasing unused restored CIDR identities during agent restart (default 10m0s)
+      --install-iptables-rules                                  Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
+      --install-no-conntrack-iptables-rules                     Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
+      --ip-allocation-timeout duration                          Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
+      --ip-masq-agent-config-path string                        ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
+      --ipam string                                             Backend to use for IPAM (default "cluster-pool")
+      --ipsec-key-file string                                   Path to IPSec key file
+      --iptables-lock-timeout duration                          Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
+      --iptables-random-fully                                   Set iptables flag random-fully on masquerading rules
+      --ipv4-native-routing-cidr string                         Allows to explicitly specify the IPv4 CIDR for native routing. This value corresponds to the configured cluster-cidr.
+      --ipv4-node string                                        IPv4 address of node (default "auto")
+      --ipv4-pod-subnets strings                                List of IPv4 pod subnets to preconfigure for encryption
+      --ipv4-range string                                       Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
+      --ipv4-service-loopback-address string                    IPv4 address for service loopback SNAT (default "169.254.42.1")
+      --ipv4-service-range string                               Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
+      --ipv6-cluster-alloc-cidr string                          IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
+      --ipv6-mcast-device string                                Device that joins a Solicited-Node multicast group for IPv6
+      --ipv6-node string                                        IPv6 address of node (default "auto")
+      --ipv6-pod-subnets strings                                List of IPv6 pod subnets to preconfigure for encryption
+      --ipv6-range string                                       Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
+      --ipv6-service-range string                               Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
+      --join-cluster                                            Join a Cilium cluster via kvstore registration
+      --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                    Name of the Kubernetes namespace in which Cilium is deployed in
+      --k8s-require-ipv4-pod-cidr                               Require IPv4 PodCIDR to be specified in node resource
+      --k8s-require-ipv6-pod-cidr                               Require IPv6 PodCIDR to be specified in node resource
+      --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --k8s-watcher-endpoint-selector string                    K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
+      --keep-config                                             When restoring state, keeps containers' configuration in place
+      --kube-proxy-replacement string                           auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
+      --kube-proxy-replacement-healthz-bind-address string      The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
+      --kvstore string                                          Key-value store type
+      --kvstore-connectivity-timeout duration                   Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
+      --kvstore-max-consecutive-quorum-errors int               Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure (default 2)
+      --kvstore-opt map                                         Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --kvstore-periodic-sync duration                          Periodic KVstore synchronization interval (default 5m0s)
+      --label-prefix-file string                                Valid label prefixes file path
+      --labels strings                                          List of label prefixes used to determine identity of an endpoint
+      --lib-dir string                                          Directory path to store runtime build environment (default "/var/lib/cilium")
+      --local-router-ipv4 string                                Link-local IPv4 used for Cilium's router devices
+      --local-router-ipv6 string                                Link-local IPv6 used for Cilium's router devices
+      --log-driver strings                                      Logging endpoints to use for example syslog
+      --log-opt map                                             Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
+      --log-system-load                                         Enable periodic logging of system load
+      --metrics strings                                         Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
+      --monitor-aggregation string                              Level of monitor aggregation for traces from the datapath (default "None")
+      --monitor-aggregation-flags strings                       TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
+      --monitor-aggregation-interval duration                   Monitor report interval when monitor aggregation is enabled (default 5s)
+      --monitor-queue-size int                                  Size of the event queue when reading monitor events
+      --mtu int                                                 Overwrite auto-detected MTU of underlying network
+      --nat46-range string                                      IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
+      --node-port-bind-protection                               Reject application bind(2) requests to service ports in the NodePort range (default true)
+      --node-port-range strings                                 Set the min/max NodePort port range (default [30000,32767])
+      --policy-audit-mode                                       Enable policy audit (non-drop) mode
+      --policy-queue-size int                                   size of queues for policy-related events (default 100)
+      --pprof                                                   Enable serving the pprof debugging API
+      --pprof-port int                                          Port that the pprof listens on (default 6060)
+      --preallocate-bpf-maps                                    Enable BPF map pre-allocation (default true)
+      --prepend-iptables-chains                                 Prepend custom iptables chains instead of appending (default true)
+      --prometheus-serve-addr string                            IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-connect-timeout uint                              Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-gid uint                                          Group ID for proxy control plane sockets. (default 1337)
+      --proxy-prometheus-port int                               Port to serve Envoy metrics on. Default 0 (disabled).
+      --read-cni-conf string                                    Read to the CNI configuration at specified path to extract per node configuration
+      --restore                                                 Restores state, if possible, from previous daemon (default true)
+      --route-metric int                                        Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
+      --sidecar-istio-proxy-image string                        Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
+      --single-cluster-route                                    Use a single cluster route instead of per node routes
+      --socket-path string                                      Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
+      --sockops-enable                                          Enable sockops when kernel supported
+      --state-dir string                                        Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdns-dns-reject-response-code string                 DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
+      --tofqdns-enable-dns-compression                          Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
+      --tofqdns-endpoint-max-ip-per-hostname int                Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
+      --tofqdns-idle-connection-grace-period duration           Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)
+      --tofqdns-max-deferred-connection-deletes int             Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
+      --tofqdns-min-ttl int                                     The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
+      --tofqdns-pre-cache string                                DNS cache data at this path is preloaded on agent startup
+      --tofqdns-proxy-port int                                  Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+      --tofqdns-proxy-response-max-delay duration               The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
+      --trace-payloadlen int                                    Length of payload to capture when tracing (default 128)
+  -t, --tunnel string                                           Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
+      --tunnel-port int                                         Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
+      --version                                                 Print version information
+      --vlan-bpf-bypass ints                                    List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs
+      --write-cni-conf-when-ready string                        Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
 ```
 

--- a/Documentation/gettingstarted/clustermesh/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh/clustermesh.rst
@@ -43,7 +43,7 @@ Specify the Cluster Name and ID
 ===============================
 
 Each cluster must be assigned a unique human-readable name as well as a numeric
-cluster ID (0-255). It is best to assign both these attributes at installation
+cluster ID (1-255). It is best to assign both these attributes at installation
 time of Cilium:
 
  * ConfigMap options ``cluster-name`` and ``cluster-id``

--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -113,7 +113,7 @@ interface as follows:
 
        .. code-block:: shell-session
 
-          cilium install --encryption ipsec --config encryption-interface=ethX
+          cilium install --encryption ipsec --config encrypt-interface=ethX
 
     .. group-tab:: Helm
 

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -568,7 +568,7 @@
    * - healthPort
      - TCP port for the agent health API. This is not the port for cilium-health.
      - int
-     - ``9876``
+     - ``9879``
    * - hostFirewall
      - Configure the host firewall.
      - object

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -374,7 +374,7 @@ Port Range / Protocol    Description
 6062/tcp                 Hubble Relay pprof server (listening on 127.0.0.1)
 6942/tcp                 operator Prometheus metrics
 9090/tcp                 cilium-agent Prometheus metrics
-9876/tcp                 cilium-agent health status API (listening on 127.0.0.1 and/or ::1)
+9879/tcp                 cilium-agent health status API (listening on 127.0.0.1 and/or ::1)
 9890/tcp                 cilium-agent gops server (listening on 127.0.0.1)
 9891/tcp                 operator gops server (listening on 127.0.0.1)
 9892/tcp                 clustermesh-apiserver gops server (listening on 127.0.0.1)

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -363,9 +363,9 @@ ICMP 8/0                 egress          ``worker-sg`` (self) health checks
 
 The following ports should also be available on each node:
 
-======================== ===========================================================
+======================== ==================================================================
 Port Range / Protocol    Description
-======================== ===========================================================
+======================== ==================================================================
 4240/tcp                 cluster health checks (``cilium-health``)
 4244/tcp                 Hubble server
 4245/tcp                 Hubble Relay
@@ -374,13 +374,13 @@ Port Range / Protocol    Description
 6062/tcp                 Hubble Relay pprof server (listening on 127.0.0.1)
 6942/tcp                 operator Prometheus metrics
 9090/tcp                 cilium-agent Prometheus metrics
-9876/tcp                 cilium-agent health status API
+9876/tcp                 cilium-agent health status API (listening on 127.0.0.1 and/or ::1)
 9890/tcp                 cilium-agent gops server (listening on 127.0.0.1)
 9891/tcp                 operator gops server (listening on 127.0.0.1)
 9892/tcp                 clustermesh-apiserver gops server (listening on 127.0.0.1)
 9893/tcp                 Hubble Relay gops server (listening on 127.0.0.1)
 51871/udp                WireGuard encryption tunnel endpoint
-======================== ===========================================================
+======================== ==================================================================
 
 .. _admin_mount_bpffs:
 

--- a/cilium/cmd/policy.go
+++ b/cilium/cmd/policy.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -34,6 +35,14 @@ var (
 
 func init() {
 	rootCmd.AddCommand(policyCmd)
+
+	// Initialize LRU here because the policy subcommands (validate, import)
+	// will call down to sanitizing the FQDN rules which contains regexes.
+	// Regexes need to be compiled as part of the FQDN rule validation.
+	//
+	// It's not necessary to pass a useful size here because it's not
+	// necessary to cache regexes in a short-lived binary (CLI).
+	re.InitRegexCompileLRU(1)
 }
 
 func getContext(content []byte, offset int64) (int, string, int) {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -890,7 +890,7 @@ func initializeFlags() {
 	flags.DurationVar(&option.Config.FQDNProxyResponseMaxDelay, option.FQDNProxyResponseMaxDelay, 100*time.Millisecond, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
 	option.BindEnv(option.FQDNProxyResponseMaxDelay)
 
-	flags.Int(option.FQDNRegexCompileLRUSize, 1024, "Size of the FQDN regex compilation LRU. Useful for heavy but repeated FQDN MatchName or MatchPattern use")
+	flags.Int(option.FQDNRegexCompileLRUSize, defaults.FQDNRegexCompileLRUSize, "Size of the FQDN regex compilation LRU. Useful for heavy but repeated DNS L7 rules with MatchName or MatchPattern")
 	flags.MarkHidden(option.FQDNRegexCompileLRUSize)
 	option.BindEnv(option.FQDNRegexCompileLRUSize)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -900,6 +900,12 @@ func initializeFlags() {
 	flags.Bool(option.ToFQDNsEnableDNSCompression, defaults.ToFQDNsEnableDNSCompression, "Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present")
 	option.BindEnv(option.ToFQDNsEnableDNSCompression)
 
+	flags.Int(option.DNSProxyConcurrencyLimit, 0, "Limit concurrency of DNS message processing")
+	option.BindEnv(option.DNSProxyConcurrencyLimit)
+
+	flags.Duration(option.DNSProxyConcurrencyProcessingGracePeriod, 0, "Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing")
+	option.BindEnv(option.DNSProxyConcurrencyProcessingGracePeriod)
+
 	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "size of queues for policy-related events")
 	option.BindEnv(option.PolicyQueueSize)
 

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -43,8 +43,10 @@ import (
 )
 
 const (
-	upstream       = "upstreamTime"
-	processingTime = "processingTime"
+	upstream        = "upstreamTime"
+	processingTime  = "processingTime"
+	semaphoreTime   = "semaphoreTime"
+	policyCheckTime = "policyCheckTime"
 
 	metricErrorTimeout = "timeout"
 	metricErrorProxy   = "proxyErr"
@@ -329,7 +331,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	}
 	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
 		option.Config.DNSMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
-		d.notifyOnDNSMsg)
+		d.notifyOnDNSMsg, option.Config.DNSProxyConcurrencyLimit)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
 		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.GetBindPort())
@@ -409,6 +411,10 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 			stat.UpstreamTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(
 			stat.ProcessingTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, semaphoreTime).Observe(
+			stat.SemaphoreAcquireTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyCheckTime).Observe(
+			stat.PolicyCheckTime.Total().Seconds())
 	}
 
 	switch {

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/counter"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
@@ -37,6 +39,10 @@ type DaemonFQDNSuite struct {
 }
 
 var _ = Suite(&DaemonFQDNSuite{})
+
+func (ds *DaemonFQDNSuite) SetUpSuite(c *C) {
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
+}
 
 type FakeRefcountingIdentityAllocator struct {
 	*testidentity.MockIdentityAllocator

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -192,7 +192,7 @@ contributors across the globe, there is almost always someone available to help.
 | extraInitContainers | list | `[]` | Additional InitContainers to initialize the pod. |
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
-| healthPort | int | `9876` | TCP port for the agent health API. This is not the port for cilium-health. |
+| healthPort | int | `9879` | TCP port for the agent health API. This is not the port for cilium-health. |
 | hostFirewall | object | `{"enabled":false}` | Configure the host firewall. |
 | hostFirewall.enabled | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |
 | hostPort.enabled | bool | `false` | Enable hostPort service support. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -139,7 +139,7 @@ data:
   debug-verbose: "{{ .Values.debug.verbose }}"
 {{- end }}
 
-{{- if ne (int .Values.healthPort) 9876 }}
+{{- if ne (int .Values.healthPort) 9879 }}
   # Set the TCP port for the agent health status API. This is not the port used
   # for cilium-health.
   agent-health-port: "{{ .Values.healthPort }}"

--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.listenAddress .Values.hubble.peerService.enabled }}
+{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.listenAddress .Values.hubble.peerService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -533,7 +533,7 @@ gke:
 healthChecking: true
 
 # -- TCP port for the agent health API. This is not the port for cilium-health.
-healthPort: 9876
+healthPort: 9879
 
 # -- Configure the host firewall.
 hostFirewall:

--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var keyValueRegex = regexp.MustCompile(`([\w-:./]+=[\w-:./]+,)*([\w-:./]+=[\w-:./]+)$`)
+var keyValueRegex = regexp.MustCompile(`([\w-:./@]+=[\w-:./@]*,)*([\w-:./@]+=[\w-:./@]*)$`)
 
 // GetStringMapString contains one enhancement to support k1=v2,k2=v2 compared to original
 // implementation of GetStringMapString function

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -75,6 +75,30 @@ func TestGetStringMapString(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "valid kv format with @",
+			args: args{
+				key:   "FOO_BAR",
+				value: "k1=v1,k2=test@test.com",
+			},
+			want: map[string]string{
+				"k1": "v1",
+				"k2": "test@test.com",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "valid kv format with empty value",
+			args: args{
+				key:   "FOO_BAR",
+				value: "k1=,k2=v2",
+			},
+			want: map[string]string{
+				"k1": "",
+				"k2": "v2",
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "valid kv format with forward slash",
 			args: args{
 				key:   "FOO_BAR",

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// AgentHealthPort is the default value for option.AgentHealthPort
-	AgentHealthPort = 9876
+	AgentHealthPort = 9879
 
 	// ClusterHealthPort is the default value for option.ClusterHealthPort
 	ClusterHealthPort = 4240

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -106,6 +106,10 @@ const (
 	// for each FQDN selector in endpoint's restored DNS rules.
 	DNSMaxIPsPerRestoredRule = 1000
 
+	// FFQDNRegexCompileLRUSize defines the maximum size for the FQDN regex
+	// compilation LRU used by the DNS proxy and policy validation.
+	FQDNRegexCompileLRUSize = 1024
+
 	// ToFQDNsMinTTL is the default lower bound for TTLs used with ToFQDNs rules.
 	// This is used in DaemonConfig.Populate
 	ToFQDNsMinTTL = 3600 // 1 hour in seconds

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -7,12 +7,15 @@
 package dnsproxy
 
 import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/golang/groupcache/lru"
+
 	. "gopkg.in/check.v1"
-	"testing"
 )
 
 type DNSProxyHelperTestSuite struct{}
@@ -38,8 +41,8 @@ func (s *DNSProxyHelperTestSuite) TestGetSelectorRegexMap(c *C) {
 			}},
 		},
 	}
-	cache := &lru.Cache{}
-	m, err := GetSelectorRegexMap(l7, cache)
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
+	m, err := GetSelectorRegexMap(l7)
 
 	c.Assert(err, Equals, nil)
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -349,10 +349,9 @@ type ProxyRequestContext struct {
 
 // IsTimeout return true if the ProxyRequest timeout
 func (proxyStat *ProxyRequestContext) IsTimeout() bool {
-	netErr, isNetErr := proxyStat.Err.(net.Error)
-	if isNetErr && netErr.Timeout() {
-		return true
-
+	var neterr net.Error
+	if errors.As(proxyStat.Err, &neterr) {
+		return neterr.Timeout()
 	}
 	return false
 }
@@ -536,7 +535,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	addr, _, err := net.SplitHostPort(epIPPort)
 	if err != nil {
 		scopedLog.WithError(err).Error("cannot extract endpoint IP from DNS request")
-		stat.Err = fmt.Errorf("Cannot extract endpoint IP from DNS request: %s", err)
+		stat.Err = fmt.Errorf("Cannot extract endpoint IP from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, "", request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
@@ -545,7 +544,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	ep, err := p.LookupEndpointByIP(net.ParseIP(addr))
 	if err != nil {
 		scopedLog.WithError(err).Error("cannot extract endpoint ID from DNS request")
-		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %s", err)
+		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, "", request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
@@ -557,7 +556,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	targetServerIP, targetServerPort, targetServerAddr, err := p.lookupTargetDNSServer(w)
 	if err != nil {
 		log.WithError(err).Error("cannot extract destination IP:port from DNS request")
-		stat.Err = fmt.Errorf("Cannot extract destination IP:port from DNS request: %s", err)
+		stat.Err = fmt.Errorf("Cannot extract destination IP:port from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, 0, targetServerAddr, request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
@@ -581,7 +580,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	switch {
 	case err != nil:
 		scopedLog.WithError(err).Error("Rejecting DNS query from endpoint due to error")
-		stat.Err = fmt.Errorf("Rejecting DNS query from endpoint due to error: %s", err)
+		stat.Err = fmt.Errorf("Rejecting DNS query from endpoint due to error: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
@@ -608,7 +607,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		client = p.TCPClient
 	default:
 		scopedLog.Error("Cannot parse DNS proxy client network to select forward client")
-		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %s", err)
+		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, request, protocol, false, &stat)
 		p.sendRefused(scopedLog, w, request)
@@ -627,7 +626,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		} else {
 			scopedLog.WithError(err).Error("Cannot forward proxied DNS lookup")
 			p.sendRefused(scopedLog, w, request)
-			stat.Err = fmt.Errorf("Cannot forward proxied DNS lookup: %s", err)
+			stat.Err = fmt.Errorf("Cannot forward proxied DNS lookup: %w", err)
 		}
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, request, protocol, false, &stat)
 		return
@@ -646,7 +645,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	err = w.WriteMsg(response)
 	if err != nil {
 		scopedLog.WithError(err).Error("Cannot forward proxied DNS response")
-		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %s", err)
+		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %w", err)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddr, response, protocol, true, &stat)
 	} else {
 		p.Lock()
@@ -665,7 +664,7 @@ func (p *DNSProxy) sendRefused(scopedLog *logrus.Entry, w dns.ResponseWriter, re
 
 	if err = w.WriteMsg(refused); err != nil {
 		scopedLog.WithError(err).Error("Cannot send REFUSED response")
-		err = fmt.Errorf("cannot send REFUSED response: %s", err)
+		err = fmt.Errorf("cannot send REFUSED response: %w", err)
 	}
 	return err
 }

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -29,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/spanstat"
 
-	"github.com/golang/groupcache/lru"
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
@@ -149,11 +149,6 @@ type DNSProxy struct {
 	// rejectReply is the OPCode send from the DNS-proxy to the endpoint if the
 	// DNS request is invalid
 	rejectReply int32
-
-	// regexCompileLRU contains an LRU cache for the regex.Compile of rules.
-	// Keeping an LRU cache avoids excessive memory allocations when compiling
-	// regex strings via regex.Compile.
-	regexCompileLRU *lru.Cache
 }
 
 // perEPAllow maps EndpointIDs to ports + selectors + rules
@@ -276,7 +271,7 @@ func (p *DNSProxy) RemoveRestoredRules(endpointID uint16) {
 // setPortRulesForID sets the matching rules for endpointID and destPort for
 // later lookups. It converts newRules into a unified regexp that can be reused
 // later.
-func (allow perEPAllow) setPortRulesForID(lru *lru.Cache, endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
+func (allow perEPAllow) setPortRulesForID(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
 	// This is the delete case
 	if len(newRules) == 0 {
 		epPorts := allow[endpointID]
@@ -287,7 +282,7 @@ func (allow perEPAllow) setPortRulesForID(lru *lru.Cache, endpointID uint64, des
 		return nil
 	}
 
-	newRE, err := GetSelectorRegexMap(newRules, lru)
+	newRE, err := GetSelectorRegexMap(newRules)
 	if err != nil {
 		return err
 	}
@@ -415,6 +410,10 @@ func (proxyStat *ProxyRequestContext) IsTimeout() bool {
 // requesting endpoint. Note that denied requests will not trigger this
 // callback.
 func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRestoreDNSIPs int, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc, concurrencyLimit int) (*DNSProxy, error) {
+	if err := re.InitRegexCompileLRU(option.Config.FQDNRegexCompileLRUSize); err != nil {
+		return nil, fmt.Errorf("failed to start DNS proxy: %w", err)
+	}
+
 	if port == 0 {
 		log.Debug("DNS Proxy port is configured to 0. A random port will be assigned by the OS.")
 	}
@@ -436,7 +435,6 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		restoredEPs:              make(restoredEPs),
 		EnableDNSCompression:     enableDNSCompression,
 		maxIPsPerRestoredDNSRule: maxRestoreDNSIPs,
-		regexCompileLRU:          lru.New(option.Config.FQDNRegexCompileLRUSize),
 	}
 	if concurrencyLimit > 0 {
 		p.ConcurrencyLimit = semaphore.NewWeighted(int64(concurrencyLimit))
@@ -446,9 +444,10 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 
 	// Start the DNS listeners on UDP and TCP
 	var (
-		UDPConn                *net.UDPConn
-		TCPListener            *net.TCPListener
-		err                    error
+		UDPConn     *net.UDPConn
+		TCPListener *net.TCPListener
+		err         error
+
 		EnableIPv4, EnableIPv6 = option.Config.EnableIPv4, option.Config.EnableIPv6
 	)
 
@@ -516,7 +515,7 @@ func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules po
 	p.Lock()
 	defer p.Unlock()
 
-	err := p.allowed.setPortRulesForID(p.regexCompileLRU, endpointID, destPort, newRules)
+	err := p.allowed.setPortRulesForID(endpointID, destPort, newRules)
 	if err == nil {
 		// Rules were updated based on policy, remove restored rules
 		p.removeRestoredRulesLocked(endpointID)
@@ -901,7 +900,7 @@ func shouldCompressResponse(request, response *dns.Msg) bool {
 	return false
 }
 
-func GetSelectorRegexMap(l7 policy.L7DataMap, lru *lru.Cache) (CachedSelectorREEntry, error) {
+func GetSelectorRegexMap(l7 policy.L7DataMap) (CachedSelectorREEntry, error) {
 	newRE := make(CachedSelectorREEntry)
 	for selector, l7Rules := range l7 {
 		if l7Rules == nil {
@@ -921,18 +920,11 @@ func GetSelectorRegexMap(l7 policy.L7DataMap, lru *lru.Cache) (CachedSelectorREE
 			}
 		}
 		mp := strings.Join(reStrings, "|")
-		rei, ok := lru.Get(mp)
-		if ok {
-			re := rei.(*regexp.Regexp)
-			newRE[selector] = re
-		} else {
-			re, err := regexp.Compile(mp)
-			if err != nil {
-				return nil, err
-			}
-			lru.Add(mp, re)
-			newRE[selector] = re
+		rei, err := re.CompileRegex(mp)
+		if err != nil {
+			return nil, err
 		}
+		newRE[selector] = rei
 	}
 
 	return newRE, nil

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -31,6 +32,7 @@ import (
 	"github.com/golang/groupcache/lru"
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -103,6 +105,15 @@ type DNSProxy struct {
 	// EnableDNSCompression allows the DNS proxy to compress responses to
 	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
 	EnableDNSCompression bool
+
+	// ConcurrencyLimit limits parallel goroutines number that serve DNS
+	ConcurrencyLimit *semaphore.Weighted
+	// ConcurrencyGracePeriod is the grace period for waiting on
+	// ConcurrencyLimit before timing out
+	ConcurrencyGracePeriod time.Duration
+	// logLimiter limits log msgs that could be bursty and too verbose.
+	// Currently used when ConcurrencyLimit is set.
+	logLimiter logging.Limiter
 
 	// lookupTargetDNSServer extracts the originally intended target of a DNS
 	// query. It is always set to lookupTargetDNSServer in
@@ -338,13 +349,49 @@ type LookupIPsBySecIDFunc func(nid identity.NumericIdentity) []string
 // See DNSProxy.LookupEndpointIDByIP for usage.
 type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error
 
+// errFailedAcquireSemaphore is an an error representing the DNS proxy's
+// failure to acquire the semaphore. This is error is treated like a timeout.
+type errFailedAcquireSemaphore struct {
+	parallel int
+}
+
+func (e errFailedAcquireSemaphore) Timeout() bool { return true }
+
+// Temporary is deprecated. Return false.
+func (e errFailedAcquireSemaphore) Temporary() bool { return false }
+func (e errFailedAcquireSemaphore) Error() string {
+	return fmt.Sprintf(
+		"failed to acquire DNS proxy semaphore, %d parallel requests already in-flight",
+		e.parallel,
+	)
+}
+
+// errTimedOutAcquireSemaphore is an an error representing the DNS proxy timing
+// out when acquiring the semaphore. It is treated the same as
+// errTimedOutAcquireSemaphore.
+type errTimedOutAcquireSemaphore struct {
+	errFailedAcquireSemaphore
+
+	gracePeriod time.Duration
+}
+
+func (e errTimedOutAcquireSemaphore) Error() string {
+	return fmt.Sprintf(
+		"timed out after %v acquiring DNS proxy semaphore, %d parallel requests already in-flight",
+		e.gracePeriod,
+		e.parallel,
+	)
+}
+
 // ProxyRequestContext proxy dns request context struct to send in the callback
 type ProxyRequestContext struct {
 	ProcessingTime spanstat.SpanStat // This is going to happen at the end of the second callback.
 	// Error is a enum of [timeout, allow, denied, proxyerr].
-	UpstreamTime spanstat.SpanStat
-	Success      bool
-	Err          error
+	UpstreamTime         spanstat.SpanStat
+	SemaphoreAcquireTime spanstat.SpanStat
+	PolicyCheckTime      spanstat.SpanStat
+	Success              bool
+	Err                  error
 }
 
 // IsTimeout return true if the ProxyRequest timeout
@@ -367,7 +414,7 @@ func (proxyStat *ProxyRequestContext) IsTimeout() bool {
 // notifyFunc will be called with DNS response data that is returned to a
 // requesting endpoint. Note that denied requests will not trigger this
 // callback.
-func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRestoreDNSIPs int, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc) (*DNSProxy, error) {
+func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRestoreDNSIPs int, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc, concurrencyLimit int) (*DNSProxy, error) {
 	if port == 0 {
 		log.Debug("DNS Proxy port is configured to 0. A random port will be assigned by the OS.")
 	}
@@ -381,6 +428,7 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		LookupSecIDByIP:          lookupSecIDFunc,
 		LookupIPsBySecID:         lookupIPsFunc,
 		NotifyOnDNSMsg:           notifyFunc,
+		logLimiter:               logging.NewLimiter(10*time.Second, 1),
 		lookupTargetDNSServer:    lookupTargetDNSServer,
 		usedServers:              make(map[string]struct{}),
 		allowed:                  make(perEPAllow),
@@ -389,6 +437,10 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		EnableDNSCompression:     enableDNSCompression,
 		maxIPsPerRestoredDNSRule: maxRestoreDNSIPs,
 		regexCompileLRU:          lru.New(option.Config.FQDNRegexCompileLRUSize),
+	}
+	if concurrencyLimit > 0 {
+		p.ConcurrencyLimit = semaphore.NewWeighted(int64(concurrencyLimit))
+		p.ConcurrencyGracePeriod = option.Config.DNSProxyConcurrencyProcessingGracePeriod
 	}
 	atomic.StoreInt32(&p.rejectReply, dns.RcodeRefused)
 
@@ -520,18 +572,42 @@ func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID ident
 //  fqdn/NameManager instance).
 //  - Write the response to the endpoint.
 func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
-	stat := ProxyRequestContext{}
-	stat.ProcessingTime.Start()
 	requestID := request.Id // keep the original request ID
 	qname := string(request.Question[0].Name)
 	protocol := w.LocalAddr().Network()
+	epIPPort := w.RemoteAddr().String()
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.DNSName:      qname,
-		logfields.IPAddr:       w.RemoteAddr(),
-		logfields.DNSRequestID: request.Id})
+		logfields.IPAddr:       epIPPort,
+		logfields.DNSRequestID: requestID,
+	})
+
+	var stat ProxyRequestContext
+	if p.ConcurrencyLimit != nil {
+		// TODO: Consider plumbing the daemon context here.
+		ctx, cancel := context.WithTimeout(context.TODO(), p.ConcurrencyGracePeriod)
+		defer cancel()
+
+		stat.SemaphoreAcquireTime.Start()
+		// Enforce the concurrency limit by attempting to acquire the
+		// semaphore.
+		if err := p.enforceConcurrencyLimit(ctx); err != nil {
+			stat.SemaphoreAcquireTime.End(false)
+			if p.logLimiter.Allow() {
+				scopedLog.WithError(err).Error("Dropping DNS request due to too many DNS requests already in-flight")
+			}
+			stat.Err = err
+			p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, "", request, protocol, false, &stat)
+			p.sendRefused(scopedLog, w, request)
+			return
+		}
+		stat.SemaphoreAcquireTime.End(true)
+		defer p.ConcurrencyLimit.Release(1)
+	}
+	stat.ProcessingTime.Start()
+
 	scopedLog.Debug("Handling DNS query from endpoint")
 
-	epIPPort := w.RemoteAddr().String()
 	addr, _, err := net.SplitHostPort(epIPPort)
 	if err != nil {
 		scopedLog.WithError(err).Error("cannot extract endpoint IP from DNS request")
@@ -576,7 +652,9 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	// Note: The cache doesn't know about the source of the DNS data (yet) and so
 	// it won't enforce any separation between results from different endpoints.
 	// This isn't ideal but we are trusting the DNS responses anyway.
+	stat.PolicyCheckTime.Start()
 	allowed, err := p.CheckAllowed(uint64(ep.ID), targetServerPort, targetServerID, targetServerIP, qname)
+	stat.PolicyCheckTime.End(err == nil)
 	switch {
 	case err != nil:
 		scopedLog.WithError(err).Error("Rejecting DNS query from endpoint due to error")
@@ -654,6 +732,29 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		p.usedServers[targetServerIP.String()] = struct{}{}
 		p.Unlock()
 	}
+}
+
+func (p *DNSProxy) enforceConcurrencyLimit(ctx context.Context) error {
+	if p.ConcurrencyGracePeriod == 0 {
+		// No grace time configured. Failing to acquire semaphore means
+		// immediately give up.
+		if !p.ConcurrencyLimit.TryAcquire(1) {
+			return errFailedAcquireSemaphore{
+				parallel: option.Config.DNSProxyConcurrencyLimit,
+			}
+		}
+	} else if err := p.ConcurrencyLimit.Acquire(ctx, 1); err != nil && errors.Is(err, context.DeadlineExceeded) {
+		// We ignore err because errTimedOutAcquireSemaphore implements the
+		// net.Error interface deeming it a timeout error which will be
+		// treated the same as context.DeadlineExceeded.
+		return errTimedOutAcquireSemaphore{
+			errFailedAcquireSemaphore: errFailedAcquireSemaphore{
+				parallel: option.Config.DNSProxyConcurrencyLimit,
+			},
+			gracePeriod: p.ConcurrencyGracePeriod,
+		}
+	}
+	return nil
 }
 
 // sendRefused creates and sends a REFUSED response for request to w

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -231,7 +231,9 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 		// NotifyOnDNSMsg
 		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error {
 			return nil
-		})
+		},
+		0,
+	)
 	c.Assert(err, IsNil, Commentf("error starting DNS Proxy"))
 	s.proxy = proxy
 
@@ -993,6 +995,13 @@ func (s *DNSProxyTestSuite) TestProxyRequestContext_IsTimeout(c *C) {
 	// IsTimeout() to return the wrong value.
 	p.Err = fmt.Errorf("sample err: %s", context.DeadlineExceeded)
 	c.Assert(p.IsTimeout(), Equals, false)
+
+	p.Err = errFailedAcquireSemaphore{}
+	c.Assert(p.IsTimeout(), Equals, true)
+	p.Err = errTimedOutAcquireSemaphore{
+		gracePeriod: 1 * time.Second,
+	}
+	c.Assert(p.IsTimeout(), Equals, true)
 }
 
 type selectorMock struct {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -39,7 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 
-	"github.com/golang/groupcache/lru"
 	"github.com/miekg/dns"
 	. "gopkg.in/check.v1"
 	"sigs.k8s.io/yaml"
@@ -192,6 +192,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 	s.dnsServer = setupServer(c)
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))
 
+	option.Config.FQDNRegexCompileLRUSize = 1024
 	proxy, err := StartDNSProxy("", 0, true, 1000, // any address, any port, enable compression, max 1000 restore IPs
 		// LookupEPByIP
 		func(ip net.IP) (*endpoint.Endpoint, error) {
@@ -1055,12 +1056,12 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	}
 
 	pea := perEPAllow{}
-	lru := lru.New(128)
+	re.InitRegexCompileLRU(128)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for epID := uint64(0); epID < 20; epID++ {
-			pea.setPortRulesForID(lru, epID, 8053, newRules)
+			pea.setPortRulesForID(epID, 8053, newRules)
 		}
 	}
 }
@@ -1136,12 +1137,12 @@ func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
 	fmt.Printf("\tNumGC = %v\n", m.NumGC)
 
 	pea := perEPAllow{}
-	lru := lru.New(128) // modify to 1024 and compare results
+	re.InitRegexCompileLRU(128) // modify to 1024 and compare results
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for epID := uint64(0); epID < 20; epID++ {
-			pea.setPortRulesForID(lru, epID, 8053, rules)
+			pea.setPortRulesForID(epID, 8053, rules)
 		}
 	}
 	b.StopTimer()

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -984,6 +984,17 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	s.restoring = false
 }
 
+func (s *DNSProxyTestSuite) TestProxyRequestContext_IsTimeout(c *C) {
+	p := new(ProxyRequestContext)
+	p.Err = fmt.Errorf("sample err: %w", context.DeadlineExceeded)
+	c.Assert(p.IsTimeout(), Equals, true)
+
+	// Assert that failing to wrap the error properly (by using '%w') causes
+	// IsTimeout() to return the wrong value.
+	p.Err = fmt.Errorf("sample err: %s", context.DeadlineExceeded)
+	c.Assert(p.IsTimeout(), Equals, false)
+}
+
 type selectorMock struct {
 	key string
 }

--- a/pkg/fqdn/fqdn_test.go
+++ b/pkg/fqdn/fqdn_test.go
@@ -10,11 +10,18 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 )
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) {
 	TestingT(t)
+}
+
+func (ds *FQDNTestSuite) SetUpSuite(c *C) {
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
 }
 
 type FQDNTestSuite struct{}

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/pkg/fqdn/dns"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 )
 
 const allowedDNSCharsREGroup = "[-a-zA-Z0-9_]"
@@ -24,7 +25,7 @@ func Validate(pattern string) (matcher *regexp.Regexp, err error) {
 		return nil, errors.New(`Only alphanumeric ASCII characters, the hyphen "-", underscore "_", "." and "*" are allowed in a matchPattern`)
 	}
 
-	return regexp.Compile(ToRegexp(pattern))
+	return re.CompileRegex(ToRegexp(pattern))
 }
 
 // Sanitize canonicalized the pattern for use by ToRegexp

--- a/pkg/fqdn/re/re.go
+++ b/pkg/fqdn/re/re.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package re provides a simple function to access compile regex objects for
+// the FQDN subsystem.
+package re
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sync/atomic"
+	"unsafe"
+
+	lru "github.com/golang/groupcache/lru"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "fqdn/re")
+)
+
+// CompileRegex compiles a pattern p into a regex and returns the regex object.
+// The regex object will be cached by an LRU. If p has already been compiled
+// and cached, this function will return the cached regex object. If not
+// already cached, it will compile p into a regex object and cache it in the
+// LRU. This function will return an error if the LRU has not already been
+// initialized.
+func CompileRegex(p string) (*regexp.Regexp, error) {
+	lru := (*RegexCompileLRU)(atomic.LoadPointer(&regexCompileLRU))
+	if lru == nil {
+		return nil, errors.New("FQDN regex compilation LRU not yet initialized")
+	}
+	lru.Lock()
+	r, ok := lru.Get(p)
+	lru.Unlock()
+	if ok {
+		return r.(*regexp.Regexp), nil
+	}
+	n, err := regexp.Compile(p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile regex: %w", err)
+	}
+	lru.Lock()
+	lru.Add(p, n)
+	lru.Unlock()
+	return n, nil
+}
+
+// InitRegexCompileLRU creates a new instance of the regex compilation LRU.
+func InitRegexCompileLRU(size int) error {
+	if size < 0 {
+		return fmt.Errorf("failed to initialize FQDN regex compilation LRU due to invalid size %d", size)
+	} else if size == 0 {
+		log.Warnf(
+			"FQDN regex compilation LRU size is unlimited, which can grow unbounded potentially consuming too much memory. Consider passing a maximum size via --%s.",
+			option.FQDNRegexCompileLRUSize)
+	}
+	atomic.StorePointer(&regexCompileLRU, unsafe.Pointer(&RegexCompileLRU{
+		Mutex: &lock.Mutex{},
+		Cache: lru.New(size),
+	}))
+	return nil
+}
+
+// regexCompileLRU is the singleton instance of the LRU that's shared
+// throughout Cilium.
+var regexCompileLRU unsafe.Pointer // *RegexCompileLRU
+
+// RegexCompileLRU is an LRU cache for storing compiled regex objects of FQDN
+// names or patterns, used in CiliumNetworkPolicy or
+// ClusterwideCiliumNetworkPolicy.
+type RegexCompileLRU struct {
+	// The lru package doesn't provide any concurrency guarantees so we must
+	// provide our own locking.
+	*lock.Mutex
+	*lru.Cache
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -445,6 +445,15 @@ const (
 	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
 	ToFQDNsEnableDNSCompression = "tofqdns-enable-dns-compression"
 
+	// DNSProxyConcurrencyLimit limits parallel processing of DNS messages in
+	// DNS proxy at any given point in time.
+	DNSProxyConcurrencyLimit = "dnsproxy-concurrency-limit"
+
+	// DNSProxyConcurrencyProcessingGracePeriod is the amount of grace time to
+	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
+	// been reached.
+	DNSProxyConcurrencyProcessingGracePeriod = "dnsproxy-concurrency-processing-grace-period"
+
 	// MTUName is the name of the MTU option
 	MTUName = "mtu"
 
@@ -1580,6 +1589,15 @@ type DaemonConfig struct {
 	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
 	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
 	ToFQDNsEnableDNSCompression bool
+
+	// DNSProxyConcurrencyLimit limits parallel processing of DNS messages in
+	// DNS proxy at any given point in time.
+	DNSProxyConcurrencyLimit int
+
+	// DNSProxyConcurrencyProcessingGracePeriod is the amount of grace time to
+	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
+	// been reached.
+	DNSProxyConcurrencyProcessingGracePeriod time.Duration
 
 	// HostDevice will be device used by Cilium to connect to the outside world.
 	HostDevice string
@@ -2751,6 +2769,8 @@ func (c *DaemonConfig) Populate() {
 	c.ToFQDNsProxyPort = viper.GetInt(ToFQDNsProxyPort)
 	c.ToFQDNsPreCache = viper.GetString(ToFQDNsPreCache)
 	c.ToFQDNsEnableDNSCompression = viper.GetBool(ToFQDNsEnableDNSCompression)
+	c.DNSProxyConcurrencyLimit = viper.GetInt(DNSProxyConcurrencyLimit)
+	c.DNSProxyConcurrencyProcessingGracePeriod = viper.GetDuration(DNSProxyConcurrencyProcessingGracePeriod)
 
 	// Convert IP strings into net.IPNet types
 	subnets, invalid := ip.ParseCIDRs(viper.GetStringSlice(IPv4PodSubnets))

--- a/pkg/policy/api/utils_test.go
+++ b/pkg/policy/api/utils_test.go
@@ -9,6 +9,8 @@ package api
 import (
 	"testing"
 
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/policy/api/kafka"
 
 	. "gopkg.in/check.v1"
@@ -17,6 +19,10 @@ import (
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) {
 	TestingT(t)
+}
+
+func (s *PolicyAPITestSuite) SetUpSuite(c *C) {
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
 }
 
 type PolicyAPITestSuite struct{}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -12,6 +12,8 @@ import (
 	stdlog "log"
 
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -91,6 +93,7 @@ var (
 func (ds *PolicyTestSuite) SetUpSuite(c *C) {
 	cachedRemoteNodeIdentitySetting = option.Config.EnableRemoteNodeIdentity
 	option.Config.EnableRemoteNodeIdentity = true
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
 }
 
 func (ds *PolicyTestSuite) TearDownSuite(c *C) {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -64,6 +64,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 	})
 
 	AfterAll(func() {
+		ExpectAllPodsTerminated(kubectl)
 		UninstallCiliumFromManifest(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
 	})


### PR DESCRIPTION
* #19702 -- fqdn/dnsproxy: Improve error wrapping (@christarazi)
 * #19683 -- Document that clustermesh cluster-id range is 1-255 (@stonith)
 * #19759 -- helm: don't generate the hubble-peer svc during preflight checks (@kaworu)
 * #19592 -- Add concurrency limiting for DNS message processing (@nebril)
 * #19767 -- docs: Fix incorrect command in IPsec GSG (@pchaigno)
 * #19632 -- Use FQDN regex LRU everywhere (@christarazi)
 * #19794 -- cli: Update regex for key value validation (@sayboras)
 * #19830 -- Change default agent health check port to avoid conflicts (@tklauser)
 * #19750 -- test: Wait for pod termination in K8sServicesTest (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19702 19683 19759 19592 19767 19632 19794 19830 19750 ; do contrib/backporting/set-labels.py $pr done 1.11; done
```