### PR TITLE
test/bpf: Minor Makefile improvements for "make clean"

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -64,6 +64,7 @@ clean:
 	@$(ECHO_CLEAN)
 	-$(QUIET) rm -rf $(TEST_ARTIFACTS)
 	-$(QUIET) rm -f .vagrant/*.box
+	-$(QUIET)$(MAKE) -C bpf/ clean
 
 BPF_TEST_FLAGS:=
 ifeq ($(V),1)

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -44,4 +44,3 @@ unit-tests: $(ALL_TESTS)
 clean:
 	@$(ECHO_CLEAN)
 	-$(QUIET)rm -f $(TARGETS)
-	$(MAKE) -C $(ROOT_DIR)/bpf/mock clean


### PR DESCRIPTION
This PR contains two trivial changes for test/Makefile and test/bpf/Makefile, refer to individual commits for details.
