### PR TITLE
Remove completed items from Service Mesh Roadmap

### DIFF
--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -81,13 +81,6 @@ capabilities. We released a beta at the end of 2021 and had very valuable
 feedback from our user community. The next steps we'd like to take for Cilium
 Service Mesh (in no particular order) are: 
 
-* Integration of service mesh branch into mainline Cilium
-* Graduating Ingress to stable
-  
-  * 100% upstream conformant
-  * Visibility via Hubble
-  * Support for additional annotations
- 
 * Graduating Prometheus metrics and OpenTelemetry collector to stable
 * Using Kubernetes as service mesh control plane 
  


### PR DESCRIPTION
The Service Mesh branch has already been merged into the main branch, and Ingress has been released as stable, so removed those two items from the roadmap.

Signed-off-by: Marga Manterola <marga@isovalent.com>
