### PR TITLE
v1.10 backports 2022-06-10

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:45453a483bc91e03c6bacdbaf
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:9c0d933166ba192713f9e2fc3901f788557286ee@sha256:943f1f522bdfcb1ca3fe951bd8186c41b970afa254096513ae6e0e0efda1a10d as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:3b70fad0b9514720f33db82841907821202c1f02@sha256:8cca16ce66a0960a207cbf518ee2e0d923ae2a49207b154cdc37c2d95f583180 as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
* #20142 -- envoy: Bump cilium envoy to latest version v1.21.3 (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20142; do contrib/backporting/set-labels.py $pr done 1.10; done
```