### PR TITLE
dnsproxy: Improve regex pattern

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -1067,7 +1067,7 @@ func (zombies *DNSZombieMappings) forceExpireLocked(expireLookupsBefore time.Tim
 // The error return is for errors compiling the internal regexp. This should
 // never happen.
 func (zombies *DNSZombieMappings) ForceExpireByNameIP(expireLookupsBefore time.Time, name string, ips ...net.IP) error {
-	reStr := matchpattern.ToRegexp(name)
+	reStr := matchpattern.ToAnchoredRegexp(name)
 	re, err := re.CompileRegex(reStr)
 	if err != nil {
 		return err

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -711,7 +711,7 @@ func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID ident
 
 	for selector, regex := range epAllow {
 		// The port was matched in getPortRulesForID, above.
-		if regex != nil && selector.Selects(destID) && regex.MatchString(name) {
+		if regex != nil && selector.Selects(destID) && (regex.String() == matchpattern.MatchAllAnchoredPattern || regex.MatchString(name)) {
 			return true, nil
 		}
 	}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -835,14 +835,14 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	expected := `
 	{
 		"53": [{
-			"Re":  "(^[-a-zA-Z0-9_]*[.]ubuntu[.]com[.]$)|(^aws[.]amazon[.]com[.]$)",
+			"Re":  "^(?:[-a-zA-Z0-9_]*[.]ubuntu[.]com[.]|aws[.]amazon[.]com[.])$",
 			"IPs": {"::": {}}
 		}, {
-			"Re":  "(^cilium[.]io[.]$)",
+			"Re":  "^(?:cilium[.]io[.])$",
 			"IPs": {"127.0.0.1": {}, "127.0.0.2": {}}
 		}],
 		"54": [{
-			"Re":  "(^example[.]com[.]$)",
+			"Re":  "^(?:example[.]com[.])$",
 			"IPs": null
 		}]
 	}`

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -55,7 +55,7 @@ func (n *NameManager) MapSelectorsToIPsLocked(fqdnSelectors map[api.FQDNSelector
 		if len(ToFQDN.MatchPattern) > 0 {
 			// lookup matching DNS names
 			dnsPattern := matchpattern.Sanitize(ToFQDN.MatchPattern)
-			patternREStr := matchpattern.ToRegexp(dnsPattern)
+			patternREStr := matchpattern.ToAnchoredRegexp(dnsPattern)
 			var (
 				err       error
 				patternRE *regexp.Regexp

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -75,12 +75,7 @@ func ToAnchoredRegexp(pattern string) string {
 		return "(^(" + allowedDNSCharsREGroup + "+[.])+$)|(^[.]$)"
 	}
 
-	// base case. * becomes .*, but only for DNS valid characters
-	// NOTE: this only works because the case above does not leave the *
-	pattern = strings.Replace(pattern, "*", allowedDNSCharsREGroup+"*", -1)
-
-	// base case. "." becomes a literal .
-	pattern = strings.Replace(pattern, ".", "[.]", -1)
+	pattern = escapeRegexpCharacters(pattern)
 
 	// Anchor the match to require the whole string to match this expression
 	return "^" + pattern + "$"

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -14,6 +14,15 @@ import (
 
 const allowedDNSCharsREGroup = "[-a-zA-Z0-9_]"
 
+// MatchAllAnchoredPattern is the simplest pattern that match all inputs. This resulting
+// parsed regular expression is the same as an empty string regex (""), but this
+// value is easier to reason about when serializing to and from json.
+const MatchAllAnchoredPattern = "(?:)"
+
+// MatchAllUnAnchoredPattern is the same as MatchAllAnchoredPattern, except that
+// it can be or-ed (joined with "|") with other rules, and still match all rules.
+const MatchAllUnAnchoredPattern = ".*"
+
 // Validate ensures that pattern is a parseable matchPattern. It returns the
 // regexp generated when validating.
 func Validate(pattern string) (matcher *regexp.Regexp, err error) {
@@ -86,7 +95,7 @@ func ToUnAnchoredRegexp(pattern string) string {
 	pattern = strings.ToLower(pattern)
 	// handle the * match-all case. This will filter down to the end.
 	if pattern == "*" {
-		return "(" + allowedDNSCharsREGroup + "+[.])+|[.]"
+		return MatchAllUnAnchoredPattern
 	}
 	pattern = escapeRegexpCharacters(pattern)
 	return pattern

--- a/pkg/fqdn/matchpattern/matchpattern_test.go
+++ b/pkg/fqdn/matchpattern/matchpattern_test.go
@@ -25,14 +25,28 @@ var _ = Suite(&MatchPatternTestSuite{})
 // cilium.io. -> cilium[.]io[.]
 // *.cilium.io. -> [-a-zA-Z0-9]+.cilium[.]io[.]
 // *cilium.io. -> "([a-zA-Z0-9]+[.])?cilium[.]io[.]
-func (ts *MatchPatternTestSuite) TestMatchPatternREConversion(c *C) {
+func (ts *MatchPatternTestSuite) TestAnchoredMatchPatternREConversion(c *C) {
 	for source, target := range map[string]string{
 		"cilium.io.":   "^cilium[.]io[.]$",
 		"*.cilium.io.": "^" + allowedDNSCharsREGroup + "*[.]cilium[.]io[.]$",
 		"*":            "(^(" + allowedDNSCharsREGroup + "+[.])+$)|(^[.]$)",
 		".":            "^[.]$",
 	} {
-		reStr := ToRegexp(source)
+		reStr := ToAnchoredRegexp(source)
+		_, err := regexp.Compile(reStr)
+		c.Assert(err, IsNil, Commentf("Regexp generated from pattern %sis not valid", source))
+		c.Assert(reStr, Equals, target, Commentf("Regexp generated from pattern %s isn't expected", source))
+	}
+}
+
+func (ts *MatchPatternTestSuite) TestUnAnchoredMatchPatternREConversion(c *C) {
+	for source, target := range map[string]string{
+		"cilium.io.":   "cilium[.]io[.]",
+		"*.cilium.io.": allowedDNSCharsREGroup + "*[.]cilium[.]io[.]",
+		"*":            "(" + allowedDNSCharsREGroup + "+[.])+|[.]",
+		".":            "[.]",
+	} {
+		reStr := ToUnAnchoredRegexp(source)
 		_, err := regexp.Compile(reStr)
 		c.Assert(err, IsNil, Commentf("Regexp generated from pattern %sis not valid", source))
 		c.Assert(reStr, Equals, target, Commentf("Regexp generated from pattern %s isn't expected", source))
@@ -44,7 +58,7 @@ func (ts *MatchPatternTestSuite) TestMatchPatternREConversion(c *C) {
 // *.cilium.io. matches anysub.cilium.io. but not cilium.io.
 // *cilium.io. matches  anysub.cilium.io. and cilium.io.
 // *.ci*.io. matches anysub.cilium.io. anysub.ci.io., anysub.ciliumandmore.io. but not cilium.io.
-func (ts *MatchPatternTestSuite) TestMatchPatternMatching(c *C) {
+func (ts *MatchPatternTestSuite) TestAnchoredMatchPatternMatching(c *C) {
 	for _, testCase := range []struct {
 		pattern string
 		accept  []string
@@ -88,7 +102,7 @@ func (ts *MatchPatternTestSuite) TestMatchPatternMatching(c *C) {
 			reject:  []string{""},
 		},
 	} {
-		reStr := ToRegexp(testCase.pattern)
+		reStr := ToAnchoredRegexp(testCase.pattern)
 		re, err := regexp.Compile(reStr)
 		c.Assert(err, IsNil, Commentf("Regexp generated from pattern is not valid"))
 		for _, accept := range testCase.accept {

--- a/pkg/fqdn/matchpattern/matchpattern_test.go
+++ b/pkg/fqdn/matchpattern/matchpattern_test.go
@@ -34,8 +34,8 @@ func (ts *MatchPatternTestSuite) TestAnchoredMatchPatternREConversion(c *C) {
 	} {
 		reStr := ToAnchoredRegexp(source)
 		_, err := regexp.Compile(reStr)
-		c.Assert(err, IsNil, Commentf("Regexp generated from pattern %sis not valid", source))
-		c.Assert(reStr, Equals, target, Commentf("Regexp generated from pattern %s isn't expected", source))
+		c.Assert(err, IsNil, Commentf("Regexp generated from pattern %q is not valid", source))
+		c.Assert(reStr, Equals, target, Commentf("Regexp generated from pattern %q isn't expected", source))
 	}
 }
 
@@ -48,8 +48,8 @@ func (ts *MatchPatternTestSuite) TestUnAnchoredMatchPatternREConversion(c *C) {
 	} {
 		reStr := ToUnAnchoredRegexp(source)
 		_, err := regexp.Compile(reStr)
-		c.Assert(err, IsNil, Commentf("Regexp generated from pattern %sis not valid", source))
-		c.Assert(reStr, Equals, target, Commentf("Regexp generated from pattern %s isn't expected", source))
+		c.Assert(err, IsNil, Commentf("Regexp generated from pattern %q is not valid", source))
+		c.Assert(reStr, Equals, target, Commentf("Regexp generated from pattern %q isn't expected", source))
 	}
 }
 

--- a/pkg/fqdn/matchpattern/matchpattern_test.go
+++ b/pkg/fqdn/matchpattern/matchpattern_test.go
@@ -43,7 +43,7 @@ func (ts *MatchPatternTestSuite) TestUnAnchoredMatchPatternREConversion(c *C) {
 	for source, target := range map[string]string{
 		"cilium.io.":   "cilium[.]io[.]",
 		"*.cilium.io.": allowedDNSCharsREGroup + "*[.]cilium[.]io[.]",
-		"*":            "(" + allowedDNSCharsREGroup + "+[.])+|[.]",
+		"*":            MatchAllUnAnchoredPattern,
 		".":            "[.]",
 	} {
 		reStr := ToUnAnchoredRegexp(source)


### PR DESCRIPTION
_TL;DR:_ This is now V3 of https://github.com/cilium/cilium/pull/20214.

The full list of changes can be found in the commits (tho. this is based off https://github.com/cilium/cilium/pull/21288);
- Extract regex anchors to the beginning and end of the full pattern
- Remove the use of regex groups since we don't use them
- Short circuit matchPatterns with just a wildcard and match all fqdns
- Skip running `.MatchString` on wildcard regexes.

The overall perf change for all commits in this PR vs. https://github.com/cilium/cilium/pull/21288 (all without the lru cache, and ignore the time/op, since they are running in docker for mac 😢 ):

```
$ benchstat <pre-this-pr> <this-pr>
name                             old time/op          new time/op          delta
_perEPAllow_setPortRulesForID-7           77.4s ± 8%           83.0s ±17%     ~     (p=0.310 n=5+5)

name                             old B(HeapInUse)/op  new B(HeapInUse)/op  delta
_perEPAllow_setPortRulesForID-7           97.3M ± 1%           74.2M ± 1%  -23.75%  (p=0.008 n=5+5)

name                             old alloc/op         new alloc/op         delta
_perEPAllow_setPortRulesForID-7          78.6GB ± 0%          73.0GB ± 0%   -7.18%  (p=0.008 n=5+5)

name                             old allocs/op        new allocs/op        delta
_perEPAllow_setPortRulesForID-7            167M ± 0%            108M ± 0%  -35.37%  (p=0.008 n=5+5)
```
---

After this we plan doing;
- Switch from string concatenation to a byte buffer in `GeneratePattern`
- Consider the regex for matchPatterns + `map[string]struct{}` for matchNames.
- Replacing the `[.]` with `\.` to reduce the regex size
- Replacing the `*` replacement from `[-a-zA-Z0-9_]*` to `[^.]*`
- ...

--

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
dnsproxy: Improve regex used for matching dns queries by reducing its complexity and size to save memory and speed up matching
```
