### PR TITLE
jenkinsfiles: fix docker manifest inspect commands in GKE pipeline

### DIFF
--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -94,9 +94,9 @@ pipeline {
                     steps {
                         retry(25) {
                             sleep(time: 60)
-                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/cilium-ci:${DOCKER_TAG}} &> /dev/null'
-                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/operator-generic-ci:${DOCKER_TAG}} &> /dev/null'
-                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/hubble-relay-ci:${DOCKER_TAG}} &> /dev/null'
+                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/cilium-ci:${DOCKER_TAG} &> /dev/null'
+                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/operator-generic-ci:${DOCKER_TAG} &> /dev/null'
+                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/hubble-relay-ci:${DOCKER_TAG} &> /dev/null'
                         }
                     }
                 }


### PR DESCRIPTION
Currently the `docker manifest inspect` commands used to wait for the CI
images to be ready fail with the following error:

    15:38:33  + docker manifest inspect quay.io/cilium/cilium-ci:c5626b69982a6af9d523a398538499e300d8c834}
    15:38:33  invalid reference format
    15:38:34  + docker manifest inspect quay.io/cilium/operator-generic-ci:c5626b69982a6af9d523a398538499e300d8c834}
    15:38:34  invalid reference format
    15:38:35  + docker manifest inspect quay.io/cilium/hubble-relay-ci:c5626b69982a6af9d523a398538499e300d8c834}
    15:38:35  invalid reference format

Drop the trailing `}`.

Fixes: 0c817496e8ea ("workflows: Use docker manifest inspect for waiting images")
Fixes: 89f67901cad6 ("jenkinsfiles: add `IMAGE_REGISTRY` env parameter")