### PR TITLE
kubectl get cep returns empty columns of policies statuses

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
@@ -31,13 +31,13 @@ spec:
       name: Identity ID
       type: integer
     - description: Ingress enforcement in the endpoint
-      jsonPath: .status.policy.ingress.enforcing
+      jsonPath: .status.policy.ingress.state
       name: Ingress Enforcement
-      type: boolean
+      type: string
     - description: Egress enforcement in the endpoint
-      jsonPath: .status.policy.egress.enforcing
+      jsonPath: .status.policy.egress.state
       name: Egress Enforcement
-      type: boolean
+      type: string
     - description: Status of visibility policy in the endpoint
       jsonPath: .status.visibility-policy-status
       name: Visibility Policy
@@ -343,6 +343,10 @@ spec:
                               type: integer
                           type: object
                         type: array
+                      state:
+                        description: 'EndpointPolicyState defines the state of the
+                          Policy mode: "enforcing", "non-enforcing", "disabled"'
+                        type: string
                     required:
                     - enforcing
                     type: object
@@ -430,6 +434,10 @@ spec:
                               type: integer
                           type: object
                         type: array
+                      state:
+                        description: 'EndpointPolicyState defines the state of the
+                          Policy mode: "enforcing", "non-enforcing", "disabled"'
+                        type: string
                     required:
                     - enforcing
                     type: object

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -23,7 +23,7 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.25.5"
+	CustomResourceDefinitionSchemaVersion = "1.25.6"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -22,8 +22,8 @@ import (
 // +kubebuilder:resource:categories={cilium},singular="ciliumendpoint",path="ciliumendpoints",scope="Namespaced",shortName={cep,ciliumep}
 // +kubebuilder:printcolumn:JSONPath=".status.id",description="Cilium endpoint id",name="Endpoint ID",type=integer
 // +kubebuilder:printcolumn:JSONPath=".status.identity.id",description="Cilium identity id",name="Identity ID",type=integer
-// +kubebuilder:printcolumn:JSONPath=".status.policy.ingress.enforcing",description="Ingress enforcement in the endpoint",name="Ingress Enforcement",type=boolean
-// +kubebuilder:printcolumn:JSONPath=".status.policy.egress.enforcing",description="Egress enforcement in the endpoint",name="Egress Enforcement",type=boolean
+// +kubebuilder:printcolumn:JSONPath=".status.policy.ingress.state",description="Ingress enforcement in the endpoint",name="Ingress Enforcement",type=string
+// +kubebuilder:printcolumn:JSONPath=".status.policy.egress.state",description="Egress enforcement in the endpoint",name="Egress Enforcement",type=string
 // +kubebuilder:printcolumn:JSONPath=".status.visibility-policy-status",description="Status of visibility policy in the endpoint",name="Visibility Policy",type=string
 // +kubebuilder:printcolumn:JSONPath=".status.state",description="Endpoint current state",name="Endpoint State",type=string
 // +kubebuilder:printcolumn:JSONPath=".status.networking.addressing[0].ipv4",description="Endpoint IPv4 address",name="IPv4",type=string
@@ -40,6 +40,9 @@ type CiliumEndpoint struct {
 	// +kubebuilder:validation:Optional
 	Status EndpointStatus `json:"status"`
 }
+
+// EndpointPolicyState defines the state of the Policy mode: "enforcing", "non-enforcing", "disabled"
+type EndpointPolicyState string
 
 // EndpointStatus is the status of a Cilium endpoint.
 type EndpointStatus struct {
@@ -141,6 +144,7 @@ type EndpointPolicyDirection struct {
 	Removing AllowedIdentityList `json:"removing,omitempty"`
 	// Deprecated
 	Adding AllowedIdentityList `json:"adding,omitempty"`
+	State  EndpointPolicyState `json:"state,omitempty"`
 }
 
 // IdentityTuple specifies a peer by identity, destination port and protocol.

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -812,6 +812,10 @@ func (in *EndpointPolicyDirection) DeepEqual(other *EndpointPolicyDirection) boo
 		}
 	}
 
+	if in.State != other.State {
+		return false
+	}
+
 	return true
 }
 


### PR DESCRIPTION
This patch will set "Status N.A." for the fields INGRESS ENFORCEMENT, EGRESS ENFORCEMENT, VISIBILITY POLICY if Cilium run with --endpoint-status disabled.

Fixes: #17880

Signed-off-by: Roman Ptitcyn romanspb@yahoo.com