### PR TITLE
v1.12 backports 2022-07-18

### DIFF
--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -56,7 +56,7 @@ Masquerading can take place only on those devices which run the eBPF masqueradin
 program. This means that a packet sent from a pod to an outside address will be
 masqueraded (to an output device IPv4 address), if the output device runs the program.
 If not specified, the program will be automatically attached to the devices selected by
-:ref:`the BPF NodePort device detection metchanism <Nodeport Devices>`.
+:ref:`the BPF NodePort device detection mechanism <Nodeport Devices>`.
 To manually change this, use the ``devices`` helm option. Use ``cilium status``
 to determine which devices the program is running on:
 

--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -53,9 +53,9 @@ The current implementation depends on :ref:`the BPF NodePort feature <kubeproxy-
 The dependency will be removed in the future (:gh-issue:`13732`).
 
 Masquerading can take place only on those devices which run the eBPF masquerading
-program. This means that a packet sent from a pod to an outside will be masqueraded
-(to an output device IPv4 address), if the output device runs the program. If not
-specified, the program will be automatically attached to the devices selected by
+program. This means that a packet sent from a pod to an outside address will be
+masqueraded (to an output device IPv4 address), if the output device runs the program.
+If not specified, the program will be automatically attached to the devices selected by
 :ref:`the BPF NodePort device detection metchanism <Nodeport Devices>`.
 To manually change this, use the ``devices`` helm option. Use ``cilium status``
 to determine which devices the program is running on:

--- a/Documentation/gettingstarted/egress-gateway.rst
+++ b/Documentation/gettingstarted/egress-gateway.rst
@@ -385,12 +385,36 @@ cluster with the IP of the node.
 Apply egress gateway policy
 ---------------------------
 
-Apply the ``egress-sample`` egress gateway Policy, which will cause all traffic
-from the mediabot pod to leave the cluster with the ``10.168.60.100`` IP:
+Download the ``egress-sample`` Egress Gateway Policy yaml:
 
 .. parsed-literal::
 
-    $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes-egress-gateway/egress-nat-policy-egress-gateway.yaml
+    $ wget \ |SCM_WEB|\/examples/kubernetes-egress-gateway/egress-nat-policy-egress-gateway.yaml
+
+Modify the ``destinationCIDRs`` to include the IP of the host where your
+designated external service is running on.
+
+Specifying an IP address in the ``egressIP`` field is optional.
+To make things easier in this example, it is possible to comment out that line.
+This way, the agent will use the first IPv4 assigned to the interface for the
+default route.
+
+To let the policy select the node designated to be the Egress Gateway, apply the
+label ``egress-node: test`` to it:
+
+.. code-block:: shell-session
+
+    $ kubectl label nodes <egress-gateway-node> egress-node=true
+
+Note that the Egress Gateway node should be a different node from the one where
+the ``mediabot`` pod is running on.
+
+Apply the ``egress-sample`` egress gateway Policy, which will cause all traffic
+from the mediabot pod to leave the cluster with the IP of the Egress Gateway node:
+
+.. code-block:: shell-session
+
+    $ kubectl apply -f egress-nat-policy-egress-gateway.yaml
 
 Verify the setup
 ----------------
@@ -403,8 +427,8 @@ We can now verify with the client pod that the policy is working correctly:
     <HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
     [...]
 
-The access log from Nginx should show that the request is coming from the egress
-IP (``192.168.60.100``) rather than one of the nodes in the Kubernetes cluster:
+The access log from Nginx should show that the request is coming from the
+selected Egress IP rather than the one of the node where the pod is running:
 
 .. code-block:: shell-session
 

--- a/Documentation/gettingstarted/egress-gateway.rst
+++ b/Documentation/gettingstarted/egress-gateway.rst
@@ -91,8 +91,7 @@ The egress gateway feature and all the requirements can be enabled as follow:
                --set egressGateway.enabled=true \\
                --set bpf.masquerade=true \\
                --set kubeProxyReplacement=strict \\
-               --set l7Proxy=false \\
-               --set rollOutCiliumPods=true
+               --set l7Proxy=false
 
     .. group-tab:: ConfigMap
 
@@ -102,6 +101,13 @@ The egress gateway feature and all the requirements can be enabled as follow:
             enable-ipv4-egress-gateway: true
             enable-l7-proxy: false
             kube-proxy-replacement: strict
+
+Rollout both the agent pods and the operator pods to make the changes effective:
+
+.. code-block:: shell-session
+
+    $ kubectl rollout restart ds cilium -n kube-system
+    $ kubectl rollout restart deploy cilium-operator -n kube-system
 
 Compatibility with cloud environments
 -------------------------------------

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1677,6 +1677,10 @@
      - VTEP CIDRs Mask that applies to all VTEP CIDRs, for example "255.255.255.0"
      - string
      - ``""``
+   * - waitForKubeProxy
+     - Wait for KUBE-PROXY-CANARY iptables rule to appear in "wait-for-kube-proxy" init container before launching cilium-agent. More context can be found in the commit message of below PR https://github.com/cilium/cilium/pull/20123
+     - bool
+     - ``false``
    * - wellKnownIdentities.enabled
      - Enable the use of well-known identities.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -990,6 +990,7 @@ vmlinux
 volumeMounts
 vtep
 vxlan
+waitForKubeProxy
 waitForMount
 waker
 wakeup

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -425,7 +425,6 @@ if [ "${TUNNEL_MODE}" != "<nil>" ]; then
 	ENCAP_DEV="cilium_${TUNNEL_MODE}"
 
 	ip link show $ENCAP_DEV || create_encap_dev
-	ip link set $ENCAP_DEV mtu $MTU || encap_fail
 
 	if [ "${TUNNEL_PORT}" != "<nil>" ]; then
 		ip -details link show $ENCAP_DEV | grep "dstport $TUNNEL_PORT" || {
@@ -434,6 +433,7 @@ if [ "${TUNNEL_MODE}" != "<nil>" ]; then
 		}
 	fi
 
+	ip link set $ENCAP_DEV mtu $MTU || encap_fail
 	setup_dev $ENCAP_DEV || encap_fail
 
 	ENCAP_IDX=$(cat "${SYSCLASSNETDIR}/${ENCAP_DEV}/ifindex")

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -470,4 +470,5 @@ contributors across the globe, there is almost always someone available to help.
 | vtep.endpoint | string | `""` | A space separated list of VTEP device endpoint IPs, for example "1.1.1.1  1.1.2.1" |
 | vtep.mac | string | `""` | A space separated list of VTEP device MAC addresses (VTEP MAC), for example "x:x:x:x:x:x  y:y:y:y:y:y:y" |
 | vtep.mask | string | `""` | VTEP CIDRs Mask that applies to all VTEP CIDRs, for example "255.255.255.0" |
+| waitForKubeProxy | bool | `false` | Wait for KUBE-PROXY-CANARY iptables rule to appear in "wait-for-kube-proxy" init container before launching cilium-agent. More context can be found in the commit message of below PR https://github.com/cilium/cilium/pull/20123 |
 | wellKnownIdentities.enabled | bool | `false` | Enable the use of well-known identities. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -7,6 +7,9 @@
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
   {{- $defaultKeepDeprecatedProbes = false -}}
 {{- end -}}
+
+{{- $kubeProxyReplacement := (coalesce .Values.kubeProxyReplacement "disabled") -}}
+
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -622,6 +625,38 @@ spec:
         resources:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
+      {{- if and .Values.waitForKubeProxy (ne $kubeProxyReplacement "strict") }}
+      - name: wait-for-kube-proxy
+        image: {{ include "cilium.image" .Values.image | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          privileged: true
+        command:
+          - bash
+          - -c
+          - |
+            while true
+            do
+              if iptables-nft-save -t mangle | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-PROXY-CANARY)'; then
+                echo "Found KUBE-IPTABLES-HINT or KUBE-PROXY-CANARY iptables rule in 'iptables-nft-save -t mangle'"
+                exit 0
+              fi
+              if ip6tables-nft-save -t mangle | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-PROXY-CANARY)'; then
+                echo "Found KUBE-IPTABLES-HINT or KUBE-PROXY-CANARY iptables rule in 'ip6tables-nft-save -t mangle'"
+                exit 0
+              fi
+              if iptables-legacy-save | grep -E '^:KUBE-PROXY-CANARY'; then
+                echo "Found KUBE-PROXY-CANARY iptables rule in 'iptables-legacy-save"
+                exit 0
+              fi
+              if ip6tables-legacy-save | grep -E '^:KUBE-PROXY-CANARY'; then
+                echo "KUBE-PROXY-CANARY iptables rule in 'ip6tables-legacy-save'"
+                exit 0
+              fi
+              echo "Waiting for kube-proxy to create iptables rules...";
+              sleep 1;
+            done
+      {{- end }} # wait-for-kube-proxy
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -345,6 +345,12 @@ cleanBpfState: false
 # WARNING: Use with care!
 cleanState: false
 
+# -- Wait for KUBE-PROXY-CANARY iptables rule to appear in "wait-for-kube-proxy"
+# init container before launching cilium-agent.
+# More context can be found in the commit message of below PR
+# https://github.com/cilium/cilium/pull/20123
+waitForKubeProxy: false
+
 cni:
   # -- Install the CNI configuration and binary files into the filesystem.
   install: true

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -342,6 +342,12 @@ cleanBpfState: false
 # WARNING: Use with care!
 cleanState: false
 
+# -- Wait for KUBE-PROXY-CANARY iptables rule to appear in "wait-for-kube-proxy"
+# init container before launching cilium-agent.
+# More context can be found in the commit message of below PR
+# https://github.com/cilium/cilium/pull/20123
+waitForKubeProxy: false
+
 cni:
   # -- Install the CNI configuration and binary files into the filesystem.
   install: true

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -238,6 +238,7 @@ spec:
                         - cluster
                         - host
                         - init
+                        - ingress
                         - unmanaged
                         - remote-node
                         - health
@@ -1054,6 +1055,7 @@ spec:
                         - cluster
                         - host
                         - init
+                        - ingress
                         - unmanaged
                         - remote-node
                         - health
@@ -1492,6 +1494,7 @@ spec:
                         - cluster
                         - host
                         - init
+                        - ingress
                         - unmanaged
                         - remote-node
                         - health
@@ -2141,6 +2144,7 @@ spec:
                         - cluster
                         - host
                         - init
+                        - ingress
                         - unmanaged
                         - remote-node
                         - health
@@ -2578,6 +2582,7 @@ spec:
                           - cluster
                           - host
                           - init
+                          - ingress
                           - unmanaged
                           - remote-node
                           - health
@@ -3409,6 +3414,7 @@ spec:
                           - cluster
                           - host
                           - init
+                          - ingress
                           - unmanaged
                           - remote-node
                           - health
@@ -3853,6 +3859,7 @@ spec:
                           - cluster
                           - host
                           - init
+                          - ingress
                           - unmanaged
                           - remote-node
                           - health
@@ -4511,6 +4518,7 @@ spec:
                           - cluster
                           - host
                           - init
+                          - ingress
                           - unmanaged
                           - remote-node
                           - health

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -242,6 +242,7 @@ spec:
                         - cluster
                         - host
                         - init
+                        - ingress
                         - unmanaged
                         - remote-node
                         - health
@@ -1058,6 +1059,7 @@ spec:
                         - cluster
                         - host
                         - init
+                        - ingress
                         - unmanaged
                         - remote-node
                         - health
@@ -1496,6 +1498,7 @@ spec:
                         - cluster
                         - host
                         - init
+                        - ingress
                         - unmanaged
                         - remote-node
                         - health
@@ -2145,6 +2148,7 @@ spec:
                         - cluster
                         - host
                         - init
+                        - ingress
                         - unmanaged
                         - remote-node
                         - health
@@ -2582,6 +2586,7 @@ spec:
                           - cluster
                           - host
                           - init
+                          - ingress
                           - unmanaged
                           - remote-node
                           - health
@@ -3413,6 +3418,7 @@ spec:
                           - cluster
                           - host
                           - init
+                          - ingress
                           - unmanaged
                           - remote-node
                           - health
@@ -3857,6 +3863,7 @@ spec:
                           - cluster
                           - host
                           - init
+                          - ingress
                           - unmanaged
                           - remote-node
                           - health
@@ -4515,6 +4522,7 @@ spec:
                           - cluster
                           - host
                           - init
+                          - ingress
                           - unmanaged
                           - remote-node
                           - health

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -12,7 +12,7 @@ import (
 // individual identities.  Entities are used to describe "outside of cluster",
 // "host", etc.
 //
-// +kubebuilder:validation:Enum=all;world;cluster;host;init;unmanaged;remote-node;health;none;kube-apiserver
+// +kubebuilder:validation:Enum=all;world;cluster;host;init;ingress;unmanaged;remote-node;health;none;kube-apiserver
 type Entity string
 
 const (
@@ -32,6 +32,9 @@ const (
 
 	// EntityInit is an entity that represents an initializing endpoint
 	EntityInit Entity = "init"
+
+	// EntityIngress is an entity that represents envoy proxy
+	EntityIngress Entity = "ingress"
 
 	// EntityUnmanaged is an entity that represents unamanaged endpoints.
 	EntityUnmanaged Entity = "unmanaged"
@@ -56,6 +59,8 @@ var (
 
 	endpointSelectorInit = NewESFromLabels(labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved))
 
+	endpointSelectorIngress = NewESFromLabels(labels.NewLabel(labels.IDNameIngress, "", labels.LabelSourceReserved))
+
 	endpointSelectorRemoteNode = NewESFromLabels(labels.NewLabel(labels.IDNameRemoteNode, "", labels.LabelSourceReserved))
 
 	endpointSelectorHealth = NewESFromLabels(labels.NewLabel(labels.IDNameHealth, "", labels.LabelSourceReserved))
@@ -73,6 +78,7 @@ var (
 		EntityWorld:         {endpointSelectorWorld},
 		EntityHost:          {endpointSelectorHost},
 		EntityInit:          {endpointSelectorInit},
+		EntityIngress:       {endpointSelectorIngress},
 		EntityRemoteNode:    {endpointSelectorRemoteNode},
 		EntityHealth:        {endpointSelectorHealth},
 		EntityUnmanaged:     {endpointSelectorUnmanaged},
@@ -113,6 +119,7 @@ func InitEntities(clusterName string, treatRemoteNodeAsHost bool) {
 		endpointSelectorHost,
 		endpointSelectorRemoteNode,
 		endpointSelectorInit,
+		endpointSelectorIngress,
 		endpointSelectorHealth,
 		endpointSelectorUnmanaged,
 		endpointSelectorKubeAPIServer,


### PR DESCRIPTION
* #20517 -- add an option to wait for kube-proxy (@michi-covalent)
 * #20538 -- docs(masquerading): add missing "address" (@raphink)
 * #20531 -- Improve Egress Gateway Getting Started Guide (@pippolo84)
 * #20552 -- Fix mtu setting for tunnel interface in init.sh (@ChengyuanLiCY)
 * #20536 -- k8s/crds: Allow ingress identity in CNP (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20517 20538 20531 20552 20536; do contrib/backporting/set-labels.py $pr done 1.12; done
```