### PR TITLE
fix blackhole route error in cleanup

### DIFF
--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -414,7 +414,8 @@ func findRoutesAndLinks() (map[int]netlink.Route, map[int]netlink.Link, error) {
 		for _, r := range routes {
 			link, err := netlink.LinkByIndex(r.LinkIndex)
 			if err != nil {
-				if strings.Contains(err.Error(), "Link not found") {
+				// when blackhole route is encountered, the LinkIndex will get 0.
+				if strings.Contains(err.Error(), "Link not found") || r.LinkIndex == 0 {
 					continue
 				}
 				return routesToRemove, linksToRemove, err


### PR DESCRIPTION
Signed-off-by: xiaoyang zhu <zhuxiaoyang1996@gmail.com>
<!-- Description of change -->

Fixes: #20040

after the dive troubleshooting, when a blackhole route is encountered, the `r.LinkIndex` will get 0 in https://github.com/cilium/cilium/blob/master/cilium/cmd/cleanup.go#L415.
so I think we can skip the blackhole route, and continue to scan route and netlinks.

```release-note
Fix blackhole route error when cleanup
```