### PR TITLE
pkg/k8s: do not wait for endpointslice cache sync in k8s >= 1.17

### DIFF
--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -162,6 +162,7 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 
 	// K8s is not running with endpoint slices enabled, stop the endpoint slice
 	// controller to avoid watching for unnecessary stuff in k8s.
+	k.cancelWaitGroupToSyncResources(apiGroup)
 	k.k8sAPIGroups.RemoveAPI(apiGroup)
 	close(ecr)
 	return false


### PR DESCRIPTION
When stopping the EndpointSlice Kubernetes watchers we should also
cancel the waiting to sync this group resource. In failing doing it so,
Cilium will timeout on waiting for these resources on Kubernetes
versions that should have EndpointSlice v1beta1 available but it's not
enabled.

Fixes: a0c1ad657ddb ("pkg/k8s/version: Set EndpointSlice cap when version >=1.17")
Signed-off-by: André Martins <andre@cilium.io>
