### PR TITLE
docs: Add required ec2:DescribeInstances when instance-tags-filter is used

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -456,6 +456,10 @@ If release excess IP enabled:
 
  * ``UnassignPrivateIpAddresses``
 
+If ``--instance-tags-filter`` is used:
+
+ * ``DescribeInstances``
+
 *****************************
 EC2 instance types ENI limits
 *****************************


### PR DESCRIPTION
`DescribeInstances` is required when using `instance-tags-filter`, which was added in  #19181. 

```
level=info msg="Starting ENI allocator..." subsys=ipam-allocator-aws
level=warning msg="Unable to synchronize EC2 interface list" error="operation error EC2: DescribeInstances, https response error StatusCode: 403, RequestID: <snap>, api error UnauthorizedOperation: You are not authorized to perform this operation." subsys=eni
level=fatal msg="Unable to start eni allocator" error="Initial synchronization with instances API failed" subsys=cilium-operator-aws
```

Signed-off-by: Haitao Li <lihaitao@gmail.com>
