### PR TITLE
e2ehelpers: automatically clean up kind cluster

### DIFF
--- a/pkg/e2ecluster/e2ehelpers/kind.go
+++ b/pkg/e2ecluster/e2ehelpers/kind.go
@@ -12,13 +12,9 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
 )
 
-const keyTempClusterName = "tempClusterName"
-
-type helperContextKey string
-
 // MaybeCreateTempKindCluster creates a new temporary kind cluster in case no kubeconfig file is
 // specified on the command line.
-func MaybeCreateTempKindCluster(namePrefix string) env.Func {
+func MaybeCreateTempKindCluster(testenv env.Environment, namePrefix string) env.Func {
 	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 		if cfg.KubeconfigFile() == "" {
 			name := envconf.RandomName(namePrefix, 16)
@@ -28,24 +24,23 @@ func MaybeCreateTempKindCluster(namePrefix string) env.Func {
 			if err != nil {
 				return ctx, err
 			}
-			return context.WithValue(ctx, helperContextKey(keyTempClusterName), name), nil
+			// Automatically clean up the cluster when the test finishes
+			testenv.Finish(deleteTempKindCluster(name))
+			return ctx, nil
 		}
 		return ctx, nil
 	}
 }
 
-// MaybeDeleteTempKindCluster deletes a new temporary kind cluster previously createed using
-// MaybeDeleteTempKindCluster.
-func MaybeDeleteTempKindCluster() env.Func {
+// deleteTempKindCluster deletes a new temporary kind cluster previously created using
+// MaybeCreateTempKindCluster.
+func deleteTempKindCluster(clusterName string) env.Func {
 	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
-		tempClusterName := ctx.Value(helperContextKey(keyTempClusterName))
-		if name, ok := tempClusterName.(string); ok {
-			klog.Infof("Deleting temporary kind cluster %s", name)
-			var err error
-			ctx, err = envfuncs.DestroyKindCluster(name)(ctx, cfg)
-			if err != nil {
-				return ctx, err
-			}
+		klog.Infof("Deleting temporary kind cluster %s", clusterName)
+		var err error
+		ctx, err = envfuncs.DestroyKindCluster(clusterName)(ctx, cfg)
+		if err != nil {
+			return ctx, err
 		}
 		return ctx, nil
 	}


### PR DESCRIPTION
This commit refactors MaybeCreateTempKindCluster so that it will automatically clean up
the temporary cluster at the end of the test rather than requiring the user to make a call
to MaybeDeleteTempKindCluster. Since it is no longer needed, we remove the
MaybeDeleteTempKindCluster helper and replace it with deleteTempKindCluster.

Signed-off-by: William Findlay <will@isovalent.com>