### PR TITLE
datapath: Improve sysctl warning for bpf_jit_enable

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -247,7 +247,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args = make([]string, initArgMax)
 
 	sysSettings := []sysctl.Setting{
-		{Name: "net.core.bpf_jit_enable", Val: "1", IgnoreErr: true},
+		{Name: "net.core.bpf_jit_enable", Val: "1", IgnoreErr: true, Warn: "Unable to ensure that BPF JIT compilation is enabled. This can be ignored when Cilium is running inside non-host network namespace (e.g. with kind or minikube)"},
 		{Name: "net.ipv4.conf.all.rp_filter", Val: "0", IgnoreErr: false},
 		{Name: "net.ipv4.fib_multipath_use_neigh", Val: "1", IgnoreErr: true},
 		{Name: "kernel.unprivileged_bpf_disabled", Val: "1", IgnoreErr: true},

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -50,6 +50,9 @@ type Setting struct {
 	Name      string
 	Val       string
 	IgnoreErr bool
+
+	// Warn if non-empty is the alternative warning log message to use when IgnoreErr is false.
+	Warn string
 }
 
 // parameterPath returns the path to the sysctl file for parameter name.
@@ -142,10 +145,15 @@ func ApplySettings(sysSettings []Setting) error {
 			if !s.IgnoreErr || errors.Is(err, ErrInvalidSysctlParameter("")) {
 				return fmt.Errorf("Failed to sysctl -w %s=%s: %s", s.Name, s.Val, err)
 			}
+
+			warn := "Failed to sysctl -w"
+			if s.Warn != "" {
+				warn = s.Warn
+			}
 			log.WithError(err).WithFields(logrus.Fields{
 				logfields.SysParamName:  s.Name,
 				logfields.SysParamValue: s.Val,
-			}).Warning("Failed to sysctl -w")
+			}).Warning(warn)
 		}
 	}
 


### PR DESCRIPTION
When running Cilium with a KinD or Minikube installation it will be ran in a non-host
network namespace under which many bpf related proc files are not available. Since
it's a common way of testing and developing Cilium, improve the warning so that the
user is not alarmed by this.

The log message under KinD will look like this:
```
  level=info msg="Setting sysctl" subsys=sysctl sysParamName=net.core.bpf_jit_enable sysParamValue=1
  level=warning msg="Could not enable BPF JIT compilation. This can be ignored when running inside non-host network namespace (KinD, Minikube)"
    error="could not open the sysctl file /proc/sys/net/core/bpf_jit_enable: open /proc/sys/net/core/bpf_jit_enable: no such file or directory"
    subsys=sysctl sysParamName=net.core.bpf_jit_enable sysParamValue=1
```
Fixes: #19847