### PR TITLE
v1.9 backports 2022-06-13

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -302,7 +302,7 @@ func (c *DNSCache) cleanupOverLimitEntries() (affectedNames []string, removed ma
 		for i := 0; i < overlimit; i++ {
 			key := sortedEntries[i]
 			delete(entries, key.ip)
-			c.removeReverse(key.ip, key.entry)
+			c.remove(key.ip, key.entry)
 			removed[key.ip] = append(removed[key.ip], key.entry)
 		}
 		affectedNames = append(affectedNames, dnsName)
@@ -504,7 +504,7 @@ func (c *DNSCache) removeExpired(entries ipEntries, now time.Time, expireLookups
 	for ip, entry := range entries {
 		if entry == nil || entry.isExpiredBy(now) || entry.LookupTime.Before(expireLookupsBefore) {
 			delete(entries, ip)
-			c.removeReverse(ip, entry)
+			c.remove(ip, entry)
 			removed[ip] = entry
 		}
 	}
@@ -525,11 +525,31 @@ func (c *DNSCache) upsertReverse(ip string, entry *cacheEntry) {
 	entries[entry.Name] = entry
 }
 
-// removeReverse removes the reference between ip and the name stored in entry.
+// remove removes the reference between ip and the name stored in entry from
+// the DNS cache (both in forward and reverse maps). This assumes the write
+// lock is taken.
+func (c *DNSCache) remove(ip string, entry *cacheEntry) {
+	c.removeForward(ip, entry)
+	c.removeReverse(ip, entry)
+}
+
+// removeForward removes the reference between ip and the name stored in entry.
 // When no more references from ip to any name exist, the map entry is deleted
 // outright.
 // It is assumed that entry includes ip.
-// This needs a write lock
+// This needs a write lock.
+func (c *DNSCache) removeForward(ip string, entry *cacheEntry) {
+	entries, exists := c.forward[entry.Name]
+	if entries == nil || !exists {
+		return
+	}
+	delete(entries, ip)
+	if len(entries) == 0 {
+		delete(c.forward, entry.Name)
+	}
+}
+
+// removeReverse is the equivalent of removeForward() but for the reverse map.
 func (c *DNSCache) removeReverse(ip string, entry *cacheEntry) {
 	entries, exists := c.reverse[ip]
 	if entries == nil || !exists {

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -109,6 +109,10 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 	for _, name := range []string{"test1.com", "test2.com", "test3.com"} {
 		ips := cache.lookupByTime(now, name)
 		c.Assert(len(ips), Equals, 2, Commentf("Wrong count of IPs returned (%v) for non-deleted name '%s'", ips, name))
+		c.Assert(cache.forward, checker.HasKey, name, Commentf("Expired name '%s' not deleted from forward", name))
+		for _, ip := range ips {
+			c.Assert(cache.reverse, checker.HasKey, ip.String(), Commentf("Expired IP '%s' not deleted from reverse", ip))
+		}
 	}
 
 	// Delete a single name and check that
@@ -121,9 +125,17 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 	c.Assert(namesAffected[0], Equals, "test1.com", Commentf("Incorrect affected name returned on forced expire: %s", namesAffected))
 	ips := cache.lookupByTime(now, "test1.com")
 	c.Assert(len(ips), Equals, 0, Commentf("IPs returned (%v) for deleted name 'test1.com'", ips))
+	c.Assert(cache.forward, Not(checker.HasKey), "test1.com", Commentf("Expired name 'test1.com' not deleted from forward"))
+	for _, ip := range ips {
+		c.Assert(cache.reverse, Not(checker.HasKey), ip.String(), Commentf("Expired IP '%s' not deleted from reverse", ip))
+	}
 	for _, name := range []string{"test2.com", "test3.com"} {
 		ips = cache.lookupByTime(now, name)
 		c.Assert(len(ips), Equals, 2, Commentf("Wrong count of IPs returned (%v) for non-deleted name '%s'", ips, name))
+		c.Assert(cache.forward, checker.HasKey, name, Commentf("Expired name '%s' not deleted from forward", name))
+		for _, ip := range ips {
+			c.Assert(cache.reverse, checker.HasKey, ip.String(), Commentf("Expired IP '%s' not deleted from reverse", ip))
+		}
 	}
 
 	// Delete the whole cache. This should leave no data.
@@ -137,6 +149,8 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 		ips = cache.lookupByTime(now, name)
 		c.Assert(len(ips), Equals, 0, Commentf("Returned IP data for %s after the cache was fully cleared: %v", name, ips))
 	}
+	c.Assert(cache.forward, HasLen, 0)
+	c.Assert(cache.reverse, HasLen, 0)
 	dump := cache.Dump()
 	c.Assert(len(dump), Equals, 0, Commentf("Returned cache entries from cache dump after the cache was fully cleared: %v", dump))
 }
@@ -872,7 +886,14 @@ func (ds *DNSCacheTestSuite) TestCacheToZombiesGCCascade(c *C) {
 
 	// Cascade expirations from cache to zombies. The 3.3.3.3 lookup has not expired
 	now = now.Add(4 * time.Second)
-	cache.GC(now, zombies)
+	expired := cache.GC(now, zombies)
+	c.Assert(expired, HasLen, 1) // test.com
+	// Not all IPs expired (3.3.3.3 still alive) so we expect test.com to be
+	// present in the cache.
+	c.Assert(cache.forward, checker.HasKey, "test.com")
+	c.Assert(cache.reverse, checker.HasKey, "3.3.3.3")
+	c.Assert(cache.reverse, Not(checker.HasKey), "1.1.1.1")
+	c.Assert(cache.reverse, Not(checker.HasKey), "2.2.2.2")
 	alive, dead := zombies.GC()
 	c.Assert(dead, HasLen, 0)
 	assertZombiesContain(c, alive, map[string][]string{
@@ -883,7 +904,13 @@ func (ds *DNSCacheTestSuite) TestCacheToZombiesGCCascade(c *C) {
 	// Cascade expirations from cache to zombies. The 3.3.3.3 lookup has expired
 	// but the older zombies are still alive.
 	now = now.Add(4 * time.Second)
-	cache.GC(now, zombies)
+	expired = cache.GC(now, zombies)
+	c.Assert(expired, HasLen, 1) // test.com
+	// Now all IPs expired so we expect test.com to be removed from the cache.
+	c.Assert(cache.forward, Not(checker.HasKey), "test.com")
+	c.Assert(cache.forward, HasLen, 0)
+	c.Assert(cache.reverse, Not(checker.HasKey), "3.3.3.3")
+	c.Assert(cache.reverse, HasLen, 0)
 	alive, dead = zombies.GC()
 	c.Assert(dead, HasLen, 0)
 	assertZombiesContain(c, alive, map[string][]string{

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -294,7 +294,7 @@ const (
 	// Devices is the devices name
 	Devices = "devices"
 
-	//DirectRoutingDevice is the name of the direct routing device
+	// DirectRoutingDevice is the name of the direct routing device
 	DirectRoutingDevice = "directRoutingDevice"
 
 	// IpvlanMasterDevice is the ipvlan master device name
@@ -507,6 +507,12 @@ const (
 
 	// LRPBackendPorts are the parsed backend ports of the Local Redirect Policy.
 	LRPBackendPorts = "lrpBackendPorts"
+
+	// LRPType is the type of the Local Redirect Policy.
+	LRPType = "lrpType"
+
+	// LRPFrontendType is the parsed frontend type of the Local Redirect Policy.
+	LRPFrontendType = "lrpFrontendType"
 
 	// Mode describes an operations mode
 	Mode = "mode"

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -151,11 +151,13 @@ func (rpm *Manager) AddRedirectPolicy(config LRPConfig) (bool, error) {
 	switch config.lrpType {
 	case lrpConfigTypeAddr:
 		log.WithFields(logrus.Fields{
+			logfields.LRPType:                  config.lrpType,
 			logfields.K8sNamespace:             config.id.Namespace,
 			logfields.LRPName:                  config.id.Name,
 			logfields.LRPFrontends:             config.frontendMappings,
 			logfields.LRPLocalEndpointSelector: config.backendSelector,
 			logfields.LRPBackendPorts:          config.backendPorts,
+			logfields.LRPFrontendType:          config.frontendType,
 		}).Debug("Add local redirect policy")
 		pods := rpm.getLocalPodsForPolicy(&config)
 		if len(pods) == 0 {
@@ -165,12 +167,14 @@ func (rpm *Manager) AddRedirectPolicy(config LRPConfig) (bool, error) {
 
 	case lrpConfigTypeSvc:
 		log.WithFields(logrus.Fields{
+			logfields.LRPType:                  config.lrpType,
 			logfields.K8sNamespace:             config.id.Namespace,
 			logfields.LRPName:                  config.id.Name,
 			logfields.K8sSvcID:                 config.serviceID,
 			logfields.LRPFrontends:             config.frontendMappings,
 			logfields.LRPLocalEndpointSelector: config.backendSelector,
 			logfields.LRPBackendPorts:          config.backendPorts,
+			logfields.LRPFrontendType:          config.frontendType,
 		}).Debug("Add local redirect policy")
 
 		rpm.getAndUpsertPolicySvcConfig(&config)
@@ -630,6 +634,10 @@ func (rpm *Manager) isValidConfig(config LRPConfig) error {
 }
 
 func (rpm *Manager) processConfig(config *LRPConfig, pods ...*podMetadata) {
+	if config.lrpType == lrpConfigTypeSvc && len(config.frontendMappings) == 0 {
+		// Frontend information will be available when the selected service is added.
+		return
+	}
 	switch config.frontendType {
 	case svcFrontendSinglePort:
 		fallthrough


### PR DESCRIPTION
 * #19925 -- pkg/fqdn: Fix missing delete for forward map (@christarazi)
 * #19522 -- redirectpolicy: Fix panic in service matcher LPR processing (@aditighag)

PRs skipped due conflicts:

 * #19565 -- ui: v0.9.0 images and drop envoy proxy container (@geakstr)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19925 19522; do contrib/backporting/set-labels.py $pr done 1.9; done
```
or with
```
$ make add-label BRANCH=v1.9 ISSUES=19925,19522
```