### PR TITLE
v1.11: tests-l4lb: Use Helm chart from local branch

### DIFF
--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -4,6 +4,7 @@ set -eux
 
 IMG_OWNER=${1:-cilium}
 IMG_TAG=${2:-latest}
+PULL_REQUEST_CHECKOUT=${3:-../..}
 
 ###########
 #  SETUP  #
@@ -44,7 +45,7 @@ nsenter -t $CONTROL_PLANE_PID -n /bin/sh -c "\
     ip l s dev l4lb-veth1 up"
 
 # Install Cilium as standalone L4LB
-helm install cilium ../../install/kubernetes/cilium \
+helm install cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
     --wait \
     --namespace kube-system \
     --set debug.enabled=true \


### PR DESCRIPTION
In addition to the upstream (i.e. v1.10, v1.11 and master branches)
checkouts, checkout also the pull request branch so that test.sh uses
the local Helm chart from the pull request. This ensures that any
Helm-related changes get reflected in the CI run.

This PR includes only the changes related to test/l4lb/test.sh, as the
workflow is being updated on the master PR #19953.