### PR TITLE
backport v1.11: datapath: Set WORLD_ID in fwd-ed NodePort BPF requests

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -610,7 +610,12 @@ int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 		info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN);
 		if (info != NULL && info->tunnel_endpoint != 0) {
 			ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
-						  SECLABEL, TRACE_PAYLOAD_LEN);
+#ifdef PRESERVE_WORLD_ID
+						  WORLD_ID,
+#else
+						  SECLABEL,
+#endif /* PRESERVE_WORLD_ID */
+						  TRACE_PAYLOAD_LEN);
 			if (ret)
 				goto drop_err;
 
@@ -779,7 +784,11 @@ skip_service_lookup:
 		switch (ret) {
 		case CT_NEW:
 redo_all:
+#ifdef PRESERVE_WORLD_ID
+			ct_state_new.src_sec_id = WORLD_ID;
+#else
 			ct_state_new.src_sec_id = SECLABEL;
+#endif /* PRESERVE_WORLD_ID */
 			ct_state_new.node_port = 1;
 			ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
 			ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
@@ -807,7 +816,11 @@ redo_local:
 				ct_flip_tuple_dir6(&tuple);
 				if (!__ct_entry_keep_alive(get_ct_map6(&tuple),
 							   &tuple)) {
+#ifdef PRESERVE_WORLD_ID
+					ct_state_new.src_sec_id = WORLD_ID;
+#else
 					ct_state_new.src_sec_id = SECLABEL;
+#endif /* PRESERVE_WORLD_ID */
 					ct_state_new.node_port = 1;
 					ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
 					goto redo_local;
@@ -1614,7 +1627,21 @@ int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 		info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
 		if (info != NULL && info->tunnel_endpoint != 0) {
 			ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
-						  SECLABEL, TRACE_PAYLOAD_LEN);
+			/* The dir == NAT_DIR_EGRESS branch is executed for
+			 * N/S LB requests which needs to be fwd-ed to a remote
+			 * node. As the request came from outside, we need to
+			 * set the security id in the tunnel header to WORLD_ID.
+			 * Otherwise, the remote node will assume, that the
+			 * request originated from a cluster node which will
+			 * bypass any netpol which disallows LB requests from
+			 * outside.
+			 */
+#ifdef PRESERVE_WORLD_ID
+						  WORLD_ID,
+#else
+						  SECLABEL,
+#endif /* PRESERVE_WORLD_ID */
+						  TRACE_PAYLOAD_LEN);
 			if (ret)
 				goto drop_err;
 
@@ -1794,7 +1821,11 @@ skip_service_lookup:
 		switch (ret) {
 		case CT_NEW:
 redo_all:
+#ifdef PRESERVE_WORLD_ID
+			ct_state_new.src_sec_id = WORLD_ID;
+#else
 			ct_state_new.src_sec_id = SECLABEL;
+#endif /* PRESERVE_WORLD_ID */
 			ct_state_new.node_port = 1;
 			ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
 			ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
@@ -1828,7 +1859,11 @@ redo_local:
 				ct_flip_tuple_dir4(&tuple);
 				if (!__ct_entry_keep_alive(get_ct_map4(&tuple),
 							   &tuple)) {
+#ifdef PRESERVE_WORLD_ID
+					ct_state_new.src_sec_id = WORLD_ID;
+#else
 					ct_state_new.src_sec_id = SECLABEL;
+#endif /* PRESERVE_WORLD_ID */
 					ct_state_new.node_port = 1;
 					ct_state_new.ifindex = NATIVE_DEV_IFINDEX;
 					goto redo_local;

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -628,6 +628,10 @@ func initializeFlags() {
 		option.NodePortAccelerationNative, option.NodePortAccelerationDisabled))
 	option.BindEnv(option.LoadBalancerAcceleration)
 
+	flags.Bool(option.LoadBalancerPreserveWorldID, false, "Set reserved:world security identity for to be forwarded LB requests in tunnel mode")
+	flags.MarkHidden(option.LoadBalancerPreserveWorldID)
+	option.BindEnv(option.LoadBalancerPreserveWorldID)
+
 	flags.Uint(option.MaglevTableSize, maglev.DefaultTableSize, "Maglev per service backend table size (parameter M)")
 	option.BindEnv(option.MaglevTableSize)
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -448,6 +448,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			extraMacrosMap["IPV6_DIRECT_ROUTING"] = directRoutingIPv6.String()
 			fw.WriteString(FmtDefineAddress("IPV6_DIRECT_ROUTING", directRoutingIPv6))
 		}
+
+		if option.Config.LoadBalancerPreserveWorldID {
+			cDefinesMap["PRESERVE_WORLD_ID"] = "1"
+		}
 	} else {
 		var directRoutingIPv6 net.IP
 		cDefinesMap["DIRECT_ROUTING_DEV_IFINDEX"] = "0"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -272,6 +272,8 @@ const (
 	// Alias to NodePortAcceleration
 	LoadBalancerAcceleration = "bpf-lb-acceleration"
 
+	LoadBalancerPreserveWorldID = "bpf-lb-preserve-world-id"
+
 	// MaglevTableSize determines the size of the backend table per service
 	MaglevTableSize = "bpf-lb-maglev-table-size"
 
@@ -1791,6 +1793,10 @@ type DaemonConfig struct {
 	// frag needed messages to client (when needed)
 	LoadBalancerPMTUDiscovery bool
 
+	// LoadBalancerPreserveWorldID indicates whether world security ID should
+	// be set for to be forwarded via tunnel LB requests
+	LoadBalancerPreserveWorldID bool
+
 	// Maglev backend table size (M) per service. Must be prime number.
 	MaglevTableSize int
 
@@ -2712,6 +2718,7 @@ func (c *DaemonConfig) Populate() {
 	c.LoadBalancerDSRL4Xlate = viper.GetString(LoadBalancerDSRL4Xlate)
 	c.LoadBalancerRSSv4CIDR = viper.GetString(LoadBalancerRSSv4CIDR)
 	c.LoadBalancerRSSv6CIDR = viper.GetString(LoadBalancerRSSv6CIDR)
+	c.LoadBalancerPreserveWorldID = viper.GetBool(LoadBalancerPreserveWorldID)
 	c.InstallNoConntrackIptRules = viper.GetBool(InstallNoConntrackIptRules)
 	c.EnableCustomCalls = viper.GetBool(EnableCustomCallsName)
 	c.BGPAnnounceLBIP = viper.GetBool(BGPAnnounceLBIP)


### PR DESCRIPTION
This commit is a backport of 595ddcdd ("datapath: Set WORLD_ID in fwd-ed
NodePort BPF requests").

The main difference is that the behavior introduced in the commit is
protected by the hidden flag --bpf-lb-preserve-world-id (defaults to
false). This is needed to avoid breaking existing network policies
assumptions on v1.11.

The original PR https://github.com/cilium/cilium/pull/19061

```upstream-prs
$ for pr in 19061; do contrib/backporting/set-labels.py $pr done 1.11; done
```