### PR TITLE
datapath: Fix race in the fake NodeHandler

### DIFF
--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -7,10 +7,12 @@ import (
 	"context"
 
 	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/lock"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
 
 type FakeNodeHandler struct {
+	mu    lock.Mutex
 	Nodes map[string]nodeTypes.Node
 }
 
@@ -21,16 +23,22 @@ func NewNodeHandler() *FakeNodeHandler {
 }
 
 func (n *FakeNodeHandler) NodeAdd(newNode nodeTypes.Node) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	n.Nodes[newNode.Name] = newNode
 	return nil
 }
 
 func (n *FakeNodeHandler) NodeUpdate(oldNode, newNode nodeTypes.Node) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	n.Nodes[newNode.Name] = newNode
 	return nil
 }
 
 func (n *FakeNodeHandler) NodeDelete(node nodeTypes.Node) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	delete(n.Nodes, node.Name)
 	return nil
 }


### PR DESCRIPTION
The assumption that the NodeHandler callbacks are called sequentially
was unfounded. Add a mutex to prevent concurrent access.

Fixes: f0d9e65b35 ("test/control-plane: Add test for node handler")
Fixes: #20651
