### PR TITLE
test: Add TS to each bash dbg output in L4LB

### DIFF
--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+PS4='+[\t] '
 set -eux
 
 IMG_OWNER=${1:-cilium}

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+PS4='+[\t] '
 set -eux
 
 IMG_OWNER=${1:-cilium}


### PR DESCRIPTION
This should help to debug why the L4LB suite is taking more than 30min
to run.

Example output:

    +[11:24:32] IMG_OWNER=cilium
    +[11:24:32] IMG_TAG=latest
    +[11:24:32] HELM_CHART_DIR=/vagrant/install/kubernetes/cilium
    +[11:24:32] kind create cluster --config kind-config.yaml
    ...