### PR TITLE
policy: avoid marshalling L4Filter with indent

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -717,9 +717,9 @@ func (l4 *L4Filter) IsProxylibRedirect() bool {
 	return l4.IsEnvoyRedirect() && l4.L7Parser != ParserTypeHTTP
 }
 
-// MarshalIndent returns the `L4Filter` in indented JSON string.
-func (l4 *L4Filter) MarshalIndent() string {
-	b, err := json.MarshalIndent(l4, "", "  ")
+// Marshal returns the `L4Filter` in a JSON string.
+func (l4 *L4Filter) Marshal() string {
+	b, err := json.Marshal(l4)
 	if err != nil {
 		b = []byte("\"L4Filter error: " + err.Error() + "\"")
 	}
@@ -1067,7 +1067,7 @@ func (l4 *L4Policy) GetModel() *models.L4Policy {
 	ingress := []*models.PolicyRule{}
 	for _, v := range l4.Ingress {
 		ingress = append(ingress, &models.PolicyRule{
-			Rule:             v.MarshalIndent(),
+			Rule:             v.Marshal(),
 			DerivedFromRules: v.DerivedFromRules.GetModel(),
 		})
 	}
@@ -1075,7 +1075,7 @@ func (l4 *L4Policy) GetModel() *models.L4Policy {
 	egress := []*models.PolicyRule{}
 	for _, v := range l4.Egress {
 		egress = append(egress, &models.PolicyRule{
-			Rule:             v.MarshalIndent(),
+			Rule:             v.Marshal(),
 			DerivedFromRules: v.DerivedFromRules.GetModel(),
 		})
 	}

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -6,6 +6,8 @@
 package policy
 
 import (
+	"bytes"
+	"encoding/json"
 	"sort"
 
 	"github.com/kr/pretty"
@@ -170,7 +172,10 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 	sort.Sort(SortablePolicyRules(model.Egress))
 	c.Assert(len(expectedEgress), Equals, len(model.Egress))
 	for i := range expectedEgress {
-		c.Assert(model.Egress[i].Rule, Equals, expectedEgress[i])
+		expected := new(bytes.Buffer)
+		err := json.Compact(expected, []byte(expectedEgress[i]))
+		c.Assert(err, Equals, nil, Commentf("Could not compact expected json"))
+		c.Assert(model.Egress[i].Rule, Equals, expected.String())
 	}
 
 	expectedIngress := []string{`{
@@ -244,7 +249,10 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 	sort.Sort(SortablePolicyRules(model.Ingress))
 	c.Assert(len(expectedIngress), Equals, len(model.Ingress))
 	for i := range expectedIngress {
-		c.Assert(model.Ingress[i].Rule, Equals, expectedIngress[i])
+		expected := new(bytes.Buffer)
+		err := json.Compact(expected, []byte(expectedIngress[i]))
+		c.Assert(err, Equals, nil, Commentf("Could not compact expected json"))
+		c.Assert(model.Ingress[i].Rule, Equals, expected.String())
 	}
 
 	c.Assert(policy.HasEnvoyRedirect(), Equals, true)


### PR DESCRIPTION
This code path is very hot since hubble fetch the
/v1/endpoint and /v1/endpoint/{ID} endpoints very often. When having a
lot of policy rules, the output of those, and all the cascading buffers
used to marshal and generate the result grow very big, and cause a lot
of memory pressure.

Since this is encoded down to a string in a struct, later marshalled
without indentation, there isn't really any need to add the extra
white spaces and newlines.

The outout of the json deep into the L4Filter struct looks like this;
````
'      {\n        \"dns\": [\n          {\n            \"matchName\": \"domain.tld\"\n          }\n        ]\n      }'
````
And with this change, it will look like this;
````
'{\"dns\":[{\"matchName\":\"domain.tld\"}]}'
````
That is a reduction from 110 characters to only 42, a more than 60%
decrease. Since this data flows through multiple buffers, the actual
saving will be even longer. We saw the output of the /v1/endpoint
be reduced by almost 50% from ~20MiB to ~10MiB with this change.

Signed-off-by: Odin Ugedal <ougedal@palantir.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Improve memory usage for encoding endpoint objects into JSON
```

^ Do you want me to add a release note to this change?
