### PR TITLE
gha: Make EKS cleanup step synchronous

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -295,7 +295,7 @@ jobs:
       - name: Clean up EKS
         if: ${{ always() }}
         run: |
-          eksctl delete cluster --name ${{ env.clusterName }}
+          eksctl delete cluster --wait --name ${{ env.clusterName }}
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -296,7 +296,7 @@ jobs:
       - name: Clean up EKS
         if: ${{ always() }}
         run: |
-          eksctl delete cluster --name ${{ env.clusterName }}
+          eksctl delete cluster --wait --name ${{ env.clusterName }}
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -299,7 +299,7 @@ jobs:
       - name: Clean up EKS
         if: ${{ always() }}
         run: |
-          eksctl delete cluster --name ${{ env.clusterName }}
+          eksctl delete cluster --wait --name ${{ env.clusterName }}
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -293,7 +293,7 @@ jobs:
       - name: Clean up EKS
         if: ${{ always() }}
         run: |
-          eksctl delete cluster --name ${{ env.clusterName }}
+          eksctl delete cluster --wait --name ${{ env.clusterName }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -320,7 +320,7 @@ jobs:
       - name: Clean up EKS
         if: ${{ always() }}
         run: |
-          eksctl delete cluster --name ${{ env.clusterName }}
+          eksctl delete cluster --wait --name ${{ env.clusterName }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -323,7 +323,7 @@ jobs:
       - name: Clean up EKS
         if: ${{ always() }}
         run: |
-          eksctl delete cluster --name ${{ env.clusterName }}
+          eksctl delete cluster --wait --name ${{ env.clusterName }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts


### PR DESCRIPTION
This commit is to add --wait flag in eksctl delete cluster command, so
that the deletion will be executed synchronously. Recently, there are
a lot of cases that eksctl is leaving dangling resources behind, making
clean-up step running synchronously will help with actual error for
further actions.

One downside is that PR build might fail, however, PR owner/reviewer
can still proceed after checking logs anyway.

```
2022-06-02 13:30:48 [✖]  AWS::EC2::VPC/VPC: CREATE_FAILED – "Resource handler returned message: \"The maximum number of VPCs has been reached. (Service: Ec2, Status Code: 400, Request ID: 35e7eaf3-34ed-4780-8803-1957f11ba2df)\"
```
