### PR TITLE
hubble: remove unused local observer field

### DIFF
--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -51,9 +51,6 @@ type LocalObserverServer struct {
 
 	log logrus.FieldLogger
 
-	// channel to receive events from observer server.
-	eventschan chan *observerpb.GetFlowsResponse
-
 	// payloadParser decodes flowpb.Payload into flowpb.Flow
 	payloadParser *parser.Parser
 
@@ -90,7 +87,6 @@ func NewLocalServer(
 		ring:          container.NewRing(opts.MaxFlows),
 		events:        make(chan *observerTypes.MonitorEvent, opts.MonitorBuffer),
 		stopped:       make(chan struct{}),
-		eventschan:    make(chan *observerpb.GetFlowsResponse, 100), // option here?
 		payloadParser: payloadParser,
 		startTime:     time.Now(),
 		opts:          opts,


### PR DESCRIPTION
`eventschan` is unused as far as I can see.