### PR TITLE
identity: make `GetAllReservedIdentities()` return ordered identities

### DIFF
--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 
 	api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -483,12 +484,20 @@ func (id NumericIdentity) ClusterID() int {
 	return int((uint32(id) >> 16) & 0xFF)
 }
 
-// GetAllReservedIdentities returns a list of all reserved numeric identities.
+// GetAllReservedIdentities returns a list of all reserved numeric identities
+// in ascending order.
+// NOTE: While this func is unused from the cilium repository, is it imported
+// and called by the hubble cli.
 func GetAllReservedIdentities() []NumericIdentity {
-	identities := []NumericIdentity{}
+	identities := make([]NumericIdentity, 0, len(reservedIdentities))
 	for _, id := range reservedIdentities {
 		identities = append(identities, id)
 	}
+	// Because our reservedIdentities source is a go map, and go map order is
+	// randomized, we need to sort the resulting slice before returning it.
+	sort.Slice(identities, func(i, j int) bool {
+		return identities[i].Uint32() < identities[j].Uint32()
+	})
 	return identities
 }
 

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -6,7 +6,11 @@
 package identity
 
 import (
+	"testing"
+
 	. "gopkg.in/check.v1"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 )
@@ -54,5 +58,16 @@ func (s *IdentityTestSuite) TestClusterID(c *C) {
 
 	for _, item := range tbl {
 		c.Assert(NumericIdentity(item.identity).ClusterID(), Equals, item.clusterID)
+	}
+}
+
+func TestGetAllReservedIdentities(t *testing.T) {
+	allReservedIdentities := GetAllReservedIdentities()
+	require.NotNil(t, allReservedIdentities)
+	require.Len(t, allReservedIdentities, len(reservedIdentities))
+	for i, id := range allReservedIdentities {
+		// NOTE: identity 0 is unknown, so the reserved identities start at 1
+		// hence the plus one here.
+		require.Equal(t, uint32(i+1), id.Uint32())
 	}
 }


### PR DESCRIPTION
Before this patch, the returned slice from `GetAllReservedIdentities()` was inconsistently ordered.

This was caused by the fact that the resulting slice is built from iterating over a go map, and "the iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next. […]", see [the Go language spec](https://go.dev/ref/spec#For_statements).

See https://github.com/cilium/hubble/pull/732 for more context.