### PR TITLE
Fix config map options validation

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -150,9 +150,9 @@
      - bool
      - ``false``
    * - cluster.id
-     - Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh.
+     - Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh, may be 0 if Cluster Mesh is not used.
      - int
-     - ``nil``
+     - ``0``
    * - cluster.name
      - Name of the cluster. Only required for Cluster Mesh.
      - string

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -411,6 +411,8 @@ Helm Options
 * The ``nodeSelector`` of all components now default to
   ``{"kubernetes.io/os":"linux"}`` to ensure these pods with Linux-based
   container images are not scheduled on non-Linux nodes.
+* ``cluster.id`` cannot be empty and a value must be specified.
+  Use the ``0`` value to leave Cluster Mesh disabled.
 
 .. _1.11_upgrade_notes:
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -88,7 +88,7 @@ contributors across the globe, there is almost always someone available to help.
 | cgroup.hostRoot | string | `"/run/cilium/cgroupv2"` | Configure cgroup root where cgroup2 filesystem is mounted on the host (see also: `cgroup.autoMount`) |
 | cleanBpfState | bool | `false` | Clean all eBPF datapath state from the initContainer of the cilium-agent DaemonSet.  WARNING: Use with care! |
 | cleanState | bool | `false` | Clean all local Cilium state from the initContainer of the cilium-agent DaemonSet. Implies cleanBpfState: true.  WARNING: Use with care! |
-| cluster.id | int | `nil` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh. |
+| cluster.id | int | `0` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh, may be 0 if Cluster Mesh is not used. |
 | cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh. |
 | clustermesh.apiserver.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for clustermesh.apiserver |
 | clustermesh.apiserver.etcd.image | object | `{"override":null,"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"}` | Clustermesh API server etcd image. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -28,8 +28,9 @@ cluster:
   # -- Name of the cluster. Only required for Cluster Mesh.
   name: default
   # -- (int) Unique ID of the cluster. Must be unique across all connected
-  # clusters and in the range of 1 to 255. Only required for Cluster Mesh.
-  id:
+  # clusters and in the range of 1 to 255. Only required for Cluster Mesh,
+  # may be 0 if Cluster Mesh is not used.
+  id: 0
 
 # -- Define serviceAccount names for components.
 # @default -- Component's fully qualified name.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -25,8 +25,9 @@ cluster:
   # -- Name of the cluster. Only required for Cluster Mesh.
   name: default
   # -- (int) Unique ID of the cluster. Must be unique across all connected
-  # clusters and in the range of 1 to 255. Only required for Cluster Mesh.
-  id:
+  # clusters and in the range of 1 to 255. Only required for Cluster Mesh,
+  # may be 0 if Cluster Mesh is not used.
+  id: 0
 
 # -- Define serviceAccount names for components.
 # @default -- Component's fully qualified name.


### PR DESCRIPTION
The validation of the config options loaded from the ConfigMap was carried out using the `pflag` package.
This is different from what Viper does when it tries to convert each string value in the appropriate config option type. Internally, Viper uses the `cast` package to convert the string in an appropriate value of the specific option type.

Using `pflag` was leading to false positives while checking the option values. One such example is this bug: https://github.com/cilium/cilium/issues/20173

To fix the validation, the APIs from the `cast` package are used, so to avoid (silent) misconfiguration while starting the cilium-agent or the cilium-operator.

Related to #20282