### PR TITLE
bpf: Check active backends count

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -369,6 +369,12 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	}
 #endif /* ENABLE_L7_LB */
 
+	/* The service count is set to number of active backends. */
+	if (svc->count == 0) {
+		update_metrics(0, METRIC_EGRESS, REASON_LB_NO_ACTIVE_BACKEND_SLOT);
+		return -ENOENT;
+	}
+
 	if (lb4_svc_is_affinity(svc)) {
 		/* Note, for newly created affinity entries there is a
 		 * small race window. Two processes on two different
@@ -1000,6 +1006,11 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 		return 0;
 	}
 #endif /* ENABLE_L7_LB */
+
+	if (svc->count == 0) {
+		update_metrics(0, METRIC_EGRESS, REASON_LB_NO_ACTIVE_BACKEND_SLOT);
+		return -ENOENT;
+	}
 
 	if (lb6_svc_is_affinity(svc)) {
 		backend_id = lb6_affinity_backend_id_by_netns(svc, &id);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -511,16 +511,17 @@ enum {
  * These are shared with pkg/monitor/api/drop.go.
  * When modifying any of the below, those files should also be updated.
  */
-#define REASON_FORWARDED		0
-#define REASON_PLAINTEXT		3
-#define REASON_DECRYPT			4
-#define REASON_LB_NO_BACKEND_SLOT	5
-#define REASON_LB_NO_BACKEND		6
-#define REASON_LB_REVNAT_UPDATE		7
-#define REASON_LB_REVNAT_STALE		8
-#define REASON_FRAG_PACKET		9
-#define REASON_FRAG_PACKET_UPDATE	10
-#define REASON_MISSED_CUSTOM_CALL	11
+#define REASON_FORWARDED			0
+#define REASON_PLAINTEXT			3
+#define REASON_DECRYPT				4
+#define REASON_LB_NO_BACKEND_SLOT		5
+#define REASON_LB_NO_BACKEND			6
+#define REASON_LB_REVNAT_UPDATE			7
+#define REASON_LB_REVNAT_STALE			8
+#define REASON_FRAG_PACKET			9
+#define REASON_FRAG_PACKET_UPDATE		10
+#define REASON_MISSED_CUSTOM_CALL		11
+#define REASON_LB_NO_ACTIVE_BACKEND_SLOT	12
 
 /* Lookup scope for externalTrafficPolicy=Local */
 #define LB_LOOKUP_SCOPE_EXT	0


### PR DESCRIPTION
When the agent adds/updates services entry,
it moves non-active backends to the end of active
ones, and sets service count in the services
BPF map to the number of active backends. This
ensures that the datapath doesn't consider the
non-active backends while selecting a backend
for load-balancing, but the non-active backends
can be restored after agent restart.
However, when there are no active backends left for
selection, datapath may end up selecting a non-active backend
(e.g., quarantined).

The fix is to check for active backends count in
the datapath before selecting a backend slot.

Reported-by: Nico Vibert <nicolas.vibert@isovalent.com>