### PR TITLE
clustermesh: Always use uint32 as ClusterID type

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -17,7 +17,7 @@ cilium-operator-alibabacloud [flags]
       --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                  Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string               Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id int                            Unique identifier of the cluster
+      --cluster-id uint32                         Unique identifier of the cluster
       --cluster-name string                       Name of the cluster (default "default")
       --cluster-pool-ipv4-cidr strings            IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool|cluster-pool-v2beta' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool|cluster-pool-v2beta' and 'enable-ipv4=true' (default 24)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -20,7 +20,7 @@ cilium-operator-aws [flags]
       --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                  Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string               Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id int                            Unique identifier of the cluster
+      --cluster-id uint32                         Unique identifier of the cluster
       --cluster-name string                       Name of the cluster (default "default")
       --cluster-pool-ipv4-cidr strings            IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool|cluster-pool-v2beta' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool|cluster-pool-v2beta' and 'enable-ipv4=true' (default 24)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -20,7 +20,7 @@ cilium-operator-azure [flags]
       --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                  Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string               Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id int                            Unique identifier of the cluster
+      --cluster-id uint32                         Unique identifier of the cluster
       --cluster-name string                       Name of the cluster (default "default")
       --cluster-pool-ipv4-cidr strings            IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool|cluster-pool-v2beta' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool|cluster-pool-v2beta' and 'enable-ipv4=true' (default 24)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -16,7 +16,7 @@ cilium-operator-generic [flags]
       --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                  Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string               Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id int                            Unique identifier of the cluster
+      --cluster-id uint32                         Unique identifier of the cluster
       --cluster-name string                       Name of the cluster (default "default")
       --cluster-pool-ipv4-cidr strings            IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool|cluster-pool-v2beta' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool|cluster-pool-v2beta' and 'enable-ipv4=true' (default 24)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -25,7 +25,7 @@ cilium-operator [flags]
       --cilium-endpoint-gc-interval duration      GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                  Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string               Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id int                            Unique identifier of the cluster
+      --cluster-id uint32                         Unique identifier of the cluster
       --cluster-name string                       Name of the cluster (default "default")
       --cluster-pool-ipv4-cidr strings            IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool|cluster-pool-v2beta' and 'enable-ipv4=true'
       --cluster-pool-ipv4-mask-size int           Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool|cluster-pool-v2beta' and 'enable-ipv4=true' (default 24)

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -98,7 +98,7 @@ var (
 	}
 
 	mockFile        string
-	clusterID       int
+	clusterID       uint32
 	ciliumK8sClient clientset.Interface
 	cfg             configuration
 
@@ -197,7 +197,7 @@ func runApiserver() error {
 	flags.String(option.IdentityAllocationMode, option.IdentityAllocationModeCRD, "Method to use for identity allocation")
 	option.BindEnv(option.IdentityAllocationMode)
 
-	flags.IntVar(&clusterID, option.ClusterIDName, 0, "Cluster ID")
+	flags.Uint32Var(&clusterID, option.ClusterIDName, 0, "Cluster ID")
 	option.BindEnv(option.ClusterIDName)
 
 	flags.StringVar(&cfg.clusterName, option.ClusterName, "default", "Cluster name")

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -44,7 +44,7 @@ func init() {
 	option.BindEnv(operatorOption.ParallelAllocWorkers)
 
 	// Clustermesh dedicated flags
-	flags.Int(option.ClusterIDName, 0, "Unique identifier of the cluster")
+	flags.Uint32(option.ClusterIDName, 0, "Unique identifier of the cluster")
 	option.BindEnv(option.ClusterIDName)
 
 	flags.String(option.ClusterName, defaults.ClusterName, "Name of the cluster")

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -480,8 +480,8 @@ func (id NumericIdentity) IsReservedIdentity() bool {
 }
 
 // ClusterID returns the cluster ID associated with the identity
-func (id NumericIdentity) ClusterID() int {
-	return int((uint32(id) >> 16) & 0xFF)
+func (id NumericIdentity) ClusterID() uint32 {
+	return (uint32(id) >> 16) & 0xFF
 }
 
 // GetAllReservedIdentities returns a list of all reserved numeric identities

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -28,7 +28,7 @@ func (s *IdentityTestSuite) TestLocalIdentity(c *C) {
 func (s *IdentityTestSuite) TestClusterID(c *C) {
 	tbl := []struct {
 		identity  uint32
-		clusterID int
+		clusterID uint32
 	}{
 		{
 			identity:  0x000000,

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -216,7 +216,7 @@ type Node struct {
 	IPv6IngressIP net.IP
 
 	// ClusterID is the unique identifier of the cluster
-	ClusterID int
+	ClusterID uint32
 
 	// Source is the source where the node configuration was generated / created.
 	Source source.Source

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1393,7 +1393,7 @@ type DaemonConfig struct {
 	ClusterName string
 
 	// ClusterID is the unique identifier of the cluster
-	ClusterID int
+	ClusterID uint32
 
 	// ClusterMeshConfig is the path to the clustermesh configuration directory
 	ClusterMeshConfig string
@@ -2768,7 +2768,7 @@ func (c *DaemonConfig) Populate() {
 	c.BPFRoot = viper.GetString(BPFRoot)
 	c.CertDirectory = viper.GetString(CertsDirectory)
 	c.CGroupRoot = viper.GetString(CGroupRoot)
-	c.ClusterID = viper.GetInt(ClusterIDName)
+	c.ClusterID = viper.GetUint32(ClusterIDName)
 	c.ClusterName = viper.GetString(ClusterName)
 	c.ClusterMeshConfig = viper.GetString(ClusterMeshConfigName)
 	c.DatapathMode = viper.GetString(DatapathMode)


### PR DESCRIPTION
Please see the commit message for more details.

```release-note
Always use uint32 as ClusterID type.
```