### PR TITLE
Add metric to track terminating endpoint events

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -362,13 +362,14 @@ Name                                     Labels                                 
 Kubernetes
 ~~~~~~~~~~
 
-======================================== ================================================== ========================================================
-Name                                     Labels                                             Description
-======================================== ================================================== ========================================================
-``kubernetes_events_received_total``     ``scope``, ``action``, ``validity``, ``equal``     Number of Kubernetes events received
-``kubernetes_events_total``              ``scope``, ``action``, ``outcome``                 Number of Kubernetes events processed
-``k8s_cnp_status_completion_seconds``    ``attempts``, ``outcome``                          Duration in seconds in how long it took to complete a CNP status update
-======================================== ================================================== ========================================================
+==========================================   ============================================== ========================================================
+Name                                         Labels                                         Description
+==========================================   ============================================== ========================================================
+``kubernetes_events_received_total``         ``scope``, ``action``, ``validity``, ``equal`` Number of Kubernetes events received
+``kubernetes_events_total``                  ``scope``, ``action``, ``outcome``             Number of Kubernetes events processed
+``k8s_cnp_status_completion_seconds``        ``attempts``, ``outcome``                      Duration in seconds in how long it took to complete a CNP status update
+``k8s_terminating_endpoints_events_total``   ``source_node_name``                           Number of terminating endpoint events received from Kubernetes
+==========================================   ============================================== ========================================================
 
 IPAM
 ~~~~

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -19,6 +19,7 @@ import (
 	slim_discovery_v1beta1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1beta1"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 )
@@ -196,6 +197,7 @@ func ParseEndpointSliceV1Beta1(ep *slim_discovery_v1beta1.EndpointSlice) (Endpoi
 				if option.Config.EnableK8sTerminatingEndpoint {
 					if sub.Conditions.Terminating != nil && *sub.Conditions.Terminating {
 						backend.Terminating = true
+						metrics.TerminatingEndpointsEvents.WithLabelValues(metrics.LabelSourceNodeName)
 					}
 				}
 			}
@@ -281,6 +283,7 @@ func ParseEndpointSliceV1(ep *slim_discovery_v1.EndpointSlice) (EndpointSliceID,
 				if option.Config.EnableK8sTerminatingEndpoint {
 					if sub.Conditions.Terminating != nil && *sub.Conditions.Terminating {
 						backend.Terminating = true
+						metrics.TerminatingEndpointsEvents.WithLabelValues(metrics.LabelSourceNodeName)
 					}
 				}
 			}

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -350,7 +350,7 @@ func (*LBBPFMap) UpdateBackendWithState(b loadbalancer.Backend) error {
 		return err
 	}
 	if err := updateBackend(backend); err != nil {
-		return fmt.Errorf("unable to update backend %+v: %s", b, err)
+		return fmt.Errorf("unable to update backend state %+v: %s", b, err)
 	}
 
 	return nil

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -30,7 +30,7 @@ const (
 	// ErrorProxy is the value used to notify errors on Proxy.
 	ErrorProxy = "proxy"
 
-	//L7DNS is the value used to report DNS label on metrics
+	// L7DNS is the value used to report DNS label on metrics
 	L7DNS = "dns"
 
 	// SubsystemBPF is the subsystem to scope metrics related to the bpf syscalls.
@@ -414,6 +414,9 @@ var (
 	// complete a CNP status update
 	KubernetesCNPStatusCompletion = NoOpObserverVec
 
+	// TerminatingEndpointsEvents is the number of terminating endpoint events received from kubernetes.
+	TerminatingEndpointsEvents = NoOpCounterVec
+
 	// IPAM events
 
 	// IpamEvent is the number of IPAM events received labeled by action and
@@ -554,6 +557,7 @@ type Configuration struct {
 	KubernetesAPIInteractionsEnabled        bool
 	KubernetesAPICallsEnabled               bool
 	KubernetesCNPStatusCompletionEnabled    bool
+	KubernetesTerminatingEndpointsEnabled   bool
 	IpamEventEnabled                        bool
 	KVStoreOperationsDurationEnabled        bool
 	KVStoreEventsQueueDurationEnabled       bool
@@ -624,6 +628,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemK8sClient + "_api_latency_time_seconds":           {},
 		Namespace + "_" + SubsystemK8sClient + "_api_calls_total":                    {},
 		Namespace + "_" + SubsystemK8s + "_cnp_status_completion_seconds":            {},
+		Namespace + "_" + SubsystemK8s + "_terminating_endpoints_events_total":       {},
 		Namespace + "_ipam_events_total":                                             {},
 		Namespace + "_" + SubsystemKVStore + "_operations_duration_seconds":          {},
 		Namespace + "_" + SubsystemKVStore + "_events_queue_seconds":                 {},
@@ -1104,6 +1109,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, KubernetesCNPStatusCompletion)
 			c.KubernetesCNPStatusCompletionEnabled = true
+
+		case Namespace + "_terminating_endpoints_events_total":
+			TerminatingEndpointsEvents = prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemK8s,
+				Name:      "_terminating_endpoints_events_total",
+				Help:      "Number of terminating endpoint events received from Kubernetes",
+			}, []string{LabelSourceNodeName})
+
+			collectors = append(collectors, TerminatingEndpointsEvents)
+			c.KubernetesTerminatingEndpointsEnabled = true
 
 		case Namespace + "_ipam_events_total":
 			IpamEvent = prometheus.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Add a new metric to track terminating endpoint
events received from Kubernetes. This can help
to check if service endpoints can be gracefully
terminated by cilium. Cilium agent will receive
these events (and thereby increment the metric)
only when the Kubernetes feature gate
`EndpointSliceTerminatingCondition` is enabled, and
service endpoint pods are correctly configured with
a graceful termination period.

Signed-off-by: Aditi Ghag <aditi@cilium.io>
