### PR TITLE
helm: Set KPR default to "disabled" for >= 1.12

### DIFF
--- a/Documentation/gettingstarted/kind.rst
+++ b/Documentation/gettingstarted/kind.rst
@@ -43,18 +43,12 @@ Then, install Cilium release via Helm:
 
    helm install cilium |CHART_RELEASE| \\
       --namespace kube-system \\
-      --set kubeProxyReplacement=partial \\
-      --set socketLB.enabled=false \\
-      --set externalIPs.enabled=true \\
-      --set nodePort.enabled=true \\
-      --set hostPort.enabled=true \\
-      --set bpf.masquerade=false \\
       --set image.pullPolicy=IfNotPresent \\
       --set ipam.mode=kubernetes
 
 .. note::
 
-   To fully enable Cilium's kube-proxy replacement (:ref:`kubeproxy-free`), kind nodes
+   To enable Cilium's kube-proxy replacement (:ref:`kubeproxy-free`), kind nodes
    need to have their own cgroup namespaces, and are different from the cgroup namespace
    of the underlying host so that Cilium can attach BPF programs at the right
    cgroup hierarchy. To verify this, run the following commands inside

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -48,6 +48,7 @@
   {{- if .Values.azure.enabled }}
       {{- $azureUsePrimaryAddress = "false" -}}
   {{- end }}
+  {{- $defaultKubeProxyReplacement = "disabled" -}}
 {{- end -}}
 
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}


### PR DESCRIPTION
The commit 7463d9f12 (`daemon: Deprecate KPR=probe`) deprecated the KPR=probe option. However, it missed to explicitly set the default for `>= 1.12` installations.

The result of it is that the "probe" is used as a default for a new installation. This is because the following condition evaluates to true when `.Values.upgradeCompatibility` is not set:

        {{- /* Default values when 1.9 was initially deployed */ -}}
        {{- if semverCompare ">=1.9" (default "1.9" .Values.upgradeCompatibility) -}}
          {{- $defaultKubeProxyReplacement = "probe" -}}
        {{- end -}}

NB: I find this very confusing and error prone. The following makes more sense:

- the default `.Values.upgradeCompatibility` should be the latest version
- `==` instead of `>=` should be used

Otherwise, all `semverCompare` if-clauses we have will evaluate to true.