### PR TITLE
fix: add a rule for allowDNS to allow node-local-dns with its label for LRP use case

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -1730,6 +1730,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -1770,6 +1773,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -1808,6 +1814,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -1855,6 +1864,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -1899,6 +1911,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -1943,6 +1958,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -1987,6 +2005,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -833,6 +833,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -873,6 +876,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -686,6 +686,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -730,6 +733,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -774,6 +780,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -818,6 +827,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -504,6 +504,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -545,6 +548,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -586,6 +592,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -627,6 +636,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -613,6 +613,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -653,6 +656,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -691,6 +697,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -945,6 +945,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -985,6 +988,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"
@@ -1023,6 +1029,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-debug-tools.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-debug-tools.yaml
@@ -68,6 +68,9 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: node-local-dns
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/resources.cue
+++ b/examples/kubernetes/connectivity-check/resources.cue
@@ -220,12 +220,21 @@ egressCNP: [ID=_]: _cnp & {
 	if _allowDNS {
 		spec: egress: _rules + [
 				{
-				toEndpoints: [{
-					matchLabels: {
-						"k8s:io.kubernetes.pod.namespace": "kube-system"
-						"k8s:k8s-app":                     "kube-dns"
-					}
-				}]
+				toEndpoints: [
+					{
+						matchLabels: {
+							"k8s:io.kubernetes.pod.namespace": "kube-system"
+							"k8s:k8s-app":                     "kube-dns"
+						}
+					},
+					{
+						// Allows connectivity to NodeLocal DNSCache when deployed with Local Redirect Policy.
+						matchLabels: {
+							"k8s:io.kubernetes.pod.namespace": "kube-system"
+							"k8s:k8s-app":                     "node-local-dns"
+						}
+					},
+				]
 				toPorts: [{
 					ports: [{
 						port:     "53"


### PR DESCRIPTION
Fixes: #20055

```release-note
Update connectivity tests for clusters running NodeLocal DNSCache with Local Redirect Policy.
```

Signed-off-by: eminaktas <eminaktas34@gmail.com>
