### PR TITLE
ci: Increase retention for release image CI artifacts to 10 days

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -105,7 +105,7 @@ jobs:
         with:
           name: image-digest ${{ matrix.name }}
           path: image-digest
-          retention-days: 1
+          retention-days: 10
 
       - name: Send slack notification
         if: ${{ !success() && (github.event_name == 'schedule' || github.event_name == 'push') }}
@@ -159,7 +159,7 @@ jobs:
         with:
           name: image-digest-output.txt-${{ steps.tag.outputs.tag }}
           path: image-digest-output.txt
-          retention-days: 1
+          retention-days: 10
 
       # Upload artifact digests
       - name: Upload artifact digests
@@ -167,4 +167,4 @@ jobs:
         with:
           name: Makefile.digests-${{ steps.tag.outputs.tag }}
           path: Makefile.digests
-          retention-days: 1
+          retention-days: 10


### PR DESCRIPTION
Sometimes it takes longer than a day to complete the release process.
These files are very small, so retaining them for 10 days should not
be a problem.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>