### PR TITLE
Fix conflicting routes for multiple ENIs in IPAM mode

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -19,6 +19,7 @@ import (
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -193,6 +194,22 @@ func (d *Daemon) allocateRouterIPv6(family types.NodeAddressingFamily) (net.IP, 
 	}
 }
 
+// Coalesce CIDRS when allocating the DatapathIPs and healthIPs. GH #18868
+func coalesceCIDRs(rCIDRs []string) (result []string) {
+	cidrs := make([]*net.IPNet, 0, len(rCIDRs))
+	for _, k := range rCIDRs {
+		ip, mask, _ := net.ParseCIDR(k)
+		cidrs = append(cidrs, &net.IPNet{IP: ip, Mask: mask.Mask})
+	}
+	ipv4cidr, ipv6cidr := iputil.CoalesceCIDRs(cidrs)
+	combinedcidrs := append(ipv4cidr, ipv6cidr...)
+	result = make([]string, len(combinedcidrs))
+	for i, k := range combinedcidrs {
+		result[i] = k.String()
+	}
+	return
+}
+
 func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerIP net.IP, err error) {
 	// Blacklist allocation of the external IP
 	d.ipam.BlacklistIP(family.PrimaryExternal(), "node-ip")
@@ -240,6 +257,10 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerI
 		node.SetRouterInfo(routingInfo)
 	}
 
+	// Coalescing multiple CIDRs. GH #18868
+	if result != nil && len(result.CIDRs) > 0 {
+		result.CIDRs = coalesceCIDRs(result.CIDRs)
+	}
 	return
 }
 
@@ -250,6 +271,11 @@ func (d *Daemon) allocateHealthIPs() error {
 			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "health")
 			if err != nil {
 				return fmt.Errorf("unable to allocate health IPs: %s, see https://cilium.link/ipam-range-full", err)
+			}
+
+			// Coalescing multiple CIDRs. GH #18868
+			if result != nil && len(result.CIDRs) > 0 {
+				result.CIDRs = coalesceCIDRs(result.CIDRs)
 			}
 
 			log.Debugf("IPv4 health endpoint address: %s", result.IP)
@@ -274,6 +300,11 @@ func (d *Daemon) allocateHealthIPs() error {
 					node.SetEndpointHealthIPv4(nil)
 				}
 				return fmt.Errorf("unable to allocate health IPs: %s, see https://cilium.link/ipam-range-full", err)
+			}
+
+			// Coalescing multiple CIDRs. GH #18868
+			if result != nil && len(result.CIDRs) > 0 {
+				result.CIDRs = coalesceCIDRs(result.CIDRs)
 			}
 
 			node.SetEndpointHealthIPv6(result.IP)

--- a/daemon/cmd/ipam_test.go
+++ b/daemon/cmd/ipam_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestCoalesceCIDRs(t *testing.T) {
+	CIDR := []string{"10.0.0.0/8"}
+	expectedCIDR := []string{"10.0.0.0/8"}
+	newCIDR := coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"10.105.0.0/16", "10.0.0.0/8"}
+	expectedCIDR = []string{"10.0.0.0/8"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"10.105.0.0/16", "10.104.0.0/19", "10.0.0.0/8"}
+	expectedCIDR = []string{"10.0.0.0/8"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
+	expectedCIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
+	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8", "f00d::a0f:0:0:0/96"}
+	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"f00d::a0f:0:0:0/96", "10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
+	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"f00d::a0f:0:0:0/96"}
+	expectedCIDR = []string{"f00d::a0f:0:0:0/96"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -163,6 +164,17 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing types.NodeAddressi
 		IP:   nodeAddressing.IPv4().Router(),
 		Mask: net.CIDRMask(32, 32),
 	}
+
+	cidrs2 := make([]*net.IPNet, 0, 0)
+	for i := range cidrs {
+		cidrs2 = append(cidrs2, &cidrs[i])
+	}
+	resultcidr, _ := iputil.CoalesceCIDRs(cidrs2)
+	cidrs = make([]net.IPNet, 0, len(resultcidr))
+	for _, cidr := range resultcidr {
+		cidrs = append(cidrs, *cidr)
+	}
+
 	for _, cidr := range cidrs {
 		if err = linuxrouting.SetupRules(&routerIP, &cidr, info.GetMac().String(), info.GetInterfaceNumber()); err != nil {
 			return nil, fmt.Errorf("unable to install ip rule for cilium_host: %w", err)


### PR DESCRIPTION
Discovered during investigation of #18868

See comment https://github.com/cilium/cilium/issues/18868#issuecomment-1077682444 of #18868 for more details on the conflicting routes for health endpoints that are left behind during restarts.

In particular we see that the health endpoint gets 2 routes associated with it. When the pod restarts it leaves one route behind, which results in a routing conflict and AWS dropping the packet when the IP is then reused for a real workload pod.

Our idea in solving this is to coalesce the 2 or more CIDR ranges into one.

Cheers,
@dezmodue
@recollir

Signed-off-by: Simone Sciarrati <s.sciarrati@gmail.com>
Signed-off-by: Federico Hernandez <f@ederi.co>
