### PR TITLE
api: change "group not found" log to debug

### DIFF
--- a/pkg/api/socket.go
+++ b/pkg/api/socket.go
@@ -34,7 +34,7 @@ func SetDefaultPermissions(socketPath string) error {
 		log.WithError(err).WithFields(logrus.Fields{
 			logfields.Path: socketPath,
 			"group":        CiliumGroupName,
-		}).Info("Group not found")
+		}).Debug("Group not found")
 	} else {
 		if err := os.Chown(socketPath, 0, gid); err != nil {
 			return fmt.Errorf("failed while setting up %s's group ID"+
@@ -42,8 +42,8 @@ func SetDefaultPermissions(socketPath string) error {
 		}
 	}
 	if err := os.Chmod(socketPath, SocketFileMode); err != nil {
-		return fmt.Errorf("failed while setting up %s's file"+
-			" permissions in %q: %s", CiliumGroupName, socketPath, err)
+		return fmt.Errorf("failed while setting up file permissions in %q: %w",
+			socketPath, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Since commit 67f74ff ("images/cilium: remove cilium group from
Dockerfile") the cilium group is no longer created in the image running
the agent, resulting in the following log message on cilium-agent start:

level=info msg="Group not found" error="group: unknown group cilium" file-path=/var/run/cilium/cilium.sock group=cilium subsys=api

Change the log message to debug level to avoid confusion.

Replaces #19850