### PR TITLE
Restore patch in ciliumnetworkpolicies/status ClusterRole

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -109,6 +109,7 @@ rules:
   - ciliumclusterwidenetworkpolicies/status
   verbs:
   # Update the auto-generated CNPs and CCNPs status.
+  - patch
   - update
 - apiGroups:
   - cilium.io


### PR DESCRIPTION
The PR restores a missing verb (`patch`) in cilium-operator ClusterRole template.
The permission was removed in https://github.com/cilium/cilium/commit/10a96dd2659d5a79a10fc687a435ce8bb086928c, but the cilium operator periodic GC needs that to patch the status.nodes field in the ClusterNetworkPolicies when `option.Config.DisableCNPStatusUpdates` is set to `false` and `operatorOption.Config.CNPNodeStatusGCInterval` is greater than `0`.