### PR TITLE
helm: use port 80/443 by default for the peer service

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -701,10 +701,6 @@
      - Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client
      - bool
      - ``true``
-   * - hubble.peerService.servicePort
-     - Service Port for the Peer service.
-     - int
-     - ``4254``
    * - hubble.peerService.targetPort
      - Target Port for the Peer service.
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -226,7 +226,6 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor hubble |
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.enabled | bool | `true` | Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client |
-| hubble.peerService.servicePort | int | `4254` | Service Port for the Peer service. |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service. |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -693,7 +693,9 @@ hubble:
     # by a non-local client
     enabled: true
     # -- Service Port for the Peer service.
-    servicePort: 4254
+    # If not set, it is dynamically assigned to port 443 if TLS is enabled and to
+    # port 80 if not.
+    # servicePort: 80
     # -- Target Port for the Peer service.
     targetPort: 4244
     # -- The cluster domain to use to query the Hubble Peer service. It should


### PR DESCRIPTION
When the service port for the peer service is not specified, it is automatically assigned port 80 or port 443 (when TLS is enabled). Using these ports make it easy to understand whether TLS is enabled for the service or not. Moreover, it makes the behavior consistent with the Hubble Relay service.