### PR TITLE
helm: add missing helm option to overwrite auto-detected MTU and missing tunnelPort helm document

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -9,6 +9,10 @@
      - Description
      - Type
      - Default
+   * - MTU
+     - Configure the underlying network MTU to overwrite auto-detected MTU.
+     - int
+     - ``0``
    * - affinity
      - Affinity for cilium-agent.
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1693,6 +1693,10 @@
      - Configure the encapsulation configuration for communication between nodes. Possible values:   - disabled   - vxlan (default)   - geneve
      - string
      - ``"vxlan"``
+   * - tunnelPort
+     - Configure VXLAN and Geneve tunnel port.
+     - int
+     - Port 8472 for VXLAN, Port 6081 for Geneve
    * - updateStrategy
      - Cilium agent update strategy
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -84,6 +84,7 @@ Leblond
 Leia
 Lund
 Lx
+MTU
 Maglev
 Majkowski
 Marek
@@ -275,7 +276,6 @@ configMap
 configMapKey
 configmap
 configs
-MTU
 conformant
 conntrack
 conntrackGCInterval
@@ -948,6 +948,7 @@ tracepoints
 transpiling
 triaged
 ttlSecondsAfterFinished
+tunnelPort
 tuples
 ubuntu
 udp

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -275,6 +275,7 @@ configMap
 configMapKey
 configmap
 configs
+MTU
 conformant
 conntrack
 conntrackGCInterval

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -474,6 +474,7 @@ contributors across the globe, there is almost always someone available to help.
 | tls.secretsBackend | string | `"local"` | This configures how the Cilium agent loads the secrets used TLS-aware CiliumNetworkPolicies (namely the secrets referenced by terminatingTLS and originatingTLS). Possible values:   - local   - k8s |
 | tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | tunnel | string | `"vxlan"` | Configure the encapsulation configuration for communication between nodes. Possible values:   - disabled   - vxlan (default)   - geneve |
+| tunnelPort | int | Port 8472 for VXLAN, Port 6081 for Geneve | Configure VXLAN and Geneve tunnel port. |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}` | Cilium agent update strategy |
 | vtep.cidr | string | `""` | A space separated list of VTEP device CIDRs, for example "1.1.1.0/24 1.1.2.0/24" |
 | vtep.enabled | bool | `false` | Enables VXLAN Tunnel Endpoint (VTEP) Integration (beta) to allow Cilium-managed pods to talk to third party VTEP devices over Cilium tunnel. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -53,6 +53,7 @@ contributors across the globe, there is almost always someone available to help.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| MTU | int | `0` | Configure the underlying network MTU to overwrite auto-detected MTU. |
 | affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-agent. |
 | agent | bool | `true` | Install the cilium agent resources. |
 | agentNotReadyTaintKey | string | `"node.cilium.io/agent-not-ready"` | Configure the key of the taint indicating that Cilium is not ready on the node. When set to a value starting with `ignore-taint.cluster-autoscaler.kubernetes.io/`, the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -391,7 +391,7 @@ data:
   tunnel: {{ .Values.tunnel | quote }}
 {{- end }}
 
-{{- if hasKey .Values "tunnelPort" }}
+{{- if .Values.tunnelPort }}
   tunnel-port: "{{ .Values.tunnelPort }}"
 {{- end }}
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -395,6 +395,10 @@ data:
   tunnel-port: "{{ .Values.tunnelPort }}"
 {{- end }}
 
+{{- if .Values.MTU }}
+  mtu: "{{ .Values.MTU }}"
+{{- end }}
+
 {{- if .Values.eni.enabled }}
   enable-endpoint-routes: "true"
   auto-create-cilium-node-resource: "true"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1443,6 +1443,10 @@ tls:
 #   - geneve
 tunnel: "vxlan"
 
+# -- Configure VXLAN and Geneve tunnel port.
+# @default -- Port 8472 for VXLAN, Port 6081 for Geneve
+tunnelPort: 0
+
 # -- Configure the underlying network MTU to overwrite auto-detected MTU.
 MTU: 0
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1443,6 +1443,9 @@ tls:
 #   - geneve
 tunnel: "vxlan"
 
+# -- Configure the underlying network MTU to overwrite auto-detected MTU.
+MTU: 0
+
 # -- Disable the usage of CiliumEndpoint CRD.
 disableEndpointCRD: "false"
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1440,6 +1440,10 @@ tls:
 #   - geneve
 tunnel: "vxlan"
 
+# -- Configure VXLAN and Geneve tunnel port.
+# @default -- Port 8472 for VXLAN, Port 6081 for Geneve
+tunnelPort: 0
+
 # -- Configure the underlying network MTU to overwrite auto-detected MTU.
 MTU: 0
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1440,6 +1440,9 @@ tls:
 #   - geneve
 tunnel: "vxlan"
 
+# -- Configure the underlying network MTU to overwrite auto-detected MTU.
+MTU: 0
+
 # -- Disable the usage of CiliumEndpoint CRD.
 disableEndpointCRD: "false"
 


### PR DESCRIPTION
cilium agent has MTU option below and also allow users to set it
in configmap cilium-config as mtu: "1500", but it is missing in helm.

--mtu int Overwrite auto-detected MTU of underlying network

found this option through https://github.com/cilium/cilium/issues/20603

add helm option --set MTU=1500 so user could use it
in helm install when needed.

also add missing helm tunnelPort document

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
add helm option configuredMTU to overwrite auto-detected MTU and tunnelPort helm document
```
