### PR TITLE
images, contrib/coccinelle: update alpine image to 3.16.0

### DIFF
--- a/contrib/coccinelle/Dockerfile
+++ b/contrib/coccinelle/Dockerfile
@@ -1,6 +1,4 @@
-# Do not upgrade to alpine 3.13 as its nslookup tool returns 1, instead of 0
-# for domain name lookups.
-FROM docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
+FROM docker.io/library/alpine:3.16.0@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
 
 LABEL maintainer="maintainer@cilium.io"
 

--- a/images/clustermesh-apiserver/Dockerfile
+++ b/images/clustermesh-apiserver/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG BASE_IMAGE=scratch
 ARG GOLANG_IMAGE=docker.io/library/golang:1.18.3@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef
-ARG ALPINE_IMAGE=docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
+ARG ALPINE_IMAGE=docker.io/library/alpine:3.16.0@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG BASE_IMAGE=scratch
 ARG GOLANG_IMAGE=docker.io/library/golang:1.18.3@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef
-ARG ALPINE_IMAGE=docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
+ARG ALPINE_IMAGE=docker.io/library/alpine:3.16.0@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG BASE_IMAGE=scratch
 ARG GOLANG_IMAGE=docker.io/library/golang:1.18.3@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef
-ARG ALPINE_IMAGE=docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
+ARG ALPINE_IMAGE=docker.io/library/alpine:3.16.0@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/images/scripts/update-alpine-image.sh
+++ b/images/scripts/update-alpine-image.sh
@@ -19,9 +19,7 @@ root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
 
-# Do not upgrade to alpine 3.13 as its nslookup tool returns 1, instead of 0
-# for domain name lookups.
-alpine_version=3.12.7
+alpine_version=3.16.0
 
 image="${1:-docker.io/library/alpine:${alpine_version}}"
 


### PR DESCRIPTION
Since alpine 3.12 is EOL and was recently dropped from docker official
images [1], update our images to alpine 3.16.0 which is currently the
most recent version.

[1] https://github.com/docker-library/official-images/pull/12477

The comment about nslookup stems from PR #15950, but none of the images
seem to use nslookup. We only use these images for ca-certificates and
python/bash, respectively.
