### PR TITLE
cilium: make error message, not segfault

### DIFF
--- a/cilium/cmd/bpf_mountfs_show.go
+++ b/cilium/cmd/bpf_mountfs_show.go
@@ -43,6 +43,9 @@ func getbpfmountFS(cmd *cobra.Command, args []string) {
 			break
 		}
 	}
+	if bpfmountDetail == nil {
+		Fatalf("No BPF filesystems are mounted")
+	}
 	if command.OutputOption() {
 		if err := command.PrintOutput(bpfmountDetail); err != nil {
 			os.Exit(1)


### PR DESCRIPTION
In (a rare) case when there is no BPF filesystem mounted the cilium client will
segfault on an attempt to display filesystem information:

    # cilium bpf fs show
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xbeef000]
    ...

This patch fixes this case and now the client will just print an error message:

    # cilium bpf fs show
    Error: No BPF filesystems are mounted

Signed-off-by: Anton Protopopov <aspsk@isovalent.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
