### PR TITLE
Revert "doc: update the api spec for fqdn egress policies code comments."

### DIFF
--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -50,9 +50,8 @@ type FQDNSelector struct {
 	// Examples:
 	// `*.cilium.io` matches subomains of cilium at that level
 	//   www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-	// `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
-	//   except those containing "." separator, subcilium.io and sub-cilium.io match,
-	//   www.cilium.io and blog.cilium.io does not
+	// `*cilium.io` matches cilium.io and all subdomains 1 level below
+	//   www.cilium.io, blog.cilium.io and cilium.io match, google.com does not
 	// sub*.cilium.io matches subdomains of cilium where the subdomain component
 	// begins with "sub"
 	//   sub.cilium.io and subdomain.cilium.io match, www.cilium.io,


### PR DESCRIPTION
This reverts commit ccc719438fc3db9e287dd50b7f2cbef33178f3af. (#20658)

The make generate-k8s-api target was failing here, so revert it until we
can fix that.
