### PR TITLE
docs: Fixed service list command in clustermesh affinity guide

### DIFF
--- a/Documentation/gettingstarted/clustermesh/affinity.rst
+++ b/Documentation/gettingstarted/clustermesh/affinity.rst
@@ -76,7 +76,7 @@ remote endpoints if and only if all of local backends are not available or unhea
 
    .. code-block:: shell-session
 
-      kubectl exec -ti ds/cilium -- cilium service list --clustermesh-affinity
+      kubectl exec -n kube-system -ti ds/cilium -- cilium service list --clustermesh-affinity
 
       ID   Frontend            Service Type   Backend
       1    10.96.0.1:443       ClusterIP      1 => 172.18.0.3:6443 (active)
@@ -109,7 +109,7 @@ remote endpoints if and only if all of local backends are not available or unhea
 
    .. code-block:: shell-session
 
-      kubectl exec -ti ds/cilium -- cilium service list --clustermesh-affinity
+      kubectl exec -n kube-system -ti ds/cilium -- cilium service list --clustermesh-affinity
 
       ID   Frontend            Service Type   Backend
       1    10.96.0.1:443       ClusterIP      1 => 172.18.0.3:6443 (active)


### PR DESCRIPTION
While testing the guide, I discovered that the command to list the
services and preferred backends didn't work because it didn't specify
a namespace. This commit adds `-n kube-system` to the command so it
works out of the box.