### PR TITLE
mlh: update Jenkins jobs following net-next fix for K8s 1.24

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -61,8 +61,8 @@ flake-tracker:
     - cilium-master-k8s-1.21-kernel-4.9
     - cilium-master-k8s-1.22-kernel-4.9
     - cilium-master-k8s-1.22-kernel-5.4
-    - cilium-master-k8s-1.23-kernel-net-next
-    - cilium-master-k8s-1.24-kernel-4.19
+    - cilium-master-k8s-1.23-kernel-4.19
+    - cilium-master-k8s-1.24-kernel-net-next
     - cilium-master-k8s-upstream
     pr-jobs:
       Cilium-PR-K8s-1.16-kernel-4.9:
@@ -131,12 +131,12 @@ flake-tracker:
       Cilium-PR-K8s-1.22-kernel-5.4:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.22-kernel-5.4
-      Cilium-PR-K8s-1.23-kernel-net-next:
+      Cilium-PR-K8s-1.23-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.23-kernel-net-next
-      Cilium-PR-K8s-1.24-kernel-4.19:
+        - cilium-master-k8s-1.23-kernel-4.19
+      Cilium-PR-K8s-1.24-kernel-net-next:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.24-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-net-next
       Cilium-PR-K8s-GKE:
         correlate-with-stable-jobs:
         - cilium-master-gke


### PR DESCRIPTION
In 679ef7769ded78b94b4085a0809266c72c39fc95, we had temporarily decided to use 4.19 instead of net-next as the kernel version for latest K8s.

Now that net-next works with K8s 1.24, we go back to our usual CI state where the latest K8s version also uses net-next.

We have rotated the Jenkins test jobs as follow:

- Changed: Kernel 4.19 on K8s 1.23 (instead of 1.24, triggered on `/test`).
- Changed: Kernel net-next on K8s 1.24 (instead of 1.23, triggered on `/test`).

See the Table of Truth:tm: for up to date status on all trigger phrases: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0/edit#gid=0
