### PR TITLE
v1.10: .github/workflows: bump kind workflow to cilium-cli v0.10.6

### DIFF
--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -23,7 +23,7 @@ concurrency:
 env:
   kind_version: v0.11.1
   kind_config: .github/kind-config.yaml
-  cilium_cli_version: v0.10.5
+  cilium_cli_version: v0.10.6
 
 jobs:
   installation-and-connectivity:


### PR DESCRIPTION
This should fix issues occuring after the change of the agent health
check port in https://github.com/cilium/cilium/pull/19830, ref https://github.com/cilium/cilium-cli/pull/869