### PR TITLE
Documentation: Only install 1 replica of operator on k3s

### DIFF
--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -240,7 +240,8 @@ Install Cilium
        .. parsed-literal::
 
           helm install cilium |CHART_RELEASE| \\
-             --namespace $CILIUM_NAMESPACE
+             --namespace $CILIUM_NAMESPACE \\
+             --set operator.replicas=1
 
     .. group-tab:: Rancher Desktop
 

--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -258,7 +258,7 @@ Install Cilium
 
           helm install cilium |CHART_RELEASE| \\
              --namespace $CILIUM_NAMESPACE \\
-             --operator.replicas=1 \\
+             --set operator.replicas=1 \\
              --set cni.binPath=/usr/libexec/cni
 
 .. include:: k8s-install-restart-pods.rst


### PR DESCRIPTION
Most k3s installs start with a single node, and thus, `cilium status
--wait` will fail because we default to 2 operator replicas 1 of the 2
pods will be unable to schedule.

So default to one operator replica, like we do with rancher-desktop.

Also fixes a typo in the rancher-desktop install steps.

```release-note
Documentation: Only install 1 replica of operator on k3s
```
