### PR TITLE
ci-l4lb: Check out stable branch

### DIFF
--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -158,7 +158,8 @@ jobs:
 
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
-          ref: ${{ steps.vars.outputs.sha }}
+          # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
+          ref: v1.10
           persist-credentials: false
 
       - name: Boot Fedora

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -158,7 +158,8 @@ jobs:
 
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
-          ref: ${{ steps.vars.outputs.sha }}
+          # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
+          ref: v1.11
           persist-credentials: false
 
       - name: Boot Fedora

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -161,7 +161,8 @@ jobs:
 
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
-          ref: ${{ steps.vars.outputs.sha }}
+          # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
+          ref: master
           persist-credentials: false
 
       - name: Boot Fedora


### PR DESCRIPTION
This reverts commit 47a215c6e2c67937937a5f19d567aee442ebfc6c.
This reverts commit c3b2948ca26930d3b55252550dcc9b891d287a80.

Ref: https://github.com/cilium/cilium/pull/19898#issuecomment-1133163172

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>