### PR TITLE
envoy: Support ca.crt Secrets

### DIFF
--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -15,6 +15,7 @@ import (
 	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
 	envoy_config_http "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_config_tls "github.com/cilium/proxy/go/envoy/extensions/transport_sockets/tls/v3"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -111,8 +112,9 @@ func ParseResources(namePrefix string, anySlice []cilium_v2.XDSResource, validat
 			// Inject listener socket option for Cilium datapath
 			listener.SocketOptions = append(listener.SocketOptions, getListenerSocketMarkOption(false /* not ingress */))
 
-			// Fill in RDS config source if unset
+			// Fill in SDS & RDS config source if unset
 			for _, fc := range listener.FilterChains {
+				fillInTransportSocketXDS(fc.TransportSocket)
 				foundCiliumNetworkFilter := false
 				for i, filter := range fc.Filters {
 					if filter.Name == "cilium.network" {
@@ -217,11 +219,9 @@ func ParseResources(namePrefix string, anySlice []cilium_v2.XDSResource, validat
 					return Resources{}, fmt.Errorf("Duplicate Cluster name %q", cluster.Name)
 				}
 			}
-			if validate {
-				if err := cluster.Validate(); err != nil {
-					return Resources{}, fmt.Errorf("ParseResources: Could not validate Cluster %q (%s): %s", cluster.Name, err, cluster.String())
-				}
-			}
+
+			fillInTransportSocketXDS(cluster.TransportSocket)
+
 			// Fill in EDS config source if unset
 			if enum := cluster.GetType(); enum == envoy_config_cluster.Cluster_EDS {
 				if cluster.EdsClusterConfig == nil {
@@ -229,6 +229,12 @@ func ParseResources(namePrefix string, anySlice []cilium_v2.XDSResource, validat
 				}
 				if cluster.EdsClusterConfig.EdsConfig == nil {
 					cluster.EdsClusterConfig.EdsConfig = ciliumXDS
+				}
+			}
+
+			if validate {
+				if err := cluster.Validate(); err != nil {
+					return Resources{}, fmt.Errorf("ParseResources: Could not validate Cluster %q (%s): %s", cluster.Name, err, cluster.String())
 				}
 			}
 
@@ -708,4 +714,50 @@ func (s *XDSServer) UpsertEnvoyEndpoints(serviceName service.Name, backendMap ma
 	// Using context.TODO() is fine as we do not upsert listener resources here - the
 	// context ends up being used only if listener(s) are included in 'resources'.
 	return s.UpsertEnvoyResources(context.TODO(), resources, nil)
+}
+
+func fillInTlsContextXDS(tls *envoy_config_tls.CommonTlsContext) bool {
+	updated := false
+	if tls != nil {
+		for _, sc := range tls.TlsCertificateSdsSecretConfigs {
+			if sc.SdsConfig == nil {
+				sc.SdsConfig = ciliumXDS
+				updated = true
+			}
+		}
+		if sdsConfig := tls.GetValidationContextSdsSecretConfig(); sdsConfig != nil {
+			if sdsConfig.SdsConfig == nil {
+				sdsConfig.SdsConfig = ciliumXDS
+				updated = true
+			}
+		}
+	}
+	return updated
+}
+
+func fillInTransportSocketXDS(ts *envoy_config_core.TransportSocket) {
+	if ts != nil {
+		if tc := ts.GetTypedConfig(); tc != nil {
+			any, err := tc.UnmarshalNew()
+			if err != nil {
+				return
+			}
+			var updated *anypb.Any
+			switch tls := any.(type) {
+			case *envoy_config_tls.DownstreamTlsContext:
+				if fillInTlsContextXDS(tls.CommonTlsContext) {
+					updated = toAny(tls)
+				}
+			case *envoy_config_tls.UpstreamTlsContext:
+				if fillInTlsContextXDS(tls.CommonTlsContext) {
+					updated = toAny(tls)
+				}
+			}
+			if updated != nil {
+				ts.ConfigType = &envoy_config_core.TransportSocket_TypedConfig{
+					TypedConfig: updated,
+				}
+			}
+		}
+	}
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -522,7 +522,7 @@ func (k *K8sWatcher) enableK8sWatchers(ctx context.Context, resourceNames []stri
 			k.initEndpointsOrSlices(k8s.WatcherClient(), serviceOptModifier)
 		case resources.K8sAPIGroupSecretV1Core:
 			swgSecret := lock.NewStoppableWaitGroup()
-			// only watch tls secret
+			// only watch secrets in cilium-secrets namespace
 			k.tlsSecretInit(k8s.WatcherClient(), option.Config.EnvoySecretNamespace, swgSecret)
 		// Custom resource definitions
 		case k8sAPIGroupCiliumNetworkPolicyV2:


### PR DESCRIPTION
Add support for CA certificates in generic secrets with `ca.crt`
key. These are translated to Envoy validation contexts. Adding support
for remaining Envoy validation context configs is TBD.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>

```release-note
CA certificates in Envoy TLS validation contexts are supported via k8s Secrets with 'ca.crt' key.
```
