### PR TITLE
vtep: skipping symbol substitution cilium_vtep_map

### DIFF
--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -60,6 +60,7 @@ var ignoredELFPrefixes = []string{
 	"cilium_srv6_state_v4",       // Global
 	"cilium_srv6_state_v6",       // Global
 	"cilium_srv6_sid",            // Global
+	"cilium_vtep_map",            // Global
 	"from-container",             // Prog name
 	"to-container",               // Prog name
 	"from-netdev",                // Prog name


### PR DESCRIPTION
cilium agent logs:

level=warning msg="Skipping symbol substitution"
                   subsys=elf symbol=cilium_vtep_map

add cilium_vtep_map to ignoredELFPrefixes to avoid
the warning log.

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
vtep skip symbol substituation cilium_vtep_map
```
