### PR TITLE
cmd: Allow more complicated patterns in map string type.

### DIFF
--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -98,6 +98,29 @@ func TestGetStringMapString(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "valid kv format with comma in value",
+			args: args{
+				key:   "API_RATE_LIMIT",
+				value: "endpoint-create=rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true,endpoint-delete=rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true",
+			},
+			want: map[string]string{
+				"endpoint-create": "rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true",
+				"endpoint-delete": "rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "another valid kv format with comma in value",
+			args: args{
+				key:   "AWS_INSTANCE_LIMIT_MAPPING",
+				value: "c6a.2xlarge=4,15,15",
+			},
+			want: map[string]string{
+				"c6a.2xlarge": "4,15,15",
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "valid kv format with forward slash",
 			args: args{
 				key:   "FOO_BAR",


### PR DESCRIPTION
The previous PR #18478 wraps existing viper GetStringMapString function
to get around upstream bugs, however, it's unintentionally restricted a
few formats, which supported before in cilium, such as:

- --aws-instance-limit-mapping=c6a.2xlarge=4,15,15,m4.xlarge=1,5,10
- --api-rate-limit=endpoint-create=rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true

For complicated attribute, we are allowing comma character in value part
of key value pair. As golang didn't support look-ahead functionalities in
built-in regex library, this commit is to replace string.Split function
by custom implementation to handle such scenario.

Relates: #18478
Fixes: #18973
Signed-off-by: Tam Mach <tam.mach@cilium.io>