### PR TITLE
plugins/cilium-docker: use log default exit code 1

### DIFF
--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -62,7 +62,6 @@ connected to a Docker network of type "cilium".`,
 func main() {
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
`log.Fatal(err)` in line 63 will call
https://github.com/cilium/cilium/blob/c39e1337f98da3ca1dd2e35bc719026442486273/vendor/github.com/sirupsen/logrus/entry.go#L325-L328

and `entry.Logger.Exit(1)` in line 327 will call

https://github.com/cilium/cilium/blob/c39e1337f98da3ca1dd2e35bc719026442486273/vendor/github.com/sirupsen/logrus/logger.go#L336-L342

and we don't set `logger.ExitFunc`. So just call `os.Exit(1)`.

In fact, the README of the log library already points this out:
https://github.com/cilium/cilium/blob/c39e1337f98da3ca1dd2e35bc719026442486273/vendor/github.com/sirupsen/logrus/README.md?plain=1#L303-L304

The line 65 of code will not be executed regardless of the exit code set.

https://github.com/cilium/cilium/blob/c39e1337f98da3ca1dd2e35bc719026442486273/plugins/cilium-docker/main.go#L62-L67


