### PR TITLE
Log policy update event errors and silently delete bwmap entries

### DIFF
--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -288,7 +288,7 @@ func (ev *EndpointPolicyBandwidthEvent) Handle(res chan interface{}) {
 			err = bwmap.Update(e.ID, bps)
 		}
 	} else {
-		err = bwmap.Delete(e.ID)
+		err = bwmap.SilentDelete(e.ID)
 	}
 	if err != nil {
 		res <- &EndpointRegenerationResult{

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -823,7 +823,12 @@ func (e *Endpoint) UpdateNoTrackRules(annoCB AnnotationsResolverCB) {
 		e.getLogger().WithError(err).Error("Unable to enqueue endpoint notrack event")
 		return
 	}
-	<-ch
+
+	updateRes := <-ch
+	regenResult := updateRes.(*EndpointRegenerationResult)
+	if regenResult.err != nil {
+		e.getLogger().WithError(regenResult.err).Error("EndpointNoTrackEvent event failed")
+	}
 }
 
 // UpdateVisibilityPolicy updates the visibility policy of this endpoint to
@@ -840,7 +845,12 @@ func (e *Endpoint) UpdateVisibilityPolicy(annoCB AnnotationsResolverCB) {
 		e.getLogger().WithError(err).Error("Unable to enqueue endpoint policy visibility event")
 		return
 	}
-	<-ch
+
+	updateRes := <-ch
+	regenResult := updateRes.(*EndpointRegenerationResult)
+	if regenResult.err != nil {
+		e.getLogger().WithError(regenResult.err).Error("EndpointPolicyVisibilityEvent event failed")
+	}
 }
 
 // UpdateBandwidthPolicy updates the egress bandwidth of this endpoint to
@@ -854,7 +864,12 @@ func (e *Endpoint) UpdateBandwidthPolicy(annoCB AnnotationsResolverCB) {
 		e.getLogger().WithError(err).Error("Unable to enqueue endpoint policy bandwidth event")
 		return
 	}
-	<-ch
+
+	updateRes := <-ch
+	regenResult := updateRes.(*EndpointRegenerationResult)
+	if regenResult.err != nil {
+		e.getLogger().WithError(regenResult.err).Error("EndpointPolicyBandwidthEvent event failed")
+	}
 }
 
 // GetRealizedPolicyRuleLabelsForKey returns the list of policy rule labels

--- a/pkg/maps/bwmap/bwmap.go
+++ b/pkg/maps/bwmap/bwmap.go
@@ -66,3 +66,10 @@ func Delete(Id uint16) error {
 	return ThrottleMap.Delete(
 		&EdtId{Id: uint64(Id)})
 }
+
+func SilentDelete(Id uint16) error {
+	_, err := ThrottleMap.SilentDelete(
+		&EdtId{Id: uint64(Id)})
+
+	return err
+}


### PR DESCRIPTION
Everything is properly logged or passed up the call stack if there is an error in the result channel that is sent over an EventQueue.

Except these 3 methods in this PR.

While adding error logging, I've found the source of false entries. We are **always** [deleting](https://github.com/cilium/cilium/blob/e75d6d0de4c466b8c6f97130e386d7019b4f406b/pkg/endpoint/events.go#L291) a bwmap entry. And if we are doing that... why are we interested in ENOENT?

<!-- Description of change -->

```release-notes
Log policy update event errors and silently delete bwmap entries on event handling
```