### PR TITLE
 fix identity gc  to return correct  max/min id

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -170,7 +170,7 @@ func NewAllocatorForGC(backend Backend, opts ...AllocatorOption) *Allocator {
 		fn(a)
 	}
 
-	return &Allocator{backend: backend}
+	return a
 }
 
 type GCStats struct {


### PR DESCRIPTION
Identity kvstore gc is not working with the following error:
```
Skipping this key" key=cilium/state/identities/v1/id/14142 reason="out of local cluster identity range [0,0]"
```
NewAllocatorForGC returns incorrect min/max ids.