### PR TITLE
iptables: fix typo in addProxyRule condition

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -702,7 +702,7 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 	scanner := bufio.NewScanner(strings.NewReader(rules))
 	for scanner.Scan() {
 		rule := scanner.Text()
-		if !strings.Contains(rule, "-A CILIUM_PRE_mangle ") || strings.Contains(rule, "cilium: TPROXY to host "+name) || !strings.Contains(rule, portMatch) {
+		if !strings.Contains(rule, "-A CILIUM_PRE_mangle ") || !strings.Contains(rule, "cilium: TPROXY to host "+name) || strings.Contains(rule, portMatch) {
 			continue
 		}
 


### PR DESCRIPTION
In d812b925de ("iptables: don't ignore errors") we introduced a typo in
the logic used to select old proxy rules in addProxyRules:

    -               if strings.Contains(rule, "-A CILIUM_PRE_mangle ") && strings.Contains(rule, "cilium: TPROXY to host "+name) && !strings.Contains(rule, portMatch) {
    +               if strings.Contains(rule, "-A CILIUM_PRE_mangle ") && !strings.Contains(rule, "cilium: TPROXY to host "+name) && strings.Contains(rule, portMatch) {

Then later on, in c61038bff4 ("iptables: invert conditions to simplify logic"),
assuming the condition was correct, we just inverted it:

    -               if strings.Contains(rule, "-A CILIUM_PRE_mangle ") && !strings.Contains(rule, "cilium: TPROXY to host "+name) && strings.Contains(rule, portMatch) {
    +               if !strings.Contains(rule, "-A CILIUM_PRE_mangle ") || strings.Contains(rule, "cilium: TPROXY to host "+name) || !strings.Contains(rule, portMatch) {

The correct condition to use should be the initial one, inverted:

    if !strings.Contains(rule, "-A CILIUM_PRE_mangle ") || !strings.Contains(rule, "cilium: TPROXY to host "+name) || strings.Contains(rule, portMatch) {

Fixes: #19693 