### PR TITLE
Revert "ci: use CLI 0.11.8 for AKS workflow"

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -156,14 +156,11 @@ jobs:
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \
-            --base-version=v1.12 \
             --version="
-          HUBBLE_ENABLE_DEFAULTS=" --chart-directory=install/kubernetes/cilium \
+          HUBBLE_ENABLE_DEFAULTS="--chart-directory=install/kubernetes/cilium \
             --relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci:${SHA} \
-            --base-version=v1.12 \
             --relay-version=${SHA}"
-          CONNECTIVITY_TEST_DEFAULTS="--base-version=v1.12 \
-            --flow-validation=disabled"
+          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
           echo ::set-output name=connectivity_test_defaults::${CONNECTIVITY_TEST_DEFAULTS}


### PR DESCRIPTION
This reverts commit 1ffa176a47f6363e9a1880be126157720d7f98a9.

Reason for revert: this was merged based on cilium-cli v0.11.8 which
still supported the --base-version flag. In the meantime, commit
135f522644f0 ("ci: pick up cilium-cli v0.11.9 for master/v1.11
workflows") was merged updating to cilium-cli v0.11.9 which dropped said
flag.

This should fix the AKS workflow on master.

Ref. https://github.com/cilium/cilium/pull/19379#issuecomment-1162193946