### PR TITLE
labels/cidr: use netip types to improve GetCIDRLabels and IPStringToLabel performace

### DIFF
--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -123,21 +123,63 @@ func (s *CIDRLabelsSuite) TestGetCIDRLabelsInCluster(c *C) {
 }
 
 func (s *CIDRLabelsSuite) TestIPStringToLabel(c *C) {
-	ipToLabels := map[string]string{
-		"0.0.0.0/0":       "cidr:0.0.0.0/0",
-		"192.0.2.3":       "cidr:192.0.2.3/32",
-		"192.0.2.3/32":    "cidr:192.0.2.3/32",
-		"192.0.2.3/24":    "cidr:192.0.2.0/24",
-		"192.0.2.0/24":    "cidr:192.0.2.0/24",
-		"::/0":            "cidr:0--0/0",
-		"fdff::ff":        "cidr:fdff--ff/128",
-		"f00d:42::ff/128": "cidr:f00d-42--ff/128",
-		"f00d:42::ff/96":  "cidr:f00d-42--0/96",
-	}
-	for ip, labelStr := range ipToLabels {
-		lbl, err := IPStringToLabel(ip)
-		c.Assert(err, IsNil)
-		c.Assert(lbl.String(), checker.DeepEquals, labelStr)
+	for _, tc := range []struct {
+		ip      string
+		label   string
+		wantErr bool
+	}{
+		{
+			ip:    "0.0.0.0/0",
+			label: "cidr:0.0.0.0/0",
+		},
+		{
+			ip:    "192.0.2.3",
+			label: "cidr:192.0.2.3/32",
+		},
+		{
+			ip:    "192.0.2.3/32",
+			label: "cidr:192.0.2.3/32",
+		},
+		{
+			ip:    "192.0.2.3/24",
+			label: "cidr:192.0.2.0/24",
+		},
+		{
+			ip:    "192.0.2.0/24",
+			label: "cidr:192.0.2.0/24",
+		},
+		{
+			ip:    "::/0",
+			label: "cidr:0--0/0",
+		},
+		{
+			ip:    "fdff::ff",
+			label: "cidr:fdff--ff/128",
+		},
+		{
+			ip:    "f00d:42::ff/128",
+			label: "cidr:f00d-42--ff/128",
+		},
+		{
+			ip:    "f00d:42::ff/96",
+			label: "cidr:f00d-42--0/96",
+		},
+		{
+			ip:      "",
+			wantErr: true,
+		},
+		{
+			ip:      "foobar",
+			wantErr: true,
+		},
+	} {
+		lbl, err := IPStringToLabel(tc.ip)
+		if !tc.wantErr {
+			c.Assert(err, IsNil)
+			c.Assert(lbl.String(), checker.DeepEquals, tc.label)
+		} else {
+			c.Assert(err, Not(IsNil))
+		}
 	}
 }
 

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -124,13 +124,15 @@ func (s *CIDRLabelsSuite) TestGetCIDRLabelsInCluster(c *C) {
 
 func (s *CIDRLabelsSuite) TestIPStringToLabel(c *C) {
 	ipToLabels := map[string]string{
-		"0.0.0.0/0":    "cidr:0.0.0.0/0",
-		"192.0.2.3":    "cidr:192.0.2.3/32",
-		"192.0.2.3/32": "cidr:192.0.2.3/32",
-		"192.0.2.3/24": "cidr:192.0.2.0/24",
-		"192.0.2.0/24": "cidr:192.0.2.0/24",
-		"::/0":         "cidr:0--0/0",
-		"fdff::ff":     "cidr:fdff--ff/128",
+		"0.0.0.0/0":       "cidr:0.0.0.0/0",
+		"192.0.2.3":       "cidr:192.0.2.3/32",
+		"192.0.2.3/32":    "cidr:192.0.2.3/32",
+		"192.0.2.3/24":    "cidr:192.0.2.0/24",
+		"192.0.2.0/24":    "cidr:192.0.2.0/24",
+		"::/0":            "cidr:0--0/0",
+		"fdff::ff":        "cidr:fdff--ff/128",
+		"f00d:42::ff/128": "cidr:f00d-42--ff/128",
+		"f00d:42::ff/96":  "cidr:f00d-42--0/96",
 	}
 	for ip, labelStr := range ipToLabels {
 		lbl, err := IPStringToLabel(ip)
@@ -191,5 +193,29 @@ func Benchmark_GetCIDRLabels(b *testing.B) {
 		for _, c := range cidrs {
 			_ = GetCIDRLabels(c)
 		}
+	}
+}
+
+func BenchmarkIPStringToLabel(b *testing.B) {
+	for _, ip := range []string{
+		"0.0.0.0/0",
+		"192.0.2.3",
+		"192.0.2.3/32",
+		"192.0.2.3/24",
+		"192.0.2.0/24",
+		"::/0",
+		"fdff::ff",
+		"f00d:42::ff/128",
+		"f00d:42::ff/96",
+	} {
+		b.Run(ip, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := IPStringToLabel(ip)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -183,38 +183,6 @@ func (s *CIDRLabelsSuite) TestIPStringToLabel(c *C) {
 	}
 }
 
-func Benchmark_maskedIPNetToLabelString(b *testing.B) {
-	type input struct {
-		prefix     *net.IPNet
-		ones, bits int
-	}
-	var ins []input
-	for _, cidr := range []string{
-		"0.0.0.0/0",
-		"10.16.0.0/16",
-		"192.0.2.3/32",
-		"192.0.2.3/24",
-		"192.0.2.0/24",
-		"::/0",
-		"fdff::ff/128",
-	} {
-		_, c, _ := net.ParseCIDR(cidr)
-		ones, bits := c.Mask.Size()
-		ins = append(ins, input{
-			prefix: c,
-			ones:   ones,
-			bits:   bits,
-		})
-	}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		for _, in := range ins {
-			_ = maskedIPNetToLabelString(in.prefix, in.ones, in.bits)
-		}
-	}
-}
-
 func mustCIDR(cidr string) *net.IPNet {
 	_, c, err := net.ParseCIDR(cidr)
 	if err != nil {


### PR DESCRIPTION
The first three commits rework and add tests and benchmarks to cover 

The fourth commit changes `GetCIDRLabels` and `IPStringLabel` to use `netip.Address` and `netip.Prefix` to improve performance both in terms of CPU and memory as follows:

```
name                               old time/op    new time/op    delta
GetCIDRLabels/0.0.0.0/0-8             699ns ± 2%     717ns ± 2%   +2.58%  (p=0.000 n=10+10)
GetCIDRLabels/10.16.0.0/16-8         10.2µs ± 3%     9.6µs ± 2%   -5.65%  (p=0.000 n=10+8)
GetCIDRLabels/192.0.2.3/32-8         20.1µs ± 4%    18.1µs ± 2%  -10.25%  (p=0.000 n=10+9)
GetCIDRLabels/192.0.2.0/24-8         14.8µs ± 5%    13.4µs ± 7%   -9.20%  (p=0.000 n=10+10)
GetCIDRLabels/192.0.2.0/24#01-8      14.8µs ± 3%    13.4µs ± 4%   -9.64%  (p=0.000 n=10+10)
GetCIDRLabels/::/0-8                  718ns ± 2%     735ns ± 3%   +2.37%  (p=0.002 n=9+10)
GetCIDRLabels/fdff::ff/128-8          111µs ± 4%     104µs ± 3%   -6.23%  (p=0.000 n=10+9)
GetCIDRLabels/f00d:42::ff/128-8       120µs ± 2%     109µs ± 3%   -8.70%  (p=0.000 n=9+10)
GetCIDRLabels/f00d:42::/96-8         80.9µs ± 4%    73.0µs ± 4%   -9.77%  (p=0.000 n=10+10)
IPStringToLabel/0.0.0.0/0-8           502ns ± 3%     226ns ± 2%  -54.98%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.3-8           473ns ± 7%     308ns ±22%  -34.89%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.3/32-8        538ns ± 3%     271ns ± 3%  -49.63%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.3/24-8        541ns ± 3%     272ns ± 3%  -49.63%  (p=0.000 n=9+10)
IPStringToLabel/192.0.2.0/24-8        544ns ± 3%     274ns ± 1%  -49.59%  (p=0.000 n=10+8)
IPStringToLabel/::/0-8                627ns ± 2%     532ns ±11%  -15.08%  (p=0.000 n=9+9)
IPStringToLabel/fdff::ff-8            783ns ± 5%     602ns ± 3%  -23.13%  (p=0.000 n=10+8)
IPStringToLabel/f00d:42::ff/128-8    1.00µs ± 3%    0.82µs ±20%  -17.97%  (p=0.000 n=9+10)
IPStringToLabel/f00d:42::ff/96-8      860ns ± 4%     596ns ±35%  -30.73%  (p=0.000 n=9+10)

name                               old alloc/op   new alloc/op   delta
GetCIDRLabels/0.0.0.0/0-8              640B ± 0%      640B ± 0%     ~     (all equal)
GetCIDRLabels/10.16.0.0/16-8         3.88kB ± 0%    3.75kB ± 0%   -3.30%  (p=0.000 n=8+7)
GetCIDRLabels/192.0.2.3/32-8         8.22kB ± 0%    8.03kB ± 0%   -2.28%  (p=0.000 n=6+10)
GetCIDRLabels/192.0.2.0/24-8         5.20kB ± 0%    5.05kB ± 0%   -2.78%  (p=0.000 n=10+10)
GetCIDRLabels/192.0.2.0/24#01-8      5.20kB ± 0%    5.06kB ± 0%   -2.76%  (p=0.000 n=10+10)
GetCIDRLabels/::/0-8                   640B ± 0%      640B ± 0%     ~     (all equal)
GetCIDRLabels/fdff::ff/128-8         34.9kB ± 0%    30.8kB ± 0%  -11.82%  (p=0.000 n=10+10)
GetCIDRLabels/f00d:42::ff/128-8      37.8kB ± 0%    33.7kB ± 0%  -10.93%  (p=0.000 n=10+10)
GetCIDRLabels/f00d:42::/96-8         23.3kB ± 0%    20.2kB ± 0%  -13.31%  (p=0.000 n=8+10)
IPStringToLabel/0.0.0.0/0-8           96.0B ± 0%     24.0B ± 0%  -75.00%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.3-8           88.0B ± 0%     40.0B ± 0%  -54.55%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.3/32-8         109B ± 0%       40B ± 0%  -63.30%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.3/24-8         109B ± 0%       40B ± 0%  -63.30%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.0/24-8         109B ± 0%       40B ± 0%  -63.30%  (p=0.000 n=10+10)
IPStringToLabel/::/0-8                 112B ± 0%       16B ± 0%  -85.71%  (p=0.000 n=10+10)
IPStringToLabel/fdff::ff-8             136B ± 0%       72B ± 0%  -47.06%  (p=0.000 n=10+10)
IPStringToLabel/f00d:42::ff/128-8      200B ± 0%      104B ± 0%  -48.00%  (p=0.000 n=10+10)
IPStringToLabel/f00d:42::ff/96-8       152B ± 0%       56B ± 0%  -63.16%  (p=0.000 n=10+10)

name                               old allocs/op  new allocs/op  delta
GetCIDRLabels/0.0.0.0/0-8              3.00 ± 0%      3.00 ± 0%     ~     (all equal)
GetCIDRLabels/10.16.0.0/16-8           72.0 ± 0%      38.0 ± 0%  -47.22%  (p=0.000 n=10+10)
GetCIDRLabels/192.0.2.3/32-8            136 ± 0%        70 ± 0%  -48.53%  (p=0.000 n=10+10)
GetCIDRLabels/192.0.2.0/24-8            104 ± 0%        54 ± 0%  -48.08%  (p=0.000 n=10+10)
GetCIDRLabels/192.0.2.0/24#01-8         104 ± 0%        54 ± 0%  -48.08%  (p=0.000 n=10+10)
GetCIDRLabels/::/0-8                   3.00 ± 0%      3.00 ± 0%     ~     (all equal)
GetCIDRLabels/fdff::ff/128-8            708 ± 0%       450 ± 0%  -36.44%  (p=0.000 n=10+10)
GetCIDRLabels/f00d:42::ff/128-8         708 ± 0%       450 ± 0%  -36.44%  (p=0.000 n=10+10)
GetCIDRLabels/f00d:42::/96-8            491 ± 0%       297 ± 0%  -39.51%  (p=0.000 n=10+10)
IPStringToLabel/0.0.0.0/0-8            6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.3-8            5.00 ± 0%      2.00 ± 0%  -60.00%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.3/32-8         6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.3/24-8         6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
IPStringToLabel/192.0.2.0/24-8         6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
IPStringToLabel/::/0-8                 7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.000 n=10+10)
IPStringToLabel/fdff::ff-8             8.00 ± 0%      5.00 ± 0%  -37.50%  (p=0.000 n=10+10)
IPStringToLabel/f00d:42::ff/128-8      9.00 ± 0%      5.00 ± 0%  -44.44%  (p=0.000 n=10+10)
IPStringToLabel/f00d:42::ff/96-8       7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.000 n=10+10)
```

See individual commits for details.