### PR TITLE
Aspsk/pr/better error reporting for cilium monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,9 @@ define generate_k8s_protobuf
 	    --go-header-file "$(PWD)/hack/custom-boilerplate.go.txt"
 endef
 
-build: $(SUBDIRS) ## Builds all the components for Cilium by executing make in the respective sub directories.
+build: check-sources $(SUBDIRS) ## Builds all the components for Cilium by executing make in the respective sub directories.
 
-build-container: ## Builds components required for cilium-agent container.
+build-container: check-sources ## Builds components required for cilium-agent container.
 	for i in $(SUBDIRS_CILIUM_CONTAINER); do $(MAKE) $(SUBMAKEOPTS) -C $$i all; done
 
 $(SUBDIRS): force ## Execute default make target(make all) for the provided subdirectory.
@@ -550,6 +550,10 @@ endif
 	@$(ECHO_CHECK) contrib/scripts/rand-check.sh
 	$(QUIET) contrib/scripts/rand-check.sh
 
+check-sources:
+	@$(ECHO_CHECK) pkg/datapath/loader/check-sources.sh
+	$(QUIET) pkg/datapath/loader/check-sources.sh
+
 pprof-heap: ## Get Go pprof heap profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/heap
 
@@ -645,5 +649,5 @@ help: ## Display help for the Makefile, from https://www.thapaliya.com/en/writin
 	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(alibabacloud, aws, azure, generic)")
 	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
 
-.PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-hubble-api install licenses-all veryclean
+.PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-hubble-api install licenses-all veryclean check-sources
 force :;

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -26,7 +26,9 @@ struct drop_notify {
 	__u32		src_label;
 	__u32		dst_label;
 	__u32		dst_id;
-	__u32		unused;
+	__u16		line;
+	__u8		file;
+	__u8		unused;
 };
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_DROP_NOTIFY)
@@ -36,6 +38,10 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 	int error = ctx_load_meta(ctx, 2) & 0xFFFFFFFF;
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, TRACE_PAYLOAD_LEN, ctx_len);
+	__u32 meta4 = ctx_load_meta(ctx, 4);
+	__u16 line = (__u16)(meta4 >> 16);
+	__u8 file = (__u8)(meta4 >> 8);
+	__u8 exitcode = (__u8)meta4;
 	struct drop_notify msg;
 
 	if (error < 0)
@@ -47,13 +53,15 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 		.src_label	= ctx_load_meta(ctx, 0),
 		.dst_label	= ctx_load_meta(ctx, 1),
 		.dst_id		= ctx_load_meta(ctx, 3),
+		.line           = line,
+		.file           = file,
 	};
 
 	ctx_event_output(ctx, &EVENTS_MAP,
 			 (cap_len << 32) | BPF_F_CURRENT_CPU,
 			 &msg, sizeof(msg));
 
-	return ctx_load_meta(ctx, 4);
+	return exitcode;
 }
 
 /**
@@ -70,14 +78,21 @@ int __send_drop_notify(struct __ctx_buff *ctx)
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
 static __always_inline int
-send_drop_notify(struct __ctx_buff *ctx, __u32 src, __u32 dst, __u32 dst_id,
-		 int reason, int exitcode, enum metric_dir direction)
+_send_drop_notify(__u8 file, __u16 line, struct __ctx_buff *ctx,
+		  __u32 src, __u32 dst, __u32 dst_id,
+		  int reason, __u32 exitcode, enum metric_dir direction)
 {
+	/* These fields should be constants and fit (together) in 32 bits */
+	if (!__builtin_constant_p(exitcode) || exitcode > 0xff ||
+	    !__builtin_constant_p(file) || file > 0xff ||
+	    !__builtin_constant_p(line) || line > 0xffff)
+		__throw_build_bug();
+
 	ctx_store_meta(ctx, 0, src);
 	ctx_store_meta(ctx, 1, dst);
 	ctx_store_meta(ctx, 2, reason);
 	ctx_store_meta(ctx, 3, dst_id);
-	ctx_store_meta(ctx, 4, exitcode);
+	ctx_store_meta(ctx, 4, exitcode | file << 8 | line << 16);
 
 	update_metrics(ctx_full_len(ctx), direction, (__u8)-reason);
 	ep_tail_call(ctx, CILIUM_CALL_DROP_NOTIFY);
@@ -86,20 +101,29 @@ send_drop_notify(struct __ctx_buff *ctx, __u32 src, __u32 dst, __u32 dst_id,
 }
 #else
 static __always_inline
-int send_drop_notify(struct __ctx_buff *ctx, __u32 src __maybe_unused,
-		     __u32 dst __maybe_unused, __u32 dst_id __maybe_unused,
-		     int reason, int exitcode, enum metric_dir direction)
+int _send_drop_notify(__u8 file __maybe_unused, __u16 line __maybe_unused,
+		      struct __ctx_buff *ctx, __u32 src __maybe_unused,
+		      __u32 dst __maybe_unused, __u32 dst_id __maybe_unused,
+		      int reason, __u32 exitcode, enum metric_dir direction)
 {
 	update_metrics(ctx_full_len(ctx), direction, (__u8)-reason);
 	return exitcode;
 }
 #endif /* DROP_NOTIFY */
 
-static __always_inline int send_drop_notify_error(struct __ctx_buff *ctx, __u32 src,
-						  int error, int exitcode,
-						  enum metric_dir direction)
+static __always_inline int _send_drop_notify_error(__u8 file, __u16 line,
+						   struct __ctx_buff *ctx, __u32 src,
+						   int error, __u32 exitcode,
+						   enum metric_dir direction)
 {
-	return send_drop_notify(ctx, src, 0, 0, error, exitcode, direction);
+	return _send_drop_notify(file, line, ctx, src, 0, 0, error, exitcode, direction);
 }
+
+#ifndef __MAGIC_FILE__
+#define __MAGIC_FILE__ 0
+#endif
+
+#define send_drop_notify(...) _send_drop_notify(__MAGIC_FILE__, __LINE__, __VA_ARGS__)
+#define send_drop_notify_error(...) _send_drop_notify_error(__MAGIC_FILE__, __LINE__, __VA_ARGS__)
 
 #endif /* __LIB_DROP__ */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -418,7 +418,7 @@ static __always_inline int xlate_dsr_v6(struct __ctx_buff *ctx,
 }
 
 static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
-					   struct ipv6hdr *ip6 __maybe_unused,
+					   const struct ipv6hdr *ip6 __maybe_unused,
 					   int code, int ohead __maybe_unused)
 {
 #ifdef ENABLE_DSR_ICMP_ERRORS

--- a/pkg/datapath/loader/check-sources.sh
+++ b/pkg/datapath/loader/check-sources.sh
@@ -1,0 +1,26 @@
+#! /bin/bash -efu
+
+#
+# This simple awk command extracts file names from the sourceNameToId map definition
+#
+defined_files=$(
+  awk -F: '/^var sourceNameToId/{found=1; next} {if (!found) next} /^}/{exit} {gsub(/"|\t/, "", $1); print $1}' pkg/datapath/loader/compile.go
+)
+
+#
+# Now we need to find all the C files in the bpf/ directory
+# and check if all of them were defined in the map
+#
+required_files=$(
+	find bpf/ -maxdepth 1 -name '*.c' | xargs -n1 basename
+)
+
+retval=0
+for f in $required_files; do
+	if ! grep --silent -w "$f" <<<"$defined_files"; then
+		echo "$0: $f is not defined, add its mapping to the sourceNameToId map" >&2
+		retval=1
+	fi
+done
+
+exit $retval

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -288,6 +288,44 @@ func progCFlags(prog *progInfo, dir *directoryInfo) []string {
 	)
 }
 
+// We need to map all bpf/*.c files to ids (an id value doesn't matter, but
+// should be a unique non-zero __u8 number).  A build will fail if there is
+// a file found for which there is no a corresponding id.
+var sourceNameToId map[string]int = map[string]int{
+	"bpf_network.c":            1,
+	"bpf_sock.c":               2,
+	"bpf_host.c":               3,
+	"bpf_overlay.c":            4,
+	"bpf_xdp.c":                5,
+	"bpf_alignchecker.c":       6,
+	"cilium-probe-kernel-hz.c": 7,
+	"bpf_lxc.c":                8,
+}
+
+var idToSourceName map[int]string
+
+func encodeSourceName(sourceName string) int {
+	if id, ok := sourceNameToId[sourceName]; ok {
+		return id
+	}
+	return 0
+}
+
+func DecodeSourceName(id int) string {
+	// auto-generate idToSourceName to simplify updates of the list
+	if idToSourceName == nil {
+		idToSourceName = make(map[int]string)
+		for sourceName, id := range sourceNameToId {
+			idToSourceName[id] = sourceName
+		}
+	}
+
+	if sourceName, ok := idToSourceName[id]; ok {
+		return sourceName
+	}
+	return "unknown"
+}
+
 // compile and link a program.
 func compile(ctx context.Context, prog *progInfo, dir *directoryInfo) (err error) {
 	args := make([]string, 0, 16)
@@ -300,6 +338,7 @@ func compile(ctx context.Context, prog *progInfo, dir *directoryInfo) (err error
 
 	args = append(args, standardCFlags...)
 	args = append(args, prog.Options...)
+	args = append(args, fmt.Sprintf("-D__MAGIC_FILE__=%d", encodeSourceName(prog.Source)))
 	args = append(args, progCFlags(prog, dir)...)
 
 	// Compilation is split between two exec calls. First clang generates

--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -81,10 +81,25 @@ var errors = map[uint8]string{
 	183: "Incorrect VNI from VTEP",
 }
 
+func extendedReason(reason uint8, extError int8) string {
+	if extError == int8(0) {
+		return ""
+	}
+	return fmt.Sprintf("%d", extError)
+}
+
+func DropReasonExt(reason uint8, extError int8) string {
+	if err, ok := errors[reason]; ok {
+		if ext := extendedReason(reason, extError); ext == "" {
+			return err
+		} else {
+			return err + ", " + ext
+		}
+	}
+	return fmt.Sprintf("%d, %d", reason, extError)
+}
+
 // DropReason prints the drop reason in a human readable string
 func DropReason(reason uint8) string {
-	if err, ok := errors[reason]; ok {
-		return err
-	}
-	return fmt.Sprintf("%d", reason)
+	return DropReasonExt(reason, int8(0))
 }

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -32,7 +32,7 @@ type DropNotify struct {
 	DstID    uint32
 	Line     uint16
 	File     uint8
-	Unused   uint8
+	ExtError int8
 	// data
 }
 

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -50,7 +50,7 @@ func (n *DropNotify) dumpIdentity(buf *bufio.Writer, numeric DisplayFormat) {
 func (n *DropNotify) DumpInfo(data []byte, numeric DisplayFormat) {
 	buf := bufio.NewWriter(os.Stdout)
 	fmt.Fprintf(buf, "xx drop (%s) flow %#x to endpoint %d, file %s line %d, ",
-		api.DropReason(n.SubType), n.Hash, n.DstID, loader.DecodeSourceName(int(n.File)), int(n.Line))
+		api.DropReasonExt(n.SubType, n.ExtError), n.Hash, n.DstID, loader.DecodeSourceName(int(n.File)), int(n.Line))
 	n.dumpIdentity(buf, numeric)
 	fmt.Fprintf(buf, ": %s\n", GetConnectionSummary(data[DropNotifyLen:]))
 	buf.Flush()
@@ -60,7 +60,7 @@ func (n *DropNotify) DumpInfo(data []byte, numeric DisplayFormat) {
 func (n *DropNotify) DumpVerbose(dissect bool, data []byte, prefix string, numeric DisplayFormat) {
 	buf := bufio.NewWriter(os.Stdout)
 	fmt.Fprintf(buf, "%s MARK %#x FROM %d DROP: %d bytes, reason %s",
-		prefix, n.Hash, n.Source, n.OrigLen, api.DropReason(n.SubType))
+		prefix, n.Hash, n.Source, n.OrigLen, api.DropReasonExt(n.SubType, n.ExtError))
 
 	if n.SrcLabel != 0 || n.DstLabel != 0 {
 		n.dumpIdentity(buf, numeric)
@@ -121,7 +121,7 @@ func DropNotifyToVerbose(n *DropNotify) DropNotifyVerbose {
 	return DropNotifyVerbose{
 		Type:     "drop",
 		Mark:     fmt.Sprintf("%#x", n.Hash),
-		Reason:   api.DropReason(n.SubType),
+		Reason:   api.DropReasonExt(n.SubType, n.ExtError),
 		Source:   n.Source,
 		Bytes:    n.OrigLen,
 		SrcLabel: n.SrcLabel,


### PR DESCRIPTION
This PR adds the following verbosity to drop notification messages:
  * add source file name information
  * add source line information
  * pass an extra error code (and implement this for `DROP_NO_FIB` type of notificatoins

See the individual commits for a more detailed description.

Fixes: #12842

```release-note
Improve verbosity of drop notification messages.
```
