### PR TITLE
gha: Add lb4lb test for v1.12 branch

### DIFF
--- a/.github/workflows/tests-l4lb-v1.12.yaml
+++ b/.github/workflows/tests-l4lb-v1.12.yaml
@@ -1,0 +1,250 @@
+name: Cilium L4LB XDP (ci-l4lb-1.12)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  issue_comment:
+    types:
+      - created
+  ### FOR TESTING PURPOSES
+  # This workflow runs in the context of `master`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  #
+  # pull_request: {}
+  ###
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # So that Sibz/github-status-action can write into the status API
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - issue_comment: PR number
+  #   - pull_request: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing:
+  # - schedule: {name} schedule {SHA}
+  # - issue_comment: {name} issue_comment {PR number}
+  # - pull_request: {name} pull_request {PR number}
+  #
+  # Note: for `issue_comment` triggers, we additionally need to filter out based
+  # on comment content, otherwise any comment will interrupt workflow runs.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'issue_comment' && (
+        github.event.comment.body == '/ci-l4lb-1.12' ||
+        github.event.comment.body == '/test-backport-1.12'
+      ) && github.event.issue.number) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.number)
+    }}
+  cancel-in-progress: true
+
+env:
+  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    if: |
+      (github.event_name == 'issue_comment' && (
+        github.event.comment.body == '/ci-l4lb-1.12' ||
+        github.event.comment.body == '/test-backport-1.12'
+      )) ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      tested: ${{ steps.tested-tree.outputs.src }}
+    steps:
+      # Because we run on issue comments, we need to checkout the code for
+      # paths-filter to work.
+      - name: Checkout code
+        if: ${{ github.event.issue.pull_request }}
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "::set-output name=base::$(jq -r '.base.sha' pr.json)"
+          echo "::set-output name=head::$(jq -r '.head.sha' pr.json)"
+      - name: Check code changes
+        if: ${{ github.event.issue.pull_request }}
+        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
+        id: tested-tree
+        with:
+          base: ${{ steps.pr.outputs.base }}
+          ref: ${{ steps.pr.outputs.head }}
+          filters: |
+            src:
+              - 'pkg/**'
+              - 'daemon/**'
+              - 'bpf/**'
+              - 'test/l4lb/**'
+
+  # This job is skipped when the workflow was triggered with the generic `/test`
+  # trigger if the only modified files were under `test/` or `Documentation/`.
+  setup-and-test:
+    needs: check_changes
+    name: Setup & Test
+    if: |
+      (github.event_name == 'issue_comment' && (
+        github.event.comment.body == '/ci-l4lb-1.12' ||
+        (github.event.comment.body == '/test-backport-1.12' && needs.check_changes.outputs.tested == 'true')
+      )) ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request'
+    # We need nested virtualisation which is supported only by MacOS runner
+    runs-on: macos-10.15
+    timeout-minutes: 45
+    steps:
+      - name: Set up job variables
+        id: vars
+        run: |
+          if [ ${{ github.event.issue.pull_request || github.event.pull_request }} ]; then
+            PR_API_JSON=$(curl \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
+            SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+          else
+            SHA=${{ github.sha }}
+          fi
+
+          echo ::set-output name=sha::${SHA}
+
+      - name: Set commit status to pending
+        uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ steps.vars.outputs.sha }}
+          context: ${{ github.workflow }}
+          description: L4LB test in progress...
+          state: pending
+          target_url: ${{ env.check_url }}
+
+      - name: Install Docker Client
+        run: |
+          cd /tmp
+          curl -sOL https://download.docker.com/mac/static/stable/x86_64/docker-20.10.9.tgz
+          tar xzf docker-20.10.9.tgz
+          sudo xattr -rc docker
+          sudo cp docker/docker /usr/local/bin/docker
+          rm -r docker docker-20.10.9.tgz
+
+      - name: Checkout upstream for Vagrantfile
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
+          ref: v1.12
+          persist-credentials: false
+
+      - name: Checkout pull request for Helm chart
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+          path: pull-request
+
+      - name: Boot Fedora
+        run: |
+          ln -sf ./test/l4lb/Vagrantfile ./Vagrantfile
+          # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
+          # Spend up to 10 seconds on this
+          for i in {1..4}; do
+            if vagrant up --provision; then
+              break
+            fi
+            sleep $i
+          done
+          vagrant ssh-config >> ~/.ssh/config
+
+      - name: Wait for image to be available
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          until docker manifest inspect quay.io/${{ github.repository_owner }}/cilium-ci:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+
+      - name: Run tests
+        run: |
+          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} /vagrant/pull-request/install/kubernetes/cilium'"
+          ssh default "sudo /bin/sh -c 'cd /vagrant/test/nat46x64 && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} /vagrant/pull-request/install/kubernetes/cilium'"
+
+      - name: Fetch cilium-sysdump
+        if: ${{ !success() }}
+        run: |
+          ssh default "sudo /bin/sh -c 'cilium sysdump --output-filename cilium-sysdump-out; mv cilium-sysdump-out.zip /tmp'"
+          scp default:/tmp/cilium-sysdump-out.zip .
+
+      - name: Upload cilium-sysdump
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
+        if: ${{ !success() }}
+        with:
+          name: cilium-sysdump-out.zip
+          path: cilium-sysdump-out.zip
+
+      - name: Set commit status to success
+        if: ${{ success() }}
+        uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ steps.vars.outputs.sha }}
+          context: ${{ github.workflow }}
+          description: L4LB test successful
+          state: success
+          target_url: ${{ env.check_url }}
+
+      - name: Set commit status to failure
+        if: ${{ failure() }}
+        uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ steps.vars.outputs.sha }}
+          context: ${{ github.workflow }}
+          description: L4LB test failed
+          state: failure
+          target_url: ${{ env.check_url }}
+
+      - name: Set commit status to cancelled
+        if: ${{ cancelled() }}
+        uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ steps.vars.outputs.sha }}
+          context: ${{ github.workflow }}
+          description: L4LB test cancelled
+          state: error
+          target_url: ${{ env.check_url }}
+
+      - name: Send slack notification
+        if: ${{ !success() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+        uses: 8398a7/action-slack@a74b761b4089b5d730d813fbedcd2ec5d394f3af
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
### Description

Similar to what we have with ci-l4lb-1.11, this is for newly branch-off
1.12.

Suggested-by: Michi Mutsuzaki <michi@isovalent.com>
Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

Diff with current master job for your reference

<details>

```diff
1c1
< name: Cilium L4LB XDP (ci-l4lb)
---
> name: Cilium L4LB XDP (ci-l4lb-1.12)
8,10d7
<   # Run every 6 hours
<   schedule:
<     - cron:  '0 5/6 * * *'
59,60c56,57
<         github.event.comment.body == '/ci-l4lb' ||
<         github.event.comment.body == '/test'
---
>         github.event.comment.body == '/ci-l4lb-1.12' ||
>         github.event.comment.body == '/test-backport-1.12'
74,75c71,72
<         github.event.comment.body == '/ci-l4lb' ||
<         github.event.comment.body == '/test'
---
>         github.event.comment.body == '/ci-l4lb-1.12' ||
>         github.event.comment.body == '/test-backport-1.12'
88a86
>           ref: ${{ steps.vars.outputs.sha }}
110d107
<               - 'test/nat46x64/**'
119,120c116,117
<         github.event.comment.body == '/ci-l4lb' ||
<         (github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'true')
---
>         github.event.comment.body == '/ci-l4lb-1.12' ||
>         (github.event.comment.body == '/test-backport-1.12' && needs.check_changes.outputs.tested == 'true')
166c163
<           ref: master
---
>           ref: v1.12
```

</details>