### PR TITLE
fix aws-cni conformance test

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -136,6 +136,9 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
+          # Set ipam.mode=cluster-pool to overwrite the ipam value set by the
+          # cilium-cli which is setting it to 'eni' because it auto-detects
+          # the cluster as being EKS.
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
             --chart-directory=install/kubernetes/cilium \
             --helm-set=image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
@@ -152,6 +155,8 @@ jobs:
             --helm-set=hubble.relay.image.tag=${SHA} \
             --helm-set=enableIPv4Masquerade=false \
             --helm-set=cni.chainingMode=aws-cni \
+            --helm-set=eni.enabled=false \
+            --helm-set=ipam.mode=cluster-pool \
             --helm-set=tunnel=disabled \
             --helm-set=bandwidthManager=false \
             --wait=false \

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -139,6 +139,9 @@ jobs:
             OWNER=${{ github.sha }}
           fi
 
+          # Set ipam.mode=cluster-pool to overwrite the ipam value set by the
+          # cilium-cli which is setting it to 'eni' because it auto-detects
+          # the cluster as being EKS.
           CILIUM_INSTALL_DEFAULTS="--cluster-name=${{ env.clusterName }} \
             --chart-directory=install/kubernetes/cilium \
             --helm-set=image.repository=quay.io/${{ github.repository_owner }}/cilium-ci \
@@ -155,6 +158,8 @@ jobs:
             --helm-set=hubble.relay.image.tag=${SHA} \
             --helm-set=enableIPv4Masquerade=false \
             --helm-set=cni.chainingMode=aws-cni \
+            --helm-set=eni.enabled=false \
+            --helm-set=ipam.mode=cluster-pool \
             --helm-set=tunnel=disabled \
             --helm-set=bandwidthManager.enabled=false \
             --wait=false \


### PR DESCRIPTION
Commit 2d7af3a (".github: add support for cilium-cli in aws-cni
conformance tests") changed the AWS-CNI workflow to install Cilium using
the CLI instead of Helm. All of the Helm flags were passed through the
CLI using --helm-set.

However, the CLI also does it's own magic and isn't aware that we want
to install Cilium in chaining mode. Therefore, it detects EKS and
incorrectly sets IPAM mode to ENI.

As a result, Cilium attempts to setup the IP rules and routes for new
pods. It seems to fail in most cases—maybe because AWS-CNI already setup
the state—but sometimes succeeds. When it succeeds, pods end up with an
egress rule pointing to a non-existing ip route table.

This usually surfaces in the workflow runs as a DNS failure: the client
pod fails to egress to the DNS backend on a remote node. In rarer cases,
it surfaces as a failing connectivity test for some of the pods.

This commit fixes it by overwriting some of the helm flags set
automatically by Cilium-cli namely "eni.enabled=false" and
"ipam=cluster-pool".

The longer-term fix would be to support chaining mode in the CLI.

Reported-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: André Martins <andre@cilium.io>