### PR TITLE
helm: Fix syntax error in Hubble UI className

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   {{- if .Values.hubble.ui.ingress.className }}
-  ingressClassName: {{- .Values.hubble.ui.ingress.className }}
+  ingressClassName: {{ .Values.hubble.ui.ingress.className }}
   {{- end }}
   {{- if .Values.hubble.ui.ingress.tls }}
   tls:


### PR DESCRIPTION
The ingressClassName in the Hubble UI chart accidentally used the `{{-`
template syntax which trims any leading whitespace, resulting in the
line being rendered as `ingressClassName:foo`, which is not valid YAML,
as YAML mandates a whitespace character between the key and value.

This fixes the issue where when the className was specified, Helm would
fail with the following error:

```
Error: Failed to render chart: exit status 1: Error: YAML parse error on cilium/templates/hubble-ui/ingress.yaml: error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
```

Fixes: #20054
Fixes: 17f42b3b19e4 ("feat(helm): add ingressClassName to ingress spec")