### PR TITLE
Enables ICMP network policy function by default

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -731,6 +731,61 @@ ports other than port 80.
 
         .. literalinclude:: ../../examples/policies/l4/cidr_l4_combined.json
 
+Limit ICMP/ICMPv6 types
+-----------------------
+
+ICMP policy can be specified in addition to layer 3 policies or independently.
+It restricts the ability of an endpoint to emit and/or receive packets on a
+particular ICMP/ICMPv6 type (currently ICMP/ICMPv6 code is not supported).
+If any ICMP policy is specified, layer 4 and ICMP communication will be blocked
+unless it's related to a connection that is otherwise allowed by the policy.
+
+ICMP policy can be specified at both ingress and egress using the
+``icmps`` field. The ``icmps`` field takes a ``ICMPField`` structure
+which is defined as follows:
+
+.. code-block:: go
+
+        // ICMPField is a ICMP field.
+        type ICMPField struct {
+        	// Family is a IP address version.
+        	// Currently, we support `IPv4` and `IPv6`.
+        	// `IPv4` is set as default.
+        	//
+        	// +default=IPv4
+        	// +optional
+        	Family string `json:"family,omitempty"`
+
+        	// Type is a ICMP-type.
+        	// It should be 0-255 (8bit).
+        	Type uint8 `json:"type"`
+        }
+
+Example (ICMP/ICMPv6)
+~~~~~~~~~~~~~~~~~~~~~
+
+The following rule limits all endpoints with the label ``app=myService`` to
+only be able to emit packets using ICMP with type 8 and ICMPv6 with type 128,
+to any layer 3 destination:
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/l4/icmp.yaml
+           :language: yaml
+
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../examples/policies/l4/icmp.json
+           :language: json
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/l4/icmp.json
+           :language: json
+
 
 
 .. _l7_policy:

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1094,7 +1094,7 @@ func initializeFlags() {
 	flags.IntSlice(option.VLANBPFBypass, []int{}, "List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs")
 	option.BindEnv(option.VLANBPFBypass)
 
-	flags.Bool(option.EnableICMPRules, false, "Enable ICMP-based rule support for Cilium Network Policies")
+	flags.Bool(option.EnableICMPRules, true, "Enable ICMP-based rule support for Cilium Network Policies")
 	flags.MarkHidden(option.EnableICMPRules)
 	option.BindEnv(option.EnableICMPRules)
 

--- a/examples/policies/l4/icmp.json
+++ b/examples/policies/l4/icmp.json
@@ -1,0 +1,10 @@
+[{
+  "labels": [{"key": "name", "value": "icmp-rule"}],
+  "endpointSelector": {"matchLabels":{"app":"myService"}},
+  "egress": [{
+    "icmps": [
+      {"fields":[ {"type": 8, "family": "IPv4"}]},
+      {"fields":[ {"type": 128, "family": "IPv6"}]}
+    ]
+  }]
+}]

--- a/examples/policies/l4/icmp.yaml
+++ b/examples/policies/l4/icmp.yaml
@@ -1,0 +1,15 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "icmp-rule"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: myService
+  egress:
+  - icmps:
+    - fields:
+      - type: 8
+        family: IPv4
+      - type: 128
+        family: IPv6

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -452,7 +452,7 @@ const (
 	ExternalClusterIP = false
 
 	// EnableICMPRules enables ICMP-based rule support for Cilium Network Policies.
-	EnableICMPRules = false
+	EnableICMPRules = true
 
 	// TunnelPortVXLAN is the default VXLAN port
 	TunnelPortVXLAN = 8472

--- a/test/k8s/manifests/icmp-policy-deny.yaml
+++ b/test/k8s/manifests/icmp-policy-deny.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "icmp-policy-deny"
+spec:
+  description: "ICMP policy deny"
+  endpointSelector:
+    matchLabels:
+      id: app1
+  ingressDeny:
+  - fromEndpoints:
+    - matchLabels:
+        id: app2
+    icmps:
+    - fields:
+      - type: 8

--- a/test/k8s/manifests/icmp-policy.yaml
+++ b/test/k8s/manifests/icmp-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "icmp-policy"
+spec:
+  description: "ICMP policy"
+  endpointSelector:
+    matchLabels:
+      id: app1
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        id: app2
+    icmps:
+    - fields:
+      - type: 8

--- a/test/k8s/manifests/icmp6-policy-deny.yaml
+++ b/test/k8s/manifests/icmp6-policy-deny.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "icmp6-policy-deny"
+spec:
+  description: "ICMPv6 policy deny"
+  endpointSelector:
+    matchLabels:
+      id: app1
+  ingressDeny:
+  - fromEndpoints:
+    - matchLabels:
+        id: app2
+    icmps:
+    - fields:
+      - type: 128
+        family: IPv6

--- a/test/k8s/manifests/icmp6-policy.yaml
+++ b/test/k8s/manifests/icmp6-policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "icmp6-policy"
+spec:
+  description: "ICMPv6 policy"
+  endpointSelector:
+    matchLabels:
+      id: app1
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        id: app2
+    icmps:
+    - fields:
+      - type: 128
+        family: IPv6


### PR DESCRIPTION
resolves: #14609

Previously, ICMP network policy function is disabled by default because of kernel complexity issue (https://github.com/cilium/cilium/pull/16516).
However, currently this issue is resolved, and this PR makes ICMP policy function is enabled by default.
Also this PR contains e2e tests and documents for ICMP rules .


