### PR TITLE
helm: Fix cluster-id arguments in clustermesh deployment

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -107,6 +107,7 @@ spec:
         - --debug
         {{- end }}
         - --cluster-name=$(CLUSTER_NAME)
+        - --cluster-id=$(CLUSTER_ID)
         - --kvstore-opt
         - etcd.config=/var/lib/cilium/etcd-config.yaml
         env:


### PR DESCRIPTION
This commit is to pass the cluster-id argument from env in clustermesh
deployment, otherwise the cluster-id will be defaulted to 0, which
potentially causes issues with identity conflict.

Before

```
$ ksyslo clustermesh-apiserver-7d77845567-5kq2d -c apiserver
level=info msg="  --allocator-list-timeout='3m0s'" subsys=clustermesh-apiserver
level=info msg="  --cluster-id='0'" subsys=clustermesh-apiserver
...
```

After

```
$ ksyslo clustermesh-apiserver-cb8f9bb7-689kn -c apiserver
level=info msg="  --allocator-list-timeout='3m0s'" subsys=clustermesh-apiserver
level=info msg="  --cluster-id='1'" subsys=clustermesh-apiserver
level=info msg="  --cluster-name='test'" subsys=clustermesh-apiserver
...
```

Signed-off-by: Tam Mach <tam.mach@cilium.io>
