### PR TITLE
images: Bump Hubble CLI to v0.10.0

### DIFF
--- a/examples/hubble/hubble-cli.yaml
+++ b/examples/hubble/hubble-cli.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: hubble-cli
-        image: quay.io/cilium/hubble:v0.9.0
+        image: quay.io/cilium/hubble:v0.10.0
         imagePullPolicy: IfNotPresent
         command:
           - tail


### PR DESCRIPTION
See https://github.com/cilium/cilium/pull/18077 for an explanation of why this needs to be backported to `v1.12`.