### PR TITLE
contrib: Add CRD generation to release process

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -97,6 +97,7 @@ main() {
         sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
     fi
 
+    $DIR/../../Documentation/check-crd-compat-table.sh "$branch"
     $DIR/prep-changelog.sh "$old_version" "$version"
 
     logecho "Next steps:"


### PR DESCRIPTION
This step is currently separate in the https://github.com/cilium/release
process. Add it to this script so it doesn't need to be run manually by
the release manager.
