### PR TITLE
ipcache/kvstore: fix panic when processing ip=<nil> entries

### DIFF
--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -220,7 +220,8 @@ func NewIPIdentityWatcher(ipc *IPCache, backend kvstore.BackendOperations) *IPId
 // automatically restart as required.
 func (iw *IPIdentityWatcher) Watch(ctx context.Context) {
 
-	var scopedLog *logrus.Entry
+	scopedLog := log
+
 restart:
 	watcher := iw.backend.ListAndWatch(ctx, "endpointIPWatcher", IPIdentitiesPath, 512)
 
@@ -276,7 +277,9 @@ restart:
 				}
 				ip := ipIDPair.PrefixString()
 				if ip == "<nil>" {
-					scopedLog.Debug("Ignoring entry with nil IP")
+					if option.Config.Debug {
+						scopedLog.Debug("Ignoring entry with nil IP")
+					}
 					continue
 				}
 				var k8sMeta *K8sMetadata


### PR DESCRIPTION
This problem was introduced in 6cbf5daf46d, which results in
a "nil pointer dereference" panic.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>