### PR TITLE
test: remove nightly test leftovers

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -33,7 +33,6 @@ determine which VMs are necessary to run particular tests. All test names
 * ``Runtime``: Test cilium in a runtime environment running on a single node.
 * ``K8s``: Create a small multi-node kubernetes environment for testing
   features beyond a single host, and for testing kubernetes-specific features.
-* ``Nightly``: sets up a multinode Kubernetes cluster to run scale, performance, and chaos testing for Cilium.
 
 .. _Ginkgo: https://onsi.github.io/ginkgo/
 .. _focus: `Focused Specs`_
@@ -171,20 +170,6 @@ supported version of Kubernetes, run the test suite with the following format:
         end
       end
 
-Running Nightly Tests
-^^^^^^^^^^^^^^^^^^^^^
-
-To run all of the Nightly tests, run the following command from the ``test`` directory:
-
-.. code-block:: shell-session
-
-    ginkgo --focus="Nightly" --tags=integration_tests
-
-Similar to the other test suites, Ginkgo searches for all tests in all
-subdirectories that are "named" beginning with the string "Nightly" and contain
-any characters after it. The default version of running Nightly test are 1.8,
-but can be changed using the environment variable ``K8S_VERSION``.
-
 Available CLI Options
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -232,7 +217,7 @@ framework in the ``test/`` directory and interact with ginkgo directly:
       -cilium.tag string
             Specifies which tag of cilium to use during tests
       -cilium.testScope string
-            Specifies scope of test to be ran (k8s, Nightly, runtime)
+            Specifies scope of test to be ran (k8s, runtime)
       -cilium.timeout duration
             Specifies timeout for test run (default 24h0m0s)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -20,7 +20,7 @@ GINKGO = $(QUIET) ginkgo
 
 REGISTRY_CREDENTIALS ?= "${DOCKER_LOGIN}:${DOCKER_PASSWORD}"
 
-.PHONY = all build test run k8s-test k8s-kind nightly clean run_bpf_tests
+.PHONY = all build test run k8s-test k8s-kind clean run_bpf_tests
 
 all: build
 
@@ -59,9 +59,6 @@ k8s-kind:
 			-cilium.operator-image="quay.io/cilium/operator" \
 			-cilium.operator-suffix="-ci" \
 			-cilium.holdEnvironment=$(HOLD_ENVIRONMENT)
-
-nightly:
-	ginkgo --focus "Nightly" -v --tags integration_tests -- --cilium.provision=$(PROVISION) --cilium.registryCredentials=$(REGISTRY_CREDENTIALS)
 
 clean:
 	@$(ECHO_CLEAN)

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -68,7 +68,7 @@ func (c *CiliumTestConfigType) ParseFlags() {
 	flagset.BoolVar(&c.ShowCommands, "cilium.showCommands", false,
 		"Output which commands are ran to stdout")
 	flagset.StringVar(&c.TestScope, "cilium.testScope", "",
-		"Specifies scope of test to be ran (k8s, Nightly, runtime)")
+		"Specifies scope of test to be ran (k8s, runtime)")
 	flagset.StringVar(&c.CiliumImage, "cilium.image", "",
 		"Specifies which image of cilium to use during tests")
 	flagset.StringVar(&c.CiliumTag, "cilium.tag", "",

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -266,13 +266,6 @@ const (
 	ReservedIdentityHost = 1
 )
 
-// NightlyStableUpgradesFrom maps the cilium image versions to the helm charts
-// that will be used to run update tests in the Nightly test.
-var NightlyStableUpgradesFrom = map[string]string{
-	"v1.8": "1.8-dev",
-	"v1.9": "1.9-dev",
-}
-
 var (
 	IsCiliumV1_8  = versioncheck.MustCompile(">=1.7.90 <1.9.0")
 	IsCiliumV1_9  = versioncheck.MustCompile(">=1.8.90 <1.10.0")

--- a/test/helpers/scope.go
+++ b/test/helpers/scope.go
@@ -27,9 +27,6 @@ func GetScope() (string, error) {
 		return Runtime, nil
 	case strings.HasPrefix(focusString, K8s):
 		return K8s, nil
-	case strings.Contains(focusString, "nightly"):
-		// Nightly tests run in a Kubernetes environment.
-		return K8s, nil
 	default:
 		return "", errors.New("Scope cannot be set")
 	}


### PR DESCRIPTION
PR #20128 removed the nightly test suites. Remove the accompanying
Makefile targets, test helper integration and documentation as well.
