### PR TITLE
Remove check on intSlice type from config map validation

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3788,9 +3788,6 @@ func validateConfigMap(cmd *cobra.Command, m map[string]interface{}) error {
 			_, err = cast.ToFloat32E(value)
 		case "float64":
 			_, err = cast.ToFloat64E(value)
-		// remove this after PR https://github.com/cilium/cilium/pull/20282 is merged
-		case "intSlice":
-			_, err = cast.ToIntSliceE(value)
 		case "int":
 			_, err = cast.ToIntE(value)
 		case "int8":


### PR DESCRIPTION
PR #20304 fixed the validation of the config map options at startup. The validation is successful if each option value, represented as a string, can be converted to a value of the specific option type, using the related type conversion function.

Due to some limitations related to the `intSlice` option type in the spf13/cast package, PR #20282 forbade its use. Therefore, no validation related to an `intSlice` option should take place either be successful.

This PR removes the branch related to `intSlice` in the options validation code.