### PR TITLE
test: Remove sockops test cases

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -197,8 +197,6 @@ framework in the ``test/`` directory and interact with ginkgo directly:
     $ ginkgo . -- -cilium.help
       -cilium.SSHConfig string
             Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')
-      -cilium.benchmarks
-            Specifies benchmark tests should be run which may increase test time
       -cilium.help
             Display this help message.
       -cilium.holdEnvironment

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -40,7 +40,6 @@ type CiliumTestConfigType struct {
 	Kubeconfig           string
 	KubectlPath          string
 	RegistryCredentials  string
-	Benchmarks           bool
 	// Multinode enables the running of tests that involve more than one
 	// node. If false, some tests will silently skip multinode checks.
 	Multinode      bool
@@ -93,8 +92,6 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Path that holds version-specific kubectl binaries")
 	flagset.StringVar(&c.RegistryCredentials, "cilium.registryCredentials", "",
 		"Registry credentials to be used to download images")
-	flagset.BoolVar(&c.Benchmarks, "cilium.benchmarks", false,
-		"Specifies benchmark tests should be run which may increase test time")
 	flagset.BoolVar(&c.Multinode, "cilium.multinode", true,
 		"Enable tests across multiple nodes. If disabled, such tests may silently pass")
 	flagset.BoolVar(&c.RunQuarantined, "cilium.runQuarantined", false,

--- a/test/k8s/assertion_helpers.go
+++ b/test/k8s/assertion_helpers.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/cilium/cilium/test/config"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 )
@@ -226,13 +225,6 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, optio
 	case helpers.CIIntegrationGKE:
 		err := vm.WaitforPods(helpers.KubeSystemNamespace, "", longTimeout)
 		ExpectWithOffset(1, err).Should(BeNil(), "kube-system pods were not able to get into ready state after restart")
-	}
-}
-
-// SkipIfBenchmark will skip the test if benchmark is not specified
-func SkipIfBenchmark() {
-	if !config.CiliumTestConfig.Benchmarks {
-		Skip("Benchmarks are skipped, specify -cilium.Benchmarks")
 	}
 }
 


### PR DESCRIPTION
The --sockops-enable=true is barely used (and working), and it might get
deprecated.