### PR TITLE
docs: Fix and clean-up the build framework for the documentation

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -6,7 +6,7 @@ include ../Makefile.quiet
 
 HELM_VALUES := helm-values.rst
 
-.PHONY: default clean builder-image cilium-build cmdref epub latex html run-server stop-server
+.PHONY: default clean builder-image cilium-build cmdref epub latex html
 
 default: html
 
@@ -100,24 +100,7 @@ html-netlify: copy-api
 
 DOCS_PORT = 9081
 
-run-server: stop-server
-	# Work around Docker issue where this directory is created as root in
-	# the `--volume` parameter below. See also GH-10869.
-	$(QUIET)mkdir -p $(CURDIR)/_build/html/
-	$(QUIET)$(CONTAINER_ENGINE) container run --rm \
-		--detach \
-		--interactive \
-		--tty \
-		--name docs-cilium \
-		--publish $(DOCS_PORT):80 \
-		--volume $(CURDIR)/_build/html/:/usr/local/apache2/htdocs/ \
-			httpd:2.4
-	@echo "$$(tput setaf 2)Running at http://localhost:$(DOCS_PORT)$$(tput sgr0)"
-
-stop-server:
-	-$(QUIET)$(CONTAINER_ENGINE) container rm --force --volumes docs-cilium 2>/dev/null
-
-live-preview: stop-server builder-image
+live-preview: builder-image
 	@echo "$$(tput setaf 2)Running at http://localhost:$(DOCS_PORT)$$(tput sgr0)"
 	$(QUIET)$(DOCKER_CTR) \
 		--publish $(DOCS_PORT):8000 \

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -13,11 +13,13 @@ default: html
 clean:
 	-$(QUIET)rm -rf _build _api _exts/__pycache__ _preview Pipfile Pipfile.lock
 
+DOCS_BUILDER_IMG ?= cilium/docs-builder
+
 builder-image: Dockerfile requirements.txt
 	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
 	grep "^FROM " $< | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
 	$(QUIET)tar c requirements.txt Dockerfile \
-	  | $(CONTAINER_ENGINE) build --tag cilium/docs-builder -
+	  | $(CONTAINER_ENGINE) build --tag $(DOCS_BUILDER_IMG) -
 
 # cilium must have all build artifacts present for
 # documentation to be generated correctly.
@@ -32,7 +34,7 @@ DOCKER_CTR := $(CONTAINER_ENGINE) container run --rm \
 		--env READTHEDOCS_VERSION=$(READTHEDOCS_VERSION) \
 		--env SKIP_LINT=$(SKIP_LINT) \
 		--user "$(shell id -u):$(shell id -g)"
-DOCKER_RUN := $(DOCKER_CTR) cilium/docs-builder
+DOCKER_RUN := $(DOCKER_CTR) $(DOCS_BUILDER_IMG)
 
 update-cmdref: builder-image cilium-build
 	@$(ECHO_GEN)cmdref
@@ -119,5 +121,5 @@ live-preview: stop-server builder-image
 	@echo "$$(tput setaf 2)Running at http://localhost:$(DOCS_PORT)$$(tput sgr0)"
 	$(QUIET)$(DOCKER_CTR) \
 		--publish $(DOCS_PORT):8000 \
-			cilium/docs-builder \
+			$(DOCS_BUILDER_IMG) \
 		sphinx-autobuild --open-browser --host 0.0.0.0 $(SPHINX_OPTS) --ignore *.swp -Q . _preview

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -7,6 +7,9 @@ set -o pipefail
 # This was ported from the makefile, it can probably be converted
 # to Python (see e.g. https://stackoverflow.com/a/47657926), that
 # way we might be able to call Sphinx only once and make it quicker
+# Update 2022-05: It seems that Sphinx cannot run multiple builders
+# (e.g. html + spelling) at once so we're stuck calling it multiple
+# times anyway.
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -19,71 +22,96 @@ shift
 
 cd "${script_dir}"
 mkdir -p "${build_dir}"
+rm -f -- "${warnings}"
+
+has_spelling_errors() {
+    # If spelling errors were found, Sphinx wrote them to files under
+    # ${spelldir}. Let's check whether the directory is empty.
+    test -n "$(ls "${spelldir}")"
+}
+
+cat_warnings() {
+    [ -s "${warnings}" ] || return
+    cat "${warnings}"
+}
+
+# Returns non-0 if we have relevant build warnings
+has_build_warnings() {
+    [ -s "${warnings}" ] || return 1
+}
+
+describe_spelling_errors() {
+    local new_words
+
+    # Show all misspelled words; display source path relative to root repository
+    find "${spelldir}" -type f -print0 | xargs -0 sed 's/^/* Documentation\//'
+
+    # Print a hint on how to add new correct words to the list of good words
+    new_words="$(sed -E "s/^([^:]+:){2} \(([^ ]+)\).*/\2/g" "${spelldir}"/* | sort -u | tr '\r\n' ' ' | sed "s/'/\\\\\\\\'/g")"
+    printf "\nIf the words are not misspelled, run:\n%s %s\n" \
+        "Documentation/update-spelling_wordlist.sh" "${new_words}"
+}
 
 build_with_spellchecker() {
     rm -rf "${spelldir}"
-    sphinx-build -b spelling -d "${build_dir}/doctrees" . "${spelldir}" -q -E 2> "${warnings}"
+    # Call with -q -W --keep-going: suppresses regular output (keeps warning;
+    # -Q would suppress warnings as well including those we write to a file),
+    # consider warnings as errors for exit status, but keep going on
+    # warning/errors so that we get the full list of errors.
+    sphinx-build -b spelling \
+        -d "${build_dir}/doctrees" . "${spelldir}" \
+        -E -n --color -q -w "${warnings}" -W --keep-going 2>/dev/null
 }
 
 build_with_linkchecker() {
     sphinx-build -b linkcheck -d "${build_dir}/doctrees" . "${spelldir}" -q -E
 }
 
-has_spelling_errors() {
-    test -n "$(ls "${spelldir}")"
+run_linter() {
+    local CONF_PY_ROLES CONF_PY_SUBSTITUTIONS ignored_messages
+
+    CONF_PY_ROLES=$(sed -n "/^extlinks = {$/,/^}$/ s/^ *'\([^']\+\)':.*/\1/p" conf.py | tr '\n' ',')
+    CONF_PY_SUBSTITUTIONS="$(sed -n 's/^\.\. |\([^|]\+\)|.*/\1/p' conf.py | tr '\n' ',')release"
+    ignored_messages="("
+    ignored_messages="${ignored_messages}bpf.rst:.*: \(INFO/1\) Enumerated list start value not ordinal"
+    ignored_messages="${ignored_messages}|Hyperlink target .*is not referenced\."
+    ignored_messages="${ignored_messages}|Duplicate implicit target name:"
+    ignored_messages="${ignored_messages}|Malformed table\."
+    ignored_messages="${ignored_messages})"
+    rstcheck \
+        --report info \
+        --ignore-language bash \
+        --ignore-message "${ignored_messages}" \
+        --ignore-directives tabs \
+        --ignore-roles "${CONF_PY_ROLES}" \
+        --ignore-substitutions "${CONF_PY_SUBSTITUTIONS}" \
+        -r .
 }
 
-describe_spelling_errors() {
-    printf "\nPlease fix the following spelling mistakes:\n"
-    # show file paths relative to repo root
-    find "${spelldir}" -type f -print0 | xargs -0 sed 's/^/* Documentation\//'
-}
-
-hint_about_wordlist_update() {
-    new_words="$(sed -E "s/^([^:]+:){2} \(([^ ]+)\).*/\2/g" "${spelldir}"/* | sort -u | tr '\r\n' ' ' | sed "s/'/\\\\\\\\'/g")"
-    printf "\nIf the words are not misspelled, run:\n%s %s\n" \
-        "Documentation/update-spelling_wordlist.sh" "${new_words}"
-}
+read_all_opt=""
 
 if [ -n "${SKIP_LINT-}" ]; then
+  # Read all files for final build if we don't read them all with linting
+  read_all_opt="-E"
+
   echo "Skipping syntax and spelling validations..."
 else
   echo "Running linter..."
-  CONF_PY_ROLES=$(sed -n "/^extlinks = {$/,/^}$/ s/^ *'\([^']\+\)':.*/\1/p" conf.py | tr '\n' ',')
-  CONF_PY_SUBSTITUTIONS="$(sed -n 's/^\.\. |\([^|]\+\)|.*/\1/p' conf.py | tr '\n' ',')release"
-  ignored_messages="("
-  ignored_messages="${ignored_messages}bpf.rst:.*: \(INFO/1\) Enumerated list start value not ordinal"
-  ignored_messages="${ignored_messages}|Hyperlink target .*is not referenced\."
-  ignored_messages="${ignored_messages}|Duplicate implicit target name:"
-  ignored_messages="${ignored_messages}|Malformed table\."
-  ignored_messages="${ignored_messages})"
-  rstcheck \
-      --report info \
-      --ignore-language bash \
-      --ignore-message "${ignored_messages}" \
-      --ignore-directives tabs \
-      --ignore-roles ${CONF_PY_ROLES}\
-      --ignore-substitutions ${CONF_PY_SUBSTITUTIONS} \
-      -r .
+  run_linter
 
   echo "Validating documentation (syntax, spelling)..."
-  if build_with_spellchecker ; then
-    status_ok=0
-    if [ -s ${warnings} ]; then
+  if ! build_with_spellchecker ; then
+    if has_build_warnings ; then
         printf "\nPlease fix the following documentation warnings:\n"
-        cat ${warnings}
-        status_ok=1
+        cat_warnings
     fi
 
     if has_spelling_errors ; then
+        printf "\nPlease fix the following spelling mistakes:\n"
         describe_spelling_errors
-        hint_about_wordlist_update
-        status_ok=1
     fi
 
-    if [ "${status_ok}" -ne 0 ] ; then
-        exit 1
-    fi
+    exit 1
   fi
 fi
 
@@ -96,11 +124,13 @@ fi
 # fi
 
 echo "Building documentation (${target})..."
-sphinx-build -M "${target}" "${script_dir}" "${build_dir}" $@ -q 2> >(tee "${warnings}" >&2)
+sphinx-build -M "${target}" "${script_dir}" "${build_dir}" $@ \
+    ${read_all_opt} -n --color -q -w "${warnings}" 2>/dev/null
 
 # We can have warnings but no errors here, or sphinx-build would return non-0
 # and we would have exited because of "set -o errexit".
-if [ -s "${warnings}" ] ; then
-    echo "Please fix the above documentation warnings"
+if has_build_warnings ; then
+    echo "Please fix the documentation warnings below"
+    cat_warnings
     exit 1
 fi

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -167,10 +167,7 @@ suppress_warnings = ['myst.header']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-if os.uname()[4] == "aarch64":
-  html_theme = "sphinx_rtd_theme"
-else:
-  html_theme = "sphinx_rtd_theme_cilium"
+html_theme = "sphinx_rtd_theme_cilium"
 
 html_context = {
     'release': release

--- a/Documentation/contributing/testing/documentation.rst
+++ b/Documentation/contributing/testing/documentation.rst
@@ -23,11 +23,7 @@ you can build the docs:
 
 .. code-block:: shell-session
 
-    $ make render-docs
-
-This generates documentation files and starts a web server using a Docker container. You can
-view the updated documentation by opening either ``Documentation/_build/html/index.html`` or
-http://localhost:9081 in a browser.
+    $ make test-docs
 
 .. note::
 

--- a/Documentation/contributing/testing/documentation.rst
+++ b/Documentation/contributing/testing/documentation.rst
@@ -14,7 +14,7 @@ real-time preview. It relies on the ``cilium/docs-builder`` Docker container.
 
 .. code-block:: shell-session
 
-    $ make render-docs-live-preview
+    $ make render-docs
 
 and preview the documentation at http://localhost:9081/ as you make changes. After making changes to
 Cilium documentation you should check that you did not introduce any new warnings or errors, and also
@@ -27,11 +27,11 @@ you can build the docs:
 
 .. note::
 
-   By default, ``render-docs-live-preview`` generates a preview with instructions to install
+   By default, ``render-docs`` generates a preview with instructions to install
    Cilium from the latest version on GitHub (i.e. from the HEAD of the master branch that has
    not been released) regardless of which Cilium branch you are in. You can target a specific
    branch by specifying ``READTHEDOCS_VERSION`` environment variable:
 
    .. code-block:: shell-session
 
-      READTHEDOCS_VERSION=v1.7 make render-docs-live-preview
+      READTHEDOCS_VERSION=v1.7 make render-docs

--- a/Makefile
+++ b/Makefile
@@ -570,7 +570,7 @@ update-authors: ## Update AUTHORS file for Cilium repository.
 test-docs: ## Build HTML documentation.
 	$(MAKE) -C Documentation html
 
-render-docs-live-preview: ## Run server with live preview to render documentation.
+render-docs: ## Run server with live preview to render documentation.
 	$(MAKE) -C Documentation live-preview
 
 manpages: ## Generate manpage for Cilium CLI.

--- a/Makefile
+++ b/Makefile
@@ -570,9 +570,6 @@ update-authors: ## Update AUTHORS file for Cilium repository.
 test-docs: ## Build HTML documentation.
 	$(MAKE) -C Documentation html
 
-render-docs: test-docs ## Run server to render documentation.
-	$(MAKE) -C Documentation run-server
-
 render-docs-live-preview: ## Run server with live preview to render documentation.
 	$(MAKE) -C Documentation live-preview
 


### PR DESCRIPTION
Several fixes and improvements for building the documentation. The objective is to ease a little bit the setup process to get started building and serving locally the documentation, based on some feedback from Divine and Yoyo and personal observations during the first steps of the Google Season of Documentation.

Please refer to individual commits for details.

Fixes: #19910