### PR TITLE
test/helpers: Fix variadic expansion related panic

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2856,7 +2856,7 @@ func (kub *Kubectl) CiliumExecMustSucceedOnAll(ctx context.Context, cmd string, 
 	gomega.Expect(err).Should(gomega.BeNil(), "failed to retrieve Cilium pods")
 
 	for _, pod := range pods {
-		kub.CiliumExecMustSucceed(ctx, pod, cmd, optionalDescription).
+		kub.CiliumExecMustSucceed(ctx, pod, cmd, optionalDescription...).
 			ExpectSuccess("failed to execute %q on Cilium pod %s", cmd, pod)
 	}
 }


### PR DESCRIPTION
The optionalDescription variable is taken in as a variadic argument to
CiliumExecMustSucceedOnAll(), but never expanded when calling
CiliumExecMustSucceed(). This causes optionalDescription to be passed as
a slice to the latter, which causes a panic when Ginkgo evaluates the
variable as it's expecting the variadic expansion.

Fixes: a63e02e109e ("test: Flush CT tables after L7 proxy tests in
K8sServices")
Fixes: https://github.com/cilium/cilium/issues/20299

Signed-off-by: Chris Tarazi <chris@isovalent.com>
