### PR TITLE
ipcache: Error out from InjectLabels if Checker is nil

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -109,8 +109,7 @@ func (ipc *IPCache) InjectLabels(src source.Source) error {
 		return ErrLocalIdentityAllocatorUninitialized
 	}
 
-	if ipc.k8sSyncedChecker != nil &&
-		!ipc.k8sSyncedChecker.K8sCacheIsSynced() {
+	if ipc.k8sSyncedChecker == nil || !ipc.k8sSyncedChecker.K8sCacheIsSynced() {
 		return errors.New("k8s cache not fully synced")
 	}
 


### PR DESCRIPTION
K8s cache is not fully synced also when k8sSyncedChecker is still nil.

Found during code inspection, not sure if this can manifest as a bug on
runtime.

Fixes: #17823
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>