### PR TITLE
Improve dnsproxy ipcache handling, metrics

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -329,6 +329,8 @@ Identity
 Name                                     Labels                                             Description
 ======================================== ================================================== ========================================================
 ``identity``                             ``type``                                           Number of identities currently allocated
+``ipcache_errors_total``                 ``type``, ``error``                                Number of errors interacting with the ipcache
+``ipcache_events_total``                 ``type``                                           Number of events interacting with the ipcache
 ======================================== ================================================== ========================================================
 
 Events external to Cilium

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -711,7 +711,7 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup, epMgr *endpointmanag
 	}
 	// Upsert restored CIDRs after the new ipcache has been opened above
 	if len(restoredCIDRidentities) > 0 {
-		d.ipcache.UpsertGeneratedIdentities(restoredCIDRidentities)
+		d.ipcache.UpsertGeneratedIdentities(restoredCIDRidentities, nil)
 	}
 	// Upsert restored local Ingress IPs
 	restoredIngressIPs := []string{}

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -179,19 +179,19 @@ func (ds *DaemonFQDNSuite) TestFQDNIdentityReferenceCounting(c *C) {
 	nameManager.Unlock()
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
-	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ciliumDNSRecord)
+	_, _, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ciliumDNSRecord)
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(idAllocator.IdentityReferenceCounter()), Equals, 1,
 		Commentf("Unexpected number of identities allocated during DNS name event handler"))
 
 	// Same thing, new reference for same identity but otherwise the same.
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ciliumDNSRecord)
+	_, _, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ciliumDNSRecord)
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(idAllocator.IdentityReferenceCounter()), Equals, 1,
 		Commentf("Unexpected number of identities allocated during DNS name event handler"))
 
 	// poll DNS for ebpf.io, check that we now have two different identities referenced
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ebpfDNSRecord)
+	_, _, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ebpfDNSRecord)
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(idAllocator.IdentityReferenceCounter()), Equals, 2,
 		Commentf("Unexpected number of identities allocated during DNS name event handler"))

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -433,7 +433,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		// TODO: Remove 'enable-selective-regeneration' agent option.  Without selective
 		// regeneration we retain the old behavior of upserting new identities to ipcache
 		// before endpoint policy maps have been updated.
-		d.ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities)
+		d.ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities, nil)
 	}
 
 	return
@@ -508,7 +508,7 @@ func (d *Daemon) reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.Endpoi
 	// policy maps are ready to classify packets using the newly allocated identities before
 	// they are upserted to the ipcache here.
 	if upsertIdentities != nil {
-		d.ipcache.UpsertGeneratedIdentities(upsertIdentities)
+		d.ipcache.UpsertGeneratedIdentities(upsertIdentities, nil)
 	}
 }
 

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -24,5 +24,5 @@ type Config struct {
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.
-	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error)
+	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error)
 }

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -116,8 +116,8 @@ func NewNameManager(config Config) *NameManager {
 	}
 
 	if config.UpdateSelectors == nil {
-		config.UpdateSelectors = func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error) {
-			return &sync.WaitGroup{}, nil, nil
+		config.UpdateSelectors = func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error) {
+			return &sync.WaitGroup{}, nil, nil, nil
 		}
 	}
 
@@ -136,7 +136,7 @@ func (n *NameManager) GetDNSCache() *DNSCache {
 
 // UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 // have changed for a name they will be reflected in updatedDNSIPs.
-func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, newlyAllocatedIdentities map[string]*identity.Identity, err error) {
+func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, usedIdentities []*identity.Identity, newlyAllocatedIdentities map[string]*identity.Identity, err error) {
 	n.RWMutex.Lock()
 	defer n.RWMutex.Unlock()
 
@@ -184,8 +184,8 @@ func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []strin
 	}
 
 	// Emit the new rules.
-	// Ignore newly allocated IDs (2nd result) as this is only used for deletes.
-	wg, _, err = n.config.UpdateSelectors(ctx, selectorIPMapping, namesMissingIPs)
+	// Ignore newly allocated IDs (3rd result) as this is only used for deletes.
+	wg, _, _, err = n.config.UpdateSelectors(ctx, selectorIPMapping, namesMissingIPs)
 	return wg, err
 }
 

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -31,11 +31,11 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return &sync.WaitGroup{}, nil, nil
+				return &sync.WaitGroup{}, nil, nil, nil
 			},
 		})
 	)
@@ -48,7 +48,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
 	// still have 1 ToFQDN rule, and that the IP is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, _, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect length for testCase with single ToFQDNs entry"))
 
@@ -60,7 +60,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
 	// different, is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.2")}}})
+	_, _, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.2")}}})
 	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Only one entry per FQDNSelector should be present"))
 	expectedIPs = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("10.0.0.2")}
@@ -77,11 +77,11 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return &sync.WaitGroup{}, nil, nil
+				return &sync.WaitGroup{}, nil, nil, nil
 			},
 		})
 	)
@@ -96,14 +96,14 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, _, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect number of plumbed FQDN selectors"))
 	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true)
 
 	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
+	_, _, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.FQDN("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.2")}},
 		dns.FQDN("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.3")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
@@ -116,7 +116,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached github.com IP, 1 new github.com IP
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
+	_, _, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.FQDN("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.2")}},
 		dns.FQDN("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("10.0.0.4")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
@@ -78,7 +79,7 @@ func (ipc *IPCache) AllocateCIDRs(
 	// Only upsert into ipcache if identity wasn't allocated
 	// before and the caller does not care doing this
 	if upsert {
-		ipc.UpsertGeneratedIdentities(newlyAllocatedIdentities)
+		ipc.UpsertGeneratedIdentities(newlyAllocatedIdentities, nil)
 	}
 
 	identities := make([]*identity.Identity, 0, len(allocatedIdentities))
@@ -99,9 +100,51 @@ func (ipc *IPCache) AllocateCIDRsForIPs(
 	return ipc.AllocateCIDRs(ip.GetCIDRPrefixesFromIPs(prefixes), nil, newlyAllocatedIdentities)
 }
 
-func (ipc *IPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[string]*identity.Identity) {
+func cidrLabelToPrefix(label string) (string, bool) {
+	if !strings.HasPrefix(label, labels.LabelSourceCIDR) {
+		return "", false
+	}
+	return strings.TrimPrefix(label, labels.LabelSourceCIDR+":"), true
+}
+
+// UpsertGeneratedIdentities unconditionally upserts 'newlyAllocatedIdentities'
+// into the ipcache, then also upserts any CIDR identities in 'usedIdentities'
+// that were not already upserted. If any 'usedIdentities' are upserted, these
+// are counted separately as they may provide an indication of another logic
+// error elsewhere in the codebase that is causing premature ipcache deletions.
+func (ipc *IPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[string]*identity.Identity, usedIdentities []*identity.Identity) {
 	for prefixString, id := range newlyAllocatedIdentities {
 		ipc.Upsert(prefixString, nil, 0, nil, Identity{
+			ID:     id.ID,
+			Source: source.Generated,
+		})
+	}
+	if len(usedIdentities) == 0 {
+		return
+	}
+
+	toUpsert := make(map[string]*identity.Identity)
+	ipc.mutex.RLock()
+	for _, id := range usedIdentities {
+		prefix, ok := cidrLabelToPrefix(id.CIDRLabel.String())
+		if !ok {
+			log.WithFields(logrus.Fields{
+				logfields.Identity: id.ID,
+			}).Warning("BUG: Attempting to upsert non-CIDR identity")
+			continue
+		}
+		if _, ok := ipc.LookupByIPRLocked(prefix); ok {
+			// Already there; continue
+			continue
+		}
+		toUpsert[prefix] = id
+	}
+	ipc.mutex.RUnlock()
+	for prefix, id := range toUpsert {
+		metrics.IPCacheErrorsTotal.WithLabelValues(
+			metricTypeRecover, metricErrorUnexpected,
+		).Inc()
+		ipc.Upsert(prefix, nil, 0, nil, Identity{
 			ID:     id.ID,
 			Source: source.Generated,
 		})
@@ -202,15 +245,15 @@ func (ipc *IPCache) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []
 	fullIdentities := make(map[string]*identity.Identity, len(identities))
 	for _, nid := range identities {
 		if id := ipc.IdentityAllocator.LookupIdentityByID(ctx, nid); id != nil {
-			cidr := id.CIDRLabel.String()
-			if !strings.HasPrefix(cidr, labels.LabelSourceCIDR) {
+			cidr, ok := cidrLabelToPrefix(id.CIDRLabel.String())
+			if !ok {
 				log.WithFields(logrus.Fields{
 					logfields.Identity: nid,
 					logfields.Labels:   id.Labels,
 				}).Warn("Unexpected release of non-CIDR identity, will leak this identity. Please report this issue to the developers.")
 				continue
 			}
-			fullIdentities[strings.TrimPrefix(cidr, labels.LabelSourceCIDR+":")] = id
+			fullIdentities[cidr] = id
 		} else {
 			log.WithFields(logrus.Fields{
 				logfields.Identity: nid,

--- a/pkg/ipcache/metrics.go
+++ b/pkg/ipcache/metrics.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+var (
+	metricTypeUpsert  = "upsert"
+	metricTypeDelete  = "delete"
+	metricTypeRecover = "recover"
+
+	metricErrorIdempotent = "idempotent_operation"
+	metricErrorInvalid    = "invalid_prefix"
+	metricErrorNoExist    = "no_such_prefix"
+	metricErrorOverwrite  = "cannot_overwrite_by_source"
+	metricErrorUnexpected = "upsert_unexpectedly_deleted_entry"
+)


### PR DESCRIPTION
A user has reported an issue where it appears that FQDN garbage collection
races with DNS proxy handling for IPs (typically with S3), where occasionally
the traffic towards a destination allowed by `ToFQDNs` policy is not correctly
allowing the traffic. In this scenario, the ipcache does not contain the target
IP for the connection, however the IP has a corresponding identity, and that
identity is plumbed into the policy packages and even into the BPF policymaps.

The first commit in this PR is intended to close this race condition to resolve
the underlying cause. The second commit improves the resiliency of the code by
ensuring that any time that a DNS request triggers policy updates, we attempt
to push corresponding identities into the IPcache again in case they were
temporarily removed by other code in the mean time. Finally, add some metrics
to help to debug issues in this area of the codebase.

For more details, see the individual commits.

- ipcache: Fix race in identity/ipcache release
- fqdn: Upsert all identities to ipcache
- ipcache: Add metrics for upsert/delete/recover

```release-note
Fix bug where traffic sent outside the cluster via ToFQDNs policy would be denied despite a policy that allows it
```