### PR TITLE
docs: Remove '\r' chars from grep result to parse Alpine image name

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -15,7 +15,7 @@ clean:
 
 builder-image: Dockerfile requirements.txt
 	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
-	grep "^FROM " $< | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
+	grep "^FROM " $< | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
 	$(QUIET)tar c requirements.txt Dockerfile \
 	  | $(CONTAINER_ENGINE) build --tag cilium/docs-builder -
 


### PR DESCRIPTION
The first step for building the cilium/docs-builder image, used for building Cilium's documentation, consists in pre-pulling the image with Docker (to avoid failures from buildkit). The relevant command is formed by parsing the name of the Alpine image from the Dockerfile.

On some setups, for example on Ubuntu running in Windows WSL with the Cilium repository mounted from a Windows partition, the Dockerfile may contain DOS-style line breaks (CR-LF). The result from `grep` being piped to `xargs` and passed to `docker pull`, we get an error because Docker cannot recognise a valid reference with this `\r` character at the end of the string. Let's remove any carriage return characters before feeding the line to `xargs`.