### PR TITLE
docs: Remove limitation on L7 visibility docs

### DIFF
--- a/Documentation/policy/visibility.rst
+++ b/Documentation/policy/visibility.rst
@@ -93,8 +93,3 @@ Limitations
 * Visibility annotations do not apply if rules are imported which select the pod
   which is annotated.
 * DNS visibility is available on egress only.
-* Proxylib parsers are not supported, including Kafka. To gain visibility on
-  these protocols, you must create a network policy that allows all of the
-  traffic at L7, either by following :ref:`l7_policy`
-  (:ref:`Kafka <kafka_policy>`) or the :ref:`envoy` proxylib extensions guide.
-  This limitation is tracked by :gh-issue:`14072`.


### PR DESCRIPTION
The underlying GitHub issue is fixed and released.

Thanks to @trvll to contribute the changes, and highlight docs
update.

Signed-off-by: Tam Mach <tam.mach@cilium.io>
