### PR TITLE
vagrant: Fix IPv6 NAT setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ end
 $cleanup = <<SCRIPT
 i=1
 while [ "$i" -le "$((num_workers+1))" ]; do
-    VBoxManage natnetwork add --netname natnet$i --network fd08::/64 --ipv6 on --enable
+    VBoxManage natnetwork add --netname natnet$i --network 192.168.0.0/16 --ipv6 on --enable
     i=$((i+1))
 done 2>/dev/null
 

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -59,8 +59,9 @@ end
 
 $cleanup = <<SCRIPT
 i=1
-while [ "$i" -le "$K8S_NODES" ]; do
-    VBoxManage natnetwork add --netname natnet$i --network fd08::/64 --ipv6 on --enable
+k8s_nodes="${K8S_NODES:-2}"
+while [ "$i" -le "$k8s_nodes" ]; do
+    VBoxManage natnetwork add --netname natnet$i --network 192.168.0.0/16 --ipv6 on --enable
     i=$((i+1))
 done 2>/dev/null
 

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -106,11 +106,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 		// This is testing bpf_lxc LB (= KPR=disabled) when both client and
 		// server are running on the same node. Thus, skipping when running with
 		// KPR.
-		// See https://github.com/cilium/cilium/issues/19787
 		SkipItIf(func() bool {
-			return helpers.RunsWithKubeProxyReplacement() ||
-				// The test case is flaky when running on the 4.9 with k8s > 1.19.0
-				(helpers.SkipQuarantined() && helpers.SkipK8sVersions(">1.19.0"))
+			return helpers.RunsWithKubeProxyReplacement()
 		}, "Checks service on same node", func() {
 			serviceNames := []string{appServiceName}
 			if helpers.DualStackSupported() {
@@ -334,11 +331,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			})
 		})
 
-		// See https://github.com/cilium/cilium/issues/19787
 		SkipContextIf(func() bool {
-			return helpers.RunsWithKubeProxyReplacement() ||
-				// The test case is flaky when running on the 4.9 with k8s > 1.19.0
-				(helpers.SkipQuarantined() && helpers.SkipK8sVersions(">1.19.0"))
+			return helpers.RunsWithKubeProxyReplacement()
 		}, "Tests NodePort inside cluster (kube-proxy)", func() {
 			SkipItIf(helpers.DoesNotRunOn419OrLaterKernel, "with IPSec and externalTrafficPolicy=Local", func() {
 				deploymentManager.SetKubectl(kubectl)
@@ -448,11 +442,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			})
 		})
 
-		// See https://github.com/cilium/cilium/issues/19787
 		SkipContextIf(func() bool {
-			return helpers.RunsWithKubeProxyReplacement() ||
-				// The test case is flaky when running on the 4.9 with k8s > 1.19.0
-				(helpers.SkipQuarantined() && helpers.SkipK8sVersions(">1.19.0"))
+			return helpers.RunsWithKubeProxyReplacement()
 		}, "with L4 policy", func() {
 			var (
 				demoPolicy string
@@ -485,11 +476,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
 			})
 		})
 
-		// See https://github.com/cilium/cilium/issues/19787
 		SkipContextIf(func() bool {
-			return helpers.RunsWithKubeProxyReplacement() ||
-				// The test case is flaky when running on the 4.9 with k8s > 1.19.0
-				(helpers.SkipQuarantined() && helpers.SkipK8sVersions(">1.19.0"))
+			return helpers.RunsWithKubeProxyReplacement()
 		}, "with L7 policy", func() {
 			var demoPolicyL7 string
 


### PR DESCRIPTION
Commit https://github.com/cilium/cilium/commit/9ddf09d88754fe247a231579543e30f662d363bb ("vagrant: Enable IPv6 connectivity to the outside world") added a VirtualBox NAT service to the dev. and test VMs to allow IPv6 connectivity to the outside world. This service includes a new device and associated routes. Commit https://github.com/cilium/cilium/commit/ef22668f60dff73605b02f1e6c7be0c4f6bafff5 ("vagrant: Don't recreate natnetworks") moved the device setup much earlier in the VM provisioning, as a Bash script instead of Ruby code.

However, this Bash script refers to Ruby variable `$K8S_NODES`. That variable doesn't exist in Bash unless it is set as an environment variable. That's always the case in CI, but not necessarily when running locally. Hence, the NAT service setup would fail locally and IPv6 traffic wouldn't egress the VM.

In addition, it seems the VirtualBox doesn't accept an IPv6 address for the `--network` argument when setting the NAT service. As a result of this, it seems the NAT service setup partially fails and doesn't recognize IPv6 traffic.

Tests `k8s-1.{17,18,19,20,21,22}-kernel-4.9` started to fail because of this second issue. Unfortunately, these tests are not run on pull requests anymore so we missed it. In addition, since we've taken the habit of disabling and forgetting about any test that's flaky, the IPv6 masquerading tests were also disabled.

Fixes: https://github.com/cilium/cilium/pull/19523.
Fixes: https://github.com/cilium/cilium/issues/19787.