### PR TITLE
helm: Guard apply sysctl init container

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -470,7 +470,6 @@ spec:
               - SYS_CHROOT
               - SYS_PTRACE
           {{- end}}
-      {{- end }}
       - name: apply-sysctl-overwrites
         image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -514,6 +513,7 @@ spec:
               - SYS_CHROOT
               - SYS_PTRACE
           {{- end}}
+      {{- end }}
       {{- if not .Values.securityContext.privileged }}
       # Mount the bpf fs if it is not mounted. We will perform this task
       # from a privileged container because the mount propagation bidirectional


### PR DESCRIPTION
The newly added init container (e.g. sysctl init) requires hostproc
volume mount, however, this volume is only mounted based on the helm
flag .Values.cgroup.autoMount.enabled. This commit is to make sure
that such condition is added to avoid any failure.

Relates: https://github.com/cilium/cilium/pull/20072
Fixes: https://github.com/cilium/cilium/issues/20626
Signed-off-by: Tam Mach <tam.mach@cilium.io>