### PR TITLE
policy: Add utility for port range mapping

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -265,17 +265,19 @@ struct remote_endpoint_info {
 };
 
 struct policy_key {
+	struct bpf_lpm_trie_key lpm_key;
 	__u32		sec_label;
-	__u16		dport;
-	__u8		protocol;
 	__u8		egress:1,
 			pad:7;
+	__u8		protocol; /* can be wildcarded if 'dport' is fully wildcarded */
+	__u16		dport; /* can be wildcarded with CIDR-like prefix */
 };
 
 struct policy_entry {
 	__be16		proxy_port;
 	__u8		deny:1,
-			pad:7;
+			wildcarded_port:1, /* port is fully wildcarded */
+			pad:6;
 	__u8		pad0;
 	__u16		pad1;
 	__u16		pad2;

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -75,15 +75,21 @@ struct {
 } EP_POLICY_MAP __section_maps_btf;
 #endif
 
+#ifdef HAVE_LPM_TRIE_MAP_TYPE
+#define LPM_MAP_TYPE BPF_MAP_TYPE_LPM_TRIE
+#else
+#define LPM_MAP_TYPE BPF_MAP_TYPE_HASH
+#endif
+
 #ifdef POLICY_MAP
 /* Per-endpoint policy enforcement map */
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, LPM_MAP_TYPE);
 	__type(key, struct policy_key);
 	__type(value, struct policy_entry);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, POLICY_MAP_SIZE);
-	__uint(map_flags, CONDITIONAL_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } POLICY_MAP __section_maps_btf;
 #endif
 
@@ -132,12 +138,6 @@ struct bpf_elf_map __section_maps CUSTOM_CALLS_MAP = {
 #define CUSTOM_CALLS_IDX_IPV6_INGRESS	2
 #define CUSTOM_CALLS_IDX_IPV6_EGRESS	3
 #endif /* ENABLE_CUSTOM_CALLS && CUSTOM_CALLS_MAP */
-
-#ifdef HAVE_LPM_TRIE_MAP_TYPE
-#define LPM_MAP_TYPE BPF_MAP_TYPE_LPM_TRIE
-#else
-#define LPM_MAP_TYPE BPF_MAP_TYPE_HASH
-#endif
 
 #ifndef HAVE_LPM_TRIE_MAP_TYPE
 /* Define a function with the following NAME which iterates through PREFIXES

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -166,10 +166,10 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 	}
 #endif /* ENABLE_ICMP_RULE */
 
-	/* L4 lookup can't be done on untracked fragments. */
-
 	/* Start with L3/L4 lookup. */
 	l3policy = map_lookup_elem(map, &key);
+
+	/* L4 lookup can't be done on untracked fragments. */
 	if (likely(!is_untracked_fragment && l3policy && !l3policy->wildcarded_port)) {
 		cilium_dbg3(ctx, DBG_L4_CREATE, remote_id, local_id,
 			    dport << 16 | proto);
@@ -180,9 +180,12 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 			return DROP_POLICY_DENY;
 		return l3policy->proxy_port;
 	}
+
 	/* L4-only lookup. */
 	key.sec_label = 0;
 	l4policy = map_lookup_elem(map, &key);
+
+	/* L4 lookup can't be done on untracked fragments. */
 	if (likely(!is_untracked_fragment && l4policy && !l4policy->wildcarded_port)) {
 		account(ctx, l4policy);
 		*match_type = POLICY_MATCH_L4_ONLY;

--- a/cilium/cmd/bpf_policy_get.go
+++ b/cilium/cmd/bpf_policy_get.go
@@ -119,6 +119,7 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 		proxyPortTitle        = "PROXY PORT"
 		bytesTitle            = "BYTES"
 		packetsTitle          = "PACKETS"
+		prefixTitle           = "PREFIX"
 	)
 
 	labelsID := map[identity.NumericIdentity]*identity.Identity{}
@@ -136,21 +137,30 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 	}
 
 	if printIDs {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
-			policyTitle, trafficDirectionTitle, labelsIDTitle, portTitle, proxyPortTitle, bytesTitle, packetsTitle)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+			policyTitle, trafficDirectionTitle, labelsIDTitle, portTitle, proxyPortTitle, bytesTitle, packetsTitle, prefixTitle)
 	} else {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
-			policyTitle, trafficDirectionTitle, labelsDesTitle, portTitle, proxyPortTitle, bytesTitle, packetsTitle)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+			policyTitle, trafficDirectionTitle, labelsDesTitle, portTitle, proxyPortTitle, bytesTitle, packetsTitle, prefixTitle)
 	}
 	for _, stat := range statsMap {
+		prefix := stat.Key.Prefixlen - policymap.GetStaticPrefixBits()
 		id := identity.NumericIdentity(stat.Key.Identity)
 		trafficDirection := trafficdirection.TrafficDirection(stat.Key.TrafficDirection)
 		trafficDirectionString := trafficDirection.String()
 		port := models.PortProtocolANY
-		if stat.Key.DestPort != 0 || stat.Key.Nexthdr == uint8(u8proto.ICMP) || stat.Key.Nexthdr == uint8(u8proto.ICMPv6) {
+		if prefix > 0 {
 			dport := byteorder.NetworkToHost16(stat.Key.DestPort)
 			proto := u8proto.U8proto(stat.Key.Nexthdr)
-			port = fmt.Sprintf("%d/%s", dport, proto.String())
+			if prefix == 24 {
+				port = fmt.Sprintf("%d/%s", dport, proto.String())
+			} else if prefix == 8 {
+				port = fmt.Sprintf("ANY/%s", proto.String())
+			} else if prefix > 8 {
+				port = fmt.Sprintf("0x%x/%d/%s", dport, prefix-8, proto.String())
+			} else {
+				port = fmt.Sprintf("<INVALID PORT PREFIX LENGTH: %d>", prefix)
+			}
 		}
 		proxyPort := "NONE"
 		if stat.ProxyPort != 0 {
@@ -163,22 +173,22 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 			policyStr = "Allow"
 		}
 		if printIDs {
-			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%d\t%d\t\n",
-				policyStr, trafficDirectionString, id, port, proxyPort, stat.Bytes, stat.Packets)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%d\t%d\t%d\t\n",
+				policyStr, trafficDirectionString, id, port, proxyPort, stat.Bytes, stat.Packets, prefix)
 		} else if lbls := labelsID[id]; lbls != nil && len(lbls.Labels) > 0 {
 			first := true
 			for _, lbl := range lbls.Labels.GetPrintableModel() {
 				if first {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t\n",
-						policyStr, trafficDirectionString, lbl, port, proxyPort, stat.Bytes, stat.Packets)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t\n",
+						policyStr, trafficDirectionString, lbl, port, proxyPort, stat.Bytes, stat.Packets, prefix)
 					first = false
 				} else {
 					fmt.Fprintf(w, "\t\t%s\t\t\t\t\t\t\n", lbl)
 				}
 			}
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%d\t%d\t\n",
-				policyStr, trafficDirectionString, id, port, proxyPort, stat.Bytes, stat.Packets)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%d\t%d\t%d\t\n",
+				policyStr, trafficDirectionString, id, port, proxyPort, stat.Bytes, stat.Packets, prefix)
 		}
 	}
 }

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -343,15 +343,15 @@ func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
 				err       error
 			)
 			if pa.isDeny {
-				err = policyMap.Deny(pa.label, pa.port, u8p, pa.trafficDirection)
+				err = policyMap.Deny(0, pa.label, pa.port, u8p, pa.trafficDirection)
 			} else {
-				err = policyMap.Allow(pa.label, pa.port, u8p, pa.trafficDirection, proxyPort)
+				err = policyMap.Allow(0, pa.label, pa.port, u8p, pa.trafficDirection, proxyPort)
 			}
 			if err != nil {
 				Fatalf("Cannot add policy key '%s': %s\n", entry, err)
 			}
 		} else {
-			if err := policyMap.Delete(pa.label, pa.port, u8p, pa.trafficDirection); err != nil {
+			if err := policyMap.Delete(0, pa.label, pa.port, u8p, pa.trafficDirection); err != nil {
 				Fatalf("Cannot delete policy key '%s': %s\n", entry, err)
 			}
 		}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1074,12 +1074,7 @@ func (e *Endpoint) updatePolicyMapPressureMetric() {
 // not otherwise changed (e.g., it is never set to 'false').
 func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool, hadProxy *bool) bool {
 	// Convert from policy.Key to policymap.Key
-	policymapKey := policymap.PolicyKey{
-		Identity:         keyToDelete.Identity,
-		DestPort:         keyToDelete.DestPort,
-		Nexthdr:          keyToDelete.Nexthdr,
-		TrafficDirection: keyToDelete.TrafficDirection,
-	}
+	policymapKey := keyToDelete.ToBPFKey()
 
 	// Do not error out if the map entry was already deleted from the bpf map.
 	// Incremental updates depend on this being OK in cases where identity change
@@ -1116,12 +1111,7 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool, had
 
 func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
-	policymapKey := policymap.PolicyKey{
-		Identity:         keyToAdd.Identity,
-		DestPort:         keyToAdd.DestPort,
-		Nexthdr:          keyToAdd.Nexthdr,
-		TrafficDirection: keyToAdd.TrafficDirection,
-	}
+	policymapKey := keyToAdd.ToBPFKey()
 
 	var err error
 	if entry.IsDeny {

--- a/pkg/maps/policymap/log.go
+++ b/pkg/maps/policymap/log.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policymap
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "policymap")

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -18,13 +18,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
-
-var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "map-policy")
 
 func Test(t *testing.T) {
 	TestingT(t)
@@ -73,7 +69,7 @@ func (pm *PolicyMapTestSuite) TearDownTest(c *C) {
 func (pm *PolicyMapTestSuite) TestPolicyMapDumpToSlice(c *C) {
 	c.Assert(testMap, NotNil)
 
-	fooEntry := newKey(1, 1, 1, 1)
+	fooEntry := newKey(0, 1, 1, 1, 1)
 	err := testMap.AllowKey(fooEntry, 0)
 	c.Assert(err, IsNil)
 
@@ -87,7 +83,7 @@ func (pm *PolicyMapTestSuite) TestPolicyMapDumpToSlice(c *C) {
 	c.Assert(dump[0].Key, checker.DeepEquals, fooEntry)
 
 	// Special case: allow-all entry
-	barEntry := newKey(0, 0, 0, 0)
+	barEntry := newKey(0, 0, 0, 0, 0)
 	err = testMap.AllowKey(barEntry, 0)
 	c.Assert(err, IsNil)
 
@@ -97,7 +93,7 @@ func (pm *PolicyMapTestSuite) TestPolicyMapDumpToSlice(c *C) {
 }
 
 func (pm *PolicyMapTestSuite) TestDeleteNonexistentKey(c *C) {
-	key := newKey(27, 80, u8proto.ANY, trafficdirection.Ingress)
+	key := newKey(0, 27, 80, u8proto.ANY, trafficdirection.Ingress)
 	err := testMap.Map.Delete(&key)
 	c.Assert(err, Not(IsNil))
 	var errno unix.Errno
@@ -108,7 +104,7 @@ func (pm *PolicyMapTestSuite) TestDeleteNonexistentKey(c *C) {
 func (pm *PolicyMapTestSuite) TestDenyPolicyMapDumpToSlice(c *C) {
 	c.Assert(testMap, NotNil)
 
-	fooEntry := newKey(1, 1, 1, 1)
+	fooEntry := newKey(0, 1, 1, 1, 1)
 	fooValue := newEntry(0, NewPolicyEntryFlag(&PolicyEntryFlagParam{IsDeny: true}))
 	err := testMap.DenyKey(fooEntry)
 	c.Assert(err, IsNil)
@@ -124,7 +120,7 @@ func (pm *PolicyMapTestSuite) TestDenyPolicyMapDumpToSlice(c *C) {
 	c.Assert(dump[0].PolicyEntry, checker.DeepEquals, fooValue)
 
 	// Special case: deny-all entry
-	barEntry := newKey(0, 0, 0, 0)
+	barEntry := newKey(0, 0, 0, 0, 0)
 	err = testMap.DenyKey(barEntry)
 	c.Assert(err, IsNil)
 

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -80,9 +80,11 @@ func (k Key) IsEgress() bool {
 // IsEgress returns true if the key refers to an egress policy key
 func (k Key) ToBPFKey() policymap.PolicyKey {
 	// Convert from policy.Key to policymap.Key
-	prefixLen := uint16(16)
-	if k.DestPort == 0 {
+	prefixLen := uint16(8 + 16)
+	if k.DestPort == 0 && k.Nexthdr == 0 {
 		prefixLen = 0
+	} else if k.DestPort == 0 {
+		prefixLen = 8
 	}
 	return policymap.PolicyKey{
 		Prefixlen:        policymap.GetPrefixLen(prefixLen),

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
@@ -74,6 +75,22 @@ func (k Key) IsIngress() bool {
 // IsEgress returns true if the key refers to an egress policy key
 func (k Key) IsEgress() bool {
 	return k.TrafficDirection == trafficdirection.Egress.Uint8()
+}
+
+// IsEgress returns true if the key refers to an egress policy key
+func (k Key) ToBPFKey() policymap.PolicyKey {
+	// Convert from policy.Key to policymap.Key
+	prefixLen := uint16(16)
+	if k.DestPort == 0 {
+		prefixLen = 0
+	}
+	return policymap.PolicyKey{
+		Prefixlen:        policymap.GetPrefixLen(prefixLen),
+		Identity:         k.Identity,
+		TrafficDirection: k.TrafficDirection,
+		Nexthdr:          k.Nexthdr,
+		DestPort:         k.DestPort,
+	}
 }
 
 type Keys map[Key]struct{}

--- a/pkg/policy/portrange.go
+++ b/pkg/policy/portrange.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+)
+
+type MaskedPort struct {
+	port uint16
+	mask uint16
+}
+
+func (m MaskedPort) String() string {
+	return fmt.Sprintf("{port: 0x%x, mask: 0x%x}", m.port, m.mask)
+}
+
+type MaskedPorts []MaskedPort
+
+// maskedPort returns a new MaskedPort where 'wildcardBits' lowest bits are wildcarded.
+func maskedPort(port uint16, wildcardBits int) MaskedPort {
+	mask := uint16(math.MaxUint16) << wildcardBits
+	return MaskedPort{port & mask, mask}
+}
+
+// PortRangeToMaskedPorts returns a slice of masked ports for the given port range.
+// Will return undefined ranges if start is past the end.
+// Ports are not returned in any particular order, so testing code needs to sort them
+// for consistency.
+func PortRangeToMaskedPorts(start uint16, end uint16) (ports MaskedPorts) {
+	// Find the number of common leading bits. The first uncommon bit will be 0 for the start
+	// and 1 for the end.
+	commonBits := bits.LeadingZeros16(start ^ end)
+
+	// Cover the case where all the bits after the common bits are zeros on start and ones on
+	// end. In this case the range can be represented by a single masked port instead of two
+	// that would be produced below.
+	// For example, if the range is from 16-31 (0b10000 - 0b11111), then we return 0b1xxxx
+	// instead of 0b10xxx and 0b11xxx that would be produced when approaching the middle from
+	// the two sides.
+	//
+	// This also covers the trivial case where all the bits are in common (i.e., start == end).
+	mask := uint16(math.MaxUint16) >> commonBits
+	if start&mask == 0 && ^end&mask == 0 {
+		return append(ports, maskedPort(start, 16-commonBits))
+	}
+
+	// Find the "middle point" toward which the masked ports approach from both sides.
+	// This "middle point" is the highest bit that differs between the range start and end.
+	middleBit := 16 - 1 - commonBits
+	middle := uint16(1 << middleBit)
+
+	// Wildcard the trailing zeroes to the right of the middle bit of the range start.
+	// This covers the values immediately following the port range start, including the start itself.
+	// The middle bit is added to avoid counting zeroes past it.
+	bit := bits.TrailingZeros16(start | middle)
+	ports = append(ports, maskedPort(start, bit))
+
+	// Find all 0-bits between the trailing zeroes and the middle bit and add MaskedPorts where
+	// each found 0-bit is set and the lower bits are wildcarded. This covers the range from the
+	// start to the middle not covered by the trailing zeroes above.
+	// The current 'bit' is skipped since we know it is 1.
+	for bit++; bit < middleBit; bit++ {
+		if start&(1<<bit) == 0 {
+			// Adding 1<<bit will set the bit since we know it is not set
+			ports = append(ports, maskedPort(start+1<<bit, bit))
+		}
+	}
+
+	// Wildcard the trailing ones to the right of the middle bit of the range end.
+	// This covers the values immediately preceding and including the range end.
+	// The middle bit is added to avoid counting ones past it.
+	bit = bits.TrailingZeros16(^end | middle)
+	ports = append(ports, maskedPort(end, bit))
+
+	// Find all 1-bits between the trailing ones and the middle bit and add MaskedPorts where
+	// each found 1-bit is cleared and the lower bits are wildcarded. This covers the range from
+	// the end to the middle not covered by the trailing ones above.
+	// The current 'bit' is skipped since we know it is 0.
+	for bit++; bit < middleBit; bit++ {
+		if end&(1<<bit) != 0 {
+			// Subtracting 1<<bit will clear the bit since we know it is set
+			ports = append(ports, maskedPort(end-1<<bit, bit))
+		}
+	}
+
+	return ports
+}

--- a/pkg/policy/portrange_test.go
+++ b/pkg/policy/portrange_test.go
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package policy
+
+import (
+	"sort"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/checker"
+)
+
+// maskedPorts have to be sorted for this check
+func validateMaskedPorts(c *C, maskedPorts MaskedPorts, start, end uint16) {
+	c.Assert(maskedPorts, NotNil)
+	c.Assert(len(maskedPorts), Not(Equals), 0)
+	// validate that range elements are continuous and non-overlapping
+	first := maskedPorts[0].port
+	last := first + ^maskedPorts[0].mask
+	for i := 1; i < len(maskedPorts); i++ {
+		c.Assert(maskedPorts[i].port, Equals, last+1)
+		last = maskedPorts[i].port + ^maskedPorts[i].mask
+	}
+	// Check that the computed range matches the given range
+	c.Assert(first, Equals, start)
+	c.Assert(last, Equals, end)
+}
+
+func (ds *PolicyTestSuite) TestPortRange(c *C) {
+	type testCase struct {
+		start, end uint16
+		expected   MaskedPorts
+	}
+
+	testCases := []testCase{
+		// worst case test
+		{
+			start: 1,
+			end:   65534,
+			expected: MaskedPorts{
+				{port: 0x1, mask: 0xffff},    // 1
+				{port: 0x2, mask: 0xfffe},    // 2-3
+				{port: 0x4, mask: 0xfffc},    // 4-7
+				{port: 0x8, mask: 0xfff8},    // 8-15
+				{port: 0x10, mask: 0xfff0},   // 16-31
+				{port: 0x20, mask: 0xffe0},   // 32-63
+				{port: 0x40, mask: 0xffc0},   // 64-127
+				{port: 0x80, mask: 0xff80},   // 128-255
+				{port: 0x100, mask: 0xff00},  // 256-511
+				{port: 0x200, mask: 0xfe00},  // 512-1023
+				{port: 0x400, mask: 0xfc00},  // 1024-2047
+				{port: 0x800, mask: 0xf800},  // 2048-4095
+				{port: 0x1000, mask: 0xf000}, // 4096-8191
+				{port: 0x2000, mask: 0xe000}, // 8192-16383
+				{port: 0x4000, mask: 0xc000}, // 16384-32767
+				{port: 0x8000, mask: 0xc000}, // 32768-49151
+				{port: 0xc000, mask: 0xe000}, // 49152-57343
+				{port: 0xe000, mask: 0xf000}, // 57344-61439
+				{port: 0xf000, mask: 0xf800}, // 61440-63487
+				{port: 0xf800, mask: 0xfc00}, // 63488-64511
+				{port: 0xfc00, mask: 0xfe00}, // 64512-65023
+				{port: 0xfe00, mask: 0xff00}, // 65024-65279
+				{port: 0xff00, mask: 0xff80}, // 65280-65407
+				{port: 0xff80, mask: 0xffc0}, // 65408-65471
+				{port: 0xffc0, mask: 0xffe0}, // 65472-65503
+				{port: 0xffe0, mask: 0xfff0}, // 65504-65519
+				{port: 0xfff0, mask: 0xfff8}, // 65520-65527
+				{port: 0xfff8, mask: 0xfffc}, // 65528-65531
+				{port: 0xfffc, mask: 0xfffe}, // 65532-65533
+				{port: 0xfffe, mask: 0xffff}, // 65534
+			},
+		},
+		{
+			start: 1,
+			end:   1023,
+			expected: MaskedPorts{
+				{port: 0x1, mask: 0xffff},   // 1
+				{port: 0x2, mask: 0xfffe},   // 2-3
+				{port: 0x4, mask: 0xfffc},   // 4-7
+				{port: 0x8, mask: 0xfff8},   // 8-15
+				{port: 0x10, mask: 0xfff0},  // 16-31
+				{port: 0x20, mask: 0xffe0},  // 32-63
+				{port: 0x40, mask: 0xffc0},  // 64-127
+				{port: 0x80, mask: 0xff80},  // 128-255
+				{port: 0x100, mask: 0xff00}, // 256-511
+				{port: 0x200, mask: 0xfe00}, // 512-1023
+			},
+		},
+		{
+			start: 0,
+			end:   1023,
+			expected: MaskedPorts{
+				{port: 0, mask: 0xfc00}, // 0-1023
+			},
+		},
+		// A typical large case test
+		{
+			start: 1024,
+			end:   65535,
+			expected: MaskedPorts{
+				{port: 0x400, mask: 0xfc00},  // 1024-2047
+				{port: 0x800, mask: 0xf800},  // 2048-4095
+				{port: 0x1000, mask: 0xf000}, // 4096-8191
+				{port: 0x2000, mask: 0xe000}, // 8192-16383
+				{port: 0x4000, mask: 0xc000}, // 16384-32767
+				{port: 0x8000, mask: 0x8000}, // 32768-65535
+			},
+		},
+		// Another typical large case test
+		{
+			start: 10000,
+			end:   20000,
+			expected: MaskedPorts{
+				{port: 0x2710, mask: 0xfff0}, // 10000 - 10015
+				{port: 0x2720, mask: 0xffe0}, // 10016 - 10047
+				{port: 0x2740, mask: 0xffc0}, // 10048 - 10111
+				{port: 0x2780, mask: 0xff80}, // 10112 - 10239
+				{port: 0x2800, mask: 0xf800}, // 10240 - 12287
+				{port: 0x3000, mask: 0xf000}, // 12288 - 16383
+				{port: 0x4000, mask: 0xf800}, // 16384 - 18431
+				{port: 0x4800, mask: 0xfc00}, // 18432 - 19455
+				{port: 0x4c00, mask: 0xfe00}, // 19456 - 19967
+				{port: 0x4e00, mask: 0xffe0}, // 19968 - 19999
+				{port: 0x4e20, mask: 0xffff}, // 20000
+			},
+		},
+		{
+			start: 1000,
+			end:   1999,
+			expected: MaskedPorts{
+				{port: 0x3e8, mask: 0xfff8},
+				{port: 0x3f0, mask: 0xfff0},
+				{port: 0x400, mask: 0xfe00},
+				{port: 0x600, mask: 0xff00},
+				{port: 0x700, mask: 0xff80},
+				{port: 0x780, mask: 0xffc0},
+				{port: 0x7c0, mask: 0xfff0},
+			},
+		},
+		{
+			start: 0,
+			end:   1,
+			expected: MaskedPorts{
+				{port: 0, mask: 0xfffe}, // 0-1
+			},
+		},
+		{
+			start: 16,
+			end:   31,
+			expected: MaskedPorts{
+				{port: 0x10, mask: 0xfff0}, // 16-31
+			},
+		},
+		{
+			start: 0xff00, // 65280
+			end:   0xffff, // 65535
+			expected: MaskedPorts{
+				{port: 0xff00, mask: 0xff00}, // 65280-65535
+			},
+		},
+		{
+			start: 0,
+			end:   0xffff,
+			expected: MaskedPorts{
+				{port: 0x0, mask: 0x0000}, // 0-0xffff
+			},
+		},
+		{
+			start: 1,
+			end:   7,
+			expected: MaskedPorts{
+				{port: 0x1, mask: 0xffff}, // 1
+				{port: 0x2, mask: 0xfffe}, // 2-3
+				{port: 0x4, mask: 0xfffc}, // 4-7
+			},
+		},
+		{
+			start: 0,
+			end:   7,
+			expected: MaskedPorts{
+				{port: 0x0, mask: 0xfff8}, // 0-7
+			},
+		},
+		{
+			start: 5,
+			end:   10,
+			expected: MaskedPorts{
+				{0b0000000000000101, 0b1111111111111111}, // 5
+				{0b0000000000000110, 0b1111111111111110}, // 6-7
+				{0b0000000000001000, 0b1111111111111110}, // 8-9
+				{0b0000000000001010, 0b1111111111111111}, // 10
+			},
+		},
+		{
+			start: 0,
+			end:   16,
+			expected: MaskedPorts{
+				{0b0000000000000000, 0b1111111111110000}, // 0xxxx
+				{0b0000000000010000, 0b1111111111111111}, // 10000
+			},
+		},
+		{
+			start: 0b0000000000010000, // 16
+			end:   0b0000000110000111, // 391
+			expected: MaskedPorts{
+				{0b0000000000010000, 0b1111111111110000}, // 00001xxxx, 16-31
+				{0b0000000000100000, 0b1111111111100000}, // 0001xxxxx, 32-63
+				{0b0000000001000000, 0b1111111111000000}, // 001xxxxxx, 64-127
+				{0b0000000010000000, 0b1111111110000000}, // 01xxxxxxx, 128-255
+				{0b0000000100000000, 0b1111111110000000}, // 01xxxxxxx, 256-383
+				{0b0000000110000000, 0b1111111111111000}, // 10000000x, 384-391
+			},
+		},
+		{
+			start: 22,
+			end:   23,
+			expected: MaskedPorts{
+				{0b0000000000010110, 0b1111111111111110}, // 22-23
+			},
+		},
+		{
+			start: 23,
+			end:   24,
+			expected: MaskedPorts{
+				{0b0000000000010111, 0b1111111111111111}, // 23
+				{0b0000000000011000, 0b1111111111111111}, // 24
+			},
+		},
+		{
+			start: 0,
+			end:   0x7fff,
+			expected: MaskedPorts{
+				{port: 0x0, mask: 0x8000}, // 0-0x7fff
+			},
+		},
+		{
+			start: 256,
+			end:   256,
+			expected: MaskedPorts{
+				{port: 0x100, mask: 0xffff},
+			},
+		},
+		{
+			start: 65535,
+			end:   65535,
+			expected: MaskedPorts{
+				{port: 65535, mask: 0xffff},
+			},
+		},
+		{
+			start: 32767,
+			end:   32768,
+			expected: MaskedPorts{
+				{port: 0x7fff, mask: 0xffff},
+				{port: 0x8000, mask: 0xffff},
+			},
+		},
+		{
+			start: 0b0101010101010101, // 0x5555
+			end:   0b0101010111010101, // 0x55d5
+			expected: MaskedPorts{
+				{port: 0b0101010101010101, mask: 0b1111111111111111},
+				{port: 0b0101010101010110, mask: 0b1111111111111110},
+				{port: 0b0101010101011000, mask: 0b1111111111111000},
+				{port: 0b0101010101100000, mask: 0b1111111111100000},
+				{port: 0b0101010110000000, mask: 0b1111111111000000},
+				{port: 0b0101010111000000, mask: 0b1111111111110000},
+				{port: 0b0101010111010000, mask: 0b1111111111111100},
+				{port: 0b0101010111010100, mask: 0b1111111111111110},
+			},
+		},
+		// These remaining tests are testing invalid cases where start > end.
+		// The expected values match the current algorithm, but are subject to change and
+		// are included here to show that this case is not fully supported.
+		{
+			start: 65535,
+			end:   0,
+			expected: MaskedPorts{
+				{port: 0x0, mask: 0xffff},    // 0
+				{port: 0xffff, mask: 0xffff}, // 65535
+			},
+		},
+		{
+			start: 65535,
+			end:   1,
+			expected: MaskedPorts{
+				{port: 0x0, mask: 0xfffe},    // 0-1
+				{port: 0xffff, mask: 0xffff}, // 65535
+			},
+		},
+		{
+			start: 65530,
+			end:   5,
+			expected: MaskedPorts{
+				{port: 0x0, mask: 0xfffc},    // 0-3
+				{port: 0x4, mask: 0xfffe},    // 4-5
+				{port: 0xfffa, mask: 0xfffe}, // 65530-65531
+				{port: 0xfffc, mask: 0xfffc}, // 65532-65535
+			},
+		},
+		{
+			start: 10,
+			end:   5,
+			expected: MaskedPorts{
+				{port: 0x0, mask: 0xfffc}, // 0-3
+				{port: 0x4, mask: 0xfffe}, // 4-5
+				{port: 0xa, mask: 0xfffe}, // 10-11
+				{port: 0xc, mask: 0xfffc}, // 12-15
+			},
+		},
+	}
+
+	for i := 0; i < len(testCases); i++ {
+		test := &testCases[i]
+		maskedPorts := PortRangeToMaskedPorts(test.start, test.end)
+		// Sort the returned slice so that PortRangeToMaskedPorts() can return masked ports
+		// in any order that is convenient for it.
+		sort.Slice(maskedPorts, func(i, j int) bool {
+			return maskedPorts[i].port < maskedPorts[j].port
+		})
+		c.Logf("TestPortRange test case: 0x%x-0x%x (%d-%d)", test.start, test.end, test.start, test.end)
+		c.Assert(maskedPorts, checker.Equals, test.expected)
+		// Validate when given a proper range
+		if test.start <= test.end {
+			// Validation checks that the masked ports form a continuous range
+			validateMaskedPorts(c, maskedPorts, test.start, test.end)
+		}
+	}
+}

--- a/test/envoy/helpers.bash
+++ b/test/envoy/helpers.bash
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+CILIUM_BIN=${CILIUM:-/usr/bin/cilium}
 CILIUM_FILES="cilium-files"
 DUMP_FILE=$(mktemp)
 MONITOR_PID=""
@@ -81,7 +82,7 @@ function monitor_start {
   local save=$-
   set +e
   log "starting monitor and dumping contents to $DUMP_FILE"
-  cilium monitor -v $@ > $DUMP_FILE &
+  ${CILIUM_BIN} monitor --debug -vv $@ > $DUMP_FILE &
   MONITOR_PID=$!
   restore_flag $save "e"
 }
@@ -90,7 +91,7 @@ function monitor_resume {
   local save=$-
   set +e
   log "resuming monitor and dumping contents to $DUMP_FILE"
-  cilium monitor -v $@ >> $DUMP_FILE &
+  ${CILIUM_BIN} monitor -v $@ >> $DUMP_FILE &
   MONITOR_PID=$!
   restore_flag $save "e"
 }
@@ -134,9 +135,9 @@ function abort {
   echo "------------------------------------------------------------------------"
 
   if [ ! -z "$DEBUG" ]; then
-    cilium status
-    cilium endpoint list
-    cilium policy get
+    ${CILIUM_BIN} status
+    ${CILIUM_BIN} endpoint list
+    ${CILIUM_BIN} policy get
     read -n 1 -p "Press any key to continue..."
   fi
 
@@ -188,8 +189,8 @@ function wait_for_endpoints {
   set +e
   check_num_params "$#" "1"
   local NUM_DESIRED="$1"
-  local CMD="cilium endpoint list | grep -v -e \"not-ready\" -e \"reserved\" | grep ready -c || true"
-  local INFO_CMD="cilium endpoint list"
+  local CMD="${CILIUM_BIN} endpoint list | grep -v -e \"not-ready\" -e \"reserved\" | grep ready -c || true"
+  local INFO_CMD="${CILIUM_BIN} endpoint list"
   local MAX_MINS="2"
   local ERROR_OUTPUT="Timeout while waiting for $NUM_DESIRED endpoints"
   log "waiting for up to ${MAX_MINS} mins for ${NUM_DESIRED} endpoints to be in \"ready\" state"
@@ -202,8 +203,8 @@ function wait_for_endpoints_deletion {
   local save=$-
   set +e
   local NUM_DESIRED="2" # When no endpoints are present there should be two lines only.
-  local CMD="cilium endpoint list | grep -v \"reserved\" | wc -l || true"
-  local INFO_CMD="cilium endpoint list"
+  local CMD="${CILIUM_BIN} endpoint list | grep -v \"reserved\" | wc -l || true"
+  local INFO_CMD="${CILIUM_BIN} endpoint list"
   local MAX_MINS="2"
   local ERROR_OUTPUT="Timeout while waiting for endpoint removal"
   log "waiting for up to ${MAX_MINS} mins for all endpoints to be removed"
@@ -265,7 +266,7 @@ function wait_for_k8s_endpoints {
 
 function wait_for_cilium_status {
   local NUM_DESIRED="1"
-  local CMD="cilium status | grep 'Cilium:' | grep -c OK || true"
+  local CMD="${CILIUM_BIN} status | grep 'Cilium:' | grep -c OK || true"
   local INFO_CMD="true"
   local MAX_MINS="1"
   local ERROR_OUTPUT="Timeout while waiting for Cilium to be ready"
@@ -303,8 +304,8 @@ function wait_for_cilium_ep_gen {
     CMD="kubectl exec -n ${NAMESPACE} ${POD} -- cilium endpoint list | grep -c regenerat"
     INFO_CMD="kubectl exec -n ${NAMESPACE} ${POD} -- cilium endpoint list"
   else
-    CMD="cilium endpoint list | grep -c regenerat"
-    INFO_CMD="cilium endpoint list"
+    CMD="${CILIUM_BIN} endpoint list | grep -c regenerat"
+    INFO_CMD="${CILIUM_BIN} endpoint list"
   fi
 
   local NUM_DESIRED="0"
@@ -375,8 +376,8 @@ function wait_for_daemon_set_not_ready {
 function wait_for_policy_enforcement {
   check_num_params "$#" "1"
   local NUM_DESIRED="$1"
-  local CMD="cilium endpoint list | grep -c Disabled"
-  local INFO_CMD="cilium endpoint list"
+  local CMD="${CILIUM_BIN} endpoint list | grep -c Disabled"
+  local INFO_CMD="${CILIUM_BIN} endpoint list"
   local MAX_MINS="2"
   local ERROR_OUTPUT="Timeout while waiting for policy to be enabled for all endpoints"
   wait_for_desired_state "$NUM_DESIRED" "$CMD" "$INFO_CMD" "$MAX_MINS" "$ERROR_OUTPUT"
@@ -570,28 +571,28 @@ function gather_files {
 function dump_cli_output {
   check_num_params "$#" "1"
   local DIR=$1
-  cilium endpoint list > ${DIR}/endpoint_list.txt
-  local EPS=$(cilium endpoint list | tail -n+3 | grep '^[0-9]' | awk '{print $1}')
+  ${CILIUM_BIN} endpoint list > ${DIR}/endpoint_list.txt
+  local EPS=$(${CILIUM_BIN} endpoint list | tail -n+3 | grep '^[0-9]' | awk '{print $1}')
   for ep in ${EPS} ; do
-    cilium endpoint get ${ep} > ${DIR}/endpoint_get_${ep}.txt
-    cilium bpf policy get ${ep} > ${DIR}/bpf_policy_list_${ep}.txt
+    ${CILIUM_BIN} endpoint get ${ep} > ${DIR}/endpoint_get_${ep}.txt
+    ${CILIUM_BIN} bpf policy get ${ep} > ${DIR}/bpf_policy_list_${ep}.txt
   done
-  cilium service list > ${DIR}/service_list.txt
-  local SVCS=$(cilium service list | tail -n+2 | awk '{print $1}')
+  ${CILIUM_BIN} service list > ${DIR}/service_list.txt
+  local SVCS=$(${CILIUM_BIN} service list | tail -n+2 | awk '{print $1}')
   for svc in ${SVCS} ; do
-    cilium service get ${svc} > ${DIR}/service_get_${svc}.txt
+    ${CILIUM_BIN} service get ${svc} > ${DIR}/service_get_${svc}.txt
   done
-  local IDS=$(cilium endpoint list | tail -n+3 | awk '{print $4}' | grep -o '[0-9]*')
+  local IDS=$(${CILIUM_BIN} endpoint list | tail -n+3 | awk '{print $4}' | grep -o '[0-9]*')
   for id in ${IDS} ; do
-    cilium identity get ${id} > ${DIR}/identity_get_${id}.txt
+    ${CILIUM_BIN} identity get ${id} > ${DIR}/identity_get_${id}.txt
   done
-  cilium config > ${DIR}/config.txt
-  cilium bpf lb list > ${DIR}/bpf_lb_list.txt
-  cilium bpf ct list global > ${DIR}/bpf_ct_list_global.txt
-  cilium bpf tunnel list > ${DIR}/bpf_tunnel_list.txt
-  cilium policy get > ${DIR}/policy_get.txt
-  cilium status > ${DIR}/status.txt
-  cilium debuginfo -f ${DIR}/debuginfo.txt
+  ${CILIUM_BIN} config > ${DIR}/config.txt
+  ${CILIUM_BIN} bpf lb list > ${DIR}/bpf_lb_list.txt
+  ${CILIUM_BIN} bpf ct list global > ${DIR}/bpf_ct_list_global.txt
+  ${CILIUM_BIN} bpf tunnel list > ${DIR}/bpf_tunnel_list.txt
+  ${CILIUM_BIN} policy get > ${DIR}/policy_get.txt
+  ${CILIUM_BIN} status > ${DIR}/status.txt
+  ${CILIUM_BIN} debuginfo -f ${DIR}/debuginfo.txt
   cilium-bugtool -t ${DIR}
 }
 
@@ -790,14 +791,14 @@ function k8s_apply_policy {
 
 function policy_delete_and_wait {
   log "deleting policy $* and waiting up to 120 seconds to complete"
-  rev=$(cilium policy delete $* | grep Revision: | awk '{print $2}')
-  timeout 120s cilium policy wait $rev
+  rev=$(${CILIUM_BIN} policy delete $* | grep Revision: | awk '{print $2}')
+  timeout 120s ${CILIUM_BIN} policy wait $rev
 }
 
 function policy_import_and_wait {
   log "importing policy $* and waiting up to 120 seconds to complete"
-  rev=$(cilium policy import $* | grep Revision: | awk '{print $2}')
-  timeout 120s cilium policy wait $rev
+  rev=$(${CILIUM_BIN} policy import $* | grep Revision: | awk '{print $2}')
+  timeout 120s ${CILIUM_BIN} policy wait $rev
 }
 
 function get_vm_identity_file {


### PR DESCRIPTION
Change endpoint policy maps from hash maps to LPM trie maps. This allows for protocol and port wildcarding with prefix, dropping the number of needed policy lookups from 4 to 2, hopefully offsetting the lookup cost penalty of a more complex map.

Eventually this change will enable support for port range matches in (Cilium) Network Policies.

Add utility function PortRangeToMaskedPorts() to convert a port range to
a set of masked ports (prefixes). This function determines the "midpoint"
as the highest bit that differs between the start and end ports, and then
adds masked ports approaching this midpoint both from the start and end.

Worst and more typical case mask counts:

range           number of masked ports produced
1-65535         30 (the worst case)
1024-65535      6
10000-20000     11
22-23           1 (consecutive ports yield 1 or 2 masked ports)
80-80           1 (start == end)
1-1023          10 (excluding 0 is costly)
0-1023          1

PortRangeToMaskedPorts() will produce undefined results if the range
start is larger than range end.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
