### PR TITLE
workflow: l4lb: pass correct path for PR checkout

### DIFF
--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -4,7 +4,7 @@ set -eux
 
 IMG_OWNER=${1:-cilium}
 IMG_TAG=${2:-latest}
-PULL_REQUEST_CHECKOUT=${3:-../..}
+HELM_CHART_DIR=${3:-/vagrant/install/kubernetes/cilium}
 
 ###########
 #  SETUP  #
@@ -45,7 +45,7 @@ nsenter -t $CONTROL_PLANE_PID -n /bin/sh -c "\
     ip l s dev l4lb-veth1 up"
 
 # Install Cilium as standalone L4LB
-helm install cilium ${PULL_REQUEST_CHECKOUT}/install/kubernetes/cilium \
+helm install cilium ${HELM_CHART_DIR} \
     --wait \
     --namespace kube-system \
     --set debug.enabled=true \


### PR DESCRIPTION
Passing ${{ github.workspace }}/pull-request to the init.sh script as
path of the PR checkout is incorrect, as inside the VM the repository
will be under a different path.

Instead of that, pass the correct absolute path for the PR checkout.

Moreover, checkout first the upstream repo (under cilium/cilium) and
only after that the PR one (under cilium/cilium/pull-request), as
otherwise the upstream checkout will nuke the directory with PR one.

This PR includes only the changes related to test/l4lb/test.sh, as the
workflow is being updated on the master PR #20007.

Fixes: #20003