### PR TITLE
bgp: Check the Condition.Ready field when adding ready endpoints

### DIFF
--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -423,16 +423,25 @@ func convertEndpointSliceV1(in *slim_discover_v1.EndpointSlice) *metallbspr.Endp
 	}
 	out := new(metallbspr.Endpoints)
 	for _, ep := range in.Endpoints {
-		for _, addr := range ep.Addresses {
-			out.Ready = append(out.Ready, metallbspr.Endpoint{
-				IP:       addr,
-				NodeName: ep.NodeName,
-			})
+		if isConditionReadyForSliceV1(ep.Conditions) {
+			for _, addr := range ep.Addresses {
+				out.Ready = append(out.Ready, metallbspr.Endpoint{
+					IP:       addr,
+					NodeName: ep.NodeName,
+				})
+			}
 		}
 		// See above comment in convertEndpoints() for why we only append
 		// "ready" endpoints.
 	}
 	return out
+}
+
+func isConditionReadyForSliceV1(conditions slim_discover_v1.EndpointConditions) bool {
+	if conditions.Ready == nil {
+		return true
+	}
+	return *conditions.Ready
 }
 
 func convertEndpointSliceV1Beta1(in *slim_discover_v1beta1.EndpointSlice) *metallbspr.Endpoints {
@@ -441,16 +450,25 @@ func convertEndpointSliceV1Beta1(in *slim_discover_v1beta1.EndpointSlice) *metal
 	}
 	out := new(metallbspr.Endpoints)
 	for _, ep := range in.Endpoints {
-		for _, addr := range ep.Addresses {
-			out.Ready = append(out.Ready, metallbspr.Endpoint{
-				IP:       addr,
-				NodeName: ep.NodeName,
-			})
+		if isConditionReadyForSliceV1Beta1(ep.Conditions) {
+			for _, addr := range ep.Addresses {
+				out.Ready = append(out.Ready, metallbspr.Endpoint{
+					IP:       addr,
+					NodeName: ep.NodeName,
+				})
+			}
 		}
 		// See above comment in convertEndpoints() for why we only append
 		// "ready" endpoints.
 	}
 	return out
+}
+
+func isConditionReadyForSliceV1Beta1(conditions slim_discover_v1beta1.EndpointConditions) bool {
+	if conditions.Ready == nil {
+		return true
+	}
+	return *conditions.Ready
 }
 
 // nodeLabels copies the provided labels and returns


### PR DESCRIPTION
This PR fixes the issue that MetalLB doesn't withdraw the route advertisements to the node where any healthy local endpoint exists for the service with externalTrafficPolicy is Local when the backend pod is terminating. Cilium takes endpoint.Conditions.Ready field into account when it determines whether to announce the route.


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #19810
