### PR TITLE
pkg/k8s/version: Also set EndpointSlice when forcing version

### DIFF
--- a/pkg/k8s/version/version.go
+++ b/pkg/k8s/version/version.go
@@ -87,6 +87,10 @@ var (
 	// discovery was introduced in K8s version 1.21.
 	isGEThanAPIDiscoveryV1 = versioncheck.MustCompile(">=1.21.0")
 
+	// Constraint to check support for discovery/v1beta1 types. Support for
+	// v1beta1 discovery was introduced in K8s version 1.17.
+	isGEThanAPIDiscoveryV1Beta1 = versioncheck.MustCompile(">=1.17.0")
+
 	// isGEThanMinimalVersionConstraint is the minimal version required to run
 	// Cilium
 	isGEThanMinimalVersionConstraint = versioncheck.MustCompile(">=" + MinimalVersionConstraint)
@@ -117,6 +121,7 @@ func updateVersion(version semver.Version) {
 	cached.capabilities.MinimalVersionMet = isGEThanMinimalVersionConstraint(version)
 	cached.capabilities.APIExtensionsV1CRD = isGEThanAPIExtensionsV1CRD(version)
 	cached.capabilities.EndpointSliceV1 = isGEThanAPIDiscoveryV1(version)
+	cached.capabilities.EndpointSlice = isGEThanAPIDiscoveryV1Beta1(version)
 }
 
 func updateServerGroupsAndResources(apiResourceLists []*metav1.APIResourceList) {


### PR DESCRIPTION
For control-plane testing with fake k8s clients we need to
forcefully set the capabilities instead of probing. This
fixes the enabling of the EndpointSlice capability when
EndpointSliceV1 is true.

Fixes: 7a1039f414 ("k8s: Consolidate check for EndpointSlice support")