### PR TITLE
endpoint: remove unused DeleteBPFProgramLocked()

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/loadinfo"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -996,13 +995,6 @@ func (e *Endpoint) deleteMaps() []error {
 	}
 
 	return errors
-}
-
-// DeleteBPFProgramLocked delete the BPF program associated with the endpoint's
-// veth interface.
-func (e *Endpoint) DeleteBPFProgramLocked() error {
-	e.getLogger().Debug("deleting bpf program from endpoint")
-	return loader.RemoveTCFilters(e.ifName, netlink.HANDLE_MIN_INGRESS)
 }
 
 // garbageCollectConntrack will run the ctmap.GC() on either the endpoint's


### PR DESCRIPTION
The last user disappeared with commit 3b64f2372319
("Deprecate legacy flannel integration").