### PR TITLE
daemon: Prevent endpoint-routes and tunneling

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1449,8 +1449,16 @@ func initEnv(cmd *cobra.Command) {
 		option.Config.EncryptInterface = append(option.Config.EncryptInterface, link)
 	}
 
-	if option.Config.TunnelingEnabled() && option.Config.EnableAutoDirectRouting {
-		log.Fatalf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName)
+	if option.Config.TunnelingEnabled() {
+		if option.Config.EnableAutoDirectRouting {
+			log.Fatalf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName)
+		}
+		if option.Config.EnableEndpointRoutes {
+			log.WithFields(logrus.Fields{
+				logfields.URL:  "https://github.com/cilium/cilium/issues/14955",
+				logfields.Hint: fmt.Sprintf("Disable %s", option.EnableEndpointRoutes),
+			}).Fatalf("%s cannot be used with tunneling.", option.EnableEndpointRoutes)
+		}
 	}
 
 	initClockSourceOption()


### PR DESCRIPTION
Tunneling mode hasn't been fully figured out with endpoint-routes mode,
which results in various issues like applying policy twice on traffic
coming into a node or other weird problems. Prevent users from
configuring this option for now until we resolve those issues.

Ref: https://github.com/cilium/cilium/issues/16446
Ref: https://github.com/cilium/cilium/issues/14657
Ref: https://github.com/cilium/cilium/issues/14955