### PR TITLE
Add a Node/CiliumNode test based on control-plane framework

### DIFF
--- a/test/control-plane/node/ciliumnodes/ciliumnodes_validation.go
+++ b/test/control-plane/node/ciliumnodes/ciliumnodes_validation.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package node
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"reflect"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/cilium/cilium/pkg/datapath/fake"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	controlplane "github.com/cilium/cilium/test/control-plane"
+)
+
+type goldenCiliumNodesValidator struct {
+	step           int
+	expectedLabels map[string]string
+}
+
+func NewGoldenCiliumNodesValidator(stateFile string, update bool) controlplane.Validator {
+	var step int
+	fmt.Sscanf(path.Base(stateFile), "state%d.yaml", &step)
+
+	switch step {
+	case 1:
+		// step 1: added label "test-label" -> "test-value"
+		return &goldenCiliumNodesValidator{
+			step: step,
+			expectedLabels: map[string]string{
+				"beta.kubernetes.io/arch": "amd64",
+				"beta.kubernetes.io/os":   "linux",
+				"cilium.io/ci-node":       "k8s1",
+				"kubernetes.io/arch":      "amd64",
+				"kubernetes.io/hostname":  "cilium-nodes-worker",
+				"kubernetes.io/os":        "linux",
+
+				"test-label": "test-value",
+			},
+		}
+	case 2:
+		// step 2: removed label "test-label"
+		return &goldenCiliumNodesValidator{
+			step: step,
+			expectedLabels: map[string]string{
+				"beta.kubernetes.io/arch": "amd64",
+				"beta.kubernetes.io/os":   "linux",
+				"cilium.io/ci-node":       "k8s1",
+				"kubernetes.io/arch":      "amd64",
+				"kubernetes.io/hostname":  "cilium-nodes-worker",
+				"kubernetes.io/os":        "linux",
+			},
+		}
+	}
+
+	return nil
+}
+
+func getTestNodeLabels(proxy *controlplane.K8sObjsProxy, name string) (map[string]string, error) {
+	nodeObj, err := proxy.Get(
+		schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"},
+		"",
+		name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get %q Node: %w", name, err)
+	}
+	node, ok := nodeObj.(*v1.Node)
+	if !ok {
+		return nil, errors.New("type assertion failed for Node obj")
+	}
+
+	return node.GetLabels(), nil
+}
+
+func getTestCiliumNodeLabels(proxy *controlplane.K8sObjsProxy, name string) (map[string]string, error) {
+	ciliumNodeObj, err := proxy.Get(
+		schema.GroupVersionResource{Group: "cilium.io", Version: "v2", Resource: "ciliumnodes"},
+		"",
+		name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get %q CiliumNode: %w", name, err)
+	}
+	ciliumNode, ok := ciliumNodeObj.(*v2.CiliumNode)
+	if !ok {
+		return nil, errors.New("type assertion failed for CiliumNode obj")
+	}
+
+	return ciliumNode.GetLabels(), nil
+}
+
+func (v *goldenCiliumNodesValidator) Validate(datapath *fake.FakeDatapath, proxy *controlplane.K8sObjsProxy) error {
+	nodeLabels, err := getTestNodeLabels(proxy, "cilium-nodes-worker")
+	if err != nil {
+		return fmt.Errorf("validation failed in step %d: %w", v.step, err)
+	}
+	if !reflect.DeepEqual(v.expectedLabels, nodeLabels) {
+		return fmt.Errorf("nodes labels validation failed in step %d, expected: %v, found: %v",
+			v.step, nodeLabels, v.expectedLabels)
+	}
+
+	ciliumNodeLabels, err := getTestCiliumNodeLabels(proxy, "cilium-nodes-worker")
+	if err != nil {
+		return fmt.Errorf("validation failed in step %d: %w", v.step, err)
+	}
+	if !reflect.DeepEqual(v.expectedLabels, ciliumNodeLabels) {
+		return fmt.Errorf("cilium nodes labels validation failed in step %d, expected: %v, found: %v",
+			v.step, ciliumNodeLabels, v.expectedLabels)
+	}
+
+	return nil
+}

--- a/test/control-plane/node/ciliumnodes/ciliumnodes_validation.go
+++ b/test/control-plane/node/ciliumnodes/ciliumnodes_validation.go
@@ -55,6 +55,36 @@ func NewGoldenCiliumNodesValidator(stateFile string, update bool) controlplane.V
 				"kubernetes.io/os":        "linux",
 			},
 		}
+	case 3:
+		// step 3: added label "another-test-label" -> "another-test-value"
+		return &goldenCiliumNodesValidator{
+			step: step,
+			expectedLabels: map[string]string{
+				"beta.kubernetes.io/arch": "amd64",
+				"beta.kubernetes.io/os":   "linux",
+				"cilium.io/ci-node":       "k8s1",
+				"kubernetes.io/arch":      "amd64",
+				"kubernetes.io/hostname":  "cilium-nodes-worker",
+				"kubernetes.io/os":        "linux",
+
+				"another-test-label": "another-test-value",
+			},
+		}
+	case 4:
+		// step 4: overwritten label "another-test-label" -> "changed-test-value"
+		return &goldenCiliumNodesValidator{
+			step: step,
+			expectedLabels: map[string]string{
+				"beta.kubernetes.io/arch": "amd64",
+				"beta.kubernetes.io/os":   "linux",
+				"cilium.io/ci-node":       "k8s1",
+				"kubernetes.io/arch":      "amd64",
+				"kubernetes.io/hostname":  "cilium-nodes-worker",
+				"kubernetes.io/os":        "linux",
+
+				"another-test-label": "changed-test-value",
+			},
+		}
 	}
 
 	return nil

--- a/test/control-plane/node/ciliumnodes/generate.sh
+++ b/test/control-plane/node/ciliumnodes/generate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Generate the golden test files for the Node test
+#
+
+set -eux
+
+export KUBECONFIG=kubeconfig
+
+versions=(1.20 1.22 1.24)
+
+for version in ${versions[*]}; do
+    mkdir -p v${version}
+
+    : Start a kind cluster
+    kind create cluster --config manifests/kind-config-${version}.yaml --name cilium-nodes
+
+    : Install cilium
+    cilium install --wait
+
+    : Dump the initial state
+    kubectl get nodes,ciliumnodes -o yaml > v${version}/init.yaml
+
+    : Apply the label to worker node
+    kubectl label nodes cilium-nodes-worker test-label=test-value
+
+    : Wait for all nodes to be ready
+    kubectl wait --for=condition=ready --timeout=60s --all nodes
+
+    : Dump the nodes
+    kubectl get nodes -o yaml > v${version}/state1.yaml
+
+    : Remove the label
+    kubectl label nodes cilium-nodes-worker test-label-
+
+    : Wait for all nodes to be ready
+    kubectl wait --for=condition=ready --timeout=60s --all nodes
+
+    : Dump the nodes
+    kubectl get nodes -o yaml > v${version}/state2.yaml
+
+    : Tear down the cluster
+    kind delete clusters cilium-nodes
+    rm -f kubeconfig
+
+done

--- a/test/control-plane/node/ciliumnodes/generate.sh
+++ b/test/control-plane/node/ciliumnodes/generate.sh
@@ -39,6 +39,24 @@ for version in ${versions[*]}; do
     : Dump the nodes
     kubectl get nodes -o yaml > v${version}/state2.yaml
 
+    : Apply another label to worker node
+    kubectl label nodes cilium-nodes-worker another-test-label=another-test-value
+
+    : Wait for all nodes to be ready
+    kubectl wait --for=condition=ready --timeout=60s --all nodes
+
+    : Dump the nodes
+    kubectl get nodes -o yaml > v${version}/state3.yaml
+
+    : Overwrite the value of the label
+    kubectl label nodes --overwrite cilium-nodes-worker another-test-label=changed-test-value
+
+    : Wait for all nodes to be ready
+    kubectl wait --for=condition=ready --timeout=60s --all nodes
+
+    : Dump the nodes
+    kubectl get nodes -o yaml > v${version}/state4.yaml
+
     : Tear down the cluster
     kind delete clusters cilium-nodes
     rm -f kubeconfig

--- a/test/control-plane/node/ciliumnodes/manifests/kind-config-1.20.yaml
+++ b/test/control-plane/node/ciliumnodes/manifests/kind-config-1.20.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+    - role: control-plane
+      image: kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
+    - role: worker
+      image: kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
+      kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "cilium.io/ci-node=k8s1"
+networking:
+    disableDefaultCNI: true

--- a/test/control-plane/node/ciliumnodes/manifests/kind-config-1.22.yaml
+++ b/test/control-plane/node/ciliumnodes/manifests/kind-config-1.22.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+    - role: control-plane
+      image: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+    - role: worker
+      image: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+      kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "cilium.io/ci-node=k8s1"
+networking:
+    disableDefaultCNI: true

--- a/test/control-plane/node/ciliumnodes/manifests/kind-config-1.24.yaml
+++ b/test/control-plane/node/ciliumnodes/manifests/kind-config-1.24.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+    - role: control-plane
+      image: kindest/node:v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1
+    - role: worker
+      image: kindest/node:v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1
+      kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "cilium.io/ci-node=k8s1"
+networking:
+    disableDefaultCNI: true

--- a/test/control-plane/node/ciliumnodes/v1.20/ciliumnode_test.go
+++ b/test/control-plane/node/ciliumnodes/v1.20/ciliumnode_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package v1_20
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/option"
+	controlplane "github.com/cilium/cilium/test/control-plane"
+	node "github.com/cilium/cilium/test/control-plane/node/ciliumnodes"
+)
+
+func TestCiliumNodes1_20(t *testing.T) {
+	tc := controlplane.NewGoldenTest(t, "cilium-nodes-control-plane", node.NewGoldenCiliumNodesValidator)
+	tc.Run(t, "1.20", func(*option.DaemonConfig) {})
+}

--- a/test/control-plane/node/ciliumnodes/v1.20/init.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.20/init.yaml
@@ -1,0 +1,341 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.0.119
+      io.cilium.network.ipv4-health-ip: 10.244.0.24
+      io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:53:20Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+    name: cilium-nodes-control-plane
+    resourceVersion: "796"
+    uid: 90d051b1-6dab-4b28-83a5-e936410dd9c7
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: cilium-nodes-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:55:19Z"
+      lastTransitionTime: "2022-08-01T08:55:19Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:53:16Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:53:16Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:53:16Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:54:49Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
+      - k8s.gcr.io/kube-proxy:v1.20.15
+      sizeBytes: 101468763
+    - names:
+      - k8s.gcr.io/etcd:3.4.13-0
+      sizeBytes: 86742272
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
+      - k8s.gcr.io/kube-apiserver:v1.20.15
+      sizeBytes: 69805873
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
+      - k8s.gcr.io/kube-controller-manager:v1.20.15
+      sizeBytes: 63301443
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
+      - k8s.gcr.io/kube-scheduler:v1.20.15
+      sizeBytes: 48523057
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns:1.7.0
+      sizeBytes: 13982350
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.20.15
+      kubeletVersion: v1.20.15
+      machineID: 37c3d32924a64de580d273e20695e870
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 20ee2534-f400-4319-b909-26c73ffca0d5
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.1.223
+      io.cilium.network.ipv4-health-ip: 10.244.1.67
+      io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:53:55Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+    name: cilium-nodes-worker
+    resourceVersion: "751"
+    uid: 33778821-cbee-4231-994f-3f84e9af4663
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-worker
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: cilium-nodes-worker
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:55:01Z"
+      lastTransitionTime: "2022-08-01T08:55:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:53:54Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:53:54Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:53:54Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:54:45Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
+      - k8s.gcr.io/kube-proxy:v1.20.15
+      sizeBytes: 101468763
+    - names:
+      - k8s.gcr.io/etcd:3.4.13-0
+      sizeBytes: 86742272
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
+      - k8s.gcr.io/kube-apiserver:v1.20.15
+      sizeBytes: 69805873
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
+      - k8s.gcr.io/kube-controller-manager:v1.20.15
+      sizeBytes: 63301443
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
+      - k8s.gcr.io/kube-scheduler:v1.20.15
+      sizeBytes: 48523057
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
+      sizeBytes: 16741278
+    - names:
+      - k8s.gcr.io/coredns:1.7.0
+      sizeBytes: 13982350
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.20.15
+      kubeletVersion: v1.20.15
+      machineID: 5b7d6e9a7c8e4afeb8d878e8f8f024da
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: a0b3088f-ebbb-4ae8-9bb8-c4d45ea68229
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-01T08:54:46Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+    name: cilium-nodes-control-plane
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: cilium-nodes-control-plane
+      uid: 90d051b1-6dab-4b28-83a5-e936410dd9c7
+    resourceVersion: "682"
+    uid: 15a7a908-c9fa-4bf0-9245-96a88bbf0269
+  spec:
+    addresses:
+    - ip: 172.18.0.2
+      type: InternalIP
+    - ip: 10.244.0.119
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.0.24
+    ipam:
+      podCIDRs:
+      - 10.244.0.0/24
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-01T08:54:43Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+    name: cilium-nodes-worker
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: cilium-nodes-worker
+      uid: 33778821-cbee-4231-994f-3f84e9af4663
+    resourceVersion: "657"
+    uid: 3fed478b-2dc5-44e1-8b2d-c001a86774c5
+  spec:
+    addresses:
+    - ip: 172.18.0.3
+      type: InternalIP
+    - ip: 10.244.1.223
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.1.67
+    ipam:
+      podCIDRs:
+      - 10.244.1.0/24
+kind: List
+metadata:
+  resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.20/init.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.20/init.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.119
-      io.cilium.network.ipv4-health-ip: 10.244.0.24
+      io.cilium.network.ipv4-cilium-host: 10.244.0.101
+      io.cilium.network.ipv4-health-ip: 10.244.0.62
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T08:53:20Z"
+    creationTimestamp: "2022-08-01T09:22:59Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -20,8 +20,8 @@ items:
       node-role.kubernetes.io/control-plane: ""
       node-role.kubernetes.io/master: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "796"
-    uid: 90d051b1-6dab-4b28-83a5-e936410dd9c7
+    resourceVersion: "763"
+    uid: 1a6618dd-509d-4726-87f6-41bf38ebf614
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -51,32 +51,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T08:55:19Z"
-      lastTransitionTime: "2022-08-01T08:55:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
+      lastTransitionTime: "2022-08-01T09:24:39Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
-      lastTransitionTime: "2022-08-01T08:53:16Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
+      lastTransitionTime: "2022-08-01T09:22:56Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
-      lastTransitionTime: "2022-08-01T08:53:16Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
+      lastTransitionTime: "2022-08-01T09:22:56Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
-      lastTransitionTime: "2022-08-01T08:53:16Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
+      lastTransitionTime: "2022-08-01T09:22:56Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
-      lastTransitionTime: "2022-08-01T08:54:49Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
+      lastTransitionTime: "2022-08-01T09:24:29Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -129,21 +129,21 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.20.15
       kubeletVersion: v1.20.15
-      machineID: 37c3d32924a64de580d273e20695e870
+      machineID: a166e22042634888adfc1b080b0509fc
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 20ee2534-f400-4319-b909-26c73ffca0d5
+      systemUUID: 9eae790a-17b0-4ab4-aaa1-c3d01cc1a008
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.223
+      io.cilium.network.ipv4-cilium-host: 10.244.1.85
       io.cilium.network.ipv4-health-ip: 10.244.1.67
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T08:53:55Z"
+    creationTimestamp: "2022-08-01T09:23:31Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -152,8 +152,8 @@ items:
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
     name: cilium-nodes-worker
-    resourceVersion: "751"
-    uid: 33778821-cbee-4231-994f-3f84e9af4663
+    resourceVersion: "746"
+    uid: fcc34a1a-86cd-4045-b26d-628d224198d1
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -180,32 +180,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T08:55:01Z"
-      lastTransitionTime: "2022-08-01T08:55:01Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:35Z"
+      lastTransitionTime: "2022-08-01T09:24:35Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
-      lastTransitionTime: "2022-08-01T08:53:54Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
+      lastTransitionTime: "2022-08-01T09:23:31Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
-      lastTransitionTime: "2022-08-01T08:53:54Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
+      lastTransitionTime: "2022-08-01T09:23:31Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
-      lastTransitionTime: "2022-08-01T08:53:54Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
+      lastTransitionTime: "2022-08-01T09:23:31Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
-      lastTransitionTime: "2022-08-01T08:54:45Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
+      lastTransitionTime: "2022-08-01T09:24:21Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -261,14 +261,14 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.20.15
       kubeletVersion: v1.20.15
-      machineID: 5b7d6e9a7c8e4afeb8d878e8f8f024da
+      machineID: 753abf1bd8904695aefc40e870c1e1ff
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: a0b3088f-ebbb-4ae8-9bb8-c4d45ea68229
+      systemUUID: 0d4f5f1a-1496-48b1-900e-d6746c441a77
 - apiVersion: cilium.io/v2
   kind: CiliumNode
   metadata:
-    creationTimestamp: "2022-08-01T08:54:46Z"
+    creationTimestamp: "2022-08-01T09:24:25Z"
     generation: 1
     labels:
       beta.kubernetes.io/arch: amd64
@@ -283,28 +283,28 @@ items:
     - apiVersion: v1
       kind: Node
       name: cilium-nodes-control-plane
-      uid: 90d051b1-6dab-4b28-83a5-e936410dd9c7
-    resourceVersion: "682"
-    uid: 15a7a908-c9fa-4bf0-9245-96a88bbf0269
+      uid: 1a6618dd-509d-4726-87f6-41bf38ebf614
+    resourceVersion: "691"
+    uid: 0aed6d71-2e51-44ed-a72c-fcbdd5db392e
   spec:
     addresses:
     - ip: 172.18.0.2
       type: InternalIP
-    - ip: 10.244.0.119
+    - ip: 10.244.0.101
       type: CiliumInternalIP
     alibaba-cloud: {}
     azure: {}
     encryption: {}
     eni: {}
     health:
-      ipv4: 10.244.0.24
+      ipv4: 10.244.0.62
     ipam:
       podCIDRs:
       - 10.244.0.0/24
 - apiVersion: cilium.io/v2
   kind: CiliumNode
   metadata:
-    creationTimestamp: "2022-08-01T08:54:43Z"
+    creationTimestamp: "2022-08-01T09:24:21Z"
     generation: 1
     labels:
       beta.kubernetes.io/arch: amd64
@@ -318,14 +318,14 @@ items:
     - apiVersion: v1
       kind: Node
       name: cilium-nodes-worker
-      uid: 33778821-cbee-4231-994f-3f84e9af4663
-    resourceVersion: "657"
-    uid: 3fed478b-2dc5-44e1-8b2d-c001a86774c5
+      uid: fcc34a1a-86cd-4045-b26d-628d224198d1
+    resourceVersion: "661"
+    uid: b81c3cb9-cc5b-4d81-96fc-651e2642a8bf
   spec:
     addresses:
     - ip: 172.18.0.3
       type: InternalIP
-    - ip: 10.244.1.223
+    - ip: 10.244.1.85
       type: CiliumInternalIP
     alibaba-cloud: {}
     azure: {}

--- a/test/control-plane/node/ciliumnodes/v1.20/state1.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.20/state1.yaml
@@ -1,0 +1,271 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.0.119
+      io.cilium.network.ipv4-health-ip: 10.244.0.24
+      io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:53:20Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+    name: cilium-nodes-control-plane
+    resourceVersion: "796"
+    uid: 90d051b1-6dab-4b28-83a5-e936410dd9c7
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: cilium-nodes-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:55:19Z"
+      lastTransitionTime: "2022-08-01T08:55:19Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:53:16Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:53:16Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:53:16Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:54:49Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
+      - k8s.gcr.io/kube-proxy:v1.20.15
+      sizeBytes: 101468763
+    - names:
+      - k8s.gcr.io/etcd:3.4.13-0
+      sizeBytes: 86742272
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
+      - k8s.gcr.io/kube-apiserver:v1.20.15
+      sizeBytes: 69805873
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
+      - k8s.gcr.io/kube-controller-manager:v1.20.15
+      sizeBytes: 63301443
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
+      - k8s.gcr.io/kube-scheduler:v1.20.15
+      sizeBytes: 48523057
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns:1.7.0
+      sizeBytes: 13982350
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.20.15
+      kubeletVersion: v1.20.15
+      machineID: 37c3d32924a64de580d273e20695e870
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 20ee2534-f400-4319-b909-26c73ffca0d5
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.1.223
+      io.cilium.network.ipv4-health-ip: 10.244.1.67
+      io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:53:55Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+      test-label: test-value
+    name: cilium-nodes-worker
+    resourceVersion: "798"
+    uid: 33778821-cbee-4231-994f-3f84e9af4663
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-worker
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: cilium-nodes-worker
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:55:01Z"
+      lastTransitionTime: "2022-08-01T08:55:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:53:54Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:53:54Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:53:54Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:54:45Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
+      - k8s.gcr.io/kube-proxy:v1.20.15
+      sizeBytes: 101468763
+    - names:
+      - k8s.gcr.io/etcd:3.4.13-0
+      sizeBytes: 86742272
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
+      - k8s.gcr.io/kube-apiserver:v1.20.15
+      sizeBytes: 69805873
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
+      - k8s.gcr.io/kube-controller-manager:v1.20.15
+      sizeBytes: 63301443
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
+      - k8s.gcr.io/kube-scheduler:v1.20.15
+      sizeBytes: 48523057
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
+      sizeBytes: 16741278
+    - names:
+      - k8s.gcr.io/coredns:1.7.0
+      sizeBytes: 13982350
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.20.15
+      kubeletVersion: v1.20.15
+      machineID: 5b7d6e9a7c8e4afeb8d878e8f8f024da
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: a0b3088f-ebbb-4ae8-9bb8-c4d45ea68229
+kind: List
+metadata:
+  resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.20/state2.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.20/state2.yaml
@@ -1,0 +1,270 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.0.119
+      io.cilium.network.ipv4-health-ip: 10.244.0.24
+      io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:53:20Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+    name: cilium-nodes-control-plane
+    resourceVersion: "796"
+    uid: 90d051b1-6dab-4b28-83a5-e936410dd9c7
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: cilium-nodes-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:55:19Z"
+      lastTransitionTime: "2022-08-01T08:55:19Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:53:16Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:53:16Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:53:16Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
+      lastTransitionTime: "2022-08-01T08:54:49Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
+      - k8s.gcr.io/kube-proxy:v1.20.15
+      sizeBytes: 101468763
+    - names:
+      - k8s.gcr.io/etcd:3.4.13-0
+      sizeBytes: 86742272
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
+      - k8s.gcr.io/kube-apiserver:v1.20.15
+      sizeBytes: 69805873
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
+      - k8s.gcr.io/kube-controller-manager:v1.20.15
+      sizeBytes: 63301443
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
+      - k8s.gcr.io/kube-scheduler:v1.20.15
+      sizeBytes: 48523057
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns:1.7.0
+      sizeBytes: 13982350
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.20.15
+      kubeletVersion: v1.20.15
+      machineID: 37c3d32924a64de580d273e20695e870
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 20ee2534-f400-4319-b909-26c73ffca0d5
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.1.223
+      io.cilium.network.ipv4-health-ip: 10.244.1.67
+      io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:53:55Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+    name: cilium-nodes-worker
+    resourceVersion: "800"
+    uid: 33778821-cbee-4231-994f-3f84e9af4663
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-worker
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: cilium-nodes-worker
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:55:01Z"
+      lastTransitionTime: "2022-08-01T08:55:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:53:54Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:53:54Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:53:54Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
+      lastTransitionTime: "2022-08-01T08:54:45Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
+      - k8s.gcr.io/kube-proxy:v1.20.15
+      sizeBytes: 101468763
+    - names:
+      - k8s.gcr.io/etcd:3.4.13-0
+      sizeBytes: 86742272
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
+      - k8s.gcr.io/kube-apiserver:v1.20.15
+      sizeBytes: 69805873
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
+      - k8s.gcr.io/kube-controller-manager:v1.20.15
+      sizeBytes: 63301443
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
+      - k8s.gcr.io/kube-scheduler:v1.20.15
+      sizeBytes: 48523057
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
+      sizeBytes: 16741278
+    - names:
+      - k8s.gcr.io/coredns:1.7.0
+      sizeBytes: 13982350
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.20.15
+      kubeletVersion: v1.20.15
+      machineID: 5b7d6e9a7c8e4afeb8d878e8f8f024da
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: a0b3088f-ebbb-4ae8-9bb8-c4d45ea68229
+kind: List
+metadata:
+  resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.20/state2.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.20/state2.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.119
-      io.cilium.network.ipv4-health-ip: 10.244.0.24
+      io.cilium.network.ipv4-cilium-host: 10.244.0.101
+      io.cilium.network.ipv4-health-ip: 10.244.0.62
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T08:53:20Z"
+    creationTimestamp: "2022-08-01T09:22:59Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -20,8 +20,8 @@ items:
       node-role.kubernetes.io/control-plane: ""
       node-role.kubernetes.io/master: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "796"
-    uid: 90d051b1-6dab-4b28-83a5-e936410dd9c7
+    resourceVersion: "763"
+    uid: 1a6618dd-509d-4726-87f6-41bf38ebf614
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -51,32 +51,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T08:55:19Z"
-      lastTransitionTime: "2022-08-01T08:55:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
+      lastTransitionTime: "2022-08-01T09:24:39Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
-      lastTransitionTime: "2022-08-01T08:53:16Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
+      lastTransitionTime: "2022-08-01T09:22:56Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
-      lastTransitionTime: "2022-08-01T08:53:16Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
+      lastTransitionTime: "2022-08-01T09:22:56Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
-      lastTransitionTime: "2022-08-01T08:53:16Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
+      lastTransitionTime: "2022-08-01T09:22:56Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:59Z"
-      lastTransitionTime: "2022-08-01T08:54:49Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
+      lastTransitionTime: "2022-08-01T09:24:29Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -129,21 +129,21 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.20.15
       kubeletVersion: v1.20.15
-      machineID: 37c3d32924a64de580d273e20695e870
+      machineID: a166e22042634888adfc1b080b0509fc
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 20ee2534-f400-4319-b909-26c73ffca0d5
+      systemUUID: 9eae790a-17b0-4ab4-aaa1-c3d01cc1a008
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.223
+      io.cilium.network.ipv4-cilium-host: 10.244.1.85
       io.cilium.network.ipv4-health-ip: 10.244.1.67
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T08:53:55Z"
+    creationTimestamp: "2022-08-01T09:23:31Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -152,8 +152,8 @@ items:
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
     name: cilium-nodes-worker
-    resourceVersion: "800"
-    uid: 33778821-cbee-4231-994f-3f84e9af4663
+    resourceVersion: "779"
+    uid: fcc34a1a-86cd-4045-b26d-628d224198d1
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -180,32 +180,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T08:55:01Z"
-      lastTransitionTime: "2022-08-01T08:55:01Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:35Z"
+      lastTransitionTime: "2022-08-01T09:24:35Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
-      lastTransitionTime: "2022-08-01T08:53:54Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
+      lastTransitionTime: "2022-08-01T09:23:31Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
-      lastTransitionTime: "2022-08-01T08:53:54Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
+      lastTransitionTime: "2022-08-01T09:23:31Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
-      lastTransitionTime: "2022-08-01T08:53:54Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
+      lastTransitionTime: "2022-08-01T09:23:31Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T08:54:55Z"
-      lastTransitionTime: "2022-08-01T08:54:45Z"
+    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
+      lastTransitionTime: "2022-08-01T09:24:21Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -261,10 +261,10 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.20.15
       kubeletVersion: v1.20.15
-      machineID: 5b7d6e9a7c8e4afeb8d878e8f8f024da
+      machineID: 753abf1bd8904695aefc40e870c1e1ff
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: a0b3088f-ebbb-4ae8-9bb8-c4d45ea68229
+      systemUUID: 0d4f5f1a-1496-48b1-900e-d6746c441a77
 kind: List
 metadata:
   resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.20/state3.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.20/state3.yaml
@@ -145,15 +145,15 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-08-01T09:23:31Z"
     labels:
+      another-test-label: another-test-value
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
-      test-label: test-value
     name: cilium-nodes-worker
-    resourceVersion: "777"
+    resourceVersion: "783"
     uid: fcc34a1a-86cd-4045-b26d-628d224198d1
   spec:
     podCIDR: 10.244.1.0/24

--- a/test/control-plane/node/ciliumnodes/v1.20/state4.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.20/state4.yaml
@@ -145,15 +145,15 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-08-01T09:23:31Z"
     labels:
+      another-test-label: changed-test-value
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
-      test-label: test-value
     name: cilium-nodes-worker
-    resourceVersion: "777"
+    resourceVersion: "787"
     uid: fcc34a1a-86cd-4045-b26d-628d224198d1
   spec:
     podCIDR: 10.244.1.0/24

--- a/test/control-plane/node/ciliumnodes/v1.22/ciliumnode_test.go
+++ b/test/control-plane/node/ciliumnodes/v1.22/ciliumnode_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package v1_22
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/option"
+	controlplane "github.com/cilium/cilium/test/control-plane"
+	node "github.com/cilium/cilium/test/control-plane/node/ciliumnodes"
+)
+
+func TestCiliumNodes1_22(t *testing.T) {
+	tc := controlplane.NewGoldenTest(t, "cilium-nodes-control-plane", node.NewGoldenCiliumNodesValidator)
+	tc.Run(t, "1.22", func(*option.DaemonConfig) {})
+}

--- a/test/control-plane/node/ciliumnodes/v1.22/init.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.22/init.yaml
@@ -1,0 +1,340 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.0.179
+      io.cilium.network.ipv4-health-ip: 10.244.0.202
+      io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:56:24Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: cilium-nodes-control-plane
+    resourceVersion: "777"
+    uid: e9f9d3e4-85c8-4931-b561-f827cd682839
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: cilium-nodes-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:58:01Z"
+      lastTransitionTime: "2022-08-01T08:58:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:56:19Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:56:19Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:56:19Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:57:57Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
+    - names:
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: 4533f85284bc43c48f4412f0159db856
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 30c25c57-858a-4bc8-9812-a3ace4f85cf3
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.1.237
+      io.cilium.network.ipv4-health-ip: 10.244.1.203
+      io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:56:48Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+    name: cilium-nodes-worker
+    resourceVersion: "764"
+    uid: 0c2046ed-23f1-43ed-bd72-72672c2f8f11
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-worker
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: cilium-nodes-worker
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:57:57Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:56:47Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:56:47Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:56:47Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:57:58Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
+    - names:
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
+      sizeBytes: 16741278
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: d740c053b51c440891063a05c8c73c98
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 98981dce-4e53-42a9-ba19-762d096cd75e
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-01T08:57:57Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: cilium-nodes-control-plane
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: cilium-nodes-control-plane
+      uid: e9f9d3e4-85c8-4931-b561-f827cd682839
+    resourceVersion: "755"
+    uid: af9ac301-6684-4f26-9075-948ccc405c1a
+  spec:
+    addresses:
+    - ip: 172.18.0.2
+      type: InternalIP
+    - ip: 10.244.0.179
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.0.202
+    ipam:
+      podCIDRs:
+      - 10.244.0.0/24
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-01T08:57:54Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+    name: cilium-nodes-worker
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: cilium-nodes-worker
+      uid: 0c2046ed-23f1-43ed-bd72-72672c2f8f11
+    resourceVersion: "732"
+    uid: d0818f79-67c7-49c4-b867-91ee9b057766
+  spec:
+    addresses:
+    - ip: 172.18.0.3
+      type: InternalIP
+    - ip: 10.244.1.237
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.1.203
+    ipam:
+      podCIDRs:
+      - 10.244.1.0/24
+kind: List
+metadata:
+  resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.22/init.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.22/init.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.179
-      io.cilium.network.ipv4-health-ip: 10.244.0.202
+      io.cilium.network.ipv4-cilium-host: 10.244.0.22
+      io.cilium.network.ipv4-health-ip: 10.244.0.206
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T08:56:24Z"
+    creationTimestamp: "2022-08-01T09:25:00Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -21,8 +21,8 @@ items:
       node-role.kubernetes.io/master: ""
       node.kubernetes.io/exclude-from-external-load-balancers: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "777"
-    uid: e9f9d3e4-85c8-4931-b561-f827cd682839
+    resourceVersion: "753"
+    uid: 5ae0722a-32ca-44df-8304-429015ad564d
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -33,7 +33,7 @@ items:
       key: node-role.kubernetes.io/master
   status:
     addresses:
-    - address: 172.18.0.2
+    - address: 172.18.0.3
       type: InternalIP
     - address: cilium-nodes-control-plane
       type: Hostname
@@ -52,32 +52,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T08:58:01Z"
-      lastTransitionTime: "2022-08-01T08:58:01Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:21Z"
+      lastTransitionTime: "2022-08-01T09:26:21Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:56:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:56:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:56:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:57:57Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -86,9 +86,6 @@ items:
       kubeletEndpoint:
         Port: 10250
     images:
-    - names:
-      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
-      sizeBytes: 159114031
     - names:
       - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
       - k8s.gcr.io/kube-proxy:v1.22.9
@@ -130,21 +127,21 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.22.9
       kubeletVersion: v1.22.9
-      machineID: 4533f85284bc43c48f4412f0159db856
+      machineID: 05c20a6e57a04683bccad029da748960
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 30c25c57-858a-4bc8-9812-a3ace4f85cf3
+      systemUUID: f609f045-ad30-41c2-b4e4-ed7dd2448f05
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.237
-      io.cilium.network.ipv4-health-ip: 10.244.1.203
+      io.cilium.network.ipv4-cilium-host: 10.244.1.240
+      io.cilium.network.ipv4-health-ip: 10.244.1.148
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T08:56:48Z"
+    creationTimestamp: "2022-08-01T09:25:23Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -153,8 +150,8 @@ items:
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
     name: cilium-nodes-worker
-    resourceVersion: "764"
-    uid: 0c2046ed-23f1-43ed-bd72-72672c2f8f11
+    resourceVersion: "744"
+    uid: 39ea5b1a-6eab-4285-a309-d4cc55bfbf12
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -162,7 +159,7 @@ items:
     providerID: kind://docker/cilium-nodes/cilium-nodes-worker
   status:
     addresses:
-    - address: 172.18.0.3
+    - address: 172.18.0.2
       type: InternalIP
     - address: cilium-nodes-worker
       type: Hostname
@@ -181,32 +178,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:57:57Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:56:47Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:56:47Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:56:47Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:57:58Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -215,6 +212,9 @@ items:
       kubeletEndpoint:
         Port: 10250
     images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
     - names:
       - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
       - k8s.gcr.io/kube-proxy:v1.22.9
@@ -259,14 +259,14 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.22.9
       kubeletVersion: v1.22.9
-      machineID: d740c053b51c440891063a05c8c73c98
+      machineID: 0cae0478f49e429987f2af4fa94d8cc5
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 98981dce-4e53-42a9-ba19-762d096cd75e
+      systemUUID: b5a94831-3b2d-4b6a-9ff5-da2332cdd018
 - apiVersion: cilium.io/v2
   kind: CiliumNode
   metadata:
-    creationTimestamp: "2022-08-01T08:57:57Z"
+    creationTimestamp: "2022-08-01T09:26:20Z"
     generation: 1
     labels:
       beta.kubernetes.io/arch: amd64
@@ -282,28 +282,28 @@ items:
     - apiVersion: v1
       kind: Node
       name: cilium-nodes-control-plane
-      uid: e9f9d3e4-85c8-4931-b561-f827cd682839
-    resourceVersion: "755"
-    uid: af9ac301-6684-4f26-9075-948ccc405c1a
+      uid: 5ae0722a-32ca-44df-8304-429015ad564d
+    resourceVersion: "705"
+    uid: a8477072-9631-44db-a2c4-e22bfaa844c6
   spec:
     addresses:
-    - ip: 172.18.0.2
+    - ip: 172.18.0.3
       type: InternalIP
-    - ip: 10.244.0.179
+    - ip: 10.244.0.22
       type: CiliumInternalIP
     alibaba-cloud: {}
     azure: {}
     encryption: {}
     eni: {}
     health:
-      ipv4: 10.244.0.202
+      ipv4: 10.244.0.206
     ipam:
       podCIDRs:
       - 10.244.0.0/24
 - apiVersion: cilium.io/v2
   kind: CiliumNode
   metadata:
-    creationTimestamp: "2022-08-01T08:57:54Z"
+    creationTimestamp: "2022-08-01T09:26:21Z"
     generation: 1
     labels:
       beta.kubernetes.io/arch: amd64
@@ -317,21 +317,21 @@ items:
     - apiVersion: v1
       kind: Node
       name: cilium-nodes-worker
-      uid: 0c2046ed-23f1-43ed-bd72-72672c2f8f11
-    resourceVersion: "732"
-    uid: d0818f79-67c7-49c4-b867-91ee9b057766
+      uid: 39ea5b1a-6eab-4285-a309-d4cc55bfbf12
+    resourceVersion: "712"
+    uid: 31894fa8-23cb-4c59-9633-58006235f1e3
   spec:
     addresses:
-    - ip: 172.18.0.3
+    - ip: 172.18.0.2
       type: InternalIP
-    - ip: 10.244.1.237
+    - ip: 10.244.1.240
       type: CiliumInternalIP
     alibaba-cloud: {}
     azure: {}
     encryption: {}
     eni: {}
     health:
-      ipv4: 10.244.1.203
+      ipv4: 10.244.1.148
     ipam:
       podCIDRs:
       - 10.244.1.0/24

--- a/test/control-plane/node/ciliumnodes/v1.22/state1.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.22/state1.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.179
-      io.cilium.network.ipv4-health-ip: 10.244.0.202
+      io.cilium.network.ipv4-cilium-host: 10.244.0.22
+      io.cilium.network.ipv4-health-ip: 10.244.0.206
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T08:56:24Z"
+    creationTimestamp: "2022-08-01T09:25:00Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -21,8 +21,8 @@ items:
       node-role.kubernetes.io/master: ""
       node.kubernetes.io/exclude-from-external-load-balancers: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "777"
-    uid: e9f9d3e4-85c8-4931-b561-f827cd682839
+    resourceVersion: "753"
+    uid: 5ae0722a-32ca-44df-8304-429015ad564d
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -33,7 +33,7 @@ items:
       key: node-role.kubernetes.io/master
   status:
     addresses:
-    - address: 172.18.0.2
+    - address: 172.18.0.3
       type: InternalIP
     - address: cilium-nodes-control-plane
       type: Hostname
@@ -52,32 +52,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T08:58:01Z"
-      lastTransitionTime: "2022-08-01T08:58:01Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:21Z"
+      lastTransitionTime: "2022-08-01T09:26:21Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:56:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:56:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:56:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:57:57Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -86,9 +86,6 @@ items:
       kubeletEndpoint:
         Port: 10250
     images:
-    - names:
-      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
-      sizeBytes: 159114031
     - names:
       - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
       - k8s.gcr.io/kube-proxy:v1.22.9
@@ -130,21 +127,21 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.22.9
       kubeletVersion: v1.22.9
-      machineID: 4533f85284bc43c48f4412f0159db856
+      machineID: 05c20a6e57a04683bccad029da748960
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 30c25c57-858a-4bc8-9812-a3ace4f85cf3
+      systemUUID: f609f045-ad30-41c2-b4e4-ed7dd2448f05
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.237
-      io.cilium.network.ipv4-health-ip: 10.244.1.203
+      io.cilium.network.ipv4-cilium-host: 10.244.1.240
+      io.cilium.network.ipv4-health-ip: 10.244.1.148
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T08:56:48Z"
+    creationTimestamp: "2022-08-01T09:25:23Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -154,8 +151,8 @@ items:
       kubernetes.io/os: linux
       test-label: test-value
     name: cilium-nodes-worker
-    resourceVersion: "794"
-    uid: 0c2046ed-23f1-43ed-bd72-72672c2f8f11
+    resourceVersion: "768"
+    uid: 39ea5b1a-6eab-4285-a309-d4cc55bfbf12
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -163,7 +160,7 @@ items:
     providerID: kind://docker/cilium-nodes/cilium-nodes-worker
   status:
     addresses:
-    - address: 172.18.0.3
+    - address: 172.18.0.2
       type: InternalIP
     - address: cilium-nodes-worker
       type: Hostname
@@ -182,32 +179,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:57:57Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:56:47Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:56:47Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:56:47Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:57:58Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -216,6 +213,9 @@ items:
       kubeletEndpoint:
         Port: 10250
     images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
     - names:
       - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
       - k8s.gcr.io/kube-proxy:v1.22.9
@@ -260,10 +260,10 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.22.9
       kubeletVersion: v1.22.9
-      machineID: d740c053b51c440891063a05c8c73c98
+      machineID: 0cae0478f49e429987f2af4fa94d8cc5
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 98981dce-4e53-42a9-ba19-762d096cd75e
+      systemUUID: b5a94831-3b2d-4b6a-9ff5-da2332cdd018
 kind: List
 metadata:
   resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.22/state1.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.22/state1.yaml
@@ -1,0 +1,269 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.0.179
+      io.cilium.network.ipv4-health-ip: 10.244.0.202
+      io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:56:24Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: cilium-nodes-control-plane
+    resourceVersion: "777"
+    uid: e9f9d3e4-85c8-4931-b561-f827cd682839
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: cilium-nodes-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:58:01Z"
+      lastTransitionTime: "2022-08-01T08:58:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:56:19Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:56:19Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:56:19Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:57:57Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
+    - names:
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: 4533f85284bc43c48f4412f0159db856
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 30c25c57-858a-4bc8-9812-a3ace4f85cf3
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.1.237
+      io.cilium.network.ipv4-health-ip: 10.244.1.203
+      io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:56:48Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+      test-label: test-value
+    name: cilium-nodes-worker
+    resourceVersion: "794"
+    uid: 0c2046ed-23f1-43ed-bd72-72672c2f8f11
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-worker
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: cilium-nodes-worker
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:57:57Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:56:47Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:56:47Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:56:47Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:57:58Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
+    - names:
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
+      sizeBytes: 16741278
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: d740c053b51c440891063a05c8c73c98
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 98981dce-4e53-42a9-ba19-762d096cd75e
+kind: List
+metadata:
+  resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.22/state2.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.22/state2.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.179
-      io.cilium.network.ipv4-health-ip: 10.244.0.202
+      io.cilium.network.ipv4-cilium-host: 10.244.0.22
+      io.cilium.network.ipv4-health-ip: 10.244.0.206
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T08:56:24Z"
+    creationTimestamp: "2022-08-01T09:25:00Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -21,8 +21,8 @@ items:
       node-role.kubernetes.io/master: ""
       node.kubernetes.io/exclude-from-external-load-balancers: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "777"
-    uid: e9f9d3e4-85c8-4931-b561-f827cd682839
+    resourceVersion: "753"
+    uid: 5ae0722a-32ca-44df-8304-429015ad564d
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -33,7 +33,7 @@ items:
       key: node-role.kubernetes.io/master
   status:
     addresses:
-    - address: 172.18.0.2
+    - address: 172.18.0.3
       type: InternalIP
     - address: cilium-nodes-control-plane
       type: Hostname
@@ -52,32 +52,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T08:58:01Z"
-      lastTransitionTime: "2022-08-01T08:58:01Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:21Z"
+      lastTransitionTime: "2022-08-01T09:26:21Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:56:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:56:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:56:19Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:57:57Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -86,9 +86,6 @@ items:
       kubeletEndpoint:
         Port: 10250
     images:
-    - names:
-      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
-      sizeBytes: 159114031
     - names:
       - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
       - k8s.gcr.io/kube-proxy:v1.22.9
@@ -130,21 +127,21 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.22.9
       kubeletVersion: v1.22.9
-      machineID: 4533f85284bc43c48f4412f0159db856
+      machineID: 05c20a6e57a04683bccad029da748960
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 30c25c57-858a-4bc8-9812-a3ace4f85cf3
+      systemUUID: f609f045-ad30-41c2-b4e4-ed7dd2448f05
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.237
-      io.cilium.network.ipv4-health-ip: 10.244.1.203
+      io.cilium.network.ipv4-cilium-host: 10.244.1.240
+      io.cilium.network.ipv4-health-ip: 10.244.1.148
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T08:56:48Z"
+    creationTimestamp: "2022-08-01T09:25:23Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -153,8 +150,8 @@ items:
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
     name: cilium-nodes-worker
-    resourceVersion: "800"
-    uid: 0c2046ed-23f1-43ed-bd72-72672c2f8f11
+    resourceVersion: "790"
+    uid: 39ea5b1a-6eab-4285-a309-d4cc55bfbf12
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -162,7 +159,7 @@ items:
     providerID: kind://docker/cilium-nodes/cilium-nodes-worker
   status:
     addresses:
-    - address: 172.18.0.3
+    - address: 172.18.0.2
       type: InternalIP
     - address: cilium-nodes-worker
       type: Hostname
@@ -181,32 +178,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
-      lastTransitionTime: "2022-08-01T08:57:57Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:56:47Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:56:47Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:56:47Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
-      lastTransitionTime: "2022-08-01T08:57:58Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -215,6 +212,9 @@ items:
       kubeletEndpoint:
         Port: 10250
     images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
     - names:
       - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
       - k8s.gcr.io/kube-proxy:v1.22.9
@@ -259,10 +259,10 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.22.9
       kubeletVersion: v1.22.9
-      machineID: d740c053b51c440891063a05c8c73c98
+      machineID: 0cae0478f49e429987f2af4fa94d8cc5
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 98981dce-4e53-42a9-ba19-762d096cd75e
+      systemUUID: b5a94831-3b2d-4b6a-9ff5-da2332cdd018
 kind: List
 metadata:
   resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.22/state2.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.22/state2.yaml
@@ -1,0 +1,268 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.0.179
+      io.cilium.network.ipv4-health-ip: 10.244.0.202
+      io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:56:24Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: cilium-nodes-control-plane
+    resourceVersion: "777"
+    uid: e9f9d3e4-85c8-4931-b561-f827cd682839
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: cilium-nodes-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:58:01Z"
+      lastTransitionTime: "2022-08-01T08:58:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:56:19Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:56:19Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:56:19Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:57:57Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
+    - names:
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: 4533f85284bc43c48f4412f0159db856
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 30c25c57-858a-4bc8-9812-a3ace4f85cf3
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.1.237
+      io.cilium.network.ipv4-health-ip: 10.244.1.203
+      io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T08:56:48Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+    name: cilium-nodes-worker
+    resourceVersion: "800"
+    uid: 0c2046ed-23f1-43ed-bd72-72672c2f8f11
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-worker
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: cilium-nodes-worker
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T08:57:57Z"
+      lastTransitionTime: "2022-08-01T08:57:57Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:56:47Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:56:47Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:56:47Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T08:57:58Z"
+      lastTransitionTime: "2022-08-01T08:57:58Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
+    - names:
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
+      sizeBytes: 16741278
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: d740c053b51c440891063a05c8c73c98
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 98981dce-4e53-42a9-ba19-762d096cd75e
+kind: List
+metadata:
+  resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.22/state3.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.22/state3.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.101
-      io.cilium.network.ipv4-health-ip: 10.244.0.62
+      io.cilium.network.ipv4-cilium-host: 10.244.0.22
+      io.cilium.network.ipv4-health-ip: 10.244.0.206
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:22:59Z"
+    creationTimestamp: "2022-08-01T09:25:00Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -19,9 +19,10 @@ items:
       kubernetes.io/os: linux
       node-role.kubernetes.io/control-plane: ""
       node-role.kubernetes.io/master: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "763"
-    uid: 1a6618dd-509d-4726-87f6-41bf38ebf614
+    resourceVersion: "753"
+    uid: 5ae0722a-32ca-44df-8304-429015ad564d
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -32,7 +33,7 @@ items:
       key: node-role.kubernetes.io/master
   status:
     addresses:
-    - address: 172.18.0.2
+    - address: 172.18.0.3
       type: InternalIP
     - address: cilium-nodes-control-plane
       type: Hostname
@@ -51,32 +52,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:24:39Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:21Z"
+      lastTransitionTime: "2022-08-01T09:26:21Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:24:29Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -86,27 +87,24 @@ items:
         Port: 10250
     images:
     - names:
-      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
-      sizeBytes: 159114031
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
     - names:
-      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
-      - k8s.gcr.io/kube-proxy:v1.20.15
-      sizeBytes: 101468763
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
     - names:
-      - k8s.gcr.io/etcd:3.4.13-0
-      sizeBytes: 86742272
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
     - names:
-      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
-      - k8s.gcr.io/kube-apiserver:v1.20.15
-      sizeBytes: 69805873
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
     - names:
-      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
-      - k8s.gcr.io/kube-controller-manager:v1.20.15
-      sizeBytes: 63301443
-    - names:
-      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
-      - k8s.gcr.io/kube-scheduler:v1.20.15
-      sizeBytes: 48523057
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
     - names:
       - docker.io/kindest/kindnetd:v20220510-4929dd75
       sizeBytes: 45239873
@@ -114,8 +112,8 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns:1.7.0
-      sizeBytes: 13982350
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
     - names:
       - docker.io/kindest/local-path-helper:v20220512-507ff70b
       sizeBytes: 2859518
@@ -127,34 +125,34 @@ items:
       bootID: b8e926d3-427c-4927-95d0-b30a218bc283
       containerRuntimeVersion: containerd://1.6.4
       kernelVersion: 5.18.0-2-amd64
-      kubeProxyVersion: v1.20.15
-      kubeletVersion: v1.20.15
-      machineID: a166e22042634888adfc1b080b0509fc
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: 05c20a6e57a04683bccad029da748960
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 9eae790a-17b0-4ab4-aaa1-c3d01cc1a008
+      systemUUID: f609f045-ad30-41c2-b4e4-ed7dd2448f05
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.85
-      io.cilium.network.ipv4-health-ip: 10.244.1.67
+      io.cilium.network.ipv4-cilium-host: 10.244.1.240
+      io.cilium.network.ipv4-health-ip: 10.244.1.148
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:23:31Z"
+    creationTimestamp: "2022-08-01T09:25:23Z"
     labels:
+      another-test-label: another-test-value
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
-      test-label: test-value
     name: cilium-nodes-worker
-    resourceVersion: "777"
-    uid: fcc34a1a-86cd-4045-b26d-628d224198d1
+    resourceVersion: "792"
+    uid: 39ea5b1a-6eab-4285-a309-d4cc55bfbf12
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -162,7 +160,7 @@ items:
     providerID: kind://docker/cilium-nodes/cilium-nodes-worker
   status:
     addresses:
-    - address: 172.18.0.3
+    - address: 172.18.0.2
       type: InternalIP
     - address: cilium-nodes-worker
       type: Hostname
@@ -181,32 +179,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:24:35Z"
-      lastTransitionTime: "2022-08-01T09:24:35Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:24:21Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -219,24 +217,24 @@ items:
       - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
       sizeBytes: 159114031
     - names:
-      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
-      - k8s.gcr.io/kube-proxy:v1.20.15
-      sizeBytes: 101468763
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
     - names:
-      - k8s.gcr.io/etcd:3.4.13-0
-      sizeBytes: 86742272
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
     - names:
-      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
-      - k8s.gcr.io/kube-apiserver:v1.20.15
-      sizeBytes: 69805873
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
     - names:
-      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
-      - k8s.gcr.io/kube-controller-manager:v1.20.15
-      sizeBytes: 63301443
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
     - names:
-      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
-      - k8s.gcr.io/kube-scheduler:v1.20.15
-      sizeBytes: 48523057
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
     - names:
       - docker.io/kindest/kindnetd:v20220510-4929dd75
       sizeBytes: 45239873
@@ -247,8 +245,8 @@ items:
       - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
       sizeBytes: 16741278
     - names:
-      - k8s.gcr.io/coredns:1.7.0
-      sizeBytes: 13982350
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
     - names:
       - docker.io/kindest/local-path-helper:v20220512-507ff70b
       sizeBytes: 2859518
@@ -260,12 +258,12 @@ items:
       bootID: b8e926d3-427c-4927-95d0-b30a218bc283
       containerRuntimeVersion: containerd://1.6.4
       kernelVersion: 5.18.0-2-amd64
-      kubeProxyVersion: v1.20.15
-      kubeletVersion: v1.20.15
-      machineID: 753abf1bd8904695aefc40e870c1e1ff
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: 0cae0478f49e429987f2af4fa94d8cc5
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 0d4f5f1a-1496-48b1-900e-d6746c441a77
+      systemUUID: b5a94831-3b2d-4b6a-9ff5-da2332cdd018
 kind: List
 metadata:
   resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.22/state4.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.22/state4.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.101
-      io.cilium.network.ipv4-health-ip: 10.244.0.62
+      io.cilium.network.ipv4-cilium-host: 10.244.0.22
+      io.cilium.network.ipv4-health-ip: 10.244.0.206
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:22:59Z"
+    creationTimestamp: "2022-08-01T09:25:00Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -19,9 +19,10 @@ items:
       kubernetes.io/os: linux
       node-role.kubernetes.io/control-plane: ""
       node-role.kubernetes.io/master: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "763"
-    uid: 1a6618dd-509d-4726-87f6-41bf38ebf614
+    resourceVersion: "753"
+    uid: 5ae0722a-32ca-44df-8304-429015ad564d
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -32,7 +33,7 @@ items:
       key: node-role.kubernetes.io/master
   status:
     addresses:
-    - address: 172.18.0.2
+    - address: 172.18.0.3
       type: InternalIP
     - address: cilium-nodes-control-plane
       type: Hostname
@@ -51,32 +52,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:24:39Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:21Z"
+      lastTransitionTime: "2022-08-01T09:26:21Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:24:56Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:24:29Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -86,27 +87,24 @@ items:
         Port: 10250
     images:
     - names:
-      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
-      sizeBytes: 159114031
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
     - names:
-      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
-      - k8s.gcr.io/kube-proxy:v1.20.15
-      sizeBytes: 101468763
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
     - names:
-      - k8s.gcr.io/etcd:3.4.13-0
-      sizeBytes: 86742272
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
     - names:
-      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
-      - k8s.gcr.io/kube-apiserver:v1.20.15
-      sizeBytes: 69805873
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
     - names:
-      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
-      - k8s.gcr.io/kube-controller-manager:v1.20.15
-      sizeBytes: 63301443
-    - names:
-      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
-      - k8s.gcr.io/kube-scheduler:v1.20.15
-      sizeBytes: 48523057
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
     - names:
       - docker.io/kindest/kindnetd:v20220510-4929dd75
       sizeBytes: 45239873
@@ -114,8 +112,8 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns:1.7.0
-      sizeBytes: 13982350
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
     - names:
       - docker.io/kindest/local-path-helper:v20220512-507ff70b
       sizeBytes: 2859518
@@ -127,34 +125,34 @@ items:
       bootID: b8e926d3-427c-4927-95d0-b30a218bc283
       containerRuntimeVersion: containerd://1.6.4
       kernelVersion: 5.18.0-2-amd64
-      kubeProxyVersion: v1.20.15
-      kubeletVersion: v1.20.15
-      machineID: a166e22042634888adfc1b080b0509fc
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: 05c20a6e57a04683bccad029da748960
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 9eae790a-17b0-4ab4-aaa1-c3d01cc1a008
+      systemUUID: f609f045-ad30-41c2-b4e4-ed7dd2448f05
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.85
-      io.cilium.network.ipv4-health-ip: 10.244.1.67
+      io.cilium.network.ipv4-cilium-host: 10.244.1.240
+      io.cilium.network.ipv4-health-ip: 10.244.1.148
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:23:31Z"
+    creationTimestamp: "2022-08-01T09:25:23Z"
     labels:
+      another-test-label: changed-test-value
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
-      test-label: test-value
     name: cilium-nodes-worker
-    resourceVersion: "777"
-    uid: fcc34a1a-86cd-4045-b26d-628d224198d1
+    resourceVersion: "794"
+    uid: 39ea5b1a-6eab-4285-a309-d4cc55bfbf12
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -162,7 +160,7 @@ items:
     providerID: kind://docker/cilium-nodes/cilium-nodes-worker
   status:
     addresses:
-    - address: 172.18.0.3
+    - address: 172.18.0.2
       type: InternalIP
     - address: cilium-nodes-worker
       type: Hostname
@@ -181,32 +179,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:24:35Z"
-      lastTransitionTime: "2022-08-01T09:24:35Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:25:23Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:24:21Z"
+    - lastHeartbeatTime: "2022-08-01T09:26:23Z"
+      lastTransitionTime: "2022-08-01T09:26:23Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -219,24 +217,24 @@ items:
       - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
       sizeBytes: 159114031
     - names:
-      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
-      - k8s.gcr.io/kube-proxy:v1.20.15
-      sizeBytes: 101468763
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
     - names:
-      - k8s.gcr.io/etcd:3.4.13-0
-      sizeBytes: 86742272
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
     - names:
-      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
-      - k8s.gcr.io/kube-apiserver:v1.20.15
-      sizeBytes: 69805873
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
     - names:
-      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
-      - k8s.gcr.io/kube-controller-manager:v1.20.15
-      sizeBytes: 63301443
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
     - names:
-      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
-      - k8s.gcr.io/kube-scheduler:v1.20.15
-      sizeBytes: 48523057
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
     - names:
       - docker.io/kindest/kindnetd:v20220510-4929dd75
       sizeBytes: 45239873
@@ -247,8 +245,8 @@ items:
       - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
       sizeBytes: 16741278
     - names:
-      - k8s.gcr.io/coredns:1.7.0
-      sizeBytes: 13982350
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
     - names:
       - docker.io/kindest/local-path-helper:v20220512-507ff70b
       sizeBytes: 2859518
@@ -260,12 +258,12 @@ items:
       bootID: b8e926d3-427c-4927-95d0-b30a218bc283
       containerRuntimeVersion: containerd://1.6.4
       kernelVersion: 5.18.0-2-amd64
-      kubeProxyVersion: v1.20.15
-      kubeletVersion: v1.20.15
-      machineID: 753abf1bd8904695aefc40e870c1e1ff
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: 0cae0478f49e429987f2af4fa94d8cc5
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 0d4f5f1a-1496-48b1-900e-d6746c441a77
+      systemUUID: b5a94831-3b2d-4b6a-9ff5-da2332cdd018
 kind: List
 metadata:
   resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.24/ciliumnode_test.go
+++ b/test/control-plane/node/ciliumnodes/v1.24/ciliumnode_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package v1_24
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/option"
+	controlplane "github.com/cilium/cilium/test/control-plane"
+	node "github.com/cilium/cilium/test/control-plane/node/ciliumnodes"
+)
+
+func TestCiliumNodes1_24(t *testing.T) {
+	tc := controlplane.NewGoldenTest(t, "cilium-nodes-control-plane", node.NewGoldenCiliumNodesValidator)
+	tc.Run(t, "1.24", func(*option.DaemonConfig) {})
+}

--- a/test/control-plane/node/ciliumnodes/v1.24/init.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.24/init.yaml
@@ -1,0 +1,340 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.0.88
+      io.cilium.network.ipv4-health-ip: 10.244.0.102
+      io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T09:01:43Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: cilium-nodes-control-plane
+    resourceVersion: "618"
+    uid: 049a584b-6d4c-4e40-b9dd-e22af97eea9d
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: cilium-nodes-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T09:03:01Z"
+      lastTransitionTime: "2022-08-01T09:03:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:01:38Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:01:38Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:01:38Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:02:58Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
+    - names:
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
+    - names:
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
+    - names:
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
+    - names:
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.6
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: 0ea4894294d644be8c7e7c00d6a2eb39
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 34047029-d493-4198-8f46-48deced6258d
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.1.125
+      io.cilium.network.ipv4-health-ip: 10.244.1.126
+      io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T09:02:02Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+    name: cilium-nodes-worker
+    resourceVersion: "626"
+    uid: c3807e7d-6241-4e8a-8797-33651142d76b
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-worker
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: cilium-nodes-worker
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T09:02:59Z"
+      lastTransitionTime: "2022-08-01T09:02:59Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:02:02Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:02:02Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:02:02Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:03:04Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
+    - names:
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
+    - names:
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
+      sizeBytes: 16741278
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
+    - names:
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
+    - names:
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.6
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: a297db144ef34ff5a4a1a3cabb0aa613
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 49775add-25e1-4ea4-8c59-9c3847d7a0d3
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-01T09:02:59Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: cilium-nodes-control-plane
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: cilium-nodes-control-plane
+      uid: 049a584b-6d4c-4e40-b9dd-e22af97eea9d
+    resourceVersion: "606"
+    uid: a28e8517-6d1d-480c-843e-2a611f567d66
+  spec:
+    addresses:
+    - ip: 172.18.0.2
+      type: InternalIP
+    - ip: 10.244.0.88
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.0.102
+    ipam:
+      podCIDRs:
+      - 10.244.0.0/24
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-01T09:02:58Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+    name: cilium-nodes-worker
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: cilium-nodes-worker
+      uid: c3807e7d-6241-4e8a-8797-33651142d76b
+    resourceVersion: "583"
+    uid: 405e75e5-76f5-401f-b062-9405b723074e
+  spec:
+    addresses:
+    - ip: 172.18.0.3
+      type: InternalIP
+    - ip: 10.244.1.125
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.1.126
+    ipam:
+      podCIDRs:
+      - 10.244.1.0/24
+kind: List
+metadata:
+  resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.24/init.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.24/init.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.88
-      io.cilium.network.ipv4-health-ip: 10.244.0.102
+      io.cilium.network.ipv4-cilium-host: 10.244.0.51
+      io.cilium.network.ipv4-health-ip: 10.244.0.170
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:01:43Z"
+    creationTimestamp: "2022-08-01T09:26:51Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -20,8 +20,8 @@ items:
       node-role.kubernetes.io/control-plane: ""
       node.kubernetes.io/exclude-from-external-load-balancers: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "618"
-    uid: 049a584b-6d4c-4e40-b9dd-e22af97eea9d
+    resourceVersion: "658"
+    uid: a0592385-5cab-48a9-bee6-52ca7bffc079
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -34,7 +34,7 @@ items:
       key: node-role.kubernetes.io/control-plane
   status:
     addresses:
-    - address: 172.18.0.2
+    - address: 172.18.0.3
       type: InternalIP
     - address: cilium-nodes-control-plane
       type: Hostname
@@ -53,32 +53,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:03:01Z"
-      lastTransitionTime: "2022-08-01T09:03:01Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:12Z"
+      lastTransitionTime: "2022-08-01T09:28:12Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:01:38Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:01:38Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:01:38Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:02:58Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:28:16Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -128,21 +128,21 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.24.2
       kubeletVersion: v1.24.2
-      machineID: 0ea4894294d644be8c7e7c00d6a2eb39
+      machineID: 220534885876474397bd79ed01371861
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 34047029-d493-4198-8f46-48deced6258d
+      systemUUID: b249437f-72f6-48e7-be13-49ba8882c97d
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.125
-      io.cilium.network.ipv4-health-ip: 10.244.1.126
+      io.cilium.network.ipv4-cilium-host: 10.244.1.75
+      io.cilium.network.ipv4-health-ip: 10.244.1.53
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:02:02Z"
+    creationTimestamp: "2022-08-01T09:27:15Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -151,8 +151,8 @@ items:
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
     name: cilium-nodes-worker
-    resourceVersion: "626"
-    uid: c3807e7d-6241-4e8a-8797-33651142d76b
+    resourceVersion: "675"
+    uid: df37c212-2f50-467d-a6a4-4b1b56f5502a
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -160,7 +160,7 @@ items:
     providerID: kind://docker/cilium-nodes/cilium-nodes-worker
   status:
     addresses:
-    - address: 172.18.0.3
+    - address: 172.18.0.2
       type: InternalIP
     - address: cilium-nodes-worker
       type: Hostname
@@ -179,32 +179,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:02:59Z"
-      lastTransitionTime: "2022-08-01T09:02:59Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:14Z"
+      lastTransitionTime: "2022-08-01T09:28:14Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:02:02Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:02:02Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:02:02Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:03:04Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:28:17Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -260,14 +260,14 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.24.2
       kubeletVersion: v1.24.2
-      machineID: a297db144ef34ff5a4a1a3cabb0aa613
+      machineID: 90defe6ef62146818d48e76bee246144
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 49775add-25e1-4ea4-8c59-9c3847d7a0d3
+      systemUUID: 25f947ca-0055-4031-b47e-e3984c4016d0
 - apiVersion: cilium.io/v2
   kind: CiliumNode
   metadata:
-    creationTimestamp: "2022-08-01T09:02:59Z"
+    creationTimestamp: "2022-08-01T09:28:10Z"
     generation: 1
     labels:
       beta.kubernetes.io/arch: amd64
@@ -282,28 +282,28 @@ items:
     - apiVersion: v1
       kind: Node
       name: cilium-nodes-control-plane
-      uid: 049a584b-6d4c-4e40-b9dd-e22af97eea9d
-    resourceVersion: "606"
-    uid: a28e8517-6d1d-480c-843e-2a611f567d66
+      uid: a0592385-5cab-48a9-bee6-52ca7bffc079
+    resourceVersion: "630"
+    uid: e3920223-c549-4743-9917-436b9410f8dd
   spec:
     addresses:
-    - ip: 172.18.0.2
+    - ip: 172.18.0.3
       type: InternalIP
-    - ip: 10.244.0.88
+    - ip: 10.244.0.51
       type: CiliumInternalIP
     alibaba-cloud: {}
     azure: {}
     encryption: {}
     eni: {}
     health:
-      ipv4: 10.244.0.102
+      ipv4: 10.244.0.170
     ipam:
       podCIDRs:
       - 10.244.0.0/24
 - apiVersion: cilium.io/v2
   kind: CiliumNode
   metadata:
-    creationTimestamp: "2022-08-01T09:02:58Z"
+    creationTimestamp: "2022-08-01T09:28:12Z"
     generation: 1
     labels:
       beta.kubernetes.io/arch: amd64
@@ -317,21 +317,21 @@ items:
     - apiVersion: v1
       kind: Node
       name: cilium-nodes-worker
-      uid: c3807e7d-6241-4e8a-8797-33651142d76b
-    resourceVersion: "583"
-    uid: 405e75e5-76f5-401f-b062-9405b723074e
+      uid: df37c212-2f50-467d-a6a4-4b1b56f5502a
+    resourceVersion: "637"
+    uid: b80ce98a-52a0-48f6-ac5d-eb842218317d
   spec:
     addresses:
-    - ip: 172.18.0.3
+    - ip: 172.18.0.2
       type: InternalIP
-    - ip: 10.244.1.125
+    - ip: 10.244.1.75
       type: CiliumInternalIP
     alibaba-cloud: {}
     azure: {}
     encryption: {}
     eni: {}
     health:
-      ipv4: 10.244.1.126
+      ipv4: 10.244.1.53
     ipam:
       podCIDRs:
       - 10.244.1.0/24

--- a/test/control-plane/node/ciliumnodes/v1.24/state1.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.24/state1.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.88
-      io.cilium.network.ipv4-health-ip: 10.244.0.102
+      io.cilium.network.ipv4-cilium-host: 10.244.0.51
+      io.cilium.network.ipv4-health-ip: 10.244.0.170
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:01:43Z"
+    creationTimestamp: "2022-08-01T09:26:51Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -20,8 +20,8 @@ items:
       node-role.kubernetes.io/control-plane: ""
       node.kubernetes.io/exclude-from-external-load-balancers: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "618"
-    uid: 049a584b-6d4c-4e40-b9dd-e22af97eea9d
+    resourceVersion: "658"
+    uid: a0592385-5cab-48a9-bee6-52ca7bffc079
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -34,7 +34,7 @@ items:
       key: node-role.kubernetes.io/control-plane
   status:
     addresses:
-    - address: 172.18.0.2
+    - address: 172.18.0.3
       type: InternalIP
     - address: cilium-nodes-control-plane
       type: Hostname
@@ -53,32 +53,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:03:01Z"
-      lastTransitionTime: "2022-08-01T09:03:01Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:12Z"
+      lastTransitionTime: "2022-08-01T09:28:12Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:01:38Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:01:38Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:01:38Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:02:58Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:28:16Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -128,21 +128,21 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.24.2
       kubeletVersion: v1.24.2
-      machineID: 0ea4894294d644be8c7e7c00d6a2eb39
+      machineID: 220534885876474397bd79ed01371861
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 34047029-d493-4198-8f46-48deced6258d
+      systemUUID: b249437f-72f6-48e7-be13-49ba8882c97d
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.125
-      io.cilium.network.ipv4-health-ip: 10.244.1.126
+      io.cilium.network.ipv4-cilium-host: 10.244.1.75
+      io.cilium.network.ipv4-health-ip: 10.244.1.53
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:02:02Z"
+    creationTimestamp: "2022-08-01T09:27:15Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -152,8 +152,8 @@ items:
       kubernetes.io/os: linux
       test-label: test-value
     name: cilium-nodes-worker
-    resourceVersion: "637"
-    uid: c3807e7d-6241-4e8a-8797-33651142d76b
+    resourceVersion: "711"
+    uid: df37c212-2f50-467d-a6a4-4b1b56f5502a
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -161,7 +161,7 @@ items:
     providerID: kind://docker/cilium-nodes/cilium-nodes-worker
   status:
     addresses:
-    - address: 172.18.0.3
+    - address: 172.18.0.2
       type: InternalIP
     - address: cilium-nodes-worker
       type: Hostname
@@ -180,32 +180,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:02:59Z"
-      lastTransitionTime: "2022-08-01T09:02:59Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:14Z"
+      lastTransitionTime: "2022-08-01T09:28:14Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:02:02Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:02:02Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:02:02Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:03:04Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:28:17Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -261,10 +261,10 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.24.2
       kubeletVersion: v1.24.2
-      machineID: a297db144ef34ff5a4a1a3cabb0aa613
+      machineID: 90defe6ef62146818d48e76bee246144
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 49775add-25e1-4ea4-8c59-9c3847d7a0d3
+      systemUUID: 25f947ca-0055-4031-b47e-e3984c4016d0
 kind: List
 metadata:
   resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.24/state1.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.24/state1.yaml
@@ -1,0 +1,270 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.0.88
+      io.cilium.network.ipv4-health-ip: 10.244.0.102
+      io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T09:01:43Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: cilium-nodes-control-plane
+    resourceVersion: "618"
+    uid: 049a584b-6d4c-4e40-b9dd-e22af97eea9d
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: cilium-nodes-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T09:03:01Z"
+      lastTransitionTime: "2022-08-01T09:03:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:01:38Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:01:38Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:01:38Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:02:58Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
+    - names:
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
+    - names:
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
+    - names:
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
+    - names:
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.6
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: 0ea4894294d644be8c7e7c00d6a2eb39
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 34047029-d493-4198-8f46-48deced6258d
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.1.125
+      io.cilium.network.ipv4-health-ip: 10.244.1.126
+      io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T09:02:02Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+      test-label: test-value
+    name: cilium-nodes-worker
+    resourceVersion: "637"
+    uid: c3807e7d-6241-4e8a-8797-33651142d76b
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-worker
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: cilium-nodes-worker
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T09:02:59Z"
+      lastTransitionTime: "2022-08-01T09:02:59Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:02:02Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:02:02Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:02:02Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:03:04Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
+    - names:
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
+    - names:
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
+      sizeBytes: 16741278
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
+    - names:
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
+    - names:
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.6
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: a297db144ef34ff5a4a1a3cabb0aa613
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 49775add-25e1-4ea4-8c59-9c3847d7a0d3
+kind: List
+metadata:
+  resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.24/state2.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.24/state2.yaml
@@ -1,0 +1,269 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.0.88
+      io.cilium.network.ipv4-health-ip: 10.244.0.102
+      io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T09:01:43Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: cilium-nodes-control-plane
+    resourceVersion: "618"
+    uid: 049a584b-6d4c-4e40-b9dd-e22af97eea9d
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: cilium-nodes-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T09:03:01Z"
+      lastTransitionTime: "2022-08-01T09:03:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:01:38Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:01:38Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:01:38Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
+      lastTransitionTime: "2022-08-01T09:02:58Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
+    - names:
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
+    - names:
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
+    - names:
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
+    - names:
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.6
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: 0ea4894294d644be8c7e7c00d6a2eb39
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 34047029-d493-4198-8f46-48deced6258d
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      io.cilium.network.ipv4-cilium-host: 10.244.1.125
+      io.cilium.network.ipv4-health-ip: 10.244.1.126
+      io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-01T09:02:02Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: cilium-nodes-worker
+      kubernetes.io/os: linux
+    name: cilium-nodes-worker
+    resourceVersion: "641"
+    uid: c3807e7d-6241-4e8a-8797-33651142d76b
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/cilium-nodes/cilium-nodes-worker
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: cilium-nodes-worker
+      type: Hostname
+    allocatable:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    capacity:
+      cpu: "8"
+      ephemeral-storage: 923557492Ki
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 32594916Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-01T09:02:59Z"
+      lastTransitionTime: "2022-08-01T09:02:59Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:02:02Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:02:02Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:02:02Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
+      lastTransitionTime: "2022-08-01T09:03:04Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
+      sizeBytes: 159114031
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
+    - names:
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
+    - names:
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
+      sizeBytes: 16741278
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
+    - names:
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
+    - names:
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
+    nodeInfo:
+      architecture: amd64
+      bootID: b8e926d3-427c-4927-95d0-b30a218bc283
+      containerRuntimeVersion: containerd://1.6.6
+      kernelVersion: 5.18.0-2-amd64
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: a297db144ef34ff5a4a1a3cabb0aa613
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 49775add-25e1-4ea4-8c59-9c3847d7a0d3
+kind: List
+metadata:
+  resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.24/state2.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.24/state2.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.88
-      io.cilium.network.ipv4-health-ip: 10.244.0.102
+      io.cilium.network.ipv4-cilium-host: 10.244.0.51
+      io.cilium.network.ipv4-health-ip: 10.244.0.170
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:01:43Z"
+    creationTimestamp: "2022-08-01T09:26:51Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -20,8 +20,8 @@ items:
       node-role.kubernetes.io/control-plane: ""
       node.kubernetes.io/exclude-from-external-load-balancers: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "618"
-    uid: 049a584b-6d4c-4e40-b9dd-e22af97eea9d
+    resourceVersion: "658"
+    uid: a0592385-5cab-48a9-bee6-52ca7bffc079
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -34,7 +34,7 @@ items:
       key: node-role.kubernetes.io/control-plane
   status:
     addresses:
-    - address: 172.18.0.2
+    - address: 172.18.0.3
       type: InternalIP
     - address: cilium-nodes-control-plane
       type: Hostname
@@ -53,32 +53,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:03:01Z"
-      lastTransitionTime: "2022-08-01T09:03:01Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:12Z"
+      lastTransitionTime: "2022-08-01T09:28:12Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:01:38Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:01:38Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:01:38Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:02:58Z"
-      lastTransitionTime: "2022-08-01T09:02:58Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:28:16Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -128,21 +128,21 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.24.2
       kubeletVersion: v1.24.2
-      machineID: 0ea4894294d644be8c7e7c00d6a2eb39
+      machineID: 220534885876474397bd79ed01371861
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 34047029-d493-4198-8f46-48deced6258d
+      systemUUID: b249437f-72f6-48e7-be13-49ba8882c97d
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.125
-      io.cilium.network.ipv4-health-ip: 10.244.1.126
+      io.cilium.network.ipv4-cilium-host: 10.244.1.75
+      io.cilium.network.ipv4-health-ip: 10.244.1.53
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:02:02Z"
+    creationTimestamp: "2022-08-01T09:27:15Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -151,8 +151,8 @@ items:
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
     name: cilium-nodes-worker
-    resourceVersion: "641"
-    uid: c3807e7d-6241-4e8a-8797-33651142d76b
+    resourceVersion: "713"
+    uid: df37c212-2f50-467d-a6a4-4b1b56f5502a
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -160,7 +160,7 @@ items:
     providerID: kind://docker/cilium-nodes/cilium-nodes-worker
   status:
     addresses:
-    - address: 172.18.0.3
+    - address: 172.18.0.2
       type: InternalIP
     - address: cilium-nodes-worker
       type: Hostname
@@ -179,32 +179,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:02:59Z"
-      lastTransitionTime: "2022-08-01T09:02:59Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:14Z"
+      lastTransitionTime: "2022-08-01T09:28:14Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:02:02Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:02:02Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:02:02Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:03:04Z"
-      lastTransitionTime: "2022-08-01T09:03:04Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:28:17Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -260,10 +260,10 @@ items:
       kernelVersion: 5.18.0-2-amd64
       kubeProxyVersion: v1.24.2
       kubeletVersion: v1.24.2
-      machineID: a297db144ef34ff5a4a1a3cabb0aa613
+      machineID: 90defe6ef62146818d48e76bee246144
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 49775add-25e1-4ea4-8c59-9c3847d7a0d3
+      systemUUID: 25f947ca-0055-4031-b47e-e3984c4016d0
 kind: List
 metadata:
   resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.24/state3.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.24/state3.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.101
-      io.cilium.network.ipv4-health-ip: 10.244.0.62
+      io.cilium.network.ipv4-cilium-host: 10.244.0.51
+      io.cilium.network.ipv4-health-ip: 10.244.0.170
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:22:59Z"
+    creationTimestamp: "2022-08-01T09:26:51Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -18,10 +18,10 @@ items:
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
       node-role.kubernetes.io/control-plane: ""
-      node-role.kubernetes.io/master: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "763"
-    uid: 1a6618dd-509d-4726-87f6-41bf38ebf614
+    resourceVersion: "658"
+    uid: a0592385-5cab-48a9-bee6-52ca7bffc079
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -30,9 +30,11 @@ items:
     taints:
     - effect: NoSchedule
       key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
   status:
     addresses:
-    - address: 172.18.0.2
+    - address: 172.18.0.3
       type: InternalIP
     - address: cilium-nodes-control-plane
       type: Hostname
@@ -51,32 +53,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:24:39Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:12Z"
+      lastTransitionTime: "2022-08-01T09:28:12Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:24:29Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:28:16Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -86,75 +88,72 @@ items:
         Port: 10250
     images:
     - names:
-      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
-      sizeBytes: 159114031
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
     - names:
-      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
-      - k8s.gcr.io/kube-proxy:v1.20.15
-      sizeBytes: 101468763
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
     - names:
-      - k8s.gcr.io/etcd:3.4.13-0
-      sizeBytes: 86742272
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
     - names:
-      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
-      - k8s.gcr.io/kube-apiserver:v1.20.15
-      sizeBytes: 69805873
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
     - names:
-      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
-      - k8s.gcr.io/kube-controller-manager:v1.20.15
-      sizeBytes: 63301443
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
     - names:
-      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
-      - k8s.gcr.io/kube-scheduler:v1.20.15
-      sizeBytes: 48523057
-    - names:
-      - docker.io/kindest/kindnetd:v20220510-4929dd75
-      sizeBytes: 45239873
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
     - names:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns:1.7.0
-      sizeBytes: 13982350
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
     - names:
-      - docker.io/kindest/local-path-helper:v20220512-507ff70b
-      sizeBytes: 2859518
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
     - names:
-      - k8s.gcr.io/pause:3.6
-      sizeBytes: 301773
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
     nodeInfo:
       architecture: amd64
       bootID: b8e926d3-427c-4927-95d0-b30a218bc283
-      containerRuntimeVersion: containerd://1.6.4
+      containerRuntimeVersion: containerd://1.6.6
       kernelVersion: 5.18.0-2-amd64
-      kubeProxyVersion: v1.20.15
-      kubeletVersion: v1.20.15
-      machineID: a166e22042634888adfc1b080b0509fc
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: 220534885876474397bd79ed01371861
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 9eae790a-17b0-4ab4-aaa1-c3d01cc1a008
+      systemUUID: b249437f-72f6-48e7-be13-49ba8882c97d
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.85
-      io.cilium.network.ipv4-health-ip: 10.244.1.67
+      io.cilium.network.ipv4-cilium-host: 10.244.1.75
+      io.cilium.network.ipv4-health-ip: 10.244.1.53
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:23:31Z"
+    creationTimestamp: "2022-08-01T09:27:15Z"
     labels:
+      another-test-label: another-test-value
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
-      test-label: test-value
     name: cilium-nodes-worker
-    resourceVersion: "777"
-    uid: fcc34a1a-86cd-4045-b26d-628d224198d1
+    resourceVersion: "715"
+    uid: df37c212-2f50-467d-a6a4-4b1b56f5502a
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -162,7 +161,7 @@ items:
     providerID: kind://docker/cilium-nodes/cilium-nodes-worker
   status:
     addresses:
-    - address: 172.18.0.3
+    - address: 172.18.0.2
       type: InternalIP
     - address: cilium-nodes-worker
       type: Hostname
@@ -181,32 +180,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:24:35Z"
-      lastTransitionTime: "2022-08-01T09:24:35Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:14Z"
+      lastTransitionTime: "2022-08-01T09:28:14Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:24:21Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:28:17Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -219,27 +218,27 @@ items:
       - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
       sizeBytes: 159114031
     - names:
-      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
-      - k8s.gcr.io/kube-proxy:v1.20.15
-      sizeBytes: 101468763
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
     - names:
-      - k8s.gcr.io/etcd:3.4.13-0
-      sizeBytes: 86742272
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
     - names:
-      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
-      - k8s.gcr.io/kube-apiserver:v1.20.15
-      sizeBytes: 69805873
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
     - names:
-      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
-      - k8s.gcr.io/kube-controller-manager:v1.20.15
-      sizeBytes: 63301443
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
     - names:
-      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
-      - k8s.gcr.io/kube-scheduler:v1.20.15
-      sizeBytes: 48523057
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
     - names:
-      - docker.io/kindest/kindnetd:v20220510-4929dd75
-      sizeBytes: 45239873
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
     - names:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
@@ -247,25 +246,25 @@ items:
       - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
       sizeBytes: 16741278
     - names:
-      - k8s.gcr.io/coredns:1.7.0
-      sizeBytes: 13982350
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
     - names:
-      - docker.io/kindest/local-path-helper:v20220512-507ff70b
-      sizeBytes: 2859518
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
     - names:
-      - k8s.gcr.io/pause:3.6
-      sizeBytes: 301773
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
     nodeInfo:
       architecture: amd64
       bootID: b8e926d3-427c-4927-95d0-b30a218bc283
-      containerRuntimeVersion: containerd://1.6.4
+      containerRuntimeVersion: containerd://1.6.6
       kernelVersion: 5.18.0-2-amd64
-      kubeProxyVersion: v1.20.15
-      kubeletVersion: v1.20.15
-      machineID: 753abf1bd8904695aefc40e870c1e1ff
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: 90defe6ef62146818d48e76bee246144
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 0d4f5f1a-1496-48b1-900e-d6746c441a77
+      systemUUID: 25f947ca-0055-4031-b47e-e3984c4016d0
 kind: List
 metadata:
   resourceVersion: ""

--- a/test/control-plane/node/ciliumnodes/v1.24/state4.yaml
+++ b/test/control-plane/node/ciliumnodes/v1.24/state4.yaml
@@ -4,13 +4,13 @@ items:
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.0.101
-      io.cilium.network.ipv4-health-ip: 10.244.0.62
+      io.cilium.network.ipv4-cilium-host: 10.244.0.51
+      io.cilium.network.ipv4-health-ip: 10.244.0.170
       io.cilium.network.ipv4-pod-cidr: 10.244.0.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:22:59Z"
+    creationTimestamp: "2022-08-01T09:26:51Z"
     labels:
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
@@ -18,10 +18,10 @@ items:
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
       node-role.kubernetes.io/control-plane: ""
-      node-role.kubernetes.io/master: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
     name: cilium-nodes-control-plane
-    resourceVersion: "763"
-    uid: 1a6618dd-509d-4726-87f6-41bf38ebf614
+    resourceVersion: "658"
+    uid: a0592385-5cab-48a9-bee6-52ca7bffc079
   spec:
     podCIDR: 10.244.0.0/24
     podCIDRs:
@@ -30,9 +30,11 @@ items:
     taints:
     - effect: NoSchedule
       key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
   status:
     addresses:
-    - address: 172.18.0.2
+    - address: 172.18.0.3
       type: InternalIP
     - address: cilium-nodes-control-plane
       type: Hostname
@@ -51,32 +53,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:24:39Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:12Z"
+      lastTransitionTime: "2022-08-01T09:28:12Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:22:56Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:26:47Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:39Z"
-      lastTransitionTime: "2022-08-01T09:24:29Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:16Z"
+      lastTransitionTime: "2022-08-01T09:28:16Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -86,75 +88,72 @@ items:
         Port: 10250
     images:
     - names:
-      - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
-      sizeBytes: 159114031
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
     - names:
-      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
-      - k8s.gcr.io/kube-proxy:v1.20.15
-      sizeBytes: 101468763
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
     - names:
-      - k8s.gcr.io/etcd:3.4.13-0
-      sizeBytes: 86742272
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
     - names:
-      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
-      - k8s.gcr.io/kube-apiserver:v1.20.15
-      sizeBytes: 69805873
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
     - names:
-      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
-      - k8s.gcr.io/kube-controller-manager:v1.20.15
-      sizeBytes: 63301443
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
     - names:
-      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
-      - k8s.gcr.io/kube-scheduler:v1.20.15
-      sizeBytes: 48523057
-    - names:
-      - docker.io/kindest/kindnetd:v20220510-4929dd75
-      sizeBytes: 45239873
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
     - names:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns:1.7.0
-      sizeBytes: 13982350
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
     - names:
-      - docker.io/kindest/local-path-helper:v20220512-507ff70b
-      sizeBytes: 2859518
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
     - names:
-      - k8s.gcr.io/pause:3.6
-      sizeBytes: 301773
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
     nodeInfo:
       architecture: amd64
       bootID: b8e926d3-427c-4927-95d0-b30a218bc283
-      containerRuntimeVersion: containerd://1.6.4
+      containerRuntimeVersion: containerd://1.6.6
       kernelVersion: 5.18.0-2-amd64
-      kubeProxyVersion: v1.20.15
-      kubeletVersion: v1.20.15
-      machineID: a166e22042634888adfc1b080b0509fc
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: 220534885876474397bd79ed01371861
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 9eae790a-17b0-4ab4-aaa1-c3d01cc1a008
+      systemUUID: b249437f-72f6-48e7-be13-49ba8882c97d
 - apiVersion: v1
   kind: Node
   metadata:
     annotations:
-      io.cilium.network.ipv4-cilium-host: 10.244.1.85
-      io.cilium.network.ipv4-health-ip: 10.244.1.67
+      io.cilium.network.ipv4-cilium-host: 10.244.1.75
+      io.cilium.network.ipv4-health-ip: 10.244.1.53
       io.cilium.network.ipv4-pod-cidr: 10.244.1.0/24
       kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
       node.alpha.kubernetes.io/ttl: "0"
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
-    creationTimestamp: "2022-08-01T09:23:31Z"
+    creationTimestamp: "2022-08-01T09:27:15Z"
     labels:
+      another-test-label: changed-test-value
       beta.kubernetes.io/arch: amd64
       beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker
       kubernetes.io/os: linux
-      test-label: test-value
     name: cilium-nodes-worker
-    resourceVersion: "777"
-    uid: fcc34a1a-86cd-4045-b26d-628d224198d1
+    resourceVersion: "717"
+    uid: df37c212-2f50-467d-a6a4-4b1b56f5502a
   spec:
     podCIDR: 10.244.1.0/24
     podCIDRs:
@@ -162,7 +161,7 @@ items:
     providerID: kind://docker/cilium-nodes/cilium-nodes-worker
   status:
     addresses:
-    - address: 172.18.0.3
+    - address: 172.18.0.2
       type: InternalIP
     - address: cilium-nodes-worker
       type: Hostname
@@ -181,32 +180,32 @@ items:
       memory: 32594916Ki
       pods: "110"
     conditions:
-    - lastHeartbeatTime: "2022-08-01T09:24:35Z"
-      lastTransitionTime: "2022-08-01T09:24:35Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:14Z"
+      lastTransitionTime: "2022-08-01T09:28:14Z"
       message: Cilium is running on this node
       reason: CiliumIsUp
       status: "False"
       type: NetworkUnavailable
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has sufficient memory available
       reason: KubeletHasSufficientMemory
       status: "False"
       type: MemoryPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has no disk pressure
       reason: KubeletHasNoDiskPressure
       status: "False"
       type: DiskPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:23:31Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:27:15Z"
       message: kubelet has sufficient PID available
       reason: KubeletHasSufficientPID
       status: "False"
       type: PIDPressure
-    - lastHeartbeatTime: "2022-08-01T09:24:31Z"
-      lastTransitionTime: "2022-08-01T09:24:21Z"
+    - lastHeartbeatTime: "2022-08-01T09:28:17Z"
+      lastTransitionTime: "2022-08-01T09:28:17Z"
       message: kubelet is posting ready status
       reason: KubeletReady
       status: "True"
@@ -219,27 +218,27 @@ items:
       - quay.io/cilium/cilium@sha256:f7f93c26739b6641a3fa3d76b1e1605b15989f25d06625260099e01c8243f54c
       sizeBytes: 159114031
     - names:
-      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
-      - k8s.gcr.io/kube-proxy:v1.20.15
-      sizeBytes: 101468763
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
     - names:
-      - k8s.gcr.io/etcd:3.4.13-0
-      sizeBytes: 86742272
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
     - names:
-      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
-      - k8s.gcr.io/kube-apiserver:v1.20.15
-      sizeBytes: 69805873
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
     - names:
-      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
-      - k8s.gcr.io/kube-controller-manager:v1.20.15
-      sizeBytes: 63301443
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
     - names:
-      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
-      - k8s.gcr.io/kube-scheduler:v1.20.15
-      sizeBytes: 48523057
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
     - names:
-      - docker.io/kindest/kindnetd:v20220510-4929dd75
-      sizeBytes: 45239873
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
     - names:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
@@ -247,25 +246,25 @@ items:
       - quay.io/cilium/operator-generic@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17
       sizeBytes: 16741278
     - names:
-      - k8s.gcr.io/coredns:1.7.0
-      sizeBytes: 13982350
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
     - names:
-      - docker.io/kindest/local-path-helper:v20220512-507ff70b
-      sizeBytes: 2859518
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
     - names:
-      - k8s.gcr.io/pause:3.6
-      sizeBytes: 301773
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
     nodeInfo:
       architecture: amd64
       bootID: b8e926d3-427c-4927-95d0-b30a218bc283
-      containerRuntimeVersion: containerd://1.6.4
+      containerRuntimeVersion: containerd://1.6.6
       kernelVersion: 5.18.0-2-amd64
-      kubeProxyVersion: v1.20.15
-      kubeletVersion: v1.20.15
-      machineID: 753abf1bd8904695aefc40e870c1e1ff
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: 90defe6ef62146818d48e76bee246144
       operatingSystem: linux
       osImage: Ubuntu 21.10
-      systemUUID: 0d4f5f1a-1496-48b1-900e-d6746c441a77
+      systemUUID: 25f947ca-0055-4031-b47e-e3984c4016d0
 kind: List
 metadata:
   resourceVersion: ""

--- a/test/control-plane/node/nodehandler_test.go
+++ b/test/control-plane/node/nodehandler_test.go
@@ -55,7 +55,7 @@ var (
 	}
 )
 
-func validateNodes(dp *fakeDatapath.FakeDatapath) error {
+func validateNodes(dp *fakeDatapath.FakeDatapath, proxy *controlplane.K8sObjsProxy) error {
 	nodes := dp.FakeNode().Nodes
 
 	if len(nodes) != 1 {

--- a/test/control-plane/services/dual-stack/run.go
+++ b/test/control-plane/services/dual-stack/run.go
@@ -9,13 +9,14 @@ import (
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
+	controlplane "github.com/cilium/cilium/test/control-plane"
 	. "github.com/cilium/cilium/test/control-plane/services"
 )
 
 func RunDualStackTestWithVersion(t *testing.T, version string) {
 	testCase := NewGoldenServicesTest(t, "dual-stack-worker")
 
-	testCase.Steps[0].AddValidationFunc(func(datapath *fakeDatapath.FakeDatapath) error {
+	testCase.Steps[0].AddValidationFunc(func(datapath *fakeDatapath.FakeDatapath, proxy *controlplane.K8sObjsProxy) error {
 		assert := NewLBMapAssert(datapath.LBMockMap())
 
 		// Verify that default/echo-dualstack service exists

--- a/test/control-plane/services/lbmap_validation.go
+++ b/test/control-plane/services/lbmap_validation.go
@@ -66,7 +66,7 @@ func (v *goldenLBMapValidator) diffStrings(expected, actual string) (string, boo
 	return "", true
 }
 
-func (v *goldenLBMapValidator) Validate(datapath *fakeDatapath.FakeDatapath) error {
+func (v *goldenLBMapValidator) Validate(datapath *fakeDatapath.FakeDatapath, proxy *controlplane.K8sObjsProxy) error {
 	lbmap := datapath.LBMockMap()
 	writeLBMap := func() error {
 		f, err := os.OpenFile(v.expectedFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)


### PR DESCRIPTION
This PR leverages the control-plane test framework for a unit test equivalent to the `test/k8s/Node.go` Ginkgo test. With the new control plane test framework, we don't need to spin up a cluster every time the test is run.

The input is generated by the `generate.sh` script that spins up a kind cluster and manipulates the Node labels. At each label manipulation operation, the Node objects status is saved in a yaml file to be used as input for the test steps. This is needed only the first time to generate the data to feed the test.
The test will verify that, at each step, the status of the CiliumNodes, managed by the agent, is updated accordingly to the current Nodes status.

To allow the test to verify such status, a proxy is passed to the validator. The proxy exposes an API to get the current status of the k8s objects.