### PR TITLE
vtep: set vtep route log level to debug and skip symbol substitution cilium_vtep_map

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -534,9 +534,6 @@ func setupRouteToVtepCidr() error {
 		return fmt.Errorf("failed to list routes: %w", err)
 	}
 	for _, rt := range routes {
-		log.WithFields(logrus.Fields{
-			logfields.IPAddr: rt.Dst.String(),
-		}).Info("VTEP route")
 		rtCIDR, err := cidr.ParseCIDR(rt.Dst.String())
 		if err != nil {
 			return fmt.Errorf("Invalid VTEP Route CIDR: %w", err)


### PR DESCRIPTION
setupRouteToVtepCidr() is called from syncEndpointsAndHostIPs()
when VTEP is enabled, the vtep route log level
in setupRouteToVtepCidr() is set to "Info" level, result
in frequent log noise in cilium agent log below, set
the log level to "Debug" to hide the log.

level=info msg="VTEP route" ipAddr=10.1.14.0/24 subsys=daemon
level=info msg="VTEP route" ipAddr=10.1.15.0/24 subsys=daemon
level=info msg="VTEP route" ipAddr=10.1.14.0/24 subsys=daemon
level=info msg="VTEP route" ipAddr=10.1.15.0/24 subsys=daemon
level=info msg="VTEP route" ipAddr=10.1.14.0/24 subsys=daemon

cilium agent also  logs:
  level=warning msg="Skipping symbol substitution" subsys=elf symbol=cilium_vtep_map
   
add cilium_vtep_map to ignoredELFPrefixes to avoid the warning log.

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Reduce the vtep route log noise and avoid cilium_vtep_map symbol substitution warning log
```
