### PR TITLE
command: fix parsing of string map strings with multiple separators

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -184,6 +184,7 @@ jenkinsfiles @cilium/ci-structure
 /pkg/cgroups/ @cilium/sig-datapath
 /pkg/client @cilium/api
 /pkg/clustermesh @cilium/sig-clustermesh
+/pkg/command/ @cilium/cli
 /pkg/completion/ @cilium/proxy
 /pkg/components/ @cilium/sig-agent
 /pkg/controller @cilium/sig-agent

--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -66,7 +66,7 @@ func GetStringMapStringE(vp *viper.Viper, key string) (map[string]string, error)
 			for _, kv := range kvs {
 				temp := strings.Split(kv, string(equal))
 				if len(temp) != 2 {
-					return map[string]string{}, fmt.Errorf("'%s' is not formatted as key=value,key1=value1", s)
+					return map[string]string{}, fmt.Errorf("'%s' in '%s' is not formatted as key=value,key1=value1", kv, s)
 				}
 				v[temp[0]] = temp[1]
 			}
@@ -110,8 +110,12 @@ func splitKeyValue(str string, sep rune, keyValueSep rune) []string {
 
 	var res []string
 	var start = 0
-	for i := 0; i < len(sepIndexes)-1; i++ {
-		if strings.Contains(str[sepIndexes[i]:sepIndexes[i+1]], string(keyValueSep)) {
+	for i := 0; i < len(sepIndexes); i++ {
+		last := len(str)
+		if i < len(sepIndexes)-1 {
+			last = sepIndexes[i+1]
+		}
+		if strings.ContainsRune(str[sepIndexes[i]:last], keyValueSep) {
 			res = append(res, str[start:sepIndexes[i]])
 			start = sepIndexes[i] + 1
 		}

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -113,10 +113,11 @@ func TestGetStringMapString(t *testing.T) {
 			name: "another valid kv format with comma in value",
 			args: args{
 				key:   "AWS_INSTANCE_LIMIT_MAPPING",
-				value: "c6a.2xlarge=4,15,15",
+				value: "c6a.2xlarge=4,15,15,m4.large=1,5,10",
 			},
 			want: map[string]string{
 				"c6a.2xlarge": "4,15,15",
+				"m4.large":    "1,5,10",
 			},
 			wantErr: assert.NoError,
 		},
@@ -140,6 +141,20 @@ func TestGetStringMapString(t *testing.T) {
 			},
 			want: map[string]string{
 				"cluster": "my-cluster",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "valid kv format from issue #20666",
+			args: args{
+				key:   "FOO_BAR",
+				value: "a=b,c=d,E=F,G=h",
+			},
+			want: map[string]string{
+				"a": "b",
+				"c": "d",
+				"E": "F",
+				"G": "h",
 			},
 			wantErr: assert.NoError,
 		},
@@ -255,7 +270,6 @@ func Test_isValidKeyValuePair(t *testing.T) {
 			},
 			want: true,
 		},
-
 		{
 			name: "valid format with multiple pairs",
 			args: args{


### PR DESCRIPTION
We need to check the last substring, i.e. the string after the last
separator for the key/value separator as well. Otherwise a string such
as a=b,c=d,e=f,g=h with more than two separators will not be considered
a valid string map string.

Fixes: #20666
Fixes: 070ded019adb ("cmd: Allow more complicated patterns in map string type.")

```release-note
Fix parsing of string map command line options when more than one separator is present.
```