### PR TITLE
daemon, option: Fix MTU when egress gateway is used

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -464,7 +464,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	mtuConfig = mtu.NewConfiguration(
 		authKeySize,
 		option.Config.EnableIPSec,
-		option.Config.TunnelingEnabled(),
+		option.Config.TunnelExists(),
 		option.Config.EnableWireguard,
 		configuredMTU,
 		externalIP,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2387,6 +2387,13 @@ func (c *DaemonConfig) TunnelingEnabled() bool {
 	return c.Tunnel != TunnelDisabled
 }
 
+// TunnelExists returns true if some traffic may go through a tunnel, including
+// if the primary mode is native routing. For example, in the egress gateway,
+// we may send such traffic to a gateway node via a tunnel.
+func (c *DaemonConfig) TunnelExists() bool {
+	return c.TunnelingEnabled() || c.EnableIPv4EgressGateway
+}
+
 // MasqueradingEnabled returns true if either IPv4 or IPv6 masquerading is enabled.
 func (c *DaemonConfig) MasqueradingEnabled() bool {
 	return c.EnableIPv4Masquerade || c.EnableIPv6Masquerade


### PR DESCRIPTION
When using the egress gateway in native routing mode, we setup a tunnel to send egressing traffic from pods to the gateway node. In that case, we therefore need to adjust the MTU for pod traffic to avoid dropping large packets. This pull request fixes that.

```release-note
Fix drop of large packets redirected through an egress gateway node when running in native routing mode.
```
