### PR TITLE
workflows: Only run CodeQL on cilium/cilium repo

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -42,7 +42,7 @@ jobs:
 
   analyze:
     needs: check_changes
-    if: ${{ needs.check_changes.outputs.go-changes == 'true' || github.event_name != 'pull_request' }}
+    if: ${{ github.repository == 'cilium/cilium' && (needs.check_changes.outputs.go-changes == 'true' || github.event_name != 'pull_request') }}
     runs-on: ubuntu-18.04
     permissions:
       security-events: write


### PR DESCRIPTION
CodeQL requires extra repo configuration that is not present in forks,
so disable it for forks.

Draft PR for now to work out the exact GitHub Actions configuration to achieve this.

Signed-off-by: Tom Payne <tom@isovalent.com>
Co-authored-by: Yutaro Hayakawa <yutaro.hayakawa@isovalent.com>
Reported-by: Michi Mutsuzaki <michi@isovalent.com>
Co-authored-by: Paul Chaignon <paul@isovalent.com>
