### PR TITLE
docs: Add default conntrack gc interval

### DIFF
--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -400,9 +400,9 @@ If connectivity fails and ``cilium monitor --type drop`` shows ``xx drop (CT:
 Map insertion failed)``, then it is likely that the connection tracking table
 is filling up and the automatic adjustment of the garbage collector interval is
 insufficient. Set ``--conntrack-gc-interval`` to an interval lower than the
-default.  Alternatively, the value for ``bpf-ct-global-any-max`` and
-``bpf-ct-global-tcp-max`` can be increased. Setting both of these options will
-be a trade-off of CPU for ``conntrack-gc-interval``, and for
+default. The default starting interval is 5 minutes. Alternatively, the value
+for ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` can be increased.
+Setting both of these options will be a trade-off of CPU for ``conntrack-gc-interval``, and for
 ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
 consumed.
 


### PR DESCRIPTION
docs: Add default conntrack gc interval

>Set ``--conntrack-gc-interval`` to an interval lower than the
default. 

The troubleshooting guide suggests tweaking
garbage collection intervals for certain
environments experiencing drops. But it does
not report the default interval for conntrack garbage
collection. As a result, this may confuse users
who interpret the `0` value of the flag as the
garbage collection happening all the time.
While the conntrack GC interval can change
throughout the time when the agent is running,
it's useful to add the default starting interval.

Reported-By: Arun Porwal
Signed-off-by: Aditi Ghag <aditi@cilium.io>