### PR TITLE
ip: Add helpers to assist net -> netip transition

### DIFF
--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -5,6 +5,7 @@ package ip
 
 import (
 	"net"
+	"net/netip"
 )
 
 // ParseCIDRs fetches all CIDRs referred to by the specified slice and returns
@@ -29,4 +30,53 @@ func ParseCIDRs(cidrs []string) (valid []*net.IPNet, invalid []string) {
 		}
 	}
 	return valid, invalid
+}
+
+// PrefixToIPNet is a convenience helper for migrating from the older 'net'
+// standard library types to the newer 'netip' types. Use this to plug the
+// new types in newer code into older types in older code during the migration.
+func PrefixToIPNet(prefix netip.Prefix) *net.IPNet {
+	if !prefix.IsValid() {
+		return nil
+	}
+	addr := prefix.Masked().Addr()
+	return &net.IPNet{
+		IP:   addr.AsSlice(),
+		Mask: net.CIDRMask(prefix.Bits(), addr.BitLen()),
+	}
+}
+
+// IPNetToPrefix is a convenience helper for migrating from the older 'net'
+// standard library types to the newer 'netip' types. Use this to plug the
+// new types in newer code into older types in older code during the migration.
+func IPNetToPrefix(prefix *net.IPNet) netip.Prefix {
+	if prefix == nil {
+		return netip.Prefix{}
+	}
+	ip, ok := netip.AddrFromSlice(prefix.IP)
+	if !ok {
+		return netip.Prefix{}
+	}
+	ones, bits := prefix.Mask.Size()
+	if bits != net.IPv4len*8 && bits != net.IPv6len*8 {
+		// invalid mask
+		return netip.Prefix{}
+	}
+	return netip.PrefixFrom(ip, ones)
+}
+
+// IPToNetPrefix is a convenience helper for migrating from the older 'net'
+// standard library types to the newer 'netip' types. Use this to plug the new
+// types in newer code into older types in older code during the migration.
+//
+// Note: This function assumes that the result of net.IP.To4() or net.IP.To16()
+// are passed in. This is because the net package always creates net.IP with a
+// length of 16 (IPv6) which causes this function to return an IPv6
+// netip.Prefix.
+func IPToNetPrefix(ip net.IP) netip.Prefix {
+	a, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return netip.Prefix{}
+	}
+	return netip.PrefixFrom(a, a.BitLen())
 }

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package ip
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrefixToIPNet(t *testing.T) {
+	_, v4IPNet, err := net.ParseCIDR("1.1.1.1/32")
+	assert.NoError(t, err)
+	_, v6IPNet, err := net.ParseCIDR("::ff/128")
+	assert.NoError(t, err)
+	assert.Equal(t, v4IPNet, PrefixToIPNet(netip.MustParsePrefix("1.1.1.1/32")))
+	assert.Equal(t, v6IPNet, PrefixToIPNet(netip.MustParsePrefix("::ff/128")))
+
+	var nilNet *net.IPNet
+	assert.Equal(t, nilNet, PrefixToIPNet(netip.Prefix{}))
+}
+
+func TestIPNetToPrefix(t *testing.T) {
+	_, v4IPNet, err := net.ParseCIDR("1.1.1.1/32")
+	assert.NoError(t, err)
+	_, v6IPNet, err := net.ParseCIDR("::ff/128")
+	assert.NoError(t, err)
+	assert.Equal(t, netip.MustParsePrefix(v4IPNet.String()), IPNetToPrefix(v4IPNet))
+	assert.Equal(t, netip.MustParsePrefix(v6IPNet.String()), IPNetToPrefix(v6IPNet))
+
+	assert.Equal(t, netip.Prefix{}, IPNetToPrefix(nil))
+}
+
+func TestIPToNetPrefix(t *testing.T) {
+	v4, _, err := net.ParseCIDR("1.1.1.1/32")
+	assert.NoError(t, err)
+	v6, _, err := net.ParseCIDR("::ff/128")
+	assert.NoError(t, err)
+	assert.Equal(t, netip.PrefixFrom(netip.MustParseAddr(v4.String()), 32), IPToNetPrefix(v4.To4()))
+	assert.Equal(t, netip.PrefixFrom(netip.MustParseAddr(v6.String()), 128), IPToNetPrefix(v6.To16()))
+
+	assert.Equal(t, netip.Prefix{}, IPToNetPrefix(nil))
+}


### PR DESCRIPTION
Resubmission: Already reviewed at #20303. Needs the VM image to be updated.

These helpers can come in useful to convert between old and new IP types
from the standard library in order to do incremental updates to
individual packages without reworking IP address/prefix usage across
the entire application all at once.

Once we've fully migrated to netip, these should no longer be necessary
and can be deleted again.

Co-authored-by: Chris Tarazi <chris@isovalent.com>
Co-authored-by: Tobias Klauser <tobias@cilium.io>
