### PR TITLE
docs: Mark Git repo as safe in Docker build-docs container

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -29,3 +29,12 @@ ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION
 ## write runtime data inside a system directory.
 ## We do rely on this extension, so we cannot just drop it.
 RUN install -m 0777 -d /usr/local/lib/python3.10/site-packages/versionwarning/_static/data
+
+## Recent Git versions refuse to work by default if the repository owner is
+## different from the user. This is the case on macOS, because we run the
+## container with --user "uid:gid", and they differ from what Linux is used to
+## (The gid from macOS seems to be 20, which corresponds to the "dialout" group
+## in the container). We pass --user "uid:gid" to have the "install" command
+## work in the workaround for versionwarning above.
+## Tell Git that this repository is safe.
+RUN  git config --global --add safe.directory /src


### PR DESCRIPTION
In commit 7faab1b290f9 ("docs: Run builder container as host UID/GID"), we updated the Dockerfile for building the documentation to create a specific directory required by the versionwarning extensions. This command required in turn to run the container with host UID/GID. 

On some setups, in particular with macOS, this may result in running with UID/GID different from what Linux Alpine usually "expects". For example, the GID can be 20 (typically on macOS), which corresponds to the "dialout" group on Alpine. In such a case, Git fails to verify that the ownership of the Cilium repository corresponds to the user running the commands. With recent versions of Git, this translates into an error, because Git refuses to work in "unsafe" repositories as this would create [security issues](https://github.blog/2022-04-12-git-security-vulnerability-announced). 

To work around this, let's mark the repository as "safe" when building the Docker image. This will update file ~/.gitconfig on the container, but will not change the configuration of the local repository mounted on that container.
