### PR TITLE
Improve Egress Gateway Getting Started Guide

### DIFF
--- a/Documentation/gettingstarted/egress-gateway.rst
+++ b/Documentation/gettingstarted/egress-gateway.rst
@@ -385,12 +385,36 @@ cluster with the IP of the node.
 Apply egress gateway policy
 ---------------------------
 
-Apply the ``egress-sample`` egress gateway Policy, which will cause all traffic
-from the mediabot pod to leave the cluster with the ``10.168.60.100`` IP:
+Download the ``egress-sample`` Egress Gateway Policy yaml:
 
 .. parsed-literal::
 
-    $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes-egress-gateway/egress-nat-policy-egress-gateway.yaml
+    $ wget \ |SCM_WEB|\/examples/kubernetes-egress-gateway/egress-nat-policy-egress-gateway.yaml
+
+Modify the ``destinationCIDRs`` to include the IP of the host where your
+designated external service is running on.
+
+Specifying an IP address in the ``egressIP`` field is optional.
+To make things easier in this example, it is possible to comment out that line.
+This way, the agent will use the first IPv4 assigned to the interface for the
+default route.
+
+To let the policy select the node designated to be the Egress Gateway, apply the
+label ``egress-node: test`` to it:
+
+.. code-block:: shell-session
+
+    $ kubectl label nodes <egress-gateway-node> egress-node=true
+
+Note that the Egress Gateway node should be a different node from the one where
+the ``mediabot`` pod is running on.
+
+Apply the ``egress-sample`` egress gateway Policy, which will cause all traffic
+from the mediabot pod to leave the cluster with the IP of the Egress Gateway node:
+
+.. code-block:: shell-session
+
+    $ kubectl apply -f egress-nat-policy-egress-gateway.yaml
 
 Verify the setup
 ----------------
@@ -403,8 +427,8 @@ We can now verify with the client pod that the policy is working correctly:
     <HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
     [...]
 
-The access log from Nginx should show that the request is coming from the egress
-IP (``192.168.60.100``) rather than one of the nodes in the Kubernetes cluster:
+The access log from Nginx should show that the request is coming from the
+selected Egress IP rather than the one of the node where the pod is running:
 
 .. code-block:: shell-session
 

--- a/Documentation/gettingstarted/egress-gateway.rst
+++ b/Documentation/gettingstarted/egress-gateway.rst
@@ -91,8 +91,7 @@ The egress gateway feature and all the requirements can be enabled as follow:
                --set egressGateway.enabled=true \\
                --set bpf.masquerade=true \\
                --set kubeProxyReplacement=strict \\
-               --set l7Proxy=false \\
-               --set rollOutCiliumPods=true
+               --set l7Proxy=false
 
     .. group-tab:: ConfigMap
 
@@ -102,6 +101,13 @@ The egress gateway feature and all the requirements can be enabled as follow:
             enable-ipv4-egress-gateway: true
             enable-l7-proxy: false
             kube-proxy-replacement: strict
+
+Rollout both the agent pods and the operator pods to make the changes effective:
+
+.. code-block:: shell-session
+
+    $ kubectl rollout restart ds cilium -n kube-system
+    $ kubectl rollout restart deploy cilium-operator -n kube-system
 
 Compatibility with cloud environments
 -------------------------------------


### PR DESCRIPTION
This PR improves (once again) the documentation about the Egress Gateway feature in the Getting Started Guides section.

The previous PR #20471 missed the rollout of the Cilium operator to apply the ConfigMap new values after the `helm upgrade` command. This is needed to restart the agent pods in a correct way.

Besides, some details about how the example Egress Gateway Policy should be modified for the specific case of the user have been added.

Relates: https://github.com/cilium/cilium/issues/20375