### PR TITLE
ipam: Shutdown retry trigger on node deletion

### DIFF
--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -329,12 +329,16 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 // Kubernetes apiserver
 func (n *NodeManager) Delete(nodeName string) {
 	n.mutex.Lock()
+
 	if node, ok := n.nodes[nodeName]; ok {
 		if node.poolMaintainer != nil {
 			node.poolMaintainer.Shutdown()
 		}
 		if node.k8sSync != nil {
 			node.k8sSync.Shutdown()
+		}
+		if node.retry != nil {
+			node.retry.Shutdown()
 		}
 	}
 


### PR DESCRIPTION
Like all the other triggers that are a part of Node, add shutdown for
the missing `retry` trigger.

Found via code inspection.

Fixes: b5c5ca9b63c ("eni/azure: Don't perform mutating operations while
instances API is unstable")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
