### PR TITLE
docs: fix a Links documentation style guide error

### DIFF
--- a/Documentation/contributing/development/documentation.rst
+++ b/Documentation/contributing/development/documentation.rst
@@ -192,7 +192,7 @@ Links
 
   .. code-block:: rst
 
-    See the `documentation for Cilium <https://docs.cilium.io/en/latest/>__`.
+    See the `documentation for Cilium <https://docs.cilium.io/en/latest/>`__.
 
 - If using embedded URIs, use anonymous hyperlinks (```... <...>`__`` with two
   underscores, see the documentation for `embedded URIs`_) instead of named
@@ -202,13 +202,13 @@ Links
 
   .. code-block:: rst
 
-    See the `documentation for Cilium <https://docs.cilium.io/en/latest/>__`.
+    See the `documentation for Cilium <https://docs.cilium.io/en/latest/>`__.
 
   Avoid:
 
   .. code-block:: rst
 
-    See the `documentation for Cilium <https://docs.cilium.io/en/latest/>_`.
+    See the `documentation for Cilium <https://docs.cilium.io/en/latest/>`_.
 
 .. _embedded URIs: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#embedded-uris-and-aliases
 .. _block-level hyperlink targets: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#hyperlink-targets


### PR DESCRIPTION
Signed-off-by: Divine Odazie <dodazie@gmail.com>

While using the style guide, I noticed an error that set me back a few mins on the **Links** style guide as annotated in the screenshot.

in the **Prefer (but see previous item)**: code block the underscore is put in the wrong place.

![annotely_image](https://user-images.githubusercontent.com/42554056/178247636-eace6b0f-2d54-4c56-a475-02d46fa95cf7.png)