### PR TITLE
bpf: fix build with the latest LLVM 15.0.0git

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1411,7 +1411,7 @@ from_host_to_lxc(struct __ctx_buff *ctx)
  * bpf_lxc program.
  */
 __section_tail(CILIUM_MAP_POLICY, TEMPLATE_HOST_EP_ID)
-handle_lxc_traffic(struct __ctx_buff *ctx)
+int handle_lxc_traffic(struct __ctx_buff *ctx)
 {
 	bool from_host = ctx_load_meta(ctx, CB_FROM_HOST);
 	__u32 lxc_id;


### PR DESCRIPTION
With the latest LLVM 15.0.0git build breaks with

    bpf_host.c:1414:1: error: type specifier missing, defaults to 'int' [-Werror,-Wimplicit-int]
    handle_lxc_traffic(struct __ctx_buff *ctx)
    ^

Add the missing return type explicitly, as dictated by -Wimplicit-int.

Fixes: a4aac43d1e ("bpf: Support hostfw with endpoint routes")

Signed-off-by: Anton Protopopov <aspsk@isovalent.com>