### PR TITLE
tests-l4lb: Use Helm chart from local branch

### DIFF
--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -156,7 +156,15 @@ jobs:
           sudo cp docker/docker /usr/local/bin/docker
           rm -r docker docker-20.10.9.tgz
 
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Checkout pull request for Helm chart
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+          path: pull-request
+
+      - name: Checkout upstream for Vagrantfile
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
           ref: v1.10
@@ -183,7 +191,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }}'"
+          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request'"
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -156,7 +156,15 @@ jobs:
           sudo cp docker/docker /usr/local/bin/docker
           rm -r docker docker-20.10.9.tgz
 
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Checkout pull request for Helm chart
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+          path: pull-request
+
+      - name: Checkout upstream for Vagrantfile
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
           ref: v1.11
@@ -183,7 +191,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }}'"
+          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request'"
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -159,7 +159,15 @@ jobs:
           sudo cp docker/docker /usr/local/bin/docker
           rm -r docker docker-20.10.9.tgz
 
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Checkout pull request for Helm chart
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+          path: pull-request
+
+      - name: Checkout upstream for Vagrantfile
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
           ref: master
@@ -186,8 +194,8 @@ jobs:
 
       - name: Run tests
         run: |
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }}'"
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/nat46x64 && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }}'"
+          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request'"
+          ssh default "sudo /bin/sh -c 'cd /vagrant/test/nat46x64 && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request'"
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -4,6 +4,7 @@ set -eux
 
 IMG_OWNER=${1:-cilium}
 IMG_TAG=${2:-latest}
+PULL_REQUEST_CHECKOUT=${3:-../..}
 
 ###########
 #  SETUP  #
@@ -44,7 +45,7 @@ nsenter -t $CONTROL_PLANE_PID -n /bin/sh -c "\
     ip l s dev l4lb-veth1 up"
 
 # Install Cilium as standalone L4LB
-helm install cilium ../../install/kubernetes/cilium \
+helm install cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --set debug.enabled=true \

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -4,6 +4,7 @@ set -eux
 
 IMG_OWNER=${1:-cilium}
 IMG_TAG=${2:-latest}
+PULL_REQUEST_CHECKOUT=${3:-../..}
 
 # With Kind we create two nodes cluster:
 #
@@ -15,7 +16,7 @@ IMG_TAG=${2:-latest}
 kind create cluster --config kind-config.yaml
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
-helm install cilium ../../install/kubernetes/cilium \
+helm install cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --set debug.enabled=true \
@@ -70,7 +71,7 @@ for i in $(seq 1 10); do
 done
 
 # Install Cilium as standalone L4LB: XDP/Maglev/SNAT
-helm upgrade cilium ../../install/kubernetes/cilium \
+helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -89,7 +90,7 @@ kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- cilium bpf lb list
 [ "$SVC_BEFORE" != "$SVC_AFTER" ] && exit 1
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
-helm upgrade cilium ../../install/kubernetes/cilium \
+helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -104,7 +105,7 @@ for i in $(seq 1 10); do
 done
 
 # Install Cilium as standalone L4LB: tc/Random/SNAT
-helm upgrade cilium ../../install/kubernetes/cilium \
+helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -145,7 +146,7 @@ done
 # Check if restore for both is proper
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
-helm upgrade cilium ../../install/kubernetes/cilium \
+helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -189,7 +190,7 @@ for i in $(seq 1 10); do
 done
 
 # Install Cilium as standalone L4LB: XDP/Maglev/SNAT
-helm upgrade cilium ../../install/kubernetes/cilium \
+helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -208,7 +209,7 @@ kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- cilium bpf lb list
 [ "$SVC_BEFORE" != "$SVC_AFTER" ] && exit 1
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
-helm upgrade cilium ../../install/kubernetes/cilium \
+helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -223,7 +224,7 @@ for i in $(seq 1 10); do
 done
 
 # Install Cilium as standalone L4LB: tc/Random/SNAT
-helm upgrade cilium ../../install/kubernetes/cilium \
+helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -264,7 +265,7 @@ done
 # Check if restore for both is proper
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
-helm upgrade cilium ../../install/kubernetes/cilium \
+helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -291,7 +292,7 @@ kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- cilium service delete 2
 ################################
 
 # Install Cilium as standalone L4LB: XDP/Maglev/SNAT/Recorder
-helm upgrade cilium ../../install/kubernetes/cilium \
+helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --reuse-values \


### PR DESCRIPTION
In addition to the upstream (i.e. v1.10, v1.11 and master branches)
checkouts, checkout also the pull request branch so that test.sh uses
the local Helm chart from the pull request. This ensures that any
Helm-related changes get reflected in the CI run.

Co-authored-by: Michi Mutsuzaki <michi@isovalent.com>
Signed-off-by: Gilberto Bertin <jibi@cilium.io>