### PR TITLE
test: Also delete hubble-peer when cleaning up old tests.

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4565,7 +4565,7 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"clusterrolebinding": "cilium cilium-operator hubble-relay",
 			"clusterrole":        "cilium cilium-operator hubble-relay hubble-ui",
 			"serviceaccount":     "cilium cilium-operator hubble-relay",
-			"service":            "cilium-agent hubble-metrics hubble-relay",
+			"service":            "cilium-agent hubble-metrics hubble-relay hubble-peer",
 			"secret":             "hubble-relay-client-certs hubble-server-certs hubble-ca-secret cilium-ca",
 			"resourcequota":      "cilium-resource-quota cilium-operator-resource-quota",
 		}


### PR DESCRIPTION
If an old test is left uncompleted, the new test will fail to run unless
this services is manually deleted due to the new installation
overwriting an existing resource.

```
Exitcode: 1
Err: exit status 1
Stdout:

Stderr:
         Error: rendered manifests contain a resource that already exists. Unable to continue with install: Service "hubble-peer" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "release-name"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kube-system"
```

Signed-off-by: Harsh Modi <harshmodi@google.com>