### PR TITLE
endpointmanager: Add extra check for out-of-range endpoint IDs

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -248,6 +248,9 @@ func (mgr *EndpointManager) Lookup(id string) (*endpoint.Endpoint, error) {
 		if err != nil {
 			return nil, err
 		}
+		if n > endpointid.MaxEndpointId {
+			return nil, fmt.Errorf("%d: endpoint ID too large", n)
+		}
 		return mgr.lookupCiliumID(uint16(n)), nil
 
 	case endpointid.CiliumGlobalIdPrefix:


### PR DESCRIPTION
Fixes the "Incorrect conversion between integer types" identified by CodeQL in https://github.com/cilium/cilium/pull/20345/checks?check_run_id=7110673804.