### PR TITLE
makefile: Remove removed mock target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,10 +479,7 @@ else
 	$(QUIET) $(CONTAINER_ENGINE) run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:v$(GOLANGCILINT_WANT_VERSION)@$(GOLANGCILINT_IMAGE_SHA) golangci-lint run
 endif
 
-bpf-mock-lint: ## Check if the helper headers in bpf/mock are up-to-date.
-	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C bpf/mock/ check_helper_headers
-
-lint: golangci-lint bpf-mock-lint ## Run golangci-lint and bpf-mock linters.
+lint: golangci-lint ## Run golangci-lint and bpf-mock linters.
 
 logging-subsys-field: ## Validate logrus subsystem field for logs in Go source code.
 	@$(ECHO_CHECK) contrib/scripts/check-logging-subsys-field.sh


### PR DESCRIPTION
bpf/mock was deleted in df1bc96607462b9cee4e961d307d8d54d1ecb390, so
don't reference it anymore. This allows `make lint` to work.

Signed-off-by: Harsh Modi <harshmodi@google.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!