### PR TITLE
v1.11: helm: disable the peer service by default

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -640,7 +640,7 @@
    * - hubble.peerService.enabled
      - Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client
      - bool
-     - ``true``
+     - ``false``
    * - hubble.peerService.targetPort
      - Target Port for the Peer service.
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -210,7 +210,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | hubble.metrics.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor hubble |
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
-| hubble.peerService.enabled | bool | `true` | Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client |
+| hubble.peerService.enabled | bool | `false` | Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service. |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -632,7 +632,7 @@ hubble:
   peerService:
     # -- Enable a K8s Service for the Peer service, so that it can be accessed
     # by a non-local client
-    enabled: true
+    enabled: false
     # -- Service Port for the Peer service.
     # If not set, it is dynamically assigned to port 443 if TLS is enabled and to
     # port 80 if not.


### PR DESCRIPTION
Commit 7d9c7e51f2ad122931efc885ef9fbc109af8b19c turns the peer service
into a Kubernetes service. The rationale for the change is that instead
of cross-mounting the Hubble Unix domain socket from the Cilium pod to
the Hubble Relay pod, Hubble Relay can directly query the Kubernetes
service to get information about Hubble peers. This is a security
improvement as it follows best-practices and streamlines the
installation process on platforms that strictly enforce SELinux policies
such as OpenShift.

However, this change is not minor and users have reported issues with
Hubble when upgrading from v1.11.x to v1.11.5. In order to follow the
principle of least astonishment and to avoid breaking a Hubble
deployment during a patch upgrade, this commit disables the peer service
by default such that the old behavior is retained, which shouldn't cause
any issue when upgrading. Users of platforms which need the peer service
can always explicitly enable it in v1.11.