### PR TITLE
docs, ci, test/l4lb: use latest cilium-cli release according to stable.txt

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -287,8 +287,8 @@ jobs:
       - name: Post-test information gathering
         if: ${{ !success() }}
         run: |
-          echo "=== Install latest stable CLI ==="
-          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          echo "=== Install Cilium CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
           sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
           sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
           rm cilium-linux-amd64.tar.gz{,.sha256sum}

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -8,6 +8,7 @@ on:
 permissions: read-all
 
 env:
+  cilium_cli_version: v0.11.7
   KIND_VERSION: v0.11.1
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -107,8 +108,8 @@ jobs:
       - name: Capture cilium-sysdump
         if: ${{ failure() }}
         run: |
-          echo "=== Install latest stable CLI ==="
-          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          echo "=== Install Cilium CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
           sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
           sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
           rm cilium-linux-amd64.tar.gz{,.sha256sum}

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  cilium_cli_version: v0.11.7
   KIND_VERSION: v0.11.1
   KIND_CONFIG: .github/kind-config-ipv6.yaml
   # Skip external traffic (e.g. 1.1.1.1 and www.google.com) due to no support for IPv6 in github action
@@ -136,8 +137,8 @@ jobs:
         # file (EOF) on stdin and displaying no flows.
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         run: |
-          echo "=== Install latest stable CLI ==="
-          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          echo "=== Install Cilium CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
           sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
           sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
           rm cilium-linux-amd64.tar.gz{,.sha256sum}

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  cilium_cli_version: v0.11.7
   KIND_VERSION: v0.11.1
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -179,8 +180,8 @@ jobs:
         # file (EOF) on stdin and displaying no flows.
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         run: |
-          echo "=== Install latest stable CLI ==="
-          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+          echo "=== Install Cilium CLI ==="
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
           sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
           sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
           rm cilium-linux-amd64.tar.gz{,.sha256sum}

--- a/Documentation/gettingstarted/cli-download.rst
+++ b/Documentation/gettingstarted/cli-download.rst
@@ -7,7 +7,8 @@ various features (e.g. clustermesh, Hubble).
 
     .. code-block:: shell-session
 
-      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-amd64.tar.gz{,.sha256sum}
       sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
       sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
       rm cilium-linux-amd64.tar.gz{,.sha256sum}
@@ -16,7 +17,8 @@ various features (e.g. clustermesh, Hubble).
 
     .. code-block:: shell-session
 
-      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-darwin-amd64.tar.gz{,.sha256sum}
+      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-amd64.tar.gz{,.sha256sum}
       shasum -a 256 -c cilium-darwin-amd64.tar.gz.sha256sum
       sudo tar xzvfC cilium-darwin-amd64.tar.gz /usr/local/bin
       rm cilium-darwin-amd64.tar.gz{,.sha256sum}
@@ -25,7 +27,8 @@ various features (e.g. clustermesh, Hubble).
 
     .. code-block:: shell-session
 
-      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-darwin-arm64.tar.gz{,.sha256sum}
+      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-arm64.tar.gz{,.sha256sum}
       shasum -a 256 -c cilium-darwin-arm64.tar.gz.sha256sum
       sudo tar xzvfC cilium-darwin-arm64.tar.gz /usr/local/bin
       rm cilium-darwin-arm64.tar.gz{,.sha256sum}

--- a/test/l4lb/Vagrantfile
+++ b/test/l4lb/Vagrantfile
@@ -35,7 +35,8 @@ Vagrant.configure("2") do |config|
     chmod +x ./get_helm.sh
     ./get_helm.sh
 
-    curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz{,.sha256sum}
+    CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+    curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-amd64.tar.gz{,.sha256sum}
     sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
     sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/bin
     rm cilium-linux-amd64.tar.gz{,.sha256sum}


### PR DESCRIPTION


This will make sure users download the latest release marked as stable
by developers in stable.txt on the master branch, instead of the latest
release according to GitHub releases [1]. The latter might point at a
release built from the v0.10 release branch, which would potentially
cause problems when running with Cilium 1.11 and later.

[1] https://github.com/cilium/cilium-cli/releases/latest
