### PR TITLE
metrics: Fix NaN value for cilium metrics list CLI

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -196,9 +196,7 @@ jobs:
           tar xzvf prometheus-${PROM_VERSION}.linux-amd64.tar.gz prometheus-${PROM_VERSION}.linux-amd64/promtool
           rm -f prometheus-${PROM_VERSION}.linux-amd64.tar.gz
           sudo mv prometheus-${PROM_VERSION}.linux-amd64/promtool /usr/bin
-          # filter go_ metrics which do not conform to the _total convention with gauges
-          # See https://github.com/prometheus/prometheus/issues/10574
-          cat metrics.prom | grep -v 'go_' | promtool check metrics
+          cat metrics.prom | promtool check metrics
 
       - name: Capture cilium-sysdump
         if: ${{ failure() }}

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/optiopay/kafka v0.0.0-00010101000000-000000000000
 	github.com/osrg/gobgp/v3 v3.2.0
 	github.com/pmezard/go-difflib v1.0.0
-	github.com/prometheus/client_golang v1.12.1
+	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/client_model v0.2.1-0.20210607210712-147c58e9608a
 	github.com/prometheus/procfs v0.7.3
 	github.com/russross/blackfriday/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -817,8 +817,9 @@ github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3O
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
+github.com/prometheus/client_golang v1.12.2 h1:51L9cDoUHVrXx4zWYlcLQIZ+d+VXHgqnYKkIuq4g/34=
+github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/collectors.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/collectors.go
@@ -14,3 +14,27 @@
 // Package collectors provides implementations of prometheus.Collector to
 // conveniently collect process and Go-related metrics.
 package collectors
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewBuildInfoCollector returns a collector collecting a single metric
+// "go_build_info" with the constant value 1 and three labels "path", "version",
+// and "checksum". Their label values contain the main module path, version, and
+// checksum, respectively. The labels will only have meaningful values if the
+// binary is built with Go module support and from source code retrieved from
+// the source repository (rather than the local file system). This is usually
+// accomplished by building from outside of GOPATH, specifying the full address
+// of the main package, e.g. "GO111MODULE=on go run
+// github.com/prometheus/client_golang/examples/random". If built without Go
+// module support, all label values will be "unknown". If built with Go module
+// support but using the source code from the local file system, the "path" will
+// be set appropriately, but "checksum" will be empty and "version" will be
+// "(devel)".
+//
+// This collector uses only the build information for the main module. See
+// https://github.com/povilasv/prommod for an example of a collector for the
+// module dependencies.
+func NewBuildInfoCollector() prometheus.Collector {
+	//nolint:staticcheck // Ignore SA1019 until v2.
+	return prometheus.NewBuildInfoCollector()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/go_collector_go116.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/go_collector_go116.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !go1.17
+// +build !go1.17
+
 package collectors
 
 import "github.com/prometheus/client_golang/prometheus"
@@ -42,28 +45,5 @@ import "github.com/prometheus/client_golang/prometheus"
 // NOTE: The problem is solved in Go 1.15, see
 // https://github.com/golang/go/issues/19812 for the related Go issue.
 func NewGoCollector() prometheus.Collector {
-	//nolint:staticcheck // Ignore SA1019 until v2.
 	return prometheus.NewGoCollector()
-}
-
-// NewBuildInfoCollector returns a collector collecting a single metric
-// "go_build_info" with the constant value 1 and three labels "path", "version",
-// and "checksum". Their label values contain the main module path, version, and
-// checksum, respectively. The labels will only have meaningful values if the
-// binary is built with Go module support and from source code retrieved from
-// the source repository (rather than the local file system). This is usually
-// accomplished by building from outside of GOPATH, specifying the full address
-// of the main package, e.g. "GO111MODULE=on go run
-// github.com/prometheus/client_golang/examples/random". If built without Go
-// module support, all label values will be "unknown". If built with Go module
-// support but using the source code from the local file system, the "path" will
-// be set appropriately, but "checksum" will be empty and "version" will be
-// "(devel)".
-//
-// This collector uses only the build information for the main module. See
-// https://github.com/povilasv/prommod for an example of a collector for the
-// module dependencies.
-func NewBuildInfoCollector() prometheus.Collector {
-	//nolint:staticcheck // Ignore SA1019 until v2.
-	return prometheus.NewBuildInfoCollector()
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/go_collector_latest.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/go_collector_latest.go
@@ -1,0 +1,91 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.17
+// +build go1.17
+
+package collectors
+
+import "github.com/prometheus/client_golang/prometheus"
+
+//nolint:staticcheck // Ignore SA1019 until v2.
+type goOptions = prometheus.GoCollectorOptions
+type goOption func(o *goOptions)
+
+type GoCollectionOption uint32
+
+const (
+	// GoRuntimeMemStatsCollection represents the metrics represented by runtime.MemStats structure such as
+	// go_memstats_alloc_bytes
+	// go_memstats_alloc_bytes_total
+	// go_memstats_sys_bytes
+	// go_memstats_lookups_total
+	// go_memstats_mallocs_total
+	// go_memstats_frees_total
+	// go_memstats_heap_alloc_bytes
+	// go_memstats_heap_sys_bytes
+	// go_memstats_heap_idle_bytes
+	// go_memstats_heap_inuse_bytes
+	// go_memstats_heap_released_bytes
+	// go_memstats_heap_objects
+	// go_memstats_stack_inuse_bytes
+	// go_memstats_stack_sys_bytes
+	// go_memstats_mspan_inuse_bytes
+	// go_memstats_mspan_sys_bytes
+	// go_memstats_mcache_inuse_bytes
+	// go_memstats_mcache_sys_bytes
+	// go_memstats_buck_hash_sys_bytes
+	// go_memstats_gc_sys_bytes
+	// go_memstats_other_sys_bytes
+	// go_memstats_next_gc_bytes
+	// so the metrics known from pre client_golang v1.12.0, except skipped go_memstats_gc_cpu_fraction (see
+	// https://github.com/prometheus/client_golang/issues/842#issuecomment-861812034 for explanation.
+	//
+	// NOTE that this mode represents runtime.MemStats statistics, but they are
+	// actually implemented using new runtime/metrics package.
+	// Deprecated: Use GoRuntimeMetricsCollection instead going forward.
+	GoRuntimeMemStatsCollection GoCollectionOption = 1 << iota
+	// GoRuntimeMetricsCollection is the new set of metrics represented by runtime/metrics package and follows
+	// consistent naming. The exposed metric set depends on Go version, but it is controlled against
+	// unexpected cardinality. This set has overlapping information with GoRuntimeMemStatsCollection, just with
+	// new names. GoRuntimeMetricsCollection is what is recommended for using going forward.
+	GoRuntimeMetricsCollection
+)
+
+// WithGoCollections allows enabling different collections for Go collector on top of base metrics
+// like go_goroutines, go_threads, go_gc_duration_seconds, go_memstats_last_gc_time_seconds, go_info.
+//
+// Check GoRuntimeMemStatsCollection and GoRuntimeMetricsCollection for more details. You can use none,
+// one or more collections at once. For example:
+// WithGoCollections(GoRuntimeMemStatsCollection | GoRuntimeMetricsCollection) means both GoRuntimeMemStatsCollection
+// metrics and GoRuntimeMetricsCollection will be exposed.
+//
+// The current default is GoRuntimeMemStatsCollection, so the compatibility mode with
+// client_golang pre v1.12 (move to runtime/metrics).
+func WithGoCollections(flags GoCollectionOption) goOption {
+	return func(o *goOptions) {
+		o.EnabledCollections = uint32(flags)
+	}
+}
+
+// NewGoCollector returns a collector that exports metrics about the current Go
+// process using debug.GCStats using runtime/metrics.
+func NewGoCollector(opts ...goOption) prometheus.Collector {
+	//nolint:staticcheck // Ignore SA1019 until v2.
+	promPkgOpts := make([]func(o *prometheus.GoCollectorOptions), len(opts))
+	for i, opt := range opts {
+		promPkgOpts[i] = opt
+	}
+	//nolint:staticcheck // Ignore SA1019 until v2.
+	return prometheus.NewGoCollector(promPkgOpts...)
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/go_collector.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/go_collector.go
@@ -197,14 +197,6 @@ func goRuntimeMemStats() memStatsMetrics {
 			),
 			eval:    func(ms *runtime.MemStats) float64 { return float64(ms.NextGC) },
 			valType: GaugeValue,
-		}, {
-			desc: NewDesc(
-				memstatNamespace("gc_cpu_fraction"),
-				"The fraction of this program's available CPU time used by the GC since the program started.",
-				nil, nil,
-			),
-			eval:    func(ms *runtime.MemStats) float64 { return ms.GCCPUFraction },
-			valType: GaugeValue,
 		},
 	}
 }
@@ -268,7 +260,6 @@ func (c *baseGoCollector) Collect(ch chan<- Metric) {
 	quantiles[0.0] = stats.PauseQuantiles[0].Seconds()
 	ch <- MustNewConstSummary(c.gcDesc, uint64(stats.NumGC), stats.PauseTotal.Seconds(), quantiles)
 	ch <- MustNewConstMetric(c.gcLastTimeDesc, GaugeValue, float64(stats.LastGC.UnixNano())/1e9)
-
 	ch <- MustNewConstMetric(c.goInfoDesc, GaugeValue, 1)
 }
 
@@ -278,6 +269,7 @@ func memstatNamespace(s string) string {
 
 // memStatsMetrics provide description, evaluator, runtime/metrics name, and
 // value type for memstat metrics.
+// TODO(bwplotka): Remove with end Go 1.16 EOL and replace with runtime/metrics.Description
 type memStatsMetrics []struct {
 	desc    *Desc
 	eval    func(*runtime.MemStats) float64

--- a/vendor/github.com/prometheus/client_golang/prometheus/internal/go_runtime_metrics.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/internal/go_runtime_metrics.go
@@ -62,7 +62,7 @@ func RuntimeMetricsToProm(d *metrics.Description) (string, string, string, bool)
 	// other data.
 	name = strings.ReplaceAll(name, "-", "_")
 	name = name + "_" + unit
-	if d.Cumulative {
+	if d.Cumulative && d.Kind != metrics.KindFloat64Histogram {
 		name = name + "_total"
 	}
 
@@ -84,12 +84,12 @@ func RuntimeMetricsToProm(d *metrics.Description) (string, string, string, bool)
 func RuntimeMetricsBucketsForUnit(buckets []float64, unit string) []float64 {
 	switch unit {
 	case "bytes":
-		// Rebucket as powers of 2.
-		return rebucketExp(buckets, 2)
+		// Re-bucket as powers of 2.
+		return reBucketExp(buckets, 2)
 	case "seconds":
-		// Rebucket as powers of 10 and then merge all buckets greater
+		// Re-bucket as powers of 10 and then merge all buckets greater
 		// than 1 second into the +Inf bucket.
-		b := rebucketExp(buckets, 10)
+		b := reBucketExp(buckets, 10)
 		for i := range b {
 			if b[i] <= 1 {
 				continue
@@ -103,11 +103,11 @@ func RuntimeMetricsBucketsForUnit(buckets []float64, unit string) []float64 {
 	return buckets
 }
 
-// rebucketExp takes a list of bucket boundaries (lower bound inclusive) and
+// reBucketExp takes a list of bucket boundaries (lower bound inclusive) and
 // downsamples the buckets to those a multiple of base apart. The end result
 // is a roughly exponential (in many cases, perfectly exponential) bucketing
 // scheme.
-func rebucketExp(buckets []float64, base float64) []float64 {
+func reBucketExp(buckets []float64, base float64) []float64 {
 	bucket := buckets[0]
 	var newBuckets []float64
 	// We may see a -Inf here, in which case, add it and skip it

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -700,7 +700,7 @@ github.com/pmezard/go-difflib/difflib
 # github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c
 ## explicit; go 1.14
 github.com/power-devops/perfstat
-# github.com/prometheus/client_golang v1.12.1
+# github.com/prometheus/client_golang v1.12.2
 ## explicit; go 1.13
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors


### PR DESCRIPTION
## Description

Please refer to commit details

## Testing

Testing was done locally before and after changes. From the changes in vendor, `gc_cpu_fraction` metric was having NaN value.

<details>
<summary>Before</summary>

```
$ ksysex ds/cilium -- cilium metrics list
Defaulted container "cilium-agent" out of: cilium-agent, mount-cgroup (init), wait-for-node-init (init), clean-cilium-state (init)
Error: Cannot get metrics list: invalid character 'I' looking for beginning of value
command terminated with exit code 1
```

</details>

<details>
<summary>After</summary>

```
$ ksysex ds/cilium -- cilium metrics list
Defaulted container "cilium-agent" out of: cilium-agent, mount-cgroup (init), wait-for-node-init (init), clean-cilium-state (init)
Metric                                                Labels                                                                                                       Value
cilium_agent_api_process_time_seconds                 method="GET" path="/v1/cluster" return_code="200"                                                            0.000121
cilium_agent_api_process_time_seconds                 method="GET" path="/v1/healthz" return_code="200"                                                            0.002257
cilium_agent_bootstrap_seconds                        outcome="success" scope="bpfBase"                                                                            7.824910
cilium_agent_bootstrap_seconds                        outcome="success" scope="cleanup"                                                                            0.001278
cilium_agent_bootstrap_seconds                        outcome="success" scope="clusterMeshInit"                                                                    0.000168
cilium_agent_bootstrap_seconds                        outcome="success" scope="daemonInit"                                                                         0.121033
cilium_agent_bootstrap_seconds                        outcome="success" scope="earlyInit"                                                                          0.335199
cilium_agent_bootstrap_seconds                        outcome="success" scope="enableConntrack"                                                                    0.005250
cilium_agent_bootstrap_seconds                        outcome="success" scope="fqdn"                                                                               0.001740
cilium_agent_bootstrap_seconds                        outcome="success" scope="healthCheck"                                                                        0.008836
cilium_agent_bootstrap_seconds                        outcome="success" scope="initAPI"                                                                            0.060499
cilium_agent_bootstrap_seconds                        outcome="success" scope="ipam"                                                                               0.000287
cilium_agent_bootstrap_seconds                        outcome="success" scope="k8sInit"                                                                            1.110813
cilium_agent_bootstrap_seconds                        outcome="success" scope="mapsInit"                                                                           0.002917
cilium_agent_bootstrap_seconds                        outcome="success" scope="overall"                                                                            9.648906
cilium_agent_bootstrap_seconds                        outcome="success" scope="proxyStart"                                                                         0.000203
cilium_agent_bootstrap_seconds                        outcome="success" scope="restore"                                                                            0.016190
cilium_bpf_map_ops_total                              map_name="call_policy" operation="delete" outcome="success"                                                  1.000000
cilium_bpf_map_ops_total                              map_name="ct4_global" operation="delete" outcome="success"                                                   13.000000
cilium_bpf_map_ops_total                              map_name="ct_any4_global" operation="delete" outcome="success"                                               2.000000
cilium_bpf_map_ops_total                              map_name="egresscall_policy" operation="delete" outcome="success"                                            1.000000
cilium_bpf_map_ops_total                              map_name="ipcache" operation="update" outcome="success"                                                      13.000000
cilium_bpf_map_ops_total                              map_name="lb4_backends_v2" operation="delete" outcome="success"                                              1.000000
cilium_bpf_map_ops_total                              map_name="lb4_backends_v2" operation="update" outcome="success"                                              1.000000
cilium_bpf_map_ops_total                              map_name="lb4_reverse_nat" operation="update" outcome="success"                                              7.000000
cilium_bpf_map_ops_total                              map_name="lb4_services_v2" operation="delete" outcome="success"                                              1.000000
cilium_bpf_map_ops_total                              map_name="lb4_services_v2" operation="update" outcome="success"                                              13.000000
cilium_bpf_map_ops_total                              map_name="lxc" operation="delete" outcome="fail"                                                             2.000000
cilium_bpf_map_ops_total                              map_name="lxc" operation="delete" outcome="success"                                                          1.000000
cilium_bpf_map_ops_total                              map_name="lxc" operation="update" outcome="success"                                                          4.000000
cilium_bpf_map_ops_total                              map_name="policy" operation="update" outcome="success"                                                       3.000000
cilium_bpf_maps_virtual_memory_max_bytes                                                                                                                           595353600.000000
cilium_bpf_progs_virtual_memory_max_bytes                                                                                                                          2248704.000000
cilium_controllers_failing                                                                                                                                         0.000000
cilium_controllers_runs_duration_seconds              status="failure"                                                                                             0.000018
cilium_controllers_runs_duration_seconds              status="success"                                                                                             24.615597
cilium_controllers_runs_total                         status="failure"                                                                                             3.000000
cilium_controllers_runs_total                         status="success"                                                                                             44.000000
cilium_datapath_conntrack_dump_resets_total           area="conntrack" family="ipv4" name="dump_interrupts"                                                        0.000000
cilium_datapath_conntrack_gc_duration_seconds         family="ipv4" protocol="TCP" status="completed"                                                              0.010602
cilium_datapath_conntrack_gc_duration_seconds         family="ipv4" protocol="non-TCP" status="completed"                                                          0.005709
cilium_datapath_conntrack_gc_entries                  family="ipv4" protocol="TCP" status="alive"                                                                  6.000000
cilium_datapath_conntrack_gc_entries                  family="ipv4" protocol="TCP" status="deleted"                                                                0.000000
cilium_datapath_conntrack_gc_entries                  family="ipv4" protocol="non-TCP" status="alive"                                                              36.000000
cilium_datapath_conntrack_gc_entries                  family="ipv4" protocol="non-TCP" status="deleted"                                                            0.000000
cilium_datapath_conntrack_gc_key_fallbacks_total      family="ipv4" protocol="TCP"                                                                                 0.000000
cilium_datapath_conntrack_gc_key_fallbacks_total      family="ipv4" protocol="non-TCP"                                                                             0.000000
cilium_datapath_conntrack_gc_runs_total               family="ipv4" protocol="TCP" status="completed"                                                              3.000000
cilium_datapath_conntrack_gc_runs_total               family="ipv4" protocol="non-TCP" status="completed"                                                          3.000000
cilium_drop_bytes_total                               direction="INGRESS" reason="Stale or unroutable IP"                                                          98180.000000
cilium_drop_count_total                               direction="INGRESS" reason="Stale or unroutable IP"                                                          1482.000000
cilium_endpoint                                                                                                                                                    5.000000
cilium_endpoint_regeneration_time_stats_seconds       scope="bpfCompilation" status="success"                                                                      10.372343
cilium_endpoint_regeneration_time_stats_seconds       scope="bpfLoadProg" status="success"                                                                         4.351671
cilium_endpoint_regeneration_time_stats_seconds       scope="bpfWaitForELF" status="success"                                                                       23.108070
cilium_endpoint_regeneration_time_stats_seconds       scope="bpfWriteELF" status="success"                                                                         0.005215
cilium_endpoint_regeneration_time_stats_seconds       scope="mapSync" status="success"                                                                             0.000529
cilium_endpoint_regeneration_time_stats_seconds       scope="policyCalculation" status="success"                                                                   0.000713
cilium_endpoint_regeneration_time_stats_seconds       scope="prepareBuild" status="success"                                                                        0.001723
cilium_endpoint_regeneration_time_stats_seconds       scope="proxyConfiguration" status="success"                                                                  0.000047
cilium_endpoint_regeneration_time_stats_seconds       scope="proxyPolicyCalculation" status="success"                                                              0.000158
cilium_endpoint_regeneration_time_stats_seconds       scope="proxyWaitForAck" status="success"                                                                     0.000158
cilium_endpoint_regeneration_time_stats_seconds       scope="total" status="success"                                                                               27.516170
cilium_endpoint_regeneration_time_stats_seconds       scope="waitingForCTClean" status="success"                                                                   0.006372
cilium_endpoint_regeneration_time_stats_seconds       scope="waitingForLock" status="success"                                                                      0.000008
cilium_endpoint_regenerations_total                   outcome="success"                                                                                            5.000000
cilium_endpoint_state                                 endpoint_state="disconnecting"                                                                               0.000000
cilium_endpoint_state                                 endpoint_state="ready"                                                                                       5.000000
cilium_endpoint_state                                 endpoint_state="regenerating"                                                                                0.000000
cilium_endpoint_state                                 endpoint_state="restoring"                                                                                   0.000000
cilium_endpoint_state                                 endpoint_state="waiting-for-identity"                                                                        0.000000
cilium_endpoint_state                                 endpoint_state="waiting-to-regenerate"                                                                       0.000000
cilium_errors_warnings_total                          level="warning" subsystem="sysctl"                                                                           1.000000
cilium_event_ts                                       source="api"                                                                                                 1653659278.271445
cilium_event_ts                                       source="docker"                                                                                              0.000000
cilium_event_ts                                       source="k8s"                                                                                                 1653659264.620509
cilium_forward_bytes_total                            direction="EGRESS"                                                                                           359899520.000000
cilium_forward_bytes_total                            direction="INGRESS"                                                                                          8989691462.000000
cilium_forward_count_total                            direction="EGRESS"                                                                                           1435292.000000
cilium_forward_count_total                            direction="INGRESS"                                                                                          1645833.000000
cilium_fqdn_gc_deletions_total                                                                                                                                     0.000000
cilium_identity                                                                                                                                                    10.000000
cilium_ip_addresses                                   family="ipv4"                                                                                                5.000000
cilium_ip_addresses                                   family="ipv6"                                                                                                0.000000
cilium_ipam_events_total                              action="allocate" family="ipv4"                                                                              5.000000
cilium_k8s_client_api_calls_total                     host="10.96.0.1:443" method="GET" return_code="200"                                                          37.000000
cilium_k8s_client_api_calls_total                     host="10.96.0.1:443" method="PUT" return_code="200"                                                          2.000000
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/api/v1/namespaces"                                                                       0.001544
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/api/v1/namespaces/cilium-secrets/secrets"                                                0.002038
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/api/v1/namespaces/kube-system"                                                           0.004157
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/api/v1/nodes"                                                                            0.003095
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/api/v1/pods"                                                                             0.002556
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/api/v1/services"                                                                         0.002220
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/apiextensions.k8s.io/v1/customresourcedefinitions"                                  0.001341
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/ciliumclusterwideenvoyconfigs"                                         0.001627
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/ciliumclusterwidenetworkpolicies"                                      0.001294
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/ciliumendpoints"                                                       0.002141
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/ciliumenvoyconfigs"                                                    0.002703
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/ciliumidentities"                                                      0.001100
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/ciliumnetworkpolicies"                                                 0.001540
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/ciliumnodes"                                                           0.001436
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/ciliumnodes/minikube"                                                  0.003007
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/namespaces/kube-system/ciliumendpoints/coredns-64897985d-v2zzs"        0.006645
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/namespaces/kube-system/ciliumendpoints/hubble-relay-85dcb5dbb-d2q7t"   0.006400
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/cilium.io/v2/namespaces/kube-system/ciliumendpoints/hubble-ui-6c569fd887-9d96l"     0.006439
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/discovery.k8s.io/v1/endpointslices"                                                 0.002290
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/apis/networking.k8s.io/v1/networkpolicies"                                               0.001629
cilium_k8s_client_api_latency_time_seconds            method="GET" path="/version"                                                                                 0.001317
cilium_k8s_client_api_latency_time_seconds            method="PUT" path="/apis/cilium.io/v2/ciliumnodes/minikube"                                                  0.010523
cilium_k8s_event_lag_seconds                          source="k8s"                                                                                                 0.000000
cilium_kubernetes_events_received_total               action="create" equal="false" scope="CiliumEndpoint" valid="true"                                            3.000000
cilium_kubernetes_events_received_total               action="create" equal="false" scope="CiliumNode" valid="true"                                                1.000000
cilium_kubernetes_events_received_total               action="create" equal="false" scope="EndpointSlice" valid="true"                                             5.000000
cilium_kubernetes_events_received_total               action="create" equal="false" scope="Node" valid="true"                                                      1.000000
cilium_kubernetes_events_received_total               action="create" equal="false" scope="Pod" valid="true"                                                       12.000000
cilium_kubernetes_events_received_total               action="create" equal="false" scope="Service" valid="true"                                                   5.000000
cilium_kubernetes_events_received_total               action="update" equal="false" scope="CiliumNode" valid="true"                                                1.000000
cilium_kubernetes_events_received_total               action="update" equal="false" scope="EndpointSlice" valid="true"                                             1.000000
cilium_kubernetes_events_received_total               action="update" equal="false" scope="Pod" valid="true"                                                       1.000000
cilium_kubernetes_events_received_total               action="update" equal="true" scope="Pod" valid="true"                                                        1.000000
cilium_kubernetes_events_total                        action="create" scope="CiliumEndpoint" status="success"                                                      3.000000
cilium_kubernetes_events_total                        action="create" scope="EndpointSlice" status="success"                                                       5.000000
cilium_kubernetes_events_total                        action="create" scope="Node" status="success"                                                                1.000000
cilium_kubernetes_events_total                        action="create" scope="Pod" status="success"                                                                 12.000000
cilium_kubernetes_events_total                        action="create" scope="Service" status="success"                                                             5.000000
cilium_kubernetes_events_total                        action="update" scope="EndpointSlice" status="success"                                                       1.000000
cilium_kubernetes_events_total                        action="update" scope="Pod" status="success"                                                                 1.000000
cilium_nodes_all_datapath_validations_total                                                                                                                        0.000000
cilium_nodes_all_events_received_total                event_type="add" source="local"                                                                              1.000000
cilium_nodes_all_num                                                                                                                                               1.000000
cilium_policy                                                                                                                                                      0.000000
cilium_policy_endpoint_enforcement_status             enforcement="audit-both"                                                                                     0.000000
cilium_policy_endpoint_enforcement_status             enforcement="audit-egress"                                                                                   0.000000
cilium_policy_endpoint_enforcement_status             enforcement="audit-ingress"                                                                                  0.000000
cilium_policy_endpoint_enforcement_status             enforcement="both"                                                                                           0.000000
cilium_policy_endpoint_enforcement_status             enforcement="egress"                                                                                         0.000000
cilium_policy_endpoint_enforcement_status             enforcement="ingress"                                                                                        0.000000
cilium_policy_endpoint_enforcement_status             enforcement="none"                                                                                           5.000000
cilium_policy_import_errors_total                                                                                                                                  0.000000
cilium_policy_l7_denied_total                                                                                                                                      0.000000
cilium_policy_l7_forwarded_total                                                                                                                                   0.000000
cilium_policy_l7_parse_errors_total                                                                                                                                0.000000
cilium_policy_l7_received_total                                                                                                                                    0.000000
cilium_policy_max_revision                                                                                                                                         0.000000
cilium_policy_regeneration_time_stats_seconds         scope="policyCalculation" status="success"                                                                   0.000059
cilium_policy_regeneration_time_stats_seconds         scope="total" status="success"                                                                               0.000128
cilium_policy_regeneration_time_stats_seconds         scope="waitingForPolicyRepository" status="success"                                                          0.000003
cilium_policy_regeneration_total                                                                                                                                   5.000000
cilium_process_cpu_seconds_total                                                                                                                                   1.090000
cilium_process_max_fds                                                                                                                                             102400.000000
cilium_process_open_fds                                                                                                                                            136.000000
cilium_process_resident_memory_bytes                                                                                                                               115998720.000000
cilium_process_start_time_seconds                                                                                                                                  1653659254.520000
cilium_process_virtual_memory_bytes                                                                                                                                820961280.000000
cilium_process_virtual_memory_max_bytes                                                                                                                            18446744073709551616.000000
cilium_subprocess_start_total                         subsystem="cilium-health"                                                                                    1.000000
cilium_triggers_policy_update_call_duration_seconds   type="duration"                                                                                              0.000041
cilium_triggers_policy_update_call_duration_seconds   type="latency"                                                                                               0.000013
cilium_triggers_policy_update_folds                                                                                                                                1.000000
cilium_triggers_policy_update_total                   reason="one or more identities created or deleted"                                                           1.000000
cilium_unreachable_health_endpoints                                                                                                                                0.000000
cilium_unreachable_nodes                                                                                                                                           0.000000
cilium_version                                        version="1.11.90"                                                                                            0.000000
go_gc_duration_seconds                                                                                                                                             0.001255
go_goroutines                                                                                                                                                      221.000000
go_info                                               version="go1.18.2"                                                                                           1.000000
go_memstats_alloc_bytes                                                                                                                                            33470824.000000
go_memstats_alloc_bytes_total                                                                                                                                      188171640.000000
go_memstats_buck_hash_sys_bytes                                                                                                                                    1610815.000000
go_memstats_frees_total                                                                                                                                            1385018.000000
go_memstats_gc_sys_bytes                                                                                                                                           6149984.000000
go_memstats_heap_alloc_bytes                                                                                                                                       33470824.000000
go_memstats_heap_idle_bytes                                                                                                                                        23830528.000000
go_memstats_heap_inuse_bytes                                                                                                                                       39149568.000000
go_memstats_heap_objects                                                                                                                                           189375.000000
go_memstats_heap_released_bytes                                                                                                                                    12951552.000000
go_memstats_heap_sys_bytes                                                                                                                                         62980096.000000
go_memstats_last_gc_time_seconds                                                                                                                                   1653659272.436278
go_memstats_lookups_total                                                                                                                                          0.000000
go_memstats_mallocs_total                                                                                                                                          1574393.000000
go_memstats_mcache_inuse_bytes                                                                                                                                     38400.000000
go_memstats_mcache_sys_bytes                                                                                                                                       46800.000000
go_memstats_mspan_inuse_bytes                                                                                                                                      599624.000000
go_memstats_mspan_sys_bytes                                                                                                                                        652800.000000
go_memstats_next_gc_bytes                                                                                                                                          41279392.000000
go_memstats_other_sys_bytes                                                                                                                                        5539950.000000
go_memstats_stack_inuse_bytes                                                                                                                                      4128768.000000
go_memstats_stack_sys_bytes                                                                                                                                        4128768.000000
go_memstats_sys_bytes                                                                                                                                              81109213.000000
go_threads                                                                                                                                                         43.000000
```
</details>