### PR TITLE
[WIP] [DNM] dnsproxy: Stop using regex groups

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -912,12 +912,12 @@ func GetSelectorRegexMap(l7 policy.L7DataMap) (CachedSelectorREEntry, error) {
 			if len(dnsRule.MatchName) > 0 {
 				dnsRuleName := strings.ToLower(dns.Fqdn(dnsRule.MatchName))
 				dnsPatternAsRE := matchpattern.ToRegexp(dnsRuleName)
-				reStrings = append(reStrings, "("+dnsPatternAsRE+")")
+				reStrings = append(reStrings, dnsPatternAsRE)
 			}
 			if len(dnsRule.MatchPattern) > 0 {
 				dnsPattern := matchpattern.Sanitize(dnsRule.MatchPattern)
 				dnsPatternAsRE := matchpattern.ToRegexp(dnsPattern)
-				reStrings = append(reStrings, "("+dnsPatternAsRE+")")
+				reStrings = append(reStrings, dnsPatternAsRE)
 			}
 		}
 		mp := strings.Join(reStrings, "|")

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -803,14 +803,14 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	expected := `
 	{
 		"53": [{
-			"Re":  "(^[-a-zA-Z0-9_]*[.]ubuntu[.]com[.]$)|(^aws[.]amazon[.]com[.]$)",
+			"Re":  "^[-a-zA-Z0-9_]*[.]ubuntu[.]com[.]$|^aws[.]amazon[.]com[.]$",
 			"IPs": {"::": {}}
 		}, {
-			"Re":  "(^cilium[.]io[.]$)",
+			"Re":  "^cilium[.]io[.]$",
 			"IPs": {"127.0.0.1": {}, "127.0.0.2": {}}
 		}],
 		"54": [{
-			"Re":  "(^example[.]com[.]$)",
+			"Re":  "^example[.]com[.]$",
 			"IPs": null
 		}]
 	}`


### PR DESCRIPTION
WIP for testing:

Would be nice to get to run all the test suites to check for correctness issues before we start testing it locally. Tested it quickly on a small 25+- node k8s cluster, and everything seemed fine. Hopefully I didn't miss any obvious reason for using groups here.

TL;DR: The code does not care (afaik.) about what group is matched, so there isn't
any reason to use groups. The regex compiler should be able to optimize the regex
way better without groups, hopefully making the actual regex prog smaller (as in memory usage) and faster (tho regex compile might be slower, but lets see).

For small regex this is probably fine, but in our case, we have 400-500-600 fqdns
in that list (as I understand it), and that crates the same amount of regex groups
that we don't need.

Worst case is the same mem and cpu usage, and no real diff in behavior.

If this works, we can look at other optimizations of this code path as well.

Signed-off-by: Odin Ugedal <ougedal@palantir.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
TBD
```
