### PR TITLE
install/kubernetes: Avoid quoting version twice

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -7,7 +7,7 @@ include $(MAKEFILE_VALUES)
 include ../../Makefile.defs
 
 ifeq ($(CILIUM_VERSION),)
-export CILIUM_VERSION:="v$(VERSION)"
+export CILIUM_VERSION:=v$(VERSION)
 endif
 
 MIN_K8S_MAJOR := 1


### PR DESCRIPTION
While backporting this to v1.11, I found that the `$CILIUM_VERSION` would
be quoted twice if the Makefile.values didn't specify it. Remove the
extra quotes to fix this.
