### PR TITLE
ci: fix AKS worfklow for 1.12 branch

### DIFF
--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -185,14 +185,16 @@ jobs:
           cilium version
 
       - name: Login to Azure
-        uses: azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010
+        uses: azure/login@24848bc889cfc0a8313c2b3e378ac0d625b9bc16
         with:
           client-id: ${{ secrets.AZURE_PR_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_PR_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_PR_SUBSCRIPTION_ID }}
 
-      - name: Display az version
+      - name: Install aks-preview CLI extension
         run: |
+            az extension add --name aks-preview
+            az extension update --name aks-preview
             az version
 
       - name: Create AKS cluster
@@ -208,7 +210,7 @@ jobs:
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
-            --network-plugin azure \
+            --network-plugin none \
             --node-count 2 \
             ${{ env.cost_reduction }} \
             --generate-ssh-keys


### PR DESCRIPTION
The AKS workflow for 1.12 was incorrect: it should be using BYOCNI, not Azure IPAM => for some reason when we branched out in 51961dd2599393b12744594101b247de1ebf6a5a 23 days ago we used the wrong workflow file as basis, and it's missing the following changes from the same day: 6d5512303c5dc1dd2f99587c17dbd85b6e88c146

Also, for some reason dependabot missed the bump to `azure/login` version in 34f867c0226d326a3c263f4941a2296396a6e2e7, so let's bump it.