### PR TITLE
v1.11 backports 2022-06-29

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -107,6 +107,7 @@ spec:
         - --debug
         {{- end }}
         - --cluster-name=$(CLUSTER_NAME)
+        - --cluster-id=$(CLUSTER_ID)
         - --kvstore-opt
         - etcd.config=/var/lib/cilium/etcd-config.yaml
         env:


### PR DESCRIPTION
* #20312 -- helm: Fix cluster-id arguments in clustermesh deployment (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20312 ; do contrib/backporting/set-labels.py $pr done 1.11; done
```