### PR TITLE
dependabot: disable gops updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
       - dependency-name: "github.com/aliyun/alibaba-cloud-sdk-go"
       - dependency-name: "github.com/aws/*"
       - dependency-name: "github.com/Azure/*"
+        # need to update the gops binary in the runtime image in lockstep
+      - dependency-name: "github.com/google/gops"
     labels:
     - kind/enhancement
     - release-note/misc


### PR DESCRIPTION
We should update the github.com/google/gops module in lockstep with the
gops binary in the runtime image as e.g. done in #20438.

Suggested-by: Robin Hahling <robin.hahling@gw-computing.net>
