### PR TITLE
bpf: Fixed session affinity test after naming conflict

### DIFF
--- a/bpf/tests/session_affinity_test.c
+++ b/bpf/tests/session_affinity_test.c
@@ -36,7 +36,7 @@ struct {
 	__array(values, int());
 } entry_call_map __section(".maps") = {
 	.values = {
-		[0] = &bpf_xdp_entry,
+		[0] = &cil_xdp_entry,
 	},
 };
 


### PR DESCRIPTION
PR #20615 added a new test which relied on the name of the XDP entry
program. PR #19735 changed this name. They were merged within short time
of each other, since the changes were not overlapping no merge conflict
resulted.

This PR fixes fixes the test so it works with the new name.