### PR TITLE
nodediscovery: ensure we cache the nodeResource 

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -341,8 +341,8 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 	ciliumClient := k8s.CiliumClient()
 
 	performGet := true
+	var nodeResource *ciliumv2.CiliumNode
 	for retryCount := 0; retryCount < maxRetryCount; retryCount++ {
-		var nodeResource *ciliumv2.CiliumNode
 		performUpdate := true
 		if performGet {
 			var err error


### PR DESCRIPTION


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

When retrying we have to explicitly use the previously fetched
nodeResource in case we want to skip fetching it. Otherwise we end up
with a null pointer exception.

Fixes: 91e68c207308 ("nodediscovery: ensure instanceID is not empty")
Signed-off-by: Odin Ugedal <ougedal@palantir.com>

---

Found this when testing the ipsec key rotation work by @jibi

```
2022-06-10 11:45:25.633
Loading IPsec keyfile
subsys: "ipsec"
file-path: "/etc/ipsec/keys"

2022-06-10 11:45:25.634
Creating or updating CiliumNode resource
node: "ip-10-0-2-6.ec2.internal"
subsys: "nodediscovery"

2022-06-10 11:45:55.642
Unable to mutate nodeResource
subsys: "nodediscovery"
retryCount: "0"
error: "failed to fetch Kubernetes Node resource: Get "[https://10.100.0.1:443/api/v1/nodes/ip-10-0-2-6.ec2.internal](https://10.100.0.1/api/v1/nodes/ip-10-0-2-6.ec2.internal)": dial tcp 10.100.0.1:443: i/o timeout"

2022-06-10 11:45:55.644
/go/src/github.com/cilium/cilium/pkg/datapath/linux/ipsec/ipsec_linux.go:732 +0x105
created by github.com/cilium/cilium/pkg/datapath/linux/ipsec.StartKeyfileWatcher
panic: runtime error: invalid memory address or nil pointer dereference
/go/src/github.com/cilium/cilium/pkg/datapath/linux/ipsec/ipsec_linux.go:713 +0x3eb
github.com/cilium/cilium/pkg/datapath/linux/ipsec.keyfileWatcher(0x2ba1dc0, 0xc000366c80, 0xc001ce2ff0, 0xc0001ca930, 0xf, 0xc000ef2b00, 0x2bc05c0, 0xc000d601e0)
github.com/cilium/cilium/pkg/nodediscovery.(*NodeDiscovery).UpdateCiliumNodeResource(0xc000ef2b00)
/go/src/github.com/cilium/cilium/pkg/nodediscovery/nodediscovery.go:389 +0x3d
github.com/cilium/cilium/pkg/nodediscovery.(*NodeDiscovery).mutateNodeResource(0xc000ef2b00, 0x0, 0xc00541cff0, 0x1)
/go/src/github.com/cilium/cilium/pkg/nodediscovery/nodediscovery.go:300 +0x7d
goroutine 961 [running]:
github.com/cilium/cilium/pkg/nodediscovery.(*NodeDiscovery).UpdateLocalNode(0xc000ef2b00)
/go/src/github.com/cilium/cilium/pkg/nodediscovery/nodediscovery.go:291 +0x5a
github.com/cilium/cilium/pkg/nodediscovery.(*NodeDiscovery).updateLocalNode(0xc000ef2b00)
/go/src/github.com/cilium/cilium/pkg/nodediscovery/nodediscovery.go:348 +0x230
```

Fixes: #issue-number

```release-note
nodediscovery: ensure we cache the nodeResource correctly to avoid null pointer dereferencing
```
