### PR TITLE
Validate duration field in helm chart

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -60,7 +60,7 @@ cilium-operator-alibabacloud [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --nodes-gc-interval duration                GC interval for CiliumNodes
+      --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -66,7 +66,7 @@ cilium-operator-aws [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --nodes-gc-interval duration                GC interval for CiliumNodes
+      --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -63,7 +63,7 @@ cilium-operator-azure [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --nodes-gc-interval duration                GC interval for CiliumNodes
+      --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -59,7 +59,7 @@ cilium-operator-generic [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --nodes-gc-interval duration                GC interval for CiliumNodes
+      --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -71,7 +71,7 @@ cilium-operator [flags]
       --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --nodes-gc-interval duration                GC interval for CiliumNodes
+      --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -142,3 +142,15 @@ Check if duration is non zero value, return duration, empty when zero.
 {{- . }}
 {{- end }}
 {{- end }}
+
+{{/*
+Validate duration field, return validated duration, 0s when provided duration is empty.
+*/}}
+{{- define "validateDuration" }}
+{{- if . }}
+{{- $_ := now | mustDateModify (toString .) }}
+{{- . }}
+{{- else -}}
+0s
+{{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -132,3 +132,13 @@ and `commonCASecretName` variables.
     {{- $_ := set (set . "commonCA" $ca) "commonCASecretName" $secretName -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Check if duration is non zero value, return duration, empty when zero.
+*/}}
+{{- define "hasDuration" }}
+{{- $now := now }}
+{{- if ne $now ($now | dateModify (toString .)) }}
+{{- . }}
+{{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -123,9 +123,7 @@ data:
   cilium-endpoint-gc-interval: "{{ .Values.operator.endpointGCInterval }}"
 {{- end }}
 
-{{- if hasKey .Values.operator "nodeGCInterval" }}
-  nodes-gc-interval: "{{ .Values.operator.nodeGCInterval | default "0s" }}"
-{{- end }}
+  nodes-gc-interval: {{ include "validateDuration" .Values.operator.nodeGCInterval | quote }}
 
 {{- if hasKey .Values "disableEndpointCRD" }}
   # Disable the usage of CiliumEndpoint CRD

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -113,16 +113,9 @@ data:
   #   the kvstore by commenting out the identity-allocation-mode below, or
   #   setting it to "kvstore".
   identity-allocation-mode: {{ .Values.identityAllocationMode }}
-{{- if hasKey .Values "identityHeartbeatTimeout" }}
-  identity-heartbeat-timeout: "{{ .Values.identityHeartbeatTimeout }}"
-{{- end }}
-{{- if hasKey .Values "identityGCInterval" }}
-  identity-gc-interval: "{{ .Values.identityGCInterval }}"
-{{- end }}
-{{- if hasKey .Values.operator "endpointGCInterval" }}
-  cilium-endpoint-gc-interval: "{{ .Values.operator.endpointGCInterval }}"
-{{- end }}
-
+  identity-heartbeat-timeout: {{ include "validateDuration" .Values.operator.identityHeartbeatTimeout | quote }}
+  identity-gc-interval: {{ include "validateDuration" .Values.operator.identityGCInterval | quote }}
+  cilium-endpoint-gc-interval: {{ include "validateDuration" .Values.operator.endpointGCInterval | quote }}
   nodes-gc-interval: {{ include "validateDuration" .Values.operator.nodeGCInterval | quote }}
 
 {{- if hasKey .Values "disableEndpointCRD" }}
@@ -267,7 +260,7 @@ data:
   # notification events for each allowed connection.
   #
   # Only effective when monitor aggregation is set to "medium" or higher.
-  monitor-aggregation-interval: {{ .Values.bpf.monitorInterval }}
+  monitor-aggregation-interval: {{ include "validateDuration" .Values.bpf.monitorInterval | quote }}
 
   # The monitor aggregation flags determine which TCP flags which, upon the
   # first observation, cause monitor notifications to be generated.
@@ -648,9 +641,7 @@ data:
 {{- if hasKey .Values.l2NeighDiscovery "enabled" }}
   enable-l2-neigh-discovery: {{ .Values.l2NeighDiscovery.enabled | quote }}
 {{- end }}
-{{- if hasKey .Values.l2NeighDiscovery "refreshPeriod" }}
-  arping-refresh-period: {{ .Values.l2NeighDiscovery.refreshPeriod | quote }}
-{{- end }}
+  arping-refresh-period: {{ include "validateDuration" .Values.l2NeighDiscovery.refreshPeriod | quote }}
 {{- end }}
 
 {{- if and .Values.pprof .Values.pprof.enabled }}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -138,11 +138,9 @@ rules:
   - get
   - list
   - watch
-{{- if .Values.operator.nodeGCInterval }}
-{{- if ne .Values.operator.nodeGCInterval "0s" }}
+{{- if include "hasDuration" .Values.operator.nodeGCInterval }}
     # To perform CiliumNode garbage collector
   - delete
-{{- end }}
 {{- end }}
 - apiGroups:
   - cilium.io

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus .Values.operator.endpointGCInterval }}
+{{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus (include "hasDuration" .Values.operator.endpointGCInterval) }}
 - apiGroups:
   - ""
   resources:

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -258,7 +258,7 @@ func init() {
 	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
 	regOpts.BindEnv(option.K8sKubeConfigPath)
 
-	flags.Duration(operatorOption.NodesGCInterval, 0*time.Second, "GC interval for CiliumNodes")
+	flags.Duration(operatorOption.NodesGCInterval, 5*time.Minute, "GC interval for CiliumNodes")
 	regOpts.BindEnv(operatorOption.NodesGCInterval)
 
 	flags.String(operatorOption.OperatorPrometheusServeAddr, operatorOption.PrometheusServeAddr, "Address to serve Prometheus metrics")


### PR DESCRIPTION
1. helm: Add zero duration check
This change adds zero duration check used in helm templates.
It covers `null` value in helm cli, empty string, `0`, `"0"`,`"0ns"`,
`"0us"`, `0µs`, `0ms`, `0s`, `0m`, `0h`, and other combo like `0h0m0s`.
Non empty value will be parsed and processed accordingly.
Apply to `.Values.operator.nodeGCInterval`.

2. helm: Add validation to duration field
This change adds validation to duration field.
It will fail for invalid format, return `"0s"` for empty value.
Apply to `nodes-gc-interval`.

3. helm: apply duration validation and zero check
This change apply validation to documented duration fields:
  * `identity-heartbeat-timeout`
  * `identity-gc-interval`
  * `cilium-endpoint-gc-interval`
  * `monitor-aggregation-interval`
  * `arping-refresh-period`
Use `hasDuration` check on `.Values.operator.endpointGCInterval`.

4. operator: change default NodesGCInterval to 5m
This change updates default NodesGCInterval to 5m to align with
default value in helm.

Fixes: #19684

```release-note
Default `NodesGCInterval` in CLI is 5m (0s before) to align with default helm value.
```
