### PR TITLE
test: Use more explicit key for k8s3's taint

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -648,7 +648,7 @@ func (kub *Kubectl) labelNodes() error {
 	if noCiliumNodeNames != "" {
 		// Prevent scheduling any pods on the node, as it will be used as an external client
 		// to send requests to k8s{1,2}
-		cmd := fmt.Sprintf("%s taint --overwrite nodes %s key=value:NoSchedule", KubectlCmd, noCiliumNodeNames)
+		cmd := fmt.Sprintf("%s taint --overwrite nodes %s prevent-scheduling:NoSchedule", KubectlCmd, noCiliumNodeNames)
 		res := kub.ExecMiddle(cmd)
 		if !res.WasSuccessful() {
 			return fmt.Errorf("unable to taint node with '%s': %s", cmd, res.OutputPrettyPrint())


### PR DESCRIPTION
Node k8s3 has a taint to prevent scheduling of pods. The key and value for the taint are key=value, which is neither very explicit about the purpose nor easy to grep. This commit changes it to `prevent-scheduling` (no value).