### PR TITLE
helm: Expose agent DNS proxy parameters as chart values

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -369,6 +369,42 @@
      - Disable the usage of CiliumEndpoint CRD.
      - string
      - ``"false"``
+   * - dnsProxy.dnsRejectResponseCode
+     - DNS response code for rejecting DNS requests, available options are '[nameError refused]'.
+     - string
+     - ``"refused"``
+   * - dnsProxy.enableDnsCompression
+     - Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
+     - bool
+     - ``true``
+   * - dnsProxy.endpointMaxIpPerHostname
+     - Maximum number of IPs to maintain per FQDN name for each endpoint.
+     - int
+     - ``50``
+   * - dnsProxy.idleConnectionGracePeriod
+     - Time during which idle but previously active connections with expired DNS lookups are still considered alive.
+     - string
+     - ``"0s"``
+   * - dnsProxy.maxDeferredConnectionDeletes
+     - Maximum number of IPs to retain for expired DNS lookups with still-active connections.
+     - int
+     - ``10000``
+   * - dnsProxy.minTtl
+     - The minimum time, in seconds, to use DNS data for toFQDNs policies.
+     - int
+     - ``3600``
+   * - dnsProxy.preCache
+     - DNS cache data at this path is preloaded on agent startup.
+     - string
+     - ``""``
+   * - dnsProxy.proxyPort
+     - Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+     - int
+     - ``0``
+   * - dnsProxy.proxyResponseMaxDelay
+     - The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.
+     - string
+     - ``"100ms"``
    * - egressGateway
      - Enables egress gateway to redirect and SNAT the traffic that leaves the cluster.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -330,6 +330,8 @@ discoverable
 distro
 distros
 dns
+dnsProxy
+dnsRejectResponseCode
 dockerhub
 dpaa
 dports
@@ -351,6 +353,7 @@ ena
 enableCiliumEndpointSlice
 enableCnpStatusUpdates
 enableCriticalPriorityClass
+enableDnsCompression
 enableHealthCheck
 enableIPv
 enableIdentityMark
@@ -363,6 +366,7 @@ endian
 endianness
 endpointGCInterval
 endpointHealthChecking
+endpointMaxIpPerHostname
 endpointRoutes
 endpointSelector
 endpointStatus
@@ -479,6 +483,7 @@ identityAllocationMode
 identityChangeGracePeriod
 identityGCInterval
 identityHeartbeatTimeout
+idleConnectionGracePeriod
 ie
 ifindex
 imagePullSecrets
@@ -618,6 +623,7 @@ masqLinkLocal
 masterDevice
 matchLabels
 matchPattern
+maxDeferredConnectionDeletes
 maxUnavailable
 mc
 mediabot
@@ -631,6 +637,7 @@ microk
 microservice
 microservices
 minAvailable
+minTtl
 minikube
 misconfigures
 mlx
@@ -650,6 +657,7 @@ mvneta
 myCA
 myapp
 mysql
+nameError
 namespace
 namespaced
 namespaces
@@ -727,11 +735,13 @@ postcheck
 powershell
 pprof
 pre
+preCache
 preallocateMaps
 prebuild
 prefilter
 preflight
 preload
+preloaded
 preloading
 prem
 prepend
@@ -747,6 +757,8 @@ programmability
 prometheus
 proto
 protobuf
+proxyPort
+proxyResponseMaxDelay
 proxying
 proxylib
 pullPolicy

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -143,6 +143,15 @@ contributors across the globe, there is almost always someone available to help.
 | datapathMode | string | `"veth"` | Configure which datapath mode should be used for configuring container connectivity. Valid options are "veth" or "ipvlan". Deprecated, to be removed in v1.12. |
 | debug.enabled | bool | `false` | Enable debug logging |
 | disableEndpointCRD | string | `"false"` | Disable the usage of CiliumEndpoint CRD. |
+| dnsProxy.dnsRejectResponseCode | string | `"refused"` | DNS response code for rejecting DNS requests, available options are '[nameError refused]'. |
+| dnsProxy.enableDnsCompression | bool | `true` | Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present. |
+| dnsProxy.endpointMaxIpPerHostname | int | `50` | Maximum number of IPs to maintain per FQDN name for each endpoint. |
+| dnsProxy.idleConnectionGracePeriod | string | `"0s"` | Time during which idle but previously active connections with expired DNS lookups are still considered alive. |
+| dnsProxy.maxDeferredConnectionDeletes | int | `10000` | Maximum number of IPs to retain for expired DNS lookups with still-active connections. |
+| dnsProxy.minTtl | int | `3600` | The minimum time, in seconds, to use DNS data for toFQDNs policies. |
+| dnsProxy.preCache | string | `""` | DNS cache data at this path is preloaded on agent startup. |
+| dnsProxy.proxyPort | int | `0` | Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port. |
+| dnsProxy.proxyResponseMaxDelay | string | `"100ms"` | The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. |
 | egressGateway | object | `{"enabled":false,"installRoutes":false}` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
 | egressGateway.installRoutes | bool | `false` | Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface |
 | enableCiliumEndpointSlice | bool | `false` | Enable CiliumEndpointSlice feature. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -885,6 +885,36 @@ data:
   unmanaged-pod-watcher-interval: "0"
 {{- end }}
 
+{{- if .Values.dnsProxy }}
+  {{- if .Values.dnsProxy.dnsRejectResponseCode }}
+  tofqdns-dns-reject-response-code: {{ .Values.dnsProxy.dnsRejectResponseCode | quote }}
+  {{- end }}
+  {{- if hasKey .Values.dnsProxy "enableDnsCompression" }}
+  tofqdns-enable-dns-compression: {{ .Values.dnsProxy.enableDnsCompression | quote }}
+  {{- end }}
+  {{- if .Values.dnsProxy.endpointMaxIpPerHostname }}
+  tofqdns-endpoint-max-ip-per-hostname: {{ .Values.dnsProxy.endpointMaxIpPerHostname | quote }}
+  {{- end }}
+  {{- if .Values.dnsProxy.idleConnectionGracePeriod }}
+  tofqdns-idle-connection-grace-period: {{ .Values.dnsProxy.idleConnectionGracePeriod | quote }}
+  {{- end }}
+  {{- if .Values.dnsProxy.maxDeferredConnectionDeletes }}
+  tofqdns-max-deferred-connection-deletes: {{ .Values.dnsProxy.maxDeferredConnectionDeletes | quote }}
+  {{- end }}
+  {{- if .Values.dnsProxy.minTtl }}
+  tofqdns-min-ttl: {{ .Values.dnsProxy.minTtl | quote }}
+  {{- end }}
+  {{- if .Values.dnsProxy.preCache }}
+  tofqdns-pre-cache: {{ .Values.dnsProxy.preCache | quote }}
+  {{- end }}
+  {{- if .Values.dnsProxy.proxyPort }}
+  tofqdns-proxy-port: {{ .Values.dnsProxy.proxyPort | quote }}
+  {{- end }}
+  {{- if .Values.dnsProxy.proxyResponseMaxDelay }}
+  tofqdns-proxy-response-max-delay: {{ .Values.dnsProxy.proxyResponseMaxDelay | quote }}
+  {{- end }}
+{{- end }}
+
 {{- if .Values.extraConfig }}
   {{ toYaml .Values.extraConfig | nindent 2 }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2057,3 +2057,23 @@ enableK8sTerminatingEndpoint: true
 # -- Configure the key of the taint indicating that Cilium is not ready on the node.
 # When set to a value starting with `ignore-taint.cluster-autoscaler.kubernetes.io/`, the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up.
 agentNotReadyTaintKey: "node.cilium.io/agent-not-ready"
+
+dnsProxy:
+  # -- DNS response code for rejecting DNS requests, available options are '[nameError refused]'.
+  dnsRejectResponseCode: refused
+  # -- Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
+  enableDnsCompression: true
+  # -- Maximum number of IPs to maintain per FQDN name for each endpoint.
+  endpointMaxIpPerHostname: 50
+  # -- Time during which idle but previously active connections with expired DNS lookups are still considered alive.
+  idleConnectionGracePeriod: 0s
+  # -- Maximum number of IPs to retain for expired DNS lookups with still-active connections.
+  maxDeferredConnectionDeletes: 10000
+  # -- The minimum time, in seconds, to use DNS data for toFQDNs policies.
+  minTtl: 3600
+  # -- DNS cache data at this path is preloaded on agent startup.
+  preCache: ""
+  # -- Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+  proxyPort: 0
+  # -- The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.
+  proxyResponseMaxDelay: 100ms

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2054,3 +2054,23 @@ enableK8sTerminatingEndpoint: true
 # -- Configure the key of the taint indicating that Cilium is not ready on the node.
 # When set to a value starting with `ignore-taint.cluster-autoscaler.kubernetes.io/`, the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up.
 agentNotReadyTaintKey: "node.cilium.io/agent-not-ready"
+
+dnsProxy:
+  # -- DNS response code for rejecting DNS requests, available options are '[nameError refused]'.
+  dnsRejectResponseCode: refused
+  # -- Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
+  enableDnsCompression: true
+  # -- Maximum number of IPs to maintain per FQDN name for each endpoint.
+  endpointMaxIpPerHostname: 50
+  # -- Time during which idle but previously active connections with expired DNS lookups are still considered alive.
+  idleConnectionGracePeriod: 0s
+  # -- Maximum number of IPs to retain for expired DNS lookups with still-active connections.
+  maxDeferredConnectionDeletes: 10000
+  # -- The minimum time, in seconds, to use DNS data for toFQDNs policies.
+  minTtl: 3600
+  # -- DNS cache data at this path is preloaded on agent startup.
+  preCache: ""
+  # -- Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+  proxyPort: 0
+  # -- The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.
+  proxyResponseMaxDelay: 100ms


### PR DESCRIPTION
Previously `extraConfig` and `extraArgs` chart values could be used to customize the agent DNS proxy parameters.
This PR proposes exposing agent DNS proxy parameters as helm chart values. Example:
```
dnsProxy:
  proxyResponseMaxDelay: 200ms
```

Signed-off-by: Joao Ubaldo <me@joaoubaldo.com>