### PR TITLE
Doc: add k3s --disable-kube-proxy

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -23,6 +23,10 @@ Install a Master Node
 The first step is to install a K3s master node making sure to disable support
 for the default CNI plugin and the built-in network policy enforcer:
 
+.. note::
+
+   If running Cilium in :ref:`kubeproxy-free` mode, add option ``--disable-kube-proxy``
+
 .. code-block:: shell-session
 
     curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none --disable-network-policy' sh -


### PR DESCRIPTION
K3s will set up iptables rules for cluster services when running
k3s with Cilium, this is redundant since Cilium will handle the
cluster services, add k3s option --disable-kube-proxy to disable
k3s setting up iptables rules for cluster service

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Doc: add k3s --disable-kube-proxy to stop k3s from setting up cluster services iptable rules
```
