### PR TITLE
test: Bump L4LB timeout from 30min to 45min

### DIFF
--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -123,7 +123,7 @@ jobs:
       github.event_name == 'pull_request'
     # We need nested virtualisation which is supported only by MacOS runner
     runs-on: macos-10.15
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Set up job variables
         id: vars


### PR DESCRIPTION
From time to time it takes longer to run the tests. After adding
timestamps to each cmd, I don't see any discrepancies. I.e., all cmds
execution time is reasonable.

There is no need to bump the v1.1{0,1} actions' timeout, as they don't
run NAT46x64 test suite which is timing out.