### PR TITLE
[v1.11] add support to override not ready taint to be ignored by the CA

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -13,6 +13,7 @@ cilium-agent [flags]
 ```
       --agent-health-port int                                   TCP port for agent health status API (default 9879)
       --agent-labels strings                                    Additional labels to identify this agent
+      --agent-not-ready-taint-key string                        Key of the taint indicating that Cilium is not ready on the node (default "node.cilium.io/agent-not-ready")
       --allocator-list-timeout duration                         Timeout for listing allocator state before exiting (default 3m0s)
       --allow-icmp-frag-needed                                  Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
       --allow-localhost string                                  Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")

--- a/Documentation/gettingstarted/taints.rst
+++ b/Documentation/gettingstarted/taints.rst
@@ -33,17 +33,24 @@ manipulate Kubernetes's `taints <https://kubernetes.io/docs/concepts/scheduling-
 on a given node to help preventing pods from starting before Cilium runs on said
 node. The mechanism works as follows:
 
-1. The cluster administrator places a taint with key
-   ``node.cilium.io/agent-not-ready`` on a given uninitialized node. Depending on
-   the taint's effect (see below), this prevents pods that don't have a matching
-   toleration from either being scheduled or altogether running on the node until
-   the taint is removed.
+1. The cluster administrator places a specific taint (see below) on a given
+   uninitialized node. Depending on the taint's effect (see below), this prevents
+   pods that don't have a matching toleration from either being scheduled or
+   altogether running on the node until the taint is removed.
 
 2. Cilium runs on the node, initializes it and, once ready, removes the
-   ``node.cilium.io/agent-not-ready`` taint.
+   aforementioned taint.
 
 3. From this point on, pods will start being scheduled and running on the node,
    having their networking managed by Cilium.
+
+By default, the taint key is ``node.cilium.io/agent-not-ready``, but in some
+scenarios (such as when Cluster Autoscaler is being used but its flags cannot be
+configured) this key may need to be tweaked. This can be done using the
+``agent-not-ready-taint-key`` option. In the aforementioned example, users should
+specify a key starting with ``ignore-taint.cluster-autoscaler.kubernetes.io/``.
+When such a value is used, the Cluster Autoscaler will ignore it when simulating
+scheduling, allowing the cluster to scale up.
 
 The taint's effect should be chosen taking into account the following
 considerations:

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -17,6 +17,10 @@
      - Install the cilium agent resources.
      - bool
      - ``true``
+   * - agentNotReadyTaintKey
+     - Configure the key of the taint indicating that Cilium is not ready on the node. When set to a value starting with ``ignore-taint.cluster-autoscaler.kubernetes.io/``\ , the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up.
+     - string
+     - ``"node.cilium.io/agent-not-ready"``
    * - alibabacloud.enabled
      - Enable AlibabaCloud ENI integration
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -144,6 +144,7 @@ Zhou
 Zookeeper
 aarch
 admin
+agentNotReadyTaintKey
 alibabacloud
 allocator
 allocators

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -495,6 +495,9 @@ func initializeFlags() {
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium is deployed in")
 	option.BindEnv(option.K8sNamespaceName)
 
+	flags.String(option.AgentNotReadyNodeTaintKeyName, defaults.AgentNotReadyNodeTaint, "Key of the taint indicating that Cilium is not ready on the node")
+	option.BindEnv(option.AgentNotReadyNodeTaintKeyName)
+
 	flags.Bool(option.JoinClusterName, false, "Join a Cilium cluster via kvstore registration")
 	option.BindEnv(option.JoinClusterName)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -55,6 +55,7 @@ contributors across the globe, there is almost always someone available to help.
 |-----|------|---------|-------------|
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]},{"matchExpressions":[{"key":"beta.kubernetes.io/os","operator":"In","values":["linux"]}]}]}},"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"k8s-app","operator":"In","values":["cilium"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Pod affinity for cilium-agent. |
 | agent | bool | `true` | Install the cilium agent resources. |
+| agentNotReadyTaintKey | string | `"node.cilium.io/agent-not-ready"` | Configure the key of the taint indicating that Cilium is not ready on the node. When set to a value starting with `ignore-taint.cluster-autoscaler.kubernetes.io/`, the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up. |
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | annotateK8sNode | bool | `true` | Annotate k8s node upon initialization with Cilium's metadata. |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -816,4 +816,9 @@ data:
 {{- if .Values.extraConfig }}
   {{ toYaml .Values.extraConfig | nindent 2 }}
 {{- end }}
+
+{{- if hasKey .Values "agentNotReadyTaintKey" }}
+  agent-not-ready-taint-key: {{ .Values.agentNotReadyTaintKey | quote }}
+{{- end }}
+
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1854,3 +1854,10 @@ cgroup:
 # -- Configure whether to enable auto detect of terminating state for endpoints
 # in order to support graceful termination.
 enableK8sTerminatingEndpoint: true
+
+# -- Configure whether to unload DNS policy rules on graceful shutdown
+# dnsPolicyUnloadOnShutdown: false
+
+# -- Configure the key of the taint indicating that Cilium is not ready on the node.
+# When set to a value starting with `ignore-taint.cluster-autoscaler.kubernetes.io/`, the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up.
+agentNotReadyTaintKey: "node.cilium.io/agent-not-ready"

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -10,8 +10,8 @@ import (
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/option"
+	pkgOption "github.com/cilium/cilium/pkg/option"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -323,7 +323,7 @@ func init() {
 	flags.String(operatorOption.CiliumPodLabels, "k8s-app=cilium", "Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false")
 	option.BindEnv(operatorOption.CiliumPodLabels)
 
-	flags.Bool(operatorOption.RemoveCiliumNodeTaints, true, fmt.Sprintf("Remove node taint %q from Kubernetes nodes once Cilium is up and running", ciliumio.AgentNotReadyNodeTaint))
+	flags.Bool(operatorOption.RemoveCiliumNodeTaints, true, fmt.Sprintf("Remove node taint %q from Kubernetes nodes once Cilium is up and running", pkgOption.Config.AgentNotReadyNodeTaintValue()))
 	option.BindEnv(operatorOption.RemoveCiliumNodeTaints)
 
 	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -12,12 +12,12 @@ import (
 	"github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s"
-	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	pkgOption "github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -203,7 +203,7 @@ func isCiliumPodRunning(nodeName string) bool {
 // Not Ready Node Taint.
 func hasAgentNotReadyTaint(k8sNode *slim_corev1.Node) bool {
 	for _, taint := range k8sNode.Spec.Taints {
-		if taint.Key == ciliumio.AgentNotReadyNodeTaint {
+		if taint.Key == pkgOption.Config.AgentNotReadyNodeTaintValue() {
 			return true
 		}
 	}
@@ -325,7 +325,7 @@ func removeNodeTaint(ctx context.Context, c kubernetes.Interface, nodeGetter sli
 
 	var taints []slim_corev1.Taint
 	for _, taint := range k8sNode.Spec.Taints {
-		if taint.Key != ciliumio.AgentNotReadyNodeTaint {
+		if taint.Key != pkgOption.Config.AgentNotReadyNodeTaintValue() {
 			taints = append(taints, taint)
 		} else {
 			taintFound = true
@@ -336,13 +336,13 @@ func removeNodeTaint(ctx context.Context, c kubernetes.Interface, nodeGetter sli
 	if !taintFound {
 		log.WithFields(logrus.Fields{
 			logfields.NodeName: nodeName,
-			"taint":            ciliumio.AgentNotReadyNodeTaint,
+			"taint":            pkgOption.Config.AgentNotReadyNodeTaintValue(),
 		}).Debug("Taint not found in node")
 		return nil
 	}
 	log.WithFields(logrus.Fields{
 		logfields.NodeName: nodeName,
-		"taint":            ciliumio.AgentNotReadyNodeTaint,
+		"taint":            pkgOption.Config.AgentNotReadyNodeTaintValue(),
 	}).Debug("Removing Node Taint")
 
 	createStatusAndNodePatch := []k8s.JSONPatch{

--- a/operator/watchers/node_taint_test.go
+++ b/operator/watchers/node_taint_test.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/k8s"
-	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	pkgOption "github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -60,7 +60,7 @@ func (n *NodeTaintSuite) TestNodeTaintWithoutCondition(c *check.C) {
 		Spec: slim_corev1.NodeSpec{
 			Taints: []slim_corev1.Taint{
 				{
-					Key: ciliumio.AgentNotReadyNodeTaint, Value: "Foo",
+					Key: pkgOption.Config.AgentNotReadyNodeTaintValue(), Value: "Foo",
 				},
 				{
 					Key: "DoNoRemoveThisTaint", Value: "Foo",
@@ -106,7 +106,7 @@ func (n *NodeTaintSuite) TestNodeTaintWithoutCondition(c *check.C) {
 				Path: "/spec/taints",
 				Value: []slim_corev1.Taint{
 					{
-						Key: ciliumio.AgentNotReadyNodeTaint, Value: "Foo",
+						Key: pkgOption.Config.AgentNotReadyNodeTaintValue(), Value: "Foo",
 					},
 					{
 						Key: "DoNoRemoveThisTaint", Value: "Foo",
@@ -196,7 +196,7 @@ func (n *NodeTaintSuite) TestNodeCondition(c *check.C) {
 		Spec: slim_corev1.NodeSpec{
 			Taints: []slim_corev1.Taint{
 				{
-					Key: ciliumio.AgentNotReadyNodeTaint, Value: "Foo",
+					Key: pkgOption.Config.AgentNotReadyNodeTaintValue(), Value: "Foo",
 				},
 				{
 					Key: "DoNoRemoveThisTaint", Value: "Foo",
@@ -329,7 +329,7 @@ func (n *NodeTaintSuite) TestNodeConditionIfCiliumIsNotReady(c *check.C) {
 		Spec: slim_corev1.NodeSpec{
 			Taints: []slim_corev1.Taint{
 				{
-					Key: ciliumio.AgentNotReadyNodeTaint, Value: "Foo",
+					Key: pkgOption.Config.AgentNotReadyNodeTaintValue(), Value: "Foo",
 				},
 				{
 					Key: "DoNoRemoveThisTaint", Value: "Foo",

--- a/pkg/defaults/node.go
+++ b/pkg/defaults/node.go
@@ -22,8 +22,18 @@ const (
 	// HostDevice is the name of the device that connects the cilium IP
 	// space with the host's networking model
 	HostDevice = "cilium_host"
+
 	// SecondHostDevice is the name of the second interface of the host veth pair.
 	SecondHostDevice = "cilium_net"
+
+	// CiliumK8sAnnotationPrefix is the prefix key for the annotations used in kubernetes.
+	CiliumK8sAnnotationPrefix = "cilium.io/"
+
+	// AgentNotReadyNodeTaint is a node taint which prevents pods from being
+	// scheduled. Once cilium is setup it is removed from the node. Mostly
+	// used in cloud providers to prevent existing CNI plugins from managing
+	// pods.
+	AgentNotReadyNodeTaint = "node." + CiliumK8sAnnotationPrefix + "agent-not-ready"
 )
 
 var (

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -62,17 +62,8 @@ const (
 	// to sync the CNP with kube-apiserver.
 	CtrlPrefixPolicyStatus = "sync-cnp-policy-status"
 
-	// CiliumK8sAnnotationPrefix is the prefix key for the annotations used in kubernetes.
-	CiliumK8sAnnotationPrefix = "cilium.io/"
-
 	// CiliumIdentityAnnotationDeprecated is the previous annotation key used to map to an endpoint's security identity.
 	CiliumIdentityAnnotationDeprecated = "cilium-identity"
-
-	// AgentNotReadyNodeTaint is a node taint which prevents pods from being
-	// scheduled. Once cilium is setup it is removed from the node. Mostly
-	// used in cloud providers to prevent existing CNI plugins from managing
-	// pods.
-	AgentNotReadyNodeTaint = "node." + CiliumK8sAnnotationPrefix + "agent-not-ready"
 )
 
 const (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -623,6 +623,10 @@ const (
 	// K8sNamespaceName is the name of the K8sNamespace option
 	K8sNamespaceName = "k8s-namespace"
 
+	// AgentNotReadyNodeTaintKeyName is the name of the option to set
+	// AgentNotReadyNodeTaintKey
+	AgentNotReadyNodeTaintKeyName = "agent-not-ready-taint-key"
+
 	// JoinClusterName is the name of the JoinCluster Option
 	JoinClusterName = "join-cluster"
 
@@ -1445,6 +1449,12 @@ type DaemonConfig struct {
 	// K8sNamespace is the name of the namespace in which Cilium is
 	// deployed in when running in Kubernetes mode
 	K8sNamespace string
+
+	// AgentNotReadyNodeTaint is a node taint which prevents pods from being
+	// scheduled. Once cilium is setup it is removed from the node. Mostly
+	// used in cloud providers to prevent existing CNI plugins from managing
+	// pods.
+	AgentNotReadyNodeTaintKey string
 
 	// JoinCluster is 'true' if the agent should join a Cilium cluster via kvstore
 	// registration
@@ -2307,6 +2317,16 @@ func (c *DaemonConfig) CiliumNamespaceName() string {
 	return c.K8sNamespace
 }
 
+// AgentNotReadyNodeTaintValue returns the value of the taint key that cilium agents
+// will manage on their nodes
+func (c *DaemonConfig) AgentNotReadyNodeTaintValue() string {
+	if c.AgentNotReadyNodeTaintKey != "" {
+		return c.AgentNotReadyNodeTaintKey
+	} else {
+		return defaults.AgentNotReadyNodeTaint
+	}
+}
+
 // K8sAPIDiscoveryEnabled returns true if API discovery of API groups and
 // resources is enabled
 func (c *DaemonConfig) K8sAPIDiscoveryEnabled() bool {
@@ -2941,6 +2961,7 @@ func (c *DaemonConfig) Populate() {
 	c.HTTP403Message = viper.GetString(HTTP403Message)
 	c.DisableEnvoyVersionCheck = viper.GetBool(DisableEnvoyVersionCheck)
 	c.K8sNamespace = viper.GetString(K8sNamespaceName)
+	c.AgentNotReadyNodeTaintKey = viper.GetString(AgentNotReadyNodeTaintKeyName)
 	c.MaxControllerInterval = viper.GetInt(MaxCtrlIntervalName)
 	c.PolicyQueueSize = sanitizeIntParam(PolicyQueueSize, defaults.PolicyQueueSize)
 	c.EndpointQueueSize = sanitizeIntParam(EndpointQueueSize, defaults.EndpointQueueSize)


### PR DESCRIPTION
[ upstream commit c1c97166164396ad148a61ae1ee481ce997afa50 ]

[ Backporter's notes: Minor conflicts in values.yaml, go imports ]

If you scale a node pool down to zero nodes the Cluster Autoscaler won't
add new nodes because pending pods don't tolerate the cilium
agent-not-ready taint. If you're managing your own CA you can ignore
the cilium taint with a command line flag on the CA. However if you're
running on managed k8s (e.g. GKE), you may not have access to configure
the CA, and will need to use a custom taint prefix to be ignored by the
autoscaler when scaling up from zero nodes in a pool.

This commit adds config to add a prefix to the agent-not-ready taint so
it can be ignored by the cluster-autoscaler.

Related: #19241
Backports: #19247

```upstream-prs
$ for pr in 19247; do contrib/backporting/set-labels.py $pr done v1.11; done
```
