### PR TITLE
test: Fix make target for k8s tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -20,7 +20,7 @@ GINKGO = $(QUIET) ginkgo
 
 REGISTRY_CREDENTIALS ?= "${DOCKER_LOGIN}:${DOCKER_PASSWORD}"
 
-.PHONY = all build test run k8s k8s-kind nightly clean run_bpf_tests
+.PHONY = all build test run k8s-test k8s-kind nightly clean run_bpf_tests
 
 all: build
 
@@ -29,12 +29,12 @@ build:
 	$(GINKGO) build -tags=integration_tests
 	$(QUIET)$(MAKE) -C bpf/
 
-test: run k8s
+test: run k8s-test
 
 run:
 	KERNEL=net-next ginkgo --focus "Runtime" --tags integration_tests -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
 
-k8s:
+k8s-test:
 	ginkgo --focus "K8s" --tags integration_tests -v -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
 
 # Match kind-image target in parent directory


### PR DESCRIPTION
The make target for the k8s tests is not working because it conflicts with the test/k8s directory. The PR #18621 has changed the directory name from k8sT to k8s which is the same as the k8s tests target. This PR fixes the target by changing it to k8sT.

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
