### PR TITLE
daemon: add cleanup for stale local ciliumendpoints that aren't being managed.

### DIFF
--- a/daemon/cmd/ciliumendpoints.go
+++ b/daemon/cmd/ciliumendpoints.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiTypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+type localEndpointCache interface {
+	LookupPodName(name string) *endpoint.Endpoint
+}
+
+// This must only be run after K8s Pod and CES/CEP caches are synced and local endpoint restoration is complete.
+func (d *Daemon) cleanStaleCEPs(ctx context.Context, eps localEndpointCache, ciliumClient ciliumv2.CiliumV2Interface, enableCiliumEndpointSlice bool) error {
+	crdType := "ciliumendpoint"
+	if enableCiliumEndpointSlice {
+		crdType = "ciliumendpointslice"
+	}
+	indexer := d.k8sWatcher.GetIndexer(crdType)
+	objs, err := indexer.ByIndex("localNode", node.GetCiliumEndpointNodeIP())
+	if err != nil {
+		return fmt.Errorf("could not get %s objects from localNode indexer: %w", crdType, err)
+	}
+	if enableCiliumEndpointSlice {
+		for _, cesObj := range objs {
+			ces, ok := cesObj.(*cilium_v2a1.CiliumEndpointSlice)
+			if !ok {
+				return fmt.Errorf("unexpected object type returned from ciliumendpointslice store: %T", cesObj)
+			}
+			for _, cep := range ces.Endpoints {
+				if cep.Networking.NodeIP == node.GetCiliumEndpointNodeIP() && eps.LookupPodName(ces.Namespace+"/"+cep.Name) == nil {
+					d.deleteCiliumEndpoint(ctx, ces.Namespace, cep.Name, nil, ciliumClient, eps)
+				}
+			}
+		}
+	} else {
+		for _, cepObj := range objs {
+			cep, ok := cepObj.(*types.CiliumEndpoint)
+			if !ok {
+				return fmt.Errorf("unexpected object type returned from ciliumendpoint store: %T", cepObj)
+			}
+
+			if cep.Networking.NodeIP == node.GetCiliumEndpointNodeIP() && eps.LookupPodName(cep.Namespace+"/"+cep.Name) == nil {
+				d.deleteCiliumEndpoint(ctx, cep.Namespace, cep.Name, &cep.ObjectMeta.UID, ciliumClient, eps)
+			}
+		}
+	}
+	return nil
+}
+
+// deleteCiliumEndpoint safely deletes a CEP by name, if no UID is passed this will reverify that
+// the CEP is still local before doing a delete.
+func (d *Daemon) deleteCiliumEndpoint(
+	ctx context.Context,
+	cepNamespace,
+	cepName string,
+	cepUID *apiTypes.UID,
+	ciliumClient ciliumv2.CiliumV2Interface,
+	eps localEndpointCache) {
+	// To avoid having to store CEP UIDs in CES Endpoints array, we have to get the latest
+	// referenced CEP from apiserver to verify that it still references this node.
+	// To avoid excessive api calls, we only do this if CES is enabled and the CEP
+	// appears to be stale.
+	if cepUID == nil {
+		cep, err := ciliumClient.CiliumEndpoints(cepNamespace).Get(ctx, cepName, metav1.GetOptions{})
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{logfields.CEPName: cepName, logfields.K8sNamespace: cepNamespace}).
+				Error("Failed to get possibly stale ciliumendpoints from apiserver, skipping.")
+			return
+		}
+		if cep.Status.Networking.NodeIP != node.GetCiliumEndpointNodeIP() {
+			log.WithError(err).WithFields(logrus.Fields{logfields.CEPName: cepName, logfields.K8sNamespace: cepNamespace}).
+				Debug("Stale CEP fetched apiserver no longer references this Node, skipping.")
+			return
+		}
+		cepUID = &cep.ObjectMeta.UID
+	}
+	// There exists a local CiliumEndpoint that is not in the endpoint manager.
+	// This function is run after completing endpoint restoration from local state and K8s cache sync.
+	// Therefore, we can delete the CiliumEndpoint as it is not referencing a Pod that is being managed.
+	// This may occur for various reasons:
+	// * Pod was restarted while Cilium was not running (likely prior to CNI conf being installed).
+	// * Local endpoint was deleted (i.e. due to reboot + temporary filesystem) and Cilium or the Pod where restarted.
+	log.WithFields(logrus.Fields{logfields.CEPName: cepName, logfields.K8sNamespace: cepNamespace}).
+		Info("Found stale ciliumendpoint for local pod that is not being managed, deleting.")
+	if err := ciliumClient.CiliumEndpoints(cepNamespace).Delete(ctx, cepName, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID: cepUID,
+		},
+	}); err != nil {
+		log.WithError(err).WithFields(logrus.Fields{logfields.CEPName: cepName, logfields.K8sNamespace: cepNamespace}).
+			Error("Could not delete stale CEP")
+	}
+}

--- a/daemon/cmd/ciliumendpoints_test.go
+++ b/daemon/cmd/ciliumendpoints_test.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
+	slimmetav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+var (
+	testCESs = []cilium_v2a1.CiliumEndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ciliumEndpointSlices-000",
+			},
+			Namespace: "x",
+			Endpoints: []cilium_v2a1.CoreCiliumEndpoint{
+				{
+					Name: "foo",
+					Networking: &ciliumv2.EndpointNetworking{
+						Addressing: ciliumv2.AddressPairList{},
+						NodeIP:     "<nil>",
+					},
+				},
+			},
+		},
+	}
+)
+
+func Test_cleanStaleCEP(t *testing.T) {
+	tests := map[string]struct {
+		ciliumEndpoints []types.CiliumEndpoint
+		// should only be used if disableCEPCRD is true.
+		ciliumEndpointSlices []cilium_v2a1.CiliumEndpointSlice
+		// if true, simulates running CiliumEndpointSlice watcher instead of CEP.
+		enableCES bool
+		// endpoints in endpointManaged.
+		managedEndpoints map[string]*endpoint.Endpoint
+		// expectedDeletedSet contains CiliumEndpoints that are expected to be deleted
+		// during test, in the form '<namespace>/<cilium_endpoint>'.
+		expectedDeletedSet []string
+		// apiserverCEPs is used to mock apiserver get requests when running with CES enabled.
+		apiserverCEPs map[string]*ciliumv2.CiliumEndpoint
+	}{
+		"CEPs with local pods without endpoints should be GCd": {
+			ciliumEndpoints:    []types.CiliumEndpoint{cep("foo", "x", "<nil>"), cep("foo", "y", "<nil>")},
+			managedEndpoints:   map[string]*endpoint.Endpoint{"y/foo": {}},
+			expectedDeletedSet: []string{"x/foo"},
+		},
+		"CEPs with local pods with endpoints should not be GCd": {
+			ciliumEndpoints:    []types.CiliumEndpoint{cep("foo", "x", "")},
+			managedEndpoints:   map[string]*endpoint.Endpoint{"x/foo": {}},
+			expectedDeletedSet: []string{},
+		},
+		"Non local CEPs should not be GCd": {
+			ciliumEndpoints:    []types.CiliumEndpoint{cep("foo", "x", "1.2.3.4")},
+			managedEndpoints:   map[string]*endpoint.Endpoint{},
+			expectedDeletedSet: []string{},
+		},
+		"Nothing should be deleted if fields are missing": {
+			ciliumEndpoints:    []types.CiliumEndpoint{cep("", "", "")},
+			managedEndpoints:   map[string]*endpoint.Endpoint{},
+			expectedDeletedSet: []string{},
+		},
+		"CES: local CEPs without endpoints should be GCd": {
+			ciliumEndpointSlices: testCESs,
+			ciliumEndpoints: []types.CiliumEndpoint{
+				cep("bar", "x", "<nil>"),
+				cep("foo", "x", "<nil>"),
+				cep("notlocal", "x", "1.2.3.4"),
+			},
+			enableCES:          true,
+			managedEndpoints:   map[string]*endpoint.Endpoint{"x/bar": {}},
+			expectedDeletedSet: []string{"x/foo"},
+			apiserverCEPs: map[string]*ciliumv2.CiliumEndpoint{
+				"x/foo": {
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "00001",
+					},
+					Status: ciliumv2.EndpointStatus{
+						Networking: &ciliumv2.EndpointNetworking{
+							NodeIP: "<nil>",
+						},
+					},
+				},
+			},
+		},
+		"CES: Test case where IP in apiserver changes and delete should be skipped": {
+			ciliumEndpointSlices: testCESs,
+			ciliumEndpoints: []types.CiliumEndpoint{
+				cep("foo", "x", "<nil>"),
+			},
+			enableCES:          true,
+			managedEndpoints:   map[string]*endpoint.Endpoint{"x/bar": {}},
+			expectedDeletedSet: []string{},
+			apiserverCEPs: map[string]*ciliumv2.CiliumEndpoint{
+				"x/foo": {
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "00001",
+					},
+					Status: ciliumv2.EndpointStatus{
+						Networking: &ciliumv2.EndpointNetworking{
+							NodeIP: "1.2.3.4",
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			d := Daemon{
+				k8sWatcher: &watchers.K8sWatcher{},
+			}
+
+			fakeClient := fake.NewSimpleClientset()
+			fakeClient.PrependReactor("create", "ciliumendpoints", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
+				cep := action.(k8stesting.CreateAction).GetObject().(*ciliumv2.CiliumEndpoint)
+				return true, cep, nil
+			}))
+			fakeClient.PrependReactor("get", "ciliumendpoints", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if !test.enableCES {
+					assert.Fail("unexpected get on ciliumendpoints in CEP mode, expected only in CES mode")
+				}
+				name := action.(k8stesting.GetAction).GetName()
+				ns := action.(k8stesting.GetActionImpl).Namespace
+				cep, ok := test.apiserverCEPs[ns+"/"+name]
+				if !ok {
+					return true, nil, fmt.Errorf("not found")
+				}
+				return true, cep, nil
+			}))
+			cepStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{
+				"localNode": watchers.CreateCiliumEndpointLocalPodIndexFunc(), // empty nodeIP means this will index all nodes.
+			})
+			ciliumEndpointSlicesStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{
+				"localNode": watchers.CreateCiliumEndpointSliceLocalPodIndexFunc(), // empty nodeIP means this will index all nodes.
+			})
+
+			for _, ces := range test.ciliumEndpointSlices {
+				ciliumEndpointSlicesStore.Add(ces.DeepCopy())
+			}
+			for _, cep := range test.ciliumEndpoints {
+				_, err := fakeClient.CiliumV2().CiliumEndpoints(cep.Namespace).Create(context.Background(), &ciliumv2.CiliumEndpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cep.Name,
+						Namespace: cep.Namespace,
+					},
+				}, metav1.CreateOptions{})
+				assert.NoError(err)
+				cepStore.Add(cep.DeepCopy())
+			}
+			d.k8sWatcher.SetIndexer("ciliumendpoint", cepStore)
+			d.k8sWatcher.SetIndexer("ciliumendpointslice", ciliumEndpointSlicesStore)
+			l := &lock.Mutex{}
+			var deletedSet []string
+			fakeClient.PrependReactor("delete", "ciliumendpoints", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
+				l.Lock()
+				defer l.Unlock()
+				a := action.(k8stesting.DeleteAction)
+				deletedSet = append(deletedSet, fmt.Sprintf("%s/%s", a.GetNamespace(), a.GetName()))
+				return true, nil, nil
+			}))
+
+			epm := &fakeEPManager{test.managedEndpoints}
+
+			err := d.cleanStaleCEPs(context.Background(), epm, fakeClient.CiliumV2(), test.enableCES)
+
+			assert.NoError(err)
+			assert.ElementsMatch(test.expectedDeletedSet, deletedSet)
+		})
+	}
+}
+
+type fakeEPManager struct {
+	byPodName map[string]*endpoint.Endpoint
+}
+
+func (epm *fakeEPManager) LookupPodName(name string) *endpoint.Endpoint {
+	ep, ok := epm.byPodName[name]
+	if !ok {
+		return nil
+	}
+	return ep
+}
+
+func cep(name, ns, nodeIP string) types.CiliumEndpoint {
+	return types.CiliumEndpoint{
+		ObjectMeta: slimmetav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Networking: &ciliumv2.EndpointNetworking{
+			NodeIP: nodeIP,
+		},
+	}
+}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -681,6 +681,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		d.cgroupManager,
 	)
 	nd.RegisterK8sGetters(d.k8sWatcher)
+
 	d.ipcache.RegisterK8sSyncedChecker(&d)
 
 	d.k8sWatcher.RegisterNodeSubscriber(d.endpointManager)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1072,6 +1072,10 @@ func initializeFlags() {
 	flags.Bool(option.EnablePMTUDiscovery, false, "Enable path MTU discovery to send ICMP fragmentation-needed replies to the client")
 	option.BindEnv(Vp, option.EnablePMTUDiscovery)
 
+	flags.Bool(option.EnableStaleCiliumEndpointCleanup, true, "Enable running cleanup init procedure of local CiliumEndpoints which are not being managed.")
+	flags.MarkHidden(option.EnableStaleCiliumEndpointCleanup)
+	option.BindEnv(Vp, option.EnableStaleCiliumEndpointCleanup)
+
 	if err := Vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1750,6 +1750,23 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 		if restoreComplete != nil {
 			<-restoreComplete
 		}
+
+		if params.Clientset.IsEnabled() {
+			// Use restored endpoints to delete local CiliumEndpoints which are not in the restored endpoint cache.
+			// This will clear out any CiliumEndpoints that may be stale.
+			// Likely causes for this are Pods having their init container restarted or the node being restarted.
+			// This must wait for both K8s watcher caches to be synced and local endpoint restoration to be complete.
+			// Note: Synchronization of endpoints to their CEPs may not be complete at this point, but we only have to
+			// know what endpoints exist post-restoration in our endpointManager cache to perform cleanup.
+			if err := d.cleanStaleCEPs(context.Background(), d.endpointManager, params.Clientset.CiliumV2(), option.Config.EnableCiliumEndpointSlice); err != nil {
+				log.WithError(err).Error("Failed to clean up stale CEPs")
+			}
+		}
+	}()
+	go func() {
+		if restoreComplete != nil {
+			<-restoreComplete
+		}
 		d.dnsNameManager.CompleteBootstrap()
 
 		ms := maps.NewMapSweeper(&EndpointMapManager{

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1844,7 +1844,7 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 	d.startAgentHealthHTTPService()
 	if option.Config.KubeProxyReplacementHealthzBindAddr != "" {
 		if option.Config.KubeProxyReplacement != option.KubeProxyReplacementDisabled {
-			d.startKubeProxyHealthzHTTPService(fmt.Sprintf("%s", option.Config.KubeProxyReplacementHealthzBindAddr))
+			d.startKubeProxyHealthzHTTPService(option.Config.KubeProxyReplacementHealthzBindAddr)
 		}
 	}
 

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -147,9 +147,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 			},
 			func() datapath.Datapath { return fakeDatapath.NewDatapath() },
 		),
-
 		ControlPlane,
-
 		cell.Invoke(func(p promise.Promise[*Daemon]) {
 			daemonPromise = p
 		}),

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -127,11 +127,7 @@ func getEndpointNetworking(mdlNetworking *models.EndpointNetworking) (networking
 		Addressing: make(cilium_v2.AddressPairList, len(mdlNetworking.Addressing)),
 	}
 
-	if option.Config.EnableIPv4 {
-		networking.NodeIP = node.GetIPv4().String()
-	} else {
-		networking.NodeIP = node.GetIPv6().String()
-	}
+	networking.NodeIP = node.GetCiliumEndpointNodeIP()
 
 	for i, pair := range mdlNetworking.Addressing {
 		networking.Addressing[i] = &cilium_v2.AddressPair{

--- a/pkg/k8s/informer/informer.go
+++ b/pkg/k8s/informer/informer.go
@@ -54,6 +54,21 @@ func NewInformer(
 	return clientState, NewInformerWithStore(lw, objType, resyncPeriod, h, convertFunc, clientState)
 }
 
+// NewIndexerInformer is a copy of k8s.io/client-go/tools/cache/NewIndexerInformer with a new
+// argument which converts an object into another object that can be stored in
+// the local cache.
+func NewIndexerInformer(
+	lw cache.ListerWatcher,
+	objType k8sRuntime.Object,
+	resyncPeriod time.Duration,
+	h cache.ResourceEventHandler,
+	convertFunc ConvertFunc,
+	indexers cache.Indexers,
+) (cache.Indexer, cache.Controller) {
+	clientState := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, indexers)
+	return clientState, NewInformerWithStore(lw, objType, resyncPeriod, h, convertFunc, clientState)
+}
+
 // NewInformerWithStore uses the same arguments as NewInformer for which a
 // caller can also set a cache.Store.
 func NewInformerWithStore(

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -4,6 +4,7 @@
 package watchers
 
 import (
+	"fmt"
 	"net"
 	"sync"
 
@@ -32,7 +33,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient client.Clientset, asyncC
 	var once sync.Once
 	apiGroup := k8sAPIGroupCiliumEndpointV2
 	for {
-		_, ciliumEndpointInformer := informer.NewInformer(
+		cepIndexer, ciliumEndpointInformer := informer.NewIndexerInformer(
 			utils.ListerWatcherFromTyped[*cilium_v2.CiliumEndpointList](ciliumNPClient.CiliumV2().CiliumEndpoints("")),
 			&cilium_v2.CiliumEndpoint{},
 			0,
@@ -75,7 +76,13 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient client.Clientset, asyncC
 				},
 			},
 			k8s.ConvertToCiliumEndpoint,
+			cache.Indexers{
+				"localNode": CreateCiliumEndpointLocalPodIndexFunc(),
+			},
 		)
+		k.ciliumEndpointIndexerMU.Lock()
+		k.ciliumEndpointIndexer = cepIndexer
+		k.ciliumEndpointIndexerMU.Unlock()
 		isConnected := make(chan struct{})
 		// once isConnected is closed, it will stop waiting on caches to be
 		// synchronized.
@@ -111,7 +118,6 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 			k.policyManager.TriggerPolicyUpdates(true, "Named ports added or updated")
 		}
 	}()
-
 	var ipsAdded []string
 	if oldEndpoint != nil && oldEndpoint.Networking != nil {
 		// Delete the old IP addresses from the IP cache
@@ -232,5 +238,22 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 	}
 	if option.Config.EnableIPv4EgressGateway {
 		k.egressGatewayManager.OnDeleteEndpoint(endpoint)
+	}
+}
+
+// CreateCiliumEndpointLocalPodIndexFunc returns an IndexFunc that indexes only local
+// CiliumEndpoints, by their local Node IP.
+func CreateCiliumEndpointLocalPodIndexFunc() cache.IndexFunc {
+	nodeIP := node.GetCiliumEndpointNodeIP()
+	return func(obj interface{}) ([]string, error) {
+		cep, ok := obj.(*types.CiliumEndpoint)
+		if !ok {
+			return nil, fmt.Errorf("unexpected object type: %T", obj)
+		}
+		indices := []string{}
+		if cep.Networking.NodeIP == nodeIP {
+			indices = append(indices, cep.Networking.NodeIP)
+		}
+		return indices, nil
 	}
 }

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -251,6 +251,11 @@ func CreateCiliumEndpointLocalPodIndexFunc() cache.IndexFunc {
 			return nil, fmt.Errorf("unexpected object type: %T", obj)
 		}
 		indices := []string{}
+		if cep.Networking == nil {
+			log.WithField("ciliumendpoint", cep.GetNamespace()+"/"+cep.GetName()).
+				Debug("cannot index CiliumEndpoint by node without network status")
+			return nil, nil
+		}
 		if cep.Networking.NodeIP == nodeIP {
 			indices = append(indices, cep.Networking.NodeIP)
 		}

--- a/pkg/k8s/watchers/cilium_endpoint_slice.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice.go
@@ -4,17 +4,20 @@
 package watchers
 
 import (
+	"fmt"
 	"sync"
 
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
 	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/node"
 )
 
 var (
@@ -22,6 +25,26 @@ var (
 	// cepMap maps CEPName to CEBName.
 	cepMap = newCEPToCESMap()
 )
+
+// CreateCiliumEndpointSliceLocalPodIndexFunc returns an IndexFunc that indexes CiliumEndpointSlices
+// by their corresponding Pod, which are running locally on this Node.
+func CreateCiliumEndpointSliceLocalPodIndexFunc() cache.IndexFunc {
+	nodeIP := node.GetCiliumEndpointNodeIP()
+	return func(obj interface{}) ([]string, error) {
+		ces, ok := obj.(*v2alpha1.CiliumEndpointSlice)
+		if !ok {
+			return nil, fmt.Errorf("unexpected object type: %T", obj)
+		}
+		indices := []string{}
+		for _, ep := range ces.Endpoints {
+			if ep.Networking.NodeIP == nodeIP {
+				indices = append(indices, ep.Networking.NodeIP)
+				break
+			}
+		}
+		return indices, nil
+	}
+}
 
 func (k *K8sWatcher) ciliumEndpointSliceInit(client client.Clientset, asyncControllers *sync.WaitGroup) {
 	log.Info("Initializing CES controller")
@@ -31,7 +54,7 @@ func (k *K8sWatcher) ciliumEndpointSliceInit(client client.Clientset, asyncContr
 	cesNotify.Register(newCESSubscriber(k))
 
 	for {
-		_, cesInformer := informer.NewInformer(
+		cesIndexer, cesInformer := informer.NewIndexerInformer(
 			utils.ListerWatcherFromTyped[*cilium_v2a1.CiliumEndpointSliceList](
 				client.CiliumV2alpha1().CiliumEndpointSlices()),
 			&cilium_v2a1.CiliumEndpointSlice{},
@@ -59,7 +82,13 @@ func (k *K8sWatcher) ciliumEndpointSliceInit(client client.Clientset, asyncContr
 				},
 			},
 			nil,
+			cache.Indexers{
+				"localNode": CreateCiliumEndpointSliceLocalPodIndexFunc(),
+			},
 		)
+		k.ciliumEndpointSliceIndexerMU.Lock()
+		k.ciliumEndpointSliceIndexer = cesIndexer
+		k.ciliumEndpointSliceIndexerMU.Unlock()
 		isConnected := make(chan struct{})
 		// once isConnected is closed, it will stop waiting on caches to be
 		// synchronized.

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -268,6 +268,13 @@ type K8sWatcher struct {
 	ciliumNodeStoreMU lock.RWMutex
 	ciliumNodeStore   cache.Store
 
+	ciliumEndpointIndexerMU lock.RWMutex
+	ciliumEndpointIndexer   cache.Indexer
+
+	ciliumEndpointSliceIndexerMU lock.RWMutex
+	// note: this store only contains endpointslices referencing local endpoints.
+	ciliumEndpointSliceIndexer cache.Indexer
+
 	namespaceStore cache.Store
 	datapath       datapath.Datapath
 
@@ -975,7 +982,45 @@ func (k *K8sWatcher) K8sEventReceived(apiResourceName, scope, action string, val
 	k.k8sResourceSynced.SetEventTimestamp(apiResourceName)
 }
 
+// GetIndexer returns an index to a k8s cache store for the given resource name.
+// Objects gotten using returned stores should *not* be mutated as they
+// are references to internal k8s watcher store state.
+func (k *K8sWatcher) GetIndexer(name string) cache.Indexer {
+	switch name {
+	case "ciliumendpointslice":
+		k.ciliumEndpointSliceIndexerMU.RLock()
+		defer k.ciliumEndpointSliceIndexerMU.RUnlock()
+		return k.ciliumEndpointSliceIndexer
+	case "ciliumendpoint":
+		k.ciliumEndpointIndexerMU.RLock()
+		defer k.ciliumEndpointIndexerMU.RUnlock()
+		return k.ciliumEndpointIndexer
+	default:
+		panic("no such indexer: " + name)
+	}
+}
+
+// SetIndexer lets you set a named cache store, only used for testing.
+func (k *K8sWatcher) SetIndexer(name string, indexer cache.Indexer) {
+	switch name {
+	case "ciliumendpointslice":
+		k.ciliumEndpointSliceIndexerMU.Lock()
+		defer k.ciliumEndpointSliceIndexerMU.Unlock()
+		k.ciliumEndpointSliceIndexer = indexer
+	case "ciliumendpoint":
+		k.ciliumEndpointIndexerMU.Lock()
+		defer k.ciliumEndpointIndexerMU.Unlock()
+		k.ciliumEndpointIndexer = indexer
+	default:
+		panic("no such indexer: " + name)
+	}
+}
+
 // GetStore returns the k8s cache store for the given resource name.
+// It's possible for valid resource names to return nil stores if that
+// watcher is not in use.
+// Objects gotten using returned stores should *not* be mutated as they
+// are references to internal k8s watcher store state.
 func (k *K8sWatcher) GetStore(name string) cache.Store {
 	switch name {
 	case "networkpolicy":
@@ -989,8 +1034,16 @@ func (k *K8sWatcher) GetStore(name string) cache.Store {
 		k.podStoreMU.RLock()
 		defer k.podStoreMU.RUnlock()
 		return k.podStore
+	case "ciliumendpoint":
+		k.ciliumEndpointIndexerMU.RLock()
+		defer k.ciliumEndpointIndexerMU.RUnlock()
+		return k.ciliumEndpointIndexer
+	case "ciliumendpointslice":
+		k.ciliumEndpointSliceIndexerMU.RLock()
+		defer k.ciliumEndpointSliceIndexerMU.RUnlock()
+		return k.ciliumEndpointSliceIndexer
 	default:
-		return nil
+		panic("no such store: " + name)
 	}
 }
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -284,6 +284,15 @@ func GetIPv4() net.IP {
 	return clone(n.GetNodeIP(false))
 }
 
+// GetCiliumEndpointNodeIP is the node IP that will be referenced by CiliumEndpoints with endpoints
+// running on this node.
+func GetCiliumEndpointNodeIP() string {
+	if option.Config.EnableIPv4 {
+		return GetIPv4().String()
+	}
+	return GetIPv6().String()
+}
+
 // SetInternalIPv4Router sets the cilium internal IPv4 node address, it is allocated from the node prefix.
 // This must not be conflated with k8s internal IP as this IP address is only relevant within the
 // Cilium-managed network (this means within the node for direct routing mode and on the overlay

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1100,6 +1100,10 @@ const (
 	// BPFMapEventBuffers specifies what maps should have event buffers enabled,
 	// and the max size and TTL of events in the buffers should be.
 	BPFMapEventBuffers = "bpf-map-event-buffers"
+
+	// EnableStaleCiliumEndpointCleanup sets whether Cilium should perform cleanup of
+	// stale CiliumEndpoints during init.
+	EnableStaleCiliumEndpointCleanup = "enable-stale-cilium-endpoint-cleanup"
 )
 
 // Default string arguments
@@ -2255,6 +2259,11 @@ type DaemonConfig struct {
 	BPFMapEventBuffers          map[string]string
 	BPFMapEventBuffersValidator func(val string) (string, error) `json:"-"`
 	bpfMapEventConfigs          BPFEventBufferConfigs
+
+	// EnableStaleCiliumEndpointCleanup enables cleanup routine during Cilium init.
+	// This will attempt to remove local CiliumEndpoints that are not managed by Cilium
+	// following Endpoint restoration.
+	EnableStaleCiliumEndpointCleanup bool
 }
 
 var (
@@ -3246,6 +3255,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableICMPRules = vp.GetBool(EnableICMPRules)
 	c.BypassIPAvailabilityUponRestore = vp.GetBool(BypassIPAvailabilityUponRestore)
 	c.EnableK8sTerminatingEndpoint = vp.GetBool(EnableK8sTerminatingEndpoint)
+	c.EnableStaleCiliumEndpointCleanup = vp.GetBool(EnableStaleCiliumEndpointCleanup)
 
 	// Disable Envoy version check if L7 proxy is disabled.
 	c.DisableEnvoyVersionCheck = vp.GetBool(DisableEnvoyVersionCheck)

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -54,9 +54,7 @@ func startCiliumAgent(t *testing.T, nodeName string, clientset k8sClient.Clients
 			func() k8sClient.Clientset { return clientset },
 			func() datapath.Datapath { return fdp },
 		),
-
 		cmd.ControlPlane,
-
 		cell.Invoke(func(p promise.Promise[*cmd.Daemon]) {
 			daemonPromise = p
 		}),


### PR DESCRIPTION
It's possible for CiliumEndpoints to become stale where they still reference existing Pods that are no longer being managed by Cilium.
In this scenario, the operator will not GC these CEPs as they have a valid pod owner reference.
This commit adds an init cleanup which cleans up stale ceps. As well, cep/ces K8s watchers will mark such CEPs for deletion and a controller GC routine will periodically GC the old CEPs.

Fixes #17631

Background, we've seen some instances where Pods CEP have become stale & out-of-sync with the actual Pod they're meant to be managing. Particularly in the following two cases:

1. Pods somehow un-managed, while retaining their CEP. One way that this can happen (i.e. I reproduced by) if the /etc/cni... Cilium config files get removed and the Node is restarted and loses its Cilium bpf state. In this case the same Pod might get re-sandboxed with another CNI (i.e. if the containers have to be restarted). At this point you'll have a Pod with a CEP but no endpoint in the endpoint manager. In this situation the CEP IP and actual Pod IP are likely to differ since the Pod has been restarted under a different CNI. Controller will not GC as the Pod.UUID and owner reference have not changed.

2. Pod becomes un-managed due to lost state. This can happen if the bpf state gets deleted for an endpoint (such as with a temporary fs following a reboot). Once you restart the Cilium pod, upon restore the existing endpoint will not be restored. But, the Pod is still running with all the Cilium state still intact.

In both cases, the agent can determine if the CEP should be deleted by checking against it's managed endpoints. If none exist then we know that that Pod is unmanaged. Endpoints that are changed, such as in the case of a Pod container being killed will have its CiliumEndpoint eventually resynced via the k8s sync controller. 

```release-note
Added Agent init check that removes all CiliumEndpoints referencing local Node that are not managed. This fixes issues where sometimes CiliumEndpoints referencing still running Pods can become unmanaged during Cilium restart.
```