### PR TITLE
Do not disable peer service when hubble.listenAddress is empty

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -705,6 +705,10 @@
      - Service Port for the Peer service.
      - int
      - ``4254``
+   * - hubble.peerService.targetPort
+     - Target Port for the Peer service.
+     - int
+     - ``4244``
    * - hubble.relay.affinity
      - Affinity for hubble-replay
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -889,6 +889,7 @@ systemd
 systemtap
 tableSize
 tarball
+targetPort
 tc
 tcp
 tcpdump

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -227,6 +227,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.enabled | bool | `true` | Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client |
 | hubble.peerService.servicePort | int | `4254` | Service Port for the Peer service. |
+| hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service. |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |

--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.listenAddress .Values.hubble.peerService.enabled }}
+{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.peerService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,7 +17,7 @@ spec:
     port: {{ .Values.hubble.tls.enabled | ternary 443 80 }}
     {{- end }}
     protocol: TCP
-    targetPort: {{ splitList ":" .Values.hubble.listenAddress | last }}
+    targetPort: {{ .Values.hubble.peerService.targetPort }}
 {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
   internalTrafficPolicy: Local
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -685,6 +685,8 @@ hubble:
     enabled: true
     # -- Service Port for the Peer service.
     servicePort: 4254
+    # -- Target Port for the Peer service.
+    targetPort: 4244
     # -- The cluster domain to use to query the Hubble Peer service. It should
     # be the local cluster.
     clusterDomain: cluster.local


### PR DESCRIPTION
Configure the peerService to access hubble on the
hubble.peerService.targetPort rather than determining the port from
hubble.listenAddress which may be empty when using hubble-rbac.

<!-- Description of change -->

```release-note
Do not disable peer service when hubble.listenAddress is empty
```
