### PR TITLE
helm: Remove duplicated key hostAliases

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -669,10 +669,6 @@
      - TCP port for the agent health API. This is not the port for cilium-health.
      - int
      - ``9879``
-   * - hostAliases
-     - Host aliases for cilium-agent.
-     - list
-     - ``[]``
    * - hostFirewall
      - Configure the host firewall.
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -218,7 +218,6 @@ contributors across the globe, there is almost always someone available to help.
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
 | healthPort | int | `9879` | TCP port for the agent health API. This is not the port for cilium-health. |
-| hostAliases | list | `[]` | Host aliases for cilium-agent. |
 | hostFirewall | object | `{"enabled":false}` | Configure the host firewall. |
 | hostFirewall.enabled | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |
 | hostPort.enabled | bool | `false` | Enable hostPort service support. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -627,10 +627,6 @@ spec:
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
-      {{- with .Values.hostAliases }}
-      hostAliases:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -117,12 +117,6 @@ tolerations:
   #   value: "value"
   #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
-# -- Host aliases for cilium-agent.
-hostAliases: []
-# - ip: 10.10.xx.xx
-#   hostnames:
-#   - cluster1.mesh.cilium.io
-
 # -- The priority class to use for cilium-agent.
 priorityClassName: ""
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -114,12 +114,6 @@ tolerations:
   #   value: "value"
   #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
-# -- Host aliases for cilium-agent.
-hostAliases: []
-# - ip: 10.10.xx.xx
-#   hostnames:
-#   - cluster1.mesh.cilium.io
-
 # -- The priority class to use for cilium-agent.
 priorityClassName: ""
 


### PR DESCRIPTION
The original commit adding .Values.hostAliases was to support cluster
mesh installation, however, recently, clustermesh installation via helm
is more polished in #17851. Hence, it's better to remove one.

Relates: 18a5fa95cf0489d4075f3d4eb1d6a976bb0ca2ee
Relates: #17851
Signed-off-by: Tam Mach <tam.mach@cilium.io>
