### PR TITLE
bpf: add hostport support in maglev loadbalance mode

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1248,14 +1248,19 @@ lb4_select_backend_id(struct __ctx_buff *ctx,
 }
 #elif LB_SELECTION == LB_SELECTION_MAGLEV
 static __always_inline __u32
-lb4_select_backend_id(struct __ctx_buff *ctx __maybe_unused,
-		      struct lb4_key *key __maybe_unused,
+lb4_select_backend_id(struct __ctx_buff *ctx,
+		      struct lb4_key *key,
 		      const struct ipv4_ct_tuple *tuple,
 		      const struct lb4_service *svc)
 {
 	__u32 zero = 0, index = svc->rev_nat_index;
 	__u32 *backend_ids;
 	void *maglev_lut;
+
+	if (svc->count == 1) {
+		struct lb4_service *be = lb4_lookup_backend_slot(ctx, key, 1);
+		return be ? be->backend_id : 0;
+	}
 
 	maglev_lut = map_lookup_elem(&LB4_MAGLEV_MAP_OUTER, &index);
 	if (unlikely(!maglev_lut))


### PR DESCRIPTION
Previosly, add hostpost service will not create a map in maglev LUT, so access outside of host will cause Service backend not found error and drop pack.
Solution may be these two:
1. In [useMaglev](https://github.com/cilium/cilium/blob/9f37f03d5c180386427d611efdd66f3910672174/pkg/service/service.go#L142) check, add type hostport support.
2. Because hostport only one backend, so before maglev lookup, check if current svc has only one endpoint, and just use current endpoint. this can avoid create maglev lookup table.

Current commit use No.2 solution.

Fixes: #19260

Signed-off-by: Rel Zhong <relzhong@outlook.com>
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->


