### PR TITLE
[WIP] dnsproxy: Reuse compiled regex patterns from memory

### DIFF
--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -8,6 +8,8 @@ package dnsproxy
 import (
 	"testing"
 
+	"regexp"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/defaults"
@@ -41,7 +43,7 @@ func (s *DNSProxyHelperTestSuite) TestGetSelectorRegexMap(c *C) {
 		},
 	}
 	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
-	m, err := GetSelectorRegexMap(l7)
+	m, err := GetSelectorRegexMap(l7, make(map[string]*regexp.Regexp))
 
 	c.Assert(err, Equals, nil)
 


### PR DESCRIPTION
This prefers reusing the in memory value of a compiled regex instead of
hitting the LRU. This has a set of advantages.

We will no longer get "false cache hits", where we in reality already have
those values in memory anyways. In the same way, in case the entry is
evicted from the cache, we reuse the one in memory. The "false cache hits"
are problematic, becuse then people think that the cache is useful, and
that its worth giving it more memory/not lowering it.

When having rulesets with very many domains, we also get a very huge
regex. Having a large LRU cache will then fill a lot of memory.

After all, If a new rulset is set, and we get a cache miss from the
cache today, chances are very high that have never calculated that
regexp before; and making the cache bigger will have no function. In the
same way, if we update rules often, and we have a huge cache, we will
keep caching values we know we probably never will use again, possibly
false positives.

By doing all this, I think we can avoid more regex recompiles, in the
case where a pattern is in memory in "allowed" but is eveicted from the
cache, get better lru stats, and give people better data for tuing the
lru size in order to improve performance! We would also allow people to
lower their LRU cache size, and using the in-mem/in "allowed" values
instead.

Instead of manually looping through the "allow" list in every
setportRulesForID call, we might also do some other type of index. Haven't thought too
much about it, and I guess others have more knowledge about the internals
here than me.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
dnsproxy: Reuse compiled regex patterns from memory
```
