### PR TITLE
docs: L7 traffic management getting started guide

### DIFF
--- a/Documentation/gettingstarted/servicemesh/envoy-traffic-management.rst
+++ b/Documentation/gettingstarted/servicemesh/envoy-traffic-management.rst
@@ -19,58 +19,52 @@ between two backend services.
 Deploy Test Applications
 ========================
 
-You will need a Kubernetes cluster with at least two nodes for this example.
-Please take a look at :ref:`gs_guide` for different installation options.
+.. parsed-literal::
 
-Run ``cilium connectivity test`` to deploy the test applications used for
-L7 egress tests:
+    $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/servicemesh/envoy/test-application.yaml
 
-.. code-block:: shell-session
-
-    $ cilium connectivity test --test egress-l7
-
-The test workloads run in the namespace ``cilium-test`` and consist of:
+The test workloads consist of:
 
 - two client deployments, ``client`` and ``client2``
-- two backend services, ``echo-other-node`` and ``echo-same-node``
+- two services, ``echo-service-1`` and ``echo-service-2``
 
 View information about these pods:
 
 .. code-block:: shell-session
 
-    $ kubectl get pods -n cilium-test --show-labels -o wide
-    NAME                               READY   STATUS    RESTARTS   AGE   IP             NODE           NOMINATED NODE   READINESS GATES   LABELS
-    client-6488dcf5d4-jkht2            1/1     Running   0          85s   10.244.1.196   kind-worker2   <none>           <none>            kind=client,name=client,pod-template-hash=6488dcf5d4
-    client2-6dd75b74c6-c65jt           1/1     Running   0          85s   10.244.1.235   kind-worker2   <none>           <none>            kind=client,name=client2,other=client,pod-template-hash=6dd75b74c6
-    echo-other-node-697d5d69b7-phx2j   1/1     Running   0          85s   10.244.2.52    kind-worker    <none>           <none>            kind=echo,name=echo-other-node,pod-template-hash=697d5d69b7
-    echo-same-node-7967996674-l82xz    1/1     Running   0          85s   10.244.1.102   kind-worker2   <none>           <none>            kind=echo,name=echo-same-node,other=echo,pod-template-hash=7967996674
+    $ kubectl get pods --show-labels -o wide
+    NAME                              READY   STATUS    RESTARTS   AGE    IP          NODE           NOMINATED NODE   READINESS GATES   LABELS
+    client-7568bc7f86-dlfqr           1/1     Running   0          100s   10.0.1.8    minikube-m02   <none>           <none>            kind=client,name=client,pod-template-hash=7568bc7f86
+    client2-8b4c4fd75-xn25d           1/1     Running   0          100s   10.0.1.24   minikube-m02   <none>           <none>            kind=client,name=client2,other=client,pod-template-hash=8b4c4fd75
+    echo-service-1-97748874-4sztx     2/2     Running   0          100s   10.0.1.86   minikube-m02   <none>           <none>            kind=echo,name=echo-service-1,other=echo,pod-template-hash=97748874
+    echo-service-2-76c584c4bf-p4z4w   2/2     Running   0          100s   10.0.1.16   minikube-m02   <none>           <none>            kind=echo,name=echo-service-2,pod-template-hash=76c584c4bf
 
 You can see that
 
 - Only ``client2`` is labeled with ``other=client`` - we will use this
   in a ``CiliumNetworkPolicy`` definition later in this example.
-- The pods for ``client``, ``client2`` and ``echo-same-node`` run on one node,
-  while ``echo-other-node`` is scheduled to another node.
 
 Make an environment variable with the pod ID for ``client2``:
 
 .. code-block:: shell-session
 
-    $ export CLIENT2=$(kubectl get pods -l name=client2 -n cilium-test  -o jsonpath='{.items[0].metadata.name}')
+    $ export CLIENT2=$(kubectl get pods -l name=client2 -o jsonpath='{.items[0].metadata.name}')
 
 We are going to use Envoy configuration to load-balance requests between
-these two backend services ``echo-other-node`` and ``echo-same-node``.
+these two services ``echo-service-1`` and ``echo-service-2``.
 
 Start Observing Traffic with Hubble
 ===================================
+
+Enable Hubble in your cluster with the step mentioned in :ref:`hubble_setup`.
 
 Start a second terminal, then enable hubble port forwarding and observe
 traffic from the ``client2`` pod:
 
 .. code-block:: shell-session
 
-    $ cilium hubble port-forward &
-    $ hubble observe --from-pod cilium-test/$CLIENT2 -f
+    $ kubectl -n kube-system port-forward deployment/hubble-relay 4245:4245 &
+    $ hubble observe --from-pod $CLIENT2 -f
 
 
 You should be able to get a response from both of the backend services
@@ -78,8 +72,8 @@ individually from ``client2``:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n cilium-test $CLIENT2 -- curl -v echo-same-node:8080/
-    $ kubectl exec -it -n cilium-test $CLIENT2 -- curl -v echo-other-node:8080/
+    $ kubectl exec -it $CLIENT2 -- curl -v echo-service-1:8080/
+    $ kubectl exec -it $CLIENT2 -- curl -v echo-service-2:8080/
 
 
 Notice that Hubble shows all the flows between these pods as being either
@@ -92,8 +86,8 @@ Verify that you get a 404 error response if you curl to the non-existent URL
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n cilium-test $CLIENT2 -- curl -v echo-same-node:8080/foo
-    $ kubectl exec -it -n cilium-test $CLIENT2 -- curl -v echo-other-node:8080/foo
+    $ kubectl exec -it $CLIENT2 -- curl -v echo-service-1:8080/foo
+    $ kubectl exec -it $CLIENT2 -- curl -v echo-service-2:8080/foo
 
 Add Layer 7 Policy
 ==================
@@ -110,12 +104,12 @@ Make a request to a backend service (either will do):
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n cilium-test $CLIENT2 -- curl -v echo-same-node:8080/
-    $ kubectl exec -it -n cilium-test $CLIENT2 -- curl -v echo-other-node:8080/foo
+    $ kubectl exec -it $CLIENT2 -- curl -v echo-service-1:8080/
+    $ kubectl exec -it $CLIENT2 -- curl -v echo-service-2:8080/foo
 
 Adding a Layer 7 policy enables Layer 7 visibility. Notice that the Hubble output
 now includes flows ``to-proxy``, and also shows the HTTP protocol information at
-level 7 (for example ``HTTP/1.1 GET http://echo-same-node:8080/``)
+level 7 (for example ``HTTP/1.1 GET http://echo-service-1:8080/``)
 
 Test Layer 7 Policy Enforcement
 ===============================
@@ -125,14 +119,14 @@ to any other URL being dropped. For example, try:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n cilium-test $CLIENT2 -- curl -v echo-same-node:8080/foo
+    $ kubectl exec -it $CLIENT2 -- curl -v echo-service-1:8080/foo
 
 
 The Hubble output will show the HTTP request being dropped, like this:
 
 ::
 
-    May 11 06:33:55.210: cilium-test/client2-6dd75b74c6-c65jt:54244 -> cilium-test/echo-same-node-7967996674-l82xz:8080 http-request DROPPED (HTTP/1.1 GET http://echo-same-node:8080/foo)
+    Jul  7 08:40:15.076: default/client2-8b4c4fd75-6pgvl:58586 -> default/echo-service-1-97748874-n7758:8080 http-request DROPPED (HTTP/1.1 GET http://echo-service-1:8080/foo)
 
 And the curl should show a ``403 Forbidden response``.
 
@@ -158,7 +152,7 @@ A request to ``/foo`` should now succeed, because of the path re-writing:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n cilium-test $CLIENT2 -- curl -v echo-same-node:8080/foo
+    $ kubectl exec -it $CLIENT2 -- curl -v echo-service-1:8080/foo
 
 
 But the network policy still prevents requests to any path that is not
@@ -167,37 +161,33 @@ being dropped and a 403 Forbidden response code:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it -n cilium-test $CLIENT2 -- curl -v echo-same-node:8080/bar
+    $ kubectl exec -it $CLIENT2 -- curl -v echo-service-1:8080/bar
 
     ### Output from hubble observe
-    May 11 06:43:51.971: cilium-test/client2-6dd75b74c6-c65jt:54112 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 http-request DROPPED (HTTP/1.1 GET http://echo-same-node:8080/bar)
+    Jul  7 08:43:47.165: default/client2-8b4c4fd75-6pgvl:33376 -> default/echo-service-2-76c584c4bf-874dm:8080 http-request DROPPED (HTTP/1.1 GET http://echo-service-1:8080/bar)
 
 
-Try making several requests to one backend service. You should see
-in the Hubble output approximately half the time, they are handled by the other
-backend.
+Try making several requests to one backend service. You should see in
+the Hubble output approximately half the time, they are handled by the
+other backend.
 
 Example:
 
 ::
 
-    May 11 06:42:19.363: cilium-test/client2-6dd75b74c6-c65jt:51545 -> kube-system/coredns-f9fd979d6-7xb2m:53 L3-L4 REDIRECTED (UDP)
-    May 11 06:42:19.363: cilium-test/client2-6dd75b74c6-c65jt:51545 -> kube-system/coredns-f9fd979d6-7xb2m:53 to-proxy FORWARDED (UDP)
-    May 11 06:42:19.363: cilium-test/client2-6dd75b74c6-c65jt:51545 -> kube-system/coredns-f9fd979d6-7xb2m:53 dns-request FORWARDED (DNS Query echo-same-node.cilium-test.svc.cluster.local. AAAA)
-    May 11 06:42:19.363: cilium-test/client2-6dd75b74c6-c65jt:51545 -> kube-system/coredns-f9fd979d6-7xb2m:53 dns-request FORWARDED (DNS Query echo-same-node.cilium-test.svc.cluster.local. A)
-    May 11 06:42:19.365: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-same-node:8080 none REDIRECTED (TCP Flags: SYN)
-    May 11 06:42:19.365: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-same-node:8080 to-proxy FORWARDED (TCP Flags: SYN)
-    May 11 06:42:19.365: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-same-node:8080 to-proxy FORWARDED (TCP Flags: ACK)
-    May 11 06:42:19.365: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-same-node:8080 to-proxy FORWARDED (TCP Flags: ACK, PSH)
-    May 11 06:42:19.365: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 L3-L4 REDIRECTED (TCP Flags: SYN)
-    May 11 06:42:19.365: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 to-overlay FORWARDED (TCP Flags: SYN)
-    May 11 06:42:19.365: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 to-endpoint FORWARDED (TCP Flags: SYN)
-    May 11 06:42:19.365: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 to-overlay FORWARDED (TCP Flags: ACK)
-    May 11 06:42:19.365: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 to-endpoint FORWARDED (TCP Flags: ACK)
-    May 11 06:42:19.366: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 to-overlay FORWARDED (TCP Flags: ACK, PSH)
-    May 11 06:42:19.366: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 to-endpoint FORWARDED (TCP Flags: ACK, PSH)
-    May 11 06:42:19.366: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 http-request FORWARDED (HTTP/1.1 GET http://echo-same-node:8080/)
-    May 11 06:42:19.368: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-same-node:8080 to-proxy FORWARDED (TCP Flags: ACK, FIN)
-    May 11 06:42:19.368: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-same-node:8080 to-proxy FORWARDED (TCP Flags: ACK)
-    May 11 06:42:24.369: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 to-overlay FORWARDED (TCP Flags: ACK, FIN)
-    May 11 06:42:24.369: cilium-test/client2-6dd75b74c6-c65jt:54110 -> cilium-test/echo-other-node-697d5d69b7-phx2j:8080 to-endpoint FORWARDED (TCP Flags: ACK, FIN)
+    Jul  7 08:45:25.807: default/client2-8b4c4fd75-6pgvl:37388 -> kube-system/coredns-64897985d-8jhhn:53 L3-L4 REDIRECTED (UDP)
+    Jul  7 08:45:25.807: default/client2-8b4c4fd75-6pgvl:37388 -> kube-system/coredns-64897985d-8jhhn:53 to-proxy FORWARDED (UDP)
+    Jul  7 08:45:25.807: default/client2-8b4c4fd75-6pgvl:37388 -> kube-system/coredns-64897985d-8jhhn:53 dns-request FORWARDED (DNS Query echo-service-1.default.svc.cluster.local. AAAA)
+    Jul  7 08:45:25.807: default/client2-8b4c4fd75-6pgvl:37388 -> kube-system/coredns-64897985d-8jhhn:53 dns-request FORWARDED (DNS Query echo-service-1.default.svc.cluster.local. A)
+    Jul  7 08:45:25.808: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-1:8080 none REDIRECTED (TCP Flags: SYN)
+    Jul  7 08:45:25.808: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-1:8080 to-proxy FORWARDED (TCP Flags: SYN)
+    Jul  7 08:45:25.808: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-1:8080 to-proxy FORWARDED (TCP Flags: ACK)
+    Jul  7 08:45:25.808: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-1:8080 to-proxy FORWARDED (TCP Flags: ACK, PSH)
+    Jul  7 08:45:25.809: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-2-76c584c4bf-874dm:8080 L3-L4 REDIRECTED (TCP Flags: SYN)
+    Jul  7 08:45:25.809: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-2-76c584c4bf-874dm:8080 to-endpoint FORWARDED (TCP Flags: SYN)
+    Jul  7 08:45:25.809: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-2-76c584c4bf-874dm:8080 to-endpoint FORWARDED (TCP Flags: ACK)
+    Jul  7 08:45:25.809: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-2-76c584c4bf-874dm:8080 to-endpoint FORWARDED (TCP Flags: ACK, PSH)
+    Jul  7 08:45:25.809: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-2-76c584c4bf-874dm:8080 http-request FORWARDED (HTTP/1.1 GET http://echo-service-1:8080/)
+    Jul  7 08:45:25.811: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-1:8080 to-proxy FORWARDED (TCP Flags: ACK, FIN)
+    Jul  7 08:45:25.811: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-1:8080 to-proxy FORWARDED (TCP Flags: ACK)
+    Jul  7 08:45:30.811: default/client2-8b4c4fd75-6pgvl:57942 -> default/echo-service-2-76c584c4bf-874dm:8080 to-endpoint FORWARDED (TCP Flags: ACK, FIN)

--- a/examples/kubernetes/servicemesh/envoy/client-egress-l7-http.yaml
+++ b/examples/kubernetes/servicemesh/envoy/client-egress-l7-http.yaml
@@ -6,7 +6,6 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-l7-http
 spec:
   description: "Allow GET one.one.one.one:80/ and GET <echo>:8080/ from client2"

--- a/examples/kubernetes/servicemesh/envoy/client-egress-only-dns.yaml
+++ b/examples/kubernetes/servicemesh/envoy/client-egress-only-dns.yaml
@@ -1,7 +1,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  namespace: cilium-test
   name: client-egress-only-dns
 spec:
   endpointSelector:

--- a/examples/kubernetes/servicemesh/envoy/envoy-traffic-management-test.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-traffic-management-test.yaml
@@ -4,10 +4,10 @@ metadata:
   name: envoy-lb-listener
 spec:
   services:
-    - name: echo-other-node
-      namespace: cilium-test
-    - name: echo-same-node
-      namespace: cilium-test
+    - name: echo-service-1
+      namespace: default
+    - name: echo-service-2
+      namespace: default
   resources:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       name: envoy-lb-listener
@@ -32,9 +32,9 @@ spec:
               route:
                 weighted_clusters:
                   clusters:
-                    - name: "cilium-test/echo-same-node"
+                    - name: "default/echo-service-1"
                       weight: 50
-                    - name: "cilium-test/echo-other-node"
+                    - name: "default/echo-service-2"
                       weight: 50
                 retry_policy:
                   retry_on: 5xx
@@ -46,7 +46,7 @@ spec:
                     regex: "^/foo.*$"
                   substitution: "/"
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      name: "cilium-test/echo-same-node"
+      name: "default/echo-service-1"
       connect_timeout: 5s
       lb_policy: ROUND_ROBIN
       type: EDS
@@ -54,7 +54,7 @@ spec:
         split_external_local_origin_errors: true
         consecutive_local_origin_failure: 2
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      name: "cilium-test/echo-other-node"
+      name: "default/echo-service-2"
       connect_timeout: 3s
       lb_policy: ROUND_ROBIN
       type: EDS

--- a/examples/kubernetes/servicemesh/envoy/test-application.yaml
+++ b/examples/kubernetes/servicemesh/envoy/test-application.yaml
@@ -1,0 +1,331 @@
+---
+apiVersion: v1
+data:
+  Corefile: |-
+    . {
+        local
+        ready
+        log
+    }
+kind: ConfigMap
+metadata:
+  name: coredns-configmap
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    kind: client
+    name: client
+  name: client
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      kind: client
+      name: client
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        kind: client
+        name: client
+      name: client
+    spec:
+      containers:
+        - command:
+            - /bin/ash
+            - -c
+            - sleep 10000000
+          env:
+            - name: PORT
+              value: "8080"
+          image: quay.io/cilium/alpine-curl:v1.4.0@sha256:2550c747831ff575f2147149b088ea981c06f9b6bcd188756d1b82cc10997956
+          imagePullPolicy: IfNotPresent
+          name: client
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          securityContext:
+            capabilities:
+              add:
+                - NET_RAW
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    kind: client
+    name: client2
+  name: client2
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      kind: client
+      name: client2
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        kind: client
+        name: client2
+        other: client
+      name: client2
+    spec:
+      containers:
+        - command:
+            - /bin/ash
+            - -c
+            - sleep 10000000
+          env:
+            - name: PORT
+              value: "8080"
+          image: quay.io/cilium/alpine-curl:v1.4.0@sha256:2550c747831ff575f2147149b088ea981c06f9b6bcd188756d1b82cc10997956
+          imagePullPolicy: IfNotPresent
+          name: client2
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+                - NET_RAW
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    kind: echo
+    name: echo-service-1
+  name: echo-service-1
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      kind: echo
+      name: echo-service-1
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        kind: echo
+        name: echo-service-1
+        other: echo
+      name: echo-service-1
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                      - client
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - env:
+            - name: PORT
+              value: "8080"
+          image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
+          imagePullPolicy: IfNotPresent
+          name: echo-service-1
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+                - NET_RAW
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        - args:
+            - -conf
+            - /etc/coredns/Corefile
+          image: coredns/coredns:1.9.3@sha256:8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a
+          imagePullPolicy: IfNotPresent
+          name: dns-test-server
+          ports:
+            - containerPort: 53
+              protocol: TCP
+            - containerPort: 53
+              protocol: UDP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/coredns
+              name: coredns-config-volume
+              readOnly: true
+      volumes:
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: Corefile
+                path: Corefile
+            name: coredns-configmap
+          name: coredns-config-volume
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    kind: echo
+    name: echo-service-2
+  name: echo-service-2
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      kind: echo
+      name: echo-service-2
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        kind: echo
+        name: echo-service-2
+      name: echo-service-2
+    spec:
+      containers:
+        - env:
+            - name: PORT
+              value: "8080"
+          image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
+          imagePullPolicy: IfNotPresent
+          name: echo-service-2
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+                - NET_RAW
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        - args:
+            - -conf
+            - /etc/coredns/Corefile
+          image: coredns/coredns:1.9.3@sha256:8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a
+          imagePullPolicy: IfNotPresent
+          name: dns-test-server
+          ports:
+            - containerPort: 53
+              protocol: TCP
+            - containerPort: 53
+              protocol: UDP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/coredns
+              name: coredns-config-volume
+              readOnly: true
+      volumes:
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: Corefile
+                path: Corefile
+            name: coredns-configmap
+          name: coredns-config-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    kind: echo
+  name: echo-service-1
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    name: echo-service-1
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    kind: echo
+  name: echo-service-2
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    name: echo-service-2
+  type: NodePort


### PR DESCRIPTION
The original guide requires multi-node clusters, just to re-use the test
application app from `cilium connectivity test --test egress-l7`. This is
not really user-friendly, as most of the users will just test guides out
with default single node cluster.

This commit is to just avoid the requirement of multiple node cluster, while
still keeping the objectives of the guide.

Suggested-by: Chance Zibolski <chance.zibolski@gmail.com>
Signed-off-by: Tam Mach <tam.mach@cilium.io>

Please ensure your pull request adheres to the following guidelines: