### PR TITLE
ci: unquarantine failing test on net-next

### DIFF
--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -1879,10 +1879,7 @@ var _ = SkipDescribeIf(func() bool {
 				validateConnectivity(HostConnectivityAllow, RemoteNodeConnectivityAllow, PodConnectivityAllow, WorldConnectivityDeny)
 			})
 
-			// Quarantined on net-next until #18520 is fixed
-			SkipItIf(func() bool {
-				return helpers.RunsOnNetNextKernel() && helpers.SkipQuarantined()
-			}, "Validates fromEntities all policy", func() {
+			It("Validates fromEntities all policy", func() {
 				installDefaultDenyIngressPolicy(kubectl, testNamespace, validateConnectivity)
 
 				By("Installing fromEntities all policy")


### PR DESCRIPTION
`K8sPolicyTest Multi-node policy test validates fromEntities policies Validates fromEntities all policy` has been stable with kernel 5.18 (VM rev 145). Now we can unquarantine it.

Fixes: #18520

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!
