### PR TITLE
ipsec: fix stale keys reclaim logic

### DIFF
--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -197,12 +197,10 @@ To replace cilium-ipsec-keys secret with a new key:
     data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128\"}}")
     kubectl patch secret -n kube-system cilium-ipsec-keys -p="${data}" -v=1
 
-Then restart Cilium agents to transition to the new key with
-``kubectl delete pod -n kube-system -l k8s-app=cilium``. During transition the
-new and old keys will be in use. The Cilium agent keeps per endpoint data on
-which key is used by each endpoint and will use the correct key if either side
-has not yet been updated. In this way encryption will work as new keys are
-rolled out.
+During transition the new and old keys will be in use. The Cilium agent keeps
+per endpoint data on which key is used by each endpoint and will use the correct
+key if either side has not yet been updated. In this way encryption will work as
+new keys are rolled out.
 
 The ``KEYID`` environment variable in the above example stores the current key
 ID used by Cilium. The key variable is a uint8 with value between 1 and 15

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1230,9 +1230,11 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	if option.Config.EnableIPSec {
-		if err := ipsec.StartKeyfileWatcher(ctx, option.Config.IPSecKeyFile, nd); err != nil {
+		if err := ipsec.StartKeyfileWatcher(ctx, option.Config.IPSecKeyFile, nd, d.Datapath().Node()); err != nil {
 			log.WithError(err).Error("Unable to start IPSec keyfile watcher")
 		}
+
+		ipsec.StartStaleKeysReclaimer(ctx)
 	}
 
 	return &d, restoredEndpoints, nil

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -70,7 +70,7 @@ type ipSecKey struct {
 }
 
 var (
-	ipSecKeysGlobalLock lock.RWMutex
+	ipSecLock lock.RWMutex
 
 	// ipSecKeysGlobal can be accessed by multiple subsystems concurrently,
 	// so it should be accessed only through the getIPSecKeys and
@@ -87,8 +87,8 @@ var (
 )
 
 func getIPSecKeys(ip net.IP) *ipSecKey {
-	ipSecKeysGlobalLock.RLock()
-	defer ipSecKeysGlobalLock.RUnlock()
+	ipSecLock.RLock()
+	defer ipSecLock.RUnlock()
 
 	key, scoped := ipSecKeysGlobal[ip.String()]
 	if scoped == false {
@@ -524,8 +524,8 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 	var keyLen int
 	scopedLog := log
 
-	ipSecKeysGlobalLock.Lock()
-	defer ipSecKeysGlobalLock.Unlock()
+	ipSecLock.Lock()
+	defer ipSecLock.Unlock()
 
 	if err := encrypt.MapCreate(); err != nil {
 		return 0, 0, fmt.Errorf("Encrypt map create failed: %v", err)
@@ -813,8 +813,8 @@ func deleteStaleXfrmPolicies(reclaimTimestamp time.Time) {
 }
 
 func doReclaimStaleKeys() {
-	ipSecKeysGlobalLock.Lock()
-	defer ipSecKeysGlobalLock.Unlock()
+	ipSecLock.Lock()
+	defer ipSecLock.Unlock()
 
 	// In case no IPSec key has been loaded yet, don't try to reclaim any
 	// old key

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -758,7 +758,7 @@ func ipSecSPICanBeReclaimed(spi uint8, reclaimTimestamp time.Time) bool {
 }
 
 func deleteStaleXfrmStates(reclaimTimestamp time.Time) {
-	scopedLog := log.WithField("spi", ipSecCurrentKeySPI)
+	scopedLog := log.WithField(logfields.SPI, ipSecCurrentKeySPI)
 
 	xfrmStateList, err := netlink.XfrmStateList(0)
 	if err != nil {
@@ -773,7 +773,7 @@ func deleteStaleXfrmStates(reclaimTimestamp time.Time) {
 			continue
 		}
 
-		scopedLog = log.WithField("oldSPI", stateSPI)
+		scopedLog = log.WithField(logfields.OldSPI, stateSPI)
 
 		scopedLog.Info("Deleting stale XFRM state")
 		if err := netlink.XfrmStateDel(&s); err != nil {
@@ -783,7 +783,7 @@ func deleteStaleXfrmStates(reclaimTimestamp time.Time) {
 }
 
 func deleteStaleXfrmPolicies(reclaimTimestamp time.Time) {
-	scopedLog := log.WithField("spi", ipSecCurrentKeySPI)
+	scopedLog := log.WithField(logfields.SPI, ipSecCurrentKeySPI)
 
 	xfrmPolicyList, err := netlink.XfrmPolicyList(0)
 	if err != nil {
@@ -803,7 +803,7 @@ func deleteStaleXfrmPolicies(reclaimTimestamp time.Time) {
 			continue
 		}
 
-		scopedLog = log.WithField("oldSPI", policySPI)
+		scopedLog = log.WithField(logfields.OldSPI, policySPI)
 
 		scopedLog.Info("Deleting stale XFRM policy")
 		if err := netlink.XfrmPolicyDel(&p); err != nil {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -296,7 +296,7 @@ func ipsecDeleteXfrmState(ip net.IP) {
 		"remote-ip": ip,
 	})
 
-	xfrmStateList, err := netlink.XfrmStateList(0)
+	xfrmStateList, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
 	if err != nil {
 		scopedLog.WithError(err).Warning("deleting xfrm state, xfrm state list error")
 		return
@@ -315,7 +315,7 @@ func ipsecDeleteXfrmPolicy(ip net.IP) {
 		"remote-ip": ip,
 	})
 
-	xfrmPolicyList, err := netlink.XfrmPolicyList(0)
+	xfrmPolicyList, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
 	if err != nil {
 		scopedLog.WithError(err).Warning("deleting policy state, xfrm policy list error")
 	}
@@ -471,7 +471,7 @@ func isXfrmStateCilium(state netlink.XfrmState) bool {
 
 // DeleteXfrm remove any remaining XFRM policy or state from tables
 func DeleteXfrm() {
-	xfrmPolicyList, err := netlink.XfrmPolicyList(0)
+	xfrmPolicyList, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
 	if err == nil {
 		for _, p := range xfrmPolicyList {
 			if isXfrmPolicyCilium(p) {
@@ -481,7 +481,7 @@ func DeleteXfrm() {
 			}
 		}
 	}
-	xfrmStateList, err := netlink.XfrmStateList(0)
+	xfrmStateList, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
 	if err == nil {
 		for _, s := range xfrmStateList {
 			if isXfrmStateCilium(s) {
@@ -760,7 +760,7 @@ func ipSecSPICanBeReclaimed(spi uint8, reclaimTimestamp time.Time) bool {
 func deleteStaleXfrmStates(reclaimTimestamp time.Time) {
 	scopedLog := log.WithField(logfields.SPI, ipSecCurrentKeySPI)
 
-	xfrmStateList, err := netlink.XfrmStateList(0)
+	xfrmStateList, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
 	if err != nil {
 		scopedLog.WithError(err).Warning("Failed to list XFRM states")
 		return
@@ -785,7 +785,7 @@ func deleteStaleXfrmStates(reclaimTimestamp time.Time) {
 func deleteStaleXfrmPolicies(reclaimTimestamp time.Time) {
 	scopedLog := log.WithField(logfields.SPI, ipSecCurrentKeySPI)
 
-	xfrmPolicyList, err := netlink.XfrmPolicyList(0)
+	xfrmPolicyList, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
 	if err != nil {
 		scopedLog.WithError(err).Warning("Failed to list XFRM policies")
 		return

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -21,9 +21,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/fswatcher"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/encrypt"
@@ -69,10 +71,19 @@ type ipSecKey struct {
 
 var (
 	ipSecKeysGlobalLock lock.RWMutex
+
 	// ipSecKeysGlobal can be accessed by multiple subsystems concurrently,
 	// so it should be accessed only through the getIPSecKeys and
 	// loadIPSecKeys functions, which will ensure the proper lock is held
 	ipSecKeysGlobal = make(map[string]*ipSecKey)
+
+	// ipSecCurrentKeySPI is the SPI of the IPSec currently in use
+	ipSecCurrentKeySPI uint8
+
+	// ipSecKeysRemovalTime is used to track at which time a given key is
+	// replaced with a newer one, allowing to reclaim old keys only after
+	// enough time has passed since their replacement
+	ipSecKeysRemovalTime = make(map[uint8]time.Time)
 )
 
 func getIPSecKeys(ip net.IP) *ipSecKey {
@@ -246,6 +257,14 @@ func ipSecXfrmMarkGetSPI(markValue uint32) uint8 {
 	return uint8(markValue >> ipSecXfrmMarkSPIShift)
 }
 
+func getSPIFromXfrmPolicy(policy *netlink.XfrmPolicy) uint8 {
+	if policy.Mark == nil {
+		return 0
+	}
+
+	return ipSecXfrmMarkGetSPI(policy.Mark.Value)
+}
+
 func ipSecReplacePolicyOut(src, dst, tmplSrc, tmplDst *net.IPNet, dir IPSecDir) error {
 	// TODO: Remove old policy pointing to target net
 
@@ -270,26 +289,6 @@ func ipSecReplacePolicyOut(src, dst, tmplSrc, tmplDst *net.IPNet, dir IPSecDir) 
 	}
 	ipSecAttachPolicyTempl(policy, key, tmplSrc.IP, tmplDst.IP, true, 0)
 	return netlink.XfrmPolicyUpdate(policy)
-}
-
-func ipsecDeleteXfrmSpi(spi uint8) {
-	var err error
-	scopedLog := log.WithFields(logrus.Fields{
-		"spi": spi,
-	})
-
-	xfrmStateList, err := netlink.XfrmStateList(0)
-	if err != nil {
-		scopedLog.WithError(err).Warning("deleting previous SPI, xfrm state list error")
-		return
-	}
-	for _, s := range xfrmStateList {
-		if s.Spi != int(spi) {
-			if err := netlink.XfrmStateDel(&s); err != nil {
-				scopedLog.WithError(err).Warning("deleting old xfrm state failed")
-			}
-		}
-	}
 }
 
 func ipsecDeleteXfrmState(ip net.IP) {
@@ -638,23 +637,8 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 			ipSecKeysGlobal[""] = ipSecKey
 		}
 
-		scopedLog := log.WithFields(logrus.Fields{
-			"oldSPI": oldSpi,
-			"SPI":    spi,
-		})
-
-		// Detect a version change and call cleanup routine to remove old
-		// keys after a timeout period. We also want to ensure on restart
-		// we remove any stale keys for example when a restart changes keys.
-		// In the restart case oldSpi will be '0' and cause the delete logic
-		// to run.
-		if oldSpi != ipSecKey.Spi {
-			go func() {
-				time.Sleep(linux_defaults.IPsecKeyDeleteDelay)
-				scopedLog.Info("New encryption keys reclaiming SPI")
-				ipsecDeleteXfrmSpi(ipSecKey.Spi)
-			}()
-		}
+		ipSecKeysRemovalTime[oldSpi] = time.Now()
+		ipSecCurrentKeySPI = spi
 	}
 	if err := encrypt.MapUpdateContext(0, spi); err != nil {
 		scopedLog.WithError(err).Warn("cilium_encrypt_state map updated failed:")
@@ -685,7 +669,7 @@ func DeleteIPsecEncryptRoute() {
 	}
 }
 
-func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath string, nodediscovery *nodediscovery.NodeDiscovery) {
+func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath string, nodediscovery *nodediscovery.NodeDiscovery, nodeHandler datapath.NodeHandler) {
 	for {
 		select {
 		case event := <-watcher.Events:
@@ -699,11 +683,23 @@ func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath
 				continue
 			}
 
+			// Update the IPSec key identity in the local node.
+			// This will set addrs.ipsecKeyIdentity in the node
+			// package
 			node.SetIPsecKeyIdentity(spi)
+
+			// NodeValidateImplementation will eventually call
+			// nodeUpdate(), which is responsible for updating the
+			// IPSec policies and states for all the different EPs
+			// with ipsec.UpsertIPsecEndpoint()
+			nodeHandler.NodeValidateImplementation(nodediscovery.LocalNode())
+
+			// Publish the updated node information to k8s/KVStore
 			nodediscovery.UpdateLocalNode()
 
 		case err := <-watcher.Errors:
-			log.WithError(err).WithField(logfields.Path, keyfilePath).Warning("Error encountered while watching file with fsnotify")
+			log.WithError(err).WithField(logfields.Path, keyfilePath).
+				Warning("Error encountered while watching file with fsnotify")
 
 		case <-ctx.Done():
 			watcher.Close()
@@ -712,13 +708,138 @@ func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath
 	}
 }
 
-func StartKeyfileWatcher(ctx context.Context, keyfilePath string, nodediscovery *nodediscovery.NodeDiscovery) error {
+func StartKeyfileWatcher(ctx context.Context, keyfilePath string, nodediscovery *nodediscovery.NodeDiscovery, nodeHandler datapath.NodeHandler) error {
 	watcher, err := fswatcher.New([]string{keyfilePath})
 	if err != nil {
 		return err
 	}
 
-	go keyfileWatcher(ctx, watcher, keyfilePath, nodediscovery)
+	go keyfileWatcher(ctx, watcher, keyfilePath, nodediscovery, nodeHandler)
 
 	return nil
+}
+
+// ipSecSPICanBeReclaimed is used to test whether a given SPI can be reclaimed
+// or not (i.e. if it's not in use, and if not, if enough time has passed since
+// when it was replaced by a newer one).
+//
+// In addition to the SPI, this function takes also a reclaimTimestamp
+// parameter which represents the time at which we started reclaiming old keys.
+// This is needed as we need to test the same SPI multiple times (since for any
+// given SPI there are multiple policies and states associated with it), and we
+// don't want to get inconsistent results because we are calling time.Now()
+// directly in this function.
+func ipSecSPICanBeReclaimed(spi uint8, reclaimTimestamp time.Time) bool {
+	// The SPI associated with the key currently in use should not be reclaimed
+	if spi == ipSecCurrentKeySPI {
+		return false
+	}
+
+	// Otherwise retrieve the time at which the key for the given SPI was removed
+	keyRemovalTime, ok := ipSecKeysRemovalTime[spi]
+	if !ok {
+		// If not found in the keyRemovalTime map, assume the key was
+		// deleted just now.
+		// In this way if the agent gets restarted before an old key is
+		// removed we will always wait at least IPsecKeyDeleteDelay time
+		// before reclaiming it
+		ipSecKeysRemovalTime[spi] = time.Now()
+
+		return false
+	}
+
+	// If the key was deleted less than the IPSec key deletion delay
+	// time ago, it should not be reclaimed
+	if reclaimTimestamp.Sub(keyRemovalTime) < linux_defaults.IPsecKeyDeleteDelay {
+		return false
+	}
+
+	return true
+}
+
+func deleteStaleXfrmStates(reclaimTimestamp time.Time) {
+	scopedLog := log.WithField("spi", ipSecCurrentKeySPI)
+
+	xfrmStateList, err := netlink.XfrmStateList(0)
+	if err != nil {
+		scopedLog.WithError(err).Warning("Failed to list XFRM states")
+		return
+	}
+
+	for _, s := range xfrmStateList {
+		stateSPI := uint8(s.Spi)
+
+		if !ipSecSPICanBeReclaimed(stateSPI, reclaimTimestamp) {
+			continue
+		}
+
+		scopedLog = log.WithField("oldSPI", stateSPI)
+
+		scopedLog.Info("Deleting stale XFRM state")
+		if err := netlink.XfrmStateDel(&s); err != nil {
+			scopedLog.WithError(err).Warning("Deleting stale XFRM state failed")
+		}
+	}
+}
+
+func deleteStaleXfrmPolicies(reclaimTimestamp time.Time) {
+	scopedLog := log.WithField("spi", ipSecCurrentKeySPI)
+
+	xfrmPolicyList, err := netlink.XfrmPolicyList(0)
+	if err != nil {
+		scopedLog.WithError(err).Warning("Failed to list XFRM policies")
+		return
+	}
+
+	for _, p := range xfrmPolicyList {
+		policySPI := getSPIFromXfrmPolicy(&p)
+
+		if !ipSecSPICanBeReclaimed(policySPI, reclaimTimestamp) {
+			continue
+		}
+
+		// Only OUT XFRM policies depend on the SPI
+		if p.Dir != netlink.XFRM_DIR_OUT {
+			continue
+		}
+
+		scopedLog = log.WithField("oldSPI", policySPI)
+
+		scopedLog.Info("Deleting stale XFRM policy")
+		if err := netlink.XfrmPolicyDel(&p); err != nil {
+			scopedLog.WithError(err).Warning("Deleting stale XFRM policy failed")
+		}
+	}
+}
+
+func doReclaimStaleKeys() {
+	ipSecKeysGlobalLock.Lock()
+	defer ipSecKeysGlobalLock.Unlock()
+
+	// In case no IPSec key has been loaded yet, don't try to reclaim any
+	// old key
+	if ipSecCurrentKeySPI == 0 {
+		return
+	}
+
+	reclaimTimestamp := time.Now()
+
+	deleteStaleXfrmStates(reclaimTimestamp)
+	deleteStaleXfrmPolicies(reclaimTimestamp)
+}
+
+func StartStaleKeysReclaimer(ctx context.Context) {
+	timer, timerDone := inctimer.New()
+
+	go func() {
+		for {
+			select {
+			case <-timer.After(1 * time.Minute):
+				doReclaimStaleKeys()
+			case <-ctx.Done():
+				timerDone()
+				return
+			}
+		}
+	}()
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -631,4 +631,10 @@ const (
 
 	// Chain is an Iptables chain
 	Chain = "chain"
+
+	// IPSec SPI
+	SPI = "spi"
+
+	// IPSec old SPI
+	OldSPI = "oldSPI"
 )

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodemanager "github.com/cilium/cilium/pkg/node/manager"
 	nodestore "github.com/cilium/cilium/pkg/node/store"
+	"github.com/cilium/cilium/pkg/node/types"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
@@ -322,6 +323,16 @@ func (n *NodeDiscovery) UpdateLocalNode() {
 
 	n.fillLocalNode()
 	n.updateLocalNode()
+}
+
+// LocalNode syncs the localNode object with the information stored in the node
+// package and then returns a copy of the localNode object
+func (n *NodeDiscovery) LocalNode() types.Node {
+	n.localNodeLock.Lock()
+	defer n.localNodeLock.Unlock()
+
+	n.fillLocalNode()
+	return n.localNode
 }
 
 // Close shuts down the node discovery engine


### PR DESCRIPTION
The current logic used to reclaim stale IPSec keys is incorrect. In
fact, whenever a new key is added we just spawn a new goroutine which
after linux_defaults.IPsecKeyDeleteDelay time will delete all keys
different than the one just added.

The issue with this approach is that if a new key is added while one of
these goroutine is still running, this goroutine will end up deleting
the new key.

This commit fixes this by introducing a single new goroutine that
periodically removes any stale key (XFRM state and XFRM policy template)
after enough time has passed since the current key has been added.

Fixes: https://github.com/cilium/cilium/pull/19814