### PR TITLE
k8s: add ingress daemonset

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1086,7 +1086,11 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	bootstrapStats.restore.End(true)
 
 	if err := d.allocateIPs(); err != nil { // will log errors/fatal internally
-		return nil, nil, err
+		if err == IngressIPAMError {
+			log.WithError(err).Info("waiting for cilium-ingress-drone pod to be deployed")
+		} else {
+			return nil, nil, err
+		}
 	}
 
 	// Must occur after d.allocateIPs(), see GH-14245 and its fix.

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -211,6 +211,9 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState, clean bool) er
 		ep.SetDefaultConfiguration(true)
 		ep.SetProxy(d.l7Proxy)
 		ep.SkipStateClean()
+		if ep.IsIngressDrone() {
+			d.setIngressIPsFromEndpoint(ep)
+		}
 
 		state.restored = append(state.restored, ep)
 

--- a/install/kubernetes/cilium/templates/cilium-ingress-drone/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-drone/daemonset.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingressController.enabled -}}
+{{- if ne .Values.cni.chainingMode "none" -}}
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: cilium-ingress-drone
+  namespace: {{ .Release.Namespace }}
+  labels:
+    io.cilium/app: ingress-drone
+    name: cilium-ingress-drone
+spec:
+  selector:
+    matchLabels:
+      io.cilium/app: ingress-drone
+      'reserved:ingress': ''
+  template:
+    metadata:
+      labels:
+        io.cilium/app: ingress-drone
+        'reserved:ingress': ''
+    spec:
+      containers:
+        - name: pause
+          image: k8s.gcr.io/pause:3.6
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+      terminationGracePeriodSeconds: 0
+{{- end }}
+{{- end }}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -391,6 +391,10 @@ func (e *Endpoint) IsHost() bool {
 	return e.isHost
 }
 
+func (e *Endpoint) IsIngressDrone() bool {
+	return e.HasLabels(labels.LabelIngress)
+}
+
 // closeBPFProgramChannel closes the channel that signals whether the endpoint
 // has had its BPF program compiled. If the channel is already closed, this is
 // a no-op.

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -41,6 +41,9 @@ const (
 	// NetworkPolicyHostsTypeURL is the type URL of NetworkPolicyHosts resources.
 	NetworkPolicyHostsTypeURL = "type.googleapis.com/cilium.NetworkPolicyHosts"
 
+	// BpfMetadataTypeURL is the type URL of Cilium BPF Metadata listener filter.
+	BpfMetadataTypeURL = "type.googleapis.com/cilium.bpf_metadata"
+
 	// DownstreamTlsContextURL is the type URL of DownstreamTlsContext
 	DownstreamTlsContextURL = "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext"
 )

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -235,6 +235,9 @@ func LookupReservedIdentityByLabels(lbls labels.Labels) *Identity {
 		case lbl.Source == labels.LabelSourceReserved:
 			id := GetReservedID(lbl.Key)
 			switch {
+			case id == ReservedIdentityIngress:
+				// Create Ingress ID with the given set of labels
+				createID = true
 			case id == ReservedIdentityKubeAPIServer && lbls.Has(labels.LabelHost[labels.IDNameHost]):
 				// Due to Golang map iteration order (random) we might get the
 				// ID returned as kube-apiserver. If there's a local host


### PR DESCRIPTION
Deploy cilium-ingress-drone daemonset when Cilium Ingress is configured,
and IPAM can not be used for allocating Ingress addresses. If deployed,
use the IPs assigned for this dummy pod as the Cilium Ingress source
addresses.

K8s watcher initialization is modified to wait for the availability of
these Ingress addresses before starting the watchers for
CiliumEnvoyConfig CRDs, so that the ingress addresses are available when
needed for Envoy configuration.

Note: Cilium-CLI needs to add support for the ingress daemonset deployment and an Ingress test case for `connectivity test` before we can test this.

```release-note
Ingress is now supported in (some) CNI chaining modes.
```
