### PR TITLE
test: bigtcp / nat46x64: delete the kind cluster after running the tests

### DIFF
--- a/test/bigtcp/test.sh
+++ b/test/bigtcp/test.sh
@@ -79,6 +79,9 @@ fi
 NETPERF_SERVER=`kubectl get pod netperf-server -o jsonpath='{.status.podIPs}' | jq -r -c '.[].ip | select(contains(":") == true)'`
 kubectl exec netperf-client -- netperf  -t TCP_RR -H ${NETPERF_SERVER} -- -r80000:80000 -O MIN_LATENCY,P90_LATENCY,P99_LATENCY,THROUGHPUT
 
+# cleanup
+kind delete cluster
+
 #####################
 
 echo "YAY!"

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -387,4 +387,7 @@ kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- cilium recorder delete 1
 kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- cilium recorder delete 2
 kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- cilium recorder list
 
+# cleanup
+kind delete cluster
+
 echo "YAY!"


### PR DESCRIPTION
Make sure to delete the kind cluster after running nat46x64 and bigtcp tests.