### PR TITLE
docs: Add interactive help for `make` targets (Documentation/Makefile)

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -6,16 +6,15 @@ include ../Makefile.quiet
 
 HELM_VALUES := helm-values.rst
 
-.PHONY: default clean builder-image cilium-build cmdref epub latex html
+.PHONY: default clean help builder-image cilium-build cmdref epub latex html
+
+##@ Targets (default: "html")
 
 default: html
 
-clean:
-	-$(QUIET)rm -rf _build _api _exts/__pycache__ _preview Pipfile Pipfile.lock
-
 DOCS_BUILDER_IMG ?= cilium/docs-builder
 
-builder-image: Dockerfile requirements.txt
+builder-image: Dockerfile requirements.txt ## Build the docs-builder image for rendering and checking the documentation.
 	$(ECHO_DOCKER)
 	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
 	grep "^FROM " $< | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
@@ -37,12 +36,12 @@ DOCKER_CTR := $(CONTAINER_ENGINE) container run --rm \
 		--user "$(shell id -u):$(shell id -g)"
 DOCKER_RUN := $(DOCKER_CTR) $(DOCS_BUILDER_IMG)
 
-update-cmdref: builder-image cilium-build
+update-cmdref: builder-image cilium-build ## Update the command reference documents (agent, bugtool, operators, etc.).
 	@$(ECHO_GEN)cmdref
 	-$(QUIET)rm -rf cmdref/cilium*.md
 	$(QUIET)$(DOCKER_RUN) ./update-cmdref.sh
 
-check: builder-image update-cmdref update-helm-values
+check: builder-image update-cmdref update-helm-values ## Validate command and Helm references, as well as policy examples.
 	@$(ECHO_CHECK) cmdref
 	$(QUIET) ./check-cmdref.sh
 	@$(ECHO_CHECK) $(HELM_VALUES)
@@ -69,7 +68,7 @@ ifneq ($(shell uname -m),x86_64)
     HELM_VALUES_DEP :=
   endif
 endif
-update-helm-values: $(HELM_VALUES_DEP)
+update-helm-values: $(HELM_VALUES_DEP) ## Update the Helm reference documentation.
 
 HELM_DOCS_ROOT_PATH := $(DOCKER_CTR_ROOT_DIR)
 HELM_DOCS_CHARTS_DIR := $(HELM_DOCS_ROOT_PATH)/install/kubernetes
@@ -91,7 +90,7 @@ $(HELM_VALUES): FORCE
 	$(QUIET)printf '..\n  %s\n\n%s\n' "AUTO-GENERATED. Please DO NOT edit manually." "$$(cat $@)" > $@
 	$(QUIET)$(RM) -- $(TMP_FILE_1) $(TMP_FILE_2)
 
-epub latex html: builder-image copy-api update-helm-values
+epub latex html: builder-image copy-api update-helm-values ## Check documentation and render it under the specified format.
 	@$(ECHO_GEN)_build/$@
 	$(QUIET)$(DOCKER_RUN) ./check-build.sh $(@) $(SPHINX_OPTS)
 
@@ -101,9 +100,15 @@ html-netlify: copy-api
 
 DOCS_PORT = 9081
 
-live-preview: builder-image
+live-preview: builder-image ## Build and serve the documentation locally.
 	@echo "$$(tput setaf 2)Running at http://localhost:$(DOCS_PORT)$$(tput sgr0)"
 	$(QUIET)$(DOCKER_CTR) \
 		--publish $(DOCS_PORT):8000 \
 			$(DOCS_BUILDER_IMG) \
 		sphinx-autobuild --open-browser --host 0.0.0.0 $(SPHINX_OPTS) --ignore *.swp -Q . _preview
+
+clean: ## Clean up all artefacts from documentation.
+	-$(QUIET)rm -rf _build _api _exts/__pycache__ _preview Pipfile Pipfile.lock
+
+help: ## Display help for the Makefile.
+	$(call print_help_from_makefile)

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,6 @@ TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddres
 
 TEST_UNITTEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/datapath.DatapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-define print_help_line
-	@printf "  \033[36m%-29s\033[0m %s.\n" $(1) $(2)
-endef
-
 define generate_k8s_api
 	cd "./vendor/k8s.io/code-generator" && \
 	GO111MODULE=off bash ./generate-groups.sh $(1) \
@@ -634,8 +630,8 @@ dev-doctor: ## Run Cilium dev-doctor to validate local development environment.
 	$(QUIET)$(GO) version 2>/dev/null || ( echo "go not found, see https://golang.org/doc/install" ; false )
 	$(QUIET)$(GO) run ./tools/dev-doctor
 
-help: Makefile ## Display help for the Makefile, from https://www.thapaliya.com/en/writings/well-documented-makefiles/
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+help: ## Display help for the Makefile, from https://www.thapaliya.com/en/writings/well-documented-makefiles/.
+	$(call print_help_from_makefile)
 	@# There is also a list of target we have to manually put the information about.
 	@# These are templated targets.
 	$(call print_help_line,"docker-cilium-image","Build cilium-agent docker image")

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -198,5 +198,5 @@ define print_help_line
 endef
 
 define print_help_from_makefile
-  @awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+  @awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9][a-zA-Z0-9 _-]*:.*?##/ { split($$1, targets, " "); for (i in targets) { printf "  \033[36m%-28s\033[0m %s\n", targets[i], $$2 } } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -192,3 +192,11 @@ endif
 HELM_DOCS_VERSION ?= "5ddabba"
 HELM_DOCS_SHA ?= "c4a91daac6bf9c181fac79e09712fcf1f9102fcab1bbacbc733883965f5fd244"
 HELM_DOCS_IMAGE ?= "docker.io/bmcustodio/helm-docs:$(HELM_DOCS_VERSION)@sha256:$(HELM_DOCS_SHA)"
+
+define print_help_line
+  @printf "  \033[36m%-29s\033[0m %s.\n" $(1) $(2)
+endef
+
+define print_help_from_makefile
+  @awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+endef


### PR DESCRIPTION
Move and share the "help" components in Cilium's main Makefile to reuse them and document the targets in Documentation/Makefile. Please refer to individual commit descriptions for details.

Output:

```
$ make help

Usage:
  make <target>

Targets (default: "html")
  builder-image                 Build the docs-builder image for rendering and checking the documentation.
  update-cmdref                 Update the command reference documents (agent, bugtool, operators, etc.).
  check                         Validate command and Helm references, as well as policy examples.
  update-helm-values            Update the Helm reference documentation.
  epub                          Check documentation and render it under the specified format.
  latex                         Check documentation and render it under the specified format.
  html                          Check documentation and render it under the specified format.
  live-preview                  Build and serve the documentation locally.
  clean                         Clean up all artefacts from documentation.
  help                          Display help for the Makefile, from https://www.thapaliya.com/en/writings/well-documented-makefiles/.
```