### PR TITLE
fqdn/dnsproxy: fix test build

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -997,9 +997,9 @@ func (s *DNSProxyTestSuite) TestProxyRequestContext_IsTimeout(c *C) {
 	p.Err = fmt.Errorf("sample err: %s", context.DeadlineExceeded)
 	c.Assert(p.IsTimeout(), Equals, false)
 
-	p.Err = errFailedAcquireSemaphore{}
+	p.Err = ErrFailedAcquireSemaphore{}
 	c.Assert(p.IsTimeout(), Equals, true)
-	p.Err = errTimedOutAcquireSemaphore{
+	p.Err = ErrTimedOutAcquireSemaphore{
 		gracePeriod: 1 * time.Second,
 	}
 	c.Assert(p.IsTimeout(), Equals, true)


### PR DESCRIPTION
Commit 372407fbb580 exported errFailedAcquireSemaphore and
errTimedOutAcquireSemaphore but didn't update the tests to use the new
types. This wasn't caught because privileged tests weren't run on the
corresponding PR #20491.

Fixes: 372407fbb580 ("Add metric on number of requests rejected by DNS Proxy semaphore")

/cc @rahulkjoshi