### PR TITLE
Revert ".travis.yml: disable arm64-graviton2"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ go: "1.18.4"
 jobs:
   include:
     - arch: amd64
-# disabled until https://github.com/cilium/cilium/issues/20337 is resolved
-#    - arch: arm64-graviton2
-#      virt: vm
-#      group: edge
+    - arch: arm64-graviton2
+      virt: vm
+      group: edge
 
 if: branch = master OR type = pull_request
 


### PR DESCRIPTION
This reverts commit 47626aec89e24fc09f6cd8c12a9b89a0a1032dcf.

It was disabled due to some infrastructure issue on Travis' side which
seems fixed. Let's re-enable the job.

Fixes #20337
