### PR TITLE
bpf: specify handle_lxc_traffic return type to fix -Wimplicit-int error

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1411,7 +1411,7 @@ from_host_to_lxc(struct __ctx_buff *ctx)
  * bpf_lxc program.
  */
 __section_tail(CILIUM_MAP_POLICY, TEMPLATE_HOST_EP_ID)
-handle_lxc_traffic(struct __ctx_buff *ctx)
+int handle_lxc_traffic(struct __ctx_buff *ctx)
 {
 	bool from_host = ctx_load_meta(ctx, CB_FROM_HOST);
 	__u32 lxc_id;


### PR DESCRIPTION
This fixes the following error when building with clang 15:

    bpf_host.c:1414:1: error: type specifier missing, defaults to 'int' [-Werror,-Wimplicit-int]
    handle_lxc_traffic(struct __ctx_buff *ctx)
    ^
    1 error generated.

Fixes: a4aac43d1ed7 ("bpf: Support hostfw with endpoint routes")
