### PR TITLE
dnsproxy: split MatchPattern and MatchName to improve perf

### DIFF
--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -9,6 +9,7 @@
 package restore
 
 import (
+	"encoding/json"
 	"regexp"
 	"sort"
 )
@@ -35,7 +36,13 @@ type RuleRegex struct {
 // Sorts in place, but returns IPRules for convenience
 func (r IPRules) Sort() IPRules {
 	sort.SliceStable(r, func(i, j int) bool {
-		return r[i].Re.String() < r[j].Re.String()
+		if r[i].Re.Regexp != nil {
+			return false
+		}
+		if r[j].Re.Regexp != nil {
+			return true
+		}
+		return r[i].Re.Regexp.String() < r[j].Re.String()
 	})
 	return r
 }
@@ -63,10 +70,10 @@ func (r *RuleRegex) UnmarshalText(b []byte) error {
 	return nil
 }
 
-// MarshalText marshals RuleRegex as string
-func (r RuleRegex) MarshalText() ([]byte, error) {
-	if r.Regexp != nil {
-		return []byte(r.Regexp.String()), nil
+// MarshalJSON marshals RuleRegex as nullable string
+func (r RuleRegex) MarshalJSON() ([]byte, error) {
+	if r.Regexp == nil {
+		return json.Marshal(nil)
 	}
-	return nil, nil
+	return json.Marshal(r.Regexp.String())
 }

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -21,8 +21,9 @@ type IPRules []IPRule
 
 // IPRule stores the allowed destination IPs for a DNS names matching a regex
 type IPRule struct {
-	Re  RuleRegex
-	IPs map[string]struct{} // IPs, nil set is wildcard and allows all IPs!
+	Re    RuleRegex
+	FQDNs map[string]struct{} // List of allowed fqdns
+	IPs   map[string]struct{} // IPs, nil set is wildcard and allows all IPs!
 }
 
 // RuleRegex is a wrapper for *regexp.Regexp so that we can define marshalers for it.


### PR DESCRIPTION
Commit msg;
```
This makes a distinction between matchNames and matchPatterns, and only
puts the matchPatterns with wildcards into the regex used to check if
dns queries are allowed or not. For the matchNames, that are plain
FQDNs, we add them to a map for easy and fast lookup. This means that
when a DNS query arrives, we first check the map, and if its not
present, we check the with the regex.

Also, this introduce a reference counted cache/index for regexes and for
the maps including the FQDNs. This means that policies with the same set
of matchNames can reuse the same map, and policies with the same
matchPatterns can reuse the same regex. This yields a huge memory
saving, since long regex tends to occupy a lot of memory.

This also makes the LRU cache for compiled regexes more or less
redundant, mitigating the drawbacks of that cache. Having a large LRU
cache is useful when a lot of similar policies are in use at the same
time, but in case a node have a small set of policies inserted at the
same time, but the churn makes new and distinct policies come and go,
the LRU cache will use a lot more memory than the benefit it gives.

benchmark TL;DR: Heap usage compared to a LRU size of 128 is down by
~99%, and ~92% with a LRU size of 1024, with the given test data*.

* defining heap usage as (HeapInuse after test) - (HeapInuse before setup)

$ go test -tags privileged_tests -v -run '^$' -bench Benchmark_perEPAllow_setPortRulesForID_large -benchmem -benchtime 1x ./pkg/fqdn/dnsproxy

// With this change;

goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/fqdn/dnsproxy
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Benchmark_perEPAllow_setPortRulesForID_large
Before Setup (N=1,EPs=20,cache=1)
Alloc = 3 MiB   HeapInuse = 5 MiB       Sys = 20 MiB    NumGC = 6
Before Test (N=1,EPs=20,cache=1)
Alloc = 37 MiB  HeapInuse = 49 MiB      Sys = 1042 MiB  NumGC = 18
After Test (N=1,EPs=20,cache=1)
Alloc = 24 MiB  HeapInuse = 33 MiB      Sys = 1042 MiB  NumGC = 44
Benchmark_perEPAllow_setPortRulesForID_large-7                 1        1717676000 ns/op        1245450592 B/op 10365195 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/fqdn/dnsproxy      6.449s

// Baseline with LRU size of 1024

goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/fqdn/dnsproxy
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Benchmark_perEPAllow_setPortRulesForID_large
Before Setup (N=1,EPs=20,cache=1024)
Alloc = 3 MiB   HeapInuse = 5 MiB       Sys = 20 MiB    NumGC = 6
Before Test (N=1,EPs=20,cache=1024)
Alloc = 37 MiB  HeapInuse = 49 MiB      Sys = 969 MiB   NumGC = 18
After Test (N=1,EPs=20,cache=1024)
Alloc = 312 MiB HeapInuse = 357 MiB     Sys = 969 MiB   NumGC = 46
Benchmark_perEPAllow_setPortRulesForID_large-7                 1        5990697400 ns/op        3470756528 B/op 36068464 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/fqdn/dnsproxy      11.813s

// Baseline with LRU size of 128
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/fqdn/dnsproxy
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Benchmark_perEPAllow_setPortRulesForID_large
Before Setup (N=1,EPs=20,cache=128)
Alloc = 3 MiB   HeapInuse = 5 MiB       Sys = 19 MiB    NumGC = 5
Before Test (N=1,EPs=20,cache=128)
Alloc = 38 MiB  HeapInuse = 49 MiB      Sys = 1047 MiB  NumGC = 17
After Test (N=1,EPs=20,cache=128)
Alloc = 1763 MiB        HeapInuse = 1907 MiB    Sys = 2918 MiB  NumGC = 44
Benchmark_perEPAllow_setPortRulesForID_large-7                 1        81058653300 ns/op       10328100808 B/op        46896658 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/fqdn/dnsproxy      93.574s
```

As a side note, I try to keep this PR as simple and clean as possible; and avoid doing any fancy perf improvements. I think we should fully agree on the approach, and then we can do all the fancy perf improvements we want on top of this! 👌 (tho. the reduced mem usage is quite evident ^)

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
dnsproxy: split MatchPattern and MatchName to improve perf and memory consumption
```
