### PR TITLE
install/kubernetes: do not initialize variable twice

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -56,7 +56,7 @@
 {{- $bpfCtTcpMax := (coalesce .Values.bpf.ctTcpMax $defaultBpfCtTcpMax) -}}
 {{- $bpfCtAnyMax := (coalesce .Values.bpf.ctAnyMax $defaultBpfCtAnyMax) -}}
 {{- $kubeProxyReplacement := (coalesce .Values.kubeProxyReplacement $defaultKubeProxyReplacement) -}}
-{{- $azureUsePrimaryAddress := (coalesce .Values.azure.usePrimaryAddress $azureUsePrimaryAddress) -}}
+{{- $azureUsePrimaryAddress = (coalesce .Values.azure.usePrimaryAddress $azureUsePrimaryAddress) -}}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
The $azureUsePrimaryAddress variable is already initialized on line 17
so we don't need it to initialize it again.

Fixes: 69be90059f9b ("Support backward compatibility for --azure-use-primary-address in helm")
Signed-off-by: André Martins <andre@cilium.io>