### PR TITLE
Add source filter for the cilium fqdn cache list command

### DIFF
--- a/Documentation/cmdref/cilium_fqdn_cache_list.md
+++ b/Documentation/cmdref/cilium_fqdn_cache_list.md
@@ -15,6 +15,7 @@ cilium fqdn cache list [flags]
   -h, --help                  help for list
   -p, --matchpattern string   List cache entries with FQDN that match matchpattern
   -o, --output string         json| yaml| jsonpath='{}'
+  -s, --source string         List cache entries from a specific source (lookup, connection)
 ```
 
 ### Options inherited from parent commands

--- a/api/v1/client/policy/get_fqdn_cache_id_parameters.go
+++ b/api/v1/client/policy/get_fqdn_cache_id_parameters.go
@@ -90,6 +90,11 @@ type GetFqdnCacheIDParams struct {
 
 	*/
 	Matchpattern *string
+	/*Source
+	  Source from which FQDN entries come from
+
+	*/
+	Source *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -162,6 +167,17 @@ func (o *GetFqdnCacheIDParams) SetMatchpattern(matchpattern *string) {
 	o.Matchpattern = matchpattern
 }
 
+// WithSource adds the source to the get fqdn cache ID params
+func (o *GetFqdnCacheIDParams) WithSource(source *string) *GetFqdnCacheIDParams {
+	o.SetSource(source)
+	return o
+}
+
+// SetSource adds the source to the get fqdn cache ID params
+func (o *GetFqdnCacheIDParams) SetSource(source *string) {
+	o.Source = source
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *GetFqdnCacheIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -201,6 +217,22 @@ func (o *GetFqdnCacheIDParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		qMatchpattern := qrMatchpattern
 		if qMatchpattern != "" {
 			if err := r.SetQueryParam("matchpattern", qMatchpattern); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.Source != nil {
+
+		// query param source
+		var qrSource string
+		if o.Source != nil {
+			qrSource = *o.Source
+		}
+		qSource := qrSource
+		if qSource != "" {
+			if err := r.SetQueryParam("source", qSource); err != nil {
 				return err
 			}
 		}

--- a/api/v1/client/policy/get_fqdn_cache_parameters.go
+++ b/api/v1/client/policy/get_fqdn_cache_parameters.go
@@ -73,6 +73,11 @@ type GetFqdnCacheParams struct {
 
 	*/
 	Matchpattern *string
+	/*Source
+	  Source from which FQDN entries come from
+
+	*/
+	Source *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -134,6 +139,17 @@ func (o *GetFqdnCacheParams) SetMatchpattern(matchpattern *string) {
 	o.Matchpattern = matchpattern
 }
 
+// WithSource adds the source to the get fqdn cache params
+func (o *GetFqdnCacheParams) WithSource(source *string) *GetFqdnCacheParams {
+	o.SetSource(source)
+	return o
+}
+
+// SetSource adds the source to the get fqdn cache params
+func (o *GetFqdnCacheParams) SetSource(source *string) {
+	o.Source = source
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *GetFqdnCacheParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -168,6 +184,22 @@ func (o *GetFqdnCacheParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		qMatchpattern := qrMatchpattern
 		if qMatchpattern != "" {
 			if err := r.SetQueryParam("matchpattern", qMatchpattern); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.Source != nil {
+
+		// query param source
+		var qrSource string
+		if o.Source != nil {
+			qrSource = *o.Source
+		}
+		qSource := qrSource
+		if qSource != "" {
+			if err := r.SetQueryParam("source", qSource); err != nil {
 				return err
 			}
 		}

--- a/api/v1/client/policy/policy_client.go
+++ b/api/v1/client/policy/policy_client.go
@@ -136,7 +136,7 @@ func (a *Client) DeletePolicy(params *DeletePolicyParams) (*DeletePolicyOK, erro
   GetFqdnCache retrieves the list of DNS lookups intercepted from all endpoints
 
   Retrieves the list of DNS lookups intercepted from endpoints,
-optionally filtered by endpoint id, DNS name, or CIDR IP range.
+optionally filtered by DNS name, CIDR IP range or source.
 
 */
 func (a *Client) GetFqdnCache(params *GetFqdnCacheParams) (*GetFqdnCacheOK, error) {
@@ -173,8 +173,8 @@ func (a *Client) GetFqdnCache(params *GetFqdnCacheParams) (*GetFqdnCacheOK, erro
 /*
   GetFqdnCacheID retrieves the list of DNS lookups intercepted from an endpoint
 
-  Retrieves the list of DNS lookups intercepted from endpoints,
-optionally filtered by endpoint id, DNS name, or CIDR IP range.
+  Retrieves the list of DNS lookups intercepted from the specific endpoint,
+optionally filtered by endpoint id, DNS name, CIDR IP range or source.
 
 */
 func (a *Client) GetFqdnCacheID(params *GetFqdnCacheIDParams) (*GetFqdnCacheIDOK, error) {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -853,12 +853,13 @@ paths:
       summary: Retrieves the list of DNS lookups intercepted from all endpoints.
       description: |
         Retrieves the list of DNS lookups intercepted from endpoints,
-        optionally filtered by endpoint id, DNS name, or CIDR IP range.
+        optionally filtered by DNS name, CIDR IP range or source.
       tags:
       - policy
       parameters:
       - "$ref": "#/parameters/matchpattern"
       - "$ref": "#/parameters/cidr"
+      - "$ref": "#/parameters/source"
       responses:
         '200':
           description: Success
@@ -894,14 +895,15 @@ paths:
     get:
       summary: Retrieves the list of DNS lookups intercepted from an endpoint.
       description: |
-        Retrieves the list of DNS lookups intercepted from endpoints,
-        optionally filtered by endpoint id, DNS name, or CIDR IP range.
+        Retrieves the list of DNS lookups intercepted from the specific endpoint,
+        optionally filtered by endpoint id, DNS name, CIDR IP range or source.
       tags:
       - policy
       parameters:
       - "$ref": "#/parameters/endpoint-id"
       - "$ref": "#/parameters/matchpattern"
       - "$ref": "#/parameters/cidr"
+      - "$ref": "#/parameters/source"
       responses:
         '200':
           description: Success
@@ -1097,6 +1099,12 @@ parameters:
   cidr:
     name: cidr
     description: A CIDR range of IPs
+    required: false
+    in: query
+    type: string
+  source:
+    name: source
+    description: Source from which FQDN entries come from
     required: false
     in: query
     type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -518,7 +518,7 @@ func init() {
     },
     "/fqdn/cache": {
       "get": {
-        "description": "Retrieves the list of DNS lookups intercepted from endpoints,\noptionally filtered by endpoint id, DNS name, or CIDR IP range.\n",
+        "description": "Retrieves the list of DNS lookups intercepted from endpoints,\noptionally filtered by DNS name, CIDR IP range or source.\n",
         "tags": [
           "policy"
         ],
@@ -529,6 +529,9 @@ func init() {
           },
           {
             "$ref": "#/parameters/cidr"
+          },
+          {
+            "$ref": "#/parameters/source"
           }
         ],
         "responses": {
@@ -578,7 +581,7 @@ func init() {
     },
     "/fqdn/cache/{id}": {
       "get": {
-        "description": "Retrieves the list of DNS lookups intercepted from endpoints,\noptionally filtered by endpoint id, DNS name, or CIDR IP range.\n",
+        "description": "Retrieves the list of DNS lookups intercepted from the specific endpoint,\noptionally filtered by endpoint id, DNS name, CIDR IP range or source.\n",
         "tags": [
           "policy"
         ],
@@ -592,6 +595,9 @@ func init() {
           },
           {
             "$ref": "#/parameters/cidr"
+          },
+          {
+            "$ref": "#/parameters/source"
           }
         ],
         "responses": {
@@ -4289,6 +4295,12 @@ func init() {
       "in": "path",
       "required": true
     },
+    "source": {
+      "type": "string",
+      "description": "Source from which FQDN entries come from",
+      "name": "source",
+      "in": "query"
+    },
     "trace-selector": {
       "description": "Context to provide policy evaluation on",
       "name": "trace-selector",
@@ -4855,7 +4867,7 @@ func init() {
     },
     "/fqdn/cache": {
       "get": {
-        "description": "Retrieves the list of DNS lookups intercepted from endpoints,\noptionally filtered by endpoint id, DNS name, or CIDR IP range.\n",
+        "description": "Retrieves the list of DNS lookups intercepted from endpoints,\noptionally filtered by DNS name, CIDR IP range or source.\n",
         "tags": [
           "policy"
         ],
@@ -4871,6 +4883,12 @@ func init() {
             "type": "string",
             "description": "A CIDR range of IPs",
             "name": "cidr",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Source from which FQDN entries come from",
+            "name": "source",
             "in": "query"
           }
         ],
@@ -4924,7 +4942,7 @@ func init() {
     },
     "/fqdn/cache/{id}": {
       "get": {
-        "description": "Retrieves the list of DNS lookups intercepted from endpoints,\noptionally filtered by endpoint id, DNS name, or CIDR IP range.\n",
+        "description": "Retrieves the list of DNS lookups intercepted from the specific endpoint,\noptionally filtered by endpoint id, DNS name, CIDR IP range or source.\n",
         "tags": [
           "policy"
         ],
@@ -4947,6 +4965,12 @@ func init() {
             "type": "string",
             "description": "A CIDR range of IPs",
             "name": "cidr",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Source from which FQDN entries come from",
+            "name": "source",
             "in": "query"
           }
         ],
@@ -9126,6 +9150,12 @@ func init() {
       "name": "id",
       "in": "path",
       "required": true
+    },
+    "source": {
+      "type": "string",
+      "description": "Source from which FQDN entries come from",
+      "name": "source",
+      "in": "query"
     },
     "trace-selector": {
       "description": "Context to provide policy evaluation on",

--- a/api/v1/server/restapi/policy/get_fqdn_cache.go
+++ b/api/v1/server/restapi/policy/get_fqdn_cache.go
@@ -37,7 +37,7 @@ func NewGetFqdnCache(ctx *middleware.Context, handler GetFqdnCacheHandler) *GetF
 Retrieves the list of DNS lookups intercepted from all endpoints.
 
 Retrieves the list of DNS lookups intercepted from endpoints,
-optionally filtered by endpoint id, DNS name, or CIDR IP range.
+optionally filtered by DNS name, CIDR IP range or source.
 
 
 */

--- a/api/v1/server/restapi/policy/get_fqdn_cache_id.go
+++ b/api/v1/server/restapi/policy/get_fqdn_cache_id.go
@@ -36,8 +36,8 @@ func NewGetFqdnCacheID(ctx *middleware.Context, handler GetFqdnCacheIDHandler) *
 
 Retrieves the list of DNS lookups intercepted from an endpoint.
 
-Retrieves the list of DNS lookups intercepted from endpoints,
-optionally filtered by endpoint id, DNS name, or CIDR IP range.
+Retrieves the list of DNS lookups intercepted from the specific endpoint,
+optionally filtered by endpoint id, DNS name, CIDR IP range or source.
 
 
 */

--- a/api/v1/server/restapi/policy/get_fqdn_cache_id_parameters.go
+++ b/api/v1/server/restapi/policy/get_fqdn_cache_id_parameters.go
@@ -58,6 +58,10 @@ type GetFqdnCacheIDParams struct {
 	  In: query
 	*/
 	Matchpattern *string
+	/*Source from which FQDN entries come from
+	  In: query
+	*/
+	Source *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -83,6 +87,11 @@ func (o *GetFqdnCacheIDParams) BindRequest(r *http.Request, route *middleware.Ma
 
 	qMatchpattern, qhkMatchpattern, _ := qs.GetOK("matchpattern")
 	if err := o.bindMatchpattern(qMatchpattern, qhkMatchpattern, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qSource, qhkSource, _ := qs.GetOK("source")
+	if err := o.bindSource(qSource, qhkSource, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -139,6 +148,24 @@ func (o *GetFqdnCacheIDParams) bindMatchpattern(rawData []string, hasKey bool, f
 	}
 
 	o.Matchpattern = &raw
+
+	return nil
+}
+
+// bindSource binds and validates parameter Source from query.
+func (o *GetFqdnCacheIDParams) bindSource(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	o.Source = &raw
 
 	return nil
 }

--- a/api/v1/server/restapi/policy/get_fqdn_cache_parameters.go
+++ b/api/v1/server/restapi/policy/get_fqdn_cache_parameters.go
@@ -41,6 +41,10 @@ type GetFqdnCacheParams struct {
 	  In: query
 	*/
 	Matchpattern *string
+	/*Source from which FQDN entries come from
+	  In: query
+	*/
+	Source *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -61,6 +65,11 @@ func (o *GetFqdnCacheParams) BindRequest(r *http.Request, route *middleware.Matc
 
 	qMatchpattern, qhkMatchpattern, _ := qs.GetOK("matchpattern")
 	if err := o.bindMatchpattern(qMatchpattern, qhkMatchpattern, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qSource, qhkSource, _ := qs.GetOK("source")
+	if err := o.bindSource(qSource, qhkSource, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -102,6 +111,24 @@ func (o *GetFqdnCacheParams) bindMatchpattern(rawData []string, hasKey bool, for
 	}
 
 	o.Matchpattern = &raw
+
+	return nil
+}
+
+// bindSource binds and validates parameter Source from query.
+func (o *GetFqdnCacheParams) bindSource(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	o.Source = &raw
 
 	return nil
 }

--- a/cilium/cmd/fqdn.go
+++ b/cilium/cmd/fqdn.go
@@ -58,6 +58,7 @@ var fqdnListCacheCmd = &cobra.Command{
 
 var fqdnCacheMatchPattern string
 var fqdnEndpointID string
+var fqdnSource string
 
 func init() {
 	fqdnCacheCmd.AddCommand(fqdnListCacheCmd)
@@ -71,6 +72,7 @@ func init() {
 
 	fqdnListCacheCmd.Flags().StringVarP(&fqdnCacheMatchPattern, "matchpattern", "p", "", "List cache entries with FQDN that match matchpattern")
 	fqdnListCacheCmd.Flags().StringVarP(&fqdnEndpointID, "endpoint", "e", "", "List cache entries for a specific endpoint id")
+	fqdnListCacheCmd.Flags().StringVarP(&fqdnSource, "source", "s", "", "List cache entries from a specific source (lookup, connection)")
 	command.AddOutputOption(fqdnListCacheCmd)
 }
 
@@ -102,6 +104,10 @@ func listFQDNCache() {
 	if fqdnEndpointID != "" {
 		params := policy.NewGetFqdnCacheIDParams()
 
+		if fqdnSource != "" {
+			params.SetSource(&fqdnSource)
+		}
+
 		if fqdnCacheMatchPattern != "" {
 			params.SetMatchpattern(&fqdnCacheMatchPattern)
 		}
@@ -122,6 +128,10 @@ func listFQDNCache() {
 		}
 	} else {
 		params := policy.NewGetFqdnCacheParams()
+
+		if fqdnSource != "" {
+			params.SetSource(&fqdnSource)
+		}
 
 		if fqdnCacheMatchPattern != "" {
 			params.SetMatchpattern(&fqdnCacheMatchPattern)

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -152,7 +152,7 @@ func (ds *DaemonSuite) BenchmarkFqdnCache(c *C) {
 	}
 	c.StartTimer()
 
-	extractDNSLookups(endpoints, "0.0.0.0/0", "*")
+	extractDNSLookups(endpoints, "0.0.0.0/0", "*", "")
 }
 
 func (ds *DaemonFQDNSuite) TestFQDNIdentityReferenceCounting(c *C) {


### PR DESCRIPTION
While exploring memory usage related to the FQDN subsystem I found myself looking at # of entries in the cache from each source and needed to grep of use the -o output + `jq` to filter to the ones I wanted. This should help provide a better UX via the CLI go filter entries.

Signed-off-by: Vlad Ungureanu <ungureanuvladvictor@gmail.com>
