### PR TITLE
test: add git safe directory in test VMs

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -77,6 +77,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Add an exception for the cilium repo for the root user to fix the
+# "fatal: unsafe repository ('/home/vagrant/go/src/github.com/cilium/cilium' is owned by someone else)"
+# error condition when running `sudo make install`
+git config --global --add safe.directory /home/vagrant/go/src/github.com/cilium/cilium
+
 if [ -x /home/vagrant/go/src/github.com/cilium/cilium/.devvmrc ] ; then
    echo "----------------------------------------------------------------"
    echo "Executing .devvmrc"


### PR DESCRIPTION
Add the cilium repo to the list of git safe directory exceptions for the
root user in order to allow installing Cilium.

This fixes the:

    fatal: unsafe repository ('/home/vagrant/go/src/github.com/cilium/cilium' is owned by someone else)
    To add an exception for this directory, call:

        git config --global --add safe.directory /home/vagrant/go/src/github.com/cilium/cilium

error raised by git when running the runtime test VM locally.

Follows commit e0998ce1ccd5 ("vagrant: add git exception in dev VMs for
cilium repo for root user") which did the same for the dev VM
Vagrantfile.