### PR TITLE
bugtool: Add structured node and health output

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -357,8 +357,10 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium status --verbose",
 		"cilium identity list",
 		"cilium-health status --verbose",
+		"cilium-health status -o json",
 		"cilium policy selectors -o json",
 		"cilium node list",
+		"cilium node list -o json",
 		"cilium lrp list",
 	}
 	var commands []string


### PR DESCRIPTION
This commit adds the `-o json` output to `cilium node list` and
`cilium-health status`, as the text version of both does not contain all
details.