### PR TITLE
daemon, option: Fix vlan bpf bypass ids loading

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -259,7 +259,7 @@ cilium-agent [flags]
   -t, --tunnel string                                           Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
       --tunnel-port int                                         Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --version                                                 Print version information
-      --vlan-bpf-bypass ints                                    List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs
+      --vlan-bpf-bypass strings                                 List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs
       --vtep-cidr strings                                       List of VTEP CIDRs that will be routed towards VTEPs for traffic cluster egress
       --vtep-endpoint strings                                   List of VTEP IP addresses
       --vtep-mac strings                                        List of VTEP MAC addresses for forwarding traffic outside the cluster

--- a/Documentation/configuration/vlan-802.1q.rst
+++ b/Documentation/configuration/vlan-802.1q.rst
@@ -14,7 +14,7 @@ Cilium enables firewalling on native devices in use and will filter all unknown 
 will always be passed through their main device with associated tag (e.g. VLAN device is ``eth0.4000`` and its main interface is ``eth0``).
 By default, Cilium will allow all tags from the native devices (i.e. if ``eth0.4000`` is controlled by Cilium and has
 an eBPF program attached, then VLAN tag ``4000`` will be allowed on device ``eth0``). Additional VLAN tags may be allowed
-with the cilium-agent flag ``--vlan-bpf-bypass=4001,4002`` (or Helm variable ``--set bpf.vlan-bpf-bypass=4001,4002``).
+with the cilium-agent flag ``--vlan-bpf-bypass=4001,4002`` (or Helm variable ``--set bpf.vlanBypass="{4001,4002}"``).
 
 The list of allowed VLAN tags cannot be too big in order to keep eBPF program of predictable size. Currently this list
 should contain no more than 5 entries. If you need more, then there is only one way for now: you need to allow

--- a/Makefile
+++ b/Makefile
@@ -541,8 +541,8 @@ endif
 	$(QUIET) contrib/scripts/check-assert-deep-equals.sh
 	@$(ECHO_CHECK) contrib/scripts/lock-check.sh
 	$(QUIET) contrib/scripts/lock-check.sh
-	@$(ECHO_CHECK) contrib/scripts/check-viper-get-string-map-string.sh
-	$(QUIET) contrib/scripts/check-viper-get-string-map-string.sh
+	@$(ECHO_CHECK) contrib/scripts/check-viper-unusable-api.sh
+	$(QUIET) contrib/scripts/check-viper-unusable-api.sh
 ifeq ($(SKIP_CUSTOMVET_CHECK),"false")
 	@$(ECHO_CHECK) contrib/scripts/custom-vet-check.sh
 	$(QUIET) contrib/scripts/custom-vet-check.sh

--- a/contrib/scripts/check-viper-unusable-api.sh
+++ b/contrib/scripts/check-viper-unusable-api.sh
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 
-# Simple script to make sure viper.GetStringMapString should not be used.
+# Simple script to make sure that some specific viper APIs are not used.
+
+# viper.GetStringMapString
 # Related upstream issue https://github.com/spf13/viper/issues/911
 if grep -r --exclude-dir={.git,_build,vendor,contrib} -i --include \*.go "viper.GetStringMapString" .; then
   echo "Found viper.GetStringMapString(key) usage. Please use command.GetStringMapString(viper.GetViper(), key) instead";
@@ -11,5 +13,12 @@ fi
 
 if grep -r --exclude-dir={.git,_build,vendor,contrib} -i --include \*.go "StringToStringVar" .; then
   echo "Found flags.StringToStringVar usage. Please use option.NewNamedMapOptions instead";
+  exit 1
+fi
+
+# viper.GetIntSlice
+# Related Cilium issue https://github.com/cilium/cilium/issues/20173 and companion PR https://github.com/cilium/cilium/pull/20282
+if grep -r --exclude-dir={.git,_build,vendor,contrib} -i --include \*.go "viper.GetIntSlice" .; then
+  echo "Found viper.GetIntSlice(key) usage. Please use a flags.StringSlice type and viper.GetStringSlice(key) instead";
   exit 1
 fi

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1094,7 +1094,9 @@ func initializeFlags() {
 	flags.Bool(option.ExternalClusterIPName, false, "Enable external access to ClusterIP services (default false)")
 	option.BindEnv(option.ExternalClusterIPName)
 
-	flags.IntSlice(option.VLANBPFBypass, []int{}, "List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs")
+	// flags.IntSlice cannot be used due to missing support for appropriate conversion in Viper.
+	// See https://github.com/cilium/cilium/pull/20282 for more information.
+	flags.StringSlice(option.VLANBPFBypass, []string{}, "List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs")
 	option.BindEnv(option.VLANBPFBypass)
 
 	flags.Bool(option.EnableICMPRules, true, "Enable ICMP-based rule support for Cilium Network Policies")

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -325,7 +325,7 @@ bpf:
 
   # -- Configure explicitly allowed VLAN id's for bpf logic bypass.
   # [0] will allow all VLAN id's without any filtering.
-  # vlan-bpf-bypass: []
+  # vlanBypass: []
 
 # -- Clean all eBPF datapath state from the initContainer of the cilium-agent
 # DaemonSet.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -322,7 +322,7 @@ bpf:
 
   # -- Configure explicitly allowed VLAN id's for bpf logic bypass.
   # [0] will allow all VLAN id's without any filtering.
-  # vlan-bpf-bypass: []
+  # vlanBypass: []
 
 # -- Clean all eBPF datapath state from the initContainer of the cilium-agent
 # DaemonSet.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2940,7 +2940,15 @@ func (c *DaemonConfig) Populate() {
 	c.EnableRuntimeDeviceDetection = viper.GetBool(EnableRuntimeDeviceDetection)
 	c.EgressMultiHomeIPRuleCompat = viper.GetBool(EgressMultiHomeIPRuleCompat)
 
-	c.VLANBPFBypass = viper.GetIntSlice(VLANBPFBypass)
+	vlanBPFBypassIDs := viper.GetStringSlice(VLANBPFBypass)
+	c.VLANBPFBypass = make([]int, 0, len(vlanBPFBypassIDs))
+	for _, vlanIDStr := range vlanBPFBypassIDs {
+		vlanID, err := strconv.Atoi(vlanIDStr)
+		if err != nil {
+			log.WithError(err).Fatalf("Cannot parse vlan ID integer from --%s option", VLANBPFBypass)
+		}
+		c.VLANBPFBypass = append(c.VLANBPFBypass, vlanID)
+	}
 
 	c.Tunnel = viper.GetString(TunnelName)
 	c.TunnelPort = viper.GetInt(TunnelPortName)


### PR DESCRIPTION
When installing cilium-agent via Helm, the configuration options are loaded reading files.
Each file represents an entry in the ConfigMap.
Doing so, all the values are loaded as strings and therefore must be converted to the specific option value type later.
This conversion is carried out by the spf13/viper package itself.

Internally, viper tries to load values from different sources:

- flag
- env
- config file
- key/value store
- default

When loading values from a config file, unlike the flag code path, the conversion from string to the requested value type is carried out by the spf13/cast package.
The cast package does not support the conversion from string to slice of ints and the viper.GetIntSlice(...) function does not report any error if the conversion goes wrong.

As a temporary workaround, the bpf.vlanBypass option value type has been changed to a slice of strings, so to leave the conversion to a slice of ints to be implemented manually.

To avoid this workaround, two things are needed:

1) Support for converting a string to a slice of ints in the cast package: https://github.com/spf13/cast/pull/146
2) Fix the `validateConfigmap` function to check option values using the cast package with the proper type conversion, instead of relying on pflag `Set` method.

Fixes: #20173