### PR TITLE
Dynamic Per Resource Timeouts

### DIFF
--- a/api/v1/server/configure_cilium_api.go
+++ b/api/v1/server/configure_cilium_api.go
@@ -304,7 +304,7 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 func setupGlobalMiddleware(handler http.Handler) http.Handler {
 	eventsHelper := &ciliumMetrics.APIEventTSHelper{
 		Next:      handler,
-		TSGauge:   ciliumMetrics.EventTSAPI,
+		TSGauge:   ciliumMetrics.EventTS,
 		Histogram: ciliumMetrics.APIInteractions,
 	}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -51,7 +51,7 @@ import (
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
@@ -556,7 +556,7 @@ func initializeFlags() {
 		option.KVStoreOpt, "Key-value store options e.g. etcd.address=127.0.0.1:4001")
 	option.BindEnv(option.KVStoreOpt)
 
-	flags.Duration(option.K8sSyncTimeoutName, defaults.K8sSyncTimeout, "Timeout for synchronizing k8s resources before exiting")
+	flags.Duration(option.K8sSyncTimeoutName, defaults.K8sSyncTimeout, "Timeout after last K8s event for synchronizing k8s resources before exiting")
 	flags.MarkHidden(option.K8sSyncTimeoutName)
 	option.BindEnv(option.K8sSyncTimeoutName)
 
@@ -1636,10 +1636,10 @@ func (d *Daemon) initKVStore() {
 		// to the service IP as well perform the service -> backend IPs for
 		// that service IP.
 		d.k8sWatcher.WaitForCacheSync(
-			watchers.K8sAPIGroupServiceV1Core,
-			watchers.K8sAPIGroupEndpointV1Core,
-			watchers.K8sAPIGroupEndpointSliceV1Discovery,
-			watchers.K8sAPIGroupEndpointSliceV1Beta1Discovery,
+			resources.K8sAPIGroupServiceV1Core,
+			resources.K8sAPIGroupEndpointV1Core,
+			resources.K8sAPIGroupEndpointSliceV1Discovery,
+			resources.K8sAPIGroupEndpointSliceV1Beta1Discovery,
 		)
 		log := log.WithField(logfields.LogSubsys, "etcd")
 		goopts.DialOption = []grpc.DialOption{

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -66,7 +66,7 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 	}
 
 	if ep.K8sPodName != "" && ep.K8sNamespace != "" && k8s.IsEnabled() {
-		d.k8sWatcher.WaitForCacheSync(watchers.K8sAPIGroupPodV1Core)
+		d.k8sWatcher.WaitForCacheSync(resources.K8sAPIGroupPodV1Core)
 		pod, err := d.k8sWatcher.GetCachedPod(ep.K8sNamespace, ep.K8sPodName)
 		if err != nil && k8serrors.IsNotFound(err) {
 			return false, fmt.Errorf("Kubernetes pod %s/%s does not exist", ep.K8sNamespace, ep.K8sPodName)

--- a/operator/cnp_event.go
+++ b/operator/cnp_event.go
@@ -18,8 +18,8 @@ import (
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/informer"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/kvstore/store"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/groups"
 )
@@ -76,9 +76,8 @@ func enableCNPWatcher() error {
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				metrics.EventTSK8s.SetToCurrentTime()
+				k8sEventMetric(resources.MetricCNP, resources.MetricCreate)
 				if cnp := k8s.ObjToSlimCNP(obj); cnp != nil {
-
 					// We need to deepcopy this structure because we are writing
 					// fields.
 					// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
@@ -91,7 +90,7 @@ func enableCNPWatcher() error {
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				metrics.EventTSK8s.SetToCurrentTime()
+				k8sEventMetric(resources.MetricCNP, resources.MetricUpdate)
 				if oldCNP := k8s.ObjToSlimCNP(oldObj); oldCNP != nil {
 					if newCNP := k8s.ObjToSlimCNP(newObj); newCNP != nil {
 						if oldCNP.DeepEqual(newCNP) {
@@ -109,7 +108,7 @@ func enableCNPWatcher() error {
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				metrics.EventTSK8s.SetToCurrentTime()
+				k8sEventMetric(resources.MetricCNP, resources.MetricDelete)
 				cnp := k8s.ObjToSlimCNP(obj)
 				if cnp == nil {
 					return

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -266,8 +266,8 @@ const (
 	// invoked only for endpoints which are selected by policy changes.
 	SelectiveRegeneration = true
 
-	// K8sSyncTimeout specifies the standard time to allow for synchronizing
-	// local caches with Kubernetes state before exiting.
+	// K8sSyncTimeout specifies the default time to wait after the last event
+	// of a Kubernetes resource type before timing out while waiting for synchronization.
 	K8sSyncTimeout = 3 * time.Minute
 
 	// AllocatorListTimeout specifies the standard time to allow for listing

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -20,9 +20,10 @@ import (
 
 type ownerMock struct{}
 
-func (o *ownerMock) K8sEventReceived(scope string, action string, valid, equal bool) {}
-func (o *ownerMock) K8sEventProcessed(scope string, action string, status bool)      {}
-func (o *ownerMock) RegisterCiliumNodeSubscriber(s subscriber.CiliumNode)            {}
+func (o *ownerMock) K8sEventReceived(resourceApiGroup, scope string, action string, valid, equal bool) {
+}
+func (o *ownerMock) K8sEventProcessed(scope string, action string, status bool) {}
+func (o *ownerMock) RegisterCiliumNodeSubscriber(s subscriber.CiliumNode)       {}
 
 func (o *ownerMock) UpdateCiliumNodeResource()                                          {}
 func (o *ownerMock) LocalAllocCIDRsUpdated(ipv4AllocCIDRs, ipv6AllocCIDRs []*cidr.CIDR) {}

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -105,7 +105,7 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg 
 	// Create the CiliumNode custom resource. This call will block until
 	// the custom resource has been created
 	owner.UpdateCiliumNodeResource()
-
+	apiGroup := "cilium/v2::CiliumNode"
 	ciliumNodeSelector := fields.ParseSelectorOrDie("metadata.name=" + nodeName)
 	ciliumNodeStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 	ciliumNodeInformer := informer.NewInformerWithStore(
@@ -116,7 +116,7 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg 
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k8sEventReg.K8sEventReceived("CiliumNode", "create", valid, equal) }()
+				defer func() { k8sEventReg.K8sEventReceived(apiGroup, "CiliumNode", "create", valid, equal) }()
 				if node, ok := obj.(*ciliumv2.CiliumNode); ok {
 					valid = true
 					store.updateLocalNodeResource(node.DeepCopy())
@@ -127,7 +127,7 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg 
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
-				defer func() { k8sEventReg.K8sEventReceived("CiliumNode", "update", valid, equal) }()
+				defer func() { k8sEventReg.K8sEventReceived(apiGroup, "CiliumNode", "update", valid, equal) }()
 				if oldNode, ok := oldObj.(*ciliumv2.CiliumNode); ok {
 					if newNode, ok := newObj.(*ciliumv2.CiliumNode); ok {
 						valid = true
@@ -159,7 +159,7 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, k8sEventReg 
 				// removed. No attempt to cast is required.
 				store.deleteLocalNodeResource()
 				k8sEventReg.K8sEventProcessed("CiliumNode", "delete", true)
-				k8sEventReg.K8sEventReceived("CiliumNode", "delete", true, false)
+				k8sEventReg.K8sEventReceived(apiGroup, "CiliumNode", "delete", true, false)
 			},
 		},
 		nil,

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -79,13 +79,16 @@ type Owner interface {
 	LocalAllocCIDRsUpdated(ipv4AllocCIDRs, ipv6AllocCIDRs []*cidr.CIDR)
 }
 
+// K8sEventRegister is used to register and handle events as they are processed
+// by K8s controllers.
 type K8sEventRegister interface {
 	// K8sEventReceived is called to do metrics accounting for received
-	// Kubernetes events
-	K8sEventReceived(scope string, action string, valid, equal bool)
+	// Kubernetes events, as well as calculating timeouts for k8s watcher
+	// cache sync.
+	K8sEventReceived(apiGroupResourceName string, scope string, action string, valid, equal bool)
 
 	// K8sEventProcessed is called to do metrics accounting for each processed
-	// Kubernetes event
+	// Kubernetes event.
 	K8sEventProcessed(scope string, action string, status bool)
 
 	// RegisterCiliumNodeSubscriber allows registration of subscriber.CiliumNode

--- a/pkg/k8s/synced/resources_test.go
+++ b/pkg/k8s/synced/resources_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package synced
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// waitForCacheTest is a table test case for testing WaitForCacheSyncWithTimeout.
+// Each test case will similate waiting for sync of every key in resourceNamesToSyncDuration
+// with their respective timeout duration.
+type waitForCacheTest struct {
+	timeout time.Duration
+	// This maps resource names (ex. "core/v1::Pods") onto the duration the simulated
+	// cache sync will take to complete.
+	resourceNamesToSyncDuration map[string]time.Duration
+	// Maps resource names to a duration to wait after init upon which an "event" will
+	// be emitted. Used to test cases where events cause pushing out of timeout.
+	resourceNamesToEvent map[string]time.Duration
+	// Array which is passed to WaitForCacheSync... function.
+	// Only resources in this array should cause return of timeout error when doing test.
+	resourceNames []string
+	expectErr     error
+	// Used to test edge cases where controller doesn't actually invoke BlockWaitGroupToSyncResources.
+	dontStartBlockWaitGroupToSyncResources bool
+}
+
+func TestWaitForCacheSyncWithTimeout(t *testing.T) {
+	unit := func(d int) time.Duration { return syncedPollPeriod * time.Duration(d) }
+	assert := assert.New(t)
+	for msg, test := range map[string]waitForCacheTest{
+		"Should complete due to event causing timeout to be extended past initial timeout": {
+			timeout: unit(5),
+			resourceNamesToSyncDuration: map[string]time.Duration{
+				"foo": unit(7),
+				"bar": unit(7),
+			},
+			resourceNamesToEvent: map[string]time.Duration{
+				"foo": unit(4),
+			},
+			resourceNames: []string{"foo"},
+		},
+		"Should timeout due to watched resource exceeding timeout": {
+			timeout: unit(1),
+			resourceNamesToSyncDuration: map[string]time.Duration{
+				"foo": unit(3),
+			},
+			resourceNamesToEvent: map[string]time.Duration{},
+			resourceNames:        []string{"foo"},
+			expectErr:            fmt.Errorf("timed out after 100ms, never received event for resource \"foo\""),
+		},
+		"Any one timeout should cause error": {
+			timeout: unit(5),
+			resourceNamesToSyncDuration: map[string]time.Duration{
+				"foo": unit(3),
+				"bar": unit(7),
+			},
+			resourceNamesToEvent: map[string]time.Duration{
+				"foo": unit(4),
+			},
+			resourceNames: []string{"foo", "bar"},
+			expectErr:     fmt.Errorf("timed out after 500ms, never received event for resource \"bar\""),
+		},
+		"Waiting for no resources should always sync": {
+			timeout: unit(5),
+			resourceNamesToSyncDuration: map[string]time.Duration{
+				"foo": unit(10),
+				"bar": unit(10),
+			},
+		},
+		// One expectation of the BlockWaitGroupToSyncResources is that waits without starting
+		// the controller sync will complete without waiting.
+		"Not invoking BlockWaitGroupToSyncResources should cause wait to succeed immediately": {
+			timeout: unit(60),
+			resourceNamesToSyncDuration: map[string]time.Duration{
+				"foo": unit(360),
+				"bar": unit(360),
+			},
+			resourceNames:                          []string{"foo", "bar"},
+			dontStartBlockWaitGroupToSyncResources: true,
+		},
+	} {
+		func(test waitForCacheTest) {
+			t.Run(msg, func(t *testing.T) {
+				t.Parallel()
+				r := &Resources{}
+				stop := make(chan struct{})
+				swg := lock.NewStoppableWaitGroup()
+				start := time.Now()
+				// Create synced functions that will begin to return true after the resource timeout duration.
+				for resourceName, syncDurations := range test.resourceNamesToSyncDuration {
+					hasSyncedFn := func(d time.Duration) func() bool {
+						return func() bool {
+							return time.Now().After(start.Add(d))
+						}
+					}(syncDurations)
+					if test.dontStartBlockWaitGroupToSyncResources {
+						continue
+					}
+					r.BlockWaitGroupToSyncResources(
+						stop,
+						swg,
+						hasSyncedFn,
+						resourceName,
+					)
+				}
+
+				// Schedule resource events to happen after specified duration.
+				for resourceName, waitForEvent := range test.resourceNamesToEvent {
+					// schedule an event.
+					rname := resourceName
+					time.AfterFunc(waitForEvent, func() {
+						r.SetEventTimestamp(rname)
+					})
+				}
+
+				err := r.WaitForCacheSyncWithTimeout(test.timeout, test.resourceNames...)
+				if test.expectErr == nil {
+					assert.NoError(err)
+				} else {
+					assert.EqualError(err, test.expectErr.Error())
+				}
+			})
+		}(test)
+	}
+}

--- a/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
@@ -11,11 +11,12 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/informer"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 )
 
 func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient *k8s.K8sCiliumClient) {
 	ccnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-
+	apiGroup := k8sAPIGroupCiliumClusterwideNetworkPolicyV2
 	ciliumV2ClusterwidePolicyController := informer.NewInformerWithStore(
 		cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
 			cilium_v2.CCNPPluralName, v1.NamespaceAll, fields.Everything()),
@@ -24,7 +25,9 @@ func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient *k8s.K8
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCCNP, metricCreate, valid, equal) }()
+				defer func() {
+					k.K8sEventReceived(apiGroup, resources.MetricCCNP, resources.MetricCreate, valid, equal)
+				}()
 				if cnp := k8s.ObjToSlimCNP(obj); cnp != nil {
 					valid = true
 					if cnp.RequiresDerivative() {
@@ -37,12 +40,12 @@ func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient *k8s.K8
 					cnpCpy := cnp.DeepCopy()
 
 					err := k.addCiliumNetworkPolicyV2(ciliumNPClient, cnpCpy)
-					k.K8sEventProcessed(metricCCNP, metricCreate, err == nil)
+					k.K8sEventProcessed(resources.MetricCCNP, resources.MetricCreate, err == nil)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCCNP, metricUpdate, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, resources.MetricCCNP, resources.MetricUpdate, valid, equal) }()
 				if oldCNP := k8s.ObjToSlimCNP(oldObj); oldCNP != nil {
 					if newCNP := k8s.ObjToSlimCNP(newObj); newCNP != nil {
 						valid = true
@@ -62,20 +65,20 @@ func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient *k8s.K8
 						newCNPCpy := newCNP.DeepCopy()
 
 						err := k.updateCiliumNetworkPolicyV2(ciliumNPClient, oldCNPCpy, newCNPCpy)
-						k.K8sEventProcessed(metricCCNP, metricUpdate, err == nil)
+						k.K8sEventProcessed(resources.MetricCCNP, resources.MetricUpdate, err == nil)
 					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCCNP, metricDelete, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, resources.MetricCCNP, resources.MetricDelete, valid, equal) }()
 				cnp := k8s.ObjToSlimCNP(obj)
 				if cnp == nil {
 					return
 				}
 				valid = true
 				err := k.deleteCiliumNetworkPolicyV2(cnp)
-				k.K8sEventProcessed(metricCCNP, metricDelete, err == nil)
+				k.K8sEventProcessed(resources.MetricCCNP, resources.MetricDelete, err == nil)
 			},
 		},
 		k8s.ConvertToCCNP,
@@ -86,9 +89,9 @@ func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient *k8s.K8
 		k.stop,
 		nil,
 		ciliumV2ClusterwidePolicyController.HasSynced,
-		k8sAPIGroupCiliumClusterwideNetworkPolicyV2,
+		apiGroup,
 	)
 
 	go ciliumV2ClusterwidePolicyController.Run(k.stop)
-	k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumClusterwideNetworkPolicyV2)
+	k.k8sAPIGroups.AddAPI(apiGroup)
 }

--- a/pkg/k8s/watchers/cilium_egress_gateway_policy.go
+++ b/pkg/k8s/watchers/cilium_egress_gateway_policy.go
@@ -14,10 +14,12 @@ import (
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/informer"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 func (k *K8sWatcher) ciliumEgressGatewayPolicyInit(ciliumNPClient *k8s.K8sCiliumClient) {
+	apiGroup := k8sAPIGroupCiliumEgressGatewayPolicyV2
 	_, egpController := informer.NewInformer(
 		cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
 			"ciliumegressgatewaypolicies", v1.NamespaceAll, fields.Everything()),
@@ -26,16 +28,16 @@ func (k *K8sWatcher) ciliumEgressGatewayPolicyInit(ciliumNPClient *k8s.K8sCilium
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCEGP, metricCreate, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, metricCEGP, resources.MetricCreate, valid, equal) }()
 				if cegp := k8s.ObjToCEGP(obj); cegp != nil {
 					valid = true
 					err := k.addCiliumEgressGatewayPolicy(cegp)
-					k.K8sEventProcessed(metricCEGP, metricCreate, err == nil)
+					k.K8sEventProcessed(metricCEGP, resources.MetricCreate, err == nil)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCEGP, metricUpdate, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, metricCEGP, resources.MetricUpdate, valid, equal) }()
 
 				newCegp := k8s.ObjToCEGP(newObj)
 				if newCegp == nil {
@@ -43,18 +45,18 @@ func (k *K8sWatcher) ciliumEgressGatewayPolicyInit(ciliumNPClient *k8s.K8sCilium
 				}
 				valid = true
 				addErr := k.addCiliumEgressGatewayPolicy(newCegp)
-				k.K8sEventProcessed(metricCEGP, metricUpdate, addErr == nil)
+				k.K8sEventProcessed(metricCEGP, resources.MetricUpdate, addErr == nil)
 			},
 			DeleteFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCEGP, metricDelete, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, metricCEGP, resources.MetricDelete, valid, equal) }()
 				cegp := k8s.ObjToCEGP(obj)
 				if cegp == nil {
 					return
 				}
 				valid = true
 				k.deleteCiliumEgressGatewayPolicy(cegp)
-				k.K8sEventProcessed(metricCEGP, metricDelete, true)
+				k.K8sEventProcessed(metricCEGP, resources.MetricDelete, true)
 			},
 		},
 		k8s.ConvertToCiliumEgressGatewayPolicy,
@@ -94,6 +96,7 @@ func (k *K8sWatcher) deleteCiliumEgressGatewayPolicy(cegp *cilium_v2.CiliumEgres
 }
 
 func (k *K8sWatcher) ciliumEgressNATPolicyInit(ciliumNPClient *k8s.K8sCiliumClient) {
+	apiGroup := k8sAPIGroupCiliumEgressNATPolicyV2
 	_, egpController := informer.NewInformer(
 		cache.NewListWatchFromClient(ciliumNPClient.CiliumV2alpha1().RESTClient(),
 			"ciliumegressnatpolicies", v1.NamespaceAll, fields.Everything()),
@@ -102,16 +105,16 @@ func (k *K8sWatcher) ciliumEgressNATPolicyInit(ciliumNPClient *k8s.K8sCiliumClie
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCENP, metricCreate, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, metricCENP, resources.MetricCreate, valid, equal) }()
 				if cenp := k8s.ObjToCENP(obj); cenp != nil {
 					valid = true
 					err := k.addCiliumEgressNATPolicy(cenp)
-					k.K8sEventProcessed(metricCENP, metricCreate, err == nil)
+					k.K8sEventProcessed(metricCENP, resources.MetricCreate, err == nil)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCENP, metricUpdate, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, metricCENP, resources.MetricUpdate, valid, equal) }()
 
 				newCenp := k8s.ObjToCENP(newObj)
 				if newCenp == nil {
@@ -119,18 +122,18 @@ func (k *K8sWatcher) ciliumEgressNATPolicyInit(ciliumNPClient *k8s.K8sCiliumClie
 				}
 				valid = true
 				addErr := k.addCiliumEgressNATPolicy(newCenp)
-				k.K8sEventProcessed(metricCENP, metricUpdate, addErr == nil)
+				k.K8sEventProcessed(metricCENP, resources.MetricUpdate, addErr == nil)
 			},
 			DeleteFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCENP, metricDelete, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, metricCENP, resources.MetricDelete, valid, equal) }()
 				cenp := k8s.ObjToCENP(obj)
 				if cenp == nil {
 					return
 				}
 				valid = true
 				k.deleteCiliumEgressNATPolicy(cenp)
-				k.K8sEventProcessed(metricCENP, metricDelete, true)
+				k.K8sEventProcessed(metricCENP, resources.MetricDelete, true)
 			},
 		},
 		k8s.ConvertToCiliumEgressNATPolicy,

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -83,6 +84,7 @@ func (r *ruleImportMetadataCache) get(cnp *types.SlimCNP) (policyImportMetadata,
 func (k *K8sWatcher) ciliumNetworkPoliciesInit(ciliumNPClient *k8s.K8sCiliumClient) {
 	cnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
+	apiGroup := k8sAPIGroupCiliumNetworkPolicyV2
 	ciliumV2Controller := informer.NewInformerWithStore(
 		cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
 			cilium_v2.CNPPluralName, v1.NamespaceAll, fields.Everything()),
@@ -91,7 +93,7 @@ func (k *K8sWatcher) ciliumNetworkPoliciesInit(ciliumNPClient *k8s.K8sCiliumClie
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCNP, metricCreate, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, resources.MetricCNP, resources.MetricCreate, valid, equal) }()
 				if cnp := k8s.ObjToSlimCNP(obj); cnp != nil {
 					valid = true
 					if cnp.RequiresDerivative() {
@@ -104,12 +106,12 @@ func (k *K8sWatcher) ciliumNetworkPoliciesInit(ciliumNPClient *k8s.K8sCiliumClie
 					cnpCpy := cnp.DeepCopy()
 
 					err := k.addCiliumNetworkPolicyV2(ciliumNPClient, cnpCpy)
-					k.K8sEventProcessed(metricCNP, metricCreate, err == nil)
+					k.K8sEventProcessed(resources.MetricCNP, resources.MetricCreate, err == nil)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCNP, metricUpdate, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, resources.MetricCNP, resources.MetricUpdate, valid, equal) }()
 				if oldCNP := k8s.ObjToSlimCNP(oldObj); oldCNP != nil {
 					if newCNP := k8s.ObjToSlimCNP(newObj); newCNP != nil {
 						valid = true
@@ -129,20 +131,20 @@ func (k *K8sWatcher) ciliumNetworkPoliciesInit(ciliumNPClient *k8s.K8sCiliumClie
 						newCNPCpy := newCNP.DeepCopy()
 
 						err := k.updateCiliumNetworkPolicyV2(ciliumNPClient, oldCNPCpy, newCNPCpy)
-						k.K8sEventProcessed(metricCNP, metricUpdate, err == nil)
+						k.K8sEventProcessed(resources.MetricCNP, resources.MetricUpdate, err == nil)
 					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricCNP, metricDelete, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, resources.MetricCNP, resources.MetricDelete, valid, equal) }()
 				cnp := k8s.ObjToSlimCNP(obj)
 				if cnp == nil {
 					return
 				}
 				valid = true
 				err := k.deleteCiliumNetworkPolicyV2(cnp)
-				k.K8sEventProcessed(metricCNP, metricDelete, err == nil)
+				k.K8sEventProcessed(resources.MetricCNP, resources.MetricDelete, err == nil)
 			},
 		},
 		k8s.ConvertToCNP,

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/informer"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
@@ -32,6 +33,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 	// CiliumNode objects are used for node discovery until the key-value
 	// store is connected
 	var once sync.Once
+	apiGroup := k8sAPIGroupCiliumNodeV2
 	for {
 		swgNodes := lock.NewStoppableWaitGroup()
 		ciliumNodeStore, ciliumNodeInformer := informer.NewInformer(
@@ -42,7 +44,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {
 					var valid, equal bool
-					defer func() { k.K8sEventReceived(metricCiliumNode, metricCreate, valid, equal) }()
+					defer func() { k.K8sEventReceived(apiGroup, metricCiliumNode, resources.MetricCreate, valid, equal) }()
 					if ciliumNode := k8s.ObjToCiliumNode(obj); ciliumNode != nil {
 						valid = true
 						n := nodeTypes.ParseCiliumNode(ciliumNode)
@@ -54,12 +56,12 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 							return
 						}
 						k.nodeDiscoverManager.NodeUpdated(n)
-						k.K8sEventProcessed(metricCiliumNode, metricCreate, errs == nil)
+						k.K8sEventProcessed(metricCiliumNode, resources.MetricCreate, errs == nil)
 					}
 				},
 				UpdateFunc: func(oldObj, newObj interface{}) {
 					var valid, equal bool
-					defer func() { k.K8sEventReceived(metricCiliumNode, metricUpdate, valid, equal) }()
+					defer func() { k.K8sEventReceived(apiGroup, metricCiliumNode, resources.MetricUpdate, valid, equal) }()
 					if oldCN := k8s.ObjToCiliumNode(oldObj); oldCN != nil {
 						if ciliumNode := k8s.ObjToCiliumNode(newObj); ciliumNode != nil {
 							valid = true
@@ -85,13 +87,13 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 								return
 							}
 							k.nodeDiscoverManager.NodeUpdated(n)
-							k.K8sEventProcessed(metricCiliumNode, metricUpdate, errs == nil)
+							k.K8sEventProcessed(metricCiliumNode, resources.MetricUpdate, errs == nil)
 						}
 					}
 				},
 				DeleteFunc: func(obj interface{}) {
 					var valid, equal bool
-					defer func() { k.K8sEventReceived(metricCiliumNode, metricDelete, valid, equal) }()
+					defer func() { k.K8sEventReceived(apiGroup, metricCiliumNode, resources.MetricDelete, valid, equal) }()
 					ciliumNode := k8s.ObjToCiliumNode(obj)
 					if ciliumNode == nil {
 						return
@@ -113,7 +115,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 		isConnected := make(chan struct{})
 		// once isConnected is closed, it will stop waiting on caches to be
 		// synchronized.
-		k.blockWaitGroupToSyncResources(isConnected, swgNodes, ciliumNodeInformer.HasSynced, k8sAPIGroupCiliumNodeV2)
+		k.blockWaitGroupToSyncResources(isConnected, swgNodes, ciliumNodeInformer.HasSynced, apiGroup)
 
 		k.ciliumNodeStoreMU.Lock()
 		k.ciliumNodeStore = ciliumNodeStore
@@ -124,7 +126,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 			// to sync resources.
 			asyncControllers.Done()
 		})
-		k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumNodeV2)
+		k.k8sAPIGroups.AddAPI(apiGroup)
 		go ciliumNodeInformer.Run(isConnected)
 
 		<-kvstore.Connected()
@@ -132,8 +134,8 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 
 		log.Info("Connected to key-value store, stopping CiliumNode watcher")
 
-		k.cancelWaitGroupToSyncResources(k8sAPIGroupCiliumNodeV2)
-		k.k8sAPIGroups.RemoveAPI(k8sAPIGroupCiliumNodeV2)
+		k.cancelWaitGroupToSyncResources(apiGroup)
+		k.k8sAPIGroups.RemoveAPI(apiGroup)
 		// Create a new node controller when we are disconnected with the
 		// kvstore
 		<-kvstore.Client().Disconnected()

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
@@ -24,7 +25,7 @@ func (k *K8sWatcher) endpointsInit(k8sClient kubernetes.Interface, swgEps *lock.
 		options.FieldSelector = fields.ParseSelectorOrDie(option.Config.K8sWatcherEndpointSelector).String()
 		optsModifier(options)
 	}
-
+	apiGroup := resources.K8sAPIGroupEndpointV1Core
 	_, endpointController := informer.NewInformer(
 		cache.NewFilteredListWatchFromClient(k8sClient.CoreV1().RESTClient(),
 			"endpoints", v1.NamespaceAll,
@@ -35,16 +36,18 @@ func (k *K8sWatcher) endpointsInit(k8sClient kubernetes.Interface, swgEps *lock.
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricEndpoint, metricCreate, valid, equal) }()
+				defer func() {
+					k.K8sEventReceived(apiGroup, resources.MetricEndpoint, resources.MetricCreate, valid, equal)
+				}()
 				if k8sEP := k8s.ObjToV1Endpoints(obj); k8sEP != nil {
 					valid = true
 					err := k.addK8sEndpointV1(k8sEP, swgEps)
-					k.K8sEventProcessed(metricEndpoint, metricCreate, err == nil)
+					k.K8sEventProcessed(resources.MetricEndpoint, resources.MetricCreate, err == nil)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricEndpoint, metricUpdate, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, resources.MetricEndpoint, resources.MetricUpdate, valid, equal) }()
 				if oldk8sEP := k8s.ObjToV1Endpoints(oldObj); oldk8sEP != nil {
 					if newk8sEP := k8s.ObjToV1Endpoints(newObj); newk8sEP != nil {
 						valid = true
@@ -54,27 +57,27 @@ func (k *K8sWatcher) endpointsInit(k8sClient kubernetes.Interface, swgEps *lock.
 						}
 
 						err := k.updateK8sEndpointV1(oldk8sEP, newk8sEP, swgEps)
-						k.K8sEventProcessed(metricEndpoint, metricUpdate, err == nil)
+						k.K8sEventProcessed(resources.MetricEndpoint, resources.MetricUpdate, err == nil)
 					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricEndpoint, metricDelete, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, resources.MetricEndpoint, resources.MetricDelete, valid, equal) }()
 				k8sEP := k8s.ObjToV1Endpoints(obj)
 				if k8sEP == nil {
 					return
 				}
 				valid = true
 				err := k.deleteK8sEndpointV1(k8sEP, swgEps)
-				k.K8sEventProcessed(metricEndpoint, metricDelete, err == nil)
+				k.K8sEventProcessed(resources.MetricEndpoint, resources.MetricDelete, err == nil)
 			},
 		},
 		nil,
 	)
-	k.blockWaitGroupToSyncResources(k.stop, swgEps, endpointController.HasSynced, K8sAPIGroupEndpointV1Core)
+	k.blockWaitGroupToSyncResources(k.stop, swgEps, endpointController.HasSynced, resources.K8sAPIGroupEndpointV1Core)
 	go endpointController.Run(k.stop)
-	k.k8sAPIGroups.AddAPI(K8sAPIGroupEndpointV1Core)
+	k.k8sAPIGroups.AddAPI(apiGroup)
 }
 
 func (k *K8sWatcher) addK8sEndpointV1(ep *slim_corev1.Endpoints, swg *lock.StoppableWaitGroup) error {

--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_discover_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
 	slim_discover_v1beta1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1beta1"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -35,7 +36,7 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 	)
 
 	if k8s.SupportsEndpointSliceV1() {
-		apiGroup = K8sAPIGroupEndpointSliceV1Discovery
+		apiGroup = resources.K8sAPIGroupEndpointSliceV1Discovery
 		esClient = k8sClient.DiscoveryV1().RESTClient()
 		objType = &slim_discover_v1.EndpointSlice{}
 		addFunc = func(obj interface{}) {
@@ -45,16 +46,20 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 				close(hasEndpointSlices)
 			})
 			var valid, equal bool
-			defer func() { k.K8sEventReceived(metricEndpointSlice, metricCreate, valid, equal) }()
+			defer func() {
+				k.K8sEventReceived(apiGroup, resources.MetricEndpointSlice, resources.MetricCreate, valid, equal)
+			}()
 			if k8sEP := k8s.ObjToV1EndpointSlice(obj); k8sEP != nil {
 				valid = true
 				k.updateK8sEndpointSliceV1(k8sEP, swgEps)
-				k.K8sEventProcessed(metricEndpointSlice, metricCreate, true)
+				k.K8sEventProcessed(resources.MetricEndpointSlice, resources.MetricCreate, true)
 			}
 		}
 		updateFunc = func(oldObj, newObj interface{}) {
 			var valid, equal bool
-			defer func() { k.K8sEventReceived(metricEndpointSlice, metricUpdate, valid, equal) }()
+			defer func() {
+				k.K8sEventReceived(apiGroup, resources.MetricEndpointSlice, resources.MetricUpdate, valid, equal)
+			}()
 			if oldk8sEP := k8s.ObjToV1EndpointSlice(oldObj); oldk8sEP != nil {
 				if newk8sEP := k8s.ObjToV1EndpointSlice(newObj); newk8sEP != nil {
 					valid = true
@@ -64,23 +69,25 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 					}
 
 					k.updateK8sEndpointSliceV1(newk8sEP, swgEps)
-					k.K8sEventProcessed(metricEndpointSlice, metricUpdate, true)
+					k.K8sEventProcessed(resources.MetricEndpointSlice, resources.MetricUpdate, true)
 				}
 			}
 		}
 		delFunc = func(obj interface{}) {
 			var valid, equal bool
-			defer func() { k.K8sEventReceived(metricEndpointSlice, metricDelete, valid, equal) }()
+			defer func() {
+				k.K8sEventReceived(apiGroup, resources.MetricEndpointSlice, resources.MetricDelete, valid, equal)
+			}()
 			k8sEP := k8s.ObjToV1EndpointSlice(obj)
 			if k8sEP == nil {
 				return
 			}
 			valid = true
 			k.K8sSvcCache.DeleteEndpointSlices(k8sEP, swgEps)
-			k.K8sEventProcessed(metricEndpointSlice, metricDelete, true)
+			k.K8sEventProcessed(resources.MetricEndpointSlice, resources.MetricDelete, true)
 		}
 	} else {
-		apiGroup = K8sAPIGroupEndpointSliceV1Beta1Discovery
+		apiGroup = resources.K8sAPIGroupEndpointSliceV1Beta1Discovery
 		esClient = k8sClient.DiscoveryV1beta1().RESTClient()
 		objType = &slim_discover_v1beta1.EndpointSlice{}
 		addFunc = func(obj interface{}) {
@@ -90,16 +97,20 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 				close(hasEndpointSlices)
 			})
 			var valid, equal bool
-			defer func() { k.K8sEventReceived(metricEndpointSlice, metricCreate, valid, equal) }()
+			defer func() {
+				k.K8sEventReceived(apiGroup, resources.MetricEndpointSlice, resources.MetricCreate, valid, equal)
+			}()
 			if k8sEP := k8s.ObjToV1Beta1EndpointSlice(obj); k8sEP != nil {
 				valid = true
 				k.updateK8sEndpointSliceV1Beta1(k8sEP, swgEps)
-				k.K8sEventProcessed(metricEndpointSlice, metricCreate, true)
+				k.K8sEventProcessed(resources.MetricEndpointSlice, resources.MetricCreate, true)
 			}
 		}
 		updateFunc = func(oldObj, newObj interface{}) {
 			var valid, equal bool
-			defer func() { k.K8sEventReceived(metricEndpointSlice, metricUpdate, valid, equal) }()
+			defer func() {
+				k.K8sEventReceived(apiGroup, resources.MetricEndpointSlice, resources.MetricUpdate, valid, equal)
+			}()
 			if oldk8sEP := k8s.ObjToV1Beta1EndpointSlice(oldObj); oldk8sEP != nil {
 				if newk8sEP := k8s.ObjToV1Beta1EndpointSlice(newObj); newk8sEP != nil {
 					valid = true
@@ -109,20 +120,22 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 					}
 
 					k.updateK8sEndpointSliceV1Beta1(newk8sEP, swgEps)
-					k.K8sEventProcessed(metricEndpointSlice, metricUpdate, true)
+					k.K8sEventProcessed(resources.MetricEndpointSlice, resources.MetricUpdate, true)
 				}
 			}
 		}
 		delFunc = func(obj interface{}) {
 			var valid, equal bool
-			defer func() { k.K8sEventReceived(metricEndpointSlice, metricDelete, valid, equal) }()
+			defer func() {
+				k.K8sEventReceived(apiGroup, resources.MetricEndpointSlice, resources.MetricDelete, valid, equal)
+			}()
 			k8sEP := k8s.ObjToV1Beta1EndpointSlice(obj)
 			if k8sEP == nil {
 				return
 			}
 			valid = true
 			k.K8sSvcCache.DeleteEndpointSlices(k8sEP, swgEps)
-			k.K8sEventProcessed(metricEndpointSlice, metricDelete, true)
+			k.K8sEventProcessed(resources.MetricEndpointSlice, resources.MetricDelete, true)
 		}
 	}
 

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -26,6 +27,7 @@ import (
 )
 
 func (k *K8sWatcher) namespacesInit(k8sClient kubernetes.Interface, asyncControllers *sync.WaitGroup) {
+	apiGroup := k8sAPIGroupNamespaceV1Core
 	namespaceStore, namespaceController := informer.NewInformer(
 		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
 			"namespaces", v1.NamespaceAll, fields.Everything()),
@@ -38,7 +40,7 @@ func (k *K8sWatcher) namespacesInit(k8sClient kubernetes.Interface, asyncControl
 			// pods belonging to that namespace are also deleted.
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricNS, metricUpdate, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, metricNS, resources.MetricUpdate, valid, equal) }()
 				if oldNS := k8s.ObjToV1Namespace(oldObj); oldNS != nil {
 					if newNS := k8s.ObjToV1Namespace(newObj); newNS != nil {
 						valid = true
@@ -48,7 +50,7 @@ func (k *K8sWatcher) namespacesInit(k8sClient kubernetes.Interface, asyncControl
 						}
 
 						err := k.updateK8sV1Namespace(oldNS, newNS)
-						k.K8sEventProcessed(metricNS, metricUpdate, err == nil)
+						k.K8sEventProcessed(metricNS, resources.MetricUpdate, err == nil)
 					}
 				}
 			},
@@ -58,7 +60,7 @@ func (k *K8sWatcher) namespacesInit(k8sClient kubernetes.Interface, asyncControl
 
 	k.namespaceStore = namespaceStore
 	k.blockWaitGroupToSyncResources(k.stop, nil, namespaceController.HasSynced, k8sAPIGroupNamespaceV1Core)
-	k.k8sAPIGroups.AddAPI(k8sAPIGroupNamespaceV1Core)
+	k.k8sAPIGroups.AddAPI(apiGroup)
 	asyncControllers.Done()
 	namespaceController.Run(k.stop)
 }

--- a/pkg/k8s/watchers/resources/resources.go
+++ b/pkg/k8s/watchers/resources/resources.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// This package contains exported resource identifiers and metric resource labels related to
+// K8s watchers.
+package resources
+
+const (
+	// K8sAPIGroupServiceV1Core is the identifier for K8s resources of type core/v1/Service.
+	K8sAPIGroupServiceV1Core = "core/v1::Service"
+	// K8sAPIGroupEndpointV1Core is the identifier for K8s resources of type core/v1/Endpoint.
+	K8sAPIGroupEndpointV1Core = "core/v1::Endpoint"
+	// K8sAPIGroupPodV1Core is the identifier for K8s resources of type core/v1/Pod.
+	K8sAPIGroupPodV1Core = "core/v1::Pods"
+	// K8sAPIGroupSecretV1Cores is the identifier for K8s resources of type core/v1/Secret.
+	K8sAPIGroupSecretV1Core = "core/v1::Secrets"
+	// K8sAPIGroupEndpointSliceV1Beta1Discovery is the identifier for K8s resources of type discovery/v1beta1/EndpointSlice.
+	K8sAPIGroupEndpointSliceV1Beta1Discovery = "discovery/v1beta1::EndpointSlice"
+	// K8sAPIGroupEndpointSliceV1Beta1Discovery is the identifier for K8s resources of type discovery/v1/EndpointSlice.
+	// todo(tom): double check the uses of these two.
+	K8sAPIGroupEndpointSliceV1Discovery = "discovery/v1::EndpointSlice"
+
+	// MetricCNP is the scope label for CiliumNetworkPolicy event metrics.
+	MetricCNP = "CiliumNetworkPolicy"
+	// MetricCCNP is the scope label for CiliumClusterwideNetworkPolicy event metrics.
+	MetricCCNP = "CiliumClusterwideNetworkPolicy"
+	// MetricService is the scope label for Kubernetes Service event metrics.
+	MetricService = "Service"
+	// MetricEndpoint is the scope label for Kubernetes Endpoint event metrics.
+	MetricEndpoint = "Endpoint"
+	// MetricEndpointSlice is the scope label for Kubernetes EndpointSlice event metrics.
+	MetricEndpointSlice = "EndpointSlice"
+
+	// MetricCreate the label for watcher metrics related to create events.
+	MetricCreate = "create"
+	// MetricUpdate the label for watcher metrics related to update events.
+	MetricUpdate = "update"
+	// MetricDelete the label for watcher metrics related to delete events.
+	MetricDelete = "delete"
+)

--- a/pkg/k8s/watchers/secret.go
+++ b/pkg/k8s/watchers/secret.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -32,6 +33,7 @@ func (k *K8sWatcher) tlsSecretInit(k8sClient kubernetes.Interface, namespace str
 		options.FieldSelector = tlsFieldSelector
 	}
 
+	apiGroup := resources.K8sAPIGroupSecretV1Core
 	_, secretController := informer.NewInformer(
 		cache.NewFilteredListWatchFromClient(k8sClient.CoreV1().RESTClient(),
 			"secrets", namespace,
@@ -43,17 +45,17 @@ func (k *K8sWatcher) tlsSecretInit(k8sClient kubernetes.Interface, namespace str
 			AddFunc: func(obj interface{}) {
 				var valid, equal bool
 				defer func() {
-					k.K8sEventReceived(metricSecret, metricCreate, valid, equal)
+					k.K8sEventReceived(apiGroup, metricSecret, resources.MetricCreate, valid, equal)
 				}()
 				if k8sSecret := k8s.ObjToV1Secret(obj); k8sSecret != nil {
 					valid = true
 					err := k.addK8sSecretV1(k8sSecret)
-					k.K8sEventProcessed(metricSecret, metricCreate, err == nil)
+					k.K8sEventProcessed(metricSecret, resources.MetricCreate, err == nil)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
-				defer func() { k.K8sEventReceived(metricSecret, metricUpdate, valid, equal) }()
+				defer func() { k.K8sEventReceived(apiGroup, metricSecret, resources.MetricUpdate, valid, equal) }()
 				if oldSecret := k8s.ObjToV1Secret(oldObj); oldSecret != nil {
 					if newSecret := k8s.ObjToV1Secret(newObj); newSecret != nil {
 						valid = true
@@ -62,14 +64,14 @@ func (k *K8sWatcher) tlsSecretInit(k8sClient kubernetes.Interface, namespace str
 							return
 						}
 						err := k.updateK8sSecretV1(oldSecret, newSecret)
-						k.K8sEventProcessed(metricSecret, metricUpdate, err == nil)
+						k.K8sEventProcessed(metricSecret, resources.MetricUpdate, err == nil)
 					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				var valid, equal bool
 				defer func() {
-					k.K8sEventReceived(metricSecret, metricDelete, valid, equal)
+					k.K8sEventReceived(apiGroup, metricSecret, resources.MetricDelete, valid, equal)
 				}()
 				k8sSecret := k8s.ObjToV1Secret(obj)
 				if k8sSecret == nil {
@@ -77,14 +79,14 @@ func (k *K8sWatcher) tlsSecretInit(k8sClient kubernetes.Interface, namespace str
 				}
 				valid = true
 				err := k.deleteK8sSecretV1(k8sSecret)
-				k.K8sEventProcessed(metricSecret, metricDelete, err == nil)
+				k.K8sEventProcessed(metricSecret, resources.MetricDelete, err == nil)
 			},
 		},
 		nil,
 	)
-	k.blockWaitGroupToSyncResources(k.stop, swgSecrets, secretController.HasSynced, K8sAPIGroupSecretV1Core)
+	k.blockWaitGroupToSyncResources(k.stop, swgSecrets, secretController.HasSynced, resources.K8sAPIGroupSecretV1Core)
 	go secretController.Run(k.stop)
-	k.k8sAPIGroups.AddAPI(K8sAPIGroupSecretV1Core)
+	k.k8sAPIGroups.AddAPI(apiGroup)
 }
 
 // addK8sSecretV1 performs Envoy upsert operation for newly added secret.

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -57,9 +58,6 @@ const (
 	k8sAPIGroupNodeV1Core                       = "core/v1::Node"
 	k8sAPIGroupNamespaceV1Core                  = "core/v1::Namespace"
 	K8sAPIGroupServiceV1Core                    = "core/v1::Service"
-	K8sAPIGroupEndpointV1Core                   = "core/v1::Endpoint"
-	K8sAPIGroupPodV1Core                        = "core/v1::Pods"
-	K8sAPIGroupSecretV1Core                     = "core/v1::Secrets"
 	k8sAPIGroupNetworkingV1Core                 = "networking.k8s.io/v1::NetworkPolicy"
 	k8sAPIGroupCiliumNetworkPolicyV2            = "cilium/v2::CiliumNetworkPolicy"
 	k8sAPIGroupCiliumClusterwideNetworkPolicyV2 = "cilium/v2::CiliumClusterwideNetworkPolicy"
@@ -71,13 +69,7 @@ const (
 	k8sAPIGroupCiliumEndpointSliceV2Alpha1      = "cilium/v2alpha1::CiliumEndpointSlice"
 	k8sAPIGroupCiliumClusterwideEnvoyConfigV2   = "cilium/v2::CiliumClusterwideEnvoyConfig"
 	k8sAPIGroupCiliumEnvoyConfigV2              = "cilium/v2::CiliumEnvoyConfig"
-	K8sAPIGroupEndpointSliceV1Beta1Discovery    = "discovery/v1beta1::EndpointSlice"
-	K8sAPIGroupEndpointSliceV1Discovery         = "discovery/v1::EndpointSlice"
 
-	metricCNP            = "CiliumNetworkPolicy"
-	metricCCNP           = "CiliumClusterwideNetworkPolicy"
-	metricEndpoint       = "Endpoint"
-	metricEndpointSlice  = "EndpointSlice"
 	metricKNP            = "NetworkPolicy"
 	metricNS             = "Namespace"
 	metricSecret         = "Secret"
@@ -90,10 +82,6 @@ const (
 	metricCEC            = "CiliumEnvoyConfig"
 	metricPod            = "Pod"
 	metricNode           = "Node"
-	metricService        = "Service"
-	metricCreate         = "create"
-	metricDelete         = "delete"
-	metricUpdate         = "update"
 )
 
 func init() {
@@ -325,6 +313,14 @@ func (k *K8sWatcher) WaitForCacheSync(resourceNames ...string) {
 	k.k8sResourceSynced.WaitForCacheSync(resourceNames...)
 }
 
+// WaitForCacheSyncWithTimeout calls WaitForCacheSync to block until given resources have had their caches
+// synced from K8s. This will wait up to the timeout duration after starting or since the last K8s
+// registered watcher event (i.e. each event causes the timeout to be pushed back). Events are recorded
+// using K8sResourcesSynced.Event function. If the timeout is exceeded, an error is returned.
+func (k *K8sWatcher) WaitForCacheSyncWithTimeout(timeout time.Duration, resourceNames ...string) error {
+	return k.k8sResourceSynced.WaitForCacheSyncWithTimeout(timeout, resourceNames...)
+}
+
 func (k *K8sWatcher) cancelWaitGroupToSyncResources(resourceName string) {
 	k.k8sResourceSynced.CancelWaitGroupToSyncResources(resourceName)
 }
@@ -403,7 +399,7 @@ func (k *K8sWatcher) resourceGroups() (beforeNodeInitGroups, afterNodeInitGroups
 		k8sAPIGroupNamespaceV1Core,
 		// Pods can contain labels which are essential for endpoints
 		// being restored to have the right identity.
-		K8sAPIGroupPodV1Core,
+		resources.K8sAPIGroupPodV1Core,
 		// We need to know the node labels to populate the host
 		// endpoint labels.
 		k8sAPIGroupNodeV1Core,
@@ -412,17 +408,17 @@ func (k *K8sWatcher) resourceGroups() (beforeNodeInitGroups, afterNodeInitGroups
 	if k.cfg.K8sIngressControllerEnabled() {
 		// While Ingress controller is part of operator, we need to watch
 		// TLS secrets in pre-defined namespace for populating Envoy xDS SDS cache.
-		k8sGroups = append(k8sGroups, K8sAPIGroupSecretV1Core)
+		k8sGroups = append(k8sGroups, resources.K8sAPIGroupSecretV1Core)
 	}
 
 	// To perform the service translation and have the BPF LB datapath
 	// with the right service -> backend (k8s endpoints) translation.
 	if k8s.SupportsEndpointSlice() {
-		k8sGroups = append(k8sGroups, K8sAPIGroupEndpointSliceV1Beta1Discovery)
+		k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointSliceV1Beta1Discovery)
 	} else if k8s.SupportsEndpointSliceV1() {
-		k8sGroups = append(k8sGroups, K8sAPIGroupEndpointSliceV1Discovery)
+		k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointSliceV1Discovery)
 	}
-	k8sGroups = append(k8sGroups, K8sAPIGroupEndpointV1Core)
+	k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointV1Core)
 	ciliumResources := synced.AgentCRDResourceNames()
 	ciliumGroups := make([]string, 0, len(ciliumResources))
 	for _, r := range ciliumResources {
@@ -470,7 +466,7 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context, cachesSynced chan str
 			return
 		}
 		log.Info("Waiting until all pre-existing resources have been received")
-		if err := k.k8sResourceSynced.WaitForCacheSyncWithTimeout(option.Config.K8sSyncTimeout, append(resources, afterNodeInitResources...)...); err != nil {
+		if err := k.WaitForCacheSyncWithTimeout(option.Config.K8sSyncTimeout, append(resources, afterNodeInitResources...)...); err != nil {
 			log.WithError(err).Fatal("Timed out waiting for pre-existing resources to be received; exiting")
 		}
 		close(cachesSynced)
@@ -484,7 +480,7 @@ type WatcherConfiguration interface {
 }
 
 // enableK8sWatchers starts watchers for given resources.
-func (k *K8sWatcher) enableK8sWatchers(ctx context.Context, resources []string) error {
+func (k *K8sWatcher) enableK8sWatchers(ctx context.Context, resourceNames []string) error {
 	if !k8s.IsEnabled() {
 		log.Debug("Not enabling k8s event listener because k8s is not enabled")
 		return nil
@@ -497,10 +493,10 @@ func (k *K8sWatcher) enableK8sWatchers(ctx context.Context, resources []string) 
 		return fmt.Errorf("error creating service list option modifier: %w", err)
 	}
 
-	for _, r := range resources {
+	for _, r := range resourceNames {
 		switch r {
 		// Core Cilium
-		case K8sAPIGroupPodV1Core:
+		case resources.K8sAPIGroupPodV1Core:
 			asyncControllers.Add(1)
 			go k.podsInit(k8s.WatcherClient(), asyncControllers)
 		case k8sAPIGroupNodeV1Core:
@@ -515,16 +511,16 @@ func (k *K8sWatcher) enableK8sWatchers(ctx context.Context, resources []string) 
 		case k8sAPIGroupNetworkingV1Core:
 			swgKNP := lock.NewStoppableWaitGroup()
 			k.networkPoliciesInit(k8s.WatcherClient(), swgKNP)
-		case K8sAPIGroupServiceV1Core:
+		case resources.K8sAPIGroupServiceV1Core:
 			swgSvcs := lock.NewStoppableWaitGroup()
 			k.servicesInit(k8s.WatcherClient(), swgSvcs, serviceOptModifier)
-		case K8sAPIGroupEndpointSliceV1Beta1Discovery:
-			// no-op; handled in K8sAPIGroupEndpointV1Core.
-		case K8sAPIGroupEndpointSliceV1Discovery:
-			// no-op; handled in K8sAPIGroupEndpointV1Core.
-		case K8sAPIGroupEndpointV1Core:
+		case resources.K8sAPIGroupEndpointSliceV1Beta1Discovery:
+			// no-op; handled in resources.K8sAPIGroupEndpointV1Core.
+		case resources.K8sAPIGroupEndpointSliceV1Discovery:
+			// no-op; handled in resources.K8sAPIGroupEndpointV1Core.
+		case resources.K8sAPIGroupEndpointV1Core:
 			k.initEndpointsOrSlices(k8s.WatcherClient(), serviceOptModifier)
-		case K8sAPIGroupSecretV1Core:
+		case resources.K8sAPIGroupSecretV1Core:
 			swgSecret := lock.NewStoppableWaitGroup()
 			// only watch tls secret
 			k.tlsSecretInit(k8s.WatcherClient(), option.Config.EnvoySecretNamespace, swgSecret)
@@ -905,22 +901,26 @@ func (k *K8sWatcher) addK8sSVCs(svcID k8s.ServiceID, oldSvc, svc *k8s.Service, e
 
 // K8sEventProcessed is called to do metrics accounting for each processed
 // Kubernetes event
-func (k *K8sWatcher) K8sEventProcessed(scope string, action string, status bool) {
+func (k *K8sWatcher) K8sEventProcessed(scope, action string, status bool) {
 	result := "success"
 	if status == false {
 		result = "failed"
 	}
-	k.k8sResourceSynced.SetEventTimestamp(scope)
 
 	metrics.KubernetesEventProcessed.WithLabelValues(scope, action, result).Inc()
 }
 
-// K8sEventReceived does metric accounting for each received Kubernetes event
-func (k *K8sWatcher) K8sEventReceived(scope string, action string, valid, equal bool) {
-	metrics.EventTSK8s.SetToCurrentTime()
+// K8sEventReceived does metric accounting for each received Kubernetes event, as well
+// as notifying of events for k8s resources synced.
+func (k *K8sWatcher) K8sEventReceived(apiResourceName, scope, action string, valid, equal bool) {
 	k8smetrics.LastInteraction.Reset()
 
-	metrics.KubernetesEventReceived.WithLabelValues(scope, action, strconv.FormatBool(valid), strconv.FormatBool(equal)).Inc()
+	metrics.EventTS.WithLabelValues(metrics.LabelEventSourceK8s, scope, action).SetToCurrentTime()
+	validStr := strconv.FormatBool(valid)
+	equalStr := strconv.FormatBool(equal)
+	metrics.KubernetesEventReceived.WithLabelValues(scope, action, validStr, equalStr).Inc()
+
+	k.k8sResourceSynced.SetEventTimestamp(apiResourceName)
 }
 
 // GetStore returns the k8s cache store for the given resource name.

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -470,17 +470,10 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context, cachesSynced chan str
 			return
 		}
 		log.Info("Waiting until all pre-existing resources have been received")
-		k.WaitForCacheSync(append(resources, afterNodeInitResources...)...)
-		close(cachesSynced)
-	}()
-
-	go func() {
-		select {
-		case <-cachesSynced:
-			log.Info("All pre-existing resources have been received; continuing")
-		case <-time.After(option.Config.K8sSyncTimeout):
-			log.Fatal("Timed out waiting for pre-existing resources to be received; exiting")
+		if err := k.k8sResourceSynced.WaitForCacheSyncWithTimeout(option.Config.K8sSyncTimeout, append(resources, afterNodeInitResources...)...); err != nil {
+			log.WithError(err).Fatal("Timed out waiting for pre-existing resources to be received; exiting")
 		}
+		close(cachesSynced)
 	}()
 }
 
@@ -917,6 +910,7 @@ func (k *K8sWatcher) K8sEventProcessed(scope string, action string, status bool)
 	if status == false {
 		result = "failed"
 	}
+	k.k8sResourceSynced.SetEventTimestamp(scope)
 
 	metrics.KubernetesEventProcessed.WithLabelValues(scope, action, result).Inc()
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -150,8 +150,12 @@ const (
 	// started by cilium (Envoy, monitor, etc..)
 	LabelSubsystem = "subsystem"
 
-	// LabelKind is the kind a label
+	// LabelKind is the kind of a label
 	LabelKind = "kind"
+
+	// LabelEventSource is the source of a label for event metrics
+	// i.e. k8s, containerd, api.
+	LabelEventSource = "source"
 
 	// LabelPath is the label for the API path
 	LabelPath = "path"
@@ -285,17 +289,11 @@ var (
 	// event that we will handle
 	// source is one of k8s, docker or apia
 
-	// EventTSK8s is the timestamp of k8s events
-	EventTSK8s = NoOpGauge
+	// EventTS is the timestamp of k8s resource events.
+	EventTS = NoOpGaugeVec
 
 	// EventLagK8s is the lag calculation for k8s Pod events.
 	EventLagK8s = NoOpGauge
-
-	// EventTSContainerd is the timestamp of docker events
-	EventTSContainerd = NoOpGauge
-
-	// EventTSAPI is the timestamp of docker events
-	EventTSAPI = NoOpGauge
 
 	// L7 statistics
 
@@ -523,7 +521,7 @@ type Configuration struct {
 	PolicyEndpointStatusEnabled             bool
 	PolicyImplementationDelayEnabled        bool
 	IdentityCountEnabled                    bool
-	EventTSK8sEnabled                       bool
+	EventTSEnabled                          bool
 	EventLagK8sEnabled                      bool
 	EventTSContainerdEnabled                bool
 	EventTSAPIEnabled                       bool
@@ -552,6 +550,7 @@ type Configuration struct {
 	SubprocessStartEnabled                  bool
 	KubernetesEventProcessedEnabled         bool
 	KubernetesEventReceivedEnabled          bool
+	KubernetesTimeBetweenEventsEnabled      bool
 	KubernetesAPIInteractionsEnabled        bool
 	KubernetesAPICallsEnabled               bool
 	KubernetesCNPStatusCompletionEnabled    bool
@@ -780,15 +779,14 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			c.IdentityCountEnabled = true
 
 		case Namespace + "_event_ts":
-			EventTSK8s = prometheus.NewGauge(prometheus.GaugeOpts{
-				Namespace:   Namespace,
-				Name:        "event_ts",
-				Help:        "Last timestamp when we received an event",
-				ConstLabels: prometheus.Labels{"source": LabelEventSourceK8s},
-			})
+			EventTS = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Name:      "event_ts",
+				Help:      "Last timestamp when we received an event",
+			}, []string{LabelEventSource, LabelScope, LabelAction})
 
-			collectors = append(collectors, EventTSK8s)
-			c.EventTSK8sEnabled = true
+			collectors = append(collectors, EventTS)
+			c.EventTSEnabled = true
 
 			EventLagK8s = prometheus.NewGauge(prometheus.GaugeOpts{
 				Namespace:   Namespace,
@@ -799,26 +797,6 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, EventLagK8s)
 			c.EventLagK8sEnabled = true
-
-			EventTSContainerd = prometheus.NewGauge(prometheus.GaugeOpts{
-				Namespace:   Namespace,
-				Name:        "event_ts",
-				Help:        "Last timestamp when we received an event",
-				ConstLabels: prometheus.Labels{"source": LabelEventSourceContainerd},
-			})
-
-			collectors = append(collectors, EventTSContainerd)
-			c.EventTSContainerdEnabled = true
-
-			EventTSAPI = prometheus.NewGauge(prometheus.GaugeOpts{
-				Namespace:   Namespace,
-				Name:        "event_ts",
-				Help:        "Last timestamp when we received an event",
-				ConstLabels: prometheus.Labels{"source": LabelEventSourceAPI},
-			})
-
-			collectors = append(collectors, EventTSAPI)
-			c.EventTSAPIEnabled = true
 
 		case Namespace + "_proxy_redirects":
 			ProxyRedirects = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -18,7 +18,7 @@ import (
 // It records the timestamp of an API call in the provided gauge.
 type APIEventTSHelper struct {
 	Next      http.Handler
-	TSGauge   prometheus.Gauge
+	TSGauge   GaugeVec
 	Histogram prometheus.ObserverVec
 }
 
@@ -52,7 +52,9 @@ func getShortPath(s string) string {
 // ServeHTTP implements the http.Handler interface. It records the timestamp
 // this API call began at, then chains to the next handler.
 func (m *APIEventTSHelper) ServeHTTP(r http.ResponseWriter, req *http.Request) {
-	m.TSGauge.SetToCurrentTime()
+	if req != nil {
+		m.TSGauge.WithLabelValues(LabelEventSourceAPI, req.URL.Path, req.Method)
+	}
 	duration := spanstat.Start()
 	rw := &responderWrapper{ResponseWriter: r}
 	m.Next.ServeHTTP(rw, req)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -210,7 +210,7 @@ const (
 	// K8sServiceCacheSize is service cache size for cilium k8s package.
 	K8sServiceCacheSize = "k8s-service-cache-size"
 
-	// K8sSyncTimeout is the timeout to synchronize all resources with k8s.
+	// K8sSyncTimeout is the timeout since last event was received to synchronize all resources with k8s.
 	K8sSyncTimeoutName = "k8s-sync-timeout"
 
 	// AllocatorListTimeout is the timeout to list initial allocator state.


### PR DESCRIPTION
To prevent k8s resource types that take a long time to sync from prematurely crashing agent Pods upon init.  Adding per resource timeouts that do not timeout sync unless the watcher has exceeded the timeout period after the last informer event of that type to be received.
That is, each watcher records the time of the last event, per API resource type. If the K8s-Synced-Timeout is reached, only timeout if event of that type was not received during the timeout period.

As well, to facilitate diagnosing such issues, adding more labels to EventsTS metrics and refactoring all uses of this metric into a single GaugeVec.

Fixes: #18776
