### PR TITLE
ctmap,daemon: Exclude host IPs from conntrack GC during startup

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1727,7 +1727,8 @@ func runDaemon() {
 	bootstrapStats.enableConntrack.Start()
 	log.Info("Starting connection tracking garbage collector")
 	gc.Enable(option.Config.EnableIPv4, option.Config.EnableIPv6,
-		restoredEndpoints.restored, d.endpointManager)
+		restoredEndpoints.restored, d.endpointManager,
+		d.datapath.LocalNodeAddressing())
 	bootstrapStats.enableConntrack.End(true)
 
 	bootstrapStats.k8sInit.Start()


### PR DESCRIPTION
When the host firewall is enabled, we start tracking (and potentially enforcing policies) on all connections to and from the host IP addresses. Thus, we also need to avoid GCing the host IPs. If we don't it can cause established connections to be broken on agent restart.

Fixes: #19367.

```release-note
Fix bug where established host connections would be interrupted on agent restart if the host firewall was enabled.
```