### PR TITLE
ipam: Fix inconsistent update of CiliumNodes

### DIFF
--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -963,6 +963,19 @@ func (n *Node) syncToAPIServer() (err error) {
 
 	origNode := node.DeepCopy()
 
+	// We create a snapshot of the IP pool before we update the status. This
+	// ensures that the pool in the spec is always older than the IPAM
+	// information in the status.
+	// This ordering is important, because otherwise a new IP could be added to
+	// the pool after we updated the status, thereby creating a situation where
+	// the agent does not have the necessary IPAM information to use the newly
+	// added IP.
+	// When an IP is removed, this is also safe. IP release is done via
+	// handshake, where the agent will never use any IP where it has
+	// acknowledged the release handshake. Therefore, having an already
+	// released IP in the pool is fine, as the agent will ignore it.
+	pool := n.Pool()
+
 	// Always update the status first to ensure that the IPAM information
 	// is synced for all addresses that are marked as available.
 	//
@@ -993,7 +1006,7 @@ func (n *Node) syncToAPIServer() (err error) {
 			node.Spec.IPAM.Pool = ipamTypes.AllocationMap{}
 		}
 
-		node.Spec.IPAM.Pool = n.Pool()
+		node.Spec.IPAM.Pool = pool
 		scopedLog.WithField("poolSize", len(node.Spec.IPAM.Pool)).Debug("Updating node in apiserver")
 
 		// The PreAllocate value is added here rather than where the CiliumNode

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -1002,10 +1002,6 @@ func (n *Node) syncToAPIServer() (err error) {
 	}
 
 	for retry := 0; retry < 2; retry++ {
-		if node.Spec.IPAM.Pool == nil {
-			node.Spec.IPAM.Pool = ipamTypes.AllocationMap{}
-		}
-
 		node.Spec.IPAM.Pool = pool
 		scopedLog.WithField("poolSize", len(node.Spec.IPAM.Pool)).Debug("Updating node in apiserver")
 


### PR DESCRIPTION
Currently, when the cilium-operator attaches new ENIs to a node, [we update the corresponding CiliumNode in two steps](https://github.com/cilium/cilium/blob/v1.12.0-rc2/pkg/ipam/node.go#L966-L1012): first the `.Status`, then the `.Spec`. That can result in an inconsistent state, where the CiliumNode `.Spec.IPAM.Pool` contains new IP addresses associated with the new ENI, while `.Status.ENI.ENIs` is still missing the ENI. This inconsistency manifests as a fatal:

    level=fatal msg="Error while creating daemon" error="Unable to allocate router IP for family ipv4: failed to associate IP 10.12.14.5 inside CiliumNode: unable to find ENI eni-9ab538c64feb9f59e" subsys=daemon

This inconsistency occurs because the following can happen:
1. cilium-operator attaches a new ENI to the CiliumNode.
2. Still at cilium-operator, `.Spec` is synced with kube-apiserver. The IP pool is updated with a new set of IP addresses and the new ENI.
3. The agent receives this half-updated CiliumNode. 
4. It allocates an IP address for the router from the pool of IPs attached to the new ENI, using `.Spec.IPAM.Pool`.
5. It fails because the new ENI is not listed in the `.Status.ENI.ENIs` of the CiliumNode object.
6. At cilium-operator, `.Status` is updated with the new ENI.

But wait, you said `.Status` is updated before `.Spec` in the function you linked? Yes, but we read the state to populate CiliumNode from two separate places (`n.ops.manager.instances` and `n.available`) in the `syncToAPIServer` function and we don't have anything to prevent having a half updated (one place only) state in the middle of the update function. We lock twice, once for each place, instead of once for the while CiliumNode update. So having a half updated state in the middle of the function would technically be the same as updating `.Spec` first and `.Status` second.

We can fix this by first creating a snapshot of the pool first, then write the .Status metadata (which may be more recent than the pool snapshot, which is safe, see comment in the source code of this patch), and then write the pool to .Spec. This ensures that the .Status is always updated before .Spec, but at the same time also ensures that .Status is still more recent than .Spec.

```release-note
Fix race condition leading to inconsistent CiliumNode that can cause the agent to fatal.
```