### PR TITLE
install/kubernetes: add missing capabilities

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1208,7 +1208,7 @@
    * - nodeinit.securityContext
      - Security context to be added to nodeinit pods.
      - object
-     - ``{"capabilities":{"add":["SYS_MODULE","NET_ADMIN","SYS_ADMIN","SYS_PTRACE"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}}``
+     - ``{"capabilities":{"add":["SYS_MODULE","NET_ADMIN","SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}}``
    * - nodeinit.tolerations
      - Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
      - list
@@ -1504,7 +1504,7 @@
    * - securityContext
      - Security context to be added to agent pods
      - object
-     - ``{"privileged":false}``
+     - ``{"extraCapabilities":["DAC_OVERRIDE","FOWNER","SETGID","SETUID"],"privileged":false}``
    * - serviceAccounts
      - Define serviceAccount names for components.
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -352,7 +352,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |
 | nodeinit.priorityClassName | string | `""` | The priority class to use for the nodeinit pod. |
 | nodeinit.resources | object | `{"requests":{"cpu":"100m","memory":"100Mi"}}` | nodeinit resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
-| nodeinit.securityContext | object | `{"capabilities":{"add":["SYS_MODULE","NET_ADMIN","SYS_ADMIN","SYS_PTRACE"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}}` | Security context to be added to nodeinit pods. |
+| nodeinit.securityContext | object | `{"capabilities":{"add":["SYS_MODULE","NET_ADMIN","SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}}` | Security context to be added to nodeinit pods. |
 | nodeinit.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | nodeinit.updateStrategy | object | `{"type":"RollingUpdate"}` | node-init update strategy |
 | operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"io.cilium/app":"operator"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-operator |
@@ -426,7 +426,7 @@ contributors across the globe, there is almost always someone available to help.
 | resourceQuotas | object | `{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}` | Enable resource quotas for priority classes used in the cluster. |
 | resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | rollOutCiliumPods | bool | `false` | Roll out cilium agent pods automatically when configmap is updated. |
-| securityContext | object | `{"privileged":false}` | Security context to be added to agent pods |
+| securityContext | object | `{"extraCapabilities":["DAC_OVERRIDE","FOWNER","SETGID","SETUID"],"privileged":false}` | Security context to be added to agent pods |
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
 | serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -252,10 +252,14 @@ spec:
             type: 'spc_t'
           capabilities:
             add:
+              # Use to set socket permission
+              - CHOWN
               # Used to terminate envoy child process
               - KILL
               # Used since cilium modifies routing tables, etc...
               - NET_ADMIN
+              # Used since cilium creates raw sockets, etc...
+              - NET_RAW
               # Used since cilium monitor uses mmap
               - IPC_LOCK
               # Used in iptables. Consider removing once we are iptables-free
@@ -271,7 +275,12 @@ spec:
               # If available, SYS_ADMIN can be removed.
               #- PERFMON
               #- BPF
-          {{- end}}
+              {{- with .Values.securityContext.extraCapabilities }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+            drop:
+              - ALL
+          {{- end }}
         volumeMounts:
         {{- if not .Values.securityContext.privileged }}
         # Unprivileged containers need to mount /proc/sys/net from the host
@@ -384,7 +393,7 @@ spec:
             [ -S /var/run/cilium/monitor1_2.sock ] && break || sleep 10;\
             done; \
           cilium monitor
-        {{- range $type := .Values.monitor.eventTypes -}} 
+        {{- range $type := .Values.monitor.eventTypes -}}
           {{ " " }}--type={{ $type }}
         {{- end }}
         volumeMounts:
@@ -435,10 +444,13 @@ spec:
             # type available on the system.
             type: 'spc_t'
           capabilities:
+            drop:
+              - ALL
             add:
               # Only used for 'mount' cgroup
               - SYS_ADMIN
               # Used for nsenter
+              - SYS_CHROOT
               - SYS_PTRACE
           {{- end}}
       {{- end }}
@@ -541,6 +553,8 @@ spec:
               # If available, SYS_ADMIN can be removed.
               #- PERFMON
               #- BPF
+            drop:
+              - ALL
           {{- end}}
         volumeMounts:
         {{- /* CRI-O already mounts the BPF filesystem */ -}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -173,6 +173,15 @@ resources: {}
 securityContext:
   # runAsUser: 0
   privileged: false
+  extraCapabilities:
+    # Allow discretionary access control (e.g. required for package installation)
+    - DAC_OVERRIDE
+    # Allow to set Access Control Lists (ACLs) on arbitrary files (e.g. required for package installation)
+    - FOWNER
+    # Allow to execute program that changes GID (e.g. required for package installation)
+    - SETGID
+    # Allow to execute program that changes UID (e.g. required for package installation)
+    - SETUID
 
 # -- Cilium agent update strategy
 updateStrategy:
@@ -1701,6 +1710,7 @@ nodeinit:
         # Used for nsenter
         - NET_ADMIN
         - SYS_ADMIN
+        - SYS_CHROOT
         - SYS_PTRACE
 
   # -- bootstrapFile is the location of the file where the bootstrap timestamp is


### PR DESCRIPTION
Dropping "privileged: true" in favor of capabilities introduced by https://github.com/cilium/cilium/pull/14446 relies on default capabilities of container runtime. The capabilities set fits `docker`/`containerd` but not enough for container runtime like `cri-o`.

```release-note
Fix missing capabilities when not running Cilium on containerd-based Kubernetes
```