### PR TITLE
docs: Fix reference to upgrade guide

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -115,7 +115,7 @@ requirements have been met:
        Passing the ``-s`` option to ``git commit`` will add the
        ``Signed-off-by:`` line to your commit message automatically.
 
-#. Document any user-facing or breaking changes in ``Documentation/install/upgrade.rst``.
+#. Document any user-facing or breaking changes in ``Documentation/operations/upgrade.rst``.
 
 #. (optional) Pick the appropriate milestone for which this PR is being
    targeted, e.g. ``1.6``, ``1.7``. This is in particular important in the time


### PR DESCRIPTION
This part of the contributing guide was pointing to the wrong location,
the upgrade guide has moved to another location for some time now.

Reported-by: Karsten Nielsen