### PR TITLE
bgp-cp: use CiliumNode object and support ClusterPool v1/v2 IPAM

### DIFF
--- a/Documentation/gettingstarted/bgp-control-plane.rst
+++ b/Documentation/gettingstarted/bgp-control-plane.rst
@@ -15,6 +15,9 @@ When set to ``true`` the ``BGP Control Plane`` ``Controllers`` will be
 instantiated and will begin listening for ``CiliumBGPPeeringPolicy``
 events.
 
+Currently, the ``BGP Control Plane`` will only work when IPAM mode is set to
+"cluster-pool", "cluster-pool-v2", and "kubernetes"
+
 CiliumBGPPeeringPolicy CRD
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1870,6 +1870,13 @@ func runDaemon() {
 	}
 
 	if option.Config.BGPControlPlaneEnabled() {
+		switch option.Config.IPAM {
+		case ipamOption.IPAMClusterPool:
+		case ipamOption.IPAMClusterPoolV2:
+		case ipamOption.IPAMKubernetes:
+		default:
+			log.Fatalf("BGP control plane cannot be utilized with IPAM mode: %v", option.Config.IPAM)
+		}
 		log.Info("Initializing BGP Control Plane")
 		if err := d.instantiateBGPControlPlane(d.ctx); err != nil {
 			log.WithError(err).Fatal("Error returned when instantiating BGP control plane")

--- a/pkg/bgpv1/agent/nodespecer.go
+++ b/pkg/bgpv1/agent/nodespecer.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package agent
+
+import (
+	"fmt"
+
+	v1 "k8s.io/client-go/listers/core/v1"
+
+	v2 "github.com/cilium/cilium/pkg/k8s/client/listers/cilium.io/v2"
+)
+
+// nodeSpecer abstracts the underlying mechanism to list information about the
+// Node resource Cilium is running on.
+//
+// The BGP Control Plane needs to obtain Node information however, it may need
+// to query the Kubernetes Node or the Cilium Node object depending on IPAM
+// configuration.
+type nodeSpecer interface {
+	PodCIDRs() ([]string, error)
+	Labels() (map[string]string, error)
+	Annotations() (map[string]string, error)
+}
+
+type kubernetesNodeSpecer struct {
+	Name       string
+	NodeLister v1.NodeLister
+}
+
+func (s *kubernetesNodeSpecer) Annotations() (map[string]string, error) {
+	n, err := s.NodeLister.Get(s.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
+	}
+	return n.Annotations, nil
+}
+
+func (s *kubernetesNodeSpecer) Labels() (map[string]string, error) {
+	n, err := s.NodeLister.Get(s.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
+	}
+	return n.Labels, nil
+}
+
+func (s *kubernetesNodeSpecer) PodCIDRs() ([]string, error) {
+	n, err := s.NodeLister.Get(s.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
+	}
+	if n.Spec.PodCIDRs != nil {
+		return n.Spec.PodCIDRs, nil
+	}
+	if n.Spec.PodCIDR != "" {
+		return []string{n.Spec.PodCIDR}, nil
+	}
+	return []string{}, nil
+}
+
+type ciliumNodeSpecer struct {
+	Name       string
+	NodeLister v2.CiliumNodeLister
+}
+
+func (s *ciliumNodeSpecer) Annotations() (map[string]string, error) {
+	n, err := s.NodeLister.Get(s.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
+	}
+	return n.Annotations, nil
+}
+
+func (s *ciliumNodeSpecer) Labels() (map[string]string, error) {
+	n, err := s.NodeLister.Get(s.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
+	}
+	return n.Labels, nil
+}
+
+func (s *ciliumNodeSpecer) PodCIDRs() ([]string, error) {
+	n, err := s.NodeLister.Get(s.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
+	}
+	if n.Spec.IPAM.PodCIDRs != nil {
+		return n.Spec.IPAM.PodCIDRs, nil
+	}
+	return []string{}, nil
+}

--- a/pkg/bgpv1/annotations.go
+++ b/pkg/bgpv1/annotations.go
@@ -10,8 +10,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-
-	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -107,18 +105,18 @@ func (e ErrMulti) Error() string {
 	return s.String()
 }
 
-// NewAnnotationMap parses a Kubernetes v1.Node object's annotations field into
-// a AnnotationMap and returns the latter.
+// NewAnnotationMap parses a Node's annotations into a AnnotationMap
+// and returns the latter.
 //
 // An error is returned containing one or more parsing errors.
 //
 // This is for convenience so the caller can log all parsing errors at once.
 // The error should still be treated as a normal descrete error and an empty
 // AnnotationMap is returned.
-func NewAnnotationMap(n *v1.Node) (AnnotationMap, error) {
+func NewAnnotationMap(a map[string]string) (AnnotationMap, error) {
 	am := AnnotationMap{}
-	errs := make([]error, 0, len(n.Annotations))
-	for key, value := range n.Annotations {
+	errs := make([]error, 0, len(a))
+	for key, value := range a {
 		asn, attrs, err := parseAnnotation(key, value)
 		if err != nil && !errors.As(err, &ErrNotVRouterAnno{}) {
 			errs = append(errs, err)

--- a/pkg/bgpv1/gobgp/reconcile.go
+++ b/pkg/bgpv1/gobgp/reconcile.go
@@ -340,7 +340,7 @@ func exportPodCIDRReconciler(ctx context.Context, _ *BGPRouterManager, sc *Serve
 	aset := map[string]*member{}
 
 	// populate the pod cidr advrts that must be present, universe a
-	for _, cidr := range cstate.Node.Spec.PodCIDRs {
+	for _, cidr := range cstate.PodCIDRs {
 		var (
 			m  *member
 			ok bool

--- a/pkg/bgpv1/gobgp/reconcile_test.go
+++ b/pkg/bgpv1/gobgp/reconcile_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	gobgp "github.com/osrg/gobgp/v3/api"
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
@@ -417,12 +416,8 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				Neighbors:     []v2alpha1api.CiliumBGPNeighbor{},
 			}
 			newcstate := agent.ControlPlaneState{
-				IPv4: net.ParseIP("127.0.0.1"),
-				Node: &v1.Node{
-					Spec: v1.NodeSpec{
-						PodCIDRs: tt.updated,
-					},
-				},
+				PodCIDRs: tt.updated,
+				IPv4:     net.ParseIP("127.0.0.1"),
 			}
 
 			err = exportPodCIDRReconciler(context.Background(), nil, testSC, newc, &newcstate)


### PR DESCRIPTION
This PR refactors bits of the BGP Control Plane to understand Cilium's Cluster Pool IPAM.

When Cluster Pool IPAM is configured the BGP control plane will configure itself to parse the CiliumNode object's PodCIDR blocks instead of the Kubernetes native Node resource's. 

When Cluster Pool IPAM is not configured, the normal Kubernetes Node resource is parsed instead.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>

```release-note
Move the BGP Control Plane to utilize CiliumNode objects. This enable support for IPAM driven PodCIDR announcements. 
```
