### PR TITLE
pkg/fqdn: Replace remaining usages of regex compile with LRU

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
@@ -1013,7 +1014,7 @@ func (zombies *DNSZombieMappings) forceExpireLocked(expireLookupsBefore time.Tim
 // never happen.
 func (zombies *DNSZombieMappings) ForceExpireByNameIP(expireLookupsBefore time.Time, name string, ips ...net.IP) error {
 	reStr := matchpattern.ToRegexp(name)
-	re, err := regexp.Compile(reStr)
+	re, err := re.CompileRegex(reStr)
 	if err != nil {
 		return err
 	}

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -18,9 +18,14 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 )
 
 type DNSCacheTestSuite struct{}
+
+func (ds *DNSCacheTestSuite) SetUpSuite(c *C) {
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
+}
 
 var _ = Suite(&DNSCacheTestSuite{})
 

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -60,7 +61,7 @@ func (n *NameManager) MapSelectorsToIPsLocked(fqdnSelectors map[api.FQDNSelector
 				patternRE *regexp.Regexp
 			)
 
-			if patternRE, err = regexp.Compile(patternREStr); err != nil {
+			if patternRE, err = re.CompileRegex(patternREStr); err != nil {
 				log.WithError(err).Error("Error compiling matchPattern")
 			}
 			lookupIPs := n.cache.LookupByRegexp(patternRE)


### PR DESCRIPTION
Fixes: 876149841c ("fqdn: Use new regex LRU package everywhere")

Signed-off-by: Chris Tarazi <chris@isovalent.com>

Related: https://github.com/cilium/cilium/pull/19632