### PR TITLE
v1.10 backports 2022-06-13

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -300,7 +300,7 @@ const (
 	// Devices is the devices name
 	Devices = "devices"
 
-	//DirectRoutingDevice is the name of the direct routing device
+	// DirectRoutingDevice is the name of the direct routing device
 	DirectRoutingDevice = "directRoutingDevice"
 
 	// IpvlanMasterDevice is the ipvlan master device name
@@ -516,6 +516,12 @@ const (
 
 	// LRPBackendPorts are the parsed backend ports of the Local Redirect Policy.
 	LRPBackendPorts = "lrpBackendPorts"
+
+	// LRPType is the type of the Local Redirect Policy.
+	LRPType = "lrpType"
+
+	// LRPFrontendType is the parsed frontend type of the Local Redirect Policy.
+	LRPFrontendType = "lrpFrontendType"
 
 	// ENPName is the name of the egress nat policy
 	ENPName = "enpName"

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -151,11 +151,13 @@ func (rpm *Manager) AddRedirectPolicy(config LRPConfig) (bool, error) {
 	switch config.lrpType {
 	case lrpConfigTypeAddr:
 		log.WithFields(logrus.Fields{
+			logfields.LRPType:                  config.lrpType,
 			logfields.K8sNamespace:             config.id.Namespace,
 			logfields.LRPName:                  config.id.Name,
 			logfields.LRPFrontends:             config.frontendMappings,
 			logfields.LRPLocalEndpointSelector: config.backendSelector,
 			logfields.LRPBackendPorts:          config.backendPorts,
+			logfields.LRPFrontendType:          config.frontendType,
 		}).Debug("Add local redirect policy")
 		pods := rpm.getLocalPodsForPolicy(&config)
 		if len(pods) == 0 {
@@ -165,12 +167,14 @@ func (rpm *Manager) AddRedirectPolicy(config LRPConfig) (bool, error) {
 
 	case lrpConfigTypeSvc:
 		log.WithFields(logrus.Fields{
+			logfields.LRPType:                  config.lrpType,
 			logfields.K8sNamespace:             config.id.Namespace,
 			logfields.LRPName:                  config.id.Name,
 			logfields.K8sSvcID:                 config.serviceID,
 			logfields.LRPFrontends:             config.frontendMappings,
 			logfields.LRPLocalEndpointSelector: config.backendSelector,
 			logfields.LRPBackendPorts:          config.backendPorts,
+			logfields.LRPFrontendType:          config.frontendType,
 		}).Debug("Add local redirect policy")
 
 		rpm.getAndUpsertPolicySvcConfig(&config)
@@ -626,6 +630,10 @@ func (rpm *Manager) isValidConfig(config LRPConfig) error {
 }
 
 func (rpm *Manager) processConfig(config *LRPConfig, pods ...*podMetadata) {
+	if config.lrpType == lrpConfigTypeSvc && len(config.frontendMappings) == 0 {
+		// Frontend information will be available when the selected service is added.
+		return
+	}
 	switch config.frontendType {
 	case svcFrontendSinglePort:
 		fallthrough


### PR DESCRIPTION
 * ~~#18348 -- metrics: Add extra clustermesh metrics (@sayboras)~~
 * #19522 -- redirectpolicy: Fix panic in service matcher LPR processing (@aditighag)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19522; do contrib/backporting/set-labels.py $pr done 1.10; done
```
or with
```
$ make add-label BRANCH=v1.10 ISSUES=19522
```