### PR TITLE
Misc Makefile improvements for quiet mode V=0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install: ./.travis/prepare.sh
 
 before_script:
   - export PATH=/usr/local/clang/bin:$PATH
+  - export V=0
 
 script: ./.travis/build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
 before_install: ./.travis/prepare.sh
 
 before_script:
+  - export DOCKER_BUILD_FLAGS=--quiet
   - export PATH=/usr/local/clang/bin:$PATH
   - export V=0
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -4,8 +4,8 @@ set -o errexit
 
 export CFLAGS="-Werror"
 
-make -j 2
-make integration-tests
+make -j 2 --quiet
+make integration-tests --quiet
 
 $HOME/gopath/bin/goveralls -coverprofile=coverage-all.out -service=travis-ci || true
 

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -16,10 +16,11 @@ clean:
 DOCS_BUILDER_IMG ?= cilium/docs-builder
 
 builder-image: Dockerfile requirements.txt
+	$(ECHO_DOCKER)
 	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
 	grep "^FROM " $< | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
 	$(QUIET)tar c requirements.txt Dockerfile \
-	  | $(CONTAINER_ENGINE) build --tag $(DOCS_BUILDER_IMG) -
+	  | $(CONTAINER_ENGINE) build $(DOCKER_BUILD_FLAGS) --tag $(DOCS_BUILDER_IMG) -
 
 # cilium must have all build artifacts present for
 # documentation to be generated correctly.

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,6 @@ GO_MAJOR_AND_MINOR_VERSION := $(shell sed 's/\([0-9]\+\).\([0-9]\+\)\(.[0-9]\+\)
 GO_IMAGE_VERSION := $(shell awk -F. '{ z=$$3; if (z == "") z=0; print $$1 "." $$2 "." z}' GO_VERSION)
 GO_INSTALLED_MAJOR_AND_MINOR_VERSION := $(shell $(GO) version | sed 's/go version go\([0-9]\+\).\([0-9]\+\)\(.[0-9]\+\)\?.*/\1.\2/')
 
-DOCKER_FLAGS ?=
-
 TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddress=https://consul:8443 \
 	-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002 \
 	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,10 @@ build-container: ## Builds components required for cilium-agent container.
 $(SUBDIRS): force ## Execute default make target(make all) for the provided subdirectory.
 	@ $(MAKE) $(SUBMAKEOPTS) -C $@ all
 
-PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $$pkg; done | xargs grep --include='*.go' -ril 'go:build [^!]*privileged_tests' | xargs dirname | sort | uniq)
+# If the developer provides TESTPKGS to filter the set of packages to use for testing, filter that to only packages with privileged tests.
+# The period at EOL ensures that if TESTPKGS becomes empty, we can still pass some paths to 'xargs dirname' to avoid errors.
+PRIV_TEST_PKGS_FILTER := $(shell for pkg in $(TESTPKGS); do echo $$pkg; done | xargs grep --include='*.go' -ril 'go:build [^!]*privileged_tests') .
+PRIV_TEST_PKGS_EVAL := $(shell echo $(PRIV_TEST_PKGS_FILTER) | xargs dirname | sort | uniq | grep -Ev '^\.$$')
 PRIV_TEST_PKGS ?= $(PRIV_TEST_PKGS_EVAL)
 tests-privileged: GO_TAGS_FLAGS+=privileged_tests ## Run integration-tests for Cilium that requires elevated privileges.
 tests-privileged:

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -29,6 +29,8 @@ export GOARCH ?= $(NATIVE_ARCH)
 INSTALL = install
 
 CONTAINER_ENGINE?=docker
+DOCKER_FLAGS?=
+DOCKER_BUILD_FLAGS?=
 
 # use gsed if avaiable, otherwise use sed.
 # gsed is needed for MacOS to make in-place replacement work correctly.

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -78,9 +78,10 @@ endif
 define DOCKER_IMAGE_TEMPLATE
 .PHONY: $(1)
 $(1): GIT_VERSION $(2) $(2).dockerignore GIT_VERSION builder-info
+	$(ECHO_DOCKER)$(2) $(IMAGE_REPOSITORY)/$(IMAGE_NAME)$${UNSTRIPPED}:$(4)
 	$(eval IMAGE_NAME := $(subst %,$$$$*,$(3)))
 	$(QUIET) $(CONTAINER_ENGINE) buildx build -f $(subst %,$$*,$(2)) \
-		$(DOCKER_FLAGS) \
+		$(DOCKER_BUILD_FLAGS) $(DOCKER_FLAGS) \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		--build-arg NOSTRIP=$${NOSTRIP} \
 		--build-arg NOOPT=${NOOPT} \

--- a/Makefile.quiet
+++ b/Makefile.quiet
@@ -7,20 +7,22 @@ ifeq ($(ROOT_DIR),)
 endif
 ifeq ($(V),0)
 	QUIET=@
-	ECHO_CC=echo "  CC    $(RELATIVE_DIR)/$@"
-	ECHO_GEN=echo "  GEN   $(RELATIVE_DIR)/"
-	ECHO_GO=echo "  GO    $(RELATIVE_DIR)/$@"
-	ECHO_CHECK=echo "  CHECK $(RELATIVE_DIR)"
-	ECHO_GINKGO=echo "  GINKG $(RELATIVE_DIR)"
-	ECHO_CLEAN=echo "  CLEAN $(RELATIVE_DIR)"
+	ECHO_CC=echo "  CC     $(RELATIVE_DIR)/$@"
+	ECHO_CHECK=echo "  CHECK  $(RELATIVE_DIR)"
+	ECHO_CLEAN=echo "  CLEAN  $(RELATIVE_DIR)"
+	ECHO_DOCKER=echo "  DOCKER $(RELATIVE_DIR) $@"
+	ECHO_GEN=echo "  GEN    $(RELATIVE_DIR)/"
+	ECHO_GINKGO=echo "  GINKGO $(RELATIVE_DIR)"
+	ECHO_GO=echo "  GO     $(RELATIVE_DIR)/$@"
 	SUBMAKEOPTS="-s"
 else
 	# The whitespace at below EOLs is required for verbose case!
 	ECHO_CC=: 
-	ECHO_GEN=: 
-	ECHO_GO=: 
 	ECHO_CHECK=: 
-	ECHO_GINKGO=: 
 	ECHO_CLEAN=: 
+	ECHO_DOCKER=: 
+	ECHO_GEN=: 
+	ECHO_GINKGO=: 
+	ECHO_GO=: 
 	SUBMAKEOPTS=
 endif

--- a/bpf/mock/Makefile
+++ b/bpf/mock/Makefile
@@ -5,10 +5,11 @@ include ../../Makefile.defs
 include ../../Makefile.quiet
 
 builder-image: Dockerfile
+	$(ECHO_DOCKER)
 	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
 	grep "^FROM " $< | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
 	$(QUIET)tar c Dockerfile \
-	 | $(CONTAINER_ENGINE) build --tag cilium/bpf-mock -
+	 | $(CONTAINER_ENGINE) build $(DOCKER_BUILD_FLAGS) --tag cilium/bpf-mock -
 
 DOCKER_CTR_ROOT_DIR := /src
 DOCKER_CTR := $(CONTAINER_ENGINE) container run --rm \

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -24,7 +24,7 @@ BPF_LLC_FLAGS := -march=bpf -mcpu=probe -filetype=obj
 
 LIB := $(shell find ../../bpf/ -name '*.h')
 
-CLANG ?= $(QUIET) clang
+CLANG ?= clang
 LLC ?= llc
 
 BPF_TARGETS := elf-demo.o
@@ -35,11 +35,11 @@ all: $(TARGETS) unit-tests
 
 elf-demo.o: elf-demo.c
 	@$(ECHO_CC)
-	$(CLANG) ${FLAGS_CLANG} ${BPF_CC_FLAGS} -c $< -o - | $(LLC) ${BPF_LLC_FLAGS} -o $@
+	$(QUIET) $(CLANG) ${FLAGS_CLANG} ${BPF_CC_FLAGS} -c $< -o - | $(LLC) ${BPF_LLC_FLAGS} -o $@
 
 %: %.c $(LIB)
 	@$(ECHO_CC)
-	$(CLANG) ${FLAGS_CLANG} ${FLAGS} -I../../bpf/ $< -o $@
+	$(QUIET) $(CLANG) ${FLAGS_CLANG} ${FLAGS} -I../../bpf/ $< -o $@
 
 mocks:
 	$(QUIET)$(MAKE) -C $(ROOT_DIR)/bpf/mock generate_helper_headers


### PR DESCRIPTION
See commits for more details.

- test/bpf: Fix compilation with V=0
- Makefile: Fix dirname errors with empty PRIV_TEST_PKGS
- .travis: Make output less verbose
- .travis: Quieten docker build output 

One side effect here is to trim 10,000+ lines of docker build output from the test output on Travis, making it easier to scroll through and find which tests succeeded/failed. In conjunction with #20032, this should be much easier for developers to read and interact with.