### PR TITLE
test/k8s/manifests: bump test-verifier image to latest version

### DIFF
--- a/test/k8s/manifests/test-verifier.yaml
+++ b/test/k8s/manifests/test-verifier.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/test-verifier:110522f9cb32ac55b68db668433c85268945be5f@sha256:8c474c287ed530c269ae3ae350c1e9ca8116184cabf4cd22b703926762ac7961
+    image: quay.io/cilium/test-verifier:d2464f1f0bcc35d6c1e3dd0507ef7231816dd241@sha256:4b55ac470e6920e2aefc21036d0aab419af63a5cf50901f2db12a933dcdebc33
     workingDir: /cilium
     command: ["sleep"]
     args:


### PR DESCRIPTION
This will pull in Go 1.18 and will allow commit ee2e83f352c6 ("ip: Add
helpers to assist net -> netip transition") to be applied again without
breaking the K8sVerifier test in CI.
