### PR TITLE
daemon: Fix build after VTEP routes conflict

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -555,7 +555,7 @@ func setupRouteToVtepCidr() error {
 				MTU:    vtepMTU,
 				Table:  linux_defaults.RouteTableVtep,
 			}
-			if _, err := route.Upsert(r); err != nil {
+			if err := route.Upsert(r); err != nil {
 				return fmt.Errorf("Update VTEP CIDR route error: %w", err)
 			}
 			log.WithFields(logrus.Fields{


### PR DESCRIPTION
Commit f77456dd603b ("vtep: VTEP policy routing setup when L7 policy
enabled") was recently merged without rebasing on top of master, which
introduced a compile-time conflict vs commit 8906f2b42e8c
("datapath/linux/route: remove unused Upsert bool return value"). Fix it
by updating the Upsert() call.

Fixes: f77456dd603b ("vtep: VTEP policy routing setup when L7 policy enabled")
