### PR TITLE
config: Fix unit tests for native routing CIDR

### DIFF
--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -543,6 +543,8 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			err := tt.d.checkIPv4NativeRoutingCIDR()
 			if tt.wantErr && err == nil {
 				t.Error("expected error, but got nil")
+			} else if !tt.wantErr && err != nil {
+				t.Errorf("expected no error, but got %q", err)
 			}
 		})
 	}
@@ -603,6 +605,8 @@ func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
 			err := tt.d.checkIPv6NativeRoutingCIDR()
 			if tt.wantErr && err == nil {
 				t.Error("expected error, but got nil")
+			} else if !tt.wantErr && err != nil {
+				t.Errorf("expected no error, but got %q", err)
 			}
 		})
 	}

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -515,7 +515,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "without native routing cidr and tunnel enabled",
+			name: "without native routing cidr and tunnel disabled",
 			d: &DaemonConfig{
 				EnableIPv4Masquerade: true,
 				EnableIPv6Masquerade: true,


### PR DESCRIPTION
We were missing a few error cases in the `TestCheckIPv{4,6}NativeRoutingCIDR` tests, which means the test may pass even though some test cases are failing. This pull request fixes it.

Fixes: https://github.com/cilium/cilium/pull/11132
Fixes: https://github.com/cilium/cilium/pull/17332