### PR TITLE
.travis.yml: disable arm64-graviton2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ go: "1.18.3"
 jobs:
   include:
     - arch: amd64
-    - arch: arm64-graviton2
-      virt: vm
-      group: edge
+# disabled until https://github.com/cilium/cilium/issues/20337 is resolved
+#    - arch: arm64-graviton2
+#      virt: vm
+#      group: edge
 
 if: branch = master OR type = pull_request
 


### PR DESCRIPTION
The job is currently failing consistently, see #20337. Disable it for
now.
