### PR TITLE
pkg/bpf: Include BPF map names during map creation

### DIFF
--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -19,7 +19,7 @@ import (
 var (
 	log          = logging.DefaultLogger.WithField(logfields.LogSubsys, "map-ep-policy")
 	MapName      = "cilium_ep_to_policy"
-	innerMapName = "ep-policy-inner-map"
+	innerMapName = "ep_policy_inner_map"
 )
 
 const (

--- a/pkg/maps/eppolicymap/eppolicymap_test.go
+++ b/pkg/maps/eppolicymap/eppolicymap_test.go
@@ -56,7 +56,7 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpoint(c *C) {
 	fd, err := bpf.CreateMap(bpf.MapTypeHash,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0,
-		"ep-policy-inner-map")
+		innerMapName)
 	c.Assert(err, IsNil)
 
 	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))
@@ -82,7 +82,7 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpointFails(c *C) {
 	_, err := bpf.CreateMap(bpf.MapTypeHash,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0,
-		"ep-policy-inner-map")
+		innerMapName)
 	c.Assert(err, IsNil)
 
 	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))
@@ -98,7 +98,7 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpointDisabled(c *C) {
 	fd, err := bpf.CreateMap(bpf.MapTypeHash,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0,
-		"ep-policy-inner-map")
+		innerMapName)
 	c.Assert(err, IsNil)
 
 	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))


### PR DESCRIPTION
See previous commit for preparing for the main commit below:

----

This commit passes the name of the map to the bpf() syscall on map
creation. This allows bpftool via `bpftool map show` to show the map
names along side the maps.

Before:
```
8623: lpm_trie  flags 0x1
        key 24B  value 12B  max_entries 512000  memlock 20480000B
```

After:
```
8417: lpm_trie  name cilium_ipcache  flags 0x1
        key 24B  value 12B  max_entries 512000  memlock 20480000B
```

Signed-off-by: Chris Tarazi <chris@isovalent.com>
