### PR TITLE
Add support for disabling ENI PD at node level

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/smithy-go"
 	"github.com/sirupsen/logrus"
 
@@ -671,6 +672,10 @@ func (n *Node) IsPrefixDelegated() bool {
 	}
 	// Allocating prefixes is supported only on nitro instances
 	if limits.HypervisorType != "nitro" {
+		return false
+	}
+	// Check if this node is allowed to use prefix delegation
+	if n.k8sObj.Spec.ENI.DisablePrefixDelegation != nil && aws.ToBool(n.k8sObj.Spec.ENI.DisablePrefixDelegation) {
 		return false
 	}
 	// Verify if all interfaces are prefix delegated. We don't want to enable prefix delegation on nodes that already

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -128,6 +128,12 @@ type ENISpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	UsePrimaryAddress *bool `json:"use-primary-address,omitempty"`
+
+	// DisablePrefixDelegation determines whether ENI prefix delegation should be
+	// disabled on this node.
+	//
+	// +kubebuilder:validation:Optional
+	DisablePrefixDelegation *bool `json:"disable-prefix-delegation,omitempty"`
 }
 
 // ENI represents an AWS Elastic Network Interface

--- a/pkg/aws/eni/types/zz_generated.deepcopy.go
+++ b/pkg/aws/eni/types/zz_generated.deepcopy.go
@@ -134,6 +134,11 @@ func (in *ENISpec) DeepCopyInto(out *ENISpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisablePrefixDelegation != nil {
+		in, out := &in.DisablePrefixDelegation, &out.DisablePrefixDelegation
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/aws/eni/types/zz_generated.deepequal.go
+++ b/pkg/aws/eni/types/zz_generated.deepequal.go
@@ -315,6 +315,14 @@ func (in *ENISpec) DeepEqual(other *ENISpec) bool {
 		}
 	}
 
+	if (in.DisablePrefixDelegation == nil) != (other.DisablePrefixDelegation == nil) {
+		return false
+	} else if in.DisablePrefixDelegation != nil {
+		if *in.DisablePrefixDelegation != *other.DisablePrefixDelegation {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -353,6 +353,10 @@ const (
 	// CiliumNode.Spec.ENI.UsePrimaryAddress if no value is set.
 	UseENIPrimaryAddress = false
 
+	// ENIDisableNodeLevelPD  is the default value for
+	// CiliumNode.Spec.ENI.DisablePrefixDelegation if no value is set.
+	ENIDisableNodeLevelPD = false
+
 	// ParallelAllocWorkers is the default max number of parallel workers doing allocation in the operator
 	ParallelAllocWorkers = 50
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -126,6 +126,10 @@ spec:
                       is not set the default behavior is to delete the ENI on instance
                       termination.
                     type: boolean
+                  disable-prefix-delegation:
+                    description: DisablePrefixDelegation determines whether ENI prefix
+                      delegation should be disabled on this node.
+                    type: boolean
                   exclude-interface-tags:
                     additionalProperties:
                       type: string

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -23,7 +23,7 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.25.4"
+	CustomResourceDefinitionSchemaVersion = "1.25.5"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -549,6 +549,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		nodeResource.Spec.ENI.VpcID = vpcID
 		nodeResource.Spec.ENI.FirstInterfaceIndex = getInt(defaults.ENIFirstInterfaceIndex)
 		nodeResource.Spec.ENI.UsePrimaryAddress = getBool(defaults.UseENIPrimaryAddress)
+		nodeResource.Spec.ENI.DisablePrefixDelegation = getBool(defaults.ENIDisableNodeLevelPD)
 
 		if c := n.NetConf; c != nil {
 			if c.IPAM.MinAllocate != 0 {
@@ -589,6 +590,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 
 			if c.ENI.UsePrimaryAddress != nil {
 				nodeResource.Spec.ENI.UsePrimaryAddress = c.ENI.UsePrimaryAddress
+			}
+
+			if c.ENI.DisablePrefixDelegation != nil {
+				nodeResource.Spec.ENI.DisablePrefixDelegation = c.ENI.DisablePrefixDelegation
 			}
 
 			nodeResource.Spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination


### PR DESCRIPTION
Currently [prefix delegation](https://github.com/cilium/cilium/pull/18463) (PD) can only be enabled cluster wide. On
nodes with low pod density, PD can be wasteful in terms of number of
unused IP addresses allocated to the node. This commit adds a new field
to the ENI spec on ciliumnode CRD to opt out of PD at a node level.
Other IPAM settings like pre and min allocate are already defined on the
ciliumnode CRD.

Setting `eni.disable-prefix-delegation`  in the node's CNI config will
result in the corresponding node's ciliumnode ENI spec to be updated. Operator
uses this field to decide if prefix delegation should be enabled on a given node.

```
{
    ...
    "name": "cilium",
    "plugins": [
      {
        "name": "cilium",
        "type": "cilium-cni",
        "eni": {
          "delete-on-termination": true,
          "disable-prefix-delegation": true
        },
        "ipam": {
          "pre-allocate": 2,
          "min-allocate": 5
        }
      }
    ]
}
```

Signed-off-by: Hemanth Malla <hemanth.malla@datadoghq.com>
