### PR TITLE
Add support for tparse in go test targets

### DIFF
--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -46,3 +46,4 @@ install_clang
 export PATH="/usr/local/clang/bin:$PATH"
 
 go install github.com/mattn/goveralls@a36c7ef8f23b2952fa6e39663f52107dfc8ad69d # v0.0.11
+go install github.com/mfridman/tparse@a20c511a88b880dc2544d77d8bc2cc66a8dec507 # v0.10.3

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ tests-privileged: GO_TAGS_FLAGS+=privileged_tests ## Run integration-tests for C
 tests-privileged:
 	$(MAKE) init-coverage
 	for pkg in $(patsubst %,github.com/cilium/cilium/%,$(PRIV_TEST_PKGS)); do \
+		>&2 $(ECHO_TEST) $$pkg; \
 		PATH=$(PATH):$(ROOT_DIR)/bpf $(GO_TEST) $(TEST_LDFLAGS) $$pkg $(GOTEST_UNIT_BASE) $(GOTEST_COVER_OPTS) -coverpkg $$pkg \
 		|| exit 1; \
 		tail -n +2 coverage.out >> coverage-all-tmp.out; \
@@ -199,6 +200,7 @@ endif
 	# hence will trigger an error of too many arguments. As a workaround, we
 	# have to process these packages in different subshells.
 	for pkg in $(patsubst %,github.com/cilium/cilium/%,$(TESTPKGS)); do \
+		>&2 $(ECHO_TEST) $$pkg; \
 		$(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $$pkg $(GOTEST_BASE) $(GOTEST_COVER_OPTS) -coverpkg $$pkg \
 		|| exit 1; \
 		tail -n +2 coverage.out >> coverage-all-tmp.out; \

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ tests-privileged:
 		PATH=$(PATH):$(ROOT_DIR)/bpf $(GO_TEST) $(TEST_LDFLAGS) $$pkg $(GOTEST_UNIT_BASE) $(GOTEST_COVER_OPTS) -coverpkg $$pkg \
 		|| exit 1; \
 		tail -n +2 coverage.out >> coverage-all-tmp.out; \
-	done
+	done | $(GOTEST_FORMATTER)
 	$(MAKE) generate-cov
 
 start-kvstores: ## Start running kvstores required for running Cilium integration-tests. More specifically this will run etcd and consul containers.
@@ -202,7 +202,7 @@ endif
 		$(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $$pkg $(GOTEST_BASE) $(GOTEST_COVER_OPTS) -coverpkg $$pkg \
 		|| exit 1; \
 		tail -n +2 coverage.out >> coverage-all-tmp.out; \
-	done
+	done | $(GOTEST_FORMATTER)
 	$(MAKE) generate-cov
 	$(MAKE) stop-kvstores
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -70,6 +70,18 @@ GO_TAGS_FLAGS = osusergo
 # RACE is specified.
 GOTEST_COVER_OPTS =
 
+# By default, just print go test output immediately to the terminal. If tparse
+# is installed, use it to format the output. This is either silent silent (V=0)
+# or gives some signal about ongoing progress by teeing to the terminal (V=1).
+GOTEST_FORMATTER ?= cat
+ifneq ($(shell which tparse),)
+	GOTEST_COVER_OPTS += -json
+	GOTEST_FORMATTER = tparse
+ifneq ($(V),0)
+	GOTEST_FORMATTER += -follow
+endif
+endif
+
 GOLANGCILINT_WANT_VERSION = 1.46.2
 GOLANGCILINT_IMAGE_SHA = sha256:e84b639c061c8888be91939c78dae9b1525359954e405ab0d9868a46861bd21b
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)

--- a/Makefile.quiet
+++ b/Makefile.quiet
@@ -14,6 +14,7 @@ ifeq ($(V),0)
 	ECHO_GEN=echo "  GEN    $(RELATIVE_DIR)/"
 	ECHO_GINKGO=echo "  GINKGO $(RELATIVE_DIR)"
 	ECHO_GO=echo "  GO     $(RELATIVE_DIR)/$@"
+	ECHO_TEST=echo "  TEST "
 	SUBMAKEOPTS="-s"
 else
 	# The whitespace at below EOLs is required for verbose case!
@@ -24,5 +25,6 @@ else
 	ECHO_GEN=: 
 	ECHO_GINKGO=: 
 	ECHO_GO=: 
+	ECHO_TEST=: 
 	SUBMAKEOPTS=
 endif

--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -56,6 +56,13 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 			minVersion:    &minGoVersion,
 		},
 		&binaryCheck{
+			name:          "tparse",
+			ifNotFound:    checkWarning,
+			versionArgs:   []string{"-v"},
+			versionRegexp: regexp.MustCompile(`tparse version: v(\d+\.\d+\.\d+)`),
+			hint:          `Run "go install github.com/mfridman/tparse@latest"`,
+		},
+		&binaryCheck{
 			name:          "clang",
 			ifNotFound:    checkError,
 			versionArgs:   []string{"--version"},


### PR DESCRIPTION
Expand the integration-tests and privileged-tests targets to optionally
run the output through [tparse](https://github.com/mfridman/tparse) for a friendlier testing experience.
Install this by default in Travis as well so that the format is more
readable in that environment, and add it to the dev-doctor to help teach
developers how to get this output format when running tests like this.

This mode supports a few options:
* Don't install tparse. This is fine, just output to the terminal.
* Install tparse, verbose mode. Output all test output to the terminal
  while the tests are running. Summarize afterwards using tparse.
* Install tparse, quiet mode (V=0). Only output the summary once all of
  the tests have run. This relies on #20031 to fix quiet build.

This support is not extended to the benchmark targets so far, as it
seemed like the tparse format doesn't summarize go bench results so this
will only make it more difficult to see the benchmark results.

Suggested-by: @aditighag
