### PR TITLE
doc: Remove  VTEP  pod static ARP and pod L7 policy and hostnetwork limitation

### DIFF
--- a/Documentation/gettingstarted/vtep.rst
+++ b/Documentation/gettingstarted/vtep.rst
@@ -30,13 +30,6 @@ endpoint IPs, CIDRs, and MAC addresses.
    identifier (VNI) *must* be configured as VNI ``2``, which represents traffic
    from the VTEP as the world identity. See :ref:`reserved_labels` for more details.
 
-.. warning::
-
-   This feature is in beta, and currently, it is partially incompatible the L7 policy.
-   When a pod with an egress L7 policy sends a request to VTEP devices, the VTEP redirection
-   is bypassed. The improvement is tracked in :gh-issue:`19699`.
-
-
 Enable VXLAN Tunnel Endpoint (VTEP) integration
 ===============================================
 
@@ -118,14 +111,9 @@ run the commands below using ``sudo``.
    ip addr add 10.1.1.236/24 dev vxlan2
    # Assume Cilium podCIDR network is 10.0.0.0/16, add route to 10.0.0.0/16
    ip route add 10.0.0.0/16 dev vxlan2  proto kernel  scope link  src 10.1.1.236
-   # Allow Linux VM send ARP broadcast request to Cilium node for busybox pod ARP resolution
-   # through vxlan2 device, note this depend on if Cilium is able to proxy busybox pod ARP
-   # see https://github.com/cilium/cilium/issues/16890
+   # Allow Linux VM to send ARP broadcast request to Cilium node for busybox pod
+   # ARP resolution through vxlan2 device
    bridge fdb append 00:00:00:00:00:00 dst 10.169.72.233 dev vxlan2
-   # Another way is to manually add busybox pod ARP address with Cilium node 10.169.72.233
-   # cilium_vxlan interface MAC address like below
-   bridge fdb append  <cilium_vxlan MAC> dst 10.169.72.233 dev vxlan2
-   arp -i vxlan2 -s <busybox pod IP> <cilium_vxlan MAC>
 
 If you are managing multiple VTEPs, follow the above process for each instance.
 Once the VTEPs are configured, you can configure Cilium to use the MAC, IP and CIDR ranges that
@@ -141,5 +129,4 @@ To test the VTEP network connectivity:
 Limitations
 ===========
 
-* This feature does not work with traffic from the host network namespace (including pods with ``hostNetwork=true``).
 * This feature does not work with ipsec encryption between Cilium managed pod and VTEPs.


### PR DESCRIPTION
Static pod ARP is not required since
https://github.com/cilium/cilium/pull/18758 is merged

Pod with L7 policy and hostnetwork limitation are removed  since
https://github.com/cilium/cilium/pull/19473 is merged

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
doc: Remove  static pod ARP and pod hostnetwork limitation
```
