### PR TITLE
mlh: update Jenkins jobs following 1.24 support

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -59,9 +59,10 @@ flake-tracker:
     - cilium-master-k8s-1.19-kernel-4.9
     - cilium-master-k8s-1.20-kernel-4.9
     - cilium-master-k8s-1.21-kernel-4.9
-    - cilium-master-k8s-1.21-kernel-5.4
-    - cilium-master-k8s-1.22-kernel-4.19
+    - cilium-master-k8s-1.22-kernel-4.9
+    - cilium-master-k8s-1.22-kernel-5.4
     - cilium-master-k8s-1.23-kernel-net-next
+    - cilium-master-k8s-1.24-kernel-4.19
     - cilium-master-k8s-upstream
     pr-jobs:
       Cilium-PR-K8s-1.16-kernel-4.9:
@@ -72,6 +73,7 @@ flake-tracker:
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
       Cilium-PR-K8s-1.17-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -80,6 +82,7 @@ flake-tracker:
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
       Cilium-PR-K8s-1.18-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -88,6 +91,7 @@ flake-tracker:
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
       Cilium-PR-K8s-1.19-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -96,6 +100,7 @@ flake-tracker:
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
       Cilium-PR-K8s-1.20-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -104,6 +109,7 @@ flake-tracker:
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
       Cilium-PR-K8s-1.21-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -112,15 +118,25 @@ flake-tracker:
         - cilium-master-k8s-1.19-kernel-4.9
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
-      Cilium-PR-K8s-1.21-kernel-5.4:
+        - cilium-master-k8s-1.22-kernel-4.9
+      Cilium-PR-K8s-1.22-kernel-4.9:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.21-kernel-5.4
-      Cilium-PR-K8s-1.22-kernel-4.19:
+        - cilium-master-k8s-1.16-kernel-4.9
+        - cilium-master-k8s-1.17-kernel-4.9
+        - cilium-master-k8s-1.18-kernel-4.9
+        - cilium-master-k8s-1.19-kernel-4.9
+        - cilium-master-k8s-1.20-kernel-4.9
+        - cilium-master-k8s-1.21-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
+      Cilium-PR-K8s-1.22-kernel-5.4:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-5.4
       Cilium-PR-K8s-1.23-kernel-net-next:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.23-kernel-net-next
+      Cilium-PR-K8s-1.24-kernel-4.19:
+        correlate-with-stable-jobs:
+        - cilium-master-k8s-1.24-kernel-4.19
       Cilium-PR-K8s-GKE:
         correlate-with-stable-jobs:
         - cilium-master-gke


### PR DESCRIPTION
K8s 1.24 support was added in f321a6a8f08321a4997797f6fe17cbad27ddaccc.

As discussed in community meetings, we can't use net-next for testing K8s 1.24 for now, yet need a kernel recent enough so that we can still test dual-stack IPv6: we have settled on using 4.19 for K8s 1.24.

We have rotated the Jenkins test jobs as follow:

- Changed: Kernel 5.4 on K8s 1.22 (instead of 1.21, triggered on `/test`).
- Changed: Kernel 4.19 on K8s 1.24 (instead of 1.22, triggered on `/test`).
- Not changed: Kernel net-next on K8s 1.23 (triggered on `/test`).
- Added: Kernel 4.9 on K8s 1.22 (not triggered on `/test`).

See the Table of Truth™️ for up to date status on all trigger phrases: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0/edit#gid=0