### PR TITLE
fix increasing serive's backend counter incorrectly when restore backend

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1337,8 +1337,14 @@ func (s *Service) restoreServicesLocked() error {
 			restoredFromDatapath: true,
 		}
 
+		backendSet := map[string]struct{}{}
 		for j, backend := range svc.Backends {
 			hash := backend.L3n4Addr.Hash()
+
+			// skip when same port and ip address exist.
+			if _, found := backendSet[hash]; found {
+				continue
+			}
 			s.backendRefCount.Add(hash)
 			newSVC.backendByHash[hash] = svc.Backends[j]
 		}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1345,6 +1345,7 @@ func (s *Service) restoreServicesLocked() error {
 			if _, found := backendSet[hash]; found {
 				continue
 			}
+			backendSet[hash] = struct{}{}
 			s.backendRefCount.Add(hash)
 			newSVC.backendByHash[hash] = svc.Backends[j]
 		}


### PR DESCRIPTION

When serivce have two same backend address and port and restore backends from bpf map in lb-only mode, service's backend counter increases duplicately so backend counter can't have zero and backend naver will be deleted.

```
% cilium service update  --id=101  --frontend=3.3.3.3:80 --backends=1.1.1.1:80,1.1.1.1:80    --k8s-external
Creating new service with id '101'
Added service with 2 backends
% cilium    service list
ID    Frontend          Service Type   Backend
101   3.3.3.3:80        ExternalIPs    1 => 1.1.1.1:80
                                       2 => 1.1.1.1:80
```

So I will skip increasing backend count when backend already exits.
