### PR TITLE
Add metric on datapath update latency due to FQDN IP updates

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -45,6 +45,7 @@ const (
 	processingTime  = "processingTime"
 	semaphoreTime   = "semaphoreTime"
 	policyCheckTime = "policyCheckTime"
+	dataplaneTime   = "dataplaneTime"
 
 	metricErrorTimeout = "timeout"
 	metricErrorProxy   = "proxyErr"
@@ -417,6 +418,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 	stat.ProcessingTime.Start()
 
 	endMetric := func() {
+		stat.DataplaneTime.End(true)
 		stat.ProcessingTime.End(true)
 		metrics.ProxyUpstreamTime.WithLabelValues(metrics.ErrorTimeout, metrics.L7DNS, upstream).Observe(
 			stat.UpstreamTime.Total().Seconds())
@@ -426,6 +428,8 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 			stat.SemaphoreAcquireTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyCheckTime).Observe(
 			stat.PolicyCheckTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, dataplaneTime).Observe(
+			stat.DataplaneTime.Total().Seconds())
 	}
 
 	switch {
@@ -513,6 +517,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 	record.Log()
 
 	if msg.Response && msg.Rcode == dns.RcodeSuccess && len(responseIPs) > 0 {
+		stat.DataplaneTime.Start()
 		// This must happen before the NameManager update below, to ensure that
 		// this data is included in the serialized Endpoint object.
 		// We also need to add to the cache before we purge any matching zombies

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -385,6 +385,7 @@ type ProxyRequestContext struct {
 	UpstreamTime         spanstat.SpanStat
 	SemaphoreAcquireTime spanstat.SpanStat
 	PolicyCheckTime      spanstat.SpanStat
+	DataplaneTime        spanstat.SpanStat
 	Success              bool
 	Err                  error
 }


### PR DESCRIPTION
While there is an overall processing metric, it would be good to extract the datapath update time from other sections of the FQDN processing. This makes it easier to diagnose the source of any backups.

It should be noted that dataplaneTime will be capped to `option.Config.FQDNProxyResponseMaxDelay`. After that time has elapsed, the update is cancelled and the DNS packet forwarded to the endpoint.

```release-note
Add metric on datapath update latency due to FQDN IP updates
```

Signed-off-by: Rahul Joshi <rkjoshi@google.com>
