### PR TITLE
test: Remove `maptool` compilation in K8sVerifier

### DIFF
--- a/test/k8s/verifier.go
+++ b/test/k8s/verifier.go
@@ -150,9 +150,6 @@ var _ = Describe("K8sVerifier", func() {
 	})
 
 	It("Runs the kernel verifier against Cilium's BPF datapath", func() {
-		res := kubectl.ExecPodCmd(helpers.DefaultNamespace, podName, "make -C tools/maptool/")
-		res.ExpectSuccess("Expected compilation of maptool to succeed")
-
 		for _, bpfProgram := range bpfPrograms {
 			file, err := os.Open(getDatapathConfigFile(bpfProgram.name))
 			Expect(err).Should(BeNil(), fmt.Sprintf("Unable to open list of datapath configurations for %s", bpfProgram.name))


### PR DESCRIPTION
The `maptool` binary doesn't seem to be required to run the complexity tests anymore. That may be the case since we moved to the libbpf definitions for maps.