### PR TITLE
v1.10 backports 2022-07-21

### DIFF
--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -56,7 +56,7 @@ Masquerading can take place only on those devices which run the eBPF masqueradin
 program. This means that a packet sent from a pod to an outside address will be
 masqueraded (to an output device IPv4 address), if the output device runs the program.
 If not specified, the program will be automatically attached to the devices selected by
-:ref:`the BPF NodePort device detection metchanism <Nodeport Devices>`.
+:ref:`the BPF NodePort device detection mechanism <Nodeport Devices>`.
 To manually change this, use the ``devices`` helm option. Use ``cilium status``
 to determine which devices the program is running on:
 

--- a/Documentation/concepts/networking/masquerading.rst
+++ b/Documentation/concepts/networking/masquerading.rst
@@ -53,9 +53,9 @@ The current implementation depends on :ref:`the BPF NodePort feature <kubeproxy-
 The dependency will be removed in the future (:gh-issue:`13732`).
 
 Masquerading can take place only on those devices which run the eBPF masquerading
-program. This means that a packet sent from a pod to an outside will be masqueraded
-(to an output device IPv4 address), if the output device runs the program. If not
-specified, the program will be automatically attached to the devices selected by
+program. This means that a packet sent from a pod to an outside address will be
+masqueraded (to an output device IPv4 address), if the output device runs the program.
+If not specified, the program will be automatically attached to the devices selected by
 :ref:`the BPF NodePort device detection metchanism <Nodeport Devices>`.
 To manually change this, use the ``devices`` helm option. Use ``cilium status``
 to determine which devices the program is running on:

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -411,15 +411,16 @@ func (d *Daemon) lookupIPsBySecID(nid identity.NumericIdentity) []string {
 	return ipcache.IPIdentityCache.LookupByIdentity(nid)
 }
 
-// NotifyOnDNSMsg handles DNS data in the daemon by emitting monitor
+// notifyOnDNSMsg handles DNS data in the daemon by emitting monitor
 // events, proxy metrics and storing DNS data in the DNS cache. This may
 // result in rule generation.
 // It will:
-// - Report a monitor error event and proxy metrics when the proxy sees an
-//   error, and when it can't process something in this function
-// - Report the verdict in a monitor event and emit proxy metrics
-// - Insert the DNS data into the cache when msg is a DNS response and we
-//   can lookup the endpoint related to it
+//   - Report a monitor error event and proxy metrics when the proxy sees an
+//     error, and when it can't process something in this function
+//   - Report the verdict in a monitor event and emit proxy metrics
+//   - Insert the DNS data into the cache when msg is a DNS response and we
+//     can lookup the endpoint related to it
+//
 // epIPPort and serverAddr should match the original request, where epAddr is
 // the source for egress (the only case current).
 func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
@@ -432,6 +433,9 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 	endMetric := func() {
 		stat.DataplaneTime.End(true)
 		stat.ProcessingTime.End(true)
+		if errors.Is(stat.Err, dnsproxy.ErrFailedAcquireSemaphore{}) || errors.Is(stat.Err, dnsproxy.ErrTimedOutAcquireSemaphore{}) {
+			metrics.FQDNSemaphoreRejectedTotal.Add(1)
+		}
 		metrics.ProxyUpstreamTime.WithLabelValues(metrics.ErrorTimeout, metrics.L7DNS, upstream).Observe(
 			stat.UpstreamTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -360,33 +360,33 @@ type LookupIPsBySecIDFunc func(nid identity.NumericIdentity) []string
 // See DNSProxy.LookupEndpointIDByIP for usage.
 type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error
 
-// errFailedAcquireSemaphore is an an error representing the DNS proxy's
+// ErrFailedAcquireSemaphore is an an error representing the DNS proxy's
 // failure to acquire the semaphore. This is error is treated like a timeout.
-type errFailedAcquireSemaphore struct {
+type ErrFailedAcquireSemaphore struct {
 	parallel int
 }
 
-func (e errFailedAcquireSemaphore) Timeout() bool { return true }
+func (e ErrFailedAcquireSemaphore) Timeout() bool { return true }
 
 // Temporary is deprecated. Return false.
-func (e errFailedAcquireSemaphore) Temporary() bool { return false }
-func (e errFailedAcquireSemaphore) Error() string {
+func (e ErrFailedAcquireSemaphore) Temporary() bool { return false }
+func (e ErrFailedAcquireSemaphore) Error() string {
 	return fmt.Sprintf(
 		"failed to acquire DNS proxy semaphore, %d parallel requests already in-flight",
 		e.parallel,
 	)
 }
 
-// errTimedOutAcquireSemaphore is an an error representing the DNS proxy timing
+// ErrTimedOutAcquireSemaphore is an an error representing the DNS proxy timing
 // out when acquiring the semaphore. It is treated the same as
-// errTimedOutAcquireSemaphore.
-type errTimedOutAcquireSemaphore struct {
-	errFailedAcquireSemaphore
+// ErrTimedOutAcquireSemaphore.
+type ErrTimedOutAcquireSemaphore struct {
+	ErrFailedAcquireSemaphore
 
 	gracePeriod time.Duration
 }
 
-func (e errTimedOutAcquireSemaphore) Error() string {
+func (e ErrTimedOutAcquireSemaphore) Error() string {
 	return fmt.Sprintf(
 		"timed out after %v acquiring DNS proxy semaphore, %d parallel requests already in-flight",
 		e.gracePeriod,
@@ -751,7 +751,7 @@ func (p *DNSProxy) enforceConcurrencyLimit(ctx context.Context) error {
 		// No grace time configured. Failing to acquire semaphore means
 		// immediately give up.
 		if !p.ConcurrencyLimit.TryAcquire(1) {
-			return errFailedAcquireSemaphore{
+			return ErrFailedAcquireSemaphore{
 				parallel: option.Config.DNSProxyConcurrencyLimit,
 			}
 		}
@@ -759,8 +759,8 @@ func (p *DNSProxy) enforceConcurrencyLimit(ctx context.Context) error {
 		// We ignore err because errTimedOutAcquireSemaphore implements the
 		// net.Error interface deeming it a timeout error which will be
 		// treated the same as context.DeadlineExceeded.
-		return errTimedOutAcquireSemaphore{
-			errFailedAcquireSemaphore: errFailedAcquireSemaphore{
+		return ErrTimedOutAcquireSemaphore{
+			ErrFailedAcquireSemaphore: ErrFailedAcquireSemaphore{
 				parallel: option.Config.DNSProxyConcurrencyLimit,
 			},
 			gracePeriod: p.ConcurrencyGracePeriod,

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1007,9 +1007,9 @@ func (s *DNSProxyTestSuite) TestProxyRequestContext_IsTimeout(c *C) {
 	p.Err = fmt.Errorf("sample err: %s", context.DeadlineExceeded)
 	c.Assert(p.IsTimeout(), Equals, false)
 
-	p.Err = errFailedAcquireSemaphore{}
+	p.Err = ErrFailedAcquireSemaphore{}
 	c.Assert(p.IsTimeout(), Equals, true)
-	p.Err = errTimedOutAcquireSemaphore{
+	p.Err = ErrTimedOutAcquireSemaphore{
 		gracePeriod: 1 * time.Second,
 	}
 	c.Assert(p.IsTimeout(), Equals, true)

--- a/pkg/k8s/version/version.go
+++ b/pkg/k8s/version/version.go
@@ -98,6 +98,10 @@ var (
 	// discovery was introduced in K8s version 1.21.
 	isGEThanAPIDiscoveryV1 = versioncheck.MustCompile(">=1.21.0")
 
+	// Constraint to check support for discovery/v1beta1 types. Support for
+	// v1beta1 discovery was introduced in K8s version 1.17.
+	isGEThanAPIDiscoveryV1Beta1 = versioncheck.MustCompile(">=1.17.0")
+
 	// isGEThanMinimalVersionConstraint is the minimal version required to run
 	// Cilium
 	isGEThanMinimalVersionConstraint = versioncheck.MustCompile(">=" + MinimalVersionConstraint)
@@ -128,6 +132,7 @@ func updateVersion(version semver.Version) {
 	cached.capabilities.MinimalVersionMet = isGEThanMinimalVersionConstraint(version)
 	cached.capabilities.APIExtensionsV1CRD = isGEThanAPIExtensionsV1CRD(version)
 	cached.capabilities.EndpointSliceV1 = isGEThanAPIDiscoveryV1(version)
+	cached.capabilities.EndpointSlice = isGEThanAPIDiscoveryV1Beta1(version)
 }
 
 func updateServerGroupsAndResources(apiResourceLists []*metav1.APIResourceList) {

--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -158,6 +158,7 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 
 	// K8s is not running with endpoint slices enabled, stop the endpoint slice
 	// controller to avoid watching for unnecessary stuff in k8s.
+	k.cancelWaitGroupToSyncResources(apiGroup)
 	k.k8sAPIGroups.RemoveAPI(apiGroup)
 	close(ecr)
 	return false

--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -108,7 +108,7 @@ func maskedIPNetToLabelString(cidr *net.IPNet, prefix, bits int) string {
 // The identity reserved:world is always added as it includes any CIDR.
 func GetCIDRLabels(cidr *net.IPNet) labels.Labels {
 	ones, bits := cidr.Mask.Size()
-	result := []string{}
+	result := make([]string, 0, ones+1)
 
 	// If ones is zero, then it's the default CIDR prefix /0 which should
 	// just be regarded as reserved:world. In all other cases, we need
@@ -121,7 +121,7 @@ func GetCIDRLabels(cidr *net.IPNet) labels.Labels {
 		}
 	}
 
-	result = append(result, fmt.Sprintf("%s:%s", labels.LabelSourceReserved, labels.IDNameWorld))
+	result = append(result, labels.LabelSourceReserved+":"+labels.IDNameWorld)
 
 	return labels.NewLabelsFromModel(result)
 }

--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -17,6 +17,7 @@ package cidr
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/labels"
@@ -42,8 +43,23 @@ func maskedIPToLabelString(ip *net.IP, prefix int) string {
 	if ipNoColons[len(ipNoColons)-1] == '-' {
 		postZero = "0"
 	}
-	return fmt.Sprintf("%s:%s%s%s/%d", labels.LabelSourceCIDR, preZero,
-		ipNoColons, postZero, prefix)
+	var str strings.Builder
+	str.Grow(
+		len(labels.LabelSourceCIDR) +
+			len(preZero) +
+			len(ipNoColons) +
+			len(postZero) +
+			2 /*len of prefix*/ +
+			2, /* ':' '/' */
+	)
+	str.WriteString(labels.LabelSourceCIDR)
+	str.WriteRune(':')
+	str.WriteString(preZero)
+	str.WriteString(ipNoColons)
+	str.WriteString(postZero)
+	str.WriteRune('/')
+	str.WriteString(strconv.Itoa(prefix))
+	return str.String()
 }
 
 // ipNetToLabel turns a CIDR into a Label object which can be used to create

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -148,3 +148,58 @@ func (s *CIDRLabelsSuite) TestIPStringToLabel(c *C) {
 		c.Assert(lbl.String(), checker.DeepEquals, labelStr)
 	}
 }
+
+func Benchmark_maskedIPNetToLabelString(b *testing.B) {
+	type input struct {
+		prefix     *net.IPNet
+		ones, bits int
+	}
+	var ins []input
+	for _, cidr := range []string{
+		"0.0.0.0/0",
+		"10.16.0.0/16",
+		"192.0.2.3/32",
+		"192.0.2.3/24",
+		"192.0.2.0/24",
+		"::/0",
+		"fdff::ff/128",
+	} {
+		_, c, _ := net.ParseCIDR(cidr)
+		ones, bits := c.Mask.Size()
+		ins = append(ins, input{
+			prefix: c,
+			ones:   ones,
+			bits:   bits,
+		})
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, in := range ins {
+			_ = maskedIPNetToLabelString(in.prefix, in.ones, in.bits)
+		}
+	}
+}
+
+func Benchmark_GetCIDRLabels(b *testing.B) {
+	var cidrs []*net.IPNet
+	for _, cidr := range []string{
+		"0.0.0.0/0",
+		"10.16.0.0/16",
+		"192.0.2.3/32",
+		"192.0.2.3/24",
+		"192.0.2.0/24",
+		"::/0",
+		"fdff::ff/128",
+	} {
+		_, c, _ := net.ParseCIDR(cidr)
+		cidrs = append(cidrs, c)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, c := range cidrs {
+			_ = GetCIDRLabels(c)
+		}
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -419,6 +419,11 @@ var (
 	// connection (aka zombie), per endpoint.
 	FQDNAliveZombieConnections = NoOpGaugeVec
 
+	// FQDNSemaphoreRejectedTotal is the total number of DNS requests rejected
+	// by the DNS proxy because too many requests were in flight, as enforced by
+	// the admission semaphore.
+	FQDNSemaphoreRejectedTotal = NoOpCounter
+
 	// BPFSyscallDuration is the metric for bpf syscalls duration.
 	BPFSyscallDuration = NoOpObserverVec
 
@@ -527,6 +532,7 @@ type Configuration struct {
 	FQDNActiveNames                         bool
 	FQDNActiveIPs                           bool
 	FQDNActiveZombiesConnections            bool
+	FQDNSemaphoreRejectedTotal              bool
 	BPFSyscallDurationEnabled               bool
 	BPFMapOps                               bool
 	BPFMapPressure                          bool
@@ -1175,6 +1181,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, FQDNAliveZombieConnections)
 			c.FQDNActiveZombiesConnections = true
+
+		case metricName + "_" + SubsystemFQDN + "_sempaphore_rejected_total":
+			FQDNSemaphoreRejectedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemFQDN,
+				Name:      "semaphore_rejected_total",
+				Help:      "Number of DNS request rejected by the DNS Proxy's admission semaphore",
+			})
+
+			collectors = append(collectors, FQDNSemaphoreRejectedTotal)
+			c.FQDNSemaphoreRejectedTotal = true
 
 		case Namespace + "_" + SubsystemBPF + "_syscall_duration_seconds":
 			BPFSyscallDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2763,7 +2763,8 @@ func (c *DaemonConfig) Populate() {
 
 	// Metrics Setup
 	defaultMetrics := metrics.DefaultMetrics()
-	for _, metric := range viper.GetStringSlice(Metrics) {
+	flagMetrics := append(viper.GetStringSlice(Metrics), c.additionalMetrics()...)
+	for _, metric := range flagMetrics {
 		switch metric[0] {
 		case '+':
 			defaultMetrics[metric[1:]] = struct{}{}
@@ -2876,6 +2877,17 @@ func (c *DaemonConfig) populateMasqueradingSettings() error {
 	c.DeriveMasqIPAddrFromDevice = viper.GetString(DeriveMasqIPAddrFromDevice)
 
 	return nil
+}
+
+func (c *DaemonConfig) additionalMetrics() []string {
+	addMetric := func(name string) string {
+		return "+" + metrics.Namespace + name
+	}
+	var m []string
+	if c.DNSProxyConcurrencyLimit > 0 {
+		m = append(m, addMetric(metrics.SubsystemFQDN+"_sempaphore_rejected_total"))
+	}
+	return m
 }
 
 func (c *DaemonConfig) populateDevices() {


### PR DESCRIPTION
- [x]  #19843 -- Optimize CIDR label functions (@christarazi) 
  :information_source: Minor conflicts in copyright header
- [x]  #20491 -- Add metric on number of requests rejected by DNS Proxy semaphore (@rahulkjoshi)
- [ ]  #20383 -- pkg/k8s/version: Also set EndpointSlice when forcing version (@joamaki)
- [x]  #20537 -- fqdn/dnsproxy: fix test build (@tklauser)
- [ ]  #20538 -- docs(masquerading): add missing "address" (@raphink)
- [x]  #20569 -- pkg/k8s: do not wait for endpointslice cache sync in k8s >= 1.17 (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 19843 20491 20383 20537 20538 20569; do contrib/backporting/set-labels.py $pr done 1.10; done
```