### PR TITLE
bug: Prevent CiliumIdentities from Being Deleted Improperly

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -92,6 +92,13 @@ rules:
   - create
 - apiGroups:
   - cilium.io
+  # To synchronize garbage collection of such resources
+  resources:
+  - ciliumidentities
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
   resources:
   - ciliumendpoints
   verbs:

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -123,6 +123,13 @@ rules:
 - apiGroups:
   - cilium.io
   resources:
+  - ciliumidentities
+  verbs:
+  # To synchronize garbage collection of such resources
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
   - ciliumnodes
   verbs:
   - create

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -92,6 +92,13 @@ rules:
   - create
 - apiGroups:
   - cilium.io
+  # To synchronize garbage collection of such resources
+  resources:
+  - ciliumidentities
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
   resources:
   - ciliumendpoints
   verbs:

--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -148,7 +148,10 @@ func (c *cache) OnDelete(id idpool.ID, key AllocatorKey) {
 		if value := a.localKeys.lookupID(id); value != nil {
 			ctx, cancel := context.WithTimeout(context.TODO(), backendOpTimeout)
 			defer cancel()
-			a.backend.UpdateKey(ctx, id, value, true)
+			err := a.backend.UpdateKey(ctx, id, value, true)
+			if err != nil {
+				log.WithError(err).Errorf("OnDelete MasterKeyProtection update for key %q", id)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
Allocated CiliumIdentities can sometimes be improperly deleted before
being utilized. Instead of having the operator delete them immediately,
they are now "marked" for later deletion. This will give a Node a chance
to avoid racing the operator for the identity. If the CiliumIdentity
is going to be used by a Node the Node will see the mark for deletion
and remove it before utilizing the CiliumIdentity.

A race between unmarking for deletion on the Node and deletion
from the operator is avoided by enforcing a ResourceVersion
check on deletion in the operator logic.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

```release-note
bug: Fixed a rare CiliumIdentity race deletion. 
```

Fixes: https://github.com/cilium/cilium/issues/19827
