### PR TITLE
ci: update AWS VPC CNI plugin for AWS-CNI workflow in v1.11/v1.12 branches

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -247,7 +247,7 @@ jobs:
 
       - name: Update AWS VPC CNI plugin
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.7.10/config/v1.7/aws-k8s-cni.yaml
+          kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.11/config/master/aws-k8s-cni.yaml
 
       - name: Wait for images to be available
         timeout-minutes: 10

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -247,7 +247,7 @@ jobs:
 
       - name: Update AWS VPC CNI plugin
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.7.10/config/v1.7/aws-k8s-cni.yaml
+          kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.11/config/master/aws-k8s-cni.yaml
 
       - name: Wait for images to be available
         timeout-minutes: 10


### PR DESCRIPTION
While updating eksctl to v0.101.0 in master/v1.11 as part of commit
396eb1bd41dd ("ci: update eksctl to v0.101.0 and AWS VPC CNI plugin to
v1.11"), the AWS VPC CNI was updated to 1.11 on master, but not on the
v1.11 branch. Do that now to fix the following error on that workflow:

    error: unable to recognize "https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.7.10/config/v1.7/aws-k8s-cni.yaml": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1"

Since v1.12 was branched of in the meantime, also using the outdated AWS
VPC CNI version bump it in the corresponding workflow as well.

Fixes: 396eb1bd41dd ("ci: update eksctl to v0.101.0 and AWS VPC CNI plugin to v1.11")

Reported-by: Martynas Pumputis <m@lambda.lt>
