### PR TITLE
datapath: Fix error propagation in bpf_lxc.

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -598,8 +598,7 @@ TAIL_CT_LOOKUP6(CILIUM_CALL_IPV6_CT_EGRESS, tail_ipv6_ct_egress, CT_EGRESS,
 		is_defined(ENABLE_PER_PACKET_LB),
 		CILIUM_CALL_IPV6_FROM_LXC_CONT, tail_handle_ipv6_cont)
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_LXC)
-int tail_handle_ipv6(struct __ctx_buff *ctx)
+static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -683,6 +682,17 @@ skip_service_lookup:
 
 	invoke_tailcall_if(is_defined(ENABLE_PER_PACKET_LB),
 			   CILIUM_CALL_IPV6_CT_EGRESS, tail_ipv6_ct_egress);
+	return ret;
+}
+
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_LXC)
+int tail_handle_ipv6(struct __ctx_buff *ctx)
+{
+	int ret = __tail_handle_ipv6(ctx);
+
+	if (IS_ERR(ret))
+		return send_drop_notify_error(ctx, SECLABEL, ret,
+		    CTX_ACT_DROP, METRIC_EGRESS);
 	return ret;
 }
 #endif /* ENABLE_IPV6 */
@@ -1160,8 +1170,7 @@ TAIL_CT_LOOKUP4(CILIUM_CALL_IPV4_CT_EGRESS, tail_ipv4_ct_egress, CT_EGRESS,
 		is_defined(ENABLE_PER_PACKET_LB),
 		CILIUM_CALL_IPV4_FROM_LXC_CONT, tail_handle_ipv4_cont)
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_FROM_LXC)
-int tail_handle_ipv4(struct __ctx_buff *ctx)
+static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	struct iphdr *ip4;
@@ -1231,6 +1240,17 @@ skip_service_lookup:
 
 	invoke_tailcall_if(is_defined(ENABLE_PER_PACKET_LB),
 			   CILIUM_CALL_IPV4_CT_EGRESS, tail_ipv4_ct_egress);
+	return ret;
+}
+
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_FROM_LXC)
+int tail_handle_ipv4(struct __ctx_buff *ctx)
+{
+	int ret = __tail_handle_ipv4(ctx);
+
+	if (IS_ERR(ret))
+		return send_drop_notify_error(ctx, SECLABEL, ret,
+		    CTX_ACT_DROP, METRIC_EGRESS);
 	return ret;
 }
 


### PR DESCRIPTION
handle_tail_ipv[4|6] both directly return raw error codes, but since
they are tail calls, they should be calling send_drop_notify() prior to
returning these error codes to translate to the appropriate drop return
code.

This was introduced as part of a refactor in
7575ba03ccaa5038255c8c1e5c31a8011ed9aaa1.

Fixes #20143

Signed-off-by: Harsh Modi <harshmodi@google.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

```release-note
Fix error propagation in bpf_lxc
```
