### PR TITLE
k8s: allow setting multiple k8s API server addresses

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -195,6 +195,7 @@ cilium-agent [flags]
       --ipv6-service-range string                               Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
       --join-cluster                                            Join a Cilium cluster via kvstore registration
       --k8s-api-server string                                   Kubernetes API server URL
+      --k8s-api-server-urls strings                             List of URLs for Kubernetes API server instances
       --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                                    Name of the Kubernetes namespace in which Cilium is deployed in

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -194,7 +194,6 @@ cilium-agent [flags]
       --ipv6-range string                                       Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
       --ipv6-service-range string                               Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
       --join-cluster                                            Join a Cilium cluster via kvstore registration
-      --k8s-api-server string                                   Kubernetes API server URL
       --k8s-api-server-urls strings                             List of URLs for Kubernetes API server instances
       --k8s-heartbeat-timeout duration                          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                              Absolute path of the kubernetes kubeconfig file

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -44,7 +44,6 @@ cilium-operator-alibabacloud [flags]
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "alibabacloud")
-      --k8s-api-server string                     Kubernetes API server URL
       --k8s-api-server-urls strings               List of URLs for Kubernetes API server instances
       --k8s-client-burst int                      Burst value allowed for the K8s client
       --k8s-client-qps float32                    Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -45,6 +45,7 @@ cilium-operator-alibabacloud [flags]
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "alibabacloud")
       --k8s-api-server string                     Kubernetes API server URL
+      --k8s-api-server-urls strings               List of URLs for Kubernetes API server instances
       --k8s-client-burst int                      Burst value allowed for the K8s client
       --k8s-client-qps float32                    Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -51,6 +51,7 @@ cilium-operator-aws [flags]
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "eni")
       --k8s-api-server string                     Kubernetes API server URL
+      --k8s-api-server-urls strings               List of URLs for Kubernetes API server instances
       --k8s-client-burst int                      Burst value allowed for the K8s client
       --k8s-client-qps float32                    Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -50,7 +50,6 @@ cilium-operator-aws [flags]
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "eni")
-      --k8s-api-server string                     Kubernetes API server URL
       --k8s-api-server-urls strings               List of URLs for Kubernetes API server instances
       --k8s-client-burst int                      Burst value allowed for the K8s client
       --k8s-client-qps float32                    Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -48,6 +48,7 @@ cilium-operator-azure [flags]
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "azure")
       --k8s-api-server string                     Kubernetes API server URL
+      --k8s-api-server-urls strings               List of URLs for Kubernetes API server instances
       --k8s-client-burst int                      Burst value allowed for the K8s client
       --k8s-client-qps float32                    Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -47,7 +47,6 @@ cilium-operator-azure [flags]
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "azure")
-      --k8s-api-server string                     Kubernetes API server URL
       --k8s-api-server-urls strings               List of URLs for Kubernetes API server instances
       --k8s-client-burst int                      Burst value allowed for the K8s client
       --k8s-client-qps float32                    Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -43,7 +43,6 @@ cilium-operator-generic [flags]
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
-      --k8s-api-server string                     Kubernetes API server URL
       --k8s-api-server-urls strings               List of URLs for Kubernetes API server instances
       --k8s-client-burst int                      Burst value allowed for the K8s client
       --k8s-client-qps float32                    Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -44,6 +44,7 @@ cilium-operator-generic [flags]
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                     Kubernetes API server URL
+      --k8s-api-server-urls strings               List of URLs for Kubernetes API server instances
       --k8s-client-burst int                      Burst value allowed for the K8s client
       --k8s-client-qps float32                    Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -56,6 +56,7 @@ cilium-operator [flags]
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                     Kubernetes API server URL
+      --k8s-api-server-urls strings               List of URLs for Kubernetes API server instances
       --k8s-client-burst int                      Burst value allowed for the K8s client
       --k8s-client-qps float32                    Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -55,7 +55,6 @@ cilium-operator [flags]
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
-      --k8s-api-server string                     Kubernetes API server URL
       --k8s-api-server-urls strings               List of URLs for Kubernetes API server instances
       --k8s-client-burst int                      Burst value allowed for the K8s client
       --k8s-client-qps float32                    Queries per second limit for the K8s client

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -365,6 +365,9 @@ New Options
 * ``nodes-gc-interval``: This option was marked as deprecated and has no effect
   in 1.11. Cilium Node Garbage collector is added back in 1.12 (but for k8s GC instead
   of kvstore), so this flag is moved out of deprecated list.
+* ``k8s-api-server-urls``: This option specifies a list of URLs for Kubernetes
+  API server instances. The client will be configured to connect to one of these servers.
+  A new backend server is selected for client connections if the heartbeat check fails.
 
 Removed Options
 ~~~~~~~~~~~~~~~
@@ -393,6 +396,8 @@ Deprecated Options
   Helm) was deprecated, and it will be removed in version 1.13.
 * The ``probe`` option of ``kube-proxy-replacement`` was deprecated, and it will
   be removed in version 1.13.
+* ``k8s-api-server``: This option has been deprecated in favor of ``k8s-api-server-urls``
+  and will be removed in 1.13.
 
 Helm Options
 ~~~~~~~~~~~~
@@ -423,6 +428,8 @@ Helm Options
   container images are not scheduled on non-Linux nodes.
 * ``cluster.id`` cannot be empty and a value must be specified.
   Use the ``0`` value to leave Cluster Mesh disabled.
+* ``k8s.apiServerURLs`` has been introduced to specify multiple Kubernetes API
+  server instances for k8s client configuration.
 
 .. _1.11_upgrade_notes:
 

--- a/cilium/cmd/preflight_identity_crd_migrate.go
+++ b/cilium/cmd/preflight_identity_crd_migrate.go
@@ -181,7 +181,7 @@ func initK8s(ctx context.Context) (crdBackend allocator.Backend, crdAllocator *a
 	k8sClientQPSLimit := viper.GetFloat64(option.K8sClientQPSLimit)
 	k8sClientBurst := viper.GetInt(option.K8sClientBurst)
 
-	k8s.Configure(k8sAPIServer, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
+	k8s.Configure([]string{k8sAPIServer}, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
 
 	if err := k8s.Init(k8sconfig.NewDefaultConfiguration()); err != nil {
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")

--- a/cilium/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium/cmd/preflight_k8s_valid_cnp.go
@@ -56,7 +56,7 @@ func validateCNPs() error {
 	k8sClientQPSLimit := viper.GetFloat64(option.K8sClientQPSLimit)
 	k8sClientBurst := viper.GetInt(option.K8sClientBurst)
 
-	k8s.Configure(k8sAPIServer, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
+	k8s.Configure([]string{k8sAPIServer}, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
 
 	if err := k8s.Init(k8sconfig.NewDefaultConfiguration()); err != nil {
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -571,7 +571,7 @@ func runServer(cmd *cobra.Command) {
 	}).Info("Starting clustermesh-apiserver...")
 
 	if mockFile == "" {
-		k8s.Configure("", option.Config.K8sKubeConfigPath, 0.0, 0)
+		k8s.Configure([]string{}, option.Config.K8sKubeConfigPath, 0.0, 0)
 		if err := k8s.Init(k8sconfig.NewDefaultConfiguration()); err != nil {
 			log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 		}

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -182,7 +182,7 @@ func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
 	status := &models.DaemonConfigurationStatus{
 		Addressing:       node.GetNodeAddressing(),
 		K8sConfiguration: k8s.GetKubeconfigPath(),
-		K8sEndpoint:      k8s.GetAPIServerURL(),
+		K8sEndpoint:      k8s.GetAPIServerURLString(),
 		NodeMonitor:      d.monitorAgent.State(),
 		KvstoreConfiguration: &models.KVstoreConfiguration{
 			Type:    option.Config.KVStore,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -513,6 +513,8 @@ func initializeFlags() {
 
 	flags.String(option.K8sAPIServer, "", "Kubernetes API server URL")
 	option.BindEnv(option.K8sAPIServer)
+	flags.MarkDeprecated(option.K8sAPIServer,
+		fmt.Sprintf("This option is deprecated in favor of %s and will be removed in v1.13", option.K8sAPIServerURLs))
 
 	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
 	option.BindEnv(option.K8sKubeConfigPath)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1146,6 +1146,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableBGPControlPlane, false, "Enable the BGP control plane.")
 	option.BindEnv(option.EnableBGPControlPlane)
 
+	flags.StringSlice(option.K8sAPIServerURLs, []string{}, "List of URLs for Kubernetes API server instances")
+	option.BindEnv(option.K8sAPIServerURLs)
+
 	viper.BindPFlags(flags)
 }
 
@@ -1202,7 +1205,20 @@ func initEnv(cmd *cobra.Command) {
 	// Configure k8s as soon as possible so that k8s.IsEnabled() has the right
 	// behavior.
 	bootstrapStats.k8sInit.Start()
-	k8s.Configure(option.Config.K8sAPIServer, option.Config.K8sKubeConfigPath, defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
+	// The flag K8sAPIServerURLs takes precedence over K8sAPIServer.
+	if len(option.Config.K8sAPIServerURLs) > 0 {
+		k8s.Configure(
+			option.Config.K8sAPIServerURLs,
+			option.Config.K8sKubeConfigPath,
+			defaults.K8sClientQPSLimit,
+			defaults.K8sClientBurst)
+	} else {
+		k8s.Configure(
+			[]string{option.Config.K8sAPIServer},
+			option.Config.K8sKubeConfigPath,
+			defaults.K8sClientQPSLimit,
+			defaults.K8sClientBurst)
+	}
 	bootstrapStats.k8sInit.End(true)
 
 	for _, grp := range option.Config.DebugVerbose {

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -675,6 +675,9 @@ data:
 {{- if hasKey .Values.k8s "requireIPv6PodCIDR" }}
   k8s-require-ipv6-pod-cidr: {{ .Values.k8s.requireIPv6PodCIDR | quote }}
 {{- end }}
+{{- if hasKey .Values.k8s "apiServerURLs" }}
+  k8s-api-server-urls: {{ .Values.k8s.apiServerURLs | quote }}
+{{- end }}
 {{- if .Values.endpointStatus.enabled }}
   endpoint-status: {{ required "endpointStatus.status required: policy, health, controllers, logs and / or state. For 2 or more options use a comma: \"policy, health\"" .Values.endpointStatus.status | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1172,6 +1172,10 @@ k8s: {}
   # range via the Kubernetes node resource
   # requireIPv6PodCIDR: false
 
+  # -- A space separated list of Kubernetes API server URLs to use with the client.
+  # For example "https://192.168.0.1:6443 https://192.168.0.2:6443"
+  # apiServerURLs: ""
+
 # -- Keep the deprecated selector labels when deploying Cilium DaemonSet.
 keepDeprecatedLabels: false
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1169,6 +1169,10 @@ k8s: {}
   # range via the Kubernetes node resource
   # requireIPv6PodCIDR: false
 
+  # -- A space separated list of Kubernetes API server URLs to use with the client.
+  # For example "https://192.168.0.1:6443 https://192.168.0.2:6443"
+  # apiServerURLs: ""
+
 # -- Keep the deprecated selector labels when deploying Cilium DaemonSet.
 keepDeprecatedLabels: false
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -238,6 +238,9 @@ func init() {
 	flags.String(option.K8sAPIServer, "", "Kubernetes API server URL")
 	option.BindEnv(option.K8sAPIServer)
 
+	flags.StringSlice(option.K8sAPIServerURLs, []string{}, "List of URLs for Kubernetes API server instances")
+	option.BindEnv(option.K8sAPIServerURLs)
+
 	flags.Float32(option.K8sClientQPSLimit, defaults.K8sClientQPSLimit, "Queries per second limit for the K8s client")
 	flags.Int(option.K8sClientBurst, defaults.K8sClientBurst, "Burst value allowed for the K8s client")
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -237,6 +237,8 @@ func init() {
 
 	flags.String(option.K8sAPIServer, "", "Kubernetes API server URL")
 	option.BindEnv(option.K8sAPIServer)
+	flags.MarkDeprecated(option.K8sAPIServer,
+		fmt.Sprintf("This option is deprecated in favor of %s and will be removed in v1.13", option.K8sAPIServerURLs))
 
 	flags.StringSlice(option.K8sAPIServerURLs, []string{}, "List of URLs for Kubernetes API server instances")
 	option.BindEnv(option.K8sAPIServerURLs)

--- a/operator/main.go
+++ b/operator/main.go
@@ -138,7 +138,7 @@ func initEnv() {
 
 func initK8s(k8sInitDone chan struct{}) {
 	k8s.Configure(
-		option.Config.K8sAPIServer,
+		[]string{option.Config.K8sAPIServer},
 		option.Config.K8sKubeConfigPath,
 		float32(option.Config.K8sClientQPSLimit),
 		option.Config.K8sClientBurst,

--- a/operator/main.go
+++ b/operator/main.go
@@ -137,8 +137,16 @@ func initEnv() {
 }
 
 func initK8s(k8sInitDone chan struct{}) {
+	var apiServerURLs []string
+
+	if len(option.Config.K8sAPIServerURLs) > 0 {
+		apiServerURLs = option.Config.K8sAPIServerURLs
+	} else if option.Config.K8sAPIServer != "" {
+		apiServerURLs = []string{option.Config.K8sAPIServer}
+	}
+
 	k8s.Configure(
-		[]string{option.Config.K8sAPIServer},
+		apiServerURLs,
 		option.Config.K8sKubeConfigPath,
 		float32(option.Config.K8sClientQPSLimit),
 		option.Config.K8sClientBurst,

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -273,10 +273,10 @@ func runHeartbeat(heartBeat func(context.Context) error, timeout time.Duration, 
 			log.WithError(err).Warn("Network status error received, restarting client connections")
 
 			// Reinitialize clients if we have alternate API server addresses available.
-			// KubeconfigPath takes precedence over APIServerAddresses
+			// KubeconfigPath takes precedence over APIServerURLs
 			if config.KubeconfigPath == "" && len(config.APIServerURLs) > 1 {
 				RotateAPIServerURL()
-				log.WithField("address", config.APIServerURL).Info("Rotating Kubernetes API server URL for connection")
+				log.WithField("url", config.APIServerURL).Info("Rotating Kubernetes API server URL for client connections")
 			}
 
 			for _, fn := range closeAllConns {

--- a/pkg/k8s/cnp_test.go
+++ b/pkg/k8s/cnp_test.go
@@ -65,9 +65,9 @@ func (k *K8sIntegrationSuite) SetUpSuite(c *C) {
 	}
 	if os.Getenv("INTEGRATION") != "" {
 		if k8sConfigPath := os.Getenv("KUBECONFIG"); k8sConfigPath == "" {
-			Configure("", "/var/lib/cilium/cilium.kubeconfig", defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
+			Configure([]string{}, "/var/lib/cilium/cilium.kubeconfig", defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
 		} else {
-			Configure("", k8sConfigPath, defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
+			Configure([]string{}, k8sConfigPath, defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
 		}
 		restConfig, err := CreateConfig()
 		c.Assert(err, IsNil)

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -87,6 +87,18 @@ func RotateAPIServerURL() {
 	}
 }
 
+// CanRotateAPIServerURL returns true if we can Rotate the APIServer URL used
+// for client connections.
+// If Kubeconfig path is provided it takes precedence over api server addresses
+// for client configuration.
+func CanRotateAPIServerURL() bool {
+	if config.KubeconfigPath == "" && len(config.APIServerURLs) > 1 {
+		return true
+	}
+
+	return false
+}
+
 // GetKubeconfigPath returns the configured path to the kubeconfig
 // configuration file
 func GetKubeconfigPath() string {

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -5,10 +5,15 @@
 package k8s
 
 import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -19,7 +24,10 @@ var (
 
 type configuration struct {
 	// APIServerURL is the URL address of the API server
-	APIServerURL string
+	APIServerURL *url.URL
+
+	// APIServerURLs is the list of addresses for the API server instances
+	APIServerURLs []*url.URL
 
 	// KubeconfigPath is the local path to the kubeconfig configuration
 	// file on the filesystem
@@ -30,11 +38,53 @@ type configuration struct {
 
 	// Burst is the burst to pass to the kubernetes client configuration.
 	Burst int
+
+	lock.RWMutex
 }
 
-// GetAPIServerURL returns the configured API server URL address
-func GetAPIServerURL() string {
+// GetAPIServerURL returns the configured API server URL address.
+func GetAPIServerURL() *url.URL {
+	config.RLock()
+	defer config.RUnlock()
+
 	return config.APIServerURL
+}
+
+// GetAPIServerURLString returns the string representation of configured API server
+// address.
+func GetAPIServerURLString() string {
+	config.RLock()
+	defer config.RUnlock()
+
+	if config.APIServerURL == nil {
+		return ""
+	}
+	return config.APIServerURL.String()
+}
+
+// RotateAPIServerURL rotates the kubernetes API server URL used for clients.
+// This is used when the currently registered kubernetes API server instance
+// is not responding (failing heartbeat check).
+func RotateAPIServerURL() {
+	config.Lock()
+	defer config.Unlock()
+
+	if len(config.APIServerURLs) < 2 {
+		return
+	}
+
+	log.WithField("oldURL", config.APIServerURL.String()).Info("Rotating API server URL")
+	rand.Shuffle(len(config.APIServerURLs), func(i, j int) {
+		config.APIServerURLs[i], config.APIServerURLs[j] = config.APIServerURLs[j], config.APIServerURLs[i]
+	})
+
+	for _, apiServerURL := range config.APIServerURLs {
+		if apiServerURL.String() != config.APIServerURL.String() {
+			log.WithField("url", apiServerURL.String()).Info("Using new API server URL")
+			config.APIServerURL = apiServerURL
+			break
+		}
+	}
 }
 
 // GetKubeconfigPath returns the configured path to the kubeconfig
@@ -54,17 +104,42 @@ func GetBurst() int {
 }
 
 // Configure sets the parameters of the Kubernetes package
-func Configure(apiServerURL, kubeconfigPath string, qps float32, burst int) {
-	config.APIServerURL = apiServerURL
+func Configure(apiServerURLs []string, kubeconfigPath string, qps float32, burst int) {
+	config.APIServerURL = nil
+	config.APIServerURLs = []*url.URL{}
+
+	for _, apiServerURL := range apiServerURLs {
+		if len(apiServerURL) == 0 {
+			// Simply skip empty URLs in the list
+			continue
+		}
+
+		// Default to HTTP scheme for server address.
+		if !strings.HasPrefix(apiServerURL, "http") {
+			apiServerURL = fmt.Sprintf("http://%s", apiServerURL)
+		}
+
+		parsedUrl, err := url.ParseRequestURI(apiServerURL)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to parse APIServer URL %s, skipping", apiServerURL)
+			continue
+		}
+
+		if config.APIServerURL == nil {
+			config.APIServerURL = parsedUrl
+		} else {
+			// All the APIServer URLs should have the same schemes
+			// This is because we set up the client only once and then
+			// modify the host using http.RoundTripper
+			parsedUrl.Scheme = config.APIServerURL.Scheme
+		}
+
+		config.APIServerURLs = append(config.APIServerURLs, parsedUrl)
+	}
+
 	config.KubeconfigPath = kubeconfigPath
 	config.QPS = qps
 	config.Burst = burst
-
-	if IsEnabled() &&
-		config.APIServerURL != "" &&
-		!strings.HasPrefix(apiServerURL, "http") {
-		config.APIServerURL = "http://" + apiServerURL // default to HTTP
-	}
 }
 
 // IsEnabled checks if Cilium is being used in tandem with Kubernetes.
@@ -73,9 +148,24 @@ func IsEnabled() bool {
 		return false
 	}
 
-	return config.APIServerURL != "" ||
+	return config.APIServerURL != nil ||
 		config.KubeconfigPath != "" ||
 		(os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
 			os.Getenv("KUBERNETES_SERVICE_PORT") != "") ||
 		os.Getenv("K8S_NODE_NAME") != ""
+}
+
+type httpRoundTripper struct {
+	delegate http.RoundTripper
+}
+
+func (rt *httpRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Host = GetAPIServerURL().Host
+	return rt.delegate.RoundTrip(req)
+}
+
+func defaultHTTPRoundTripper(rt http.RoundTripper) http.RoundTripper {
+	return &httpRoundTripper{
+		delegate: rt,
+	}
 }

--- a/pkg/k8s/config_test.go
+++ b/pkg/k8s/config_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package k8s
+
+import (
+	"gopkg.in/check.v1"
+)
+
+func (s *K8sSuite) TestK8sPkgConfiguration(c *check.C) {
+	c.Assert(GetAPIServerURL(), check.IsNil)
+	c.Assert(config.APIServerURLs, check.HasLen, 0)
+
+	Configure([]string{"http://192.168.0.1"}, "/home/cilium/.kube/config", 100, 10)
+
+	c.Assert(GetAPIServerURLString(), check.Equals, "http://192.168.0.1")
+	c.Assert(config.APIServerURLs, check.HasLen, 1)
+	c.Assert(GetKubeconfigPath(), check.Equals, "/home/cilium/.kube/config")
+	c.Assert(GetBurst(), check.Equals, 10)
+	c.Assert(GetQPS(), check.Equals, float32(100))
+
+	config = configuration{}
+	Configure([]string{"192.168.0.1:6443"}, "", 100, 10)
+
+	c.Assert(GetAPIServerURLString(), check.Equals, "http://192.168.0.1:6443")
+	c.Assert(config.APIServerURLs, check.HasLen, 1)
+
+	config = configuration{}
+	Configure([]string{"http://192.168.0.1", "https://192.168.0.2", "https://192.168.0.3"}, "", 100, 10)
+
+	c.Assert(GetAPIServerURLString(), check.Equals, "http://192.168.0.1")
+	RotateAPIServerURL()
+	c.Assert(GetAPIServerURLString() != "http://192.168.0.1", check.Equals, true)
+	c.Assert(GetAPIServerURL().Scheme, check.Equals, "http")
+	c.Assert(config.APIServerURLs, check.HasLen, 3)
+
+	config = configuration{}
+	Configure([]string{"192.168.0.1:6443", "https://192.168.0.2:6443", " AAAA", ""}, "", 100, 10)
+
+	c.Assert(GetAPIServerURLString(), check.Equals, "http://192.168.0.1:6443")
+	RotateAPIServerURL()
+	c.Assert(GetAPIServerURLString(), check.Equals, "http://192.168.0.2:6443")
+	c.Assert(config.APIServerURLs, check.HasLen, 2)
+}

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -38,9 +38,9 @@ var _ = Suite(&K8sIntegrationSuite{})
 func (k *K8sIntegrationSuite) SetUpSuite(c *C) {
 	if os.Getenv("INTEGRATION") != "" {
 		if k8sConfigPath := os.Getenv("KUBECONFIG"); k8sConfigPath == "" {
-			k8s.Configure("", "/var/lib/cilium/cilium.kubeconfig", defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
+			k8s.Configure([]string{}, "/var/lib/cilium/cilium.kubeconfig", defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
 		} else {
-			k8s.Configure("", k8sConfigPath, defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
+			k8s.Configure([]string{}, k8sConfigPath, defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
 		}
 	}
 }

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -142,6 +142,13 @@ func Init(conf k8sconfig.Configuration) error {
 		return fmt.Errorf("unable to create k8s client rest configuration: %s", err)
 	}
 
+	// If the user provided multiple APIServer URLs modify the restConfig
+	// with a http.RoundTripper wrapper to get APIServer URL for every request
+	// from the configuration
+	if len(config.APIServerURLs) > 1 {
+		restConfig.Wrap(defaultHTTPRoundTripper)
+	}
+
 	defaultCloseAllConns := setDialer(restConfig)
 
 	// Use the same http client for all k8s connections. It does not matter that

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2439,10 +2439,10 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		if DoesNotRunOnGKE() {
 			nodeIP, err := kub.GetNodeIPByLabel(K8s1, false)
 			if err != nil {
-				return fmt.Errorf("Cannot retrieve Node IP for k8s1: %s", err)
+				return fmt.Errorf("cannot retrieve Node IP for k8s1: %s", err)
 			}
-			opts["k8sServiceHost"] = nodeIP
-			opts["k8sServicePort"] = "6443"
+
+			opts["k8s.apiServerURLs"] = fmt.Sprintf("https://%s:6443", nodeIP)
 		}
 
 		if RunsOn419OrLaterKernel() {


### PR DESCRIPTION
See commit message for detailed description

Introduce a new command line parameter(`--k8s-api-server-urls`) and helm option(`k8s.apiServerURLs`) to specify multiple k8s API server addresses for the client to use.

Fixes: #19038 

```release-note
Allow setting of multiple k8s API server URLs for client
```
