### PR TITLE
ci: include v1.11 and v1.12 branches in CI image garbage collection

### DIFF
--- a/.github/workflows/ci-images-garbage-collect.yaml
+++ b/.github/workflows/ci-images-garbage-collect.yaml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
-      - uses: docker://quay.io/cilium/scruffy:v0.0.1@sha256:15e3926d8e74aa6a278cc07fb61d5888322fabdae49637384dc6a3fb32452969
+      - uses: docker://quay.io/cilium/scruffy:v0.0.2@sha256:6492638de03f4afd05ccb487f995766ebc8f2cddf034ee211107b3b4a0cf7aa7
         with:
           entrypoint: scruffy
-          args: --git-repository=./
+          args: --git-repository=./ --stable-branches=origin/master,origin/v1.9,origin/v1.10,origin/v1.11,origin/v1.12
         env:
           QUAY_TOKEN: ${{ secrets.SCRUFFY_QUAY_TOKEN }}


### PR DESCRIPTION
Explicitly specify the branches to look for tags, so we hopefully don't
forget to include future release branches.

Also pull in the latest version of the cilium/scruffy image which
correctly considers the value passed via the `--stable-branches` flag,
see https://github.com/cilium/scruffy/pull/1
