### PR TITLE
ctmap: Do not use nil locks

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -343,8 +343,10 @@ func purgeCtEntry6(m *Map, key CtKey, natMap *nat.Map) error {
 // filter.
 func doGC6(m *Map, filter *GCFilter) gcStats {
 	ctMap := mapInfo[m.mapType]
-	ctMap.natMapLock.Lock()
-	defer ctMap.natMapLock.Unlock()
+	if ctMap.natMapLock != nil {
+		ctMap.natMapLock.Lock()
+		defer ctMap.natMapLock.Unlock()
+	}
 	natMap := ctMap.natMap
 	stats := statStartGc(m)
 	defer stats.finish()
@@ -426,8 +428,10 @@ func purgeCtEntry4(m *Map, key CtKey, natMap *nat.Map) error {
 // filter.
 func doGC4(m *Map, filter *GCFilter) gcStats {
 	ctMap := mapInfo[m.mapType]
-	ctMap.natMapLock.Lock()
-	defer ctMap.natMapLock.Unlock()
+	if ctMap.natMapLock != nil {
+		ctMap.natMapLock.Lock()
+		defer ctMap.natMapLock.Unlock()
+	}
 	natMap := ctMap.natMap
 	stats := statStartGc(m)
 	defer stats.finish()
@@ -586,8 +590,10 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 	// Both CT maps should point to the same natMap, so use the first one
 	// to determine natMap
 	ctMap := mapInfo[ctMapTCP.mapType]
-	ctMap.natMapLock.Lock()
-	defer ctMap.natMapLock.Unlock()
+	if ctMap.natMapLock != nil {
+		ctMap.natMapLock.Lock()
+		defer ctMap.natMapLock.Unlock()
+	}
 	natMap := ctMap.natMap
 	if natMap == nil {
 		return nil


### PR DESCRIPTION
natMapLock is nil for local CT maps and attempting to access a nil lock results in a SIGSEGV:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1d6df5b]

goroutine 1358 [running]:
github.com/cilium/cilium/pkg/maps/ctmap.doGC4(0xc004c510e0, 0xc00284ffa8)
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/ctmap.go:429 +0xbb
github.com/cilium/cilium/pkg/maps/ctmap.doGC(0x10?, 0x2aecbc0?)
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/ctmap.go:532 +0xf1
github.com/cilium/cilium/pkg/maps/ctmap.GC(0xc0045a80f0?, 0xc00284ffa8?)
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/ctmap.go:552 +0x6c
github.com/cilium/cilium/pkg/maps/ctmap/gc.runGC(0xc0044a9180, 0x1, 0x1, 0x0, 0x1?)
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/gc/gc.go:195 +0x54f
github.com/cilium/cilium/pkg/maps/ctmap/gc.Enable.func1()
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/gc/gc.go:103 +0x646
created by github.com/cilium/cilium/pkg/maps/ctmap/gc.Enable
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/gc/gc.go:45 +0x231
```

Fix this by only attempting to lock if the lock is not nil.

Fixes: #18952