### PR TITLE
v1.12 backports 2022-06-28

### DIFF
--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -13,7 +13,7 @@ cilium-operator-azure [flags]
 ```
       --azure-resource-group string               Resource group to use for Azure IPAM
       --azure-subscription-id string              Subscription ID to access Azure API
-      --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations (default true)
+      --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string    ID of the user assigned identity used to auth with the Azure API
       --bgp-announce-lb-ip                        Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                    Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -18,7 +18,7 @@ cilium-operator [flags]
       --aws-use-primary-address                   Allows for using primary address of the ENI for allocations on the node
       --azure-resource-group string               Resource group to use for Azure IPAM
       --azure-subscription-id string              Subscription ID to access Azure API
-      --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations (default true)
+      --azure-use-primary-address                 Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string    ID of the user assigned identity used to auth with the Azure API
       --bgp-announce-lb-ip                        Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                    Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")

--- a/Documentation/gettinghelp.rst
+++ b/Documentation/gettinghelp.rst
@@ -41,6 +41,23 @@ new feature please file the issue according to the `GitHub template
 **Contributing**: If you want to contribute, reading the :ref:`dev_guide` should
 help you.
 
+Training
+========
+
+**Training courses**: Our website lists `training courses
+<https://cilium.io/enterprise>`__ that have been
+`approved
+<https://github.com/cilium/cilium.io/blob/main/CONTRIBUTING.md#listing-cilium-training>`__
+by the Cilium project. 
+
+Enterprise support
+==================
+
+**Distributions**: Enterprise-ready, supported and `approved
+<https://github.com/cilium/cilium.io/blob/main/CONTRIBUTING.md#listing-cilium-distributions>`__
+Cilium distributions are
+listed on the `Cilium website <https://cilium.io/enterprise>`__.
+
 Security Bugs
 =============
 

--- a/Documentation/gettingstarted/clustermesh/affinity.rst
+++ b/Documentation/gettingstarted/clustermesh/affinity.rst
@@ -1,0 +1,146 @@
+.. _gs_clustermesh_service_affinity:
+
+****************
+Service Affinity
+****************
+
+This tutorial will guide you to enable service affinity across multiple
+Kubernetes clusters.
+
+Prerequisites
+#############
+
+You need to have a functioning Cluster Mesh with a Global Service, please
+follow the guide :ref:`gs_clustermesh` and :ref:`gs_clustermesh_services`
+to set it up.
+
+Enabling Global Service Affinity
+################################
+
+Load-balancing across multiple clusters might not be ideal in some cases.
+The annotation ``io.cilium/service-affinity: "local|remote|none"`` can be used
+to specify the preferred endpoint destination.
+
+For example, if the value of annotation ``io.cilium/service-affinity`` is local,
+the Global Service will load-balance across healthy ``local`` backends, and only user
+remote endpoints if and only if all of local backends are not available or unhealthy.
+
+.. code-block:: yaml
+
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: rebel-base
+     annotations:
+        io.cilium/global-service: "true"
+        # Possible values:
+        # - local
+        #    preferred endpoints from local cluster if available
+        # - remote
+        #    preferred endpoints from remote cluster if available
+        # none (default)
+        #    no preference. Default behavior if this annotation does not exist
+        io.cilium/service-affinity: "local"
+   spec:
+     type: ClusterIP
+     ports:
+     - port: 80
+     selector:
+       name: rebel-base
+
+
+1. In cluster 1, add ``io.cilium/service-affinity="local"`` to existing global service
+
+   .. code-block:: shell-session
+
+      kubectl annotate service rebel-base io.cilium/service-affinity=local --overwrite
+
+2. From cluster 1, access the global service:
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+   You will see replies from pods in ``cluster 1`` only.
+
+3. From cluster 2, access the global service:
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+   You will see replies from pods in both clusters as usual.
+
+4. From cluster 1, check the service endpoints, the local endpoints are marked
+   as preferred.
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti ds/cilium -- cilium service list --clustermesh-affinity
+
+      ID   Frontend            Service Type   Backend
+      1    10.96.0.1:443       ClusterIP      1 => 172.18.0.3:6443 (active)
+      2    10.96.0.10:53       ClusterIP      1 => 10.244.1.171:53 (active)
+                                              2 => 10.244.2.206:53 (active)
+      3    10.96.0.10:9153     ClusterIP      1 => 10.244.1.171:9153 (active)
+                                              2 => 10.244.2.206:9153 (active)
+      4    10.96.210.49:2379   ClusterIP      1 => 10.244.2.216:2379 (active)
+      5    10.96.173.113:80    ClusterIP      1 => 10.244.2.136:80 (active)
+                                              2 => 10.244.1.61:80 (active) (preferred)
+                                              3 => 10.244.2.31:80 (active) (preferred)
+                                              4 => 10.244.2.200:80 (active)
+
+5. In cluster 1, change ``io.cilium/service-affinity`` value to ``remote`` for existing global service
+
+   .. code-block:: shell-session
+
+      kubectl annotate service rebel-base io.cilium/service-affinity=remote --overwrite
+
+6. From cluster 1, access the global service:
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+   This time, the replies are coming from pods in ``cluster 2`` only.
+
+7. From cluster 1, check the service endpoints, now the remote endpoints are marked
+   as preferred.
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti ds/cilium -- cilium service list --clustermesh-affinity
+
+      ID   Frontend            Service Type   Backend
+      1    10.96.0.1:443       ClusterIP      1 => 172.18.0.3:6443 (active)
+      2    10.96.0.10:53       ClusterIP      1 => 10.244.1.171:53 (active)
+                                              2 => 10.244.2.206:53 (active)
+      3    10.96.0.10:9153     ClusterIP      1 => 10.244.1.171:9153 (active)
+                                              2 => 10.244.2.206:9153 (active)
+      4    10.96.210.49:2379   ClusterIP      1 => 10.244.2.216:2379 (active)
+      5    10.96.173.113:80    ClusterIP      1 => 10.244.2.136:80 (active) (preferred)
+                                              2 => 10.244.1.61:80 (active)
+                                              3 => 10.244.2.31:80 (active)
+                                              4 => 10.244.2.200:80 (active) (preferred)
+
+8. From cluster 2, access the global service:
+
+   .. code-block:: shell-session
+
+      kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+   You will see replies from pods in both clusters as usual.
+
+9. In cluster 1, remove ``io.cilium/service-affinity`` annotation for existing global service
+
+   .. code-block:: shell-session
+
+      kubectl annotate service rebel-base io.cilium/service-affinity- --overwrite
+
+10. From either cluster, access the global service:
+
+    .. code-block:: shell-session
+
+        kubectl exec -ti deployment/x-wing -- curl rebel-base
+
+    You will see replies from pods in both clusters again.

--- a/Documentation/gettingstarted/index.rst
+++ b/Documentation/gettingstarted/index.rst
@@ -90,6 +90,7 @@ Cluster Mesh
 
    clustermesh/clustermesh
    clustermesh/services
+   clustermesh/affinity
    clustermesh/policy
    external-workloads
 

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -673,10 +673,6 @@
      - TCP port for the agent health API. This is not the port for cilium-health.
      - int
      - ``9879``
-   * - hostAliases
-     - Host aliases for cilium-agent.
-     - list
-     - ``[]``
    * - hostFirewall
      - Configure the host firewall.
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1240,7 +1240,7 @@
    * - nodeinit.nodeSelector
      - Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object
-     - ``{}``
+     - ``{"kubernetes.io/os":"linux"}``
    * - nodeinit.podAnnotations
      - Annotations to be added to node-init pods.
      - object
@@ -1440,7 +1440,7 @@
    * - preflight.nodeSelector
      - Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object
-     - ``{}``
+     - ``{"kubernetes.io/os":"linux"}``
    * - preflight.podAnnotations
      - Annotations to be added to preflight pods
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -176,7 +176,7 @@
    * - clustermesh.apiserver.nodeSelector
      - Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object
-     - ``{}``
+     - ``{"kubernetes.io/os":"linux"}``
    * - clustermesh.apiserver.podAnnotations
      - Annotations to be added to clustermesh-apiserver pods
      - object
@@ -580,7 +580,7 @@
    * - etcd.nodeSelector
      - Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object
-     - ``{}``
+     - ``{"kubernetes.io/os":"linux"}``
    * - etcd.podAnnotations
      - Annotations to be added to cilium-etcd-operator pods
      - object
@@ -776,7 +776,7 @@
    * - hubble.relay.nodeSelector
      - Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object
-     - ``{}``
+     - ``{"kubernetes.io/os":"linux"}``
    * - hubble.relay.podAnnotations
      - Annotations to be added to hubble-relay pods
      - object
@@ -972,7 +972,7 @@
    * - hubble.ui.nodeSelector
      - Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object
-     - ``{}``
+     - ``{"kubernetes.io/os":"linux"}``
    * - hubble.ui.podAnnotations
      - Annotations to be added to hubble-ui pods
      - object
@@ -1320,7 +1320,7 @@
    * - operator.nodeSelector
      - Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object
-     - ``{}``
+     - ``{"kubernetes.io/os":"linux"}``
    * - operator.podAnnotations
      - Annotations to be added to cilium-operator pods
      - object

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -311,6 +311,8 @@ If you are running Cilium in an environment that requires firewall rules to enab
 
 It is recommended but optional that all nodes running Cilium in a given cluster must be able to ping each other so ``cilium-health`` can report and monitor connectivity among nodes. This requires ICMP Type 0/8, Code 0 open among all nodes. TCP 4240 should also be open among all nodes for ``cilium-health`` monitoring. Note that it is also an option to only use one of these two methods to enable health monitoring. If the firewall does not permit either of these methods, Cilium will still operate fine but will not be able to provide health information.
 
+For IPSec enabled Cilium deployments, you need to ensure that the firewall allows ESP traffic through. For example, AWS Security Groups doesn't allow ESP traffic by default.
+
 If you are using VXLAN overlay network mode, Cilium uses Linux's default VXLAN port 8472 over UDP, unless Linux has been configured otherwise. In this case, UDP 8472 must be open among all nodes to enable VXLAN overlay mode. The same applies to Geneve overlay network mode, except the port is UDP 6081.
 
 If you are running in direct routing mode, your network must allow routing of pod IPs.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -400,6 +400,9 @@ Helm Options
 * ``tls.enabled`` has been removed as this attribute is not used at all.
 * Only one CA will be generated with either the helm or CronJob auto method, there will
   be a short disruption while the new CA is propagated to all nodes.
+* ``nodeinit.nodeSelector`` and ``preflight.nodeSelector`` now default to
+  ``{"kubernetes.io/os":"linux"}`` to ensure these pods are not scheduled on
+  non-Linux nodes.
 
 .. _1.11_upgrade_notes:
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -400,9 +400,9 @@ Helm Options
 * ``tls.enabled`` has been removed as this attribute is not used at all.
 * Only one CA will be generated with either the helm or CronJob auto method, there will
   be a short disruption while the new CA is propagated to all nodes.
-* ``nodeinit.nodeSelector`` and ``preflight.nodeSelector`` now default to
-  ``{"kubernetes.io/os":"linux"}`` to ensure these pods are not scheduled on
-  non-Linux nodes.
+* The ``nodeSelector`` of all components now default to
+  ``{"kubernetes.io/os":"linux"}`` to ensure these pods with Linux-based
+  container images are not scheduled on non-Linux nodes.
 
 .. _1.11_upgrade_notes:
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -337,7 +337,14 @@ Annotations:
   +-----------------------+-----------------------+-------------------------+
   | Hubble                |  9091                 | 9965                    |
   +-----------------------+-----------------------+-------------------------+
-  
+
+* In Azure IPAM mode, the default for ``--azure-use-primary-address`` has changed from
+  true to false. With this change pod interface's primary IP is no longer included in the
+  node's IP pool by default. The previous default required users to disable DHCP on the
+  pod's interface to avoid primary IP from interfering with host networking. Unless the
+  flag is explicitly set to true, ``--bypass-ip-availability-upon-restore`` also needs
+  to be set to ensure that pods using primary IP get a new IP address. This flag can be
+  removed once the upgrade is complete.
 
 New Options
 ~~~~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -344,7 +344,8 @@ Annotations:
   pod's interface to avoid primary IP from interfering with host networking. Unless the
   flag is explicitly set to true, ``--bypass-ip-availability-upon-restore`` also needs
   to be set to ensure that pods using primary IP get a new IP address. This flag can be
-  removed once the upgrade is complete.
+  removed once the upgrade is complete. Backward compatibility will be maintained when
+  ``upgradeCompatibility`` is set on the helm chart.
 
 New Options
 ~~~~~~~~~~~

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -850,6 +850,12 @@ latter rule will have no effect.
 .. note:: Layer 7 rules are not currently supported in `HostPolicies`, i.e.,
           policies that use :ref:`NodeSelector`.
 
+.. note:: Layer 7 policies --and pod annotations-- result in traffic being
+   proxied through an Envoy instance provided in each Cilium agent pod.
+   As a result, L7 traffic targeted by policies depend on the availability
+   of the Cilium agent pod.
+   This includes L7 policies as well as :ref:`proxy_visibility` annotations.
+
 HTTP
 ----
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -521,6 +521,11 @@ DNS responses seen by Cilium on the node. Multiple selectors may be included in
 a single egress rule. See :ref:`DNS Obtaining Data` for information on
 collecting this IP data.
 
+.. note:: The DNS Proxy is provided in each Cilium agent.
+   As a result, DNS requests targeted by policies depend on the availability
+   of the Cilium agent pod.
+   This includes DNS policies as well as :ref:`proxy_visibility` annotations.
+
 ``toFQDNs`` egress rules cannot contain any other L3 rules, such as
 ``toEndpoints`` (under `Labels Based`_) and ``toCIDRs`` (under `CIDR Based`_).
 They may contain L4/L7 rules, such as ``toPorts`` (see `Layer 4 Examples`_)

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -760,6 +760,7 @@ programmability
 prometheus
 proto
 protobuf
+proxied
 proxyPort
 proxyResponseMaxDelay
 proxying

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1590,7 +1590,7 @@ func initEnv(cmd *cobra.Command) {
 	// mode which support the bypass.
 	if option.Config.BypassIPAvailabilityUponRestore {
 		switch option.Config.IPAMMode() {
-		case ipamOption.IPAMENI:
+		case ipamOption.IPAMENI, ipamOption.IPAMAzure:
 			log.Info(
 				"Running with bypass of IP not available errors upon endpoint " +
 					"restore. Be advised that this mode is intended to be " +

--- a/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
+++ b/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
@@ -76,7 +76,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_errors_warnings_total{k8s_app=\"cilium\"}[1m])) by (pod, level) * 60",
+          "expr": "sum(rate(cilium_errors_warnings_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, level) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{level}}",
@@ -185,21 +185,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\"}[1m])) by (pod) * 100",
+          "expr": "min(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min",
           "refId": "A"
         },
         {
-          "expr": "avg(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\"}[1m])) by (pod) * 100",
+          "expr": "avg(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\"}[1m])) by (pod) * 100",
+          "expr": "max(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -325,21 +325,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\"})",
+          "expr": "min(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Min Virtual Memory",
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\"})",
+          "expr": "avg(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Average Virtual Memory",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\"})",
+          "expr": "max(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Max Virtual Memory",
@@ -440,7 +440,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(cilium_process_resident_memory_bytes{k8s_app=\"cilium\"})",
+          "expr": "avg(cilium_process_resident_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -448,7 +448,7 @@
           "refId": "C"
         },
         {
-          "expr": "max(cilium_process_resident_memory_bytes{k8s_app=\"cilium\"})",
+          "expr": "max(cilium_process_resident_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -456,7 +456,7 @@
           "refId": "D"
         },
         {
-          "expr": "min(cilium_process_resident_memory_bytes{k8s_app=\"cilium\"})",
+          "expr": "min(cilium_process_resident_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "MIN_resident_memory_bytes_min",
@@ -560,28 +560,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(cilium_process_open_fds{k8s_app=\"cilium\"})",
+          "expr": "sum(cilium_process_open_fds{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "all nodes",
           "refId": "A"
         },
         {
-          "expr": "min(cilium_process_open_fds{k8s_app=\"cilium\"})",
+          "expr": "min(cilium_process_open_fds{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min/node",
           "refId": "B"
         },
         {
-          "expr": "avg(cilium_process_open_fds{k8s_app=\"cilium\"})",
+          "expr": "avg(cilium_process_open_fds{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg/node",
           "refId": "C"
         },
         {
-          "expr": "max(cilium_process_open_fds{k8s_app=\"cilium\"})",
+          "expr": "max(cilium_process_open_fds{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max/node",
@@ -683,7 +683,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\"})",
+          "expr": "avg(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -692,7 +692,7 @@
           "refId": "C"
         },
         {
-          "expr": "max(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\"})",
+          "expr": "max(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -701,7 +701,7 @@
           "refId": "D"
         },
         {
-          "expr": "min(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\"})",
+          "expr": "min(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -802,7 +802,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "cilium_bpf_map_pressure",
+          "expr": "cilium_bpf_map_pressure{k8s_app=\"cilium\", pod=~\"$pod\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -918,7 +918,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_agent_api_process_time_seconds_sum{k8s_app=\"cilium\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+          "expr": "avg(rate(cilium_agent_api_process_time_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}}",
@@ -1019,7 +1019,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(cilium_agent_api_process_time_seconds_sum{k8s_app=\"cilium\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+          "expr": "max(rate(cilium_agent_api_process_time_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}}",
@@ -1120,7 +1120,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+          "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}} ",
@@ -1221,7 +1221,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+          "expr": "max(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}} ",
@@ -1322,7 +1322,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path, return_code)",
+          "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path, return_code)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{return_code}} ({{method}} {{path}} )",
@@ -1423,7 +1423,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path, return_code)",
+          "expr": "sum(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path, return_code)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{return_code}} ({{method}} {{path}} )",
@@ -1559,7 +1559,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, operation)",
+          "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, operation)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{operation}}",
@@ -1661,7 +1661,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, operation)",
+          "expr": "max(rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, operation)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{operation}}",
@@ -1763,7 +1763,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_sum{k8s_app=\"cilium\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, operation)",
+          "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, operation)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{operation}}",
@@ -1862,7 +1862,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(cilium_bpf_syscall_duration_seconds_sum{k8s_app=\"cilium\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, operation)",
+          "expr": "max(rate(cilium_bpf_syscall_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, operation)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{operation}}",
@@ -1963,7 +1963,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, map_name, operation))",
+          "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\", pod=~\"$pod\"}[5m])) by (pod, map_name, operation))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{map_name}} {{operation}}",
@@ -2064,7 +2064,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, map_name, operation))",
+          "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\", pod=~\"$pod\"}[5m])) by (pod, map_name, operation))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{map_name}} {{operation}}",
@@ -2165,7 +2165,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\",outcome=\"fail\"}[5m])) by (pod, map_name, operation)",
+          "expr": "sum(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\",outcome=\"fail\", pod=~\"$pod\"}[5m])) by (pod, map_name, operation)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{map_name}} {{operation}}",
@@ -2288,7 +2288,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(kvstore_operations_total{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, scope, action)",
+          "expr": "sum(rate(kvstore_operations_total{pod=~\"$pod\"}[1m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}} {{action}}",
@@ -2391,7 +2391,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(kvstore_operations_total{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, scope, action)",
+          "expr": "max(rate(kvstore_operations_total{pod=~\"$pod\"}[1m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}} {{action}}",
@@ -2493,7 +2493,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, avg(rate(cilium_kvstore_operations_duration_seconds_sum{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, action, scope))",
+          "expr": "topk(5, avg(rate(cilium_kvstore_operations_duration_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, action, scope))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -2594,7 +2594,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, max(rate(cilium_kvstore_operations_duration_seconds_sum{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, action, scope))",
+          "expr": "topk(5, max(rate(cilium_kvstore_operations_duration_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, action, scope))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -2693,7 +2693,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kvstore_events_queue_seconds_count{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, scope, action)",
+          "expr": "avg(rate(cilium_kvstore_events_queue_seconds_count{pod=~\"$pod\"}[1m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -2811,7 +2811,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_forward_count_total{k8s_app=\"cilium\"}[1m])) by (pod, direction)",
+          "expr": "sum(rate(cilium_forward_count_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, direction)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{direction}}",
@@ -2913,7 +2913,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_forward_bytes_total{k8s_app=\"cilium\"}[1m])) by (pod, direction) * 8",
+          "expr": "sum(rate(cilium_forward_bytes_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, direction) * 8",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{direction}}",
@@ -3050,7 +3050,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\"}) by (family,status)",
+          "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3058,28 +3058,28 @@
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted",
           "refId": "D"
         },
         {
-          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted max",
@@ -3216,7 +3216,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\"}) by (family,status)",
+          "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3224,28 +3224,28 @@
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted",
           "refId": "D"
         },
         {
-          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted max",
@@ -3382,7 +3382,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3390,28 +3390,28 @@
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted",
           "refId": "D"
         },
         {
-          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted max",
@@ -3548,7 +3548,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3556,28 +3556,28 @@
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted",
           "refId": "D"
         },
         {
-          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted max",
@@ -3684,7 +3684,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(cilium_ip_addresses{k8s_app=\"cilium\"}) by (pod, family)\n",
+          "expr": "sum(cilium_ip_addresses{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod, family)\n",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{family}}",
@@ -3784,7 +3784,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(cilium_datapath_conntrack_dump_resets_total{k8s_app=\"cilium\"}) by (pod, area, family, name)",
+          "expr": "sum(cilium_datapath_conntrack_dump_resets_total{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod, area, family, name)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{name}} {{area}} {{family}}",
@@ -3881,7 +3881,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_services_events_total{k8s_app=\"cilium\"}[1m])) by (pod, action)",
+          "expr": "avg(rate(cilium_services_events_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -3987,14 +3987,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(cilium_unreachable_nodes{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "sum(cilium_unreachable_nodes{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unreachable nodes",
           "refId": "A"
         },
         {
-          "expr": "sum(cilium_unreachable_health_endpoints{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "sum(cilium_unreachable_health_endpoints{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unreachable health endpoints",
@@ -4091,7 +4091,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_drop_count_total{direction=\"EGRESS\", k8s_app=\"cilium\"}[1m])) by (reason)",
+          "expr": "sum(rate(cilium_drop_count_total{direction=\"EGRESS\", k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (reason)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{reason}}",
@@ -4217,7 +4217,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_nodes_all_events_received_total{k8s_app=\"cilium\"}[1m])) by (pod, event_type, source) * 60",
+          "expr": "avg(rate(cilium_nodes_all_events_received_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, event_type, source) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{eventType}} {{source}}",
@@ -4314,7 +4314,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_drop_bytes_total{direction=\"EGRESS\", k8s_app=\"cilium\"}[1m])) by (reason) * 8",
+          "expr": "sum(rate(cilium_drop_bytes_total{direction=\"EGRESS\", k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (reason) * 8",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{reason}}",
@@ -4426,21 +4426,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(cilium_nodes_all_num{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "avg(cilium_nodes_all_num{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Average Nodes",
           "refId": "A"
         },
         {
-          "expr": "min(cilium_nodes_all_num{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "min(cilium_nodes_all_num{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Min Nodes",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_nodes_all_num{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "max(cilium_nodes_all_num{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Max Nodes",
@@ -4571,21 +4571,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_policy_l7_denied_total{k8s_app=\"cilium\"}[1m]))",
+          "expr": "sum(rate(cilium_policy_l7_denied_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "denied",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(cilium_policy_l7_forwarded_total{k8s_app=\"cilium\"}[1m]))",
+          "expr": "sum(rate(cilium_policy_l7_forwarded_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "forwarded",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(cilium_policy_l7_received_total{k8s_app=\"cilium\"}[1m]))",
+          "expr": "sum(rate(cilium_policy_l7_received_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "received",
@@ -4682,7 +4682,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_drop_count_total{direction=\"INGRESS\", k8s_app=\"cilium\"}[5m])) by (reason)",
+          "expr": "sum(rate(cilium_drop_count_total{direction=\"INGRESS\", k8s_app=\"cilium\", pod=~\"$pod\"}[5m])) by (reason)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{reason}}",
@@ -4734,7 +4734,7 @@
       "aliasColors": {
         "Max per node processingTime": "#e24d42",
         "Max per node upstreamTime": "#58140c",
-        "avg(cilium_policy_l7_parse_errors_total{kubernetes_pod_name=~\"cilium.*\"})": "#bf1b00",
+        "avg(cilium_policy_l7_parse_errors_total{pod=~\"cilium.*\"})": "#bf1b00",
         "parse errors": "#bf1b00"
       },
       "bars": true,
@@ -4790,7 +4790,7 @@
           "yaxis": 2
         },
         {
-          "alias": "avg(cilium_policy_l7_parse_errors_total{kubernetes_pod_name=~\"cilium.*\"})",
+          "alias": "avg(cilium_policy_l7_parse_errors_total{pod=~\"cilium.*\"})",
           "yaxis": 2
         },
         {
@@ -4803,7 +4803,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+          "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -4811,7 +4811,7 @@
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_policy_l7_parse_errors_total{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "avg(cilium_policy_l7_parse_errors_total{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "parse errors",
@@ -4908,7 +4908,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_drop_bytes_total{direction=\"INGRESS\", k8s_app=\"cilium\"}[1m])) by (reason) * 8",
+          "expr": "sum(rate(cilium_drop_bytes_total{direction=\"INGRESS\", k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (reason) * 8",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{reason}}",
@@ -5031,21 +5031,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+          "expr": "min(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min",
           "refId": "A"
         },
         {
-          "expr": "avg(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+          "expr": "avg(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+          "expr": "max(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -5153,14 +5153,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(cilium_proxy_upstream_reply_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+          "expr": "max(rate(cilium_proxy_upstream_reply_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Max {{scope}}",
           "refId": "B"
         },
         {
-          "expr": "max(rate(cilium_policy_l7_parse_errors_total{k8s_app=\"cilium\"}[1m])) by (pod)",
+          "expr": "max(rate(cilium_policy_l7_parse_errors_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "parse errors",
@@ -5265,7 +5265,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(cilium_policy_endpoint_enforcement_status{k8s_app=\"cilium\"}) by (enforcement)",
+          "expr": "sum(cilium_policy_endpoint_enforcement_status{k8s_app=\"cilium\", pod=~\"$pod\"}) by (enforcement)",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -5381,21 +5381,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cilium_proxy_redirects{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "min(cilium_proxy_redirects{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min",
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_proxy_redirects{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "avg(cilium_proxy_redirects{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_proxy_redirects{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "max(cilium_proxy_redirects{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -5513,28 +5513,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\"}[1m])) by (pod) * 60",
+          "expr": "min(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min trigger",
           "refId": "A"
         },
         {
-          "expr": "avg(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\"}[1m])) by (pod) * 60",
+          "expr": "avg(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "average trigger",
           "refId": "B"
         },
         {
-          "expr": "max(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\"}[1m])) by (pod) * 60",
+          "expr": "max(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max trigger",
           "refId": "C"
         },
         {
-          "expr": "max(rate(cilium_triggers_policy_update_folds{k8s_app=\"cilium\"}[1m])) by (pod) * 60",
+          "expr": "max(rate(cilium_triggers_policy_update_folds{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "folds",
@@ -5655,28 +5655,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
+          "expr": "min(cilium_policy{k8s_app=\"cilium\", pod=~\"$pod\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min",
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
+          "expr": "avg(cilium_policy{k8s_app=\"cilium\", pod=~\"$pod\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
+          "expr": "max(cilium_policy{k8s_app=\"cilium\", pod=~\"$pod\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "sum(cilium_policy_import_errors_total{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "sum(cilium_policy_import_errors_total{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "policy import errors",
@@ -5784,7 +5784,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+          "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}}",
@@ -5895,21 +5895,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cilium_policy_max_revision{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "min(cilium_policy_max_revision{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min",
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_policy_max_revision{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "avg(cilium_policy_max_revision{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_policy_max_revision{k8s_app=\"cilium\"}) by (pod)",
+          "expr": "max(cilium_policy_max_revision{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -6030,7 +6030,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\"}[5m]))) by (scope)",
+          "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}}",
@@ -6130,7 +6130,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\"}[5m]))) by (scope)",
+          "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}}",
@@ -6240,7 +6240,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_endpoint_regenerations_total{k8s_app=\"cilium\"}[30s])) by(outcome)",
+          "expr": "sum(rate(cilium_endpoint_regenerations_total{k8s_app=\"cilium\", pod=~\"$pod\"}[30s])) by(outcome)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -6343,7 +6343,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(cilium_endpoint_state{k8s_app=\"cilium\"}) by (endpoint_state)",
+          "expr": "sum(cilium_endpoint_state{k8s_app=\"cilium\", pod=~\"$pod\"}) by (endpoint_state)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{endpoint_state}}",
@@ -6475,14 +6475,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_controllers_runs_total{k8s_app=\"cilium\"}[1m])) by (pod)",
+          "expr": "sum(rate(cilium_controllers_runs_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Runs",
           "refId": "A"
         },
         {
-          "expr": "sum(cilium_controllers_failing{k8s_app=\"cilium\"}) by(pod)",
+          "expr": "sum(cilium_controllers_failing{k8s_app=\"cilium\", pod=~\"$pod\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Failed",
@@ -6600,7 +6600,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_controllers_runs_duration_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, status) / sum(rate(cilium_controllers_runs_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, status)",
+          "expr": "sum(rate(cilium_controllers_runs_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, status) / sum(rate(cilium_controllers_runs_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{status}}",
@@ -6722,7 +6722,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_k8s_client_api_latency_time_seconds_sum{k8s_app=\"cilium\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+          "expr": "avg(rate(cilium_k8s_client_api_latency_time_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}}",
@@ -6823,7 +6823,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(cilium_k8s_client_api_latency_time_seconds_sum{k8s_app=\"cilium\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+          "expr": "max(rate(cilium_k8s_client_api_latency_time_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}}",
@@ -6924,7 +6924,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+          "expr": "sum(rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}}",
@@ -7025,7 +7025,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_k8s_client_api_calls_total{k8s_app=\"cilium\"}[1m])) by (pod, method, return_code)",
+          "expr": "sum(rate(cilium_k8s_client_api_calls_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, return_code)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{return_code}}",
@@ -7125,7 +7125,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"true\", valid=\"true\"}[5m])) by (pod, scope, action)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"true\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7224,7 +7224,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"true\", valid=\"false\"}[5m])) by (pod, scope, action)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"true\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7323,7 +7323,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"false\", valid=\"true\"}[5m])) by (pod, scope, action, valid)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"false\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action, valid)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7422,7 +7422,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"false\", valid=\"false\"}[5m])) by (pod, scope, action)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"false\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7521,7 +7521,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"CiliumNetworkPolicy\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"CiliumNetworkPolicy\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -7624,7 +7624,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"NetworkPolicy\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"NetworkPolicy\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -7727,7 +7727,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Pod\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Pod\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -7830,7 +7830,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Node\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Node\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -7929,7 +7929,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Service\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Service\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -8028,7 +8028,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Endpoint\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Endpoint\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -8127,7 +8127,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Namespace\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Namespace\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -8190,14 +8190,14 @@
           "value": "$__all"
         },
         "datasource": "prometheus",
-        "definition": "label_values(kube_pod_created{pod=~\"^cilium-[a-z|A-Z|0-9]+$\"},pod)",
+        "definition": "label_values(cilium_version, pod)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": false,
         "name": "pod",
         "options": [],
-        "query": "label_values(kube_pod_created{pod=~\"^cilium-[a-z|A-Z|0-9]+$\"},pod)",
+        "query": "label_values(cilium_version, pod)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/examples/kubernetes/addons/prometheus/files/prometheus/prometheus.yaml
+++ b/examples/kubernetes/addons/prometheus/files/prometheus/prometheus.yaml
@@ -33,10 +33,10 @@ scrape_configs:
         regex: __meta_kubernetes_service_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_service_name]
         action: replace
-        target_label: kubernetes_name
+        target_label: service
 
   # https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml#L156
   - job_name: 'kubernetes-pods'
@@ -59,10 +59,10 @@ scrape_configs:
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod
       - source_labels: [__meta_kubernetes_pod_container_port_number]
         action: keep
         regex: \d+
@@ -86,9 +86,9 @@ scrape_configs:
       - action: labelmap
         regex: __meta_kubernetes_service_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_service_name]
-        target_label: kubernetes_name
+        target_label: service
 
   - job_name: 'kubernetes-cadvisor'
     scheme: https

--- a/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+++ b/examples/kubernetes/addons/prometheus/monitoring-example.yaml
@@ -428,7 +428,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_errors_warnings_total{k8s_app=\"cilium\"}[1m])) by (pod, level) * 60",
+              "expr": "sum(rate(cilium_errors_warnings_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, level) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{level}}",
@@ -537,21 +537,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\"}[1m])) by (pod) * 100",
+              "expr": "min(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "min",
               "refId": "A"
             },
             {
-              "expr": "avg(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\"}[1m])) by (pod) * 100",
+              "expr": "avg(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
               "refId": "B"
             },
             {
-              "expr": "max(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\"}[1m])) by (pod) * 100",
+              "expr": "max(irate(cilium_process_cpu_seconds_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
@@ -677,21 +677,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\"})",
+              "expr": "min(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Min Virtual Memory",
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\"})",
+              "expr": "avg(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Average Virtual Memory",
               "refId": "B"
             },
             {
-              "expr": "max(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\"})",
+              "expr": "max(cilium_process_virtual_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Max Virtual Memory",
@@ -792,7 +792,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(cilium_process_resident_memory_bytes{k8s_app=\"cilium\"})",
+              "expr": "avg(cilium_process_resident_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -800,7 +800,7 @@ data:
               "refId": "C"
             },
             {
-              "expr": "max(cilium_process_resident_memory_bytes{k8s_app=\"cilium\"})",
+              "expr": "max(cilium_process_resident_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -808,7 +808,7 @@ data:
               "refId": "D"
             },
             {
-              "expr": "min(cilium_process_resident_memory_bytes{k8s_app=\"cilium\"})",
+              "expr": "min(cilium_process_resident_memory_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "MIN_resident_memory_bytes_min",
@@ -912,28 +912,28 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(cilium_process_open_fds{k8s_app=\"cilium\"})",
+              "expr": "sum(cilium_process_open_fds{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "all nodes",
               "refId": "A"
             },
             {
-              "expr": "min(cilium_process_open_fds{k8s_app=\"cilium\"})",
+              "expr": "min(cilium_process_open_fds{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "min/node",
               "refId": "B"
             },
             {
-              "expr": "avg(cilium_process_open_fds{k8s_app=\"cilium\"})",
+              "expr": "avg(cilium_process_open_fds{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg/node",
               "refId": "C"
             },
             {
-              "expr": "max(cilium_process_open_fds{k8s_app=\"cilium\"})",
+              "expr": "max(cilium_process_open_fds{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max/node",
@@ -1035,7 +1035,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\"})",
+              "expr": "avg(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -1044,7 +1044,7 @@ data:
               "refId": "C"
             },
             {
-              "expr": "max(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\"})",
+              "expr": "max(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -1053,7 +1053,7 @@ data:
               "refId": "D"
             },
             {
-              "expr": "min(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\"})",
+              "expr": "min(cilium_bpf_maps_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app=\"cilium\", pod=~\"$pod\"})",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -1154,7 +1154,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "cilium_bpf_map_pressure",
+              "expr": "cilium_bpf_map_pressure{k8s_app=\"cilium\", pod=~\"$pod\"}",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -1270,7 +1270,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_agent_api_process_time_seconds_sum{k8s_app=\"cilium\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+              "expr": "avg(rate(cilium_agent_api_process_time_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}}",
@@ -1371,7 +1371,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(rate(cilium_agent_api_process_time_seconds_sum{k8s_app=\"cilium\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+              "expr": "max(rate(cilium_agent_api_process_time_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}}",
@@ -1472,7 +1472,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+              "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}} ",
@@ -1573,7 +1573,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+              "expr": "max(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}} ",
@@ -1674,7 +1674,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path, return_code)",
+              "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path, return_code)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{return_code}} ({{method}} {{path}} )",
@@ -1775,7 +1775,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path, return_code)",
+              "expr": "sum(rate(cilium_agent_api_process_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path, return_code)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{return_code}} ({{method}} {{path}} )",
@@ -1911,7 +1911,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, operation)",
+              "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, operation)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{operation}}",
@@ -2013,7 +2013,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, operation)",
+              "expr": "max(rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, operation)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{operation}}",
@@ -2115,7 +2115,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_sum{k8s_app=\"cilium\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, operation)",
+              "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, operation)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{operation}}",
@@ -2214,7 +2214,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(rate(cilium_bpf_syscall_duration_seconds_sum{k8s_app=\"cilium\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, operation)",
+              "expr": "max(rate(cilium_bpf_syscall_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, operation)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{operation}}",
@@ -2315,7 +2315,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, map_name, operation))",
+              "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\", pod=~\"$pod\"}[5m])) by (pod, map_name, operation))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{map_name}} {{operation}}",
@@ -2416,7 +2416,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\"}[5m])) by (pod, map_name, operation))",
+              "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\", pod=~\"$pod\"}[5m])) by (pod, map_name, operation))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{map_name}} {{operation}}",
@@ -2517,7 +2517,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\",outcome=\"fail\"}[5m])) by (pod, map_name, operation)",
+              "expr": "sum(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\",outcome=\"fail\", pod=~\"$pod\"}[5m])) by (pod, map_name, operation)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{map_name}} {{operation}}",
@@ -2640,7 +2640,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(kvstore_operations_total{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, scope, action)",
+              "expr": "sum(rate(kvstore_operations_total{pod=~\"$pod\"}[1m])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}} {{action}}",
@@ -2743,7 +2743,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(rate(kvstore_operations_total{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, scope, action)",
+              "expr": "max(rate(kvstore_operations_total{pod=~\"$pod\"}[1m])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}} {{action}}",
@@ -2845,7 +2845,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(5, avg(rate(cilium_kvstore_operations_duration_seconds_sum{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, action, scope))",
+              "expr": "topk(5, avg(rate(cilium_kvstore_operations_duration_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, action, scope))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -2946,7 +2946,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(5, max(rate(cilium_kvstore_operations_duration_seconds_sum{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, action, scope))",
+              "expr": "topk(5, max(rate(cilium_kvstore_operations_duration_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, action, scope))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -3045,7 +3045,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_kvstore_events_queue_seconds_count{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod, scope, action)",
+              "expr": "avg(rate(cilium_kvstore_events_queue_seconds_count{pod=~\"$pod\"}[1m])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -3163,7 +3163,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_forward_count_total{k8s_app=\"cilium\"}[1m])) by (pod, direction)",
+              "expr": "sum(rate(cilium_forward_count_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, direction)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{direction}}",
@@ -3265,7 +3265,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_forward_bytes_total{k8s_app=\"cilium\"}[1m])) by (pod, direction) * 8",
+              "expr": "sum(rate(cilium_forward_bytes_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, direction) * 8",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{direction}}",
@@ -3402,7 +3402,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\"}) by (family,status)",
+              "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -3410,28 +3410,28 @@ data:
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\"}) by (family,status)",
+              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
               "refId": "B"
             },
             {
-              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\"}) by (family,status)",
+              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
               "refId": "C"
             },
             {
-              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\"}) by (family,status)",
+              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "deleted",
               "refId": "D"
             },
             {
-              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\"}) by (family,status)",
+              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "deleted max",
@@ -3568,7 +3568,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\"}) by (family,status)",
+              "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -3576,28 +3576,28 @@ data:
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\"}) by (family,status)",
+              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
               "refId": "B"
             },
             {
-              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\"}) by (family,status)",
+              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
               "refId": "C"
             },
             {
-              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\"}) by (family,status)",
+              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "deleted",
               "refId": "D"
             },
             {
-              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\"}) by (family,status)",
+              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "deleted max",
@@ -3734,7 +3734,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+              "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -3742,28 +3742,28 @@ data:
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
               "refId": "B"
             },
             {
-              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
               "refId": "C"
             },
             {
-              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "deleted",
               "refId": "D"
             },
             {
-              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "deleted max",
@@ -3900,7 +3900,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\"}) by (family,status)",
+              "expr": "min(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -3908,28 +3908,28 @@ data:
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\"}) by (family,status)",
+              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
               "refId": "B"
             },
             {
-              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\"}) by (family,status)",
+              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
               "refId": "C"
             },
             {
-              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\"}) by (family,status)",
+              "expr": "avg(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "deleted",
               "refId": "D"
             },
             {
-              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\"}) by (family,status)",
+              "expr": "max(cilium_datapath_conntrack_gc_entries{k8s_app=\"cilium\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "deleted max",
@@ -4036,7 +4036,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(cilium_ip_addresses{k8s_app=\"cilium\"}) by (pod, family)\n",
+              "expr": "sum(cilium_ip_addresses{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod, family)\n",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{family}}",
@@ -4136,7 +4136,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(cilium_datapath_conntrack_dump_resets_total{k8s_app=\"cilium\"}) by (pod, area, family, name)",
+              "expr": "sum(cilium_datapath_conntrack_dump_resets_total{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod, area, family, name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{name}} {{area}} {{family}}",
@@ -4233,7 +4233,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_services_events_total{k8s_app=\"cilium\"}[1m])) by (pod, action)",
+              "expr": "avg(rate(cilium_services_events_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}}",
@@ -4339,14 +4339,14 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(cilium_unreachable_nodes{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "sum(cilium_unreachable_nodes{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "unreachable nodes",
               "refId": "A"
             },
             {
-              "expr": "sum(cilium_unreachable_health_endpoints{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "sum(cilium_unreachable_health_endpoints{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "unreachable health endpoints",
@@ -4443,7 +4443,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_drop_count_total{direction=\"EGRESS\", k8s_app=\"cilium\"}[1m])) by (reason)",
+              "expr": "sum(rate(cilium_drop_count_total{direction=\"EGRESS\", k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (reason)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{reason}}",
@@ -4569,7 +4569,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_nodes_all_events_received_total{k8s_app=\"cilium\"}[1m])) by (pod, event_type, source) * 60",
+              "expr": "avg(rate(cilium_nodes_all_events_received_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, event_type, source) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{eventType}} {{source}}",
@@ -4666,7 +4666,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_drop_bytes_total{direction=\"EGRESS\", k8s_app=\"cilium\"}[1m])) by (reason) * 8",
+              "expr": "sum(rate(cilium_drop_bytes_total{direction=\"EGRESS\", k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (reason) * 8",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{reason}}",
@@ -4778,21 +4778,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(cilium_nodes_all_num{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "avg(cilium_nodes_all_num{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Average Nodes",
               "refId": "A"
             },
             {
-              "expr": "min(cilium_nodes_all_num{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "min(cilium_nodes_all_num{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Min Nodes",
               "refId": "B"
             },
             {
-              "expr": "max(cilium_nodes_all_num{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "max(cilium_nodes_all_num{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Max Nodes",
@@ -4923,21 +4923,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_policy_l7_denied_total{k8s_app=\"cilium\"}[1m]))",
+              "expr": "sum(rate(cilium_policy_l7_denied_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "denied",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(cilium_policy_l7_forwarded_total{k8s_app=\"cilium\"}[1m]))",
+              "expr": "sum(rate(cilium_policy_l7_forwarded_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "forwarded",
               "refId": "B"
             },
             {
-              "expr": "sum(rate(cilium_policy_l7_received_total{k8s_app=\"cilium\"}[1m]))",
+              "expr": "sum(rate(cilium_policy_l7_received_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "received",
@@ -5034,7 +5034,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_drop_count_total{direction=\"INGRESS\", k8s_app=\"cilium\"}[5m])) by (reason)",
+              "expr": "sum(rate(cilium_drop_count_total{direction=\"INGRESS\", k8s_app=\"cilium\", pod=~\"$pod\"}[5m])) by (reason)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{reason}}",
@@ -5086,7 +5086,7 @@ data:
           "aliasColors": {
             "Max per node processingTime": "#e24d42",
             "Max per node upstreamTime": "#58140c",
-            "avg(cilium_policy_l7_parse_errors_total{kubernetes_pod_name=~\"cilium.*\"})": "#bf1b00",
+            "avg(cilium_policy_l7_parse_errors_total{pod=~\"cilium.*\"})": "#bf1b00",
             "parse errors": "#bf1b00"
           },
           "bars": true,
@@ -5142,7 +5142,7 @@ data:
               "yaxis": 2
             },
             {
-              "alias": "avg(cilium_policy_l7_parse_errors_total{kubernetes_pod_name=~\"cilium.*\"})",
+              "alias": "avg(cilium_policy_l7_parse_errors_total{pod=~\"cilium.*\"})",
               "yaxis": 2
             },
             {
@@ -5155,7 +5155,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+              "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -5163,7 +5163,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_policy_l7_parse_errors_total{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "avg(cilium_policy_l7_parse_errors_total{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "parse errors",
@@ -5260,7 +5260,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_drop_bytes_total{direction=\"INGRESS\", k8s_app=\"cilium\"}[1m])) by (reason) * 8",
+              "expr": "sum(rate(cilium_drop_bytes_total{direction=\"INGRESS\", k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (reason) * 8",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{reason}}",
@@ -5383,21 +5383,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+              "expr": "min(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "min",
               "refId": "A"
             },
             {
-              "expr": "avg(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+              "expr": "avg(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
               "refId": "B"
             },
             {
-              "expr": "max(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+              "expr": "max(rate(cilium_triggers_policy_update_call_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
@@ -5505,14 +5505,14 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(rate(cilium_proxy_upstream_reply_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+              "expr": "max(rate(cilium_proxy_upstream_reply_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Max {{scope}}",
               "refId": "B"
             },
             {
-              "expr": "max(rate(cilium_policy_l7_parse_errors_total{k8s_app=\"cilium\"}[1m])) by (pod)",
+              "expr": "max(rate(cilium_policy_l7_parse_errors_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "parse errors",
@@ -5617,7 +5617,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(cilium_policy_endpoint_enforcement_status{k8s_app=\"cilium\"}) by (enforcement)",
+              "expr": "sum(cilium_policy_endpoint_enforcement_status{k8s_app=\"cilium\", pod=~\"$pod\"}) by (enforcement)",
               "format": "time_series",
               "hide": false,
               "instant": true,
@@ -5733,21 +5733,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(cilium_proxy_redirects{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "min(cilium_proxy_redirects{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "min",
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_proxy_redirects{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "avg(cilium_proxy_redirects{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
               "refId": "B"
             },
             {
-              "expr": "max(cilium_proxy_redirects{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "max(cilium_proxy_redirects{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
@@ -5865,28 +5865,28 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\"}[1m])) by (pod) * 60",
+              "expr": "min(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "min trigger",
               "refId": "A"
             },
             {
-              "expr": "avg(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\"}[1m])) by (pod) * 60",
+              "expr": "avg(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "average trigger",
               "refId": "B"
             },
             {
-              "expr": "max(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\"}[1m])) by (pod) * 60",
+              "expr": "max(rate(cilium_triggers_policy_update_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max trigger",
               "refId": "C"
             },
             {
-              "expr": "max(rate(cilium_triggers_policy_update_folds{k8s_app=\"cilium\"}[1m])) by (pod) * 60",
+              "expr": "max(rate(cilium_triggers_policy_update_folds{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "folds",
@@ -6007,28 +6007,28 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
+              "expr": "min(cilium_policy{k8s_app=\"cilium\", pod=~\"$pod\"}) by(pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "min",
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
+              "expr": "avg(cilium_policy{k8s_app=\"cilium\", pod=~\"$pod\"}) by(pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
               "refId": "B"
             },
             {
-              "expr": "max(cilium_policy{k8s_app=\"cilium\"}) by(pod)",
+              "expr": "max(cilium_policy{k8s_app=\"cilium\", pod=~\"$pod\"}) by(pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
               "refId": "C"
             },
             {
-              "expr": "sum(cilium_policy_import_errors_total{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "sum(cilium_policy_import_errors_total{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "policy import errors",
@@ -6136,7 +6136,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, scope)",
+              "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}}",
@@ -6247,21 +6247,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "min(cilium_policy_max_revision{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "min(cilium_policy_max_revision{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "min",
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_policy_max_revision{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "avg(cilium_policy_max_revision{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
               "refId": "B"
             },
             {
-              "expr": "max(cilium_policy_max_revision{k8s_app=\"cilium\"}) by (pod)",
+              "expr": "max(cilium_policy_max_revision{k8s_app=\"cilium\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
@@ -6382,7 +6382,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\"}[5m]))) by (scope)",
+              "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}}",
@@ -6482,7 +6482,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\"}[5m]))) by (scope)",
+              "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app=\"cilium\", scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}}",
@@ -6592,7 +6592,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_endpoint_regenerations_total{k8s_app=\"cilium\"}[30s])) by(outcome)",
+              "expr": "sum(rate(cilium_endpoint_regenerations_total{k8s_app=\"cilium\", pod=~\"$pod\"}[30s])) by(outcome)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -6695,7 +6695,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(cilium_endpoint_state{k8s_app=\"cilium\"}) by (endpoint_state)",
+              "expr": "sum(cilium_endpoint_state{k8s_app=\"cilium\", pod=~\"$pod\"}) by (endpoint_state)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{endpoint_state}}",
@@ -6827,14 +6827,14 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_controllers_runs_total{k8s_app=\"cilium\"}[1m])) by (pod)",
+              "expr": "sum(rate(cilium_controllers_runs_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Runs",
               "refId": "A"
             },
             {
-              "expr": "sum(cilium_controllers_failing{k8s_app=\"cilium\"}) by(pod)",
+              "expr": "sum(cilium_controllers_failing{k8s_app=\"cilium\", pod=~\"$pod\"}) by(pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Failed",
@@ -6952,7 +6952,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_controllers_runs_duration_seconds_sum{k8s_app=\"cilium\"}[1m])) by (pod, status) / sum(rate(cilium_controllers_runs_duration_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, status)",
+              "expr": "sum(rate(cilium_controllers_runs_duration_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, status) / sum(rate(cilium_controllers_runs_duration_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{status}}",
@@ -7074,7 +7074,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_k8s_client_api_latency_time_seconds_sum{k8s_app=\"cilium\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+              "expr": "avg(rate(cilium_k8s_client_api_latency_time_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}}",
@@ -7175,7 +7175,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(rate(cilium_k8s_client_api_latency_time_seconds_sum{k8s_app=\"cilium\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+              "expr": "max(rate(cilium_k8s_client_api_latency_time_seconds_sum{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}}",
@@ -7276,7 +7276,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\"}[1m])) by (pod, method, path)",
+              "expr": "sum(rate(cilium_k8s_client_api_latency_time_seconds_count{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}}",
@@ -7377,7 +7377,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_k8s_client_api_calls_total{k8s_app=\"cilium\"}[1m])) by (pod, method, return_code)",
+              "expr": "sum(rate(cilium_k8s_client_api_calls_total{k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (pod, method, return_code)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{return_code}}",
@@ -7477,7 +7477,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"true\", valid=\"true\"}[5m])) by (pod, scope, action)",
+              "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"true\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -7576,7 +7576,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"true\", valid=\"false\"}[5m])) by (pod, scope, action)",
+              "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"true\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -7675,7 +7675,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"false\", valid=\"true\"}[5m])) by (pod, scope, action, valid)",
+              "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"false\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action, valid)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -7774,7 +7774,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"false\", valid=\"false\"}[5m])) by (pod, scope, action)",
+              "expr": "sum(rate(cilium_kubernetes_events_received_total{k8s_app=\"cilium\", equal=\"false\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -7873,7 +7873,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"CiliumNetworkPolicy\"}[1m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"CiliumNetworkPolicy\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} avg",
@@ -7976,7 +7976,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"NetworkPolicy\"}[1m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"NetworkPolicy\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} avg",
@@ -8079,7 +8079,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Pod\"}[1m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Pod\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} avg",
@@ -8182,7 +8182,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Node\"}[1m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Node\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} avg",
@@ -8281,7 +8281,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Service\"}[1m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Service\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}}",
@@ -8380,7 +8380,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Endpoint\"}[1m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Endpoint\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}}",
@@ -8479,7 +8479,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Namespace\"}[1m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{k8s_app=\"cilium\", scope=\"Namespace\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}}",
@@ -8542,14 +8542,14 @@ data:
               "value": "$__all"
             },
             "datasource": "prometheus",
-            "definition": "label_values(kube_pod_created{pod=~\"^cilium-[a-z|A-Z|0-9]+$\"},pod)",
+            "definition": "label_values(cilium_version, pod)",
             "hide": 0,
             "includeAll": true,
             "label": null,
             "multi": false,
             "name": "pod",
             "options": [],
-            "query": "label_values(kube_pod_created{pod=~\"^cilium-[a-z|A-Z|0-9]+$\"},pod)",
+            "query": "label_values(cilium_version, pod)",
             "refresh": 2,
             "regex": "",
             "skipUrlSync": false,
@@ -12891,10 +12891,10 @@ data:
             regex: __meta_kubernetes_service_label_(.+)
           - source_labels: [__meta_kubernetes_namespace]
             action: replace
-            target_label: kubernetes_namespace
+            target_label: namespace
           - source_labels: [__meta_kubernetes_service_name]
             action: replace
-            target_label: kubernetes_name
+            target_label: service
   
       # https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml#L156
       - job_name: 'kubernetes-pods'
@@ -12917,10 +12917,10 @@ data:
             regex: __meta_kubernetes_pod_label_(.+)
           - source_labels: [__meta_kubernetes_namespace]
             action: replace
-            target_label: kubernetes_namespace
+            target_label: namespace
           - source_labels: [__meta_kubernetes_pod_name]
             action: replace
-            target_label: kubernetes_pod_name
+            target_label: pod
           - source_labels: [__meta_kubernetes_pod_container_port_number]
             action: keep
             regex: \d+
@@ -12944,9 +12944,9 @@ data:
           - action: labelmap
             regex: __meta_kubernetes_service_label_(.+)
           - source_labels: [__meta_kubernetes_namespace]
-            target_label: kubernetes_namespace
+            target_label: namespace
           - source_labels: [__meta_kubernetes_service_name]
-            target_label: kubernetes_name
+            target_label: service
   
       - job_name: 'kubernetes-cadvisor'
         scheme: https

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -219,7 +219,6 @@ contributors across the globe, there is almost always someone available to help.
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
 | healthPort | int | `9879` | TCP port for the agent health API. This is not the port for cilium-health. |
-| hostAliases | list | `[]` | Host aliases for cilium-agent. |
 | hostFirewall | object | `{"enabled":false}` | Configure the host firewall. |
 | hostFirewall.enabled | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |
 | hostPort.enabled | bool | `false` | Enable hostPort service support. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -94,7 +94,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.etcd.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/coreos/etcd","tag":"v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"}` | Clustermesh API server etcd image. |
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
 | clustermesh.apiserver.image | object | `{"digest":"sha256:a8667dcc95195005ed22bd949a6b1c8b8af9b68c1a1e2bae0a81dfffc6060b29","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/clustermesh-apiserver","tag":"v1.12.0-rc3","useDigest":true}` | Clustermesh API server image. |
-| clustermesh.apiserver.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| clustermesh.apiserver.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | clustermesh.apiserver.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
@@ -195,7 +195,7 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.extraArgs | list | `[]` | Additional cilium-etcd-operator container arguments. |
 | etcd.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-etcd-operator","tag":"v2.0.7@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc"}` | cilium-etcd-operator image. |
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
-| etcd.nodeSelector | object | `{}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| etcd.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | etcd.podAnnotations | object | `{}` | Annotations to be added to cilium-etcd-operator pods |
 | etcd.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | etcd.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
@@ -244,7 +244,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.image | object | `{"digest":"sha256:b678ee945d0e7750a795a9ac06483152b41b4a7a9c862df4e00c545c37047182","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.12.0-rc3","useDigest":true}` | Hubble-relay container image. |
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
-| hubble.relay.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| hubble.relay.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.relay.podAnnotations | object | `{}` | Annotations to be added to hubble-relay pods |
 | hubble.relay.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | hubble.relay.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
@@ -293,7 +293,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.frontend.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-ui","tag":"v0.9.0@sha256:0ef04e9a29212925da6bdfd0ba5b581765e41a01f1cc30563cef9b30b457fea0"}` | Hubble-ui frontend image. |
 | hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
-| hubble.ui.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| hubble.ui.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
 | hubble.ui.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | hubble.ui.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
@@ -380,7 +380,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
 | operator.image | object | `{"alibabacloudDigest":"sha256:cd73bf6b35ec509ef0cd406f59308bd3c4eb12cefc07e96e797ffe23602d9941","awsDigest":"sha256:65f2cafeccbc1b88528b69962d3dee017aa0e6808b609cec2b41b3a5a69eea4c","azureDigest":"sha256:e60d109bfb5eb2995a344550a9e8fc5d2188a79925ca5b2cdb6a4cda6d3ab437","genericDigest":"sha256:8b672895e0248beedc62be0b563056b5ef4ea0c2d7331aaaef15b6b31f622ed0","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.12.0-rc3","useDigest":true}` | cilium-operator image. |
 | operator.nodeGCInterval | string | `"5m0s"` | Interval for cilium node garbage collection. |
-| operator.nodeSelector | object | `{}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| operator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
 | operator.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | operator.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -360,7 +360,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraEnv | list | `[]` | Additional nodeinit environment variables. |
 | nodeinit.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"d69851597ea019af980891a4628fb36b7880ec26"}` | node-init image. |
-| nodeinit.nodeSelector | object | `{}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| nodeinit.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |
 | nodeinit.priorityClassName | string | `""` | The priority class to use for the nodeinit pod. |
@@ -410,7 +410,7 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
 | preflight.extraEnv | list | `[]` | Additional preflight environment variables. |
 | preflight.image | object | `{"digest":"sha256:e4cf44318235764561e19ef4e49d64d4d2b465fbe7acf424689bc29d2f7d30cf","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.12.0-rc3","useDigest":true}` | Cilium pre-flight image. |
-| preflight.nodeSelector | object | `{}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| preflight.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
 | preflight.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | preflight.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -92,6 +92,13 @@ rules:
   - create
 - apiGroups:
   - cilium.io
+  # To synchronize garbage collection of such resources
+  resources:
+  - ciliumidentities
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
   resources:
   - ciliumendpoints
   verbs:

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -627,10 +627,6 @@ spec:
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
-      {{- with .Values.hostAliases }}
-      hostAliases:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -14,6 +14,7 @@
 {{- $fragmentTracking := "true" -}}
 {{- $crdWaitTimeout := "5m" -}}
 {{- $defaultKubeProxyReplacement := "probe" -}}
+{{- $azureUsePrimaryAddress := "true" -}}
 
 {{- /* Default values when 1.8 was initially deployed */ -}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
@@ -39,10 +40,18 @@
   {{- $defaultBpfMasquerade = "false" -}}
 {{- end -}}
 
+{{- /* Default values when 1.12 was initially deployed */ -}}
+{{- if semverCompare ">=1.12" (default "1.12" .Values.upgradeCompatibility) -}}
+  {{- if .Values.azure.enabled }}
+      {{- $azureUsePrimaryAddress = "false" -}}
+  {{- end }}
+{{- end -}}
+
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}
 {{- $bpfCtTcpMax := (coalesce .Values.bpf.ctTcpMax $defaultBpfCtTcpMax) -}}
 {{- $bpfCtAnyMax := (coalesce .Values.bpf.ctAnyMax $defaultBpfCtAnyMax) -}}
 {{- $kubeProxyReplacement := (coalesce .Values.kubeProxyReplacement $defaultKubeProxyReplacement) -}}
+{{- $azureUsePrimaryAddress := (coalesce .Values.azure.usePrimaryAddress $azureUsePrimaryAddress) -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -407,6 +416,7 @@ data:
 {{- if .Values.azure.userAssignedIdentityID }}
   azure-user-assigned-identity-id: {{ .Values.azure.userAssignedIdentityID | quote }}
 {{- end }}
+  azure-use-primary-address: {{ $azureUsePrimaryAddress | quote }}
 {{- end }}
 
 {{- if .Values.alibabacloud.enabled }}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -123,6 +123,13 @@ rules:
 - apiGroups:
   - cilium.io
   resources:
+  - ciliumidentities
+  verbs:
+  # To synchronize garbage collection of such resources
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
   - ciliumnodes
   verbs:
   - create

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -92,6 +92,13 @@ rules:
   - create
 - apiGroups:
   - cilium.io
+  # To synchronize garbage collection of such resources
+  resources:
+  - ciliumidentities
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
   resources:
   - ciliumendpoints
   verbs:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -107,6 +107,7 @@ spec:
         - --debug
         {{- end }}
         - --cluster-name=$(CLUSTER_NAME)
+        - --cluster-id=$(CLUSTER_ID)
         - --kvstore-opt
         - etcd.config=/var/lib/cilium/etcd-config.yaml
         env:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -117,12 +117,6 @@ tolerations:
   #   value: "value"
   #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
-# -- Host aliases for cilium-agent.
-hostAliases: []
-# - ip: 10.10.xx.xx
-#   hostnames:
-#   - cluster1.mesh.cilium.io
-
 # -- The priority class to use for cilium-agent.
 priorityClassName: ""
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -206,6 +206,7 @@ azure:
   # Note that this is incompatible with AKS clusters created in BYOCNI mode: use
   # AKS BYOCNI integration (`aksbyocni.enabled`) instead.
   enabled: false
+  # usePrimaryAddress: false
   # resourceGroup: group1
   # subscriptionID: 00000000-0000-0000-0000-000000000000
   # tenantID: 00000000-0000-0000-0000-000000000000

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1673,7 +1673,8 @@ nodeinit:
   # -- Node labels for nodeinit pod assignment
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
   #
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   # -- Node tolerations for nodeinit scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -1756,7 +1757,8 @@ preflight:
   # -- Node labels for preflight pod assignment
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
   #
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   # -- Node tolerations for preflight scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -800,7 +800,8 @@ hubble:
 
     # -- Node labels for pod assignment
     # ref: https://kubernetes.io/docs/user-guide/node-selection/
-    nodeSelector: {}
+    nodeSelector:
+      kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
     # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -1001,7 +1002,8 @@ hubble:
 
     # -- Node labels for pod assignment
     # ref: https://kubernetes.io/docs/user-guide/node-selection/
-    nodeSelector: {}
+    nodeSelector:
+      kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
     # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -1434,7 +1436,8 @@ etcd:
 
   # -- Node labels for cilium-etcd-operator pod assignment
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   # -- Annotations to be added to cilium-etcd-operator pods
   podAnnotations: {}
@@ -1539,7 +1542,8 @@ operator:
   # -- Node labels for cilium-operator pod assignment
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
   #
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   # -- Node tolerations for cilium-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -1944,7 +1948,8 @@ clustermesh:
 
     # -- Node labels for pod assignment
     # ref: https://kubernetes.io/docs/user-guide/node-selection/
-    nodeSelector: {}
+    nodeSelector:
+      kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
     # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -114,12 +114,6 @@ tolerations:
   #   value: "value"
   #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
-# -- Host aliases for cilium-agent.
-hostAliases: []
-# - ip: 10.10.xx.xx
-#   hostnames:
-#   - cluster1.mesh.cilium.io
-
 # -- The priority class to use for cilium-agent.
 priorityClassName: ""
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -797,7 +797,8 @@ hubble:
 
     # -- Node labels for pod assignment
     # ref: https://kubernetes.io/docs/user-guide/node-selection/
-    nodeSelector: {}
+    nodeSelector:
+      kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
     # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -998,7 +999,8 @@ hubble:
 
     # -- Node labels for pod assignment
     # ref: https://kubernetes.io/docs/user-guide/node-selection/
-    nodeSelector: {}
+    nodeSelector:
+      kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
     # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -1431,7 +1433,8 @@ etcd:
 
   # -- Node labels for cilium-etcd-operator pod assignment
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   # -- Annotations to be added to cilium-etcd-operator pods
   podAnnotations: {}
@@ -1536,7 +1539,8 @@ operator:
   # -- Node labels for cilium-operator pod assignment
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
   #
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   # -- Node tolerations for cilium-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -1941,7 +1945,8 @@ clustermesh:
 
     # -- Node labels for pod assignment
     # ref: https://kubernetes.io/docs/user-guide/node-selection/
-    nodeSelector: {}
+    nodeSelector:
+      kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
     # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1670,7 +1670,8 @@ nodeinit:
   # -- Node labels for nodeinit pod assignment
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
   #
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   # -- Node tolerations for nodeinit scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -1753,7 +1754,8 @@ preflight:
   # -- Node labels for preflight pod assignment
   # ref: https://kubernetes.io/docs/user-guide/node-selection/
   #
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   # -- Node tolerations for preflight scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -94,9 +94,9 @@ pipeline {
                     steps {
                         retry(25) {
                             sleep(time: 60)
-                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/cilium-ci:${DOCKER_TAG}} &> /dev/null'
-                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/operator-generic-ci:${DOCKER_TAG}} &> /dev/null'
-                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/hubble-relay-ci:${DOCKER_TAG}} &> /dev/null'
+                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/cilium-ci:${DOCKER_TAG} &> /dev/null'
+                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/operator-generic-ci:${DOCKER_TAG} &> /dev/null'
+                            sh 'docker manifest inspect ${IMAGE_REGISTRY}/hubble-relay-ci:${DOCKER_TAG} &> /dev/null'
                         }
                     }
                 }

--- a/operator/provider_azure_flags.go
+++ b/operator/provider_azure_flags.go
@@ -24,7 +24,7 @@ func init() {
 	flags.String(operatorOption.AzureUserAssignedIdentityID, "", "ID of the user assigned identity used to auth with the Azure API")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureUserAssignedIdentityID, "AZURE_USER_ASSIGNED_IDENTITY_ID")
 
-	flags.Bool(operatorOption.AzureUsePrimaryAddress, true, "Use Azure IP address from interface's primary IPConfigurations")
+	flags.Bool(operatorOption.AzureUsePrimaryAddress, false, "Use Azure IP address from interface's primary IPConfigurations")
 	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureUsePrimaryAddress, "AZURE_USE_PRIMARY_ADDRESS")
 
 	viper.BindPFlags(flags)

--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -148,7 +148,10 @@ func (c *cache) OnDelete(id idpool.ID, key AllocatorKey) {
 		if value := a.localKeys.lookupID(id); value != nil {
 			ctx, cancel := context.WithTimeout(context.TODO(), backendOpTimeout)
 			defer cancel()
-			a.backend.UpdateKey(ctx, id, value, true)
+			err := a.backend.UpdateKey(ctx, id, value, true)
+			if err != nil {
+				log.WithError(err).Errorf("OnDelete MasterKeyProtection update for key %q", id)
+			}
 			return
 		}
 	}

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -100,7 +100,7 @@ func (s *linuxTestSuite) TestCreateNodeRouteSpecMtu(c *check.C) {
 
 func (s *linuxTestSuite) TestStoreLoadNeighLinks(c *check.C) {
 	tmpDir := c.MkDir()
-	devExpected := "dev1"
+	devExpected := []string{"dev1"}
 	err := storeNeighLink(tmpDir, devExpected)
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
* #19936 -- bug: Prevent CiliumIdentities from Being Deleted Improperly (@nathanjsweet)
 * #20278 -- helm: Remove duplicated key hostAliases (@sayboras)
 * #20216 -- helm: Set Linux nodeSelector for nodeinit and preflight (@gandro)
 * #20092 -- neigh: Support multi device neighbor discovery (@ysksuzuki)
 * #20289 -- docs(policy): add notes on DNS/L7 policies & Cilium agent availability (@raphink)
 * #20325 -- jenkinsfiles: fix docker manifest inspect commands in GKE pipeline (@tklauser)
 * #20314 -- Add ESP to firewall requirements in documentation for IPSec enabled C… (@Kikiodazie)
 * #20312 -- helm: Fix cluster-id arguments in clustermesh deployment (@sayboras)
 * #20307 -- Update cilium agent Grafana dashboard to filter by pod (@ungureanuvladvictor)
 * #19743 -- Exclude interface's primary address from IP pool by default in Azure (@hemanthmalla)
 * #20194 -- [docs] Add training and support information to Getting Help (@lizrice)
 * #20228 -- docs: Add Getting Started docs for clustermesh service affinity (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19936 20278 20216 20092 20289 20325 20314 20312 20307 19743 20194 20228; do contrib/backporting/set-labels.py $pr done 1.12; done
```