### PR TITLE
Disable Envoy version check if L7 proxy is disabled

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3213,7 +3213,6 @@ func (c *DaemonConfig) Populate() {
 	c.CompilerFlags = viper.GetStringSlice(CompilerFlags)
 	c.ConfigFile = viper.GetString(ConfigFile)
 	c.HTTP403Message = viper.GetString(HTTP403Message)
-	c.DisableEnvoyVersionCheck = viper.GetBool(DisableEnvoyVersionCheck)
 	c.K8sNamespace = viper.GetString(K8sNamespaceName)
 	c.AgentNotReadyNodeTaintKey = viper.GetString(AgentNotReadyNodeTaintKeyName)
 	c.MaxControllerInterval = viper.GetInt(MaxCtrlIntervalName)
@@ -3225,6 +3224,12 @@ func (c *DaemonConfig) Populate() {
 	c.EnableICMPRules = viper.GetBool(EnableICMPRules)
 	c.BypassIPAvailabilityUponRestore = viper.GetBool(BypassIPAvailabilityUponRestore)
 	c.EnableK8sTerminatingEndpoint = viper.GetBool(EnableK8sTerminatingEndpoint)
+
+	// Disable Envoy version check if L7 proxy is disabled.
+	c.DisableEnvoyVersionCheck = viper.GetBool(DisableEnvoyVersionCheck)
+	if !c.EnableL7Proxy {
+		c.DisableEnvoyVersionCheck = true
+	}
 
 	// VTEP integration enable option
 	c.EnableVTEP = viper.GetBool(EnableVTEP)


### PR DESCRIPTION
If `--enable-l7-proxy` is set to `false`, there is no point in performing the Envoy version check, and so it should be automatically disabled. One of the motivations for this change is that in some scenarios it's necessary to disable the L7 proxy to allow Cilium to start (eg. https://github.com/cilium/cilium/issues/17467), but specifying `--enable-l7-proxy=false` is not enough due to the version check still being performed in this situation. This commit attempts to improve the UX by disabling the version check if Envoy itself is disabled.

```release-note
Envoy version checking is now disabled whenever L7 proxy is disabled too
```
