### PR TITLE
docs: Fix update-spelling_wordlist.sh to run command on spelling errors

### DIFF
--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -52,7 +52,11 @@ describe_spelling_errors() {
     find "${spelldir}" -type f -print0 | xargs -0 sed 's/^/* Documentation\//'
 
     # Print a hint on how to add new correct words to the list of good words
-    new_words="$(sed -E "s/^([^:]+:){2} \(([^ ]+)\).*/\2/g" "${spelldir}"/* | sort -u | tr '\r\n' ' ' | sed "s/'/\\\\\\\\'/g")"
+    new_words="$(find "${spelldir}" -type f -print0 | \
+        xargs -0 sed -E "s/^([^:]+:){2} \(([^ ]+)\).*/\2/g" | \
+        sort -u | \
+        tr '\r\n' ' ' | \
+        sed "s/'/\\\\\\\\'/g")"
     printf "\nIf the words are not misspelled, run:\n%s %s\n" \
         "Documentation/update-spelling_wordlist.sh" "${new_words}"
 }


### PR DESCRIPTION
When spelling mistakes are detected during documentation builds, check-build.sh suggests running update-spelling_wordlist.sh if the words are false positives and should be added to the list of exceptions.

The command to run is generated from the entries in the files resulting from the spell check. But when generating this command, the code assumes that all such files are directly under _build/spelling/. This is not the case: they may be in subdirectories instead. If this happens, we fail to retreive the entries and to generate the suggested update-spelling_wordlist.sh command properly.

Fix the issue by searching for all files under _build/spelling/ and passing them to the pipeline.
