### PR TITLE
workflow: l4lb: pass correct path for PR checkout

### DIFF
--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -156,19 +156,19 @@ jobs:
           sudo cp docker/docker /usr/local/bin/docker
           rm -r docker docker-20.10.9.tgz
 
-      - name: Checkout pull request for Helm chart
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-        with:
-          ref: ${{ steps.vars.outputs.sha }}
-          persist-credentials: false
-          path: pull-request
-
       - name: Checkout upstream for Vagrantfile
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
           ref: v1.10
           persist-credentials: false
+
+      - name: Checkout pull request for Helm chart
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+          path: pull-request
 
       - name: Boot Fedora
         run: |
@@ -191,7 +191,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request'"
+          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} /vagrant/pull-request/install/kubernetes/cilium'"
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -156,19 +156,19 @@ jobs:
           sudo cp docker/docker /usr/local/bin/docker
           rm -r docker docker-20.10.9.tgz
 
-      - name: Checkout pull request for Helm chart
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-        with:
-          ref: ${{ steps.vars.outputs.sha }}
-          persist-credentials: false
-          path: pull-request
-
       - name: Checkout upstream for Vagrantfile
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
           ref: v1.11
           persist-credentials: false
+
+      - name: Checkout pull request for Helm chart
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+          path: pull-request
 
       - name: Boot Fedora
         run: |
@@ -191,7 +191,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request'"
+          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} /vagrant/pull-request/install/kubernetes/cilium'"
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -159,19 +159,19 @@ jobs:
           sudo cp docker/docker /usr/local/bin/docker
           rm -r docker docker-20.10.9.tgz
 
-      - name: Checkout pull request for Helm chart
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-        with:
-          ref: ${{ steps.vars.outputs.sha }}
-          persist-credentials: false
-          path: pull-request
-
       - name: Checkout upstream for Vagrantfile
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
           ref: master
           persist-credentials: false
+
+      - name: Checkout pull request for Helm chart
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+          path: pull-request
 
       - name: Boot Fedora
         run: |
@@ -194,8 +194,8 @@ jobs:
 
       - name: Run tests
         run: |
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request'"
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/nat46x64 && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request'"
+          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} /vagrant/pull-request/install/kubernetes/cilium'"
+          ssh default "sudo /bin/sh -c 'cd /vagrant/test/nat46x64 && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} /vagrant/pull-request/install/kubernetes/cilium'"
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -4,7 +4,7 @@ set -eux
 
 IMG_OWNER=${1:-cilium}
 IMG_TAG=${2:-latest}
-PULL_REQUEST_CHECKOUT=${3:-../..}
+HELM_CHART_DIR=${3:-/vagrant/install/kubernetes/cilium}
 
 ###########
 #  SETUP  #
@@ -45,7 +45,7 @@ nsenter -t $CONTROL_PLANE_PID -n /bin/sh -c "\
     ip l s dev l4lb-veth1 up"
 
 # Install Cilium as standalone L4LB
-helm install cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm install cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --set debug.enabled=true \

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -4,7 +4,7 @@ set -eux
 
 IMG_OWNER=${1:-cilium}
 IMG_TAG=${2:-latest}
-PULL_REQUEST_CHECKOUT=${3:-../..}
+HELM_CHART_DIR=${3:-/vagrant/install/kubernetes/cilium}
 
 # With Kind we create two nodes cluster:
 #
@@ -16,7 +16,7 @@ PULL_REQUEST_CHECKOUT=${3:-../..}
 kind create cluster --config kind-config.yaml
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
-helm install cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm install cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --set debug.enabled=true \
@@ -71,7 +71,7 @@ for i in $(seq 1 10); do
 done
 
 # Install Cilium as standalone L4LB: XDP/Maglev/SNAT
-helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm upgrade cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -90,7 +90,7 @@ kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- cilium bpf lb list
 [ "$SVC_BEFORE" != "$SVC_AFTER" ] && exit 1
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
-helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm upgrade cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -105,7 +105,7 @@ for i in $(seq 1 10); do
 done
 
 # Install Cilium as standalone L4LB: tc/Random/SNAT
-helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm upgrade cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -146,7 +146,7 @@ done
 # Check if restore for both is proper
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
-helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm upgrade cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -190,7 +190,7 @@ for i in $(seq 1 10); do
 done
 
 # Install Cilium as standalone L4LB: XDP/Maglev/SNAT
-helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm upgrade cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -209,7 +209,7 @@ kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- cilium bpf lb list
 [ "$SVC_BEFORE" != "$SVC_AFTER" ] && exit 1
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
-helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm upgrade cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -224,7 +224,7 @@ for i in $(seq 1 10); do
 done
 
 # Install Cilium as standalone L4LB: tc/Random/SNAT
-helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm upgrade cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -265,7 +265,7 @@ done
 # Check if restore for both is proper
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
-helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm upgrade cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --reuse-values \
@@ -292,7 +292,7 @@ kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- cilium service delete 2
 ################################
 
 # Install Cilium as standalone L4LB: XDP/Maglev/SNAT/Recorder
-helm upgrade cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm upgrade cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --reuse-values \


### PR DESCRIPTION
Passing ${{ github.workspace }}/pull-request to the init.sh script as
path of the PR checkout is incorrect, as inside the VM the repository
will be under a different path.

Instead of that, pass the correct absolute path for the PR checkout.

Moreover, checkout first the upstream repo (under cilium/cilium) and
only after that the PR one (under cilium/cilium/pull-request), as
otherwise the upstream checkout will nuke the directory with PR one.

Fixes: #19953