### PR TITLE
Use DeleteOnMetadataMatch instead of Delete for endpointUpdated

### DIFF
--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -124,13 +124,13 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 					}
 				}
 				if !v4Added {
-					portsChanged := k.ipcache.Delete(oldPair.IPV4, source.CustomResource)
+					portsChanged := k.ipcache.DeleteOnMetadataMatch(oldPair.IPV4, source.CustomResource, endpoint.Namespace, endpoint.Name)
 					if portsChanged {
 						namedPortsChanged = true
 					}
 				}
 				if !v6Added {
-					portsChanged := k.ipcache.Delete(oldPair.IPV6, source.CustomResource)
+					portsChanged := k.ipcache.DeleteOnMetadataMatch(oldPair.IPV6, source.CustomResource, endpoint.Namespace, endpoint.Name)
 					if portsChanged {
 						namedPortsChanged = true
 					}


### PR DESCRIPTION
Node restart may lead to ip addresses 'swap' for services.
In such case using ipcache.Delete may lead to deleting newly assigned ip address of other service.

Fixes: #19958

Signed-off-by: Viktor Kuzmin <kvaster@gmail.com>

```
Fix issue where Cilium can misidentify (and drop) pod traffic if the node is restarted and IPAM reallocates pod IPs to different pods following the restart.
```