### PR TITLE
Enable L7 DNS proxy for nodes

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -836,6 +836,10 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	if k8s.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
+		if err := k8s.Init(option.Config); err != nil {
+			log.WithError(err).Fatal("Unable to initialize Kubernetes subsystem")
+		}
+
 		// Errors are handled inside WaitForCRDsToRegister. It will fatal on a
 		// context deadline or if the context has been cancelled, the context's
 		// error will be returned. Otherwise, it succeeded.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1695,14 +1695,6 @@ func runDaemon() {
 		link.DeleteByName(wireguardTypes.IfaceName)
 	}
 
-	if k8s.IsEnabled() {
-		bootstrapStats.k8sInit.Start()
-		if err := k8s.Init(option.Config); err != nil {
-			log.WithError(err).Fatal("Unable to initialize Kubernetes subsystem")
-		}
-		bootstrapStats.k8sInit.End(true)
-	}
-
 	ctx, cancel := context.WithCancel(server.ServerCtx)
 	d, restoredEndpoints, err := NewDaemon(ctx, cancel,
 		WithDefaultEndpointManager(ctx, endpoint.CheckHealth),

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -58,6 +58,10 @@ func (f *fakeDatapath) WriteEndpointConfig(io.Writer, datapath.EndpointConfigura
 	return nil
 }
 
+func (f *fakeDatapath) InstallHostDnsProxyRules(install bool) error {
+	return nil
+}
+
 func (f *fakeDatapath) InstallProxyRules(context.Context, uint16, bool, string) error {
 	return nil
 }

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -68,6 +68,13 @@ var ciliumChains = []customChain{
 		feederArgs: []string{""},
 	},
 	{
+		name:       ciliumOutMangleChain,
+		table:      "mangle",
+		hook:       "OUTPUT",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
 		name:       ciliumPostMangleChain,
 		table:      "mangle",
 		hook:       "POSTROUTING",

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -49,6 +49,10 @@ type Proxy interface {
 
 // IptablesManager manages iptables rules.
 type IptablesManager interface {
+	// InstallHostDnsProxyRules creates the necessary datapath config rules
+	// for redirecting host L7 traffic to proxy
+	InstallHostDnsProxyRules(install bool) error
+
 	// InstallProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
 	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress bool, name string) error

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -408,6 +408,23 @@ func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 		return err
 	}
 
+	// KLUDGE
+	if e.isHost {
+		install := false
+		if e.desiredPolicy != nil && e.desiredPolicy.L4Policy != nil {
+			for _, filter := range e.desiredPolicy.L4Policy.Egress {
+				if filter.L7Parser == policy.ParserTypeDNS {
+					install = true
+				}
+			}
+		}
+
+		err = e.owner.Datapath().InstallHostDnsProxyRules(install)
+		if err != nil {
+			return fmt.Errorf("installing host DNS proxy rules failed: %s", err)
+		}
+	}
+
 	return e.updateRealizedState(stats, origDir, revision, stateDirComplete)
 }
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -520,11 +520,14 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		}(s)
 	}
 
+	// Mark outgoing packets forwarded by proxy
+	dialer := dialerConfig(linux_defaults.MagicMarkEgress)
+
 	// Bind the DNS forwarding clients on UDP and TCP
 	// Note: SingleInFlight should remain disabled. When enabled it folds DNS
 	// retries into the previous lookup, suppressing them.
-	p.UDPClient = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: false}
-	p.TCPClient = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: false}
+	p.UDPClient = &dns.Client{Dialer: dialer, Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: false}
+	p.TCPClient = &dns.Client{Dialer: dialer, Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: false}
 
 	return p, nil
 }

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -9,6 +9,9 @@
 package restore
 
 import (
+	"bytes"
+	"fmt"
+	"net/netip"
 	"regexp"
 	"sort"
 )
@@ -22,7 +25,70 @@ type IPRules []IPRule
 // IPRule stores the allowed destination IPs for a DNS names matching a regex
 type IPRule struct {
 	Re  RuleRegex
-	IPs map[string]struct{} // IPs, nil set is wildcard and allows all IPs!
+	IPs map[RuleIPOrCIDR]struct{} // IPs, nil set is wildcard and allows all IPs!
+}
+
+// RuleIPOrCIDR is one allowed destination IP or CIDR
+// It marshals to/from text in a way that is compatible with net.IP and CIDRs
+type RuleIPOrCIDR netip.Prefix
+
+func ParseRuleIPOrCIDR(s string) (ip RuleIPOrCIDR, err error) {
+	err = ip.UnmarshalText([]byte(s))
+	return
+}
+
+func MustParseRuleIPOrCIDR(s string) (ip RuleIPOrCIDR) {
+	if err := ip.UnmarshalText([]byte(s)); err != nil {
+		panic(fmt.Errorf("bad input '%s': %s", s, err))
+	}
+	return
+}
+
+func (ip RuleIPOrCIDR) ContainsAddr(addr RuleIPOrCIDR) bool {
+	return addr.IsAddr() && netip.Prefix(ip).Contains(netip.Prefix(addr).Addr())
+}
+
+func (ip RuleIPOrCIDR) IsAddr() bool {
+	return netip.Prefix(ip).Bits() == -1
+}
+
+func (ip RuleIPOrCIDR) String() string {
+	if ip.IsAddr() {
+		return netip.Prefix(ip).Addr().String()
+	} else {
+		return netip.Prefix(ip).String()
+	}
+}
+
+func (ip RuleIPOrCIDR) ToSingleCIDR() RuleIPOrCIDR {
+	addr := netip.Prefix(ip).Addr()
+	return RuleIPOrCIDR(netip.PrefixFrom(addr, addr.BitLen()))
+}
+
+func (ip RuleIPOrCIDR) MarshalText() ([]byte, error) {
+	if ip.IsAddr() {
+		return netip.Prefix(ip).Addr().MarshalText()
+	} else {
+		return netip.Prefix(ip).MarshalText()
+	}
+}
+
+func (ip *RuleIPOrCIDR) UnmarshalText(b []byte) (err error) {
+	if b == nil {
+		return fmt.Errorf("cannot unmarshal nil into RuleIPOrCIDR")
+	}
+	if i := bytes.IndexByte(b, byte('/')); i < 0 {
+		var addr netip.Addr
+		if err = addr.UnmarshalText(b); err == nil {
+			*ip = RuleIPOrCIDR(netip.PrefixFrom(addr, 0xff))
+		}
+	} else {
+		var prefix netip.Prefix
+		if err = prefix.UnmarshalText(b); err == nil {
+			*ip = RuleIPOrCIDR(prefix)
+		}
+	}
+	return
 }
 
 // RuleRegex is a wrapper for *regexp.Regexp so that we can define marshalers for it.

--- a/pkg/policy/api/egress_test.go
+++ b/pkg/policy/api/egress_test.go
@@ -349,7 +349,7 @@ func (s *PolicyAPITestSuite) TestIsLabelBasedEgress(c *C) {
 	for _, tt := range tests {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		c.Assert(args.eg.sanitize(), Equals, nil, Commentf("Test name: %q", tt.name))
+		c.Assert(args.eg.sanitize(false), Equals, nil, Commentf("Test name: %q", tt.name))
 		isLabelBased := args.eg.AllowsWildcarding()
 		c.Assert(isLabelBased, checker.DeepEquals, want.isLabelBased, Commentf("Test name: %q", tt.name))
 	}

--- a/pkg/policy/api/ingress_test.go
+++ b/pkg/policy/api/ingress_test.go
@@ -230,7 +230,7 @@ func (s *PolicyAPITestSuite) TestIsLabelBasedIngress(c *C) {
 	for _, tt := range tests {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		c.Assert(args.eg.sanitize(), Equals, nil, Commentf("Test name: %q", tt.name))
+		c.Assert(args.eg.sanitize(false), Equals, nil, Commentf("Test name: %q", tt.name))
 		isLabelBased := args.eg.AllowsWildcarding()
 		c.Assert(isLabelBased, checker.DeepEquals, want.isLabelBased, Commentf("Test name: %q", tt.name))
 	}


### PR DESCRIPTION
FQDN-based network policy is extremely useful for egress filtering, but is currently only supported in pods. This means that nodes must either rely on some other filtering mechanism, or resort to periodically updating L3/L4 CIDR policies. However, the code which collects DNS requests and combines them with policy to automatically produce L3/L4 filters is at endpoint level and is almost agnostic with respect to kind of endpoint (pod or node). This PR enables FQDN-based network policy for nodes by adding suitable iptables rules which redirect node's DNS requests to the same transparent proxy that is used for pods, and modifying the daemon startup sequence to avoid catch-22 between bootstrapping FQDN code and initialization of Kubernetes subsystem.

This PR works in simple cases (e.g. AKS cluster with default settings) but contains several kludges. I ask the community for advice and/or collaboration on these.

0. Node DNS traffic probably should be directed to the DNS proxy by the node's BPF program. I don't know BPF so I am adding rules to the OUTPUT chain of the mangle table (pkg/datapath/iptables/iptables.go:InstallHostDnsProxyRules) in what I hope is the correct place (pkg/endpoint/policy.go). These rules redirect node DNS packets to the proxy via the loopback interface using the same rule-based routing table used to redirect pod packets. To avoid infinite packet loops, I mark DNS proxy's forward requests as coming from proxy and also skip marking packets being redirected to the proxy as coming from host.
1. The host endpoint currently does not have any IP addresses associated with it. I could not figure out whether this was intentional, what was the correct place to source those addresses, and what would be the implications of associating IP addresses with the host endpoint, but this prevented existing DNS proxy code from allowing node's DNS requests, as it could not look up the source endpoint. Therefore I added a kludge which makes endpoint lookup work in the simple case of one node IPv4 address (daemon/cmd/fqdn.go:lookupEPByIP). This is also the reason why I added the `isHost bool` return value to the lookup callback and a special field for the restored host endpoint (fqdn/dnsproxy/proxy.go).
2. ~~Restored IP rules contain a string representation of the CIDR identifying the DNS server and don't match the destination IP address (fqdn/dnsproxy/proxy.go). It may be better to save/restore a richer representation of IP rules.~~ (Fixed.)
3. ~~Enabling L7 DNS rules for nodes prevents upgrades of the agent image from working, as the OUTPUT mangle rules redirecting node DNS requests to the proxy are not flushed but the proxy is not operational. This can be worked around by pre-pulling the images while the agent is still working. This is not elegant but on the other hand allowing any DNS traffic while the agent is not up would be a security hole. Agent pod restarts work thanks to restored IP rules.~~ (Struck out because [Cilium upgrade guide](https://docs.cilium.io/en/stable/operations/upgrade/) already requires a pre-flight check that pre-pulls agent images.)

FQDN-based network policy for nodes is likely to be a good addition to Cilium, as it would enable egress filtering by FQDNs for the whole cluster without relying on third-party solutions. Also, the same approach may possibly work for other L7 rules.