### PR TITLE
fix: add a rule for allowDNS to allow node-local-dns with ip

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -1732,6 +1732,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -1772,6 +1778,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -1808,6 +1820,15 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      rules:
+        dns:
+        - matchPattern: '*'
+    toEntities:
+    - world
   - toPorts:
     - ports:
       - port: "5353"
@@ -1857,6 +1878,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -1899,6 +1926,12 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
   - toPorts:
     - ports:
       - port: "5353"
@@ -1945,6 +1978,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -1987,6 +2026,12 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -835,6 +835,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -873,6 +879,12 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -688,6 +688,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -730,6 +736,12 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
   - toPorts:
     - ports:
       - port: "5353"
@@ -776,6 +788,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -818,6 +836,12 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -506,6 +506,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -545,6 +551,12 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
   - toPorts:
     - ports:
       - port: "5353"
@@ -588,6 +600,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -627,6 +645,12 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -615,6 +615,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -655,6 +661,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -691,6 +703,15 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      rules:
+        dns:
+        - matchPattern: '*'
+    toEntities:
+    - world
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -947,6 +947,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -987,6 +993,12 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
     toEndpoints:
@@ -1023,6 +1035,15 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: kube-dns
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      rules:
+        dns:
+        - matchPattern: '*'
+    toEntities:
+    - world
   - toPorts:
     - ports:
       - port: "5353"

--- a/examples/kubernetes/connectivity-check/connectivity-debug-tools.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-debug-tools.yaml
@@ -70,6 +70,15 @@ spec:
         k8s:k8s-app: kube-dns
   - toPorts:
     - ports:
+      - port: "53"
+        protocol: UDP
+      rules:
+        dns:
+        - matchPattern: '*'
+    toEntities:
+    - world
+  - toPorts:
+    - ports:
       - port: "5353"
         protocol: UDP
       rules:

--- a/examples/kubernetes/connectivity-check/resources.cue
+++ b/examples/kubernetes/connectivity-check/resources.cue
@@ -237,6 +237,21 @@ egressCNP: [ID=_]: _cnp & {
 				}]
 			},
 			{
+				// Allows connectivity to NodeLocal DNSCache when deployed with local IP.
+				toEntities: [
+					"world",
+				]
+				toPorts: [{
+					ports: [{
+						port:     "53"
+						protocol: "UDP"
+					}]
+					if _enableDNSVisibility {
+						rules: dns: [{matchPattern: "*"}]
+					}
+				}]
+			},
+			{
 				toEndpoints: [{
 					matchLabels: {
 						"k8s:io.kubernetes.pod.namespace":             "openshift-dns"


### PR DESCRIPTION
Fixes: #20055

```release-note
Update connectivity tests for clusters running NodeLocal DNSCache with Local IP.
```

Signed-off-by: eminaktas <eminaktas34@gmail.com>
