### PR TITLE
Documentation: Improve cilium-cli and hubble cli installation instructions

### DIFF
--- a/Documentation/gettingstarted/cli-download.rst
+++ b/Documentation/gettingstarted/cli-download.rst
@@ -8,7 +8,7 @@ various features (e.g. clustermesh, Hubble).
     .. code-block:: shell-session
 
       CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-amd64.tar.gz{,.sha256sum}
+      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-amd64.tar.gz{,.sha256sum}
       sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
       sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
       rm cilium-linux-amd64.tar.gz{,.sha256sum}
@@ -18,7 +18,7 @@ various features (e.g. clustermesh, Hubble).
     .. code-block:: shell-session
 
       CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-amd64.tar.gz{,.sha256sum}
+      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-amd64.tar.gz{,.sha256sum}
       shasum -a 256 -c cilium-darwin-amd64.tar.gz.sha256sum
       sudo tar xzvfC cilium-darwin-amd64.tar.gz /usr/local/bin
       rm cilium-darwin-amd64.tar.gz{,.sha256sum}
@@ -28,7 +28,7 @@ various features (e.g. clustermesh, Hubble).
     .. code-block:: shell-session
 
       CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-      curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-arm64.tar.gz{,.sha256sum}
+      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-arm64.tar.gz{,.sha256sum}
       shasum -a 256 -c cilium-darwin-arm64.tar.gz.sha256sum
       sudo tar xzvfC cilium-darwin-arm64.tar.gz /usr/local/bin
       rm cilium-darwin-arm64.tar.gz{,.sha256sum}

--- a/Documentation/gettingstarted/cli-download.rst
+++ b/Documentation/gettingstarted/cli-download.rst
@@ -8,30 +8,24 @@ various features (e.g. clustermesh, Hubble).
     .. code-block:: shell-session
 
       CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-amd64.tar.gz{,.sha256sum}
-      sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
-      sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
-      rm cilium-linux-amd64.tar.gz{,.sha256sum}
+      CLI_ARCH=amd64
+      if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
+      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
+      sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
+      sudo tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
+      rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
 
-  .. group-tab:: macOS (Intel)
-
-    .. code-block:: shell-session
-
-      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-amd64.tar.gz{,.sha256sum}
-      shasum -a 256 -c cilium-darwin-amd64.tar.gz.sha256sum
-      sudo tar xzvfC cilium-darwin-amd64.tar.gz /usr/local/bin
-      rm cilium-darwin-amd64.tar.gz{,.sha256sum}
-
-  .. group-tab:: macOS (Apple Silicon - ARM)
+  .. group-tab:: macOS
 
     .. code-block:: shell-session
 
       CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
-      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-arm64.tar.gz{,.sha256sum}
-      shasum -a 256 -c cilium-darwin-arm64.tar.gz.sha256sum
-      sudo tar xzvfC cilium-darwin-arm64.tar.gz /usr/local/bin
-      rm cilium-darwin-arm64.tar.gz{,.sha256sum}
+      CLI_ARCH=amd64
+      if [ "$(uname -m)" = "arm64" ]; then CLI_ARCH=arm64; fi
+      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-${CLI_ARCH}.tar.gz{,.sha256sum}
+      shasum -a 256 -c cilium-darwin-${CLI_ARCH}.tar.gz.sha256sum
+      sudo tar xzvfC cilium-darwin-${CLI_ARCH}.tar.gz /usr/local/bin
+      rm cilium-darwin-${CLI_ARCH}.tar.gz{,.sha256sum}
 
   .. group-tab:: Other
 

--- a/Documentation/gettingstarted/hubble-install.rst
+++ b/Documentation/gettingstarted/hubble-install.rst
@@ -7,7 +7,7 @@
       .. code-block:: shell-session
 
          export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
-         curl -L --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-amd64.tar.gz{,.sha256sum}
+         curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-amd64.tar.gz{,.sha256sum}
          sha256sum --check hubble-linux-amd64.tar.gz.sha256sum
          sudo tar xzvfC hubble-linux-amd64.tar.gz /usr/local/bin
          rm hubble-linux-amd64.tar.gz{,.sha256sum}
@@ -19,7 +19,7 @@
       .. code-block:: shell-session
 
          export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
-         curl -L --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-amd64.tar.gz{,.sha256sum}
+         curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-amd64.tar.gz{,.sha256sum}
          shasum -a 256 -c hubble-darwin-amd64.tar.gz.sha256sum
          sudo tar xzvfC hubble-darwin-amd64.tar.gz /usr/local/bin
          rm hubble-darwin-amd64.tar.gz{,.sha256sum}
@@ -32,8 +32,8 @@
 
          curl -LO "https://raw.githubusercontent.com/cilium/hubble/master/stable.txt"
          set /p HUBBLE_VERSION=<stable.txt
-         curl -LO "https://github.com/cilium/hubble/releases/download/%HUBBLE_VERSION%/hubble-windows-amd64.tar.gz"
-         curl -LO "https://github.com/cilium/hubble/releases/download/%HUBBLE_VERSION%/hubble-windows-amd64.tar.gz.sha256sum"
+         curl -L --fail -O "https://github.com/cilium/hubble/releases/download/%HUBBLE_VERSION%/hubble-windows-amd64.tar.gz"
+         curl -L --fail -O "https://github.com/cilium/hubble/releases/download/%HUBBLE_VERSION%/hubble-windows-amd64.tar.gz.sha256sum"
          certutil -hashfile hubble-windows-amd64.tar.gz SHA256
          type hubble-windows-amd64.tar.gz.sha256sum
          :: verify that the checksum from the two commands above match

--- a/Documentation/gettingstarted/hubble-install.rst
+++ b/Documentation/gettingstarted/hubble-install.rst
@@ -7,10 +7,12 @@
       .. code-block:: shell-session
 
          export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
-         curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-amd64.tar.gz{,.sha256sum}
-         sha256sum --check hubble-linux-amd64.tar.gz.sha256sum
-         sudo tar xzvfC hubble-linux-amd64.tar.gz /usr/local/bin
-         rm hubble-linux-amd64.tar.gz{,.sha256sum}
+         HUBBLE_ARCH=amd64
+         if [ "$(uname -m)" = "aarch64" ]; then HUBBLE_ARCH=arm64; fi
+         curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
+         sha256sum --check hubble-linux-${HUBBLE_ARCH}.tar.gz.sha256sum
+         sudo tar xzvfC hubble-linux-${HUBBLE_ARCH}.tar.gz /usr/local/bin
+         rm hubble-linux-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
 
    .. group-tab:: MacOS
 
@@ -19,10 +21,12 @@
       .. code-block:: shell-session
 
          export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
-         curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-amd64.tar.gz{,.sha256sum}
-         shasum -a 256 -c hubble-darwin-amd64.tar.gz.sha256sum
-         sudo tar xzvfC hubble-darwin-amd64.tar.gz /usr/local/bin
-         rm hubble-darwin-amd64.tar.gz{,.sha256sum}
+         HUBBLE_ARCH=amd64
+         if [ "$(uname -m)" = "arm64" ]; then HUBBLE_ARCH=arm64; fi
+         curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
+         shasum -a 256 -c hubble-darwin-${HUBBLE_ARCH}.tar.gz.sha256sum
+         sudo tar xzvfC hubble-darwin-${HUBBLE_ARCH}.tar.gz /usr/local/bin
+         rm hubble-darwin-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
 
    .. group-tab:: Windows
 


### PR DESCRIPTION
- Improve the CLI install by failing fast if the binary is missing (can happen if stable.txt is bumped before 
the new release comes out)
- Download correct binary on Linux based on the architecture.

```release-note
Documentation: Improve cilium-cli and hubble cli installation instructions
```
