### PR TITLE
clustermesh: Add EndpointSlice support for API server

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -234,6 +234,9 @@ func runApiserver() error {
 	flags.Bool(option.EnableWellKnownIdentities, defaults.EnableWellKnownIdentities, "Enable well-known identities for known Kubernetes components")
 	option.BindEnv(option.EnableWellKnownIdentities)
 
+	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enable support of Kubernetes EndpointSlice")
+	option.BindEnv(option.K8sEnableEndpointSlice)
+
 	viper.BindPFlags(flags)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -131,6 +131,12 @@ spec:
             configMapKeyRef:
               name: cilium-config
               key: identity-allocation-mode
+        - name: ENABLE_K8S_ENDPOINT_SLICE
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: enable-k8s-endpoint-slice
+              optional: true
         {{- with .Values.clustermesh.apiserver.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Please see the commit message for details. I think we need to backport this to 1.10 and 1.11 because it meets the backport criteria "Major bugfixes relevant to the correct operation of Cilium" because, without this change, global service only contains local endpoints for secondary IP family when users configure dual-stack service and their k8s support EndpointSlice which is an incorrect behavior I think.

```release-note
Add EndpointSlice support for clustermesh-apiserver
```