### PR TITLE
hubble: Improve performance of identity getter

### DIFF
--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/server"
 	"github.com/cilium/cilium/pkg/hubble/server/serveroption"
 	"github.com/cilium/cilium/pkg/identity"
-	identitymodel "github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging"
@@ -275,12 +274,12 @@ func (d *Daemon) launchHubble() {
 // to populate source and destination labels of flows.
 //
 //  - IdentityGetter: https://github.com/cilium/hubble/blob/04ab72591faca62a305ce0715108876167182e04/pkg/parser/getters/getters.go#L40
-func (d *Daemon) GetIdentity(securityIdentity uint32) (*models.Identity, error) {
+func (d *Daemon) GetIdentity(securityIdentity uint32) (*identity.Identity, error) {
 	ident := d.identityAllocator.LookupIdentityByID(context.Background(), identity.NumericIdentity(securityIdentity))
 	if ident == nil {
 		return nil, fmt.Errorf("identity %d not found", securityIdentity)
 	}
-	return identitymodel.CreateModel(ident), nil
+	return ident, nil
 }
 
 // GetEndpointInfo returns endpoint info for a given IP address. Hubble uses this function to populate

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
-	"github.com/cilium/cilium/api/v1/models"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/policy"
 )
@@ -39,7 +39,7 @@ type EndpointsGetter interface {
 // IdentityGetter ...
 type IdentityGetter interface {
 	// GetIdentity fetches a full identity object given a numeric security id.
-	GetIdentity(id uint32) (*models.Identity, error)
+	GetIdentity(id uint32) (*identity.Identity, error)
 }
 
 // IPGetter fetches per-IP metadata

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -337,7 +337,7 @@ func (p *Parser) resolveEndpoint(ip net.IP, datapathSecurityIdentity uint32) *pb
 			p.log.WithError(err).WithField("identity", numericIdentity).
 				Debug("failed to resolve identity")
 		} else {
-			labels = sortAndFilterLabels(p.log, id.Labels, numericIdentity)
+			labels = sortAndFilterLabels(p.log, id.Labels.GetModel(), numericIdentity)
 		}
 	}
 

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -392,11 +392,11 @@ var NoopServiceGetter = FakeServiceGetter{
 
 // FakeIdentityGetter is used for unit tests that need IdentityGetter.
 type FakeIdentityGetter struct {
-	OnGetIdentity func(securityIdentity uint32) (*models.Identity, error)
+	OnGetIdentity func(securityIdentity uint32) (*identity.Identity, error)
 }
 
 // GetIdentity implements IdentityGetter.GetIPIdentity.
-func (f *FakeIdentityGetter) GetIdentity(securityIdentity uint32) (*models.Identity, error) {
+func (f *FakeIdentityGetter) GetIdentity(securityIdentity uint32) (*identity.Identity, error) {
 	if f.OnGetIdentity != nil {
 		return f.OnGetIdentity(securityIdentity)
 	}
@@ -405,8 +405,8 @@ func (f *FakeIdentityGetter) GetIdentity(securityIdentity uint32) (*models.Ident
 
 // NoopIdentityGetter always returns an empty response.
 var NoopIdentityGetter = FakeIdentityGetter{
-	OnGetIdentity: func(securityIdentity uint32) (*models.Identity, error) {
-		return &models.Identity{}, nil
+	OnGetIdentity: func(securityIdentity uint32) (*identity.Identity, error) {
+		return &identity.Identity{}, nil
 	},
 }
 


### PR DESCRIPTION
Profiling Hubble showed that the `GetIdentity` getter is responsible for
a lot of CPU time when Hubble is enabled, as it translates the internal
identity object into a API model. This stems from the fact that Hubble
used to fetch these identities via external API. However, these days
Hubble can directly access the identity allocator, thus making the
conversion unnecessary.

This PR removes the conversion step from the identity type to the model
and directly returns the identity type instead.

Reported-by: Michi Mutsuzaki <michi@isovalent.com>
Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
