### PR TITLE
Move NodeManager over to asynchronous IPCache API 

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -4,6 +4,7 @@
 package ipcache
 
 import (
+	"errors"
 	"net"
 	"net/netip"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache/types"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -424,6 +426,27 @@ func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
 	ipc.RLock()
 	ipc.DumpToListenerLocked(listener)
 	ipc.RUnlock()
+}
+
+// UpsertIdentity is currently unused. The idea is that this API will interface
+// with the IPCache.metadata to associate the identity with the prefix, causing
+// the identity determination to be overruled based on the source here, but
+// still merge all of the other metadata from the IPCache.metadata map like the
+// encrypt key.
+//
+// TODO: Do we need the host for this identity? Seems kinda like it.
+func (ipc *IPCache) UpsertIdentity(addr netip.Addr, hostIP net.IP, id Identity, src source.Source, resource types.ResourceID, aux ...IPMetadata) (bool, error) {
+	// TODO: It would be nice to make this play nice with InjectLabels()
+	// to ensure proper identity allocation/release when different
+	// identities are associated with a particular prefix.
+	// Could we get away with making this asynchronous too?
+	// Also store/merge info like encrypt keys, k8sMeta in ipc.metadata?
+	return false, errors.New("not implemented")
+}
+
+func (ipc *IPCache) RemoveIdentity(addr netip.Addr, resource types.ResourceID) error {
+	// TODO: Implement
+	return errors.New("not implemented")
 }
 
 // UpsertMetadata upserts a given IP and some corresponding information into

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -270,6 +270,11 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 	ipc.mutex.Lock()
 	defer ipc.mutex.Unlock()
 	for p, id := range entriesToReplace {
+		// TODO: We should be able to store & restore this info from
+		// the prefixInfo structure so that there isn't this weird
+		// split where some ipcache updates come through the metadata
+		// side and merge with other relevant info while other updates
+		// come down directly to the IPCache.Upsert codepath.
 		prefix := p.String()
 		hIP, key := ipc.getHostIPCache(prefix)
 		meta := ipc.getK8sMetadata(prefix)

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -6,7 +6,9 @@ package ipcache
 import (
 	"github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/sirupsen/logrus"
 )
 
 // prefixInfo holds all of the information (labels, etc.) about a given prefix
@@ -20,8 +22,10 @@ type prefixInfo map[types.ResourceID]*resourceInfo
 // value that indicates that it should be ignored for purposes of merging
 // multiple resourceInfo across multiple ResourceIDs together.
 type resourceInfo struct {
-	labels labels.Labels
-	source source.Source
+	labels     labels.Labels
+	EncryptKey *types.EncryptKey
+	TunnelPeer types.TunnelPeer
+	source     source.Source
 }
 
 // IPMetadata is an empty interface intended to inform developers using the
@@ -43,6 +47,10 @@ func (m *resourceInfo) merge(info IPMetadata, src source.Source) {
 		l := labels.NewLabelsFromModel(nil)
 		l.MergeLabels(info)
 		m.labels = l
+	case types.EncryptKey:
+		m.EncryptKey = &info
+	case types.TunnelPeer:
+		m.TunnelPeer = info
 	default:
 		log.Errorf("BUG: Invalid IPMetadata passed to ipinfo.merge(): %+v", info)
 		return
@@ -55,6 +63,10 @@ func (m *resourceInfo) unmerge(info IPMetadata) {
 	switch info.(type) {
 	case labels.Labels:
 		m.labels = nil
+	case types.EncryptKey:
+		m.EncryptKey = nil
+	case types.TunnelPeer:
+		m.TunnelPeer = ""
 	default:
 		log.Errorf("BUG: Invalid IPMetadata passed to ipinfo.unmerge(): %+v", info)
 		return
@@ -62,7 +74,16 @@ func (m *resourceInfo) unmerge(info IPMetadata) {
 }
 
 func (m *resourceInfo) isValid() bool {
-	return m.labels != nil
+	if m.labels != nil {
+		return true
+	}
+	if m.EncryptKey != nil {
+		return true
+	}
+	if m.TunnelPeer != "" {
+		return true
+	}
+	return false
 }
 
 func (s prefixInfo) isValid() bool {
@@ -90,4 +111,51 @@ func (s prefixInfo) Source() source.Source {
 		}
 	}
 	return src
+}
+
+func (s prefixInfo) EncryptKey(prefix string) uint8 {
+	var (
+		key         types.EncryptKey
+		keyResource types.ResourceID
+	)
+	for resource, v := range s {
+		if v.EncryptKey != nil {
+			if key != types.EncryptKey(0) {
+				log.WithFields(logrus.Fields{
+					logfields.CIDR:                prefix,
+					logfields.Key:                 key,
+					logfields.Resource:            keyResource,
+					logfields.ConflictingKey:      *v.EncryptKey,
+					logfields.ConflictingResource: resource,
+				}).Warning("Detected conflicting encrypt-key for prefix")
+			}
+			key = *v.EncryptKey
+			keyResource = resource
+		}
+	}
+	return uint8(key)
+}
+
+func (s prefixInfo) TunnelPeer(prefix string) string {
+	var (
+		peer         types.TunnelPeer
+		peerResource types.ResourceID
+	)
+	for resource, v := range s {
+		if v.TunnelPeer != "" {
+			if peer != "" {
+				log.WithFields(logrus.Fields{
+					logfields.CIDR:                prefix,
+					logfields.Key:                 peer,
+					logfields.Resource:            peerResource,
+					logfields.ConflictingKey:      *v.EncryptKey,
+					logfields.ConflictingResource: resource,
+				}).Warning("Detected conflicting encrypt-key for prefix")
+			}
+			peer = v.TunnelPeer
+			peerResource = resource
+			break
+		}
+	}
+	return string(peer)
 }

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -55,3 +55,6 @@ func NewResourceID(kind ResourceKind, namespace, name string) ResourceID {
 	str.WriteString(name)
 	return ResourceID(str.String())
 }
+
+type EncryptKey uint8
+type TunnelPeer string

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -375,6 +375,9 @@ const (
 	// Resource is a resource
 	Resource = "resource"
 
+	// ConflictingResource is a resource that conflicts with 'Resource'
+	ConflictingResource = "conflicting-resource"
+
 	// Route is a L2 or L3 Linux route
 	Route = "route"
 
@@ -513,6 +516,10 @@ const (
 
 	// Key is the identity of the encryption key
 	Key = "key"
+
+	// ConflictingKey is the identity of the encryption key that conflicts
+	// with 'Key'.
+	ConflictingKey = "conflicting-key"
 
 	// URL represents a Uniform Resource Locator.
 	URL = "url"

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/node/addressing"
@@ -42,6 +43,7 @@ func ParseCiliumNode(n *ciliumv2.CiliumNode) (node Node) {
 		Cluster:         option.Config.ClusterName,
 		ClusterID:       option.Config.ClusterID,
 		Source:          source.CustomResource,
+		ResourceID:      ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name),
 		Labels:          n.ObjectMeta.Labels,
 		NodeIdentity:    uint32(n.Spec.NodeIdentity),
 		WireguardPubKey: n.ObjectMeta.Annotations[annotation.WireguardPubKey],
@@ -220,6 +222,9 @@ type Node struct {
 
 	// Source is the source where the node configuration was generated / created.
 	Source source.Source
+
+	// ResourceID is the identifier for this resource in Kubernetes.
+	ResourceID ipcacheTypes.ResourceID
 
 	// Key index used for transparent encryption or 0 for no encryption
 	EncryptionKey uint8


### PR DESCRIPTION
Meta: https://github.com/cilium/cilium/issues/21142

Depends on https://github.com/cilium/cilium/pull/19765

A few WIP notes:
* NodeManager expects to complete the IPCache push to then trigger
  updates to datapath routes, encrypt state, etc.; New interface doesn't
  provide this guarantee.
* There's a bit of weirdness in how IPCache just accepts random numeric
  identities as input, meaning that another node could tell us what its
  identity is but we don't yet know what that identity means(!). How
  should we handle this? Seems like something we could route through the
  ipcache to defer until we understand what it means & resolve policy
  etc....
* Should 'hostIP' for a (pod / node) ipcache entry be part of 'aux'?
* We could probably fold Identity source info with encryptKey/tunnel key
  / etc. when generating ipcache entries. Would require making identity
  ipcache updates async though. But maybe that's where we should go
  anyway.