### PR TITLE
ci: fix code changes detection on `push` events

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -30,6 +30,9 @@ jobs:
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: docs-tree
         with:
+          # For `push` events, compare against the `ref` base branch
+          # For `pull_request` events, this is ignored and will compare against the pull request base branch
+          base: ${{ github.ref }}
           filters: |
             src:
               - .github/workflows/documentation.yaml

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -31,6 +31,9 @@ jobs:
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: changes
         with:
+          # For `push` events, compare against the `ref` base branch
+          # For `pull_request` events, this is ignored and will compare against the pull request base branch
+          base: ${{ github.ref }}
           filters: |
             bpf-tree:
               - 'bpf/**'

--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -22,17 +22,10 @@ jobs:
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}
     steps:
-      - name: Checkout code
-        if: ${{ !github.event.pull_request }}
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-        with:
-          persist-credentials: false
       - name: Check code changes
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: go-changes
         with:
-          base: ${{ github.event.pull_request.base.sha }}
-          ref: ${{ github.event.pull_request.head.sha }}
           filters: |
             src:
               - .github/workflows/lint-codeql.yaml

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -39,6 +39,9 @@ jobs:
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: tested-tree
         with:
+          # For `push` events, compare against the `ref` base branch
+          # For `pull_request` events, this is ignored and will compare against the pull request base branch
+          base: ${{ github.ref }}
           filters: |
             src:
               - '!(test|Documentation)/**'

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -39,6 +39,9 @@ jobs:
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: tested-tree
         with:
+          # For `push` events, compare against the `ref` base branch
+          # For `pull_request` events, this is ignored and will compare against the pull request base branch
+          base: ${{ github.ref }}
           filters: |
             src:
               - '!(test|Documentation)/**'


### PR DESCRIPTION
The `dorny/paths-filter` actions needs to know against which `base` to compare on `push` events, as otherwise it will default to the default repository branch (`master` in our case).

Since we have checks for stable branchs (e.g. `v1.12`), we want these to check against the proper `base` and not `master`, thus we use GitHub context to determine to which branch we pushed.

The `base` parameter is ignored for `pull_request` events, so we need not have additional safeguards.

Doc: https://github.com/dorny/paths-filter#supported-workflows

Notes:

- This PR will have no effect since `push` events on `master` already compare against `master` (being the default branch), however backporting this PR will fix the stable branches (since they have `push` events on e.g. `v1.12` and need their `base` adjusted not to default to `master`). [Here is an example](https://github.com/cilium/cilium/runs/7519860782?check_suite_focus=true) of a workflow run on `push` event to `v1.11`, which checks changes between `v1.11` and `master` when it should be checking against `v1.11`.
- We also take the opportunity to tidy up the CodeQL workflow.