### PR TITLE
Add metric for FQDN regex LRU access

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -412,6 +412,7 @@ Name                               Labels                           Default     
 ``fqdn_active_names``              ``endpoint``                     Disabled    Number of domains inside the DNS cache that have not expired (by TTL), per endpoint
 ``fqdn_active_ips``                ``endpoint``                     Disabled    Number of IPs inside the DNS cache associated with a domain that has not expired (by TTL), per endpoint
 ``fqdn_alive_zombie_connections``  ``endpoint``                     Disabled    Number of IPs associated with domains that have expired (by TTL) yet still associated with an active connection (aka zombie), per endpoint
+``fqdn_regex_lru_accesses_total``  ``type``                         Disabled    Keeps track of the total number of hits and misses to the FQDN regex LRU
 ================================== ================================ =========== ========================================================
 
 .. _metrics_api_rate_limiting:

--- a/pkg/fqdn/re/re.go
+++ b/pkg/fqdn/re/re.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -39,8 +40,10 @@ func CompileRegex(p string) (*regexp.Regexp, error) {
 	r, ok := lru.Get(p)
 	lru.Unlock()
 	if ok {
+		metrics.FQDNRegexLRUAccesses.WithLabelValues(metrics.LabelValueCacheHit).Inc() // hit
 		return r.(*regexp.Regexp), nil
 	}
+	metrics.FQDNRegexLRUAccesses.WithLabelValues(metrics.LabelValueCacheMiss).Inc() // miss
 	n, err := regexp.Compile(p)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile regex: %w", err)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -88,6 +88,12 @@ const (
 	// LabelValueOutcomeFail is used as an unsuccessful outcome of an operation
 	LabelValueOutcomeFail = "fail"
 
+	// LabelValueCacheHit is used when there's a cache hit.
+	LabelValueCacheHit = "hit"
+
+	// LabelValueCacheMiss is used when there's a cache miss.
+	LabelValueCacheMiss = "miss"
+
 	// LabelEventSourceAPI marks event-related metrics that come from the API
 	LabelEventSourceAPI = "api"
 
@@ -458,6 +464,10 @@ var (
 	// the admission semaphore.
 	FQDNSemaphoreRejectedTotal = NoOpCounter
 
+	// FQDNRegexLRUAccesses is the metric to keep track of the total number of
+	// hits and misses to the FQDN regex LRU.
+	FQDNRegexLRUAccesses = NoOpCounterVec
+
 	// BPFSyscallDuration is the metric for bpf syscalls duration.
 	BPFSyscallDuration = NoOpObserverVec
 
@@ -572,6 +582,7 @@ type Configuration struct {
 	FQDNActiveIPs                           bool
 	FQDNActiveZombiesConnections            bool
 	FQDNSemaphoreRejectedTotal              bool
+	FQDNRegexLRUAccesses                    bool
 	BPFSyscallDurationEnabled               bool
 	BPFMapOps                               bool
 	BPFMapPressure                          bool
@@ -1225,6 +1236,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, FQDNSemaphoreRejectedTotal)
 			c.FQDNSemaphoreRejectedTotal = true
+
+		case Namespace + "_" + SubsystemFQDN + "_regex_lru_accesses_total":
+			FQDNRegexLRUAccesses = prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemFQDN,
+				Name:      "regex_lru_accesses_total",
+				Help:      "Keeps track of the total number of hits and misses to the FQDN regex LRU",
+			}, []string{LabelType})
+
+			collectors = append(collectors, FQDNRegexLRUAccesses)
+			c.FQDNRegexLRUAccesses = true
 
 		case Namespace + "_" + SubsystemBPF + "_syscall_duration_seconds":
 			BPFSyscallDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
Based on https://github.com/cilium/cilium/pull/20516

---

This commit enables visibility into the FQDN regex compilation LRU by
showing "hit" accesses (cache hit) and "miss" accesses (cache miss).

To enable, the user must enable the metric via `--metrics
+cilium_fqdn_regex_lru_accesses_total`.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
