### PR TITLE
.github: add more operations per run in stale bot

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Close stale issues
       uses: actions/stale@3cc123766321e9f15a6676375c154ccffb12a358
       with:
-        operations-per-run: 250
+        operations-per-run: 1000
         stale-issue-label: stale
         exempt-all-issue-assignees: true
         exempt-issue-labels: pinned,security,good-first-issue


### PR DESCRIPTION
This is a follow up of ae691fe36fed (".github: add more operations per run in stale bot")
since 250 operations were not enough we will be increasing them to 1000.

Signed-off-by: André Martins <andre@cilium.io>