### PR TITLE
lbmap: Del Maglev table if backend count != 0

### DIFF
--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -212,7 +212,7 @@ func deleteServiceProto(svc loadbalancer.L3n4AddrID, backendCount int, useMaglev
 		}
 	}
 
-	if useMaglev {
+	if useMaglev && backendCount > 0 {
 		if err := deleteMaglevTable(ipv6, uint16(svc.ID)); err != nil {
 			return fmt.Errorf("Unable to delete maglev lookup table %d: %s", svc.ID, err)
 		}

--- a/pkg/maps/lbmap/maglev_test.go
+++ b/pkg/maps/lbmap/maglev_test.go
@@ -4,6 +4,7 @@
 package lbmap
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -103,6 +104,18 @@ func (s *MaglevSuite) TestInitMaps(c *C) {
 	}
 	err = lbm.UpsertService(params)
 	c.Assert(err, IsNil)
+
+	params.ActiveBackends = nil
+	err = lbm.UpsertService(params)
+	c.Assert(err, IsNil)
+
+	err = deleteMaglevTable(false, 1)
+	c.Assert(err, IsNil)
+
+	svc, err := maglevOuter4Map.GetService(1)
+	fmt.Println(svc)
+	c.Assert(err, IsNil)
+
 	deleted, err = deleteMapIfMNotMatch(MaglevOuter4MapName, uint32(option.Config.MaglevTableSize))
 	c.Assert(err, IsNil)
 	c.Assert(deleted, Equals, false)


### PR DESCRIPTION
We don't create the Maglev lookup table when backend count == 0, so we
need to do the same when deleting. Otherwise, it will lead to the
"Unable to delete maglev lookup table X: delete: key does not exist"
error.