### PR TITLE
nodediscovery: make LocalNode return a deep copy of localNode

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -692,7 +692,7 @@ func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath
 			// nodeUpdate(), which is responsible for updating the
 			// IPSec policies and states for all the different EPs
 			// with ipsec.UpsertIPsecEndpoint()
-			nodeHandler.NodeValidateImplementation(nodediscovery.LocalNode())
+			nodeHandler.NodeValidateImplementation(*nodediscovery.LocalNode())
 
 			// Publish the updated node information to k8s/KVStore
 			nodediscovery.UpdateLocalNode()

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -327,12 +327,12 @@ func (n *NodeDiscovery) UpdateLocalNode() {
 
 // LocalNode syncs the localNode object with the information stored in the node
 // package and then returns a copy of the localNode object
-func (n *NodeDiscovery) LocalNode() types.Node {
+func (n *NodeDiscovery) LocalNode() *types.Node {
 	n.localNodeLock.Lock()
 	defer n.localNodeLock.Unlock()
 
 	n.fillLocalNode()
-	return n.localNode
+	return n.localNode.DeepCopy()
 }
 
 // Close shuts down the node discovery engine


### PR DESCRIPTION
as that object contains a few slices that will get modified after
StartDiscovery() is called