### PR TITLE
v1.9 backports 2022-05-31

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -93,7 +93,7 @@ run-server: stop-server
 stop-server:
 	-$(QUIET)$(CONTAINER_ENGINE) container rm --force --volumes docs-cilium 2>/dev/null
 
-live-preview: stop-server
+live-preview: stop-server builder-image
 	@echo "$$(tput setaf 2)Running at http://localhost:$(DOCS_PORT)$$(tput sgr0)"
 	$(QUIET)$(DOCKER_CTR) \
 		--publish $(DOCS_PORT):8000 \

--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -188,7 +188,7 @@ To replace cilium-ipsec-keys secret with a new keys,
 .. code-block:: shell-session
 
     KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o yaml | awk '/^\s*keys:/ {print $2}' | base64 -d | awk '{print $1}')
-    if [[ $KEYID -gt 15 ]]; then KEYID=0; fi
+    if [[ $KEYID -ge 15 ]]; then KEYID=0; fi
     data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128\"}}")
     kubectl patch secret -n kube-system cilium-ipsec-keys -p="${data}" -v=1
 
@@ -199,9 +199,10 @@ has not yet been updated. In this way encryption will work as new keys are
 rolled out.
 
 The KEYID environment variable in the above example stores the current key ID
-used by Cilium. The key variable is a uint8 with value between 0-16 and should
-be monotonically increasing every re-key with a rollover from 16 to 0. The
-Cilium agent will default to KEYID of zero if its not specified in the secret.
+used by Cilium. The key variable is a uint8 with value between 1 and 15
+included and should be monotonically increasing every re-key with a rollover
+from 15 to 1. The Cilium agent will default to KEYID of zero if its not
+specified in the secret.
 
 Troubleshooting
 ===============

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -602,7 +602,7 @@ quickly. In order to limit the number of IP addresses that map a particular
 FQDN, each FQDN has a per-endpoint max capacity of IPs that will be retained
 (default: 50). Once this limit is exceeded, the oldest IP entries are
 automatically expired from the cache. This capacity can be changed using the
-``--tofqdns-max-ip-per-hostname`` option.
+``--tofqdns-endpoint-max-ip-per-hostname`` option.
 
 As with long-lived connections above, live connections are not expired until
 they terminate. It is safe to mix long- and short-lived connections from the

--- a/pkg/api/socket.go
+++ b/pkg/api/socket.go
@@ -45,7 +45,7 @@ func SetDefaultPermissions(socketPath string) error {
 		log.WithError(err).WithFields(logrus.Fields{
 			logfields.Path: socketPath,
 			"group":        CiliumGroupName,
-		}).Info("Group not found")
+		}).Debug("Group not found")
 	} else {
 		if err := os.Chown(socketPath, 0, gid); err != nil {
 			return fmt.Errorf("failed while setting up %s's group ID"+
@@ -53,8 +53,8 @@ func SetDefaultPermissions(socketPath string) error {
 		}
 	}
 	if err := os.Chmod(socketPath, SocketFileMode); err != nil {
-		return fmt.Errorf("failed while setting up %s's file"+
-			" permissions in %q: %s", CiliumGroupName, socketPath, err)
+		return fmt.Errorf("failed while setting up file permissions in %q: %w",
+			socketPath, err)
 	}
 	return nil
 }

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -524,10 +524,10 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 			offset = -1
 		}
 		if spiI > linux_defaults.IPsecMaxKeyVersion {
-			return 0, 0, fmt.Errorf("encryption Key space exhausted, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion, s[0])
+			return 0, 0, fmt.Errorf("encryption Key space exhausted, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion+1, s[0])
 		}
 		if spiI == 0 {
-			return 0, 0, fmt.Errorf("zero is not a valid key to disable encryption use `--enable-ipsec=false`, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion, s[0])
+			return 0, 0, fmt.Errorf("zero is not a valid key to disable encryption use `--enable-ipsec=false`, id must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion+1, s[0])
 		}
 		spi = uint8(spiI)
 

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -89,7 +89,7 @@ const (
 	TunnelDeviceName = "cilium_vxlan"
 
 	// IPSec offset value for node rules
-	IPsecMaxKeyVersion = 16
+	IPsecMaxKeyVersion = 15
 
 	// IPsecMarkMask is the mask required for the IPsec SPI and encrypt/decrypt bits
 	IPsecMarkMask = 0xFF00


### PR DESCRIPTION
 * #16647 -- ipsec: Fix off-by-one error on max keyID (@pchaigno)
 * #19885 -- docs: Add docs-builder build as dependency to live preview (@qmonnet)
 * #19927 -- api: change "group not found" log to debug (@tklauser)
 * #19893 -- docs: Fix max SPI value for IPsec key rotations (@pchaigno)
 * #19930 -- docs: Fix incorrect FQDN flag (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 16647 19885 19927 19893 19930; do contrib/backporting/set-labels.py $pr done 1.9; done
```
or with
```
$ make add-label BRANCH=v1.9 ISSUES=16647,19885,19927,19893,19930
```