### PR TITLE
[v1.10] Consider VPC's secondary CIDRs during cilium_host IP restoration

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -269,27 +269,31 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 // that the most up-to-date information has been retrieved. At this point, the
 // daemon is aware of all the necessary information to restore the appropriate
 // IP.
-func restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
+func (d *Daemon) restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
 	var (
-		cidr   *cidr.CIDR
+		cidrs  []*cidr.CIDR
 		fromFS net.IP
 	)
 
 	if ipv6 {
-		cidr = node.GetIPv6AllocRange()
+		cidrs = []*cidr.CIDR{node.GetIPv6AllocRange()}
 		fromFS = node.GetIPv6Router()
 	} else {
 		switch option.Config.IPAMMode() {
-		case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
-			// The native routing CIDR is the pod CIDR in these IPAM modes.
-			cidr = option.Config.IPv4NativeRoutingCIDR()
+		case ipamOption.IPAMCRD:
+			// The native routing CIDR is the pod CIDR in CRD mode.
+			cidrs = []*cidr.CIDR{option.Config.IPv4NativeRoutingCIDR()}
+		case ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
+			// d.startIPAM() has already been called at this stage to initialize sharedNodeStore with ownNode info
+			// needed for GetVpcCIDRs()
+			cidrs = d.ipam.GetVpcCIDRs()
 		default:
-			cidr = node.GetIPv4AllocRange()
+			cidrs = []*cidr.CIDR{node.GetIPv4AllocRange()}
 		}
 		fromFS = node.GetInternalIPv4Router()
 	}
 
-	restoredIP := node.RestoreHostIPs(ipv6, fromK8s, fromFS, cidr)
+	restoredIP := node.RestoreHostIPs(ipv6, fromK8s, fromFS, cidrs)
 	if err := removeOldRouterState(restoredIP); err != nil {
 		log.WithError(err).Warnf(
 			"Failed to remove old router IPs (restored IP: %s) from cilium_host. Manual intervention is required to remove all other old IPs.",
@@ -857,17 +861,16 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 	// Start IPAM
 	d.startIPAM()
-
 	// After the IPAM is started, in particular IPAM modes (CRD, ENI, Alibaba)
 	// which use the VPC CIDR as the pod CIDR, we must attempt restoring the
 	// router IPs from the K8s resources if we weren't able to restore them
 	// from the fs. We must do this after IPAM because we must wait until the
 	// K8s resources have been synced. Part 2/2 of restoration.
 	if option.Config.EnableIPv4 {
-		restoreCiliumHostIPs(false, router4FromK8s)
+		d.restoreCiliumHostIPs(false, router4FromK8s)
 	}
 	if option.Config.EnableIPv6 {
-		restoreCiliumHostIPs(true, router6FromK8s)
+		d.restoreCiliumHostIPs(true, router6FromK8s)
 	}
 
 	// restore endpoints before any IPs are allocated to avoid eventual IP

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -17,6 +17,7 @@ package ipam
 import (
 	"net"
 
+	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/lock"
 
@@ -124,4 +125,20 @@ func (ipam *IPAM) DebugStatus() string {
 	str := spew.Sdump(ipam)
 	ipam.allocatorMutex.RUnlock()
 	return str
+}
+
+// GetVpcCIDRs returns all the CIDRs associated with the VPC this node belongs to.
+// This works only cloud provider IPAM modes and returns nil for other modes.
+// sharedNodeStore must be initialized before calling this method.
+func (ipam *IPAM) GetVpcCIDRs() (vpcCIDRs []*cidr.CIDR) {
+	sharedNodeStore.mutex.RLock()
+	defer sharedNodeStore.mutex.RUnlock()
+	primary, secondary := deriveVpcCIDRs(sharedNodeStore.ownNode)
+	if primary == nil {
+		return nil
+	}
+	if secondary == nil {
+		return []*cidr.CIDR{primary}
+	}
+	return append(secondary, primary)
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -182,8 +182,11 @@ const (
 	// IPv6CIDRs is a list of IPv6 CIDRs
 	IPv6CIDRs = "ipv6CIDRs"
 
-	// CIDR is a IPv4/IPv4 subnet/CIDR
+	// CIDR is a IPv4/IPv6 subnet/CIDR
 	CIDR = "cidr"
+
+	// CIDRS is a list of IPv4/IPv6 CIDRs
+	CIDRS = "cidrs"
 
 	// IPAddrs is a lsit of IP addrs
 	IPAddrs = "ipAddrs"

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -386,7 +386,7 @@ func AutoComplete() error {
 // If not, then the router IP is discarded and not restored.
 //
 // The restored IP is returned.
-func RestoreHostIPs(ipv6 bool, fromK8s, fromFS net.IP, cidr *cidr.CIDR) net.IP {
+func RestoreHostIPs(ipv6 bool, fromK8s, fromFS net.IP, cidrs []*cidr.CIDR) net.IP {
 	if !option.Config.EnableHostIPRestore {
 		return nil
 	}
@@ -400,11 +400,11 @@ func RestoreHostIPs(ipv6 bool, fromK8s, fromFS net.IP, cidr *cidr.CIDR) net.IP {
 		setter = SetInternalIPv4Router
 	}
 
-	ip, err := chooseHostIPsToRestore(ipv6, fromK8s, fromFS, cidr)
+	ip, err := chooseHostIPsToRestore(ipv6, fromK8s, fromFS, cidrs)
 	switch {
 	case err != nil && errors.Is(err, errDoesNotBelong):
 		log.WithFields(logrus.Fields{
-			logfields.CIDR: cidr,
+			logfields.CIDRS: cidrs,
 		}).Infof(
 			"The router IP (%s) considered for restoration does not belong in the Pod CIDR of the node. Discarding old router IP.",
 			ip,
@@ -426,7 +426,7 @@ func RestoreHostIPs(ipv6 bool, fromK8s, fromFS net.IP, cidr *cidr.CIDR) net.IP {
 	return ip
 }
 
-func chooseHostIPsToRestore(ipv6 bool, fromK8s, fromFS net.IP, cidr *cidr.CIDR) (ip net.IP, err error) {
+func chooseHostIPsToRestore(ipv6 bool, fromK8s, fromFS net.IP, cidrs []*cidr.CIDR) (ip net.IP, err error) {
 	switch {
 	// If both IPs are available, then check both for validity. We prefer the
 	// local IP from the FS over the K8s IP.
@@ -441,11 +441,13 @@ func chooseHostIPsToRestore(ipv6 bool, fromK8s, fromFS net.IP, cidr *cidr.CIDR) 
 			// case that the IP from the FS is not within the CIDR. If we
 			// fallback, then we also need to check the fromK8s IP is also
 			// within the CIDR.
-			if cidr != nil && cidr.Contains(ip) {
-				return
-			} else if cidr != nil && cidr.Contains(fromK8s) {
-				ip = fromK8s
-				return
+			for _, cidr := range cidrs {
+				if cidr != nil && cidr.Contains(ip) {
+					return
+				} else if cidr != nil && cidr.Contains(fromK8s) {
+					ip = fromK8s
+					return
+				}
 			}
 		}
 	case fromK8s == nil && fromFS != nil:
@@ -458,8 +460,10 @@ func chooseHostIPsToRestore(ipv6 bool, fromK8s, fromFS net.IP, cidr *cidr.CIDR) 
 		return
 	}
 
-	if cidr != nil && cidr.Contains(ip) {
-		return
+	for _, cidr := range cidrs {
+		if cidr != nil && cidr.Contains(ip) {
+			return
+		}
 	}
 
 	err = errDoesNotBelong

--- a/pkg/node/address_test.go
+++ b/pkg/node/address_test.go
@@ -135,7 +135,7 @@ func (s *NodeSuite) Test_chooseHostIPsToRestore(c *C) {
 	}
 	for _, tt := range tests {
 		c.Log("Test: " + tt.name)
-		got, err := chooseHostIPsToRestore(tt.ipv6, tt.fromK8s, tt.fromFS, tt.cidr)
+		got, err := chooseHostIPsToRestore(tt.ipv6, tt.fromK8s, tt.fromFS, []*cidr.CIDR{tt.cidr})
 		if tt.expect == nil {
 			// If we don't expect to change it, set it to what's currently the
 			// router IP.


### PR DESCRIPTION
This is a custom v1.10 backport of 

- #19341 by @hemanthmalla 

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19341; do contrib/backporting/set-labels.py $pr done 1.10; done
```