### PR TITLE
ipvlan: clean up leftover  in setupBaseDevice()

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -338,16 +338,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		args[initArgHostReachableServicesPeer] = "false"
 	}
 
-	devices := make([]netlink.Link, 0, len(option.Config.GetDevices()))
 	if len(option.Config.GetDevices()) != 0 {
-		for _, device := range option.Config.GetDevices() {
-			link, err := netlink.LinkByName(device)
-			if err != nil {
-				log.WithError(err).WithField("device", device).Warn("Link does not exist")
-				return err
-			}
-			devices = append(devices, link)
-		}
 		args[initArgDevices] = strings.Join(option.Config.GetDevices(), ";")
 	} else {
 		args[initArgDevices] = "<nil>"
@@ -418,7 +409,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	sysctl.ApplySettings(sysSettings)
 
 	// Datapath initialization
-	hostDev1, hostDev2, err := setupBaseDevice(devices, mode, deviceMTU)
+	hostDev1, hostDev2, err := setupBaseDevice(deviceMTU)
 	if err != nil {
 		return fmt.Errorf("failed to setup base devices in mode %s: %w", mode, err)
 	}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -220,7 +220,7 @@ func setupVethPair(name, peerName string) error {
 // the first step of datapath initialization, then performs the setup (and
 // creation, if needed) of those interfaces. It returns two links and an error.
 // By default, it sets up the veth pair - cilium_host and cilium_net.
-func setupBaseDevice(nativeDevs []netlink.Link, mode baseDeviceMode, mtu int) (netlink.Link, netlink.Link, error) {
+func setupBaseDevice(mtu int) (netlink.Link, netlink.Link, error) {
 	if err := setupVethPair(defaults.HostDevice, defaults.SecondHostDevice); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
commit c3adaec9dc06a68 removed IPVLAN code, clean up setupBaseDevice().

found this through https://github.com/cilium/cilium/issues/20603
don't think IPVLAN leftover code is related to that issue. clean it up

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
clean up IPVLAN leftover code  in setupBaseDevice()
```
