### PR TITLE
hubble: Add hubble_policy_verdicts_total metric

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -637,6 +637,26 @@ Options
 
 This metric supports :ref:`Context Options<hubble_context_options>`.
 
+``policy``
+~~~~~~~~~~
+
+================================ ======================================== ===============================
+Name                             Labels                                   Description
+================================ ======================================== ===============================
+``policy_verdicts_total``        ``action``, ``direction``, ``match``     Number of policy verdict events
+================================ ======================================== ===============================
+
+.. note::
+
+   ``policy_verdicts_total`` metric does not count policy verdict events with ``reserved:host`` as
+   the source since ``reserved:host`` is allowed to connect to any local endpoints regardless of
+   whether a Cilium network policy rule explicitly allows it.
+
+Options
+"""""""
+
+This metric supports :ref:`Context Options<hubble_context_options>`.
+
 ``tcp``
 ~~~~~~~
 

--- a/pkg/hubble/metrics/metrics.go
+++ b/pkg/hubble/metrics/metrics.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/flows-to-world"    // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/http"              // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/icmp"              // invoke init
+	_ "github.com/cilium/cilium/pkg/hubble/metrics/policy"            // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/port-distribution" // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/tcp"               // invoke init
 )

--- a/pkg/hubble/metrics/policy/handler.go
+++ b/pkg/hubble/metrics/policy/handler.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"context"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+	"github.com/cilium/cilium/pkg/identity"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+)
+
+type policyHandler struct {
+	verdicts *prometheus.CounterVec
+	context  *api.ContextOptions
+}
+
+func (d *policyHandler) Init(registry *prometheus.Registry, options api.Options) error {
+	c, err := api.ParseContextOptions(options)
+	if err != nil {
+		return err
+	}
+	d.context = c
+
+	labels := []string{"direction", "match", "action"}
+	labels = append(labels, d.context.GetLabelNames()...)
+
+	d.verdicts = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: api.DefaultPrometheusNamespace,
+		Name:      "policy_verdicts_total",
+		Help:      "Total number of Cilium network policy verdicts",
+	}, labels)
+
+	registry.MustRegister(d.verdicts)
+	return nil
+}
+
+func (d *policyHandler) Status() string {
+	return d.context.Status()
+}
+
+func (d *policyHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) {
+	if flow.GetEventType().GetType() != monitorAPI.MessageTypePolicyVerdict {
+		return
+	}
+	// ignore verdict if the source is host since host is allowed to connect to any local endpoints.
+	if flow.GetSource().GetIdentity() == uint32(identity.ReservedIdentityHost) {
+		return
+	}
+
+	direction := strings.ToLower(flow.GetTrafficDirection().String())
+	match := strings.ToLower(monitorAPI.PolicyMatchType(flow.GetPolicyMatchType()).String())
+	action := strings.ToLower(flow.Verdict.String())
+	labels := []string{direction, match, action}
+	labels = append(labels, d.context.GetLabelValues(flow)...)
+
+	d.verdicts.WithLabelValues(labels...).Inc()
+}

--- a/pkg/hubble/metrics/policy/handler_test.go
+++ b/pkg/hubble/metrics/policy/handler_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package policy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+	"github.com/cilium/cilium/pkg/identity"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicyHandler(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	h := &policyHandler{}
+	assert.NoError(t, h.Init(registry, api.Options{}))
+	assert.NoError(t, testutil.CollectAndCompare(h.verdicts, strings.NewReader("")))
+	flow := flowpb.Flow{
+		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+		TrafficDirection: flowpb.TrafficDirection_EGRESS,
+		PolicyMatchType:  monitorAPI.PolicyMatchNone,
+		Verdict:          flowpb.Verdict_DROPPED,
+	}
+
+	h.ProcessFlow(context.Background(), &flow)
+	flow.TrafficDirection = flowpb.TrafficDirection_INGRESS
+	flow.PolicyMatchType = monitorAPI.PolicyMatchL3L4
+	flow.Verdict = flowpb.Verdict_REDIRECTED
+	h.ProcessFlow(context.Background(), &flow)
+
+	// Policy verdicts from host shouldn't be counted.
+	flow.PolicyMatchType = monitorAPI.PolicyMatchAll
+	flow.Source = &flowpb.Endpoint{Identity: uint32(identity.ReservedIdentityHost)}
+	h.ProcessFlow(context.Background(), &flow)
+
+	expected := strings.NewReader(`# HELP hubble_policy_verdicts_total Total number of Cilium network policy verdicts
+# TYPE hubble_policy_verdicts_total counter
+hubble_policy_verdicts_total{action="dropped",direction="egress",match="none"} 1
+hubble_policy_verdicts_total{action="redirected",direction="ingress",match="l3-l4"} 1
+`)
+	assert.NoError(t, testutil.CollectAndCompare(h.verdicts, expected))
+}

--- a/pkg/hubble/metrics/policy/plugin.go
+++ b/pkg/hubble/metrics/policy/plugin.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+)
+
+type policyPlugin struct{}
+
+func (p *policyPlugin) NewHandler() api.Handler {
+	return &policyHandler{}
+}
+
+func (p *policyPlugin) HelpText() string {
+	return `policy - Policy metrics
+Reports metrics related to Cilium network policies.
+
+Metrics:
+  hubble_policy_verdicts_total Total number of policy verdict events
+
+Options:` +
+		api.ContextOptionsHelp
+}
+
+func init() {
+	api.DefaultRegistry().Register("policy", &policyPlugin{})
+}


### PR DESCRIPTION
This metric allows you to monitor policy verdict events by direction and
match type.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

```release-note
hubble: Add hubble_policy_verdicts_total metric
```
