### PR TITLE
Include DeleteNetworkInterface in ENI Required Privileges Docs

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -441,6 +441,7 @@ Required Privileges
 The following EC2 privileges are required by the Cilium operator in order to
 perform ENI creation and IP allocation:
 
+ * ``DeleteNetworkInterface``
  * ``DescribeNetworkInterfaces``
  * ``DescribeSubnets``
  * ``DescribeVpcs``


### PR DESCRIPTION
* If a network interface fails to attach Cilium needs permissions
  to delete it

Signed-off-by: Ellie Springsteen <ellie.springsteen@appian.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [N/A] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Include DeleteNetworkInterface in ENI Required Privileges Docs
```
