### PR TITLE
helm: Use hubble-relay-ci image for master branch

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -772,7 +772,7 @@
    * - hubble.relay.image
      - Hubble-relay container image.
      - object
-     - ``{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-relay","tag":"latest","useDigest":false}``
+     - ``{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-relay-ci","tag":"latest","useDigest":false}``
    * - hubble.relay.listenHost
      - Host to listen to. Specify an empty string to bind to all the interfaces.
      - string

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -10,6 +10,7 @@ export USE_DIGESTS ?= $(shell if grep -q '""' $(DIGESTS_PATH); then echo "false"
 #export CILIUM_BRANCH:=vX.Y
 #export CILIUM_REPO:=quay.io/cilium/cilium
 #export CLUSTERMESH_APISERVER_REPO:=quay.io/cilium/clustermesh-apiserver
+#export HUBBLE_RELAY_REPO:=quay.io/cilium/hubble-relay
 export PULL_POLICY:=Always
 export CILIUM_BRANCH:=master
 export CILIUM_REPO:=quay.io/cilium/cilium-ci
@@ -31,7 +32,7 @@ export CILIUM_OPERATOR_BASE_REPO:=quay.io/cilium/operator
 export ETCD_REPO:=quay.io/coreos/etcd
 export ETCD_VERSION:=v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3
 
-export HUBBLE_RELAY_REPO:=quay.io/cilium/hubble-relay
+export HUBBLE_RELAY_REPO:=quay.io/cilium/hubble-relay-ci
 export HUBBLE_UI_BACKEND_REPO:=quay.io/cilium/hubble-ui-backend
 export HUBBLE_UI_BACKEND_VERSION:=v0.9.0@sha256:000df6b76719f607a9edefb9af94dfd1811a6f1b6a8a9c537cba90bf12df474b
 export HUBBLE_UI_FRONTEND_REPO:=quay.io/cilium/hubble-ui

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -243,7 +243,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
 | hubble.relay.extraEnv | list | `[]` | Additional hubble-relay environment variables. |
-| hubble.relay.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-relay","tag":"latest","useDigest":false}` | Hubble-relay container image. |
+| hubble.relay.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-relay-ci","tag":"latest","useDigest":false}` | Hubble-relay container image. |
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
 | hubble.relay.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -784,7 +784,7 @@ hubble:
     # -- Hubble-relay container image.
     image:
       override: ~
-      repository: "quay.io/cilium/hubble-relay"
+      repository: "quay.io/cilium/hubble-relay-ci"
       tag: "latest"
        # hubble-relay-digest
       digest: ""


### PR DESCRIPTION
Hubble Relay is built from the master branch same as the cilium,
operator or clustermesh-apiserver image.

This fixes an issue where `helm install cilium install/kubernetes/cilium -n kube-system --set hubble.relay.enabled=true` would fail to use the correct Hubble Relay image. 

See also
 - #20066
 - #20206