### PR TITLE
#19693 v1.11 backport

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -972,7 +972,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	// iptables rules can be updated only after d.init() intializes the iptables above.
-	err = d.updateDNSDatapathRules()
+	err = d.updateDNSDatapathRules(d.ctx)
 	if err != nil {
 		log.WithError(err).Error("error encountered while updating DNS datapath rules.")
 		return nil, restoredEndpoints, fmt.Errorf("error encountered while updating DNS datapath rules: %w", err)

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -366,8 +366,8 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 // updateDNSDatapathRules updates the DNS proxy iptables rules. Must be
 // called after iptables has been initailized, and only after
 // successful bootstrapFQDN().
-func (d *Daemon) updateDNSDatapathRules() error {
-	return d.l7Proxy.AckProxyPort(policy.ParserTypeDNS, false)
+func (d *Daemon) updateDNSDatapathRules(ctx context.Context) error {
+	return d.l7Proxy.AckProxyPort(ctx, policy.ParserTypeDNS, false)
 }
 
 // updateSelectors propagates the mapping of FQDNSelector to identity, as well

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -57,7 +57,7 @@ func (f *fakeDatapath) WriteEndpointConfig(io.Writer, datapath.EndpointConfigura
 	return nil
 }
 
-func (f *fakeDatapath) InstallProxyRules(uint16, bool, string) error {
+func (f *fakeDatapath) InstallProxyRules(context.Context, uint16, bool, string) error {
 	return nil
 }
 
@@ -65,7 +65,7 @@ func (f *fakeDatapath) SupportsOriginalSourceAddr() bool {
 	return false
 }
 
-func (f *fakeDatapath) InstallRules(ifName string, quiet, install bool) error {
+func (f *fakeDatapath) InstallRules(ctx context.Context, ifName string, quiet, install bool) error {
 	return nil
 }
 

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -122,13 +122,13 @@ func (c *customChain) doAdd(prog iptablesInterface) error {
 	return nil
 }
 
-func (c *customChain) add() error {
-	if option.Config.EnableIPv4 {
+func (c *customChain) add(ipv4, ipv6 bool) error {
+	if ipv4 {
 		if err := c.doAdd(ip4tables); err != nil {
 			return err
 		}
 	}
-	if option.Config.EnableIPv6 && c.ipv6 == true {
+	if ipv6 && c.ipv6 {
 		if err := c.doAdd(ip6tables); err != nil {
 			return err
 		}
@@ -154,13 +154,13 @@ func (c *customChain) doRename(prog iptablesInterface, newName string) error {
 	return nil
 }
 
-func (c *customChain) rename(name string) error {
-	if option.Config.EnableIPv4 {
+func (c *customChain) rename(ipv4, ipv6 bool, name string) error {
+	if ipv4 {
 		if err := c.doRename(ip4tables, name); err != nil {
 			return err
 		}
 	}
-	if option.Config.EnableIPv6 && c.ipv6 {
+	if ipv6 && c.ipv6 {
 		if err := c.doRename(ip6tables, name); err != nil {
 			return nil
 		}
@@ -193,13 +193,13 @@ func (c *customChain) doRemove(prog iptablesInterface) error {
 	return nil
 }
 
-func (c *customChain) remove() error {
-	if option.Config.EnableIPv4 {
+func (c *customChain) remove(ipv4, ipv6 bool) error {
+	if ipv4 {
 		if err := c.doRemove(ip4tables); err != nil {
 			return err
 		}
 	}
-	if option.Config.EnableIPv6 && c.ipv6 {
+	if ipv6 && c.ipv6 {
 		if err := c.doRemove(ip6tables); err != nil {
 			return err
 		}
@@ -234,14 +234,14 @@ func (c *customChain) doInstallFeeder(prog iptablesInterface, feedArgs string) e
 	return nil
 }
 
-func (c *customChain) installFeeder() error {
+func (c *customChain) installFeeder(ipv4, ipv6 bool) error {
 	for _, feedArgs := range c.feederArgs {
-		if option.Config.EnableIPv4 {
+		if ipv4 {
 			if err := c.doInstallFeeder(ip4tables, feedArgs); err != nil {
 				return err
 			}
 		}
-		if option.Config.EnableIPv6 && c.ipv6 == true {
+		if ipv6 && c.ipv6 == true {
 			if err := c.doInstallFeeder(ip6tables, feedArgs); err != nil {
 				return err
 			}

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptables
+
+import (
+	"github.com/mattn/go-shellwords"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type customChain struct {
+	name       string
+	table      string
+	hook       string
+	feederArgs []string
+	ipv6       bool // ip6tables chain in addition to iptables chain
+}
+
+// ciliumChains is the list of custom iptables chain used by Cilium. Custom
+// chains are used to allow for simple replacements of all rules.
+//
+// WARNING: If you change or remove any of the feeder rules you have to ensure
+// that the old feeder rules is also removed on agent start, otherwise,
+// flushing and removing the custom chains will fail.
+var ciliumChains = []customChain{
+	{
+		name:       ciliumInputChain,
+		table:      "filter",
+		hook:       "INPUT",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumOutputChain,
+		table:      "filter",
+		hook:       "OUTPUT",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumOutputRawChain,
+		table:      "raw",
+		hook:       "OUTPUT",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumPostNatChain,
+		table:      "nat",
+		hook:       "POSTROUTING",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumOutputNatChain,
+		table:      "nat",
+		hook:       "OUTPUT",
+		feederArgs: []string{""},
+	},
+	{
+		name:       ciliumPreNatChain,
+		table:      "nat",
+		hook:       "PREROUTING",
+		feederArgs: []string{""},
+	},
+	{
+		name:       ciliumPostMangleChain,
+		table:      "mangle",
+		hook:       "POSTROUTING",
+		feederArgs: []string{""},
+	},
+	{
+		name:       ciliumPreMangleChain,
+		table:      "mangle",
+		hook:       "PREROUTING",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumPreRawChain,
+		table:      "raw",
+		hook:       "PREROUTING",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+	{
+		name:       ciliumForwardChain,
+		table:      "filter",
+		hook:       "FORWARD",
+		feederArgs: []string{""},
+		ipv6:       true,
+	},
+}
+
+func (c *customChain) add() error {
+	var err error
+	if option.Config.EnableIPv4 {
+		err = ip4tables.runProg([]string{"-t", c.table, "-N", c.name}, false)
+	}
+	if err == nil && option.Config.EnableIPv6 && c.ipv6 == true {
+		err = ip6tables.runProg([]string{"-t", c.table, "-N", c.name}, false)
+	}
+	return err
+}
+
+func (c *customChain) doRename(prog iptablesInterface, name string, quiet bool) {
+	args := []string{"-t", c.table, "-E", c.name, name}
+	operation := "rename"
+	combinedOutput, err := prog.runProgCombinedOutput(args, true)
+	if err != nil && !quiet {
+		log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog, c.name, string(combinedOutput))
+	}
+}
+
+func (c *customChain) rename(name string, quiet bool) {
+	if option.Config.EnableIPv4 {
+		c.doRename(ip4tables, name, quiet)
+	}
+	if option.Config.EnableIPv6 && c.ipv6 {
+		c.doRename(ip6tables, name, quiet)
+	}
+}
+
+func (c *customChain) remove(quiet bool) {
+	doProcess := func(c *customChain, prog iptablesInterface, args []string, operation string, quiet bool) {
+		combinedOutput, err := prog.runProgCombinedOutput(args, true)
+		if err != nil && !quiet {
+			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog.getProg(), c.name, string(combinedOutput))
+		}
+	}
+	doRemove := func(c *customChain, prog iptablesInterface, quiet bool) {
+		args := []string{"-t", c.table, "-F", c.name}
+		doProcess(c, prog, args, "flush", quiet)
+		args = []string{"-t", c.table, "-X", c.name}
+		doProcess(c, prog, args, "delete", quiet)
+	}
+	if option.Config.EnableIPv4 {
+		doRemove(c, ip4tables, quiet)
+	}
+	if option.Config.EnableIPv6 && c.ipv6 {
+		doRemove(c, ip6tables, quiet)
+	}
+}
+
+func getFeedRule(name, args string) []string {
+	ruleTail := []string{"-m", "comment", "--comment", feederDescription + " " + name, "-j", name}
+	if args == "" {
+		return ruleTail
+	}
+	argsList, err := shellwords.Parse(args)
+	if err != nil {
+		log.WithError(err).WithField(logfields.Object, args).Fatal("Unable to parse rule into argument slice")
+	}
+	return append(argsList, ruleTail...)
+}
+
+func (c *customChain) installFeeder() error {
+	installMode := "-A"
+	if option.Config.PrependIptablesChains {
+		installMode = "-I"
+	}
+
+	for _, feedArgs := range c.feederArgs {
+		if option.Config.EnableIPv4 {
+			err := ip4tables.runProg(append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
+			if err != nil {
+				return err
+			}
+		}
+		if option.Config.EnableIPv6 && c.ipv6 == true {
+			err := ip6tables.runProg(append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -75,14 +75,6 @@ const (
 	waitString = "-w"
 )
 
-type customChain struct {
-	name       string
-	table      string
-	hook       string
-	feederArgs []string
-	ipv6       bool // ip6tables chain in addition to iptables chain
-}
-
 type iptablesInterface interface {
 	getProg() string
 	getIpset() string
@@ -151,18 +143,6 @@ func (ipt *ipt) runProg(args []string, quiet bool) error {
 	return err
 }
 
-func getFeedRule(name, args string) []string {
-	ruleTail := []string{"-m", "comment", "--comment", feederDescription + " " + name, "-j", name}
-	if args == "" {
-		return ruleTail
-	}
-	argsList, err := shellwords.Parse(args)
-	if err != nil {
-		log.WithError(err).WithField(logfields.Object, args).Fatal("Unable to parse rule into argument slice")
-	}
-	return append(argsList, ruleTail...)
-}
-
 // skipPodTrafficConntrack returns true if it's possible to install iptables
 // `-j CT --notrack` rules to skip tracking pod traffic.
 func skipPodTrafficConntrack(ipv6 bool) bool {
@@ -185,17 +165,6 @@ func KernelHasNetfilter() bool {
 		return true
 	}
 	return false
-}
-
-func (c *customChain) add() error {
-	var err error
-	if option.Config.EnableIPv4 {
-		err = ip4tables.runProg([]string{"-t", c.table, "-N", c.name}, false)
-	}
-	if err == nil && option.Config.EnableIPv6 && c.ipv6 == true {
-		err = ip6tables.runProg([]string{"-t", c.table, "-N", c.name}, false)
-	}
-	return err
 }
 
 func reverseRule(rule string) ([]string, error) {
@@ -263,144 +232,6 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 			}
 		}
 	}
-}
-
-func (c *customChain) doRename(prog iptablesInterface, name string, quiet bool) {
-	args := []string{"-t", c.table, "-E", c.name, name}
-	operation := "rename"
-	combinedOutput, err := prog.runProgCombinedOutput(args, true)
-	if err != nil && !quiet {
-		log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog, c.name, string(combinedOutput))
-	}
-}
-
-func (c *customChain) rename(name string, quiet bool) {
-	if option.Config.EnableIPv4 {
-		c.doRename(ip4tables, name, quiet)
-	}
-	if option.Config.EnableIPv6 && c.ipv6 {
-		c.doRename(ip6tables, name, quiet)
-	}
-}
-
-func (c *customChain) remove(quiet bool) {
-	doProcess := func(c *customChain, prog iptablesInterface, args []string, operation string, quiet bool) {
-		combinedOutput, err := prog.runProgCombinedOutput(args, true)
-		if err != nil && !quiet {
-			log.WithError(err).WithField(logfields.Object, args).Warnf("Unable to %s %s chain %s: %s", operation, prog.getProg(), c.name, string(combinedOutput))
-		}
-	}
-	doRemove := func(c *customChain, prog iptablesInterface, quiet bool) {
-		args := []string{"-t", c.table, "-F", c.name}
-		doProcess(c, prog, args, "flush", quiet)
-		args = []string{"-t", c.table, "-X", c.name}
-		doProcess(c, prog, args, "delete", quiet)
-	}
-	if option.Config.EnableIPv4 {
-		doRemove(c, ip4tables, quiet)
-	}
-	if option.Config.EnableIPv6 && c.ipv6 {
-		doRemove(c, ip6tables, quiet)
-	}
-}
-
-func (c *customChain) installFeeder() error {
-	installMode := "-A"
-	if option.Config.PrependIptablesChains {
-		installMode = "-I"
-	}
-
-	for _, feedArgs := range c.feederArgs {
-		if option.Config.EnableIPv4 {
-			err := ip4tables.runProg(append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
-			if err != nil {
-				return err
-			}
-		}
-		if option.Config.EnableIPv6 && c.ipv6 == true {
-			err := ip6tables.runProg(append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// ciliumChains is the list of custom iptables chain used by Cilium. Custom
-// chains are used to allow for simple replacements of all rules.
-//
-// WARNING: If you change or remove any of the feeder rules you have to ensure
-// that the old feeder rules is also removed on agent start, otherwise,
-// flushing and removing the custom chains will fail.
-var ciliumChains = []customChain{
-	{
-		name:       ciliumInputChain,
-		table:      "filter",
-		hook:       "INPUT",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumOutputChain,
-		table:      "filter",
-		hook:       "OUTPUT",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumOutputRawChain,
-		table:      "raw",
-		hook:       "OUTPUT",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumPostNatChain,
-		table:      "nat",
-		hook:       "POSTROUTING",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumOutputNatChain,
-		table:      "nat",
-		hook:       "OUTPUT",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumPreNatChain,
-		table:      "nat",
-		hook:       "PREROUTING",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumPostMangleChain,
-		table:      "mangle",
-		hook:       "POSTROUTING",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumPreMangleChain,
-		table:      "mangle",
-		hook:       "PREROUTING",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumPreRawChain,
-		table:      "raw",
-		hook:       "PREROUTING",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
-	{
-		name:       ciliumForwardChain,
-		table:      "filter",
-		hook:       "FORWARD",
-		feederArgs: []string{""},
-		ipv6:       true,
-	},
 }
 
 // IptablesManager manages the iptables-related configuration for Cilium.

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -346,12 +346,8 @@ func (m *IptablesManager) removeRules(prefix string) error {
 		if err := m.removeCiliumRules(t, ip4tables, prefix+"CILIUM_"); err != nil {
 			return err
 		}
-	}
 
-	// Set of tables that have had ip6tables rules in any Cilium version
-	if m.haveIp6tables {
-		tables6 := []string{"nat", "mangle", "raw", "filter"}
-		for _, t := range tables6 {
+		if m.haveIp6tables {
 			if err := m.removeCiliumRules(t, ip6tables, prefix+"CILIUM_"); err != nil {
 				return err
 			}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -638,21 +638,18 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 		return err
 	}
 
-	if ingress {
-		if err := m.iptIngressProxyRule(rules, prog, "tcp", proxyPort, name); err != nil {
-			return err
-		}
-		if err := m.iptIngressProxyRule(rules, prog, "udp", proxyPort, name); err != nil {
-			return err
-		}
-	} else {
-		if err := m.iptEgressProxyRule(rules, prog, "tcp", proxyPort, name); err != nil {
-			return err
-		}
-		if err := m.iptEgressProxyRule(rules, prog, "udp", proxyPort, name); err != nil {
-			return err
+	for _, proto := range []string{"tcp", "udp"} {
+		if ingress {
+			if err := m.iptIngressProxyRule(rules, prog, proto, proxyPort, name); err != nil {
+				return err
+			}
+		} else {
+			if err := m.iptEgressProxyRule(rules, prog, proto, proxyPort, name); err != nil {
+				return err
+			}
 		}
 	}
+
 	// Delete all other rules for this same proxy name
 	// These may accumulate if there is a bind failure on a previously used port
 	portMatch := fmt.Sprintf("TPROXY --on-port %d ", proxyPort)

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -667,7 +667,7 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 	scanner := bufio.NewScanner(strings.NewReader(rules))
 	for scanner.Scan() {
 		rule := scanner.Text()
-		if !strings.Contains(rule, "-A CILIUM_PRE_mangle ") || strings.Contains(rule, "cilium: TPROXY to host "+name) || !strings.Contains(rule, portMatch) {
+		if !strings.Contains(rule, "-A CILIUM_PRE_mangle ") || !strings.Contains(rule, "cilium: TPROXY to host "+name) || strings.Contains(rule, portMatch) {
 			continue
 		}
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -131,6 +131,10 @@ func (ipt *ipt) getVersion() (semver.Version, error) {
 }
 
 func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
+	fullCommand := fmt.Sprintf("%s %s", ipt.getProg(), strings.Join(args, " "))
+
+	log.Debugf("Running '%s' command", fullCommand)
+
 	// Add wait argument to deal with concurrent calls that would fail otherwise
 	iptArgs := make([]string, 0, len(ipt.waitArgs)+len(args))
 	iptArgs = append(iptArgs, ipt.waitArgs...)
@@ -140,8 +144,7 @@ func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
 	outStr := string(out)
 
 	if err != nil {
-		return outStr, fmt.Errorf("unable to run '%s %s' iptables command: %s (%w)",
-			ipt.getProg(), args, outStr, err)
+		return outStr, fmt.Errorf("unable to run '%s' iptables command: %s (%w)", fullCommand, outStr, err)
 	}
 
 	return outStr, nil
@@ -600,7 +603,6 @@ func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string,
 			continue
 		}
 
-		log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
 		args, err := shellwords.Parse(strings.Replace(rule, oldChain, newChain, 1))
 		if err != nil {
 			log.WithFields(logrus.Fields{
@@ -1000,7 +1002,6 @@ func AddToNodeIpset(nodeIP net.IP) {
 	if ip.IsIPv6(nodeIP) {
 		ciliumNodeIpset = ciliumNodeIpsetV6
 	}
-	scopedLog.Debugf("Adding IP to ipset %s", ciliumNodeIpset)
 	if err := createIpset(ciliumNodeIpset, ip.IsIPv6(nodeIP)); err != nil {
 		scopedLog.WithError(err).Errorf("Failed to create ipset %s", ciliumNodeIpset)
 		return
@@ -1018,7 +1019,6 @@ func RemoveFromNodeIpset(nodeIP net.IP) {
 	if ip.IsIPv6(nodeIP) {
 		ciliumNodeIpset = ciliumNodeIpsetV6
 	}
-	scopedLog.Debugf("Removing IP from ipset %s", ciliumNodeIpset)
 	progArgs := []string{"del", ciliumNodeIpset, nodeIP.String()}
 	if err := ipset.runProg(progArgs); err != nil {
 		scopedLog.WithError(err).Errorf("Failed to remove IP from ipset %s", ciliumNodeIpset)

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -691,70 +691,69 @@ func (m *IptablesManager) iptProxyRules(proxyPort uint16, ingress bool, name str
 	return nil
 }
 
-func (m *IptablesManager) endpointNoTrackRules(prog iptablesInterface, cmd string, IP string, port *lb.L4Addr, ingress bool) error {
+func (m *IptablesManager) endpointNoTrackRules(prog iptablesInterface, cmd string, IP string, port *lb.L4Addr) error {
 	protocol := strings.ToLower(port.Protocol)
 	p := strconv.FormatUint(uint64(port.Port), 10)
-	if ingress {
-		if err := prog.runProg([]string{
-			"-t", "raw",
-			cmd, ciliumPreRawChain,
-			"-p", protocol,
-			"-d", IP,
-			"--dport", p,
-			"-j", "CT",
-			"--notrack"}); err != nil {
-			return err
-		}
-		if err := prog.runProg([]string{
-			"-t", "filter",
-			cmd, ciliumInputChain,
-			"-p", protocol,
-			"-d", IP,
-			"--dport",
-			p, "-j",
-			"ACCEPT"}); err != nil {
-			return err
-		}
-		if err := prog.runProg([]string{
-			"-t", "raw",
-			cmd, ciliumOutputRawChain,
-			"-p", protocol,
-			"-d", IP,
-			"--dport", p,
-			"-j", "CT",
-			"--notrack"}); err != nil {
-			return err
-		}
-		if err := prog.runProg([]string{
-			"-t", "filter",
-			cmd, ciliumOutputChain,
-			"-p", protocol,
-			"-d", IP,
-			"--dport", p,
-			"-j", "ACCEPT"}); err != nil {
-			return err
-		}
-	} else {
-		if err := prog.runProg([]string{
-			"-t", "raw",
-			cmd, ciliumOutputRawChain,
-			"-p", protocol,
-			"-s", IP,
-			"--sport", p,
-			"-j", "CT",
-			"--notrack"}); err != nil {
-			return err
-		}
-		if err := prog.runProg([]string{
-			"-t", "filter",
-			cmd, ciliumOutputChain,
-			"-p", protocol,
-			"-s", IP,
-			"--sport", p,
-			"-j", "ACCEPT"}); err != nil {
-			return err
-		}
+
+	if err := prog.runProg([]string{
+		"-t", "raw",
+		cmd, ciliumPreRawChain,
+		"-p", protocol,
+		"-d", IP,
+		"--dport", p,
+		"-j", "CT",
+		"--notrack"}); err != nil {
+		return err
 	}
+	if err := prog.runProg([]string{
+		"-t", "filter",
+		cmd, ciliumInputChain,
+		"-p", protocol,
+		"-d", IP,
+		"--dport",
+		p, "-j",
+		"ACCEPT"}); err != nil {
+		return err
+	}
+	if err := prog.runProg([]string{
+		"-t", "raw",
+		cmd, ciliumOutputRawChain,
+		"-p", protocol,
+		"-d", IP,
+		"--dport", p,
+		"-j", "CT",
+		"--notrack"}); err != nil {
+		return err
+	}
+	if err := prog.runProg([]string{
+		"-t", "filter",
+		cmd, ciliumOutputChain,
+		"-p", protocol,
+		"-d", IP,
+		"--dport", p,
+		"-j", "ACCEPT"}); err != nil {
+		return err
+	}
+	if err := prog.runProg([]string{
+		"-t", "raw",
+		cmd, ciliumOutputRawChain,
+		"-p", protocol,
+		"-s", IP,
+		"--sport", p,
+		"-j", "CT",
+		"--notrack"}); err != nil {
+		return err
+	}
+	if err := prog.runProg([]string{
+		"-t", "filter",
+		cmd, ciliumOutputChain,
+		"-p", protocol,
+		"-s", IP,
+		"--sport", p,
+		"-j", "ACCEPT"}); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -779,10 +778,7 @@ func (m *IptablesManager) InstallNoTrackRules(IP string, port uint16, ipv6 bool)
 	}
 
 	for _, p := range noTrackPorts(port) {
-		if err := m.endpointNoTrackRules(prog, "-A", IP, p, true); err != nil {
-			return err
-		}
-		if err := m.endpointNoTrackRules(prog, "-A", IP, p, false); err != nil {
+		if err := m.endpointNoTrackRules(prog, "-A", IP, p); err != nil {
 			return err
 		}
 	}
@@ -807,10 +803,7 @@ func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) 
 	}
 
 	for _, p := range noTrackPorts(port) {
-		if err := m.endpointNoTrackRules(prog, "-D", IP, p, true); err != nil {
-			return err
-		}
-		if err := m.endpointNoTrackRules(prog, "-D", IP, p, false); err != nil {
+		if err := m.endpointNoTrackRules(prog, "-D", IP, p); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -192,6 +192,26 @@ func reverseRule(rule string) ([]string, error) {
 	return []string{}, nil
 }
 
+func ruleReferencesDisabledChain(rule string) (bool, string) {
+	for _, disabledChain := range option.Config.DisableIptablesFeederRules {
+		if strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
+			return true, disabledChain
+		}
+	}
+
+	return false, ""
+}
+
+func isDisabledChain(chain string) bool {
+	for _, disabledChain := range option.Config.DisableIptablesFeederRules {
+		if strings.EqualFold(chain, disabledChain) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) error {
 	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
 	if err != nil {
@@ -213,15 +233,8 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 		// do not remove feeder for chains that are set to be disabled
 		// ie catch the beginning of the rule like -A POSTROUTING to match it against
 		// disabled chains
-		skipFeeder := false
-		for _, disabledChain := range option.Config.DisableIptablesFeederRules {
-			if strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
-				log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
-				skipFeeder = true
-				break
-			}
-		}
-		if skipFeeder {
+		if skip, disabledChain := ruleReferencesDisabledChain(rule); skip {
+			log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
 			continue
 		}
 
@@ -1311,14 +1324,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 	for _, c := range ciliumChains {
 		if err := c.add(); err != nil {
 			// do not return error for chain creation that are linked to disabled feeder rules
-			skipFeeder := false
-			for _, disabledChain := range option.Config.DisableIptablesFeederRules {
-				if strings.EqualFold(c.hook, disabledChain) {
-					skipFeeder = true
-					break
-				}
-			}
-			if skipFeeder {
+			if isDisabledChain(c.hook) {
 				log.WithField("chain", c.name).Warningf("ignoring creation of chain since feeder rules for %s is disabled", c.hook)
 				continue
 			}
@@ -1399,15 +1405,8 @@ func (m *IptablesManager) installRules(ifName string) error {
 
 	for _, c := range ciliumChains {
 		// do not install feeder for chains that are set to be disabled
-		skipFeeder := false
-		for _, disabledChain := range option.Config.DisableIptablesFeederRules {
-			if strings.EqualFold(c.hook, disabledChain) {
-				log.WithField("chain", c.hook).Infof("Skipping the install of feeder rule")
-				skipFeeder = true
-				break
-			}
-		}
-		if skipFeeder {
+		if isDisabledChain(c.hook) {
+			log.WithField("chain", c.hook).Infof("Skipping the install of feeder rule")
 			continue
 		}
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -817,7 +817,7 @@ func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) 
 	return nil
 }
 
-func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name string) error {
+func (m *IptablesManager) InstallProxyRules(ctx context.Context, proxyPort uint16, ingress bool, name string) error {
 	backoff := backoff.Exponential{
 		Min:  20 * time.Second,
 		Max:  3 * time.Minute,
@@ -840,7 +840,7 @@ func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name
 		}
 
 		log.WithError(err).Warning("Failed to install iptables proxy rules")
-		backoff.Wait(context.TODO())
+		backoff.Wait(ctx)
 	}
 }
 
@@ -1229,7 +1229,7 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 
 // InstallRules installs iptables rules for Cilium in specific use-cases
 // (most specifically, interaction with kube-proxy).
-func (m *IptablesManager) InstallRules(ifName string, firstInitialization, install bool) error {
+func (m *IptablesManager) InstallRules(ctx context.Context, ifName string, firstInitialization, install bool) error {
 	backoff := backoff.Exponential{
 		Min:  20 * time.Second,
 		Max:  3 * time.Minute,
@@ -1252,7 +1252,7 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 		}
 
 		log.WithError(err).Warning("Failed to install iptables rules")
-		backoff.Wait(context.TODO())
+		backoff.Wait(ctx)
 	}
 }
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -5,7 +5,6 @@ package iptables
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"net"
 	"regexp"
@@ -79,8 +78,8 @@ type iptablesInterface interface {
 	getProg() string
 	getIpset() string
 	getVersion() (semver.Version, error)
-	runProgCombinedOutput(args []string, quiet bool) ([]byte, error)
-	runProg(args []string, quiet bool) error
+	runProgCombinedOutput(args []string) (string, error)
+	runProg(args []string) error
 }
 
 type ipt struct {
@@ -129,17 +128,25 @@ func (ipt *ipt) getVersion() (semver.Version, error) {
 	return versioncheck.Version(vString[1])
 }
 
-func (ipt *ipt) runProgCombinedOutput(args []string, quiet bool) ([]byte, error) {
+func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
 	// Add wait argument to deal with concurrent calls that would fail otherwise
 	iptArgs := make([]string, 0, len(ipt.waitArgs)+len(args))
 	iptArgs = append(iptArgs, ipt.waitArgs...)
 	iptArgs = append(iptArgs, args...)
-	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).CombinedOutput(log, !quiet)
-	return out, err
+	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).CombinedOutput(log, false)
+
+	outStr := string(out)
+
+	if err != nil {
+		return outStr, fmt.Errorf("unable to run '%s %s' iptables command: %s (%w)",
+			ipt.getProg(), args, outStr, err)
+	}
+
+	return outStr, nil
 }
 
-func (ipt *ipt) runProg(args []string, quiet bool) error {
-	_, err := ipt.runProgCombinedOutput(args, quiet)
+func (ipt *ipt) runProg(args []string) error {
+	_, err := ipt.runProgCombinedOutput(args)
 	return err
 }
 
@@ -183,18 +190,15 @@ func reverseRule(rule string) ([]string, error) {
 	return []string{}, nil
 }
 
-func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) {
-	args := []string{"-t", table, "-S"}
-
-	out, err := prog.runProgCombinedOutput(args, false)
+func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) error {
+	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
 	if err != nil {
-		return
+		return err
 	}
 
-	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner := bufio.NewScanner(strings.NewReader(rules))
 	for scanner.Scan() {
 		rule := scanner.Text()
-		log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering removing %s rule", prog)
 
 		// All rules installed by cilium either belong to a chain with
 		// the name CILIUM_ or call a chain with the name CILIUM_:
@@ -224,14 +228,14 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 
 			if len(reversedRule) > 0 {
 				deleteRule := append([]string{"-t", table}, reversedRule...)
-				log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debugf("Removing %s rule", prog)
-				err = prog.runProg(deleteRule, true)
-				if err != nil {
-					log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to delete Cilium %s rule", prog)
+				if err := prog.runProg(deleteRule); err != nil {
+					return err
 				}
 			}
 		}
 	}
+
+	return nil
 }
 
 // IptablesManager manages the iptables-related configuration for Cilium.
@@ -331,33 +335,44 @@ func (m *IptablesManager) SupportsOriginalSourceAddr() bool {
 }
 
 // removeRules removes iptables rules installed by Cilium.
-func (m *IptablesManager) removeRules(prefix string, quiet bool) {
+func (m *IptablesManager) removeRules(prefix string) error {
 	// Set of tables that have had iptables rules in any Cilium version
 	tables := []string{"nat", "mangle", "raw", "filter"}
 	for _, t := range tables {
-		m.removeCiliumRules(t, ip4tables, prefix+"CILIUM_")
+		if err := m.removeCiliumRules(t, ip4tables, prefix+"CILIUM_"); err != nil {
+			return err
+		}
 	}
 
 	// Set of tables that have had ip6tables rules in any Cilium version
 	if m.haveIp6tables {
 		tables6 := []string{"nat", "mangle", "raw", "filter"}
 		for _, t := range tables6 {
-			m.removeCiliumRules(t, ip6tables, prefix+"CILIUM_")
+			if err := m.removeCiliumRules(t, ip6tables, prefix+"CILIUM_"); err != nil {
+				return err
+			}
 		}
 	}
 
 	for _, c := range ciliumChains {
 		c.name = prefix + c.name
-		c.remove(quiet)
+		if err := c.remove(); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
 // renameChains renames iptables chains installed by Cilium.
-func (m *IptablesManager) renameChains(prefix string, quiet bool) {
-	// Rename any old chains we may have
+func (m *IptablesManager) renameChains(prefix string) error {
 	for _, c := range ciliumChains {
-		c.rename(prefix+c.name, quiet)
+		if err := c.rename(prefix + c.name); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
 func (m *IptablesManager) ingressProxyRule(l4Match, markMatch, mark, port, name string) []string {
@@ -404,7 +419,8 @@ func (m *IptablesManager) iptIngressProxyRule(rules string, prog iptablesInterfa
 		return nil
 	}
 
-	return prog.runProg(m.ingressProxyRule(l4proto, ingressMarkMatch, ingressProxyMark, ingressProxyPort, name), false)
+	rule := m.ingressProxyRule(l4proto, ingressMarkMatch, ingressProxyMark, ingressProxyPort, name)
+	return prog.runProg(rule)
 }
 
 func (m *IptablesManager) egressProxyRule(l4Match, markMatch, mark, port, name string) []string {
@@ -431,7 +447,8 @@ func (m *IptablesManager) iptEgressProxyRule(rules string, prog iptablesInterfac
 		return nil
 	}
 
-	return prog.runProg(m.egressProxyRule(l4proto, egressMarkMatch, egressProxyMark, egressProxyPort, name), false)
+	rule := m.egressProxyRule(l4proto, egressMarkMatch, egressProxyMark, egressProxyPort, name)
+	return prog.runProg(rule)
 }
 
 func (m *IptablesManager) installStaticProxyRules() error {
@@ -440,118 +457,134 @@ func (m *IptablesManager) installStaticProxyRules() error {
 	// proxy return traffic has 0 ID in the mask
 	matchProxyReply := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyNoIDMask)
 
-	var err error
 	if option.Config.EnableIPv4 {
 		// No conntrack for traffic to proxy
-		err = ip4tables.runProg([]string{
+		if err := ip4tables.runProg([]string{
 			"-t", "raw",
 			"-A", ciliumPreRawChain,
 			"-m", "mark", "--mark", matchToProxy,
 			"-m", "comment", "--comment", "cilium: NOTRACK for proxy traffic",
-			"-j", "CT", "--notrack"}, false)
-		if err == nil {
-			// Explicit ACCEPT for the proxy traffic. Needed when the INPUT defaults to DROP.
-			// Matching needs to be the same as for the NOTRACK rule above.
-			err = ip4tables.runProg([]string{
-				"-t", "filter",
-				"-A", ciliumInputChain,
-				"-m", "mark", "--mark", matchToProxy,
-				"-m", "comment", "--comment", "cilium: ACCEPT for proxy traffic",
-				"-j", "ACCEPT"}, false)
+			"-j", "CT", "--notrack"}); err != nil {
+			return err
 		}
-		if err == nil {
-			// No conntrack for proxy return traffic that is heading to lxc+
-			err = ip4tables.runProg([]string{
-				"-t", "raw",
-				"-A", ciliumOutputRawChain,
-				"-o", "lxc+",
-				"-m", "mark", "--mark", matchProxyReply,
-				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
-				"-j", "CT", "--notrack"}, false)
+
+		// Explicit ACCEPT for the proxy traffic. Needed when the INPUT defaults to DROP.
+		// Matching needs to be the same as for the NOTRACK rule above.
+		if err := ip4tables.runProg([]string{
+			"-t", "filter",
+			"-A", ciliumInputChain,
+			"-m", "mark", "--mark", matchToProxy,
+			"-m", "comment", "--comment", "cilium: ACCEPT for proxy traffic",
+			"-j", "ACCEPT"}); err != nil {
+			return err
 		}
-		if err == nil {
-			// No conntrack for proxy return traffic that is heading to cilium_host
-			err = ip4tables.runProg([]string{
-				"-t", "raw",
-				"-A", ciliumOutputRawChain,
-				"-o", "cilium_host",
-				"-m", "mark", "--mark", matchProxyReply,
-				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
-				"-j", "CT", "--notrack"}, false)
+
+		// No conntrack for proxy return traffic that is heading to cilium_host
+		if err := ip4tables.runProg([]string{
+			"-t", "raw",
+			"-A", ciliumOutputRawChain,
+			"-o", "cilium_host",
+			"-m", "mark", "--mark", matchProxyReply,
+			"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
+			"-j", "CT", "--notrack"}); err != nil {
+			return err
 		}
-		if err == nil {
-			// Explicit ACCEPT for the proxy return traffic. Needed when the OUTPUT defaults to DROP.
-			// Matching needs to be the same as for the NOTRACK rule above.
-			err = ip4tables.runProg([]string{
-				"-t", "filter",
-				"-A", ciliumOutputChain,
-				"-m", "mark", "--mark", matchProxyReply,
-				"-m", "comment", "--comment", "cilium: ACCEPT for proxy return traffic",
-				"-j", "ACCEPT"}, false)
+
+		// No conntrack for proxy return traffic that is heading to lxc+
+		if err := ip4tables.runProg([]string{
+			"-t", "raw",
+			"-A", ciliumOutputRawChain,
+			"-o", "lxc+",
+			"-m", "mark", "--mark", matchProxyReply,
+			"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
+			"-j", "CT", "--notrack"}); err != nil {
+			return err
 		}
-		if err == nil && m.haveSocketMatch {
+
+		// Explicit ACCEPT for the proxy return traffic. Needed when the OUTPUT defaults to DROP.
+		// Matching needs to be the same as for the NOTRACK rule above.
+		if err := ip4tables.runProg([]string{
+			"-t", "filter",
+			"-A", ciliumOutputChain,
+			"-m", "mark", "--mark", matchProxyReply,
+			"-m", "comment", "--comment", "cilium: ACCEPT for proxy return traffic",
+			"-j", "ACCEPT"}); err != nil {
+			return err
+		}
+
+		if m.haveSocketMatch {
 			// Direct inbound TPROXYed traffic towards the socket
-			err = ip4tables.runProg(m.inboundProxyRedirectRule("-A"), false)
+			if err := ip4tables.runProg(m.inboundProxyRedirectRule("-A")); err != nil {
+				return err
+			}
 		}
 	}
-	if err == nil && option.Config.EnableIPv6 {
+
+	if option.Config.EnableIPv6 {
 		// No conntrack for traffic to ingress proxy
-		err = ip6tables.runProg([]string{
+		if err := ip6tables.runProg([]string{
 			"-t", "raw",
 			"-A", ciliumPreRawChain,
 			"-m", "mark", "--mark", matchToProxy,
 			"-m", "comment", "--comment", "cilium: NOTRACK for proxy traffic",
-			"-j", "CT", "--notrack"}, false)
-		if err == nil {
-			// Explicit ACCEPT for the proxy traffic. Needed when the INPUT defaults to DROP.
-			// Matching needs to be the same as for the NOTRACK rule above.
-			err = ip6tables.runProg([]string{
-				"-t", "filter",
-				"-A", ciliumInputChain,
-				"-m", "mark", "--mark", matchToProxy,
-				"-m", "comment", "--comment", "cilium: ACCEPT for proxy traffic",
-				"-j", "ACCEPT"}, false)
+			"-j", "CT", "--notrack"}); err != nil {
+			return err
 		}
-		if err == nil {
-			// No conntrack for proxy return traffic
-			err = ip6tables.runProg([]string{
-				"-t", "raw",
-				"-A", ciliumOutputRawChain,
-				"-m", "mark", "--mark", matchProxyReply,
-				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
-				"-j", "CT", "--notrack"}, false)
+
+		// Explicit ACCEPT for the proxy traffic. Needed when the INPUT defaults to DROP.
+		// Matching needs to be the same as for the NOTRACK rule above.
+		if err := ip6tables.runProg([]string{
+			"-t", "filter",
+			"-A", ciliumInputChain,
+			"-m", "mark", "--mark", matchToProxy,
+			"-m", "comment", "--comment", "cilium: ACCEPT for proxy traffic",
+			"-j", "ACCEPT"}); err != nil {
+			return err
 		}
-		if err == nil {
-			// Explicit ACCEPT for the proxy return traffic. Needed when the OUTPUT defaults to DROP.
-			// Matching needs to be the same as for the NOTRACK rule above.
-			err = ip6tables.runProg([]string{
-				"-t", "filter",
-				"-A", ciliumOutputChain,
-				"-m", "mark", "--mark", matchProxyReply,
-				"-m", "comment", "--comment", "cilium: ACCEPT for proxy return traffic",
-				"-j", "ACCEPT"}, false)
+
+		// No conntrack for proxy return traffic
+		if err := ip6tables.runProg([]string{
+			"-t", "raw",
+			"-A", ciliumOutputRawChain,
+			"-m", "mark", "--mark", matchProxyReply,
+			"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
+			"-j", "CT", "--notrack"}); err != nil {
+			return err
 		}
-		if err == nil && m.haveSocketMatch {
+
+		// Explicit ACCEPT for the proxy return traffic. Needed when the OUTPUT defaults to DROP.
+		// Matching needs to be the same as for the NOTRACK rule above.
+		if err := ip6tables.runProg([]string{
+			"-t", "filter",
+			"-A", ciliumOutputChain,
+			"-m", "mark", "--mark", matchProxyReply,
+			"-m", "comment", "--comment", "cilium: ACCEPT for proxy return traffic",
+			"-j", "ACCEPT"}); err != nil {
+			return err
+		}
+
+		if m.haveSocketMatch {
 			// Direct inbound TPROXYed traffic towards the socket
-			err = ip6tables.runProg(m.inboundProxyRedirectRule("-A"), false)
+			if err := ip6tables.runProg(m.inboundProxyRedirectRule("-A")); err != nil {
+				return err
+			}
 		}
 	}
-	return err
+
+	return nil
 }
 
-func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, match, oldChain, newChain string) {
-	output, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"}, true)
+func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, match, oldChain, newChain string) error {
+	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"table": table,
-			"prog":  prog.getProg(),
-		}).WithError(err).Warning("Cannot list rules in table. Layer 7 proxy port may get reallocated, which could cause disruption for traffic selected by L7 policy", prog.getProg(), table)
-		return
+		return err
 	}
-	scanner := bufio.NewScanner(bytes.NewReader(output))
+
+	scanner := bufio.NewScanner(strings.NewReader(rules))
 	for scanner.Scan() {
 		rule := scanner.Text()
 		if re.MatchString(rule) && strings.Contains(rule, match) {
+
 			log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
 			args, err := shellwords.Parse(strings.Replace(rule, oldChain, newChain, 1))
 			if err != nil {
@@ -562,40 +595,44 @@ func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string,
 				}).WithError(err).Warn("Unable to parse TPROXY rule, disruption to traffic selected by L7 policy possible")
 				continue
 			}
+
 			copyRule := append([]string{"-t", table}, args...)
-			log.WithField(logfields.Object, logfields.Repr(copyRule)).Debugf("Copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
-			err = prog.runProg(copyRule, true)
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					"table":          table,
-					"prog":           prog.getProg(),
-					logfields.Object: rule,
-				}).WithError(err).Warn("Unable to copy TPROXY rule, disruption to traffic selected by L7 policy possible")
+			if err := prog.runProg(copyRule); err != nil {
+				return err
 			}
 		}
 	}
+
+	return nil
 }
 
 var tproxyMatch = regexp.MustCompile("CILIUM_PRE_mangle .*cilium: TPROXY")
 
 // copies old proxy rules
-func (m *IptablesManager) copyProxyRules(oldChain string, match string) {
+func (m *IptablesManager) copyProxyRules(oldChain string, match string) error {
 	if option.Config.EnableIPv4 {
-		m.doCopyProxyRules(ip4tables, "mangle", tproxyMatch, match, oldChain, ciliumPreMangleChain)
+		if err := m.doCopyProxyRules(ip4tables, "mangle", tproxyMatch, match, oldChain, ciliumPreMangleChain); err != nil {
+			return err
+		}
 	}
+
 	if option.Config.EnableIPv6 {
-		m.doCopyProxyRules(ip6tables, "mangle", tproxyMatch, match, oldChain, ciliumPreMangleChain)
+		if err := m.doCopyProxyRules(ip6tables, "mangle", tproxyMatch, match, oldChain, ciliumPreMangleChain); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
 // Redirect packets to the host proxy via TPROXY, as directed by the Cilium
 // datapath bpf programs via skb marks (egress) or DSCP (ingress).
 func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16, ingress bool, name string) error {
-	output, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-S"}, true)
+	rules, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-S"})
 	if err != nil {
-		log.WithError(err).Warnf("Unable to list %s TPROXY rules: %s", prog, string(output))
+		return err
 	}
-	rules := string(output)
+
 	if ingress {
 		if err := m.iptIngressProxyRule(rules, prog, "tcp", proxyPort, name); err != nil {
 			return err
@@ -614,20 +651,20 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 	// Delete all other rules for this same proxy name
 	// These may accumulate if there is a bind failure on a previously used port
 	portMatch := fmt.Sprintf("TPROXY --on-port %d ", proxyPort)
-	scanner := bufio.NewScanner(bytes.NewReader(output))
+	scanner := bufio.NewScanner(strings.NewReader(rules))
 	for scanner.Scan() {
 		rule := scanner.Text()
-		if strings.Contains(rule, "-A CILIUM_PRE_mangle ") && strings.Contains(rule, "cilium: TPROXY to host "+name) && !strings.Contains(rule, portMatch) {
+		if strings.Contains(rule, "-A CILIUM_PRE_mangle ") && !strings.Contains(rule, "cilium: TPROXY to host "+name) && strings.Contains(rule, portMatch) {
+
 			args, err := shellwords.Parse(strings.Replace(rule, "-A", "-D", 1))
 			if err != nil {
 				log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to parse %s TPROXY rule", prog)
 				continue
 			}
+
 			deleteRule := append([]string{"-t", "mangle"}, args...)
-			log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debugf("Deleting stale %s TPROXY rule from mangle table", prog)
-			err = prog.runProg(deleteRule, true)
-			if err != nil {
-				log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to delete %s TPROXY rule", prog)
+			if err := prog.runProg(deleteRule); err != nil {
+				return err
 			}
 		}
 	}
@@ -636,37 +673,82 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 }
 
 // install or remove rules for a single proxy port
-func (m *IptablesManager) iptProxyRules(proxyPort uint16, ingress bool, name string) (err error) {
+func (m *IptablesManager) iptProxyRules(proxyPort uint16, ingress bool, name string) error {
 	if option.Config.EnableIPv4 {
-		err = m.addProxyRules(ip4tables, proxyPort, ingress, name)
+		if err := m.addProxyRules(ip4tables, proxyPort, ingress, name); err != nil {
+			return err
+		}
 	}
-	if err == nil && option.Config.EnableIPv6 {
-		err = m.addProxyRules(ip6tables, proxyPort, ingress, name)
+	if option.Config.EnableIPv6 {
+		if err := m.addProxyRules(ip6tables, proxyPort, ingress, name); err != nil {
+			return err
+		}
 	}
-	return err
+
+	return nil
 }
 
 func (m *IptablesManager) endpointNoTrackRules(prog iptablesInterface, cmd string, IP string, port *lb.L4Addr, ingress bool) error {
 	protocol := strings.ToLower(port.Protocol)
 	p := strconv.FormatUint(uint64(port.Port), 10)
 	if ingress {
-		if _, err := prog.runProgCombinedOutput([]string{"-t", "raw", cmd, ciliumPreRawChain, "-p", protocol, "-d", IP, "--dport", p, "-j", "CT", "--notrack"}, false); err != nil {
+		if err := prog.runProg([]string{
+			"-t", "raw",
+			cmd, ciliumPreRawChain,
+			"-p", protocol,
+			"-d", IP,
+			"--dport", p,
+			"-j", "CT",
+			"--notrack"}); err != nil {
 			return err
 		}
-		if _, err := prog.runProgCombinedOutput([]string{"-t", "filter", cmd, ciliumInputChain, "-p", protocol, "-d", IP, "--dport", p, "-j", "ACCEPT"}, false); err != nil {
+		if err := prog.runProg([]string{
+			"-t", "filter",
+			cmd, ciliumInputChain,
+			"-p", protocol,
+			"-d", IP,
+			"--dport",
+			p, "-j",
+			"ACCEPT"}); err != nil {
 			return err
 		}
-		if _, err := prog.runProgCombinedOutput([]string{"-t", "raw", cmd, ciliumOutputRawChain, "-p", protocol, "-d", IP, "--dport", p, "-j", "CT", "--notrack"}, false); err != nil {
+		if err := prog.runProg([]string{
+			"-t", "raw",
+			cmd, ciliumOutputRawChain,
+			"-p", protocol,
+			"-d", IP,
+			"--dport", p,
+			"-j", "CT",
+			"--notrack"}); err != nil {
 			return err
 		}
-		if _, err := prog.runProgCombinedOutput([]string{"-t", "filter", cmd, ciliumOutputChain, "-p", protocol, "-d", IP, "--dport", p, "-j", "ACCEPT"}, false); err != nil {
+		if err := prog.runProg([]string{
+			"-t", "filter",
+			cmd, ciliumOutputChain,
+			"-p", protocol,
+			"-d", IP,
+			"--dport", p,
+			"-j", "ACCEPT"}); err != nil {
 			return err
 		}
 	} else {
-		if _, err := prog.runProgCombinedOutput([]string{"-t", "raw", cmd, ciliumOutputRawChain, "-p", protocol, "-s", IP, "--sport", p, "-j", "CT", "--notrack"}, false); err != nil {
+		if err := prog.runProg([]string{
+			"-t", "raw",
+			cmd, ciliumOutputRawChain,
+			"-p", protocol,
+			"-s", IP,
+			"--sport", p,
+			"-j", "CT",
+			"--notrack"}); err != nil {
 			return err
 		}
-		if _, err := prog.runProgCombinedOutput([]string{"-t", "filter", cmd, ciliumOutputChain, "-p", protocol, "-s", IP, "--sport", p, "-j", "ACCEPT"}, false); err != nil {
+		if err := prog.runProg([]string{
+			"-t", "filter",
+			cmd, ciliumOutputChain,
+			"-p", protocol,
+			"-s", IP,
+			"--sport", p,
+			"-j", "ACCEPT"}); err != nil {
 			return err
 		}
 	}
@@ -689,30 +771,19 @@ func (m *IptablesManager) InstallNoTrackRules(IP string, port uint16, ipv6 bool)
 	}
 
 	prog := ip4tables
-	ipField := logfields.IPv4
 	if ipv6 {
 		prog = ip6tables
-		ipField = logfields.IPv6
 	}
-	ports := noTrackPorts(port)
-	for _, p := range ports {
+
+	for _, p := range noTrackPorts(port) {
 		if err := m.endpointNoTrackRules(prog, "-A", IP, p, true); err != nil {
-			log.WithFields(logrus.Fields{
-				ipField:            IP,
-				logfields.Port:     p.Port,
-				logfields.Protocol: p.Protocol,
-			}).WithError(err).Warn("Unable to install ingress NOTRACK rules")
 			return err
 		}
 		if err := m.endpointNoTrackRules(prog, "-A", IP, p, false); err != nil {
-			log.WithFields(logrus.Fields{
-				ipField:            IP,
-				logfields.Port:     p.Port,
-				logfields.Protocol: p.Protocol,
-			}).WithError(err).Warn("Unable to install egress NOTRACK rules")
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -728,30 +799,19 @@ func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) 
 	}
 
 	prog := ip4tables
-	ipField := logfields.IPv4
 	if ipv6 {
 		prog = ip6tables
-		ipField = logfields.IPv6
 	}
-	ports := noTrackPorts(port)
-	for _, p := range ports {
+
+	for _, p := range noTrackPorts(port) {
 		if err := m.endpointNoTrackRules(prog, "-D", IP, p, true); err != nil {
-			log.WithFields(logrus.Fields{
-				ipField:            IP,
-				logfields.Port:     p.Port,
-				logfields.Protocol: p.Protocol,
-			}).WithError(err).Warn("Unable to remove ingress NOTRACK rules")
 			return err
 		}
 		if err := m.endpointNoTrackRules(prog, "-D", IP, p, false); err != nil {
-			log.WithFields(logrus.Fields{
-				ipField:            IP,
-				logfields.Port:     p.Port,
-				logfields.Protocol: p.Protocol,
-			}).WithError(err).Warn("Unable to remove egress NOTRACK rules")
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -780,13 +840,13 @@ func (m *IptablesManager) GetProxyPort(name string) uint16 {
 }
 
 func (m *IptablesManager) doGetProxyPort(prog iptablesInterface, name string) uint16 {
-	res, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain}, true)
+	rules, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
 	if err != nil {
 		return 0
 	}
 
 	re := regexp.MustCompile(name + ".*TPROXY redirect (0.0.0.0|::):([1-9][0-9]*) mark")
-	strs := re.FindAllString(string(res), -1)
+	strs := re.FindAllString(rules, -1)
 	if len(strs) == 0 {
 		return 0
 	}
@@ -797,6 +857,7 @@ func (m *IptablesManager) doGetProxyPort(prog iptablesInterface, name string) ui
 		log.WithError(err).Debugf("Port number cannot be parsed: %s", portStr)
 		return 0
 	}
+
 	return uint16(portUInt64)
 }
 
@@ -810,14 +871,14 @@ func getDeliveryInterface(ifName string) string {
 
 func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterface, forwardChain string) error {
 	if option.Config.EnableIPv4 {
-		err := m.installForwardChainRulesIpX(ip4tables, ifName, localDeliveryInterface, forwardChain)
-		if err != nil {
+		if err := m.installForwardChainRulesIpX(ip4tables, ifName, localDeliveryInterface, forwardChain); err != nil {
 			return err
 		}
 	}
 	if option.Config.EnableIPv6 {
 		return m.installForwardChainRulesIpX(ip6tables, ifName, localDeliveryInterface, forwardChain)
 	}
+
 	return nil
 }
 
@@ -847,21 +908,21 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 		"-A", forwardChain,
 		"-o", ifName,
 		"-m", "comment", "--comment", "cilium: any->cluster on " + ifName + " forward accept",
-		"-j", "ACCEPT"}, false); err != nil {
+		"-j", "ACCEPT"}); err != nil {
 		return err
 	}
 	if err := prog.runProg([]string{
 		"-A", forwardChain,
 		"-i", ifName,
 		"-m", "comment", "--comment", "cilium: cluster->any on " + ifName + " forward accept (nodeport)",
-		"-j", "ACCEPT"}, false); err != nil {
+		"-j", "ACCEPT"}); err != nil {
 		return err
 	}
 	if err := prog.runProg([]string{
 		"-A", forwardChain,
 		"-i", "lxc+",
 		"-m", "comment", "--comment", "cilium: cluster->any on lxc+ forward accept",
-		"-j", "ACCEPT"}, false); err != nil {
+		"-j", "ACCEPT"}); err != nil {
 		return err
 	}
 	// Proxy return traffic to a remote source needs '-i cilium_net'.
@@ -872,7 +933,7 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 			"-A", forwardChain,
 			"-i", ifPeerName,
 			"-m", "comment", "--comment", "cilium: cluster->any on " + ifPeerName + " forward accept (nodeport)",
-			"-j", "ACCEPT"}, false); err != nil {
+			"-j", "ACCEPT"}); err != nil {
 			return err
 		}
 	}
@@ -884,14 +945,14 @@ func (m *IptablesManager) installForwardChainRulesIpX(prog iptablesInterface, if
 			"-A", forwardChain,
 			"-o", localDeliveryInterface,
 			"-m", "comment", "--comment", "cilium: any->cluster on " + localDeliveryInterface + " forward accept",
-			"-j", "ACCEPT"}, false); err != nil {
+			"-j", "ACCEPT"}); err != nil {
 			return err
 		}
 		if err := prog.runProg([]string{
 			"-A", forwardChain,
 			"-i", localDeliveryInterface,
 			"-m", "comment", "--comment", "cilium: cluster->any on " + localDeliveryInterface + " forward accept (nodeport)",
-			"-j", "ACCEPT"}, false); err != nil {
+			"-j", "ACCEPT"}); err != nil {
 			return err
 		}
 	}
@@ -913,7 +974,7 @@ func AddToNodeIpset(nodeIP net.IP) {
 		return
 	}
 	progArgs := []string{"add", ciliumNodeIpset, nodeIP.String(), "-exist"}
-	if err := ipset.runProg(progArgs, false); err != nil {
+	if err := ipset.runProg(progArgs); err != nil {
 		scopedLog.WithError(err).Errorf("Failed to add IP to ipset %s", ciliumNodeIpset)
 	}
 }
@@ -927,7 +988,7 @@ func RemoveFromNodeIpset(nodeIP net.IP) {
 	}
 	scopedLog.Debugf("Removing IP from ipset %s", ciliumNodeIpset)
 	progArgs := []string{"del", ciliumNodeIpset, nodeIP.String()}
-	if err := ipset.runProg(progArgs, false); err != nil {
+	if err := ipset.runProg(progArgs); err != nil {
 		scopedLog.WithError(err).Errorf("Failed to remove IP from ipset %s", ciliumNodeIpset)
 	}
 }
@@ -939,15 +1000,14 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 		if err := createIpset(prog.getIpset(), prog.getProg() == "ip6tables"); err != nil {
 			return err
 		}
-		progArgs := []string{
+
+		if err := prog.runProg([]string{
 			"-t", "nat",
 			"-A", ciliumPostNatChain,
 			"-s", allocRange,
 			"-m", "set", "--match-set", prog.getIpset(), "dst",
 			"-m", "comment", "--comment", "exclude traffic to cluster nodes from masquerade",
-			"-j", "ACCEPT",
-		}
-		if err := prog.runProg(progArgs, false); err != nil {
+			"-j", "ACCEPT"}); err != nil {
 			return err
 		}
 	}
@@ -990,7 +1050,7 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 	if option.Config.IPTablesRandomFully {
 		progArgs = append(progArgs, "--random-fully")
 	}
-	if err := prog.runProg(progArgs, false); err != nil {
+	if err := prog.runProg(progArgs); err != nil {
 		return err
 	}
 
@@ -1005,7 +1065,7 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 		// Don't match proxy (return) traffic
 		"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsProxy, linux_defaults.MagicMarkProxyMask),
 		"-m", "comment", "--comment", "exclude proxy return traffic from masquerade",
-		"-j", "ACCEPT"}, false); err != nil {
+		"-j", "ACCEPT"}); err != nil {
 		return err
 	}
 
@@ -1024,7 +1084,7 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 			"!", "-d", allocRange,
 			"-o", "cilium_host",
 			"-m", "comment", "--comment", "cilium host->cluster masquerade",
-			"-j", "SNAT", "--to-source", hostMasqueradeIP}, false); err != nil {
+			"-j", "SNAT", "--to-source", hostMasqueradeIP}); err != nil {
 			return err
 		}
 	}
@@ -1048,7 +1108,7 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 		"-s", loopbackAddr,
 		"-o", localDeliveryInterface,
 		"-m", "comment", "--comment", "cilium host->cluster from " + loopbackAddr + " masquerade",
-		"-j", "SNAT", "--to-source", hostMasqueradeIP}, false); err != nil {
+		"-j", "SNAT", "--to-source", hostMasqueradeIP}); err != nil {
 		return err
 	}
 
@@ -1075,7 +1135,7 @@ func (m *IptablesManager) installMasqueradeRules(prog iptablesInterface, ifName,
 			"-o", localDeliveryInterface,
 			"-m", "conntrack", "--ctstate", "DNAT",
 			"-m", "comment", "--comment", "hairpin traffic that originated from a local pod",
-			"-j", "SNAT", "--to-source", hostMasqueradeIP}, false); err != nil {
+			"-j", "SNAT", "--to-source", hostMasqueradeIP}); err != nil {
 			return err
 		}
 	}
@@ -1089,23 +1149,20 @@ func createIpset(name string, ipv6 bool) error {
 		ipsetFamily = "inet6"
 	}
 	progArgs := []string{"create", name, "iphash", "family", ipsetFamily, "-exist"}
-	return ipset.runProg(progArgs, true)
+	return ipset.runProg(progArgs)
 }
 
-func removeIpset(name string) {
+func removeIpset(name string) error {
 	if !ipsetExists(name) {
-		return
+		return nil
 	}
 	progArgs := []string{"destroy", name}
-	err := ipset.runProg(progArgs, true)
-	if err != nil {
-		log.WithError(err).Warnf("Unable to delete Cilium %s ipset", name)
-	}
+	return ipset.runProg(progArgs)
 }
 
 func ipsetExists(name string) bool {
 	progArgs := []string{"list", name}
-	err := ipset.runProg(progArgs, true)
+	err := ipset.runProg(progArgs)
 	return err == nil
 }
 
@@ -1138,35 +1195,39 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt, // Don't match ipsec traffic
 		"-m", "mark", "!", "--mark", matchFromProxy, // Don't match proxy traffic
 		"-m", "comment", "--comment", "cilium: host->any mark as from host",
-		"-j", "MARK", "--set-xmark", markAsFromHost}, false)
+		"-j", "MARK", "--set-xmark", markAsFromHost})
 }
 
 // InstallRules installs iptables rules for Cilium in specific use-cases
 // (most specifically, interaction with kube-proxy).
-func (m *IptablesManager) InstallRules(ifName string, firstInitialization, install bool) (err error) {
+func (m *IptablesManager) InstallRules(ifName string, firstInitialization, install bool) error {
 	m.Lock()
 	defer m.Unlock()
 
-	quiet := firstInitialization
-
 	// Make sure we have no old "backups"
-	m.removeRules(oldCiliumPrefix, true)
+	if err := m.removeRules(oldCiliumPrefix); err != nil {
+		return err
+	}
 
-	m.renameChains(oldCiliumPrefix, quiet)
+	if err := m.renameChains(oldCiliumPrefix); err != nil {
+		return err
+	}
 
 	// install rules if needed
 	if install {
-		err = m.installRules(ifName)
+		if err := m.installRules(ifName); err != nil {
+			return err
+		}
+
 		// copy old proxy rules over
 		match := ""
 		if firstInitialization {
 			match = "cilium-dns-egress"
 		}
-		m.copyProxyRules(oldCiliumPrefix+ciliumPreMangleChain, match)
-	}
 
-	if err != nil {
-		return err
+		if err := m.copyProxyRules(oldCiliumPrefix+ciliumPreMangleChain, match); err != nil {
+			return fmt.Errorf("cannot install proxy rules, disruption to traffic selected by L7 policy possible: %w", err)
+		}
 	}
 
 	// Create ipsets for node IP address only if needed. If they already exist,
@@ -1176,27 +1237,25 @@ func (m *IptablesManager) InstallRules(ifName string, firstInitialization, insta
 	// needed depends on the configuration, but the content doesn't.
 	if option.Config.NodeIpsetNeeded() {
 		if option.Config.IptablesMasqueradingIPv4Enabled() {
-			if err = createIpset(ciliumNodeIpsetV4, false); err != nil {
+			if err := createIpset(ciliumNodeIpsetV4, false); err != nil {
 				return err
 			}
 		}
 		if option.Config.IptablesMasqueradingIPv6Enabled() {
-			if err = createIpset(ciliumNodeIpsetV6, true); err != nil {
+			if err := createIpset(ciliumNodeIpsetV6, true); err != nil {
 				return err
 			}
 		}
 	} else {
-		// ipset removal is always quiet since there won't be anything to
-		// remove if Cilium wasn't using iptables-based masquerading before the restart.
-		removeIpset(ciliumNodeIpsetV4)
-		removeIpset(ciliumNodeIpsetV6)
+		if err := removeIpset(ciliumNodeIpsetV4); err != nil {
+			return err
+		}
+		if err := removeIpset(ciliumNodeIpsetV6); err != nil {
+			return err
+		}
 	}
 
-	// only remove old rules if new ones were successfully installed
-	if err == nil {
-		m.removeRules(oldCiliumPrefix, quiet)
-	}
-	return err
+	return m.removeRules(oldCiliumPrefix)
 }
 
 // installRules installs iptables rules for Cilium in specific use-cases
@@ -1218,16 +1277,16 @@ func (m *IptablesManager) installRules(ifName string) error {
 				continue
 			}
 
-			return fmt.Errorf("cannot add custom chain %s: %s", c.name, err)
+			return fmt.Errorf("cannot add custom chain %s: %w", c.name, err)
 		}
 	}
 
 	if err := m.installStaticProxyRules(); err != nil {
-		return fmt.Errorf("cannot add static proxy rules: %s", err)
+		return fmt.Errorf("cannot install static proxy rules: %w", err)
 	}
 
 	if err := m.addCiliumAcceptXfrmRules(); err != nil {
-		return err
+		return fmt.Errorf("cannot install xfrm rules: %w", err)
 	}
 
 	localDeliveryInterface := getDeliveryInterface(ifName)
@@ -1238,7 +1297,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 
 	if option.Config.EnableIPv4 {
 		if err := m.installHostTrafficMarkRule(ip4tables); err != nil {
-			return err
+			return fmt.Errorf("cannot install host traffic mark rule: %w", err)
 		}
 
 		if option.Config.IptablesMasqueradingIPv4Enabled() {
@@ -1247,14 +1306,14 @@ func (m *IptablesManager) installRules(ifName string) error {
 				node.GetIPv4AllocRange().String(),
 				node.GetHostMasqueradeIPv4().String(),
 			); err != nil {
-				return err
+				return fmt.Errorf("cannot install masquerade rules: %w", err)
 			}
 		}
 	}
 
 	if option.Config.EnableIPv6 {
 		if err := m.installHostTrafficMarkRule(ip6tables); err != nil {
-			return err
+			return fmt.Errorf("cannot install host traffic mark rule: %w", err)
 		}
 
 		if option.Config.IptablesMasqueradingIPv6Enabled() {
@@ -1263,7 +1322,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 				node.GetIPv6AllocRange().String(),
 				node.GetHostMasqueradeIPv6().String(),
 			); err != nil {
-				return err
+				return fmt.Errorf("cannot install masquerade rules: %w", err)
 			}
 		}
 	}
@@ -1288,7 +1347,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 		podsCIDR := option.Config.GetIPv4NativeRoutingCIDR().String()
 
 		if err := m.addNoTrackPodTrafficRules(ip4tables, podsCIDR); err != nil {
-			return fmt.Errorf("Cannot install rules to skip pod traffic CT: %w", err)
+			return fmt.Errorf("cannot install pod traffic no CT rules: %w", err)
 		}
 	}
 
@@ -1307,7 +1366,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 		}
 
 		if err := c.installFeeder(); err != nil {
-			return fmt.Errorf("cannot install feeder rule %s: %s", c.feederArgs, err)
+			return fmt.Errorf("cannot install feeder rule: %w", err)
 		}
 	}
 
@@ -1323,7 +1382,7 @@ func (m *IptablesManager) ciliumNoTrackXfrmRules(prog iptablesInterface, input s
 			"-t", "raw", input, ciliumPreRawChain,
 			"-m", "mark", "--mark", match,
 			"-m", "comment", "--comment", xfrmDescription,
-			"-j", "CT", "--notrack"}, false); err != nil {
+			"-j", "CT", "--notrack"}); err != nil {
 			return err
 		}
 	}
@@ -1338,6 +1397,7 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 	if option.Config.EnableIPSec == false {
 		return nil
 	}
+
 	insertAcceptXfrm := func(table, chain string) error {
 		matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 		matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
@@ -1349,7 +1409,7 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 			"-A", chain,
 			"-m", "mark", "--mark", matchFromIPSecEncrypt,
 			"-m", "comment", "--comment", comment,
-			"-j", "ACCEPT"}, false); err != nil {
+			"-j", "ACCEPT"}); err != nil {
 			return err
 		}
 
@@ -1358,8 +1418,9 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 			"-A", chain,
 			"-m", "mark", "--mark", matchFromIPSecDecrypt,
 			"-m", "comment", "--comment", comment,
-			"-j", "ACCEPT"}, false)
+			"-j", "ACCEPT"})
 	}
+
 	if err := insertAcceptXfrm("filter", ciliumInputChain); err != nil {
 		return err
 	}
@@ -1395,8 +1456,7 @@ func (m *IptablesManager) addNoTrackPodTrafficRules(prog iptablesInterface, pods
 			"-I", chain,
 			"-s", podsCIDR,
 			"-m", "comment", "--comment", "cilium: NOTRACK for pod traffic",
-			"-j", "CT", "--notrack"},
-			false); err != nil {
+			"-j", "CT", "--notrack"}); err != nil {
 			return err
 		}
 
@@ -1405,8 +1465,7 @@ func (m *IptablesManager) addNoTrackPodTrafficRules(prog iptablesInterface, pods
 			"-I", chain,
 			"-d", podsCIDR,
 			"-m", "comment", "--comment", "cilium: NOTRACK for pod traffic",
-			"-j", "CT", "--notrack"},
-			false); err != nil {
+			"-j", "CT", "--notrack"}); err != nil {
 			return err
 		}
 	}
@@ -1436,15 +1495,14 @@ func (m *IptablesManager) addCiliumENIRules() error {
 		"-i", iface.Attrs().Name,
 		"-m", "comment", "--comment", "cilium: primary ENI",
 		"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
-		"-j", "CONNMARK", "--set-xmark", nfmask + "/" + ctmask},
-		false); err != nil {
+		"-j", "CONNMARK", "--set-xmark", nfmask + "/" + ctmask}); err != nil {
 		return err
 	}
+
 	return ip4tables.runProg([]string{
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
 		"-i", "lxc+",
 		"-m", "comment", "--comment", "cilium: primary ENI",
-		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask},
-		false)
+		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask})
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -206,33 +206,35 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 		// the name CILIUM_ or call a chain with the name CILIUM_:
 		// -A CILIUM_FORWARD -o cilium_host -m comment --comment "cilium: any->cluster on cilium_host forward accept" -j ACCEPT
 		// -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST" -j CILIUM_POST
-		if strings.Contains(rule, match) {
-			// do not remove feeder for chains that are set to be disabled
-			// ie catch the beginning of the rule like -A POSTROUTING to match it against
-			// disabled chains
-			skipFeeder := false
-			for _, disabledChain := range option.Config.DisableIptablesFeederRules {
-				if strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
-					log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
-					skipFeeder = true
-					break
-				}
-			}
-			if skipFeeder {
-				continue
-			}
+		if !strings.Contains(rule, match) {
+			continue
+		}
 
-			reversedRule, err := reverseRule(rule)
-			if err != nil {
-				log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to parse %s rule into slice. Leaving rule behind.", prog)
-				continue
+		// do not remove feeder for chains that are set to be disabled
+		// ie catch the beginning of the rule like -A POSTROUTING to match it against
+		// disabled chains
+		skipFeeder := false
+		for _, disabledChain := range option.Config.DisableIptablesFeederRules {
+			if strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
+				log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
+				skipFeeder = true
+				break
 			}
+		}
+		if skipFeeder {
+			continue
+		}
 
-			if len(reversedRule) > 0 {
-				deleteRule := append([]string{"-t", table}, reversedRule...)
-				if err := prog.runProg(deleteRule); err != nil {
-					return err
-				}
+		reversedRule, err := reverseRule(rule)
+		if err != nil {
+			log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to parse %s rule into slice. Leaving rule behind.", prog)
+			continue
+		}
+
+		if len(reversedRule) > 0 {
+			deleteRule := append([]string{"-t", table}, reversedRule...)
+			if err := prog.runProg(deleteRule); err != nil {
+				return err
 			}
 		}
 	}
@@ -585,23 +587,24 @@ func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string,
 	scanner := bufio.NewScanner(strings.NewReader(rules))
 	for scanner.Scan() {
 		rule := scanner.Text()
-		if re.MatchString(rule) && strings.Contains(rule, match) {
+		if !re.MatchString(rule) || !strings.Contains(rule, match) {
+			continue
+		}
 
-			log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
-			args, err := shellwords.Parse(strings.Replace(rule, oldChain, newChain, 1))
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					"table":          table,
-					"prog":           prog.getProg(),
-					logfields.Object: rule,
-				}).WithError(err).Warn("Unable to parse TPROXY rule, disruption to traffic selected by L7 policy possible")
-				continue
-			}
+		log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering copying %s TPROXY rule from %s to %s", prog, oldChain, newChain)
+		args, err := shellwords.Parse(strings.Replace(rule, oldChain, newChain, 1))
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"table":          table,
+				"prog":           prog.getProg(),
+				logfields.Object: rule,
+			}).WithError(err).Warn("Unable to parse TPROXY rule, disruption to traffic selected by L7 policy possible")
+			continue
+		}
 
-			copyRule := append([]string{"-t", table}, args...)
-			if err := prog.runProg(copyRule); err != nil {
-				return err
-			}
+		copyRule := append([]string{"-t", table}, args...)
+		if err := prog.runProg(copyRule); err != nil {
+			return err
 		}
 	}
 
@@ -656,18 +659,19 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 	scanner := bufio.NewScanner(strings.NewReader(rules))
 	for scanner.Scan() {
 		rule := scanner.Text()
-		if strings.Contains(rule, "-A CILIUM_PRE_mangle ") && !strings.Contains(rule, "cilium: TPROXY to host "+name) && strings.Contains(rule, portMatch) {
+		if !strings.Contains(rule, "-A CILIUM_PRE_mangle ") || strings.Contains(rule, "cilium: TPROXY to host "+name) || !strings.Contains(rule, portMatch) {
+			continue
+		}
 
-			args, err := shellwords.Parse(strings.Replace(rule, "-A", "-D", 1))
-			if err != nil {
-				log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to parse %s TPROXY rule", prog)
-				continue
-			}
+		args, err := shellwords.Parse(strings.Replace(rule, "-A", "-D", 1))
+		if err != nil {
+			log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to parse %s TPROXY rule", prog)
+			continue
+		}
 
-			deleteRule := append([]string{"-t", "mangle"}, args...)
-			if err := prog.runProg(deleteRule); err != nil {
-				return err
-			}
+		deleteRule := append([]string{"-t", "mangle"}, args...)
+		if err := prog.runProg(deleteRule); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -372,7 +372,7 @@ func (m *IptablesManager) removeRules(prefix string) error {
 
 	for _, c := range ciliumChains {
 		c.name = prefix + c.name
-		if err := c.remove(); err != nil {
+		if err := c.remove(true, m.haveIp6tables); err != nil {
 			return err
 		}
 	}
@@ -383,7 +383,7 @@ func (m *IptablesManager) removeRules(prefix string) error {
 // renameChains renames iptables chains installed by Cilium.
 func (m *IptablesManager) renameChains(prefix string) error {
 	for _, c := range ciliumChains {
-		if err := c.rename(prefix + c.name); err != nil {
+		if err := c.rename(true, m.haveIp6tables, prefix+c.name); err != nil {
 			return err
 		}
 	}
@@ -1322,7 +1322,7 @@ func (m *IptablesManager) doInstallRules(ifName string, firstInitialization, ins
 func (m *IptablesManager) installRules(ifName string) error {
 	// Install new rules
 	for _, c := range ciliumChains {
-		if err := c.add(); err != nil {
+		if err := c.add(option.Config.EnableIPv4, option.Config.EnableIPv6); err != nil {
 			// do not return error for chain creation that are linked to disabled feeder rules
 			if isDisabledChain(c.hook) {
 				log.WithField("chain", c.name).Warningf("ignoring creation of chain since feeder rules for %s is disabled", c.hook)
@@ -1410,7 +1410,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 			continue
 		}
 
-		if err := c.installFeeder(); err != nil {
+		if err := c.installFeeder(option.Config.EnableIPv4, option.Config.EnableIPv6); err != nil {
 			return fmt.Errorf("cannot install feeder rule: %w", err)
 		}
 	}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/modules"
 	"github.com/cilium/cilium/pkg/node"
@@ -404,6 +405,12 @@ var ciliumChains = []customChain{
 
 // IptablesManager manages the iptables-related configuration for Cilium.
 type IptablesManager struct {
+	// This lock ensures there are no concurrent executions of the InstallRules() and
+	// InstallProxyRules() methods, as otherwise we may end up with errors (as rules may have
+	// been already removed or installed by a different execution of the method) or with an
+	// inconsistent ruleset
+	lock.Mutex
+
 	haveIp6tables        bool
 	haveSocketMatch      bool
 	haveBPFSocketAssign  bool
@@ -841,6 +848,9 @@ func (m *IptablesManager) endpointNoTrackRules(prog iptablesInterface, cmd strin
 // When InstallNoConntrackIptRules is not set, this function will be executed to install NOTRACK rules.
 // The rules installed by this function is very specific, for now, the only user is node-local-dns pods.
 func (m *IptablesManager) InstallNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	m.Lock()
+	defer m.Unlock()
+
 	// Do not install per endpoint NOTRACK rules if we are already skipping
 	// conntrack for all pod traffic.
 	if skipPodTrafficConntrack(ipv6) {
@@ -877,6 +887,9 @@ func (m *IptablesManager) InstallNoTrackRules(IP string, port uint16, ipv6 bool)
 
 // See comments for InstallNoTrackRules.
 func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) error {
+	m.Lock()
+	defer m.Unlock()
+
 	// Do not install per endpoint NOTRACK rules if we are already skipping
 	// conntrack for all pod traffic.
 	if skipPodTrafficConntrack(ipv6) {
@@ -912,6 +925,9 @@ func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) 
 }
 
 func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name string) error {
+	m.Lock()
+	defer m.Unlock()
+
 	if m.haveBPFSocketAssign {
 		log.WithField("port", proxyPort).
 			Debug("Skipping proxy rule install due to BPF support")
@@ -1297,6 +1313,9 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 // InstallRules installs iptables rules for Cilium in specific use-cases
 // (most specifically, interaction with kube-proxy).
 func (m *IptablesManager) InstallRules(ifName string, firstInitialization, install bool) (err error) {
+	m.Lock()
+	defer m.Unlock()
+
 	quiet := firstInitialization
 
 	// Make sure we have no old "backups"

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -5,6 +5,7 @@ package iptables
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"regexp"
@@ -12,6 +13,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
+	"github.com/mattn/go-shellwords"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/datapath"
@@ -28,10 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/versioncheck"
-
-	"github.com/blang/semver/v4"
-	"github.com/mattn/go-shellwords"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -816,6 +818,33 @@ func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) 
 }
 
 func (m *IptablesManager) InstallProxyRules(proxyPort uint16, ingress bool, name string) error {
+	backoff := backoff.Exponential{
+		Min:  20 * time.Second,
+		Max:  3 * time.Minute,
+		Name: "iptables-proxy-rules-installer",
+	}
+
+	maxAttempts := 3
+	attempt := 0
+
+	for {
+		attempt += 1
+		err := m.doInstallProxyRules(proxyPort, ingress, name)
+		if err == nil {
+			log.Info("Iptables proxy rules installed")
+			return nil
+		}
+
+		if attempt == maxAttempts {
+			return fmt.Errorf("failed to install iptables proxy rules: %w", err)
+		}
+
+		log.WithError(err).Warning("Failed to install iptables proxy rules")
+		backoff.Wait(context.TODO())
+	}
+}
+
+func (m *IptablesManager) doInstallProxyRules(proxyPort uint16, ingress bool, name string) error {
 	m.Lock()
 	defer m.Unlock()
 
@@ -1201,6 +1230,33 @@ func (m *IptablesManager) installHostTrafficMarkRule(prog iptablesInterface) err
 // InstallRules installs iptables rules for Cilium in specific use-cases
 // (most specifically, interaction with kube-proxy).
 func (m *IptablesManager) InstallRules(ifName string, firstInitialization, install bool) error {
+	backoff := backoff.Exponential{
+		Min:  20 * time.Second,
+		Max:  3 * time.Minute,
+		Name: "iptables-rules-installer",
+	}
+
+	maxAttempts := 3
+	attempt := 0
+
+	for {
+		attempt += 1
+		err := m.doInstallRules(ifName, firstInitialization, install)
+		if err == nil {
+			log.Info("Iptables rules installed")
+			return nil
+		}
+
+		if attempt == maxAttempts {
+			return fmt.Errorf("failed to install iptables rules: %w", err)
+		}
+
+		log.WithError(err).Warning("Failed to install iptables rules")
+		backoff.Wait(context.TODO())
+	}
+}
+
+func (m *IptablesManager) doInstallRules(ifName string, firstInitialization, install bool) error {
 	m.Lock()
 	defer m.Unlock()
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1289,6 +1289,10 @@ func (m *IptablesManager) doInstallRules(ifName string, firstInitialization, ins
 		}
 	}
 
+	if err := m.removeRules(oldCiliumPrefix); err != nil {
+		return err
+	}
+
 	// Create ipsets for node IP address only if needed. If they already exist,
 	// we will simply ignore the error.
 	// Note we don't need a backup system as for iptables rules because the
@@ -1314,7 +1318,7 @@ func (m *IptablesManager) doInstallRules(ifName string, firstInitialization, ins
 		}
 	}
 
-	return m.removeRules(oldCiliumPrefix)
+	return nil
 }
 
 // installRules installs iptables rules for Cilium in specific use-cases

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -237,7 +237,7 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 		// ie catch the beginning of the rule like -A POSTROUTING to match it against
 		// disabled chains
 		if skip, disabledChain := ruleReferencesDisabledChain(rule); skip {
-			log.WithField("chain", disabledChain).Info("Skipping the removal of feeder chain")
+			log.WithField(logfields.Chain, disabledChain).Info("Skipping the removal of feeder chain")
 			continue
 		}
 
@@ -1329,7 +1329,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 		if err := c.add(option.Config.EnableIPv4, option.Config.EnableIPv6); err != nil {
 			// do not return error for chain creation that are linked to disabled feeder rules
 			if isDisabledChain(c.hook) {
-				log.WithField("chain", c.name).Warningf("ignoring creation of chain since feeder rules for %s is disabled", c.hook)
+				log.WithField(logfields.Chain, c.name).Warningf("ignoring creation of chain since feeder rules for %s is disabled", c.hook)
 				continue
 			}
 
@@ -1410,7 +1410,7 @@ func (m *IptablesManager) installRules(ifName string) error {
 	for _, c := range ciliumChains {
 		// do not install feeder for chains that are set to be disabled
 		if isDisabledChain(c.hook) {
-			log.WithField("chain", c.hook).Infof("Skipping the install of feeder rule")
+			log.WithField(logfields.Chain, c.hook).Infof("Skipping the install of feeder rule")
 			continue
 		}
 

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -55,27 +55,27 @@ func (ipt *mockIptables) getVersion() (semver.Version, error) {
 	return semver.Version{}, nil
 }
 
-func (ipt *mockIptables) runProgCombinedOutput(args []string, quiet bool) (out []byte, err error) {
+func (ipt *mockIptables) runProgCombinedOutput(args []string) (out string, err error) {
 	a := strings.Join(args, " ")
 	i := ipt.index
 	ipt.index++
 
 	if len(ipt.expectations) < ipt.index {
 		ipt.c.Errorf("%d: Unexpected %s %s", i, ipt.prog, a)
-		return nil, fmt.Errorf("Unexpected %s %s", ipt.prog, a)
+		return "", fmt.Errorf("Unexpected %s %s", ipt.prog, a)
 	}
 	if a != ipt.expectations[i].args {
 		ipt.c.Errorf("%d: Unexpected %s (%q != %q)", i, ipt.prog, a, ipt.expectations[i].args)
-		return nil, fmt.Errorf("Unexpected %s %s", ipt.prog, a)
+		return "", fmt.Errorf("Unexpected %s %s", ipt.prog, a)
 	}
-	out = ipt.expectations[i].out
+	out = string(ipt.expectations[i].out)
 	err = ipt.expectations[i].err
 
 	return out, err
 }
 
-func (ipt *mockIptables) runProg(args []string, quiet bool) error {
-	out, err := ipt.runProgCombinedOutput(args, quiet)
+func (ipt *mockIptables) runProg(args []string) error {
+	out, err := ipt.runProgCombinedOutput(args)
 	if len(out) > 0 {
 		ipt.c.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
 	}
@@ -109,6 +109,9 @@ func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
 	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
+			args: "-t mangle -L CILIUM_PRE_mangle",
+		},
+		{
 			args: "-t mangle -E CILIUM_PRE_mangle OLD_CILIUM_PRE_mangle",
 		},
 	}
@@ -116,13 +119,13 @@ func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
 		table: "mangle",
 		name:  "CILIUM_PRE_mangle",
 	}
-	chain.doRename(mockIp4tables, "OLD_CILIUM_PRE_mangle", false)
+	chain.doRename(mockIp4tables, "OLD_CILIUM_PRE_mangle")
 	err := mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
 	mockIp6tables := &mockIptables{c: c, prog: "ip6tables"}
 	mockIp6tables.expectations = mockIp4tables.expectations
-	chain.doRename(mockIp6tables, "OLD_CILIUM_PRE_mangle", false)
+	chain.doRename(mockIp6tables, "OLD_CILIUM_PRE_mangle")
 	err = mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -44,20 +44,20 @@ type PreFilter interface {
 // Proxy is any type which installs rules related to redirecting traffic to
 // a proxy.
 type Proxy interface {
-	ReinstallRules() error
+	ReinstallRules(ctx context.Context) error
 }
 
 // IptablesManager manages iptables rules.
 type IptablesManager interface {
 	// InstallProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	InstallProxyRules(proxyPort uint16, ingress bool, name string) error
+	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress bool, name string) error
 
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream
 	// connections.
 	SupportsOriginalSourceAddr() bool
-	InstallRules(ifName string, quiet, install bool) error
+	InstallRules(ctx context.Context, ifName string, quiet, install bool) error
 
 	// GetProxyPort fetches the existing proxy port configured for the
 	// specified listener. Used early in bootstrap to reopen proxy ports.

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -44,7 +44,7 @@ type PreFilter interface {
 // Proxy is any type which installs rules related to redirecting traffic to
 // a proxy.
 type Proxy interface {
-	ReinstallRules()
+	ReinstallRules() error
 }
 
 // IptablesManager manages iptables rules.

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -454,13 +454,13 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return err
 	}
 
-	if err := iptMgr.InstallRules(option.Config.HostDevice, firstInitialization, option.Config.InstallIptRules); err != nil {
+	if err := iptMgr.InstallRules(ctx, option.Config.HostDevice, firstInitialization, option.Config.InstallIptRules); err != nil {
 		return err
 	}
 
 	// Reinstall proxy rules for any running proxies if needed
 	if p != nil {
-		if err := p.ReinstallRules(); err != nil {
+		if err := p.ReinstallRules(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -460,7 +460,9 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	// Reinstall proxy rules for any running proxies if needed
 	if p != nil {
-		p.ReinstallRules()
+		if err := p.ReinstallRules(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -255,7 +255,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				}
 
 				var err error
-				redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(l4, proxyID, e, proxyWaitGroup)
+				redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(e.aliveCtx, l4, proxyID, e, proxyWaitGroup)
 				if err != nil {
 					revertStack.Revert() // Ignore errors while reverting. This is best-effort.
 					return err, nil, nil
@@ -381,7 +381,7 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 			continue
 		}
 
-		redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(visMeta, proxyID, e, proxyWaitGroup)
+		redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(e.aliveCtx, visMeta, proxyID, e, proxyWaitGroup)
 		if err != nil {
 			revertStack.Revert() // Ignore errors while reverting. This is best-effort.
 			return err, nil, nil

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -4,6 +4,7 @@
 package endpoint
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -14,7 +15,7 @@ import (
 
 // EndpointProxy defines any L7 proxy with which an Endpoint must interact.
 type EndpointProxy interface {
-	CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
+	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
 	UpdateNetworkPolicy(ep logger.EndpointUpdater, vis *policy.VisibilityPolicy, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
@@ -43,7 +44,7 @@ func (e *Endpoint) isProxyDisabled() bool {
 type FakeEndpointProxy struct{}
 
 // CreateOrUpdateRedirect does nothing.
-func (f *FakeEndpointProxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+func (f *FakeEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	return
 }
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -43,7 +43,7 @@ type RedirectSuiteProxy struct {
 
 // CreateOrUpdateRedirect returns the proxy port for the given L7Parser from the
 // ProxyPolicy parameter.
-func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	pp := r.parserProxyPortMap[l4.GetL7Parser()]
 	return pp, nil, nil, nil
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -571,4 +571,7 @@ const (
 
 	// GatewayIP is the gateway IP used in a given egress policy
 	GatewayIP = "gatewayIP"
+
+	// Chain is an Iptables chain
+	Chain = "chain"
 )

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -39,7 +40,7 @@ const (
 )
 
 type DatapathUpdater interface {
-	InstallProxyRules(proxyPort uint16, ingress bool, name string) error
+	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress bool, name string) error
 	SupportsOriginalSourceAddr() bool
 }
 
@@ -225,21 +226,21 @@ func findProxyPort(name string) *ProxyPort {
 
 // AckProxyPort() marks the proxy of the given type as successfully
 // created and creates or updates the datapath rules accordingly.
-func (p *Proxy) AckProxyPort(l7Type policy.L7ParserType, ingress bool) error {
+func (p *Proxy) AckProxyPort(ctx context.Context, l7Type policy.L7ParserType, ingress bool) error {
 	proxyPortsMutex.Lock()
 	defer proxyPortsMutex.Unlock()
 	pp := getProxyPort(l7Type, ingress)
 	if pp == nil {
 		return proxyNotFoundError(l7Type, ingress)
 	}
-	return p.ackProxyPort(pp) // creates datapath rules, increases the reference count
+	return p.ackProxyPort(ctx, pp) // creates datapath rules, increases the reference count
 }
 
 // ackProxyPort() marks the proxy as successfully created and creates or updates the datapath rules
 // accordingly. Each call must eventually be paired with a corresponding releaseProxyPort() call
 // to keep the use count up-to-date.
 // Must be called with proxyPortsMutex held!
-func (p *Proxy) ackProxyPort(pp *ProxyPort) error {
+func (p *Proxy) ackProxyPort(ctx context.Context, pp *ProxyPort) error {
 	if pp.nRedirects == 0 {
 		scopedLog := log.WithField("proxy port name", pp.name)
 		scopedLog.Debugf("Considering updating proxy port rules for %s:%d (old: %d)", pp.name, pp.proxyPort, pp.rulesPort)
@@ -256,7 +257,7 @@ func (p *Proxy) ackProxyPort(pp *ProxyPort) error {
 			// Add rules for the new port
 			// This should always succeed if we have managed to start-up properly
 			scopedLog.Infof("Adding new proxy port rules for %s:%d", pp.name, pp.proxyPort)
-			if err := p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.ingress, pp.name); err != nil {
+			if err := p.datapathUpdater.InstallProxyRules(ctx, pp.proxyPort, pp.ingress, pp.name); err != nil {
 				return fmt.Errorf("Cannot install proxy rules for %s: %w", pp.name, err)
 			}
 			pp.rulesPort = pp.proxyPort
@@ -357,13 +358,13 @@ func (p *Proxy) SetProxyPort(name string, port uint16) error {
 
 // ReinstallRules is called by daemon reconfiguration to re-install proxy ports rules that
 // were removed during the removal of all Cilium rules.
-func (p *Proxy) ReinstallRules() error {
+func (p *Proxy) ReinstallRules(ctx context.Context) error {
 	proxyPortsMutex.Lock()
 	defer proxyPortsMutex.Unlock()
 	for _, pp := range proxyPorts {
 		if pp.rulesPort > 0 {
 			// This should always succeed if we have managed to start-up properly
-			if err := p.datapathUpdater.InstallProxyRules(pp.rulesPort, pp.ingress, pp.name); err != nil {
+			if err := p.datapathUpdater.InstallProxyRules(ctx, pp.rulesPort, pp.ingress, pp.name); err != nil {
 				return fmt.Errorf("Can't install proxy rules for %s: %w", pp.name, err)
 			}
 		}
@@ -383,7 +384,7 @@ func (p *Proxy) ReinstallRules() error {
 // - finalizeFunc to make the changes stick, or
 // - revertFunc to cancel the changes.
 // Called with 'localEndpoint' locked!
-func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater,
+func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater,
 	wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 
 	p.mutex.Lock()
@@ -506,7 +507,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEn
 				}
 
 				proxyPortsMutex.Lock()
-				err := p.ackProxyPort(pp)
+				err := p.ackProxyPort(ctx, pp)
 				proxyPortsMutex.Unlock()
 				if err != nil {
 					log.WithError(err).Errorf("Datapath proxy redirection cannot be enabled for %s, L7 proxy may be bypassed", pp.name)


### PR DESCRIPTION
Following up on the v1.10 backport, here's the v1.11 backport of:
* https://github.com/cilium/cilium/pull/19693
* https://github.com/cilium/cilium/pull/20109 (extra fix for the original master PR discovered while reviewing this backport)

There were still minor conflicts in https://github.com/cilium/cilium/pull/20178/commits/cc047e7e0d1f780bd3a712e7da1b53d816f71454 and https://github.com/cilium/cilium/pull/20178/commits/14670afe379354e52828d45b0a0d40f6d3c891eb, but compared to the v1.10 backport the patches applied much more cleanly.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19693 20109; do contrib/backporting/set-labels.py $pr done 1.11; done
```