### PR TITLE
docs: use the same variable name for install guide as in deployment

### DIFF
--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -112,15 +112,15 @@ Install Cilium
        .. code-block:: shell-session
 
           AZURE_SUBSCRIPTION_ID=$(az account show --query "id" --output tsv)
-          AZURE_NODE_RESOURCE_GROUP=$(az aks show --resource-group ${RESOURCE_GROUP} --name ${CLUSTER_NAME} --query "nodeResourceGroup" --output tsv)
-          AZURE_SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --scopes /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_NODE_RESOURCE_GROUP} --role Contributor --output json --only-show-errors)
+          AZURE_RESOURCE_GROUP=$(az aks show --resource-group ${RESOURCE_GROUP} --name ${CLUSTER_NAME} --query "nodeResourceGroup" --output tsv)
+          AZURE_SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --scopes /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP} --role Contributor --output json --only-show-errors)
           AZURE_TENANT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.tenant')
           AZURE_CLIENT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.appId')
           AZURE_CLIENT_SECRET=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.password')
 
        .. note::
 
-          The ``AZURE_NODE_RESOURCE_GROUP`` node resource group is *not* the
+          The ``AZURE_RESOURCE_GROUP`` node resource group is *not* the
           resource group of the AKS cluster. A single resource group may hold
           multiple AKS clusters, but each AKS cluster regroups all resources in
           an automatically managed secondary resource group. See `Why are two
@@ -139,7 +139,7 @@ Install Cilium
           helm install cilium |CHART_RELEASE| \\
             --namespace kube-system \\
             --set azure.enabled=true \\
-            --set azure.resourceGroup=$AZURE_NODE_RESOURCE_GROUP \\
+            --set azure.resourceGroup=$AZURE_RESOURCE_GROUP \\
             --set azure.subscriptionID=$AZURE_SUBSCRIPTION_ID \\
             --set azure.tenantID=$AZURE_TENANT_ID \\
             --set azure.clientID=$AZURE_CLIENT_ID \\

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -796,7 +796,7 @@ will automatically configure your virtual network to route pod traffic correctly
      --namespace kube-system \\
      --set ipam.mode=azure \\
      --set azure.enabled=true \\
-     --set azure.resourceGroup=$AZURE_NODE_RESOURCE_GROUP \\
+     --set azure.resourceGroup=$AZURE_RESOURCE_GROUP \\
      --set azure.subscriptionID=$AZURE_SUBSCRIPTION_ID \\
      --set azure.tenantID=$AZURE_TENANT_ID \\
      --set azure.clientID=$AZURE_CLIENT_ID \\

--- a/pkg/azure/api/api_interaction_test.go
+++ b/pkg/azure/api/api_interaction_test.go
@@ -19,8 +19,8 @@ import (
 // 1. Modify testSubscription and testResourceGroup
 // 2. Set
 //      AZURE_SUBSCRIPTION_ID=$(az account show --query "id" --output tsv)
-//      AZURE_NODE_RESOURCE_GROUP=$(az aks show --resource-group ${RESOURCE_GROUP} --name ${CLUSTER_NAME} --query "nodeResourceGroup" --output tsv)
-// 			AZURE_SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --scopes /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_NODE_RESOURCE_GROUP} --role Contributor --output json --only-show-errors)
+//      AZURE_RESOURCE_GROUP=$(az aks show --resource-group ${RESOURCE_GROUP} --name ${CLUSTER_NAME} --query "nodeResourceGroup" --output tsv)
+// 			AZURE_SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --scopes /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP} --role Contributor --output json --only-show-errors)
 //      AZURE_TENANT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.tenant')
 //      AZURE_CLIENT_ID=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.appId')
 //      AZURE_CLIENT_SECRET=$(echo ${AZURE_SERVICE_PRINCIPAL} | jq -r '.password')


### PR DESCRIPTION
remove confusing naming of Azure resource group
changes made using:
```
grep --exclude-dir=.git -rl AZURE_NODE_RESOURCE_GROUP|xargs sed -i -e 's/AZURE_NODE_RESOURCE_GROUP/AZURE_RESOURCE_GROUP/'
```

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
synchronize Azure variable name for resource group with cilium operator deployment
```
