### PR TITLE
v1.12 backports 2022-07-18

### DIFF
--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -162,6 +162,7 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 
 	// K8s is not running with endpoint slices enabled, stop the endpoint slice
 	// controller to avoid watching for unnecessary stuff in k8s.
+	k.cancelWaitGroupToSyncResources(apiGroup)
 	k.k8sAPIGroups.RemoveAPI(apiGroup)
 	close(ecr)
 	return false


### PR DESCRIPTION
* #20568 -- Revert ".travis.yml: disable arm64-graviton2" (@tklauser)
 * #20569 -- pkg/k8s: do not wait for endpointslice cache sync in k8s >= 1.17 (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20569; do contrib/backporting/set-labels.py $pr done 1.12; done
```