### PR TITLE
Revert ".github: add support for cilium-cli in aws-cni conformance tests"

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -136,39 +136,10 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --chart-directory=install/kubernetes/cilium \
-            --helm-set=image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --helm-set=image.useDigest=false \
-            --helm-set=image.tag=${SHA} \
-            --helm-set=operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
-            --helm-set=operator.image.suffix=-ci \
-            --helm-set=operator.image.tag=${SHA} \
-            --helm-set=operator.image.useDigest=false \
-            --helm-set=clustermesh.apiserver.image.repository=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \
-            --helm-set=clustermesh.apiserver.image.tag=${SHA} \
-            --helm-set=clustermesh.apiserver.image.useDigest=false \
-            --helm-set=hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
-            --helm-set=hubble.relay.image.tag=${SHA} \
-            --helm-set=enableIPv4Masquerade=false \
-            --helm-set=cni.chainingMode=aws-cni \
-            --helm-set=tunnel=disabled \
-            --helm-set=bandwidthManager=false \
-            --wait=false \
-            --rollback=false \
-            --config monitor-aggregation=none \
-            --base-version=v1.11.5 \
-            --version="
-          HUBBLE_ENABLE_DEFAULTS=" --chart-directory=install/kubernetes/cilium \
-            --relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci:${SHA} \
-            --base-version=v1.11.5  \
-            --relay-version=${SHA}"
           # L7 policies are not supported in chaining mode.
           CONNECTIVITY_TEST_DEFAULTS="--base-version=v1.11.5 \
             --flow-validation=disabled \
             --test '!fqdn,!l7'"
-          echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
-          echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
           echo ::set-output name=connectivity_test_defaults::${CONNECTIVITY_TEST_DEFAULTS}
           echo ::set-output name=sha::${SHA}
           echo ::set-output name=owner::${OWNER}
@@ -264,11 +235,31 @@ jobs:
 
       - name: Install Cilium
         run: |
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+          cd install/kubernetes
+          helm install cilium ./cilium \
+            --namespace kube-system \
+            --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
+            --set image.tag=${{ steps.vars.outputs.sha }} \
+            --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
+            --set operator.image.suffix="-ci" \
+            --set operator.image.tag=${{ steps.vars.outputs.sha }} \
+            --set cni.chainingMode=aws-cni \
+            --set enableIPv4Masquerade=false \
+            --set tunnel=disabled \
+            --set nodeinit.enabled=true \
+            --set bpf.monitorAggregation=none \
+            --set bandwidthManager.enabled=false
 
       - name: Enable Relay
         run: |
-          cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
+          cd install/kubernetes
+          helm upgrade cilium ./cilium \
+            --namespace kube-system \
+            --reuse-values \
+            --set hubble.relay.enabled=true \
+            --set hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+            --set hubble.relay.image.tag=${{ steps.vars.outputs.sha }} \
+            --set hubble.relay.image.useDigest=false
 
       - name: Wait for Cilium status to be ready
         run: |

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -19,7 +19,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  #
+  # 
   # pull_request: {}
   ###
 
@@ -66,7 +66,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
-  cilium_cli_version: v0.11.7
+  cilium_cli_version: v0.10.4
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.94.0
   kubectl_version: v1.23.6
@@ -139,39 +139,10 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
-          CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
-            --chart-directory=install/kubernetes/cilium \
-            --helm-set=image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
-            --helm-set=image.useDigest=false \
-            --helm-set=image.tag=${SHA} \
-            --helm-set=operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
-            --helm-set=operator.image.suffix=-ci \
-            --helm-set=operator.image.tag=${SHA} \
-            --helm-set=operator.image.useDigest=false \
-            --helm-set=clustermesh.apiserver.image.repository=quay.io/${{ github.repository_owner }}/clustermesh-apiserver-ci \
-            --helm-set=clustermesh.apiserver.image.tag=${SHA} \
-            --helm-set=clustermesh.apiserver.image.useDigest=false \
-            --helm-set=hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
-            --helm-set=hubble.relay.image.tag=${SHA} \
-            --helm-set=enableIPv4Masquerade=false \
-            --helm-set=cni.chainingMode=aws-cni \
-            --helm-set=tunnel=disabled \
-            --helm-set=bandwidthManager.enabled=false \
-            --wait=false \
-            --rollback=false \
-            --config monitor-aggregation=none \
-            --base-version=v1.12 \
-            --version="
-          HUBBLE_ENABLE_DEFAULTS=" --chart-directory=install/kubernetes/cilium \
-            --relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci:${SHA} \
-            --base-version=v1.12 \
-            --relay-version=${SHA}"
           # L7 policies are not supported in chaining mode.
           CONNECTIVITY_TEST_DEFAULTS="--base-version=v1.12 \
             --flow-validation=disabled \
             --test '!fqdn,!l7'"
-          echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
-          echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
           echo ::set-output name=connectivity_test_defaults::${CONNECTIVITY_TEST_DEFAULTS}
           echo ::set-output name=sha::${SHA}
           echo ::set-output name=owner::${OWNER}
@@ -267,11 +238,31 @@ jobs:
 
       - name: Install Cilium
         run: |
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+          cd install/kubernetes
+          helm install cilium ./cilium \
+            --namespace kube-system \
+            --set image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
+            --set image.tag=${{ steps.vars.outputs.sha }} \
+            --set operator.image.repository=quay.io/${{ github.repository_owner }}/operator \
+            --set operator.image.suffix="-ci" \
+            --set operator.image.tag=${{ steps.vars.outputs.sha }} \
+            --set cni.chainingMode=aws-cni \
+            --set enableIPv4Masquerade=false \
+            --set tunnel=disabled \
+            --set nodeinit.enabled=true \
+            --set bpf.monitorAggregation=none \
+            --set bandwidthManager.enabled=false
 
       - name: Enable Relay
         run: |
-          cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
+          cd install/kubernetes
+          helm upgrade cilium ./cilium \
+            --namespace kube-system \
+            --reuse-values \
+            --set hubble.relay.enabled=true \
+            --set hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
+            --set hubble.relay.image.tag=${{ steps.vars.outputs.sha }} \
+            --set hubble.relay.image.useDigest=false
 
       - name: Wait for Cilium status to be ready
         run: |
@@ -290,6 +281,13 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
+          echo "=== Install latest stable CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
+
           echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           cilium status


### PR DESCRIPTION
Commit https://github.com/cilium/cilium/commit/2d7af3a655e3ed32578acaf9b0d2ced3ade41ec5 (".github: add support for cilium-cli in aws-cni conformance tests") changed the AWS-CNI worflow to install Cilium using the CLI instead of Helm. All of the Helm flags were passed through the CLI using `--helm-set`.

However, the CLI also does it's own magic and isn't aware that we want to install Cilium in chaining mode. Therefore, it detects EKS and incorrectly sets IPAM mode to ENI.

As a result, Cilium attempts to setup the IP rules and routes for new pods. It seems to fail in most cases—maybe because AWS-CNI already setup the state—but sometimes succeeds. When it succeeds, pods end up with an egress rule pointing to a non-existing ip route table.

This usually surfaces in the workflow runs as a DNS failure: the client pod fails to egress to the DNS backend on a remote node. In rarer cases, it surfaces as a failing connectivity test for some of the pods.

This pull request fixes it by reverting https://github.com/cilium/cilium/pull/19555. We unfortunately can't simply set IPAM mode to cluster-pool (default) explicitly because the CLI also uses the wrong operator image (operator-aws instead of operator-generic).

The longer-term fix would be to support chaining mode in the CLI (cf. https://github.com/cilium/cilium-cli/issues/461).

I tested this revert by running the workflow with the test commit ten times at https://github.com/cilium/cilium/runs/6644709056?check_suite_focus=true.