### PR TITLE
.github: add more operations per run in stale bot

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Close stale issues
       uses: actions/stale@3cc123766321e9f15a6676375c154ccffb12a358
       with:
+        operations-per-run: 250
         stale-issue-label: stale
         exempt-all-issue-assignees: true
         exempt-issue-labels: pinned,security,good-first-issue
@@ -28,7 +29,7 @@ jobs:
         close-issue-message: |
           This issue has not seen any activity since it was marked stale.
           Closing.
-          
+
         stale-pr-label: stale
         exempt-pr-labels: pinned,security,good-first-issue
 
@@ -41,4 +42,3 @@ jobs:
         close-pr-message: |
           This pull request has not seen any activity since it was marked stale.
           Closing.
-        


### PR DESCRIPTION
Accordingly to the official stale bot documentation[1], we should increase
the number of operations per run if a Warning shows that not enough
items were processed.

[1] https://github.com/actions/stale#operations-per-run

Signed-off-by: André Martins <andre@cilium.io>