### PR TITLE
probes: replace ProbeManager with features API in cilium/ebpf

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -944,7 +944,7 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup, epMgr *endpointmanag
 		}
 	}
 	if option.Config.EnableIPv4EgressGateway {
-		if !probes.NewProbeManager().GetMisc().HaveLargeInsnLimit {
+		if probes.HaveLargeInstructionLimit() != nil {
 			log.WithError(err).Error("egress gateway needs kernel 5.2 or newer")
 			return nil, nil, fmt.Errorf("egress gateway needs kernel 5.2 or newer")
 		}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cilium/ebpf/rlimit"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sync/semaphore"
@@ -452,13 +451,6 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup, epMgr *endpointmanag
 		lbmapInitParams.MaglevMapMaxEntries = option.Config.LBMaglevMapEntries
 	}
 	lbmap.Init(lbmapInitParams)
-
-	if option.Config.DryMode == false {
-		if err := rlimit.RemoveMemlock(); err != nil {
-			log.WithError(err).Error("unable to set memory resource limits")
-			return nil, nil, fmt.Errorf("unable to set memory resource limits: %w", err)
-		}
-	}
 
 	authKeySize, encryptKeyID, err := setupIPSec()
 	if err != nil {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cilium/ebpf/rlimit"
 	"github.com/go-openapi/loads"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -1219,6 +1220,12 @@ func initEnv() {
 		scopedLog.Fatalf("Invalid %s value %d", option.MaxCtrlIntervalName, option.Config.MaxControllerInterval)
 	}
 
+	// set rlimit Memlock to INFINITY before creating any bpf resources.
+	if !option.Config.DryMode {
+		if err := rlimit.RemoveMemlock(); err != nil {
+			log.WithError(err).Fatal("unable to set memory resource limits")
+		}
+	}
 	linuxdatapath.CheckMinRequirements()
 
 	if err := pidfile.Write(defaults.PidFilePath); err != nil {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cilium/ebpf"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
@@ -352,10 +353,8 @@ func (d *Daemon) initMaps() error {
 		}
 	}
 
-	pm := probes.NewProbeManager()
-	supportedMapTypes := pm.GetMapTypes()
 	createSockRevNatMaps := option.Config.EnableSocketLB &&
-		option.Config.EnableHostServicesUDP && supportedMapTypes.HaveLruHashMapType
+		option.Config.EnableHostServicesUDP && probes.HaveMapType(ebpf.LRUHash) == nil
 	if err := d.svc.InitMaps(option.Config.EnableIPv6, option.Config.EnableIPv4,
 		createSockRevNatMaps, option.Config.RestoreState); err != nil {
 		log.WithError(err).Fatal("Unable to initialize service maps")

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -4,6 +4,8 @@
 package bandwidth
 
 import (
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -40,15 +42,10 @@ func ProbeBandwidthManager() {
 		return
 	}
 
-	kernelGood := false
-	if h := probes.NewProbeManager().GetHelpers("sched_cls"); h != nil {
-		// We at least need 5.1 kernel for native TCP EDT integration
-		// and writable queue_mapping that we use. Below helper is
-		// available for 5.1 kernels and onwards.
-		if _, ok := h["bpf_skb_ecn_set_ce"]; ok {
-			kernelGood = true
-		}
-	}
+	// We at least need 5.1 kernel for native TCP EDT integration
+	// and writable queue_mapping that we use. Below helper is
+	// available for 5.1 kernels and onwards.
+	kernelGood := probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnSkbEcnSetCe) == nil
 	option.Config.ResetQueueMapping = kernelGood
 	if !option.Config.EnableBandwidthManager {
 		return
@@ -64,19 +61,14 @@ func ProbeBandwidthManager() {
 		return
 	}
 	if option.Config.EnableBBR {
-		if h := probes.NewProbeManager().GetHelpers("sched_cls"); h != nil {
-			// We at least need 5.18 kernel for Pod-based BBR TCP congestion
-			// control since earlier kernels just clear the skb->tstamp upon
-			// netns traversal. See also:
-			//
-			// - https://lpc.events/event/11/contributions/953/
-			// - https://lore.kernel.org/bpf/20220302195519.3479274-1-kafai@fb.com/
-			if _, ok := h["bpf_skb_set_tstamp"]; !ok {
-				log.Fatalf("Cannot enable --%s, needs kernel 5.18 or newer.",
-					option.EnableBBR)
-			}
-		} else {
-			log.Fatalf("Cannot enable --%s. Unable to probe underlying kernel.",
+		// We at least need 5.18 kernel for Pod-based BBR TCP congestion
+		// control since earlier kernels just clear the skb->tstamp upon
+		// netns traversal. See also:
+		//
+		// - https://lpc.events/event/11/contributions/953/
+		// - https://lore.kernel.org/bpf/20220302195519.3479274-1-kafai@fb.com/
+		if probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnSkbSetTstamp) != nil {
+			log.Fatalf("Cannot enable --%s, needs kernel 5.18 or newer.",
 				option.EnableBBR)
 		}
 	}

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -17,7 +17,6 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/cilium/ebpf/rlimit"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
@@ -687,9 +686,7 @@ func TestDummyProg(progType ProgType, attachType uint32) error {
 		Insns:      uintptr(unsafe.Pointer(&insns[0])),
 		License:    uintptr(unsafe.Pointer(&license[0])),
 	}
-	if err := rlimit.RemoveMemlock(); err != nil {
-		return err
-	}
+
 	fd, _, errno := unix.Syscall(unix.SYS_BPF, BPF_PROG_LOAD,
 		uintptr(unsafe.Pointer(&bpfAttr)),
 		unsafe.Sizeof(bpfAttr))

--- a/pkg/datapath/linux/bigtcp/bigtcp.go
+++ b/pkg/datapath/linux/bigtcp/bigtcp.go
@@ -4,11 +4,12 @@
 package bigtcp
 
 import (
-	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
-
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -90,11 +91,7 @@ func InitBIGTCP(bigTCPConfig *Configuration) {
 		return
 	}
 
-	kernelGood := false
-	if h := probes.NewProbeManager().GetHelpers("sched_cls"); h != nil {
-		_, kernelGood = h["bpf_dynptr_data"]
-	}
-	if !kernelGood {
+	if probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnDynptrData) != nil {
 		if option.Config.EnableIPv6BIGTCP {
 			log.Warnf("Cannot enable --%s, needs kernel 5.19 or newer",
 				option.EnableIPv6BIGTCP)

--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -12,6 +12,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
@@ -501,12 +503,7 @@ func findK8SNodeIPLink() (netlink.Link, error) {
 // supportL3Dev returns true if the kernel is new enough to support BPF host routing of
 // packets coming from L3 devices using bpf_skb_redirect_peer.
 func supportL3Dev() bool {
-	probesManager := probes.NewProbeManager()
-	if h := probesManager.GetHelpers("sched_cls"); h != nil {
-		_, found := h["bpf_skb_change_head"]
-		return found
-	}
-	return false
+	return probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnSkbChangeHead) == nil
 }
 
 type deviceFilter []string

--- a/pkg/datapath/linux/probes/probes_privileged_test.go
+++ b/pkg/datapath/linux/probes/probes_privileged_test.go
@@ -30,18 +30,6 @@ func (s *ProbesPrivTestSuite) TestSystemConfigProbes(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *ProbesPrivTestSuite) TestMapTypes(c *C) {
-	pm := NewProbeManager()
-	mapTypes := pm.GetMapTypes()
-	c.Assert(mapTypes, NotNil)
-}
-
-func (s *ProbesPrivTestSuite) TestHelpers(c *C) {
-	pm := NewProbeManager()
-	_, ok := pm.GetHelpers("sched_act")["bpf_map_lookup_elem"]
-	c.Assert(ok, Equals, true)
-}
-
 func (s *ProbesPrivTestSuite) TestWriteHeaders(c *C) {
 	var buf bytes.Buffer
 

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -138,8 +138,7 @@ func CheckMinRequirements() {
 
 		// VTEP integration feature requires kernel 1m large instruction support
 		if option.Config.EnableVTEP {
-			supportedMisc := probeManager.GetMisc()
-			if !supportedMisc.HaveLargeInsnLimit {
+			if probes.HaveLargeInstructionLimit() != nil {
 				log.Fatalf("VXLAN Tunnel Endpoint (VTEP) Integration: requires support for large programs (Linux 5.2.0 or newer)")
 			}
 		}

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -11,8 +11,6 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/cilium/ebpf/rlimit"
-
 	"github.com/cilium/cilium/pkg/bpf"
 )
 
@@ -43,11 +41,6 @@ func (p *probeValue) DeepCopyMapValue() bpf.MapValue { return &probeValue{p.Valu
 // with proper bpf.GetNextKey() traversal. Needs 4.16 or higher.
 func HaveFullLPM() bool {
 	haveFullLPMOnce.Do(func() {
-
-		if err := rlimit.RemoveMemlock(); err != nil {
-			return
-		}
-
 		m := bpf.NewMap("cilium_test", bpf.MapTypeLPMTrie,
 			&probeKey{}, int(unsafe.Sizeof(probeKey{})),
 			&probeValue{}, int(unsafe.Sizeof(probeValue{})),

--- a/vendor/github.com/cilium/ebpf/features/doc.go
+++ b/vendor/github.com/cilium/ebpf/features/doc.go
@@ -1,0 +1,19 @@
+// Package features allows probing for BPF features available to the calling process.
+//
+// In general, the error return values from feature probes in this package
+// all have the following semantics unless otherwise specified:
+//
+//   err == nil: The feature is available.
+//   errors.Is(err, ebpf.ErrNotSupported): The feature is not available.
+//   err != nil: Any errors encountered during probe execution, wrapped.
+//
+// Note that the latter case may include false negatives, and that resource
+// creation may succeed despite an error being returned. For example, some
+// map and program types cannot reliably be probed and will return an
+// inconclusive error.
+//
+// As a rule, only `nil` and `ebpf.ErrNotSupported` are conclusive.
+//
+// Probe results are cached by the library and persist throughout any changes
+// to the process' environment, like capability changes.
+package features

--- a/vendor/github.com/cilium/ebpf/features/map.go
+++ b/vendor/github.com/cilium/ebpf/features/map.go
@@ -1,0 +1,180 @@
+package features
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+func init() {
+	mc.mapTypes = make(map[ebpf.MapType]error)
+}
+
+var (
+	mc mapCache
+)
+
+type mapCache struct {
+	sync.Mutex
+	mapTypes map[ebpf.MapType]error
+}
+
+func createMapTypeAttr(mt ebpf.MapType) *sys.MapCreateAttr {
+	var (
+		keySize        uint32 = 4
+		valueSize      uint32 = 4
+		maxEntries     uint32 = 1
+		innerMapFd     uint32
+		flags          uint32
+		btfKeyTypeID   uint32
+		btfValueTypeID uint32
+		btfFd          uint32
+	)
+
+	// switch on map types to generate correct MapCreateAttr
+	switch mt {
+	case ebpf.StackTrace:
+		// valueSize needs to be sizeof(uint64)
+		valueSize = 8
+	case ebpf.LPMTrie:
+		// keySize and valueSize need to be sizeof(struct{u32 + u8}) + 1 + padding = 8
+		// BPF_F_NO_PREALLOC needs to be set
+		// checked at allocation time for lpm_trie maps
+		keySize = 8
+		valueSize = 8
+		flags = unix.BPF_F_NO_PREALLOC
+	case ebpf.ArrayOfMaps, ebpf.HashOfMaps:
+		// assign invalid innerMapFd to pass validation check
+		// will return EBADF
+		innerMapFd = ^uint32(0)
+	case ebpf.CGroupStorage, ebpf.PerCPUCGroupStorage:
+		// keySize needs to be sizeof(struct{u32 + u64}) = 12 (+ padding = 16)
+		// by using unsafe.Sizeof(int) we are making sure that this works on 32bit and 64bit archs
+		// checked at allocation time
+		var align int
+		keySize = uint32(8 + unsafe.Sizeof(align))
+		maxEntries = 0
+	case ebpf.Queue, ebpf.Stack:
+		// keySize needs to be 0, see alloc_check for queue and stack maps
+		keySize = 0
+	case ebpf.RingBuf:
+		// keySize and valueSize need to be 0
+		// maxEntries needs to be power of 2 and PAGE_ALIGNED
+		// checked at allocation time
+		keySize = 0
+		valueSize = 0
+		maxEntries = uint32(os.Getpagesize())
+	case ebpf.SkStorage, ebpf.InodeStorage, ebpf.TaskStorage:
+		// maxEntries needs to be 0
+		// BPF_F_NO_PREALLOC needs to be set
+		// btf* fields need to be set
+		// see alloc_check for local_storage map types
+		maxEntries = 0
+		flags = unix.BPF_F_NO_PREALLOC
+		btfKeyTypeID = 1   // BTF_KIND_INT
+		btfValueTypeID = 3 // BTF_KIND_ARRAY
+		btfFd = ^uint32(0)
+	}
+
+	return &sys.MapCreateAttr{
+		MapType:        sys.MapType(mt),
+		KeySize:        keySize,
+		ValueSize:      valueSize,
+		MaxEntries:     maxEntries,
+		InnerMapFd:     innerMapFd,
+		MapFlags:       flags,
+		BtfKeyTypeId:   btfKeyTypeID,
+		BtfValueTypeId: btfValueTypeID,
+		BtfFd:          btfFd,
+	}
+}
+
+// HaveMapType probes the running kernel for the availability of the specified map type.
+//
+// See the package documentation for the meaning of the error return value.
+func HaveMapType(mt ebpf.MapType) error {
+	if err := validateMaptype(mt); err != nil {
+		return err
+	}
+
+	return haveMapType(mt)
+}
+
+func validateMaptype(mt ebpf.MapType) error {
+	if mt > mt.Max() {
+		return os.ErrInvalid
+	}
+
+	if mt == ebpf.StructOpsMap {
+		// A probe for StructOpsMap has vmlinux BTF requirements we currently
+		// cannot meet. Once we figure out how to add a working probe in this
+		// package, we can remove this check.
+		return errors.New("a probe for MapType StructOpsMap isn't implemented")
+	}
+
+	return nil
+}
+
+func haveMapType(mt ebpf.MapType) error {
+	mc.Lock()
+	defer mc.Unlock()
+	err, ok := mc.mapTypes[mt]
+	if ok {
+		return err
+	}
+
+	fd, err := sys.MapCreate(createMapTypeAttr(mt))
+
+	switch {
+	// For nested and storage map types we accept EBADF as indicator that these maps are supported
+	case errors.Is(err, unix.EBADF):
+		if isMapOfMaps(mt) || isStorageMap(mt) {
+			err = nil
+		}
+
+	// EINVAL occurs when attempting to create a map with an unknown type.
+	// E2BIG occurs when MapCreateAttr contains non-zero bytes past the end
+	// of the struct known by the running kernel, meaning the kernel is too old
+	// to support the given map type.
+	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
+		err = ebpf.ErrNotSupported
+
+	// EPERM is kept as-is and is not converted or wrapped.
+	case errors.Is(err, unix.EPERM):
+		break
+
+	// Wrap unexpected errors.
+	case err != nil:
+		err = fmt.Errorf("unexpected error during feature probe: %w", err)
+
+	default:
+		fd.Close()
+	}
+
+	mc.mapTypes[mt] = err
+
+	return err
+}
+
+func isMapOfMaps(mt ebpf.MapType) bool {
+	switch mt {
+	case ebpf.ArrayOfMaps, ebpf.HashOfMaps:
+		return true
+	}
+	return false
+}
+
+func isStorageMap(mt ebpf.MapType) bool {
+	switch mt {
+	case ebpf.SkStorage, ebpf.InodeStorage, ebpf.TaskStorage:
+		return true
+	}
+
+	return false
+}

--- a/vendor/github.com/cilium/ebpf/features/misc.go
+++ b/vendor/github.com/cilium/ebpf/features/misc.go
@@ -1,0 +1,168 @@
+package features
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+func init() {
+	miscs.miscTypes = make(map[miscType]error)
+}
+
+var (
+	miscs miscCache
+)
+
+type miscCache struct {
+	sync.Mutex
+	miscTypes map[miscType]error
+}
+
+type miscType uint32
+
+const (
+	// largeInsn support introduced in Linux 5.2
+	// commit c04c0d2b968ac45d6ef020316808ef6c82325a82
+	largeInsn miscType = iota
+	// boundedLoops support introduced in Linux 5.3
+	// commit 2589726d12a1b12eaaa93c7f1ea64287e383c7a5
+	boundedLoops
+	// v2ISA support introduced in Linux 4.14
+	// commit 92b31a9af73b3a3fc801899335d6c47966351830
+	v2ISA
+	// v3ISA support introduced in Linux 5.1
+	// commit 092ed0968bb648cd18e8a0430cd0a8a71727315c
+	v3ISA
+)
+
+const (
+	maxInsns = 4096
+)
+
+// HaveLargeInstructions probes the running kernel if more than 4096 instructions
+// per program are supported.
+//
+// See the package documentation for the meaning of the error return value.
+func HaveLargeInstructions() error {
+	return probeMisc(largeInsn)
+}
+
+// HaveBoundedLoops probes the running kernel if bounded loops are supported.
+//
+// See the package documentation for the meaning of the error return value.
+func HaveBoundedLoops() error {
+	return probeMisc(boundedLoops)
+}
+
+// HaveV2ISA probes the running kernel if instructions of the v2 ISA are supported.
+//
+// See the package documentation for the meaning of the error return value.
+func HaveV2ISA() error {
+	return probeMisc(v2ISA)
+}
+
+// HaveV3ISA probes the running kernel if instructions of the v3 ISA are supported.
+//
+// See the package documentation for the meaning of the error return value.
+func HaveV3ISA() error {
+	return probeMisc(v3ISA)
+}
+
+// probeMisc checks the kernel for a given supported misc by creating
+// a specialized program probe and loading it.
+func probeMisc(mt miscType) error {
+	mc.Lock()
+	defer mc.Unlock()
+	err, ok := miscs.miscTypes[mt]
+	if ok {
+		return err
+	}
+
+	attr, err := createMiscProbeAttr(mt)
+	if err != nil {
+		return fmt.Errorf("couldn't create the attributes for the probe: %w", err)
+	}
+
+	fd, err := sys.ProgLoad(attr)
+
+	switch {
+	// EINVAL occurs when attempting to create a program with an unknown type.
+	// E2BIG occurs when ProgLoadAttr contains non-zero bytes past the end
+	// of the struct known by the running kernel, meaning the kernel is too old
+	// to support the given map type.
+	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
+		err = ebpf.ErrNotSupported
+
+	// EPERM is kept as-is and is not converted or wrapped.
+	case errors.Is(err, unix.EPERM):
+		break
+
+	// Wrap unexpected errors.
+	case err != nil:
+		err = fmt.Errorf("unexpected error during feature probe: %w", err)
+
+	default:
+		fd.Close()
+	}
+
+	miscs.miscTypes[mt] = err
+
+	return err
+}
+
+func createMiscProbeAttr(mt miscType) (*sys.ProgLoadAttr, error) {
+	var insns asm.Instructions
+	switch mt {
+	case largeInsn:
+		for i := 0; i < maxInsns; i++ {
+			insns = append(insns, asm.Mov.Imm(asm.R0, 1))
+		}
+		insns = append(insns, asm.Return())
+	case boundedLoops:
+		insns = asm.Instructions{
+			asm.Mov.Imm(asm.R0, 10),
+			asm.Sub.Imm(asm.R0, 1).WithSymbol("loop"),
+			asm.JNE.Imm(asm.R0, 0, "loop"),
+			asm.Return(),
+		}
+	case v2ISA:
+		insns = asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.JLT.Imm(asm.R0, 0, "exit"),
+			asm.Mov.Imm(asm.R0, 1),
+			asm.Return().WithSymbol("exit"),
+		}
+	case v3ISA:
+		insns = asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.JLT.Imm32(asm.R0, 0, "exit"),
+			asm.Mov.Imm(asm.R0, 1),
+			asm.Return().WithSymbol("exit"),
+		}
+	default:
+		return nil, fmt.Errorf("misc probe %d not implemented", mt)
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, insns.Size()))
+	if err := insns.Marshal(buf, internal.NativeEndian); err != nil {
+		return nil, err
+	}
+
+	bytecode := buf.Bytes()
+	instructions := sys.NewSlicePointer(bytecode)
+
+	return &sys.ProgLoadAttr{
+		ProgType: sys.BPF_PROG_TYPE_SOCKET_FILTER,
+		Insns:    instructions,
+		InsnCnt:  uint32(len(bytecode) / asm.InstructionSize),
+		License:  sys.NewStringPointer("MIT"),
+	}, nil
+}

--- a/vendor/github.com/cilium/ebpf/features/prog.go
+++ b/vendor/github.com/cilium/ebpf/features/prog.go
@@ -1,0 +1,255 @@
+package features
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+func init() {
+	pc.types = make(map[ebpf.ProgramType]error)
+	pc.helpers = make(map[ebpf.ProgramType]map[asm.BuiltinFunc]error)
+	allocHelperCache()
+}
+
+func allocHelperCache() {
+	for pt := ebpf.UnspecifiedProgram + 1; pt <= pt.Max(); pt++ {
+		pc.helpers[pt] = make(map[asm.BuiltinFunc]error)
+	}
+}
+
+var (
+	pc progCache
+)
+
+type progCache struct {
+	typeMu sync.Mutex
+	types  map[ebpf.ProgramType]error
+
+	helperMu sync.Mutex
+	helpers  map[ebpf.ProgramType]map[asm.BuiltinFunc]error
+}
+
+func createProgLoadAttr(pt ebpf.ProgramType, helper asm.BuiltinFunc) (*sys.ProgLoadAttr, error) {
+	var expectedAttachType ebpf.AttachType
+	var progFlags uint32
+
+	insns := asm.Instructions{
+		asm.LoadImm(asm.R0, 0, asm.DWord),
+		asm.Return(),
+	}
+
+	if helper != asm.FnUnspec {
+		insns = append(asm.Instructions{helper.Call()}, insns...)
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, insns.Size()))
+	if err := insns.Marshal(buf, internal.NativeEndian); err != nil {
+		return nil, err
+	}
+
+	bytecode := buf.Bytes()
+	instructions := sys.NewSlicePointer(bytecode)
+
+	// Some programs have expected attach types which are checked during the
+	// BPD_PROG_LOAD syscall.
+	switch pt {
+	case ebpf.CGroupSockAddr:
+		expectedAttachType = ebpf.AttachCGroupInet4Connect
+	case ebpf.CGroupSockopt:
+		expectedAttachType = ebpf.AttachCGroupGetsockopt
+	case ebpf.SkLookup:
+		expectedAttachType = ebpf.AttachSkLookup
+	case ebpf.Syscall:
+		progFlags = unix.BPF_F_SLEEPABLE
+	default:
+		expectedAttachType = ebpf.AttachNone
+	}
+
+	// Kernels before 5.0 (6c4fc209fcf9 "bpf: remove useless version check for prog load")
+	// require the version field to be set to the value of the KERNEL_VERSION
+	// macro for kprobe-type programs.
+	v, err := internal.KernelVersion()
+	if err != nil {
+		return nil, fmt.Errorf("detecting kernel version: %w", err)
+	}
+
+	return &sys.ProgLoadAttr{
+		ProgType:           sys.ProgType(pt),
+		Insns:              instructions,
+		InsnCnt:            uint32(len(bytecode) / asm.InstructionSize),
+		ProgFlags:          progFlags,
+		ExpectedAttachType: sys.AttachType(expectedAttachType),
+		License:            sys.NewStringPointer("GPL"),
+		KernVersion:        v.Kernel(),
+	}, nil
+}
+
+// HaveProgType probes the running kernel for the availability of the specified program type.
+//
+// Deprecated: use HaveProgramType() instead.
+var HaveProgType = HaveProgramType
+
+// HaveProgramType probes the running kernel for the availability of the specified program type.
+//
+// See the package documentation for the meaning of the error return value.
+func HaveProgramType(pt ebpf.ProgramType) error {
+	if err := validateProgramType(pt); err != nil {
+		return err
+	}
+
+	return haveProgramType(pt)
+
+}
+
+func validateProgramType(pt ebpf.ProgramType) error {
+	if pt > pt.Max() {
+		return os.ErrInvalid
+	}
+
+	if progLoadProbeNotImplemented(pt) {
+		// A probe for a these prog types has BTF requirements we currently cannot meet
+		// Once we figure out how to add a working probe in this package, we can remove
+		// this check
+		return fmt.Errorf("a probe for ProgType %s isn't implemented", pt.String())
+	}
+
+	return nil
+}
+
+func haveProgramType(pt ebpf.ProgramType) error {
+	pc.typeMu.Lock()
+	defer pc.typeMu.Unlock()
+	if err, ok := pc.types[pt]; ok {
+		return err
+	}
+
+	attr, err := createProgLoadAttr(pt, asm.FnUnspec)
+	if err != nil {
+		return fmt.Errorf("couldn't create the program load attribute: %w", err)
+	}
+
+	fd, err := sys.ProgLoad(attr)
+
+	switch {
+	// EINVAL occurs when attempting to create a program with an unknown type.
+	// E2BIG occurs when ProgLoadAttr contains non-zero bytes past the end
+	// of the struct known by the running kernel, meaning the kernel is too old
+	// to support the given prog type.
+	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
+		err = ebpf.ErrNotSupported
+
+	// EPERM is kept as-is and is not converted or wrapped.
+	case errors.Is(err, unix.EPERM):
+		break
+
+	// Wrap unexpected errors.
+	case err != nil:
+		err = fmt.Errorf("unexpected error during feature probe: %w", err)
+
+	default:
+		fd.Close()
+	}
+
+	pc.types[pt] = err
+
+	return err
+}
+
+// HaveProgramHelper probes the running kernel for the availability of the specified helper
+// function to a specified program type.
+// Return values have the following semantics:
+//
+//   err == nil: The feature is available.
+//   errors.Is(err, ebpf.ErrNotSupported): The feature is not available.
+//   err != nil: Any errors encountered during probe execution, wrapped.
+//
+// Note that the latter case may include false negatives, and that program creation may
+// succeed despite an error being returned.
+// Only `nil` and `ebpf.ErrNotSupported` are conclusive.
+//
+// Probe results are cached and persist throughout any process capability changes.
+func HaveProgramHelper(pt ebpf.ProgramType, helper asm.BuiltinFunc) error {
+	if err := validateProgramType(pt); err != nil {
+		return err
+	}
+
+	if err := validateProgramHelper(helper); err != nil {
+		return err
+	}
+
+	return haveProgramHelper(pt, helper)
+}
+
+func validateProgramHelper(helper asm.BuiltinFunc) error {
+	if helper > helper.Max() {
+		return os.ErrInvalid
+	}
+
+	return nil
+}
+
+func haveProgramHelper(pt ebpf.ProgramType, helper asm.BuiltinFunc) error {
+	pc.helperMu.Lock()
+	defer pc.helperMu.Unlock()
+	if err, ok := pc.helpers[pt][helper]; ok {
+		return err
+	}
+
+	attr, err := createProgLoadAttr(pt, helper)
+	if err != nil {
+		return fmt.Errorf("couldn't create the program load attribute: %w", err)
+	}
+
+	fd, err := sys.ProgLoad(attr)
+
+	switch {
+	// If there is no error we need to close the FD of the prog.
+	case err == nil:
+		fd.Close()
+
+	// EACCES occurs when attempting to create a program probe with a helper
+	// while the register args when calling this helper aren't set up properly.
+	// We interpret this as the helper being available, because the verifier
+	// returns EINVAL if the helper is not supported by the running kernel.
+	case errors.Is(err, unix.EACCES):
+		// TODO: possibly we need to check verifier output here to be sure
+		err = nil
+
+	// EINVAL occurs when attempting to create a program with an unknown helper.
+	// E2BIG occurs when BPFProgLoadAttr contains non-zero bytes past the end
+	// of the struct known by the running kernel, meaning the kernel is too old
+	// to support the given prog type.
+	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
+		// TODO: possibly we need to check verifier output here to be sure
+		err = ebpf.ErrNotSupported
+
+	// EPERM is kept as-is and is not converted or wrapped.
+	case errors.Is(err, unix.EPERM):
+		break
+
+	// Wrap unexpected errors.
+	case err != nil:
+		err = fmt.Errorf("unexpected error during feature probe: %w", err)
+	}
+
+	pc.helpers[pt][helper] = err
+
+	return err
+}
+
+func progLoadProbeNotImplemented(pt ebpf.ProgramType) bool {
+	switch pt {
+	case ebpf.Tracing, ebpf.StructOps, ebpf.Extension, ebpf.LSM:
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/cilium/ebpf/features/version.go
+++ b/vendor/github.com/cilium/ebpf/features/version.go
@@ -1,0 +1,18 @@
+package features
+
+import "github.com/cilium/ebpf/internal"
+
+// LinuxVersionCode returns the version of the currently running kernel
+// as defined in the LINUX_VERSION_CODE compile-time macro. It is represented
+// in the format described by the KERNEL_VERSION macro from linux/version.h.
+//
+// Do not use the version to make assumptions about the presence of certain
+// kernel features, always prefer feature probes in this package. Some
+// distributions backport or disable eBPF features.
+func LinuxVersionCode() (uint32, error) {
+	v, err := internal.KernelVersion()
+	if err != nil {
+		return 0, err
+	}
+	return v.Kernel(), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -172,6 +172,7 @@ github.com/cilium/deepequal-gen/generators
 github.com/cilium/ebpf
 github.com/cilium/ebpf/asm
 github.com/cilium/ebpf/btf
+github.com/cilium/ebpf/features
 github.com/cilium/ebpf/internal
 github.com/cilium/ebpf/internal/epoll
 github.com/cilium/ebpf/internal/sys


### PR DESCRIPTION
The first commit makes sure we call `rlimit.RemoveMemlock()` only once and early enough on the startup of the agent for all probes being able to execute without `EPERM`.
 
The second commit vendors the github.com/cilium/ebpf/features package.

With the third commit we replace most of the feature probes done with the current ProbeManager system with the features API in cilium/ebpf.

Fixes: #20062


