### PR TITLE
v1.10 backports 2022-06-28

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -111,6 +111,25 @@ jobs:
             RACE=1
             OPERATOR_VARIANT=${{ matrix.name }}
 
+      - name: CI Unstripped Binaries Build ${{ matrix.name }}
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
+        id: docker_build_ci_v1_10_unstripped
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          # Only push when the event name was a GitHub push, this is to avoid
+          # re-pushing the image tags when we only want to re-create the Golang
+          # docker cache after the workflow "Image CI Cache Cleaner" was terminated.
+          push: ${{ github.event_name == 'push' }}
+          platforms: linux/amd64
+          tags: |
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:v1.10-unstripped
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped
+          build-args: |
+            NOSTRIP=1
+            OPERATOR_VARIANT=${{ matrix.name }}
+
       - name: CI Image Releases digests
         if: ${{ github.event_name != 'pull_request_target' }}
         shell: bash
@@ -118,8 +137,10 @@ jobs:
           mkdir -p image-digest/
           echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:v1.10@${{ steps.docker_build_ci_v1_10.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
           echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:v1.10-race@${{ steps.docker_build_ci_v1_10_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:v1.10-unstripped@${{ steps.docker_build_ci_v1_10_unstripped.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
           echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_v1_10.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
           echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_v1_10_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped@${{ steps.docker_build_ci_v1_10_unstripped.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
 
       # PR updates
       - name: CI Build ${{ matrix.name }}
@@ -160,6 +181,21 @@ jobs:
             RACE=1
             OPERATOR_VARIANT=${{ matrix.name }}
 
+      - name: CI Unstripped Binaries Build ${{ matrix.name }}
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
+        id: docker_build_ci_pr_unstripped
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: |
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped
+          build-args: |
+            NOSTRIP=1
+            OPERATOR_VARIANT=${{ matrix.name }}
+
       - name: CI Image Releases digests
         if: ${{ github.event_name == 'pull_request_target' }}
         shell: bash
@@ -167,6 +203,7 @@ jobs:
           mkdir -p image-digest/
           echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci_pr.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
           echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_pr_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped@${{ steps.docker_build_ci_pr_unstripped.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests
       - name: Upload artifact digests

--- a/Documentation/concepts/networking/ipam/cluster-pool.rst
+++ b/Documentation/concepts/networking/ipam/cluster-pool.rst
@@ -57,3 +57,15 @@ Check the ``Error`` field in the ``Status.Operator`` field:
 .. code-block:: shell-session
 
     kubectl get ciliumnodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.operator.error}{"\n"}{end}'
+    
+Check for conflicting node CIDRs
+================================
+
+``10.0.0.0/8`` is the default pod CIDR. If your node network is in the same range
+you will lose connectivity to other nodes. All egress traffic will be assumed
+to target pods on a given node rather than other nodes.
+
+You can solve it in two ways:
+
+  - Explicitly set ``clusterPoolIPv4PodCIDRList`` to a non-conflicting CIDR
+  - Use a different CIDR for your nodes

--- a/Documentation/gettinghelp.rst
+++ b/Documentation/gettinghelp.rst
@@ -41,6 +41,23 @@ new feature please file the issue according to the `GitHub template
 **Contributing**: If you want to contribute, reading the :ref:`dev_guide` should
 help you.
 
+Training
+========
+
+**Training courses**: Our website lists `training courses
+<https://cilium.io/enterprise>`__ that have been
+`approved
+<https://github.com/cilium/cilium.io/blob/main/CONTRIBUTING.md#listing-cilium-training>`__
+by the Cilium project. 
+
+Enterprise support
+==================
+
+**Distributions**: Enterprise-ready, supported and `approved
+<https://github.com/cilium/cilium.io/blob/main/CONTRIBUTING.md#listing-cilium-distributions>`__
+Cilium distributions are
+listed on the `Cilium website <https://cilium.io/enterprise>`__.
+
 Security Bugs
 =============
 

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -262,6 +262,8 @@ If you are running Cilium in an environment that requires firewall rules to enab
 
 It is recommended but optional that all nodes running Cilium in a given cluster must be able to ping each other so ``cilium-health`` can report and monitor connectivity among nodes. This requires ICMP Type 0/8, Code 0 open among all nodes. TCP 4240 should also be open among all nodes for ``cilium-health`` monitoring. Note that it is also an option to only use one of these two methods to enable health monitoring. If the firewall does not permit either of these methods, Cilium will still operate fine but will not be able to provide health information.
 
+For IPSec enabled Cilium deployments, you need to ensure that the firewall allows ESP traffic through. For example, AWS Security Groups doesn't allow ESP traffic by default.
+
 If you are using VXLAN overlay network mode, Cilium uses Linux's default VXLAN port 8472 over UDP, unless Linux has been configured otherwise. In this case, UDP 8472 must be open among all nodes to enable VXLAN overlay mode. The same applies to Geneve overlay network mode, except the port is UDP 6081.
 
 If you are running in direct routing mode, your network must allow routing of pod IPs.

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -517,6 +517,11 @@ DNS responses seen by Cilium on the node. Multiple selectors may be included in
 a single egress rule. See :ref:`DNS Obtaining Data` for information on
 collecting this IP data.
 
+.. note:: The DNS Proxy is provided in each Cilium agent.
+   As a result, DNS requests targeted by policies depend on the availability
+   of the Cilium agent pod.
+   This includes DNS policies as well as :ref:`proxy_visibility` annotations.
+
 ``toFQDNs`` egress rules cannot contain any other L3 rules, such as
 ``toEndpoints`` (under `Labels Based`_) and ``toCIDRs`` (under `CIDR Based`_).
 They may contain L4/L7 rules, such as ``toPorts`` (see `Layer 4 Examples`_)

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -791,6 +791,12 @@ latter rule will have no effect.
 .. note:: Layer 7 rules are not currently supported in `HostPolicies`, i.e.,
           policies that use :ref:`NodeSelector`.
 
+.. note:: Layer 7 policies --and pod annotations-- result in traffic being
+   proxied through an Envoy instance provided in each Cilium agent pod.
+   As a result, L7 traffic targeted by policies depend on the availability
+   of the Cilium agent pod.
+   This includes L7 policies as well as :ref:`proxy_visibility` annotations.
+
 HTTP
 ----
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -701,6 +701,7 @@ prog
 programmability
 prometheus
 protobuf
+proxied
 proxylib
 pullPolicy
 qdisc

--- a/install/kubernetes/cilium/templates/cilium-agent-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-clusterrole.yaml
@@ -84,4 +84,11 @@ rules:
   - ciliumegressnatpolicies
   verbs:
   - '*'
+- apiGroups:
+  - cilium.io
+  # To synchronize garbage collection of such resources
+  resources:
+  - ciliumidentities
+  verbs:
+  - update
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-clusterrole.yaml
@@ -124,6 +124,13 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - cilium.io
+  resources:
+  - ciliumidentities
+  verbs:
+  # To synchronize garbage collection of such resources
+  - update
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/install/kubernetes/cilium/templates/cilium-preflight-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-clusterrole.yaml
@@ -84,4 +84,11 @@ rules:
   - ciliumegressnatpolicies
   verbs:
   - '*'
+- apiGroups:
+  - cilium.io
+  # To synchronize garbage collection of such resources
+  resources:
+  - ciliumidentities
+  verbs:
+  - update
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
@@ -109,6 +109,7 @@ spec:
           - --debug
 {{- end }}
           - --cluster-name=$(CLUSTER_NAME)
+          - --cluster-id=$(CLUSTER_ID)
           - --kvstore-opt
           - etcd.config=/var/lib/cilium/etcd-config.yaml
         env:

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -92,9 +92,9 @@ pipeline {
                     steps {
                         retry(25) {
                             sleep(time: 60)
-                            sh 'docker manifest inspect quay.io/cilium/cilium-ci:${DOCKER_TAG}} &> /dev/null'
-                            sh 'docker manifest inspect quay.io/cilium/operator-generic-ci:${DOCKER_TAG}} &> /dev/null'
-                            sh 'docker manifest inspect quay.io/cilium/hubble-relay-ci:${DOCKER_TAG}} &> /dev/null'
+                            sh 'docker manifest inspect quay.io/cilium/cilium-ci:${DOCKER_TAG} &> /dev/null'
+                            sh 'docker manifest inspect quay.io/cilium/operator-generic-ci:${DOCKER_TAG} &> /dev/null'
+                            sh 'docker manifest inspect quay.io/cilium/hubble-relay-ci:${DOCKER_TAG} &> /dev/null'
                         }
                     }
                 }

--- a/operator/k8s_identity.go
+++ b/operator/k8s_identity.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/controller"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/identitybackend"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
@@ -62,6 +63,20 @@ func deleteIdentity(ctx context.Context, identity *v2.CiliumIdentity) error {
 	return err
 }
 
+func updateIdentity(ctx context.Context, identity *v2.CiliumIdentity) error {
+	_, err := ciliumK8sClient.CiliumV2().CiliumIdentities().Update(
+		ctx,
+		identity,
+		metav1.UpdateOptions{})
+	if err != nil {
+		log.WithError(err).Error("Updating Identity")
+	} else {
+		log.WithField(logfields.Identity, identity.GetName()).Debug("Updated identity")
+	}
+
+	return err
+}
+
 var identityHeartbeat *identity.IdentityHeartbeatStore
 
 // identityGCIteration is a single iteration of a garbage collection. It will
@@ -96,9 +111,26 @@ func identityGCIteration(ctx context.Context) {
 			continue
 		}
 		if !identityHeartbeat.IsAlive(identity.Name) {
+			ts, ok := identity.Annotations[identitybackend.HeartBeatAnnotation]
+			if !ok {
+				identity = identity.DeepCopy()
+				if identity.Annotations == nil {
+					identity.Annotations = make(map[string]string)
+				}
+				log.WithField(logfields.Identity, identity).Info("Marking identity for later deletion")
+				identity.Annotations[identitybackend.HeartBeatAnnotation] = timeNow.Format(time.RFC3339Nano)
+				err := updateIdentity(ctx, identity)
+				if err != nil {
+					log.WithError(err).
+						WithField(logfields.Identity, identity).
+						Error("Marking identity for later deletion")
+				}
+				continue
+			}
+
 			log.WithFields(logrus.Fields{
 				logfields.Identity: identity,
-			}).Debug("Deleting unused identity")
+			}).Debugf("Deleting unused identity; marked for deletion at %s", ts)
 			if err := deleteIdentity(ctx, identity); err != nil {
 				log.WithError(err).WithFields(logrus.Fields{
 					logfields.Identity: identity,

--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -159,7 +159,10 @@ func (c *cache) OnDelete(id idpool.ID, key AllocatorKey) {
 		if value := a.localKeys.lookupID(id); value != nil {
 			ctx, cancel := context.WithTimeout(context.TODO(), backendOpTimeout)
 			defer cancel()
-			a.backend.UpdateKey(ctx, id, value, true)
+			err := a.backend.UpdateKey(ctx, id, value, true)
+			if err != nil {
+				log.WithError(err).Errorf("OnDelete MasterKeyProtection update for key %q", id)
+			}
 			return
 		}
 	}

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -432,6 +432,16 @@ func (c *Client) AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, v
 	ipConfigurations = append(*netIfConfig.IPConfigurations, ipConfigurations...)
 	netIfConfig.IPConfigurations = &ipConfigurations
 
+	// Unset imageReference, because if this contains a reference to an image from the
+	// Azure Compute Gallery, including this reference in an update to the VMSS instance
+	// will cause a permissions error, because the reference includes an Azure-managed
+	// subscription ID.
+	// Removing the image reference indicates to the API that we don't want to change it.
+	// See https://github.com/Azure/AKS/issues/1819.
+	if result.StorageProfile != nil {
+		result.StorageProfile.ImageReference = nil
+	}
+
 	future, err := c.vmss.Update(ctx, c.resourceGroup, vmssName, instanceID, result)
 	if err != nil {
 		return fmt.Errorf("unable to update virtualmachinescaleset: %s", err)

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -401,6 +401,7 @@ type ProxyRequestContext struct {
 	UpstreamTime         spanstat.SpanStat
 	SemaphoreAcquireTime spanstat.SpanStat
 	PolicyCheckTime      spanstat.SpanStat
+	DataplaneTime        spanstat.SpanStat
 	Success              bool
 	Err                  error
 }

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -45,6 +45,10 @@ var (
 )
 
 const (
+	// HeartBeatAnnotation is an annotation applied by the operator to indicate
+	// that a CiliumIdentity has been marked for deletion.
+	HeartBeatAnnotation = "io.cilium.heartbeat"
+
 	k8sPrefix               = labels.LabelSourceK8s + ":"
 	k8sNamespaceLabelPrefix = labels.LabelSourceK8s + ":" + k8sConst.PodNamespaceMetaLabels + labels.PathDelimiter
 )
@@ -117,8 +121,43 @@ func (c *crdBackend) AllocateIDIfLocked(ctx context.Context, id idpool.ID, key a
 func (c *crdBackend) AcquireReference(ctx context.Context, id idpool.ID, key allocator.AllocatorKey, lock kvstore.KVLocker) error {
 	// For CiliumIdentity-based allocation, the reference counting is
 	// handled via CiliumEndpoint. Any CiliumEndpoint referring to a
-	// CiliumIdentity will keep the CiliumIdentity alive. No action is
-	// needed to acquire the reference here.
+	// CiliumIdentity will keep the CiliumIdentity alive. However,
+	// there is a brief window where a CiliumEndpoint may not exist
+	// for a given CiliumIdentity (according to the operator), in
+	// which case the operator marks the CiliumIdentity for deletion.
+	// This checks to see if the CiliumIdentity has been marked for
+	// deletion and removes the mark so that the CiliumIdentity can
+	// be safely used.
+	//
+	// NOTE: A race against using a CiliumIdentity that might otherwise
+	// be (immediately) deleted is prevented by the operator logic that
+	// validates the ResourceVersion of the CiliumIdentity before deleting
+	// it. If a CiliumIdentity does (eventually) get deleted by the
+	// operator, the agent will then have a chance to recreate it.
+	var (
+		ts string
+		ok bool
+	)
+	// check to see if the cached copy of the identity
+	// has the annotation
+	ci, exists, err := c.getById(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("identity (id:%q,key:%q) does not exist", id, key)
+	}
+	ci = ci.DeepCopy()
+
+	ts, ok = ci.Annotations[HeartBeatAnnotation]
+	if ok {
+		log.WithField(logfields.Identity, ci).Infof("Identity marked for deletion (at %s); attempting to unmark it", ts)
+		delete(ci.Annotations, HeartBeatAnnotation)
+		_, err = c.Client.CiliumV2().CiliumIdentities().Update(ctx, ci, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -156,9 +195,10 @@ func (c *crdBackend) UpdateKey(ctx context.Context, id idpool.ID, key allocator.
 		if err = c.AllocateID(ctx, id, key); err != nil {
 			return fmt.Errorf("Unable recreate missing CRD identity %q->%q: %s", key, id, err)
 		}
+		return nil
 	}
 
-	return nil
+	return err
 }
 
 func (c *crdBackend) UpdateKeyIfLocked(ctx context.Context, id idpool.ID, key allocator.AllocatorKey, reliablyMissing bool, lock kvstore.KVLocker) error {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -298,8 +298,8 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 	ciliumClient := k8s.CiliumClient()
 
 	performGet := true
+	var nodeResource *ciliumv2.CiliumNode
 	for retryCount := 0; retryCount < maxRetryCount; retryCount++ {
-		var nodeResource *ciliumv2.CiliumNode
 		performUpdate := true
 		if performGet {
 			var err error


### PR DESCRIPTION
* #19697 -- Unset `ImageReference` when updating Azure VMSS (@andrew-bulford-form3)
 * #19992 -- Add metric on datapath update latency due to FQDN IP updates (@rahulkjoshi)
 * #20158 -- nodediscovery: ensure we cache the nodeResource  (@odinuge)
 * #20208 -- Add a note about conflicting node CIDRs #20204 (@wokalski)
    - Trivial conflicts.
 * #20238 -- ci: provide CI images with unstripped binaries (@tklauser)
    - Couple conflicts. Not too bad but not trivial either. Needs to be checked.
 * #20289 -- docs(policy): add notes on DNS/L7 policies & Cilium agent availability (@raphink)
    - Trivial conflict on the spelling dictionnary.
 * #20325 -- jenkinsfiles: fix docker manifest inspect commands in GKE pipeline (@tklauser)
    - Trivial conflict.
 * #20314 -- Add ESP to firewall requirements in documentation for IPSec enabled C… (@Kikiodazie)
 * #20312 -- helm: Fix cluster-id arguments in clustermesh deployment (@sayboras)
    - Minor conflict.
 * #20194 -- [docs] Add training and support information to Getting Help (@lizrice)
 * #19936 -- bug: Prevent CiliumIdentities from Being Deleted Improperly (@nathanjsweet)

Skipped due to conflicts:
 * #20072 -- datapath: Create sysctl `rp_filter` overwrite config on agent init (@dylandreimerink)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19697 19992 20158 20208 20238 20289 20325 20314 20312 20194 19936; do contrib/backporting/set-labels.py $pr done 1.10; done
```