### PR TITLE
pkg/fqdn: Fix missing delete for forward map

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -300,7 +300,7 @@ func (c *DNSCache) cleanupOverLimitEntries() (affectedNames []string, removed ma
 		for i := 0; i < overlimit; i++ {
 			key := sortedEntries[i]
 			delete(entries, key.ip)
-			c.removeReverse(key.ip, key.entry)
+			c.remove(key.ip, key.entry)
 			removed[key.ip] = append(removed[key.ip], key.entry)
 		}
 		affectedNames = append(affectedNames, dnsName)
@@ -502,7 +502,7 @@ func (c *DNSCache) removeExpired(entries ipEntries, now time.Time, expireLookups
 	for ip, entry := range entries {
 		if entry == nil || entry.isExpiredBy(now) || entry.LookupTime.Before(expireLookupsBefore) {
 			delete(entries, ip)
-			c.removeReverse(ip, entry)
+			c.remove(ip, entry)
 			removed[ip] = entry
 		}
 	}
@@ -523,11 +523,31 @@ func (c *DNSCache) upsertReverse(ip string, entry *cacheEntry) {
 	entries[entry.Name] = entry
 }
 
-// removeReverse removes the reference between ip and the name stored in entry.
+// remove removes the reference between ip and the name stored in entry from
+// the DNS cache (both in forward and reverse maps). This assumes the write
+// lock is taken.
+func (c *DNSCache) remove(ip string, entry *cacheEntry) {
+	c.removeForward(ip, entry)
+	c.removeReverse(ip, entry)
+}
+
+// removeForward removes the reference between ip and the name stored in entry.
 // When no more references from ip to any name exist, the map entry is deleted
 // outright.
 // It is assumed that entry includes ip.
-// This needs a write lock
+// This needs a write lock.
+func (c *DNSCache) removeForward(ip string, entry *cacheEntry) {
+	entries, exists := c.forward[entry.Name]
+	if entries == nil || !exists {
+		return
+	}
+	delete(entries, ip)
+	if len(entries) == 0 {
+		delete(c.forward, entry.Name)
+	}
+}
+
+// removeReverse is the equivalent of removeForward() but for the reverse map.
 func (c *DNSCache) removeReverse(ip string, entry *cacheEntry) {
 	entries, exists := c.reverse[ip]
 	if entries == nil || !exists {

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -99,6 +99,10 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 	for _, name := range []string{"test1.com", "test2.com", "test3.com"} {
 		ips := cache.lookupByTime(now, name)
 		c.Assert(len(ips), Equals, 2, Commentf("Wrong count of IPs returned (%v) for non-deleted name '%s'", ips, name))
+		c.Assert(cache.forward, checker.HasKey, name, Commentf("Expired name '%s' not deleted from forward", name))
+		for _, ip := range ips {
+			c.Assert(cache.reverse, checker.HasKey, ip.String(), Commentf("Expired IP '%s' not deleted from reverse", ip))
+		}
 	}
 
 	// Delete a single name and check that
@@ -111,9 +115,17 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 	c.Assert(namesAffected[0], Equals, "test1.com", Commentf("Incorrect affected name returned on forced expire: %s", namesAffected))
 	ips := cache.lookupByTime(now, "test1.com")
 	c.Assert(len(ips), Equals, 0, Commentf("IPs returned (%v) for deleted name 'test1.com'", ips))
+	c.Assert(cache.forward, Not(checker.HasKey), "test1.com", Commentf("Expired name 'test1.com' not deleted from forward"))
+	for _, ip := range ips {
+		c.Assert(cache.reverse, Not(checker.HasKey), ip.String(), Commentf("Expired IP '%s' not deleted from reverse", ip))
+	}
 	for _, name := range []string{"test2.com", "test3.com"} {
 		ips = cache.lookupByTime(now, name)
 		c.Assert(len(ips), Equals, 2, Commentf("Wrong count of IPs returned (%v) for non-deleted name '%s'", ips, name))
+		c.Assert(cache.forward, checker.HasKey, name, Commentf("Expired name '%s' not deleted from forward", name))
+		for _, ip := range ips {
+			c.Assert(cache.reverse, checker.HasKey, ip.String(), Commentf("Expired IP '%s' not deleted from reverse", ip))
+		}
 	}
 
 	// Delete the whole cache. This should leave no data.
@@ -127,6 +139,8 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 		ips = cache.lookupByTime(now, name)
 		c.Assert(len(ips), Equals, 0, Commentf("Returned IP data for %s after the cache was fully cleared: %v", name, ips))
 	}
+	c.Assert(cache.forward, HasLen, 0)
+	c.Assert(cache.reverse, HasLen, 0)
 	dump := cache.Dump()
 	c.Assert(len(dump), Equals, 0, Commentf("Returned cache entries from cache dump after the cache was fully cleared: %v", dump))
 }
@@ -886,7 +900,14 @@ func (ds *DNSCacheTestSuite) TestCacheToZombiesGCCascade(c *C) {
 
 	// Cascade expirations from cache to zombies. The 3.3.3.3 lookup has not expired
 	now = now.Add(4 * time.Second)
-	cache.GC(now, zombies)
+	expired := cache.GC(now, zombies)
+	c.Assert(expired, HasLen, 1) // test.com
+	// Not all IPs expired (3.3.3.3 still alive) so we expect test.com to be
+	// present in the cache.
+	c.Assert(cache.forward, checker.HasKey, "test.com")
+	c.Assert(cache.reverse, checker.HasKey, "3.3.3.3")
+	c.Assert(cache.reverse, Not(checker.HasKey), "1.1.1.1")
+	c.Assert(cache.reverse, Not(checker.HasKey), "2.2.2.2")
 	alive, dead := zombies.GC()
 	c.Assert(dead, HasLen, 0)
 	assertZombiesContain(c, alive, map[string][]string{
@@ -897,7 +918,13 @@ func (ds *DNSCacheTestSuite) TestCacheToZombiesGCCascade(c *C) {
 	// Cascade expirations from cache to zombies. The 3.3.3.3 lookup has expired
 	// but the older zombies are still alive.
 	now = now.Add(4 * time.Second)
-	cache.GC(now, zombies)
+	expired = cache.GC(now, zombies)
+	c.Assert(expired, HasLen, 1) // test.com
+	// Now all IPs expired so we expect test.com to be removed from the cache.
+	c.Assert(cache.forward, Not(checker.HasKey), "test.com")
+	c.Assert(cache.forward, HasLen, 0)
+	c.Assert(cache.reverse, Not(checker.HasKey), "3.3.3.3")
+	c.Assert(cache.reverse, HasLen, 0)
 	alive, dead = zombies.GC()
 	c.Assert(dead, HasLen, 0)
 	assertZombiesContain(c, alive, map[string][]string{


### PR DESCRIPTION
This commit fixes a bug where the keys of the forward map inside the DNS
cache were never removed, causing the map to grow forever. By contrast,
the reverse map keys were being deleted.

For both the forward and reverse maps (which are both maps whose values
are another map), the inner map keys were being deleted.

In other words, the delete on the outer map key was missing for the
forward map.

In addition to fixing the bug, this commit expands the unit test
coverage to assert after any deletes (entries expiring or GC) that the
forward and reverse maps contain what we expect.

Particularly, in an environment where there are many unique DNS lookups
(unique FQDNs) being done, this forward map could grow quite large over
time, especially for a long-lived workload (endpoint). This fixes this
memory-leak-like bug.

Fixes: cf387ce5058 ("fqdn: Introduce TTL-aware cache for DNS retention")
Fixes: f6ce522d55d ("FQDN: Added garbage collector functions.")

Signed-off-by: Chris Tarazi <chris@isovalent.com>

```release-note
Fix memory leak in the DNS cache when a long-lived endpoint makes many unique DNS lookups over time
```
