### PR TITLE
v1.10 backports 2022-05-31

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -95,7 +95,7 @@ run-server: stop-server
 stop-server:
 	-$(QUIET)$(CONTAINER_ENGINE) container rm --force --volumes docs-cilium 2>/dev/null
 
-live-preview: stop-server
+live-preview: stop-server builder-image
 	@echo "$$(tput setaf 2)Running at http://localhost:$(DOCS_PORT)$$(tput sgr0)"
 	$(QUIET)$(DOCKER_CTR) \
 		--publish $(DOCS_PORT):8000 \

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -13,7 +13,7 @@ clean:
 
 builder-image: Dockerfile requirements.txt
 	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
-	grep "^FROM " $< | cut -d ' ' -f2 | xargs -n1 docker pull
+	grep "^FROM " $< | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 docker pull
 	$(QUIET)tar c requirements.txt Dockerfile \
 	  | $(CONTAINER_ENGINE) build --tag cilium/docs-builder -
 

--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -196,7 +196,7 @@ To replace cilium-ipsec-keys secret with a new key:
 .. code-block:: shell-session
 
     KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o yaml | awk '/^\s*keys:/ {print $2}' | base64 -d | awk '{print $1}')
-    if [[ $KEYID -gt 15 ]]; then KEYID=0; fi
+    if [[ $KEYID -ge 15 ]]; then KEYID=0; fi
     data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128\"}}")
     kubectl patch secret -n kube-system cilium-ipsec-keys -p="${data}" -v=1
 
@@ -208,10 +208,10 @@ has not yet been updated. In this way encryption will work as new keys are
 rolled out.
 
 The ``KEYID`` environment variable in the above example stores the current key
-ID used by Cilium. The key variable is a uint8 with value between 0-16 and
-should be monotonically increasing every re-key with a rollover from 16 to 0.
-The Cilium agent will default to ``KEYID`` of zero if its not specified in the
-secret.
+ID used by Cilium. The key variable is a uint8 with value between 1 and 15
+included and should be monotonically increasing every re-key with a rollover
+from 15 to 1. The Cilium agent will default to ``KEYID`` of zero if its not
+specified in the secret.
 
 Troubleshooting
 ===============

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -128,7 +128,7 @@
    * - clustermesh.apiserver.image
      - Clustermesh API server image.
      - object
-     - ``{"digest":"sha256:e13d41db3f5ee93d8b3abcaa10cc4005522bc797be3d69fc96ac5e03b60c7b11","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/clustermesh-apiserver","tag":"v1.10.10","useDigest":true}``
+     - ``{"digest":"sha256:ea07dd1c842befe9c5941a328497a47d41b2af47379527750e4b0f03af20532b","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/clustermesh-apiserver","tag":"v1.10.11","useDigest":true}``
    * - clustermesh.apiserver.nodeSelector
      - Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object
@@ -597,6 +597,10 @@
      - Service Port for the Peer service.
      - int
      - ``4254``
+   * - hubble.peerService.targetPort
+     - Target Port for the Peer service.
+     - int
+     - ``4244``
    * - hubble.relay.dialTimeout
      - Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
      - string
@@ -608,7 +612,7 @@
    * - hubble.relay.image
      - Hubble-relay container image.
      - object
-     - ``{"digest":"sha256:a0769e44299bba301dee08d489f4e2d3b3924916bed985346dcf9fcf10861c8a","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.10.10","useDigest":true}``
+     - ``{"digest":"sha256:8f30fb40bd46be4d1bfb55eb91cff7d0f8958eeb486d6184b5495f6624cf6ff1","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.10.11","useDigest":true}``
    * - hubble.relay.listenHost
      - Host to listen to. Specify an empty string to bind to all the interfaces.
      - string
@@ -788,7 +792,7 @@
    * - image
      - Agent container image.
      - object
-     - ``{"digest":"sha256:83bfc1052543e8b1e31f06fa2b5bbd2bd41cc79f264010241fc1994e35281616","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.10.10","useDigest":true}``
+     - ``{"digest":"sha256:48e1a261046c2e534e370f960f0920233f9fd5ad4623aebdca0e403264a06202","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.10.11","useDigest":true}``
    * - imagePullSecrets
      - Configure image pull secrets for pulling container images
      - string
@@ -1024,7 +1028,7 @@
    * - operator.image
      - cilium-operator image.
      - object
-     - ``{"alibabacloudDigest":"sha256:6154fcc069700cca6754cff0ee7bf6990bbf4a2865076b5358cb0c70c0043d52","awsDigest":"sha256:9bc04377606cb57c16f699a5b34dcdd6b6ffc1c4f43f5e6da81015fc16c10edc","azureDigest":"sha256:6973d45f7255c1791c0502339675a42105b8cbeca1a98634362623433674efe1","genericDigest":"sha256:8a317287b6ac8fe0ba4999342c9627dc913e0c1591552164f96d0aadf5d1a740","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.10.10","useDigest":true}``
+     - ``{"alibabacloudDigest":"sha256:83e18445ef3285317ed712514966cda8213722f548bea5ded61ad3446067b94b","awsDigest":"sha256:aed283cb4932fec07746c09770b7a9ec959aab6d5051dfdd3449c9d7d9be2a33","azureDigest":"sha256:1acea544097ede5f120d190309b46c1ea62da5fa6c61203945073d86a7891203","genericDigest":"sha256:468ce59342298f1cf87ca8512cd9192754e83348b347a4bc7c27158ef9c4a37d","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.10.11","useDigest":true}``
    * - operator.nodeGCInterval
      - Interval for cilium node garbage collection.
      - string
@@ -1156,7 +1160,7 @@
    * - preflight.image
      - Cilium pre-flight image.
      - object
-     - ``{"digest":"sha256:83bfc1052543e8b1e31f06fa2b5bbd2bd41cc79f264010241fc1994e35281616","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.10.10","useDigest":true}``
+     - ``{"digest":"sha256:48e1a261046c2e534e370f960f0920233f9fd5ad4623aebdca0e403264a06202","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.10.11","useDigest":true}``
    * - preflight.nodeSelector
      - Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object

--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -294,6 +294,7 @@ Name                                     Labels                                 
 ======================================== ================================================== ========================================================
 ``proxy_redirects``                      ``protocol``                                       Number of redirects installed for endpoints
 ``proxy_upstream_reply_seconds``                                                            Seconds waited for upstream server to reply to a request
+``proxy_datapath_update_timeout_total``                                                     Number of total datapath update timeouts due to FQDN IP updates
 ``policy_l7_total``                      ``type``                                           Number of total L7 requests/responses
 ======================================== ================================================== ========================================================
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -610,7 +610,7 @@ quickly. In order to limit the number of IP addresses that map a particular
 FQDN, each FQDN has a per-endpoint max capacity of IPs that will be retained
 (default: 50). Once this limit is exceeded, the oldest IP entries are
 automatically expired from the cache. This capacity can be changed using the
-``--tofqdns-max-ip-per-hostname`` option.
+``--tofqdns-endpoint-max-ip-per-hostname`` option.
 
 As with long-lived connections above, live connections are not expired until
 they terminate. It is safe to mix long- and short-lived connections from the

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -835,6 +835,7 @@ systemd
 systemtap
 tableSize
 tarball
+targetPort
 tc
 tcp
 tcpdump

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,6 +138,9 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		// Get list of open file descriptors managed by the agent
 		fmt.Sprintf("ls -la /proc/$(pidof %s)/fd", components.CiliumAgentName),
 		"lsmod",
+		// tc
+		"tc -s qdisc", // Show statistics on queuing disciplines
+		"tc qdisc show",
 	}
 
 	if bpffsMountpoint := bpffsMountpoint(); bpffsMountpoint != "" {
@@ -210,6 +214,13 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 	commands = append(commands, copyConfigCommands(confDir, k8sPods)...)
 	commands = append(commands, copyCiliumInfoCommands(cmdDir, k8sPods)...)
 
+	tcCommands, err := tcInterfaceCommands()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to generate per interface tc commands: %s\n", err)
+	} else {
+		commands = append(commands, tcCommands...)
+	}
+
 	return k8sCommands(commands, k8sPods)
 }
 
@@ -243,6 +254,23 @@ func loadConfigFile(path string) (*BugtoolConfiguration, error) {
 	var c BugtoolConfiguration
 	err = json.Unmarshal(content, &c)
 	return &c, err
+}
+
+// Listing tc filter/chain/classes requires specific interface names.
+// Commands are generated per-interface.
+func tcInterfaceCommands() ([]string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("could not list network interfaces: %v", err)
+	}
+	commands := []string{}
+	for _, iface := range ifaces {
+		commands = append(commands,
+			fmt.Sprintf("tc filter show dev %s", iface.Name),
+			fmt.Sprintf("tc chain show dev %s", iface.Name),
+			fmt.Sprintf("tc class show dev %s", iface.Name))
+	}
+	return commands, nil
 }
 
 func catCommands() []string {

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -593,6 +593,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		select {
 		case <-updateCtx.Done():
 			log.Error("Timed out waiting for datapath updates of FQDN IP information; returning response")
+			metrics.ProxyDatapathUpdateTimeout.Inc()
 		case <-updateComplete:
 		}
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -200,6 +200,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.enabled | bool | `true` | Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client |
 | hubble.peerService.servicePort | int | `4254` | Service Port for the Peer service. |
+| hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service. |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
 | hubble.relay.image | object | `{"digest":"sha256:8f30fb40bd46be4d1bfb55eb91cff7d0f8958eeb486d6184b5495f6624cf6ff1","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.10.11","useDigest":true}` | Hubble-relay container image. |

--- a/install/kubernetes/cilium/templates/hubble-peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-peer-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.listenAddress .Values.hubble.peerService.enabled }}
+{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.peerService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,7 +17,7 @@ spec:
     port: {{ .Values.hubble.tls.enabled | ternary 443 80 }}
     {{- end }}
     protocol: TCP
-    targetPort: {{ splitList ":" .Values.hubble.listenAddress | last }}
+    targetPort: {{ .Values.hubble.peerService.targetPort }}
 {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
   internalTrafficPolicy: Local
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -614,6 +614,8 @@ hubble:
     enabled: true
     # -- Service Port for the Peer service.
     servicePort: 4254
+    # -- Target Port for the Peer service.
+    targetPort: 4244
     # -- The cluster domain to use to query the Hubble Peer service. It should
     # be the local cluster.
     clusterDomain: cluster.local

--- a/pkg/api/socket.go
+++ b/pkg/api/socket.go
@@ -45,7 +45,7 @@ func SetDefaultPermissions(socketPath string) error {
 		log.WithError(err).WithFields(logrus.Fields{
 			logfields.Path: socketPath,
 			"group":        CiliumGroupName,
-		}).Info("Group not found")
+		}).Debug("Group not found")
 	} else {
 		if err := os.Chown(socketPath, 0, gid); err != nil {
 			return fmt.Errorf("failed while setting up %s's group ID"+
@@ -53,8 +53,8 @@ func SetDefaultPermissions(socketPath string) error {
 		}
 	}
 	if err := os.Chmod(socketPath, SocketFileMode); err != nil {
-		return fmt.Errorf("failed while setting up %s's file"+
-			" permissions in %q: %s", CiliumGroupName, socketPath, err)
+		return fmt.Errorf("failed while setting up file permissions in %q: %w",
+			socketPath, err)
 	}
 	return nil
 }

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -100,6 +100,29 @@ func TestGetStringMapString(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "valid kv format with comma in value",
+			args: args{
+				key:   "API_RATE_LIMIT",
+				value: "endpoint-create=rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true,endpoint-delete=rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true",
+			},
+			want: map[string]string{
+				"endpoint-create": "rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true",
+				"endpoint-delete": "rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "another valid kv format with comma in value",
+			args: args{
+				key:   "AWS_INSTANCE_LIMIT_MAPPING",
+				value: "c6a.2xlarge=4,15,15",
+			},
+			want: map[string]string{
+				"c6a.2xlarge": "4,15,15",
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "valid kv format with forward slash",
 			args: args{
 				key:   "FOO_BAR",

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -524,10 +524,10 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 			offset = -1
 		}
 		if spiI > linux_defaults.IPsecMaxKeyVersion {
-			return 0, 0, fmt.Errorf("encryption Key space exhausted, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion, s[0])
+			return 0, 0, fmt.Errorf("encryption Key space exhausted, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion+1, s[0])
 		}
 		if spiI == 0 {
-			return 0, 0, fmt.Errorf("zero is not a valid key to disable encryption use `--enable-ipsec=false`, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion, s[0])
+			return 0, 0, fmt.Errorf("zero is not a valid key to disable encryption use `--enable-ipsec=false`, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion+1, s[0])
 		}
 		spi = uint8(spiI)
 

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -96,7 +96,7 @@ const (
 	TunnelDeviceName = "cilium_vxlan"
 
 	// IPSec offset value for node rules
-	IPsecMaxKeyVersion = 16
+	IPsecMaxKeyVersion = 15
 
 	// IPsecMarkMask is the mask required for the IPsec SPI and encrypt/decrypt bits
 	IPsecMarkMask = 0xFF00

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -284,6 +284,10 @@ var (
 	// by error, protocol and span time
 	ProxyUpstreamTime = NoOpObserverVec
 
+	// ProxyDatapathUpdateTimeout is a count of all the timeouts encountered while
+	// updating the datapath due to an FQDN IP update
+	ProxyDatapathUpdateTimeout = NoOpCounter
+
 	// L3-L4 statistics
 
 	// DropCount is the total drop requests,
@@ -471,6 +475,7 @@ type Configuration struct {
 	ProxyForwardedEnabled                   bool
 	ProxyDeniedEnabled                      bool
 	ProxyReceivedEnabled                    bool
+	ProxyDatapathUpdateTimeoutEnabled       bool
 	NoOpObserverVecEnabled                  bool
 	DropCountEnabled                        bool
 	DropBytesEnabled                        bool
@@ -820,6 +825,16 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, ProxyUpstreamTime)
 			c.NoOpObserverVecEnabled = true
+
+		case Namespace + "_proxy_datapath_update_timeout_total":
+			ProxyDatapathUpdateTimeout = prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Name:      "proxy_datapath_update_timeout_total",
+				Help:      "Number of total datapath update timeouts due to FQDN IP updates",
+			})
+
+			collectors = append(collectors, ProxyDatapathUpdateTimeout)
+			c.ProxyDatapathUpdateTimeoutEnabled = true
 
 		case Namespace + "_drop_count_total":
 			DropCount = prometheus.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
 * #16647 -- ipsec: Fix off-by-one error on max keyID (@pchaigno)
 * #19885 -- docs: Add docs-builder build as dependency to live preview (@qmonnet)
 * #19888 -- docs: Remove '\r' chars from grep result to parse Alpine image name (@qmonnet)
   * small conflict as the builder-image command was slightly different
 * #19886 -- Do not disable peer service when hubble.listenAddress is empty (@chancez)
   * some minor conflicts for docs, had to run make -C install/kubernetes && make -C Documentation helm-values.rst
 * #19856 -- Bugtool: Add additional tc commands. (@tommyp1ckles)
 * #19927 -- api: change "group not found" log to debug (@tklauser)
 * #19809 -- Add counter to track all datapath timeouts due to FQDN IP updates (@ungureanuvladvictor)
 * #19893 -- docs: Fix max SPI value for IPsec key rotations (@pchaigno)
 * #19930 -- docs: Fix incorrect FQDN flag (@pchaigno)
 * #19955 -- cmd: Allow more complicated patterns in map string type. (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16647 19885 19888 19886 19856 19927 19809 19893 19930 19955; do contrib/backporting/set-labels.py $pr done 1.10; done
```
or with
```
$ make add-label BRANCH=v1.10 ISSUES=16647,19885,19888,19886,19856,19927,19809,19893,19930,19955
```
