### PR TITLE
docs: Add docs-builder build as dependency to live preview

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -115,7 +115,7 @@ run-server: stop-server
 stop-server:
 	-$(QUIET)$(CONTAINER_ENGINE) container rm --force --volumes docs-cilium 2>/dev/null
 
-live-preview: stop-server
+live-preview: stop-server builder-image
 	@echo "$$(tput setaf 2)Running at http://localhost:$(DOCS_PORT)$$(tput sgr0)"
 	$(QUIET)$(DOCKER_CTR) \
 		--publish $(DOCS_PORT):8000 \


### PR DESCRIPTION
With `make render-docs-live-preview`, we use the cilium/docs-builder image to build a preview of the documentation, to serve it locally, and to watch the source files for changes to update automatically the preview.

When the Docker image is present locally, the command uses it. When this is not the case, it pulls it from Docker, in its `:latest` version by default. This can be an issue due to commit 0da7224218ab ("ci: pin down image for documentation workflow"), where we pinned down the docs-builder image to use in the CI. Since this commit, the reference image is not longer `:latest`, but the tag in use in the CI files. As a consequence, the live preview may attempt to use an outdated version of the image. This is currently the case: running the command with no local image raises an error about a missing `myst_parser` extension, which is not present on the version tagged with `:latest`. 

To fix this, we mark builder-image as a dependency for the render-docs-live-preview target, so that the image gets built locally.

@joestringer: Following this PR, we might want to remove the `latest` tag for cilium/docs-builder from Docker Hub?