### PR TITLE
Don't unnecessarily calculate SHA256 over identity labels

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -567,15 +567,6 @@ func (e *Endpoint) HostInterface() string {
 	return e.ifName
 }
 
-// GetLabelsSHA returns the SHA of labels
-func (e *Endpoint) GetLabelsSHA() string {
-	if e.SecurityIdentity == nil {
-		return ""
-	}
-
-	return e.SecurityIdentity.GetLabelsSHA256()
-}
-
 // GetOpLabels returns the labels as slice
 func (e *Endpoint) GetOpLabels() []string {
 	e.unconditionalRLock()

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -50,7 +50,6 @@ type EndpointInfoSource interface {
 	GetIPv6Address() string
 	GetIdentity() identity.NumericIdentity
 	GetLabels() []string
-	GetLabelsSHA() string
 	HasSidecarProxy() bool
 	ConntrackName() string
 	ConntrackNameLocked() string

--- a/pkg/identity/model/identity.go
+++ b/pkg/identity/model/identity.go
@@ -33,9 +33,8 @@ func CreateModel(id *identity.Identity) *models.Identity {
 	}
 
 	ret := &models.Identity{
-		ID:           int64(id.ID),
-		Labels:       make([]string, 0, len(id.Labels)),
-		LabelsSHA256: id.GetLabelsSHA256(),
+		ID:     int64(id.ID),
+		Labels: make([]string, 0, len(id.Labels)),
 	}
 
 	for _, v := range id.Labels {

--- a/pkg/identity/reserved.go
+++ b/pkg/identity/reserved.go
@@ -20,8 +20,6 @@ var (
 // label into the map of reserved identity cache.
 func AddReservedIdentity(ni NumericIdentity, lbl string) {
 	identity := NewIdentity(ni, labels.Labels{lbl: labels.NewLabel(lbl, "", labels.LabelSourceReserved)})
-	// Pre-calculate the SHA256 hash.
-	identity.GetLabelsSHA256()
 	cacheMU.Lock()
 	reservedIdentityCache[ni] = identity
 	cacheMU.Unlock()
@@ -31,8 +29,6 @@ func AddReservedIdentity(ni NumericIdentity, lbl string) {
 // multiple labels.
 func AddReservedIdentityWithLabels(ni NumericIdentity, lbls labels.Labels) {
 	identity := NewIdentity(ni, lbls)
-	// Pre-calculate the SHA256 hash.
-	identity.GetLabelsSHA256()
 	cacheMU.Lock()
 	reservedIdentityCache[ni] = identity
 	cacheMU.Unlock()

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -5,7 +5,6 @@ package labels
 
 import (
 	"bytes"
-	"crypto/sha512"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -450,12 +449,6 @@ func (l Labels) Remove(from Labels) Labels {
 	return result
 }
 
-// SHA256Sum calculates l' internal SHA256Sum. For a particular set of labels is
-// guarantee that it will always have the same SHA256Sum.
-func (l Labels) SHA256Sum() string {
-	return fmt.Sprintf("%x", sha512.Sum512_256(l.SortedList()))
-}
-
 // FormatForKVStore returns the label as a formatted string, ending in
 // a semicolon
 //
@@ -464,8 +457,7 @@ func (l Labels) SHA256Sum() string {
 //
 // Non-pointer receiver allows this to be called on a value in a map.
 func (l Label) FormatForKVStore() []byte {
-	// We don't care if the values already have a '=' since this method is
-	// only used to calculate a SHA256Sum
+	// We don't care if the values already have a '='.
 	//
 	// We absolutely care that the final character is a semi-colon.
 	// Identity allocation in the kvstore depends on this (see

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -43,11 +43,6 @@ var (
 	DefaultLabelSourceKeyPrefix = LabelSourceAny + "."
 )
 
-func (s *LabelsSuite) TestSHA256Sum(c *C) {
-	str := lbls.SHA256Sum()
-	c.Assert(str, Equals, "cf51cc7e153a09e82b242f2f0fb2f0f3923d2742a9d84de8bb0de669e5e558e3")
-}
-
 func (s *LabelsSuite) TestSortMap(c *C) {
 	lblsString := strings.Join(lblsArray, ";")
 	lblsString += ";"

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -84,10 +84,6 @@ type EndpointInfo struct {
 
 	// Labels is the list of security relevant labels of the endpoint
 	Labels []string
-
-	// LabelsSHA256 is the hex encoded SHA-256 signature over the Labels
-	// slice, 64 characters in length
-	LabelsSHA256 string
 }
 
 // ServiceInfo contains information about the Kubernetes service

--- a/pkg/proxy/epinfo.go
+++ b/pkg/proxy/epinfo.go
@@ -77,6 +77,5 @@ func (r *endpointInfoRegistry) FillEndpointInfo(info *accesslog.EndpointInfo, ip
 	identity := Allocator.LookupIdentityByID(context.TODO(), id)
 	if identity != nil {
 		info.Labels = identity.Labels.GetModel()
-		info.LabelsSHA256 = identity.GetLabelsSHA256()
 	}
 }

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -19,7 +19,6 @@ type EndpointInfoSource interface {
 	GetIPv6Address() string
 	GetIdentityLocked() identity.NumericIdentity
 	GetLabels() []string
-	GetLabelsSHA() string
 	HasSidecarProxy() bool
 	// ConntrackName assumes that the caller has *not* acquired any mutexes
 	// that may be associated with this EndpointInfoSource. It is (unfortunately)
@@ -60,6 +59,5 @@ type EndpointInfoRegistry interface {
 	//  - info.IPv6           (if 'ip' is not IPv4)
 	//  - info.Identity       (defaults to WORLD if not known)
 	//  - info.Labels         (only if identity is found)
-	//  - info.LabelsSHA256   (only if identity is found)
 	FillEndpointInfo(info *accesslog.EndpointInfo, ip net.IP, id identity.NumericIdentity)
 }

--- a/pkg/proxy/logger/test/epinfo.go
+++ b/pkg/proxy/logger/test/epinfo.go
@@ -8,7 +8,6 @@ package test
 import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
@@ -34,12 +33,9 @@ func (m *ProxyUpdaterMock) GetEgressPolicyEnabledLocked() bool            { retu
 func (m *ProxyUpdaterMock) GetIngressPolicyEnabledLocked() bool           { return true }
 func (m *ProxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity   { return m.Identity }
 func (m *ProxyUpdaterMock) GetNamedPortLocked(bool, string, uint8) uint16 { return 0 }
-func (m *ProxyUpdaterMock) GetLabelsSHA() string {
-	return labels.NewLabelsFromModel(m.Labels).SHA256Sum()
-}
-func (m *ProxyUpdaterMock) HasSidecarProxy() bool       { return m.SidecarProxy }
-func (m *ProxyUpdaterMock) ConntrackName() string       { return m.ConntrackNameLocked() }
-func (m *ProxyUpdaterMock) ConntrackNameLocked() string { return "global" }
+func (m *ProxyUpdaterMock) HasSidecarProxy() bool                         { return m.SidecarProxy }
+func (m *ProxyUpdaterMock) ConntrackName() string                         { return m.ConntrackNameLocked() }
+func (m *ProxyUpdaterMock) ConntrackNameLocked() string                   { return "global" }
 
 func (m *ProxyUpdaterMock) OnProxyPolicyUpdate(policyRevision uint64) {}
 func (m *ProxyUpdaterMock) UpdateProxyStatistics(l4Protocol string, port uint16, ingress, request bool,

--- a/test/k8s/cli.go
+++ b/test/k8s/cli.go
@@ -40,7 +40,6 @@ var _ = Describe("K8sCLI", func() {
 			const (
 				manifestYAML = "test-cli.yaml"
 				fooID        = "foo"
-				fooSHA       = "c97de9490c28e929fd143f1988deba185345aab2a3a171fabcb8a0d03db68240"
 				fooNode      = "k8s1"
 				// These labels are automatically added to all pods in the default namespace.
 				defaultLabels = "k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default " +
@@ -77,15 +76,6 @@ var _ = Describe("K8sCLI", func() {
 			AfterAll(func() {
 				_ = kubectl.Delete(cliManifest)
 				ExpectAllPodsTerminated(kubectl)
-			})
-
-			It("Test labelsSHA256", func() {
-				cmd := fmt.Sprintf("cilium identity get %d -o json", identity)
-				res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, cmd)
-				res.ExpectSuccess()
-				out, err := res.Filter("{[0].labelsSHA256}")
-				Expect(err).Should(BeNil(), "Error getting SHA from identity")
-				Expect(out.String()).Should(Equal(fooSHA))
 			})
 
 			It("Test identity list", func() {


### PR DESCRIPTION
The methods generating identity labels' SHA256 show up high in certain
CPU profiles when generating Hubble flows. It turns out, the SHA256
value isn't actually used anywhere in the code anymore.

Thus drop the SHA256 calcuation and related fields/methods to speed up
identity lookup, e.g. when generating Hubble flows.

See individual commit messages for details.

```release-note
Speed up identity lookup in Hubble and L7 proxy by no longer calculating SHA256 over labels.
```