### PR TITLE
helm: add missing azure.usePrimaryAddress in values template

### DIFF
--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -203,6 +203,7 @@ azure:
   # Note that this is incompatible with AKS clusters created in BYOCNI mode: use
   # AKS BYOCNI integration (`aksbyocni.enabled`) instead.
   enabled: false
+  # usePrimaryAddress: false
   # resourceGroup: group1
   # subscriptionID: 00000000-0000-0000-0000-000000000000
   # tenantID: 00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
The values.yaml check introduced in commit 6a1ed23547a5 ("Makefile:
Check values.yaml for modifications") complains about the
azure.usePrimaryAddress value not being in values.yaml.tmpl. That value
was introduced in commit 69be90059f9b ("Support backward compatibility
for --azure-use-primary-address in helm") which was implemented while
check was not yet in place and thus not caught in CI.