### PR TITLE
hubble/parser/threefour: check (*Parser).linkGetter before accessing it

### DIFF
--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -664,9 +664,12 @@ func (p *Parser) decodeNetworkInterface(tn *monitor.TraceNotify, dbg *monitor.De
 		return nil
 	}
 
-	// if the interface is not found, `name` will be an empty string and thus
-	// omitted in the protobuf message
-	name, _ := p.linkGetter.GetIfNameCached(int(ifIndex))
+	var name string
+	if p.linkGetter != nil {
+		// if the interface is not found, `name` will be an empty string and thus
+		// omitted in the protobuf message
+		name, _ = p.linkGetter.GetIfNameCached(int(ifIndex))
+	}
 	return &pb.NetworkInterface{
 		Index: ifIndex,
 		Name:  name,

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -180,6 +180,11 @@ func TestL34Decode(t *testing.T) {
 
 	assert.Equal(t, flowpb.TraceObservationPoint_FROM_HOST, f.GetTraceObservationPoint())
 
+	nilParser, err := New(log, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	err = nilParser.Decode(d, f)
+	require.NoError(t, err)
+
 	// ICMP packet so no ports until that support is merged into master
 	//
 	//SOURCE              DESTINATION          TYPE   SUMMARY
@@ -240,6 +245,9 @@ func TestL34Decode(t *testing.T) {
 	assert.Equal(t, (*flowpb.TCPFlags)(nil), f.L4.GetTCP().GetFlags())
 
 	assert.Equal(t, flowpb.TraceObservationPoint_FROM_ENDPOINT, f.GetTraceObservationPoint())
+
+	err = nilParser.Decode(d, f)
+	require.NoError(t, err)
 }
 
 func BenchmarkL34Decode(b *testing.B) {
@@ -979,6 +987,11 @@ func TestDebugCapture(t *testing.T) {
 		Name:  loIfName,
 	}, f.Interface)
 
+	nilParser, err := New(log, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	err = nilParser.Decode(data, f)
+	require.NoError(t, err)
+
 	dbg = monitor.DebugCapture{
 		Type:    api.MessageTypeCapture,
 		SubType: monitor.DbgCaptureProxyPost,
@@ -994,6 +1007,9 @@ func TestDebugCapture(t *testing.T) {
 	assert.Equal(t, int32(dbg.SubType), f.EventType.SubType)
 	assert.Equal(t, flowpb.DebugCapturePoint_DBG_CAPTURE_PROXY_POST, f.DebugCapturePoint)
 	assert.Equal(t, uint32(1234), f.ProxyPort)
+
+	err = nilParser.Decode(data, f)
+	require.NoError(t, err)
 }
 
 func TestTraceNotifyProxyPort(t *testing.T) {

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -254,7 +254,10 @@ func (n *DebugMsg) Message(linkMonitor getters.LinkGetter) string {
 	case DbgEncap:
 		return fmt.Sprintf("Encapsulating to node %d (%#x) from seclabel %d", n.Arg1, n.Arg1, n.Arg2)
 	case DbgLxcFound:
-		ifname := linkMonitor.Name(n.Arg1)
+		var ifname string
+		if linkMonitor != nil {
+			ifname = linkMonitor.Name(n.Arg1)
+		}
 		return fmt.Sprintf("Local container found ifindex %s seclabel %d", ifname, byteorder.NetworkToHost16(uint16(n.Arg2)))
 	case DbgPolicyDenied:
 		return fmt.Sprintf("Policy evaluation would deny packet from %d to %d", n.Arg1, n.Arg2)


### PR DESCRIPTION
It could be nil, though there are currently no code paths in Cilium that
pass it as nil. Add a test to verify that decoding from a (*Parser)
with all nil getters doesn't segfault.

Found by OSS-Fuzz: https://github.com/cilium/cilium/runs/7253558124?check_suite_focus=true

Fixes: ac7f8950acd6 ("datapath/link: Initialize link monitor explicitly")
