### PR TITLE
bpf: switch egress gateway logic to identity_is_cluster()

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1003,7 +1003,7 @@ ct_recreate4:
 		 * gateway since only traffic leaving the cluster is supposed to
 		 * be masqueraded with an egress IP.
 		 */
-		if (is_cluster_destination(ip4, *dst_id, tunnel_endpoint))
+		if (identity_is_cluster(*dst_id))
 			goto skip_egress_gateway;
 
 		/* If the packet is a reply or is related, it means that outside

--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -17,33 +17,6 @@
 #define EGRESS_PREFIX_LEN(PREFIX) (EGRESS_STATIC_PREFIX + (PREFIX))
 #define EGRESS_IPV4_PREFIX EGRESS_PREFIX_LEN(32)
 
-/* is_cluster_destination returns true if the given destination is part of the
- * cluster. It uses the ipcache and endpoint maps information.
- */
-static __always_inline bool
-is_cluster_destination(struct iphdr *ip4, __u32 dst_id, __u32 tunnel_endpoint)
-{
-	/* If tunnel endpoint is found in ipcache, it means the remote endpoint
-	 * is in cluster.
-	 */
-	if (tunnel_endpoint != 0)
-		return true;
-
-	/* If the destination is a Cilium-managed node (remote or local), it's
-	 * part of the cluster.
-	 */
-	if (identity_is_node(dst_id))
-		return true;
-
-	/* Use the endpoint map to know if the destination is a local endpoint.
-	 */
-	if (lookup_ip4_endpoint(ip4))
-		return true;
-
-	/* Everything else is outside the cluster. */
-	return false;
-}
-
 static __always_inline
 struct egress_gw_policy_entry *lookup_ip4_egress_gw_policy(__be32 saddr, __be32 daddr)
 {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1169,7 +1169,7 @@ static __always_inline bool snat_v4_needed(struct __ctx_buff *ctx, __be32 *addr,
 	 * to be masqueraded with an egress IP.
 	 */
 	if (remote_ep &&
-	    is_cluster_destination(ip4, remote_ep->sec_label, remote_ep->tunnel_endpoint))
+	    identity_is_cluster(remote_ep->sec_label))
 		goto skip_egress_gateway;
 
 	/* If the packet is a reply it means that outside has initiated the

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -225,3 +225,6 @@ return true; \
 break; \
 } \
 return false;
+
+#define CIDR_IDENTITY_RANGE_START ((1 << 24) + 1)
+#define CIDR_IDENTITY_RANGE_END   ((1 << 24) + (1<<16) - 1)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -578,6 +578,9 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_L7_PROXY"] = "1"
 	}
 
+	cDefinesMap["CIDR_IDENTITY_RANGE_START"] = fmt.Sprintf("%d", identity.MinLocalIdentity)
+	cDefinesMap["CIDR_IDENTITY_RANGE_END"] = fmt.Sprintf("%d", identity.MaxLocalIdentity)
+
 	// Since golang maps are unordered, we sort the keys in the map
 	// to get a consistent written format to the writer. This maintains
 	// the consistency when we try to calculate hash for a datapath after

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -265,7 +265,7 @@ func NewCachingIdentityAllocator(owner IdentityAllocatorOwner) *CachingIdentityA
 
 	// Local identity cache can be created synchronously since it doesn't
 	// rely upon any external resources (e.g., external kvstore).
-	m.localIdentities = newLocalIdentityCache(1, 0xFFFFFF, m.events)
+	m.localIdentities = newLocalIdentityCache(identity.MinAllocatorLocalIdentity, identity.MaxAllocatorLocalIdentity, m.events)
 
 	return m
 }

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -25,6 +25,32 @@ const (
 	// a numeric identity to have local scope
 	LocalIdentityFlag = NumericIdentity(1 << 24)
 
+	// MinAllocatorLocalIdentity represents the minimal numeric identity
+	// that the localIdentityCache allocator can allocate for a local (CIDR)
+	// identity.
+	//
+	// Note that this does not represents the minimal value for a local
+	// identity, as the allocated ID will then be bitwise OR'ed with
+	// LocalIdentityFlag.
+	MinAllocatorLocalIdentity = 1
+
+	// MinLocalIdentity represents the actual minimal numeric identity value
+	// for a local (CIDR) identity.
+	MinLocalIdentity = MinAllocatorLocalIdentity | LocalIdentityFlag
+
+	// MaxAllocatorLocalIdentity represents the maximal numeric identity
+	// that the localIdentityCache allocator can allocate for a local (CIDR)
+	// identity.
+	//
+	// Note that this does not represents the maximal value for a local
+	// identity, as the allocated ID will then be bitwise OR'ed with
+	// LocalIdentityFlag.
+	MaxAllocatorLocalIdentity = 0xFFFFFF
+
+	// MaxLocalIdentity represents the actual maximal numeric identity value
+	// for a local (CIDR) identity.
+	MaxLocalIdentity = MaxAllocatorLocalIdentity | LocalIdentityFlag
+
 	// MinimalNumericIdentity represents the minimal numeric identity not
 	// used for reserved purposes.
 	MinimalNumericIdentity = NumericIdentity(256)


### PR DESCRIPTION
See individual commits.

Fixes: https://github.com/cilium/cilium/issues/19784