### PR TITLE
bpf: Handle tuple collisions for inactive backends

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -666,6 +666,14 @@ enum {
 	SVC_FLAG_L7LOADBALANCER = (1 << 2),  /* tproxy redirect to local l7 loadbalancer */
 };
 
+/* Backend flags (lb{4,6}_backends->flags) */
+enum {
+	BE_STATE_ACTIVE		= 0,
+	BE_STATE_TERMINATING,
+	BE_STATE_QUARANTINED,
+	BE_STATE_MAINTENANCE,
+};
+
 struct ipv6_ct_tuple {
 	/* Address fields are reversed, i.e.,
 	 * these field names are correct for reply direction traffic.
@@ -891,10 +899,11 @@ struct ct_state {
 	__u16 rev_nat_index;
 	__u16 loopback:1,
 	      node_port:1,
-	      proxy_redirect:1, /* Connection is redirected to a proxy */
 	      dsr:1,
-	      from_l7lb:1, /* Connection is originated from an L7 LB proxy */
-	      reserved:11;
+	      syn:1,
+	      proxy_redirect:1,	/* Connection is redirected to a proxy */
+	      from_l7lb:1,	/* Connection is originated from an L7 LB proxy */
+	      reserved:10;
 	__be32 addr;
 	__be32 svc_addr;
 	__u32 src_sec_id;


### PR DESCRIPTION
Yusuke reports:

  Graceful termination does not seem to work as expected in a particular
  case where a client accidentally picks a stale source port. CT_SERVICE
  entries remain for six hours because FIN/ACK never comes to intermediate
  nodes. So clients are likely to hit the same source ports with the DSR
  mode.

The work in #19451 / #19800 partially resolves this case: Cilium selects a
new backend if the ct_service entry is closing and CT_SERVICE_CLOSE_REBALANCE(30)
seconds have passed since the last TX. If bpf-ct-timeout-service-tcp-grace is
set to 0, Cilium always selects a new backend when it receives an SYN packet
that has the same old tuple. Downside being that this reduction would ignore
TIME_WAIT state.

The case when backends are inactive, they are either terminating (and can
therefore disappear at any point in time), quarantied (e.g. because connectivity
may be flaky), or placed into maintenance mode (where we expect to drain traffic)
and thus for this corner case we might choose to pick a new, active backend.

Fixes: #20382
Reported-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>