### PR TITLE
Fix the bugs when empty CiliumEndpointSlices were created and leaked.

### DIFF
--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -37,6 +37,13 @@ func (r *reconciler) reconcileCESCreate(cesToCreate string) (err error) {
 		return
 	}
 
+	if len(ces.Endpoints) == 0 {
+		// The CES is empty, delete ces information from cache rather than creating
+		// empty CES.
+		r.cesManager.deleteCESFromCache(cesToCreate)
+		return
+	}
+
 	// Call the client API, to Create CES
 	if retCES, err = r.client.CiliumEndpointSlices().Create(
 		context.TODO(), ces, metav1.CreateOptions{}); err != nil {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ X ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ X ] All code is covered by unit and/or runtime tests where feasible.
- [ X ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ X ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ X ] Provide a title or release-note blurb suitable for the release notes.
- [ X ] Thanks for contributing!

<!-- Description of change -->

Fix the bugs when empty CiliumEndpointSlices were created and leaked.

Currently the logic is as follow:
1) When CES is created push it to the queue
2) While in queue add/remove endpoints
3) When it is it's turn sync CES with the api-server:
- if this is a new CES (doesn't exist in the api-server) - create it
- otherwise - update or delete it.

The case when CES is created and then all the endpoints removed from it is not handled correctly.
This PR fixes it.

```release-note
Fix the bugs when empty CiliumEndpointSlices were created and leaked.
```
