### PR TITLE
bgp: fixed PodCIDR announcement being overwritten by SVC announcement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -228,7 +228,7 @@ replace (
 	github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3
 	github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
 
-	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d
+	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47
 
 	// Using private fork of controller-tools. See commit msg for more context
 	// as to why we are using a private fork.

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyR
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
 github.com/cilium/lumberjack/v2 v2.2.2 h1:RKTdhb63DY0Xu7pE1pipMj7Zq28LyvBGSrCneHiKm4A=
 github.com/cilium/lumberjack/v2 v2.2.2/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
-github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d h1:skjwi8X3DdLWRI4AFmiAn83ruNoAw4f2kvdBlM8EI8c=
-github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
+github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47 h1:re/GRXDuD+xOLrONyqf355ioO96AbozC7QUiFzL6bT4=
+github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
 github.com/cilium/proxy v0.0.0-20220525133153-3b70fad0b951 h1:PpsSavy+lbfzVnMhJe2E+cuBniKqnW0BGl3Sdd3Uc88=
 github.com/cilium/proxy v0.0.0-20220525133153-3b70fad0b951/go.mod h1:ontBl/RX7G0GwcR38YQVp6d75MjIsL1FbBidVpn+F8I=
 github.com/cilium/workerpool v1.1.3 h1:GB5H495r6AXg8kYklLAOn7N4PDR/djeE4WYPbq8U+yY=

--- a/pkg/bgp/mock/mock.go
+++ b/pkg/bgp/mock/mock.go
@@ -16,9 +16,10 @@ import (
 // MockMetalLBSpeaker implements the speaker.Speaker interface by delegating to
 // a set of functions defined during test.
 type MockMetalLBSpeaker struct {
-	SetService_    func(name string, svc *metallbspr.Service, eps *metallbspr.Endpoints) types.SyncState
-	SetNodeLabels_ func(labels map[string]string) types.SyncState
-	PeerSession_   func() []metallbspr.Session
+	SetService_       func(name string, svc *metallbspr.Service, eps *metallbspr.Endpoints) types.SyncState
+	SetNodeLabels_    func(labels map[string]string) types.SyncState
+	PeerSession_      func() []metallbspr.Session
+	GetBGPController_ func() *metallbspr.BGPController
 }
 
 func (m *MockMetalLBSpeaker) SetService(name string, svc *metallbspr.Service, eps *metallbspr.Endpoints) types.SyncState {
@@ -31,6 +32,10 @@ func (m *MockMetalLBSpeaker) SetNodeLabels(labels map[string]string) types.SyncS
 
 func (m *MockMetalLBSpeaker) PeerSessions() []metallbspr.Session {
 	return m.PeerSession_()
+}
+
+func (m *MockMetalLBSpeaker) GetBGPController() *metallbspr.BGPController {
+	return m.GetBGPController_()
 }
 
 // MockEndpointGetter implements the method set for obtaining th endpoints

--- a/pkg/bgp/speaker/metallb.go
+++ b/pkg/bgp/speaker/metallb.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"go.universe.tf/metallb/pkg/config"
 	"go.universe.tf/metallb/pkg/k8s/types"
 	metallbspr "go.universe.tf/metallb/pkg/speaker"
 
@@ -37,6 +38,8 @@ type Speaker interface {
 	SetNodeLabels(labels map[string]string) types.SyncState
 	// PeerSessions returns any active BGP sessions.
 	PeerSessions() []metallbspr.Session
+	// GetBGPController returns the BGPController of the speaker
+	GetBGPController() *metallbspr.BGPController
 }
 
 // metalLBSpeaker implements the Speaker interface
@@ -98,4 +101,7 @@ func (m metalLBSpeaker) SetNodeLabels(labels map[string]string) types.SyncState 
 }
 func (m metalLBSpeaker) PeerSessions() []metallbspr.Session {
 	return m.C.PeerSessions()
+}
+func (m metalLBSpeaker) GetBGPController() *metallbspr.BGPController {
+	return m.C.Protocols[config.BGP].(*metallbspr.BGPController)
 }

--- a/vendor/go.universe.tf/metallb/pkg/speaker/bgp_controller.go
+++ b/vendor/go.universe.tf/metallb/pkg/speaker/bgp_controller.go
@@ -178,7 +178,7 @@ func (c *BGPController) syncPeers(l log.Logger) error {
 	}
 	if needUpdateAds {
 		// Some new sessions came up, resync advertisement state.
-		if err := c.updateAds(); err != nil {
+		if err := c.UpdateAds(); err != nil {
 			l.Log("op", "updateAds", "error", err, "msg", "failed to update BGP advertisements")
 			return err
 		}
@@ -207,7 +207,7 @@ func (c *BGPController) SetBalancer(l log.Logger, name string, lbIP net.IP, pool
 		c.SvcAds[name] = append(c.SvcAds[name], ad)
 	}
 
-	if err := c.updateAds(); err != nil {
+	if err := c.UpdateAds(); err != nil {
 		return err
 	}
 
@@ -216,7 +216,7 @@ func (c *BGPController) SetBalancer(l log.Logger, name string, lbIP net.IP, pool
 	return nil
 }
 
-func (c *BGPController) updateAds() error {
+func (c *BGPController) UpdateAds() error {
 	var allAds []*bgp.Advertisement
 	for _, ads := range c.SvcAds {
 		// This list might contain duplicates, but that's fine,
@@ -243,7 +243,7 @@ func (c *BGPController) DeleteBalancer(l log.Logger, name, reason string) error 
 		return nil
 	}
 	delete(c.SvcAds, name)
-	return c.updateAds()
+	return c.UpdateAds()
 }
 
 // Session gives access to the BGP session.

--- a/vendor/go.universe.tf/metallb/pkg/speaker/speaker.go
+++ b/vendor/go.universe.tf/metallb/pkg/speaker/speaker.go
@@ -38,7 +38,7 @@ func NewController(cfg ControllerConfig) (*Controller, error) {
 
 	ret := &Controller{
 		myNode:    cfg.MyNode,
-		protocols: protocols,
+		Protocols: protocols,
 		announced: map[string]config.Proto{},
 		svcIP:     map[string]net.IP{},
 	}
@@ -52,7 +52,7 @@ type Controller struct {
 	config *config.Config
 	Client service
 
-	protocols map[config.Proto]Protocol
+	Protocols map[config.Proto]Protocol
 	announced map[string]config.Proto // service name -> protocol advertising it
 	svcIP     map[string]net.IP       // service name -> assigned IP
 }
@@ -142,7 +142,7 @@ func (c *Controller) SetService(l gokitlog.Logger, name string, svc *Service, ep
 	}
 
 	l = gokitlog.With(l, "protocol", pool.Protocol)
-	handler := c.protocols[pool.Protocol]
+	handler := c.Protocols[pool.Protocol]
 	if handler == nil {
 		l.Log("bug", "true", "msg", "internal error: unknown balancer protocol!")
 		return c.deleteBalancer(l, name, "internalError")
@@ -179,7 +179,7 @@ func (c *Controller) deleteBalancer(l gokitlog.Logger, name, reason string) type
 		return types.SyncStateSuccess
 	}
 
-	if err := c.protocols[proto].DeleteBalancer(l, name, reason); err != nil {
+	if err := c.Protocols[proto].DeleteBalancer(l, name, reason); err != nil {
 		l.Log("op", "deleteBalancer", "error", err, "msg", "failed to clear balancer state")
 		return types.SyncStateError
 	}
@@ -225,7 +225,7 @@ func (c *Controller) SetConfig(l gokitlog.Logger, cfg *config.Config) types.Sync
 		}
 	}
 
-	for proto, handler := range c.protocols {
+	for proto, handler := range c.Protocols {
 		if err := handler.SetConfig(l, cfg); err != nil {
 			l.Log("op", "setConfig", "protocol", proto, "error", err, "msg", "applying new configuration to protocol handler failed")
 			return types.SyncStateError
@@ -242,7 +242,7 @@ func (c *Controller) SetNode(l gokitlog.Logger, node *v1.Node) types.SyncState {
 }
 
 func (c *Controller) SetNodeLabels(l gokitlog.Logger, labels map[string]string) types.SyncState {
-	for proto, handler := range c.protocols {
+	for proto, handler := range c.Protocols {
 		if err := handler.SetNodeLabels(l, labels); err != nil {
 			l.Log("op", "setNode", "error", err, "protocol", proto, "msg", "failed to propagate node info to protocol handler")
 			return types.SyncStateError
@@ -254,7 +254,7 @@ func (c *Controller) SetNodeLabels(l gokitlog.Logger, labels map[string]string) 
 // PeerSessions returns the underlying BGP sessions from the BGP controller. In
 // Layer2 mode only, this returns nil.
 func (c *Controller) PeerSessions() []Session {
-	if handler, ok := c.protocols[config.BGP]; ok {
+	if handler, ok := c.Protocols[config.BGP]; ok {
 		return handler.(*BGPController).PeerSessions()
 	}
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -873,7 +873,7 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 go.uber.org/zap/zapgrpc
-# go.universe.tf/metallb v0.11.0 => github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d
+# go.universe.tf/metallb v0.11.0 => github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47
 ## explicit; go 1.17
 go.universe.tf/metallb/pkg/allocator
 go.universe.tf/metallb/pkg/allocator/k8salloc
@@ -1655,5 +1655,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3
 # github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
-# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d
+# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47
 # sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.6.2


### PR DESCRIPTION
This PR fixes a bug, where the PodCIDR announcements would disappear
as soon as another announcement like a loadbalancer was added. The root
cause turned out the be that we created the PodCIDR announcements
directly in the BGP sessions, however the session announcements are
completely overwritten by the BGPController which maintains its own
source of truth. So we now add the PodCIDR announcements to the
BGPController and ask it to sync. This makes it so we play nice with
the other announcement types.

```release-note
Fixed PodCIDR announcement being overwritten by SVC announcement
```
