### PR TITLE
helm: Relax hubble ui image versions validation

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -35,7 +35,9 @@
 {{- end }}
 
 {{/* validate hubble-ui specific config */}}
-{{- if .Values.hubble.ui.enabled }}
+{{- if and .Values.hubble.ui.enabled
+  (ne .Values.hubble.ui.backend.image.tag "latest")
+  (ne .Values.hubble.ui.frontend.image.tag "latest") }}
   {{- if regexReplaceAll "@.*$" .Values.hubble.ui.backend.image.tag "" | trimPrefix "v" | semverCompare "<0.9.0" }}
     {{ fail "Hubble UI requires hubble.ui.backend.image.tag to be '>=v0.9.0'" }}
   {{- end }}


### PR DESCRIPTION
This commit is to allow the latest tag for hubble images, as unlike
cilium images, we are still publishing the latest tag.

Related comment https://github.com/cilium/cilium/pull/20036#pullrequestreview-991318933

Relates: #19565
Fixes: #20034

Suggested-By: Joe Stringer <joe@cilium.io>
Suggested-By: Michi Mutsuzaki <michi@isovalent.com>
Signed-off-by: Tam Mach <tam.mach@cilium.io>
