### PR TITLE
contrib/vagrant: add more permissive firewall rule

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -330,9 +330,7 @@ Vagrant.configure(2) do |config|
     config.vm.synced_folder cilium_dir, cilium_path, type: "nfs", nfs_udp: false
     # Don't forget to enable this ports on your host before starting the VM
     # in order to have nfs working
-    # iptables -I INPUT -p tcp -s 192.168.61.0/24 --dport 111 -j ACCEPT
-    # iptables -I INPUT -p tcp -s 192.168.61.0/24 --dport 2049 -j ACCEPT
-    # iptables -I INPUT -p tcp -s 192.168.61.0/24 --dport 20048 -j ACCEPT
+    # iptables -I INPUT -s 192.168.61.0/24 -j ACCEPT"
     # if using nftables, in Fedora (with firewalld), use:
     # nft -f ./contrib/vagrant/nftables.rules
 

--- a/contrib/vagrant/nftables.rules
+++ b/contrib/vagrant/nftables.rules
@@ -1,3 +1,1 @@
-insert rule inet firewalld filter_IN_public_allow ip saddr 192.168.61.0/24 tcp dport 20048 ct state { 0x8, 0x40 } accept
-insert rule inet firewalld filter_IN_public_allow ip saddr 192.168.61.0/24 tcp dport 2049 ct state { 0x8, 0x40 } accept
-insert rule inet firewalld filter_IN_public_allow ip saddr 192.168.61.0/24 tcp dport 111 ct state { 0x8, 0x40 } accept
+insert rule inet firewalld filter_IN_public_allow ip saddr 192.168.61.0/24 counter accept

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -441,9 +441,7 @@ function set_vagrant_env(){
     export 'FIRST_IP_SUFFIX_NFS'="${ipv4_array[3]}"
     echo "# NFS enabled. don't forget to enable these ports on your host"
     echo "# before starting the VMs in order to have nfs working"
-    echo "# iptables -I INPUT -p tcp -s ${IPV4_BASE_ADDR_NFS}0/24 --dport 111 -j ACCEPT"
-    echo "# iptables -I INPUT -p tcp -s ${IPV4_BASE_ADDR_NFS}0/24 --dport 2049 -j ACCEPT"
-    echo "# iptables -I INPUT -p tcp -s ${IPV4_BASE_ADDR_NFS}0/24 --dport 20048 -j ACCEPT"
+    echo "# iptables -I INPUT -s ${IPV4_BASE_ADDR_NFS}0/24 -j ACCEPT"
 
     echo "# To use kubectl on the host, you need to add the following route:"
     echo "# ip route add $MASTER_IPV4 via $MASTER_IPV4_NFS"


### PR DESCRIPTION
It seems that nfs started to perform requests on random destination
ports. Thus we should use a more permissive firewall rule that accepts
any traffic from the network assigned to development VMs.

Signed-off-by: André Martins <andre@cilium.io>