### PR TITLE
Change default prometheus ports to new reserved Cilium ports

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -163,7 +163,7 @@ jobs:
           cd $HOME
           cilium_pod=$(kubectl -n kube-system get po -o name --field-selector=status.phase==Running -l 'k8s-app=cilium' -o jsonpath='{.items[0].metadata.name}' )
           kubectl -n kube-system exec $cilium_pod -- sh -c "apt update && apt install curl -y"
-          kubectl -n kube-system exec $cilium_pod -- curl http://localhost:9090/metrics > metrics.prom
+          kubectl -n kube-system exec $cilium_pod -- curl http://localhost:9962/metrics > metrics.prom
           # Install promtool binary release. `go install` doesn't work due to
           # https://github.com/prometheus/prometheus/issues/8852 and related issues.
           curl -sSL --remote-name-all https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/{prometheus-${PROM_VERSION}.linux-amd64.tar.gz,sha256sums.txt}

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -232,7 +232,7 @@ cilium-agent [flags]
       --preallocate-bpf-maps                                    Enable BPF map pre-allocation (default true)
       --prepend-iptables-chains                                 Prepend custom iptables chains instead of appending (default true)
       --procfs string                                           Root's proc filesystem path (default "/proc")
-      --prometheus-serve-addr string                            IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --prometheus-serve-addr string                            IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off) (default ":9962")
       --proxy-connect-timeout uint                              Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
       --proxy-gid uint                                          Group ID for proxy control plane sockets. (default 1337)
       --proxy-max-connection-duration-seconds int               Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -62,7 +62,7 @@ cilium-operator-alibabacloud [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
       --pprof-port int                            Port that the pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -67,7 +67,7 @@ cilium-operator-aws [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
       --pprof-port int                            Port that the pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -65,7 +65,7 @@ cilium-operator-azure [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
       --pprof-port int                            Port that the pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -61,7 +61,7 @@ cilium-operator-generic [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
       --pprof-port int                            Port that the pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -72,7 +72,7 @@ cilium-operator [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
-      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":6942")
+      --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pprof                                     Enable pprof debugging endpoint
       --pprof-port int                            Port that the pprof listens on (default 6061)

--- a/Documentation/gettingstarted/grafana.rst
+++ b/Documentation/gettingstarted/grafana.rst
@@ -46,8 +46,8 @@ Deploy Cilium and Hubble with metrics enabled
 =============================================
 
 *Cilium*, *Hubble*, and *Cilium Operator* do not expose metrics by
-default. Enabling metrics for these services will open ports ``9090``, ``9091``,
-and ``6942`` respectively on all nodes of your cluster where these components
+default. Enabling metrics for these services will open ports ``9962``, ``9965``,
+and ``9963`` respectively on all nodes of your cluster where these components
 are running.
 
 The metrics for Cilium, Hubble, and Cilium Operator can all be enabled
@@ -100,9 +100,9 @@ Expose the port on your local machine
 
 .. code-block:: shell-session
 
-    kubectl -n cilium-monitoring port-forward service/prometheus --address 0.0.0.0 --address :: 9090:9090
+    kubectl -n cilium-monitoring port-forward service/prometheus --address 0.0.0.0 --address :: 9962:9962
 
-Access it via your browser: http://localhost:9090
+Access it via your browser: http://localhost:9962
 
 Examples
 ========

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -672,7 +672,7 @@
    * - hubble.metrics
      - Hubble metrics configuration. See https://docs.cilium.io/en/stable/operations/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics.
      - object
-     - ``{"enabled":null,"port":9091,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}``
+     - ``{"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}``
    * - hubble.metrics.enabled
      - Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:   enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http You can specify the list of metrics from the helm CLI:   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
      - string
@@ -680,7 +680,7 @@
    * - hubble.metrics.port
      - Configure the port the hubble metric server listens on.
      - int
-     - ``9091``
+     - ``9965``
    * - hubble.metrics.serviceAnnotations
      - Annotations to be added to hubble-metrics service.
      - object
@@ -1312,7 +1312,7 @@
    * - operator.prometheus
      - Enable prometheus metrics for cilium-operator on the configured port at /metrics
      - object
-     - ``{"enabled":false,"port":6942,"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}``
+     - ``{"enabled":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}``
    * - operator.prometheus.serviceMonitor.annotations
      - Annotations to add to ServiceMonitor cilium-operator
      - object
@@ -1464,7 +1464,7 @@
    * - prometheus
      - Configure prometheus metrics on the configured port at /metrics
      - object
-     - ``{"enabled":false,"metrics":null,"port":9090,"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}``
+     - ``{"enabled":false,"metrics":null,"port":9962,"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}``
    * - prometheus.metrics
      - Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar). ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics
      - string
@@ -1484,7 +1484,7 @@
    * - proxy
      - Configure Istio proxy options.
      - object
-     - ``{"prometheus":{"enabled":true,"port":"9095"},"sidecarImageRegex":"cilium/istio_proxy"}``
+     - ``{"prometheus":{"enabled":true,"port":"9964"},"sidecarImageRegex":"cilium/istio_proxy"}``
    * - proxy.sidecarImageRegex
      - Regular expression matching compatible Istio sidecar istio-proxy container image names
      - string

--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -56,7 +56,7 @@ annotations. They can be used to signal Prometheus whether to scrape metrics:
 .. code-block:: yaml
 
         prometheus.io/scrape: true
-        prometheus.io/port: 9090
+        prometheus.io/port: 9962
 
 To collect Envoy metrics the Cilium chart will create a Kubernetes headless
 service named ``cilium-agent`` with the ``prometheus.io/scrape:'true'`` annotation set:
@@ -64,7 +64,7 @@ service named ``cilium-agent`` with the ``prometheus.io/scrape:'true'`` annotati
 .. code-block:: yaml
 
         prometheus.io/scrape: true
-        prometheus.io/port: 9095
+        prometheus.io/port: 9964
 
 This additional headless service in addition to the other Cilium components is needed
 as each component can only have one Prometheus scrape and port annotation.
@@ -127,7 +127,7 @@ with the ``prometheus.io/scrape:'true'`` annotation set:
 .. code-block:: yaml
 
         prometheus.io/scrape: true
-        prometheus.io/port: 9091
+        prometheus.io/port: 9965
 
 Set the following options in the ``scrape_configs`` section of Prometheus to
 have it scrape all Hubble metrics from the endpoints automatically:
@@ -181,7 +181,7 @@ Configuration
 
 To expose any metrics, invoke ``cilium-agent`` with the
 ``--prometheus-serve-addr`` option. This option takes a ``IP:Port`` pair but
-passing an empty IP (e.g. ``:9090``) will bind the server to all available
+passing an empty IP (e.g. ``:9962``) will bind the server to all available
 interfaces (there is usually only one in a container).
 
 Exported Metrics
@@ -435,7 +435,7 @@ Configuration
 
 ``cilium-operator`` can be configured to serve metrics by running with the
 option ``--enable-metrics``.  By default, the operator will expose metrics on
-port 6942, the port can be changed with the option
+port 9963, the port can be changed with the option
 ``--operator-prometheus-serve-addr``.
 
 Exported Metrics
@@ -471,7 +471,7 @@ Hubble metrics are served by a Hubble instance running inside ``cilium-agent``.
 The command-line options to configure them are ``--enable-hubble``,
 ``--hubble-metrics-server``, and ``--hubble-metrics``.
 ``--hubble-metrics-server`` takes an ``IP:Port`` pair, but
-passing an empty IP (e.g. ``:9091``) will bind the server to all available
+passing an empty IP (e.g. ``:9965``) will bind the server to all available
 interfaces. ``--hubble-metrics`` takes a comma-separated list of metrics.
 
 Some metrics can take additional semicolon-separated options per metric, e.g.

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -373,13 +373,14 @@ Port Range / Protocol    Description
 6060/tcp                 cilium-agent pprof server (listening on 127.0.0.1)
 6061/tcp                 cilium-operator pprof server (listening on 127.0.0.1)
 6062/tcp                 Hubble Relay pprof server (listening on 127.0.0.1)
-6942/tcp                 operator Prometheus metrics
-9090/tcp                 cilium-agent Prometheus metrics
 9879/tcp                 cilium-agent health status API (listening on 127.0.0.1 and/or ::1)
 9890/tcp                 cilium-agent gops server (listening on 127.0.0.1)
 9891/tcp                 operator gops server (listening on 127.0.0.1)
 9892/tcp                 clustermesh-apiserver gops server (listening on 127.0.0.1)
 9893/tcp                 Hubble Relay gops server (listening on 127.0.0.1)
+9962/tcp                 cilium-agent Prometheus metrics
+9963/tcp                 cilium-operator Prometheus metrics
+9964/tcp                 cilium-proxy Prometheus metrics
 51871/udp                WireGuard encryption tunnel endpoint
 ======================== ==================================================================
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -322,6 +322,22 @@ Annotations:
   ``reserved:remote-node``. The change might impact those who have a network policy
   allowing access to the service from inside the cluster, and the policy was used
   to allow access from outside.
+* The default metrics exporter ports have changed to reserved ports in the
+  `Prometheus project <https://github.com/prometheus/prometheus/wiki/Default-port-allocations>`__.
+
+  +-----------------------+-----------------------+-------------------------+
+  | Exporter              | Default port          | Default port            |
+  |                       | Cilium <= v1.11       | Cilium >= v1.12         |
+  +=======================+=======================+=========================+
+  | Cilium Agent          |  9090                 | 9962                    |
+  +-----------------------+-----------------------+-------------------------+
+  | Cilium Operator       |  6942                 | 9963                    |
+  +-----------------------+-----------------------+-------------------------+
+  | Cilium Proxy          |  9095                 | 9964                    |
+  +-----------------------+-----------------------+-------------------------+
+  | Hubble                |  9091                 | 9965                    |
+  +-----------------------+-----------------------+-------------------------+
+  
 
 New Options
 ~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -833,7 +833,7 @@ func initializeFlags() {
 	// The second environment variable (without the CILIUM_ prefix) is here to
 	// handle the case where someone uses a new image with an older spec, and the
 	// older spec used the older variable name.
-	flags.String(option.PrometheusServeAddr, "", "IP:Port on which to serve prometheus metrics (pass \":Port\" to bind on all interfaces, \"\" is off)")
+	flags.String(option.PrometheusServeAddr, ":9962", "IP:Port on which to serve prometheus metrics (pass \":Port\" to bind on all interfaces, \"\" is off)")
 	option.BindEnvWithLegacyEnvFallback(option.PrometheusServeAddr, "PROMETHEUS_SERVE_ADDR")
 
 	flags.Int(option.CTMapEntriesGlobalTCPName, option.CTMapEntriesGlobalTCPDefault, "Maximum number of entries in TCP CT table")

--- a/examples/kubernetes/addons/prometheus/README.md
+++ b/examples/kubernetes/addons/prometheus/README.md
@@ -11,10 +11,10 @@ The default installation contains:
 ## Enable Metrics in Cilium & Cilium-operator
 
 Enable prometheus metrics on all Cilium agents, be aware this will open the
-port `9090` in all nodes of your cluster where a cilium-agent is running.
+port `9962` in all nodes of your cluster where a cilium-agent is running.
 
 ```
-$ kubectl patch -n kube-system configmap cilium-config --type merge --patch '{"data":{"prometheus-serve-addr":":9090"}}'
+$ kubectl patch -n kube-system configmap cilium-config --type merge --patch '{"data":{"prometheus-serve-addr":":9962"}}'
 configmap/cilium-config patched
 ```
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -218,9 +218,9 @@ contributors across the globe, there is almost always someone available to help.
 | hostServices.protocols | string | `"tcp,udp"` | Supported list of protocols to apply ClusterIP translation to. |
 | hubble.enabled | bool | `true` | Enable Hubble (true by default). |
 | hubble.listenAddress | string | `":4244"` | An additional address for Hubble to listen to. Set this field ":4244" if you are enabling Hubble Relay, as it assumes that Hubble is listening on port 4244. |
-| hubble.metrics | object | `{"enabled":null,"port":9091,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/operations/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
+| hubble.metrics | object | `{"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/operations/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
 | hubble.metrics.enabled | string | `nil` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:   enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http You can specify the list of metrics from the helm CLI:   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}" |
-| hubble.metrics.port | int | `9091` | Configure the port the hubble metric server listens on. |
+| hubble.metrics.port | int | `9965` | Configure the port the hubble metric server listens on. |
 | hubble.metrics.serviceAnnotations | object | `{}` | Annotations to be added to hubble-metrics service. |
 | hubble.metrics.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble |
 | hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
@@ -378,7 +378,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | operator.podLabels | object | `{}` | Labels to be added to cilium-operator pods |
 | operator.priorityClassName | string | `""` | The priority class to use for cilium-operator |
-| operator.prometheus | object | `{"enabled":false,"port":6942,"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
+| operator.prometheus | object | `{"enabled":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
 | operator.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-operator |
 | operator.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | operator.prometheus.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor cilium-operator |
@@ -416,12 +416,12 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.updateStrategy | object | `{"type":"RollingUpdate"}` | preflight update strategy |
 | preflight.validateCNPs | bool | `true` | By default we should always validate the installed CNPs before upgrading Cilium. This will make sure the user will have the policies deployed in the cluster with the right schema. |
 | priorityClassName | string | `""` | The priority class to use for cilium-agent. |
-| prometheus | object | `{"enabled":false,"metrics":null,"port":9090,"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}` | Configure prometheus metrics on the configured port at /metrics |
+| prometheus | object | `{"enabled":false,"metrics":null,"port":9962,"serviceMonitor":{"annotations":{},"enabled":false,"labels":{}}}` | Configure prometheus metrics on the configured port at /metrics |
 | prometheus.metrics | string | `nil` | Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar). ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics |
 | prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-agent |
 | prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | prometheus.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor cilium-agent |
-| proxy | object | `{"prometheus":{"enabled":true,"port":"9095"},"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
+| proxy | object | `{"prometheus":{"enabled":true,"port":"9964"},"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
 | proxy.sidecarImageRegex | string | `"cilium/istio_proxy"` | Regular expression matching compatible Istio sidecar istio-proxy container image names |
 | rbac.create | bool | `true` | Enable creation of Resource-Based Access Control configuration. |
 | readinessProbe.failureThreshold | int | `3` | failure threshold of readiness probe |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -165,7 +165,7 @@ data:
   # NOTE that this will open the port on ALL nodes where Cilium pods are
   # scheduled.
   prometheus-serve-addr: ":{{ .Values.prometheus.port }}"
-  # Port to expose Envoy metrics (e.g. "9095"). Envoy metrics listener will be disabled if this
+  # Port to expose Envoy metrics (e.g. "9964"). Envoy metrics listener will be disabled if this
   # field is not set.
   {{- if .Values.proxy.prometheus.enabled }}
   proxy-prometheus-port: "{{ .Values.proxy.prometheus.port }}"

--- a/install/kubernetes/cilium/templates/cilium-operator/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/service.yaml
@@ -12,7 +12,7 @@ spec:
   type: ClusterIP
   ports:
   - name: metrics
-    port: 6942
+    port: 9963
     protocol: TCP
     targetPort: prometheus
   selector:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -671,7 +671,7 @@ hubble:
     #
     enabled: ~
     # -- Configure the port the hubble metric server listens on.
-    port: 9091
+    port: 9965
     # -- Annotations to be added to hubble-metrics service.
     serviceAnnotations: {}
     serviceMonitor:
@@ -1304,7 +1304,7 @@ pprof:
 # -- Configure prometheus metrics on the configured port at /metrics
 prometheus:
   enabled: false
-  port: 9090
+  port: 9962
   serviceMonitor:
     # -- Enable service monitors.
     # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
@@ -1326,7 +1326,7 @@ prometheus:
 proxy:
   prometheus:
     enabled: true
-    port: "9095"
+    port: "9964"
   # -- Regular expression matching compatible Istio sidecar istio-proxy
   # container image names
   sidecarImageRegex: "cilium/istio_proxy"
@@ -1616,7 +1616,7 @@ operator:
   # /metrics
   prometheus:
     enabled: false
-    port: 6942
+    port: 9963
     serviceMonitor:
       # -- Enable service monitors.
       # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -668,7 +668,7 @@ hubble:
     #
     enabled: ~
     # -- Configure the port the hubble metric server listens on.
-    port: 9091
+    port: 9965
     # -- Annotations to be added to hubble-metrics service.
     serviceAnnotations: {}
     serviceMonitor:
@@ -1301,7 +1301,7 @@ pprof:
 # -- Configure prometheus metrics on the configured port at /metrics
 prometheus:
   enabled: false
-  port: 9090
+  port: 9962
   serviceMonitor:
     # -- Enable service monitors.
     # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
@@ -1323,7 +1323,7 @@ prometheus:
 proxy:
   prometheus:
     enabled: true
-    port: "9095"
+    port: "9964"
   # -- Regular expression matching compatible Istio sidecar istio-proxy
   # container image names
   sidecarImageRegex: "cilium/istio_proxy"
@@ -1613,7 +1613,7 @@ operator:
   # /metrics
   prometheus:
     enabled: false
-    port: 6942
+    port: 9963
     serviceMonitor:
       # -- Enable service monitors.
       # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -22,7 +22,7 @@ const (
 	EndpointGCIntervalDefault = 5 * time.Minute
 
 	// PrometheusServeAddr is the default server address for operator metrics
-	PrometheusServeAddr = ":6942"
+	PrometheusServeAddr = ":9963"
 
 	// CESMaxCEPsInCESDefault is the maximum number of cilium endpoints allowed in a CES
 	CESMaxCEPsInCESDefault = 100

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -72,7 +72,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 	log.Debug("started Envoy")
 
 	log.Debug("adding metrics listener")
-	xdsServer.AddMetricsListener(9095, s.waitGroup)
+	xdsServer.AddMetricsListener(9964, s.waitGroup)
 
 	err = s.waitForProxyCompletion()
 	c.Assert(err, IsNil)

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -42,7 +42,7 @@ var _ = Describe("K8sHubbleTest", func() {
 			app1Service    = "app1-service"
 			app1Labels     = "id=app1,zgroup=testapp"
 			apps           = []string{helpers.App1, helpers.App2, helpers.App3}
-			prometheusPort = "9091"
+			prometheusPort = "9965"
 
 			namespaceForTest string
 			appPods          map[string]string


### PR DESCRIPTION
Cilium currently have 4 different prometheus exporters.
Cilium-agent, Cilium-operator, Cilium-proxy, and hubble. None of the
exporters ports have reserved ports in the prometheus docs and can
collision with other exporters by using the default ports.

The ports in this PR has been reserved: https://github.com/prometheus/prometheus/wiki/Default-port-allocations
Search look for Cilium and Hubble.

Signed-off-by: Karsten Nielsen <karsten.nielsen@ingka.ikea.com>
