### PR TITLE
dependabot: Unignore prometheus/client_golang

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,6 @@ updates:
       - dependency-name: "github.com/aliyun/alibaba-cloud-sdk-go"
       - dependency-name: "github.com/aws/*"
       - dependency-name: "github.com/Azure/*"
-        # Remove when https://github.com/prometheus/client_golang/issues/995
-        # has been solved and shipped in a release.
-      - dependency-name: "github.com/prometheus/client_golang"
     labels:
     - kind/enhancement
     - release-note/misc


### PR DESCRIPTION
https://github.com/cilium/cilium/commit/044681a8540ba5cfc39b400bfc79a3c1723f9f13 upgraded client_golang to v1.12.2 but didn't remove the dependabot ignore.