### PR TITLE
bpf: Add send_trace_notify hook for redirect_direct_{v4,v6}

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -516,8 +516,16 @@ ct_recreate6:
 			return ret;
 	}
 #endif
-	if (is_defined(ENABLE_HOST_ROUTING))
-		return redirect_direct_v6(ctx, ETH_HLEN, ip6);
+	if (is_defined(ENABLE_HOST_ROUTING)) {
+		int oif;
+
+		ret = redirect_direct_v6(ctx, ETH_HLEN, ip6, &oif);
+		if (likely(ret == CTX_ACT_REDIRECT))
+			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
+					  *dst_id, 0, oif,
+					  trace.reason, trace.monitor);
+		return ret;
+	}
 
 	goto pass_to_stack;
 
@@ -1097,8 +1105,16 @@ skip_vtep:
 			return ret;
 	}
 #endif /* TUNNEL_MODE */
-	if (is_defined(ENABLE_HOST_ROUTING))
-		return redirect_direct_v4(ctx, ETH_HLEN, ip4);
+	if (is_defined(ENABLE_HOST_ROUTING)) {
+		int oif;
+
+		ret = redirect_direct_v4(ctx, ETH_HLEN, ip4, &oif);
+		if (likely(ret == CTX_ACT_REDIRECT))
+			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
+					  *dst_id, 0, oif,
+					  trace.reason, trace.monitor);
+		return ret;
+	}
 
 	goto pass_to_stack;
 


### PR DESCRIPTION
When BPF host routing is enabled, Hubble is missing outgoing flows from the Pod that are directed to the outside of the node. Add such trace point, so they become visible.

Revival of https://github.com/cilium/cilium/pull/19646