### PR TITLE
CODEOWNERS: Extend proxy group to pkg/fqdn

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -201,7 +201,7 @@ jenkinsfiles @cilium/ci-structure
 /pkg/endpoint/ @cilium/endpoint
 /pkg/endpointmanager/ @cilium/endpoint
 /pkg/envoy/ @cilium/proxy
-/pkg/fqdn/ @cilium/agent
+/pkg/fqdn/ @cilium/agent @cilium/proxy
 /pkg/health/ @cilium/health
 /pkg/hubble/ @cilium/hubble
 /pkg/identity @cilium/policy


### PR DESCRIPTION
There's relevant code inside this package for the proxy group to be
aware of.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
