### PR TITLE
#19693 v1.10 backport

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -947,7 +947,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	// iptables rules can be updated only after d.init() intializes the iptables above.
-	err = d.updateDNSDatapathRules()
+	err = d.updateDNSDatapathRules(d.ctx)
 	if err != nil {
 		return nil, restoredEndpoints, err
 	}

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -377,8 +377,8 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 // updateDNSDatapathRules updates the DNS proxy iptables rules. Must be
 // called after iptables has been initailized, and only after
 // successful bootstrapFQDN().
-func (d *Daemon) updateDNSDatapathRules() error {
-	return d.l7Proxy.AckProxyPort(policy.ParserTypeDNS, false)
+func (d *Daemon) updateDNSDatapathRules(ctx context.Context) error {
+	return d.l7Proxy.AckProxyPort(ctx, policy.ParserTypeDNS, false)
 }
 
 // updateSelectors propagates the mapping of FQDNSelector to identity, as well

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -84,6 +84,14 @@ func (m *fakeDatapath) GetProxyPort(name string) uint16 {
 	return 0
 }
 
+func (m *fakeDatapath) InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	return nil
+}
+
+func (m *fakeDatapath) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	return nil
+}
+
 func (f *fakeDatapath) Loader() datapath.Loader {
 	return f.loader
 }

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -68,7 +68,7 @@ func (f *fakeDatapath) WriteEndpointConfig(io.Writer, datapath.EndpointConfigura
 	return nil
 }
 
-func (f *fakeDatapath) InstallProxyRules(uint16, bool, string) error {
+func (f *fakeDatapath) InstallProxyRules(context.Context, uint16, bool, string) error {
 	return nil
 }
 
@@ -76,7 +76,7 @@ func (f *fakeDatapath) SupportsOriginalSourceAddr() bool {
 	return false
 }
 
-func (f *fakeDatapath) InstallRules(ifName string, quiet, install bool) error {
+func (f *fakeDatapath) InstallRules(ctx context.Context, ifName string, quiet, install bool) error {
 	return nil
 }
 

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -122,13 +122,13 @@ func (c *customChain) doAdd(prog iptablesInterface) error {
 	return nil
 }
 
-func (c *customChain) add() error {
-	if option.Config.EnableIPv4 {
+func (c *customChain) add(ipv4, ipv6 bool) error {
+	if ipv4 {
 		if err := c.doAdd(ip4tables); err != nil {
 			return err
 		}
 	}
-	if option.Config.EnableIPv6 && c.ipv6 == true {
+	if ipv6 && c.ipv6 {
 		if err := c.doAdd(ip6tables); err != nil {
 			return err
 		}
@@ -154,13 +154,13 @@ func (c *customChain) doRename(prog iptablesInterface, newName string) error {
 	return nil
 }
 
-func (c *customChain) rename(name string) error {
-	if option.Config.EnableIPv4 {
+func (c *customChain) rename(ipv4, ipv6 bool, name string) error {
+	if ipv4 {
 		if err := c.doRename(ip4tables, name); err != nil {
 			return err
 		}
 	}
-	if option.Config.EnableIPv6 && c.ipv6 {
+	if ipv6 && c.ipv6 {
 		if err := c.doRename(ip6tables, name); err != nil {
 			return nil
 		}
@@ -193,13 +193,13 @@ func (c *customChain) doRemove(prog iptablesInterface) error {
 	return nil
 }
 
-func (c *customChain) remove() error {
-	if option.Config.EnableIPv4 {
+func (c *customChain) remove(ipv4, ipv6 bool) error {
+	if ipv4 {
 		if err := c.doRemove(ip4tables); err != nil {
 			return err
 		}
 	}
-	if option.Config.EnableIPv6 && c.ipv6 {
+	if ipv6 && c.ipv6 {
 		if err := c.doRemove(ip6tables); err != nil {
 			return err
 		}
@@ -234,14 +234,14 @@ func (c *customChain) doInstallFeeder(prog iptablesInterface, feedArgs string) e
 	return nil
 }
 
-func (c *customChain) installFeeder() error {
+func (c *customChain) installFeeder(ipv4, ipv6 bool) error {
 	for _, feedArgs := range c.feederArgs {
-		if option.Config.EnableIPv4 {
+		if ipv4 {
 			if err := c.doInstallFeeder(ip4tables, feedArgs); err != nil {
 				return err
 			}
 		}
-		if option.Config.EnableIPv6 && c.ipv6 == true {
+		if ipv6 && c.ipv6 == true {
 			if err := c.doInstallFeeder(ip6tables, feedArgs); err != nil {
 				return err
 			}

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptables
+
+import (
+	"github.com/mattn/go-shellwords"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type customChain struct {
+	name       string
+	table      string
+	hook       string
+	feederArgs []string
+	ipv6       bool // ip6tables chain in addition to iptables chain
+}
+
+// ciliumChains is the list of custom iptables chain used by Cilium. Custom
+// chains are used to allow for simple replacements of all rules.
+//
+// WARNING: If you change or remove any of the feeder rules you have to ensure
+// that the old feeder rules is also removed on agent start, otherwise,
+// flushing and removing the custom chains will fail.
+var ciliumChains = []customChain{
+	{
+		name:       ciliumInputChain,
+		table:      "filter",
+		hook:       "INPUT",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumOutputChain,
+		table:      "filter",
+		hook:       "OUTPUT",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumOutputRawChain,
+		table:      "raw",
+		hook:       "OUTPUT",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumPostNatChain,
+		table:      "nat",
+		hook:       "POSTROUTING",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumOutputNatChain,
+		table:      "nat",
+		hook:       "OUTPUT",
+		feederArgs: []string{""},
+	},
+	{
+		name:       ciliumPreNatChain,
+		table:      "nat",
+		hook:       "PREROUTING",
+		feederArgs: []string{""},
+	},
+	{
+		name:       ciliumPostMangleChain,
+		table:      "mangle",
+		hook:       "POSTROUTING",
+		feederArgs: []string{""},
+	},
+	{
+		name:       ciliumPreMangleChain,
+		table:      "mangle",
+		hook:       "PREROUTING",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumPreRawChain,
+		table:      "raw",
+		hook:       "PREROUTING",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumForwardChain,
+		table:      "filter",
+		hook:       "FORWARD",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+}
+
+func (c *customChain) add() error {
+	var err error
+	if option.Config.EnableIPv4 {
+		err = ip4tables.runProg([]string{"-t", c.table, "-N", c.name}, false)
+	}
+	if err == nil && option.Config.EnableIPv6 && c.ipv6 == true {
+		err = ip6tables.runProg([]string{"-t", c.table, "-N", c.name}, false)
+	}
+	return err
+}
+
+func (c *customChain) doRename(prog iptablesInterface, name string, quiet bool) {
+	args := []string{"-t", c.table, "-E", c.name, name}
+	operation := "rename"
+	combinedOutput, err := prog.runProgCombinedOutput(args, true)
+	if err != nil && !quiet {
+		log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog, c.name, string(combinedOutput))
+	}
+}
+
+func (c *customChain) rename(name string, quiet bool) {
+	if option.Config.EnableIPv4 {
+		c.doRename(ip4tables, name, quiet)
+	}
+	if option.Config.EnableIPv6 && c.ipv6 {
+		c.doRename(ip6tables, name, quiet)
+	}
+}
+
+func (c *customChain) remove(quiet bool) {
+	doProcess := func(c *customChain, prog iptablesInterface, args []string, operation string, quiet bool) {
+		combinedOutput, err := prog.runProgCombinedOutput(args, true)
+		if err != nil && !quiet {
+			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog.getProg(), c.name, string(combinedOutput))
+		}
+	}
+	doRemove := func(c *customChain, prog iptablesInterface, quiet bool) {
+		args := []string{"-t", c.table, "-F", c.name}
+		doProcess(c, prog, args, "flush", quiet)
+		args = []string{"-t", c.table, "-X", c.name}
+		doProcess(c, prog, args, "delete", quiet)
+	}
+	if option.Config.EnableIPv4 {
+		doRemove(c, ip4tables, quiet)
+	}
+	if option.Config.EnableIPv6 && c.ipv6 {
+		doRemove(c, ip6tables, quiet)
+	}
+}
+
+func getFeedRule(name, args string) []string {
+	ruleTail := []string{"-m", "comment", "--comment", feederDescription + " " + name, "-j", name}
+	if args == "" {
+		return ruleTail
+	}
+	argsList, err := shellwords.Parse(args)
+	if err != nil {
+		log.WithError(err).WithField(logfields.Object, args).Fatal("Unable to parse rule into argument slice")
+	}
+	return append(argsList, ruleTail...)
+}
+
+func (c *customChain) installFeeder() error {
+	installMode := "-A"
+	if option.Config.PrependIptablesChains {
+		installMode = "-I"
+	}
+
+	for _, feedArgs := range c.feederArgs {
+		if option.Config.EnableIPv4 {
+			err := ip4tables.runProg(append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
+			if err != nil {
+				return err
+			}
+		}
+		if option.Config.EnableIPv6 && c.ipv6 == true {
+			err := ip6tables.runProg(append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -82,14 +82,6 @@ const (
 	waitString = "-w"
 )
 
-type customChain struct {
-	name       string
-	table      string
-	hook       string
-	feederArgs []string
-	ipv6       bool // ip6tables chain in addition to iptables chain
-}
-
 type iptablesInterface interface {
 	getProg() string
 	getVersion() (semver.Version, error)
@@ -151,18 +143,6 @@ func (ipt *ipt) runProg(args []string, quiet bool) error {
 	return err
 }
 
-func getFeedRule(name, args string) []string {
-	ruleTail := []string{"-m", "comment", "--comment", feederDescription + " " + name, "-j", name}
-	if args == "" {
-		return ruleTail
-	}
-	argsList, err := shellwords.Parse(args)
-	if err != nil {
-		log.WithError(err).WithField(logfields.Object, args).Fatal("Unable to parse rule into argument slice")
-	}
-	return append(argsList, ruleTail...)
-}
-
 // skipPodTrafficConntrack returns true if it's possible to install iptables
 // `-j NOTRACK` rules to skip tracking pod traffic.
 func skipPodTrafficConntrack(ipv6 bool) bool {
@@ -185,17 +165,6 @@ func KernelHasNetfilter() bool {
 		return true
 	}
 	return false
-}
-
-func (c *customChain) add() error {
-	var err error
-	if option.Config.EnableIPv4 {
-		err = ip4tables.runProg([]string{"-t", c.table, "-N", c.name}, false)
-	}
-	if err == nil && option.Config.EnableIPv6 && c.ipv6 == true {
-		err = ip6tables.runProg([]string{"-t", c.table, "-N", c.name}, false)
-	}
-	return err
 }
 
 func reverseRule(rule string) ([]string, error) {
@@ -263,144 +232,6 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 			}
 		}
 	}
-}
-
-func (c *customChain) doRename(prog iptablesInterface, name string, quiet bool) {
-	args := []string{"-t", c.table, "-E", c.name, name}
-	operation := "rename"
-	combinedOutput, err := prog.runProgCombinedOutput(args, true)
-	if err != nil && !quiet {
-		log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog, c.name, string(combinedOutput))
-	}
-}
-
-func (c *customChain) rename(name string, quiet bool) {
-	if option.Config.EnableIPv4 {
-		c.doRename(ip4tables, name, quiet)
-	}
-	if option.Config.EnableIPv6 && c.ipv6 {
-		c.doRename(ip6tables, name, quiet)
-	}
-}
-
-func (c *customChain) remove(quiet bool) {
-	doProcess := func(c *customChain, prog iptablesInterface, args []string, operation string, quiet bool) {
-		combinedOutput, err := prog.runProgCombinedOutput(args, true)
-		if err != nil && !quiet {
-			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog.getProg(), c.name, string(combinedOutput))
-		}
-	}
-	doRemove := func(c *customChain, prog iptablesInterface, quiet bool) {
-		args := []string{"-t", c.table, "-F", c.name}
-		doProcess(c, prog, args, "flush", quiet)
-		args = []string{"-t", c.table, "-X", c.name}
-		doProcess(c, prog, args, "delete", quiet)
-	}
-	if option.Config.EnableIPv4 {
-		doRemove(c, ip4tables, quiet)
-	}
-	if option.Config.EnableIPv6 && c.ipv6 {
-		doRemove(c, ip6tables, quiet)
-	}
-}
-
-func (c *customChain) installFeeder() error {
-	installMode := "-A"
-	if option.Config.PrependIptablesChains {
-		installMode = "-I"
-	}
-
-	for _, feedArgs := range c.feederArgs {
-		if option.Config.EnableIPv4 {
-			err := ip4tables.runProg(append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
-			if err != nil {
-				return err
-			}
-		}
-		if option.Config.EnableIPv6 && c.ipv6 == true {
-			err := ip6tables.runProg(append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// ciliumChains is the list of custom iptables chain used by Cilium. Custom
-// chains are used to allow for simple replacements of all rules.
-//
-// WARNING: If you change or remove any of the feeder rules you have to ensure
-// that the old feeder rules is also removed on agent start, otherwise,
-// flushing and removing the custom chains will fail.
-var ciliumChains = []customChain{
-	{
-		name:       ciliumInputChain,
-		table:      "filter",
-		hook:       "INPUT",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumOutputChain,
-		table:      "filter",
-		hook:       "OUTPUT",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumOutputRawChain,
-		table:      "raw",
-		hook:       "OUTPUT",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumPostNatChain,
-		table:      "nat",
-		hook:       "POSTROUTING",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumOutputNatChain,
-		table:      "nat",
-		hook:       "OUTPUT",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumPreNatChain,
-		table:      "nat",
-		hook:       "PREROUTING",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumPostMangleChain,
-		table:      "mangle",
-		hook:       "POSTROUTING",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumPreMangleChain,
-		table:      "mangle",
-		hook:       "PREROUTING",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumPreRawChain,
-		table:      "raw",
-		hook:       "PREROUTING",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumForwardChain,
-		table:      "filter",
-		hook:       "FORWARD",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
 }
 
 // IptablesManager manages the iptables-related configuration for Cilium.

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -802,7 +802,7 @@ func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) 
 	return nil
 }
 
-func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name string) error {
+func (m *IptablesManager) InstallProxyRules(ctx context.Context, proxyPort uint16, ingress bool, name string) error {
 	backoff := backoff.Exponential{
 		Min:  20 * time.Second,
 		Max:  3 * time.Minute,
@@ -825,7 +825,7 @@ func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name
 		}
 
 		log.WithError(err).Warning("Failed to install iptables proxy rules")
-		backoff.Wait(context.TODO())
+		backoff.Wait(ctx)
 	}
 }
 
@@ -1140,7 +1140,7 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 
 // InstallRules installs iptables rules for Cilium in specific use-cases
 // (most specifically, interaction with kube-proxy).
-func (m *IptablesManager) InstallRules(ifName string, firstInitialization, install bool) error {
+func (m *IptablesManager) InstallRules(ctx context.Context, ifName string, firstInitialization, install bool) error {
 	backoff := backoff.Exponential{
 		Min:  20 * time.Second,
 		Max:  3 * time.Minute,
@@ -1163,7 +1163,7 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 		}
 
 		log.WithError(err).Warning("Failed to install iptables rules")
-		backoff.Wait(context.TODO())
+		backoff.Wait(ctx)
 	}
 }
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/modules"
 	"github.com/cilium/cilium/pkg/node"
@@ -404,6 +405,12 @@ var ciliumChains = []customChain{
 
 // IptablesManager manages the iptables-related configuration for Cilium.
 type IptablesManager struct {
+	// This lock ensures there are no concurrent executions of the InstallRules() and
+	// InstallProxyRules() methods, as otherwise we may end up with errors (as rules may have
+	// been already removed or installed by a different execution of the method) or with an
+	// inconsistent ruleset
+	lock.Mutex
+
 	haveIp6tables        bool
 	haveSocketMatch      bool
 	haveBPFSocketAssign  bool
@@ -833,6 +840,9 @@ func (m *IptablesManager) endpointNoTrackRules(prog iptablesInterface, cmd strin
 // When InstallNoConntrackIptRules is not set, this function will be executed to install NOTRACK rules.
 // The rules installed by this function is very specific, for now, the only user is node-local-dns pods.
 func (m *IptablesManager) InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	m.Lock()
+	defer m.Unlock()
+
 	// Do not install per endpoint NOTRACK rules if we are already skipping
 	// conntrack for all pod traffic.
 	if skipPodTrafficConntrack(ipv6) {
@@ -869,6 +879,9 @@ func (m *IptablesManager) InstallNoTrackRules(IP string, port uint16, ipv6 bool)
 
 // See comments for InstallNoTrackRules.
 func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	m.Lock()
+	defer m.Unlock()
+
 	// Do not install per endpoint NOTRACK rules if we are already skipping
 	// conntrack for all pod traffic.
 	if skipPodTrafficConntrack(ipv6) {
@@ -904,6 +917,9 @@ func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) 
 }
 
 func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name string) error {
+	m.Lock()
+	defer m.Unlock()
+
 	if m.haveBPFSocketAssign {
 		log.WithField("port", proxyPort).
 			Debug("Skipping proxy rule install due to BPF support")
@@ -1211,6 +1227,9 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 // InstallRules installs iptables rules for Cilium in specific use-cases
 // (most specifically, interaction with kube-proxy).
 func (m *IptablesManager) InstallRules(ifName string, firstInitialization, install bool) (err error) {
+	m.Lock()
+	defer m.Unlock()
+
 	quiet := firstInitialization
 
 	// Make sure we have no old "backups"

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -16,12 +16,18 @@ package iptables
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
+	"github.com/mattn/go-shellwords"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/datapath"
@@ -37,10 +43,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/versioncheck"
-
-	"github.com/blang/semver/v4"
-	"github.com/mattn/go-shellwords"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -801,6 +803,33 @@ func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) 
 }
 
 func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name string) error {
+	backoff := backoff.Exponential{
+		Min:  20 * time.Second,
+		Max:  3 * time.Minute,
+		Name: "iptables-proxy-rules-installer",
+	}
+
+	maxAttempts := 3
+	attempt := 0
+
+	for {
+		attempt += 1
+		err := m.doInstallProxyRules(proxyPort, ingress, name)
+		if err == nil {
+			log.Info("Iptables proxy rules installed")
+			return nil
+		}
+
+		if attempt == maxAttempts {
+			return fmt.Errorf("failed to install iptables proxy rules: %w", err)
+		}
+
+		log.WithError(err).Warning("Failed to install iptables proxy rules")
+		backoff.Wait(context.TODO())
+	}
+}
+
+func (m *IptablesManager) doInstallProxyRules(proxyPort uint16, ingress bool, name string) error {
 	m.Lock()
 	defer m.Unlock()
 
@@ -1112,6 +1141,33 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 // InstallRules installs iptables rules for Cilium in specific use-cases
 // (most specifically, interaction with kube-proxy).
 func (m *IptablesManager) InstallRules(ifName string, firstInitialization, install bool) error {
+	backoff := backoff.Exponential{
+		Min:  20 * time.Second,
+		Max:  3 * time.Minute,
+		Name: "iptables-rules-installer",
+	}
+
+	maxAttempts := 3
+	attempt := 0
+
+	for {
+		attempt += 1
+		err := m.doInstallRules(ifName, firstInitialization, install)
+		if err == nil {
+			log.Info("Iptables rules installed")
+			return nil
+		}
+
+		if attempt == maxAttempts {
+			return fmt.Errorf("failed to install iptables rules: %w", err)
+		}
+
+		log.WithError(err).Warning("Failed to install iptables rules")
+		backoff.Wait(context.TODO())
+	}
+}
+
+func (m *IptablesManager) doInstallRules(ifName string, firstInitialization, install bool) error {
 	m.Lock()
 	defer m.Unlock()
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -131,6 +131,10 @@ func (ipt *ipt) getVersion() (semver.Version, error) {
 }
 
 func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
+	fullCommand := fmt.Sprintf("%s %s", ipt.getProg(), strings.Join(args, " "))
+
+	log.Debugf("Running '%s' command", fullCommand)
+
 	// Add wait argument to deal with concurrent calls that would fail otherwise
 	iptArgs := make([]string, 0, len(ipt.waitArgs)+len(args))
 	iptArgs = append(iptArgs, ipt.waitArgs...)
@@ -140,8 +144,7 @@ func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
 	outStr := string(out)
 
 	if err != nil {
-		return outStr, fmt.Errorf("unable to run '%s %s' iptables command: %s (%w)",
-			ipt.getProg(), args, outStr, err)
+		return outStr, fmt.Errorf("unable to run '%s' iptables command: %s (%w)", fullCommand, outStr, err)
 	}
 
 	return outStr, nil
@@ -588,7 +591,6 @@ func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string,
 			continue
 		}
 
-		log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
 		args, err := shellwords.Parse(strings.Replace(rule, oldChain, newChain, 1))
 		if err != nil {
 			log.WithFields(logrus.Fields{

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -346,12 +346,8 @@ func (m *IptablesManager) removeOldRules() error {
 		if err := m.removeCiliumRules(t, ip4tables, oldCiliumPrefix); err != nil {
 			return err
 		}
-	}
 
-	// Set of tables that have had ip6tables rules in any Cilium version
-	if m.haveIp6tables {
-		tables6 := []string{"nat", "mangle", "raw", "filter"}
-		for _, t := range tables6 {
+		if m.haveIp6tables {
 			if err := m.removeCiliumRules(t, ip6tables, oldCiliumPrefix); err != nil {
 				return err
 			}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -626,21 +626,18 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 		return err
 	}
 
-	if ingress {
-		if err := m.iptIngressProxyRule(rules, prog, "tcp", proxyPort, name); err != nil {
-			return err
-		}
-		if err := m.iptIngressProxyRule(rules, prog, "udp", proxyPort, name); err != nil {
-			return err
-		}
-	} else {
-		if err := m.iptEgressProxyRule(rules, prog, "tcp", proxyPort, name); err != nil {
-			return err
-		}
-		if err := m.iptEgressProxyRule(rules, prog, "udp", proxyPort, name); err != nil {
-			return err
+	for _, proto := range []string{"tcp", "udp"} {
+		if ingress {
+			if err := m.iptIngressProxyRule(rules, prog, proto, proxyPort, name); err != nil {
+				return err
+			}
+		} else {
+			if err := m.iptEgressProxyRule(rules, prog, proto, proxyPort, name); err != nil {
+				return err
+			}
 		}
 	}
+
 	// Delete all other rules for this same proxy name
 	// These may accumulate if there is a bind failure on a previously used port
 	portMatch := fmt.Sprintf("TPROXY --on-port %d ", proxyPort)

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -655,7 +655,7 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 	scanner := bufio.NewScanner(strings.NewReader(rules))
 	for scanner.Scan() {
 		rule := scanner.Text()
-		if !strings.Contains(rule, "-A CILIUM_PRE_mangle ") || strings.Contains(rule, "cilium: TPROXY to host "+name) || !strings.Contains(rule, portMatch) {
+		if !strings.Contains(rule, "-A CILIUM_PRE_mangle ") || !strings.Contains(rule, "cilium: TPROXY to host "+name) || strings.Contains(rule, portMatch) {
 			continue
 		}
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -237,7 +237,7 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 		// ie catch the beginning of the rule like -A POSTROUTING to match it against
 		// disabled chains
 		if skip, disabledChain := ruleReferencesDisabledChain(rule); skip {
-			log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
+			log.WithField(logfields.Chain, disabledChain).Info("Skipping the removal of feeder chain")
 			continue
 		}
 
@@ -1214,7 +1214,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 		if err := c.add(option.Config.EnableIPv4, option.Config.EnableIPv6); err != nil {
 			// do not return error for chain creation that are linked to disabled feeder rules
 			if isDisabledChain(c.hook) {
-				log.WithField("chain", c.name).Warningf("ignoring creation of chain since feeder rules for %s is disabled", c.hook)
+				log.WithField(logfields.Chain, c.name).Warningf("ignoring creation of chain since feeder rules for %s is disabled", c.hook)
 				continue
 			}
 
@@ -1295,7 +1295,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 	for _, c := range ciliumChains {
 		// do not install feeder for chains that are set to be disabled
 		if isDisabledChain(c.hook) {
-			log.WithField("chain", c.hook).Infof("Skipping the install of feeder rule")
+			log.WithField(logfields.Chain, c.hook).Infof("Skipping the install of feeder rule")
 			continue
 		}
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -192,6 +192,26 @@ func reverseRule(rule string) ([]string, error) {
 	return []string{}, nil
 }
 
+func ruleReferencesDisabledChain(rule string) (bool, string) {
+	for _, disabledChain := range option.Config.DisableIptablesFeederRules {
+		if strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
+			return true, disabledChain
+		}
+	}
+
+	return false, ""
+}
+
+func isDisabledChain(chain string) bool {
+	for _, disabledChain := range option.Config.DisableIptablesFeederRules {
+		if strings.EqualFold(chain, disabledChain) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) error {
 	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
 	if err != nil {
@@ -213,15 +233,8 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 		// do not remove feeder for chains that are set to be disabled
 		// ie catch the beginning of the rule like -A POSTROUTING to match it against
 		// disabled chains
-		skipFeeder := false
-		for _, disabledChain := range option.Config.DisableIptablesFeederRules {
-			if strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
-				log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
-				skipFeeder = true
-				break
-			}
-		}
-		if skipFeeder {
+		if skip, disabledChain := ruleReferencesDisabledChain(rule); skip {
+			log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
 			continue
 		}
 
@@ -1198,14 +1211,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 	for _, c := range ciliumChains {
 		if err := c.add(); err != nil {
 			// do not return error for chain creation that are linked to disabled feeder rules
-			skipFeeder := false
-			for _, disabledChain := range option.Config.DisableIptablesFeederRules {
-				if strings.EqualFold(c.hook, disabledChain) {
-					skipFeeder = true
-					break
-				}
-			}
-			if skipFeeder {
+			if isDisabledChain(c.hook) {
 				log.WithField("chain", c.name).Warningf("ignoring creation of chain since feeder rules for %s is disabled", c.hook)
 				continue
 			}
@@ -1286,15 +1292,8 @@ func (m *IptablesManager) installRules(ifName string) error {
 
 	for _, c := range ciliumChains {
 		// do not install feeder for chains that are set to be disabled
-		skipFeeder := false
-		for _, disabledChain := range option.Config.DisableIptablesFeederRules {
-			if strings.EqualFold(c.hook, disabledChain) {
-				log.WithField("chain", c.hook).Infof("Skipping the install of feeder rule")
-				skipFeeder = true
-				break
-			}
-		}
-		if skipFeeder {
+		if isDisabledChain(c.hook) {
+			log.WithField("chain", c.hook).Infof("Skipping the install of feeder rule")
 			continue
 		}
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -372,7 +372,7 @@ func (m *IptablesManager) removeOldRules() error {
 
 	for _, c := range ciliumChains {
 		c.name = "OLD_" + c.name
-		if err := c.remove(); err != nil {
+		if err := c.remove(true, m.haveIp6tables); err != nil {
 			return err
 		}
 	}
@@ -1182,7 +1182,7 @@ func (m *IptablesManager) doInstallRules(ifName string, firstInitialization, ins
 
 	// Rename any old chains we may have
 	for _, c := range ciliumChains {
-		if err := c.rename("OLD_" + c.name); err != nil {
+		if err := c.rename(true, m.haveIp6tables, "OLD_"+c.name); err != nil {
 			return err
 		}
 	}
@@ -1211,7 +1211,7 @@ func (m *IptablesManager) doInstallRules(ifName string, firstInitialization, ins
 func (m *IptablesManager) installRules(ifName string) error {
 	// Install new rules
 	for _, c := range ciliumChains {
-		if err := c.add(); err != nil {
+		if err := c.add(option.Config.EnableIPv4, option.Config.EnableIPv6); err != nil {
 			// do not return error for chain creation that are linked to disabled feeder rules
 			if isDisabledChain(c.hook) {
 				log.WithField("chain", c.name).Warningf("ignoring creation of chain since feeder rules for %s is disabled", c.hook)
@@ -1299,7 +1299,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 			continue
 		}
 
-		if err := c.installFeeder(); err != nil {
+		if err := c.installFeeder(option.Config.EnableIPv4, option.Config.EnableIPv6); err != nil {
 			return fmt.Errorf("cannot install feeder rule: %w", err)
 		}
 	}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -103,7 +103,6 @@ var mockManager = &IptablesManager{
 	haveSocketMatch:      true,
 	haveBPFSocketAssign:  false,
 	ipEarlyDemuxDisabled: false,
-	waitArgs:             nil,
 }
 
 func init() {
@@ -122,13 +121,13 @@ func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
 		table: "mangle",
 		name:  "CILIUM_PRE_mangle",
 	}
-	chain.doRename(mockIp4tables, nil, "OLD_CILIUM_PRE_mangle", false)
+	chain.doRename(mockIp4tables, "OLD_CILIUM_PRE_mangle", false)
 	err := mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
 	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
 	mockIp6tables.expectations = mockIp4tables.expectations
-	chain.doRename(mockIp6tables, nil, "OLD_CILIUM_PRE_mangle", false)
+	chain.doRename(mockIp6tables, "OLD_CILIUM_PRE_mangle", false)
 	err = mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -73,4 +73,18 @@ type IptablesManager interface {
 	// GetProxyPort fetches the existing proxy port configured for the
 	// specified listener. Used early in bootstrap to reopen proxy ports.
 	GetProxyPort(listener string) uint16
+
+	// InstallNoTrackRules is explicitly called when a pod has valid
+	// "io.cilium.no-track-port" annotation.  When
+	// InstallNoConntrackIptRules flag is set, a super set of v4 NOTRACK
+	// rules will be automatically installed upon agent bootstrap (via
+	// function addNoTrackPodTrafficRules) and this function will be
+	// skipped.  When InstallNoConntrackIptRules is not set, this function
+	// will be executed to install NOTRACK rules.  The rules installed by
+	// this function is very specific, for now, the only user is
+	// node-local-dns pods.
+	InstallNoTrackRules(IP string, port uint16, ipv6 bool) error
+
+	// See comments for InstallNoTrackRules.
+	RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error
 }

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -55,7 +55,7 @@ type PreFilter interface {
 // Proxy is any type which installs rules related to redirecting traffic to
 // a proxy.
 type Proxy interface {
-	ReinstallRules()
+	ReinstallRules() error
 }
 
 // IptablesManager manages iptables rules.

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -55,20 +55,20 @@ type PreFilter interface {
 // Proxy is any type which installs rules related to redirecting traffic to
 // a proxy.
 type Proxy interface {
-	ReinstallRules() error
+	ReinstallRules(ctx context.Context) error
 }
 
 // IptablesManager manages iptables rules.
 type IptablesManager interface {
 	// InstallProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	InstallProxyRules(proxyPort uint16, ingress bool, name string) error
+	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress bool, name string) error
 
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream
 	// connections.
 	SupportsOriginalSourceAddr() bool
-	InstallRules(ifName string, quiet, install bool) error
+	InstallRules(ctx context.Context, ifName string, quiet, install bool) error
 
 	// GetProxyPort fetches the existing proxy port configured for the
 	// specified listener. Used early in bootstrap to reopen proxy ports.

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -457,13 +457,13 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return err
 	}
 
-	if err := iptMgr.InstallRules(option.Config.HostDevice, firstInitialization, option.Config.InstallIptRules); err != nil {
+	if err := iptMgr.InstallRules(ctx, option.Config.HostDevice, firstInitialization, option.Config.InstallIptRules); err != nil {
 		return err
 	}
 
 	// Reinstall proxy rules for any running proxies if needed
 	if p != nil {
-		if err := p.ReinstallRules(); err != nil {
+		if err := p.ReinstallRules(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -463,7 +463,9 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	// Reinstall proxy rules for any running proxies if needed
 	if p != nil {
-		p.ReinstallRules()
+		if err := p.ReinstallRules(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -267,7 +267,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				}
 
 				var err error
-				redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(l4, proxyID, e, proxyWaitGroup)
+				redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(e.aliveCtx, l4, proxyID, e, proxyWaitGroup)
 				if err != nil {
 					revertStack.Revert() // Ignore errors while reverting. This is best-effort.
 					return err, nil, nil
@@ -397,7 +397,7 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 			revertFunc   revert.RevertFunc
 		)
 		proxyID := policy.ProxyID(e.ID, visMeta.Ingress, visMeta.Proto.String(), visMeta.Port)
-		redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(visMeta, proxyID, e, proxyWaitGroup)
+		redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(e.aliveCtx, visMeta, proxyID, e, proxyWaitGroup)
 		if err != nil {
 			revertStack.Revert() // Ignore errors while reverting. This is best-effort.
 			return err, nil, nil

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -2231,12 +2230,12 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 		}).Debug("Deleting endpoint NOTRACK rules")
 
 		if e.IPv4.IsSet() {
-			if err := iptables.RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false); err != nil {
+			if err := e.owner.Datapath().RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv4 rules: %s", err))
 			}
 		}
 		if e.IPv6.IsSet() {
-			if err := iptables.RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true); err != nil {
+			if err := e.owner.Datapath().RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint NOTRACK ipv6 rules: %s", err))
 			}
 		}

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 
 	"github.com/cilium/cilium/pkg/bandwidth"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
@@ -170,21 +169,21 @@ func (ev *EndpointNoTrackEvent) Handle(res chan interface{}) {
 		log.Debug("Updating NOTRACK rules")
 		if e.IPv4.IsSet() {
 			if port > 0 {
-				err = iptables.InstallNoTrackRules(e.IPv4.String(), port, false)
+				err = e.owner.Datapath().InstallNoTrackRules(e.IPv4.String(), port, false)
 				log.Warnf("Error installing iptable NOTRACK rules %s", err)
 			}
 			if e.noTrackPort > 0 {
-				err = iptables.RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false)
+				err = e.owner.Datapath().RemoveNoTrackRules(e.IPv4.String(), e.noTrackPort, false)
 				log.Warnf("Error removing iptable NOTRACK rules %s", err)
 			}
 		}
 		if e.IPv6.IsSet() {
 			if port > 0 {
-				iptables.InstallNoTrackRules(e.IPv6.String(), port, true)
+				e.owner.Datapath().InstallNoTrackRules(e.IPv6.String(), port, true)
 				log.Warnf("Error installing iptable NOTRACK rules %s", err)
 			}
 			if e.noTrackPort > 0 {
-				err = iptables.RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true)
+				err = e.owner.Datapath().RemoveNoTrackRules(e.IPv6.String(), e.noTrackPort, true)
 				log.Warnf("Error removing iptable NOTRACK rules %s", err)
 			}
 		}

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -15,6 +15,7 @@
 package endpoint
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -25,7 +26,7 @@ import (
 
 // EndpointProxy defines any L7 proxy with which an Endpoint must interact.
 type EndpointProxy interface {
-	CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
+	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
 	UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
@@ -54,7 +55,7 @@ func (e *Endpoint) isProxyDisabled() bool {
 type FakeEndpointProxy struct{}
 
 // CreateOrUpdateRedirect does nothing.
-func (f *FakeEndpointProxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+func (f *FakeEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	return
 }
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -53,7 +53,7 @@ type RedirectSuiteProxy struct {
 
 // CreateOrUpdateRedirect returns the proxy port for the given L7Parser from the
 // ProxyPolicy parameter.
-func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	pp := r.parserProxyPortMap[l4.GetL7Parser()]
 	return pp, nil, nil, nil
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -564,4 +564,7 @@ const (
 
 	// GatewayIP is the gateway IP used in a given egress policy
 	GatewayIP = "gatewayIP"
+
+	// Chain is an Iptables chain
+	Chain = "chain"
 )

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -266,9 +266,8 @@ func (p *Proxy) ackProxyPort(pp *ProxyPort) error {
 			// Add rules for the new port
 			// This should always succeed if we have managed to start-up properly
 			scopedLog.Infof("Adding new proxy port rules for %s:%d", pp.name, pp.proxyPort)
-			err := p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.ingress, pp.name)
-			if err != nil {
-				return fmt.Errorf("Cannot install proxy rules for %s: %s", pp.name, err)
+			if err := p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.ingress, pp.name); err != nil {
+				return fmt.Errorf("Cannot install proxy rules for %s: %w", pp.name, err)
 			}
 			pp.rulesPort = pp.proxyPort
 		}
@@ -368,18 +367,19 @@ func (p *Proxy) SetProxyPort(name string, port uint16) error {
 
 // ReinstallRules is called by daemon reconfiguration to re-install proxy ports rules that
 // were removed during the removal of all Cilium rules.
-func (p *Proxy) ReinstallRules() {
+func (p *Proxy) ReinstallRules() error {
 	proxyPortsMutex.Lock()
 	defer proxyPortsMutex.Unlock()
 	for _, pp := range proxyPorts {
 		if pp.rulesPort > 0 {
 			// This should always succeed if we have managed to start-up properly
-			err := p.datapathUpdater.InstallProxyRules(pp.rulesPort, pp.ingress, pp.name)
-			if err != nil {
-				log.WithError(err).Errorf("Can't install proxy rules for %s", pp.name)
+			if err := p.datapathUpdater.InstallProxyRules(pp.rulesPort, pp.ingress, pp.name); err != nil {
+				return fmt.Errorf("cannot install proxy rules for %s: %w", pp.name, err)
 			}
 		}
 	}
+
+	return nil
 }
 
 // CreateOrUpdateRedirect creates or updates a L4 redirect with corresponding

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -241,6 +241,7 @@ const (
 	unstableStat        = "BUG: stat() has unstable behavior"                        // from https://github.com/cilium/cilium/pull/11028
 	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
 	localIDRestoreFail  = "Could not restore all CIDR identities"                    // from https://github.com/cilium/cilium/pull/19556
+	missingIptablesWait = "Missing iptables wait arg (-w):"
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -306,6 +307,7 @@ var badLogMessages = map[string][]string{
 	unstableStat:        nil,
 	removeTransientRule: nil,
 	localIDRestoreFail:  nil,
+	missingIptablesWait: nil,
 	"DATA RACE":         nil,
 }
 


### PR DESCRIPTION
This PR is the v1.10 backport of:
* https://github.com/cilium/cilium/pull/19693
* https://github.com/cilium/cilium/pull/17593 (as while working on it I figured we also needed that)
* https://github.com/cilium/cilium/pull/20109 (extra fix for the original master PR discovered while reviewing this backport)

There were of course lots of conflicts, especially in https://github.com/cilium/cilium/commit/41922253675dea33453503e34c15e77ac4efa29e, mostly due to:

* lack of ipset support
* https://github.com/cilium/cilium/commit/f4c630f9fade848e6d7d05a2f7845cfb329a7c4e missing in v1.10 (not sure we want to backport it though)
* some other minor refactorings introduced recently (e.g. `removeOldRules` -> `removeRules` or `-j NOTRACK` vs `-j CT --notrack`)

In case of too many/complicated conflicts for a given commit my strategy was to just start from scratch and manually readd all the edits.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19693 17593 20109; do contrib/backporting/set-labels.py $pr done 1.10; done
```