### PR TITLE
Fix mtu setting for tunnel interface in init.sh

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -425,7 +425,6 @@ if [ "${TUNNEL_MODE}" != "<nil>" ]; then
 	ENCAP_DEV="cilium_${TUNNEL_MODE}"
 
 	ip link show $ENCAP_DEV || create_encap_dev
-	ip link set $ENCAP_DEV mtu $MTU || encap_fail
 
 	if [ "${TUNNEL_PORT}" != "<nil>" ]; then
 		ip -details link show $ENCAP_DEV | grep "dstport $TUNNEL_PORT" || {
@@ -434,6 +433,7 @@ if [ "${TUNNEL_MODE}" != "<nil>" ]; then
 		}
 	fi
 
+	ip link set $ENCAP_DEV mtu $MTU || encap_fail
 	setup_dev $ENCAP_DEV || encap_fail
 
 	ENCAP_IDX=$(cat "${SYSCLASSNETDIR}/${ENCAP_DEV}/ifindex")


### PR DESCRIPTION
The mtu setting could be overwritten to default value (1500) if interface is
re-created (in  TUNNEL_PORT is not nil case),
so move mtu setting after tunnel interface is re-created.

Signed-off-by: Li Chengyuan <chengyuanli@hotmail.com>
