### PR TITLE
Add metric on number of requests rejected by DNS Proxy semaphore

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -453,6 +453,11 @@ var (
 	// connection (aka zombie), per endpoint.
 	FQDNAliveZombieConnections = NoOpGaugeVec
 
+	// FQDNSemaphoreRejectedTotal is the total number of DNS requests rejected
+	// by the DNS proxy because too many requests were in flight, as enforced by
+	// the admission semaphore.
+	FQDNSemaphoreRejectedTotal = NoOpCounter
+
 	// BPFSyscallDuration is the metric for bpf syscalls duration.
 	BPFSyscallDuration = NoOpObserverVec
 
@@ -566,6 +571,7 @@ type Configuration struct {
 	FQDNActiveNames                         bool
 	FQDNActiveIPs                           bool
 	FQDNActiveZombiesConnections            bool
+	FQDNSemaphoreRejectedTotal              bool
 	BPFSyscallDurationEnabled               bool
 	BPFMapOps                               bool
 	BPFMapPressure                          bool
@@ -1208,6 +1214,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, FQDNAliveZombieConnections)
 			c.FQDNActiveZombiesConnections = true
+
+		case metricName + "_" + SubsystemFQDN + "_sempaphore_rejected_total":
+			FQDNSemaphoreRejectedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemFQDN,
+				Name:      "semaphore_rejected_total",
+				Help:      "Number of DNS request rejected by the DNS Proxy's admission semaphore",
+			})
+
+			collectors = append(collectors, FQDNSemaphoreRejectedTotal)
+			c.FQDNSemaphoreRejectedTotal = true
 
 		case Namespace + "_" + SubsystemBPF + "_syscall_duration_seconds":
 			BPFSyscallDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3134,7 +3134,8 @@ func (c *DaemonConfig) Populate() {
 
 	// Metrics Setup
 	defaultMetrics := metrics.DefaultMetrics()
-	for _, metric := range viper.GetStringSlice(Metrics) {
+	flagMetrics := append(viper.GetStringSlice(Metrics), c.additionalMetrics()...)
+	for _, metric := range flagMetrics {
 		switch metric[0] {
 		case '+':
 			defaultMetrics[metric[1:]] = struct{}{}
@@ -3246,6 +3247,17 @@ func (c *DaemonConfig) Populate() {
 
 	// Envoy secrets namespace to watch
 	c.EnvoySecretNamespace = viper.GetString(IngressSecretsNamespace)
+}
+
+func (c *DaemonConfig) additionalMetrics() []string {
+	addMetric := func(name string) string {
+		return "+" + metrics.Namespace + name
+	}
+	var m []string
+	if c.DNSProxyConcurrencyLimit > 0 {
+		m = append(m, addMetric(metrics.SubsystemFQDN+"_sempaphore_rejected_total"))
+	}
+	return m
 }
 
 func (c *DaemonConfig) populateDevices() {


### PR DESCRIPTION
<!-- Description of change -->
The DNS proxy has a configurable semaphore, which rejects requests if
there are more than the configured number of requests in flight. There
is a metric to measure how long a DNS proxy waited on the semaphore, but
no metric to track if requests were dropped because of the semaphore.

The existing monitoring isn't quite sufficient. The metric
proxy_upstream_time{"timeout", "dns", "semaphoreTime"} will measure
requests rejected due to timeouts, but also any other error which
implements neterror.Timeout (e.g. an actual timeout communicating with
upstream DNS).

```release-note
Add metric on number of requests rejected by DNS Proxy semaphore
```

Signed-off-by: Rahul Joshi <rkjoshi@google.com>