### PR TITLE
bpf: Finish rename of BPF programs to cil_ prefix

### DIFF
--- a/Documentation/contributing/testing/bpf.rst
+++ b/Documentation/contributing/testing/bpf.rst
@@ -151,7 +151,7 @@ This is an abbreviated example showing the key components:
         __array(values, int());
     } entry_call_map __section(".maps") = {
         .values = {
-            [0] = &bpf_xdp_entry,
+            [0] = &cil_xdp_entry,
         },
     };
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1141,7 +1141,7 @@ handle_srv6(struct __ctx_buff *ctx)
  * - BPF NodePort is enabled
  */
 __section("from-netdev")
-int from_netdev(struct __ctx_buff *ctx)
+int cil_from_netdev(struct __ctx_buff *ctx)
 {
 	__u32 __maybe_unused vlan_id;
 
@@ -1166,7 +1166,7 @@ int from_netdev(struct __ctx_buff *ctx)
  * interface if present.
  */
 __section("from-host")
-int from_host(struct __ctx_buff *ctx)
+int cil_from_host(struct __ctx_buff *ctx)
 {
 	/* Traffic from the host ns going through cilium_host device must
 	 * not be subject to EDT rate-limiting.
@@ -1182,7 +1182,7 @@ int from_host(struct __ctx_buff *ctx)
  * - BPF NodePort is enabled
  */
 __section("to-netdev")
-int to_netdev(struct __ctx_buff *ctx __maybe_unused)
+int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 {
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
@@ -1315,7 +1315,7 @@ out:
  * 'cilium_net' devices if present.
  */
 __section("to-host")
-int to_host(struct __ctx_buff *ctx)
+int cil_to_host(struct __ctx_buff *ctx)
 {
 	__u32 magic = ctx_load_meta(ctx, ENCRYPT_OR_PROXY_MAGIC);
 	__u16 __maybe_unused proto = 0;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1305,7 +1305,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
  * It corresponds to packets leaving the container.
  */
 __section("from-container")
-int handle_xgress(struct __ctx_buff *ctx)
+int cil_from_container(struct __ctx_buff *ctx)
 {
 	__u16 proto;
 	int ret;
@@ -2117,7 +2117,7 @@ out:
  * routes are enabled.
  */
 __section("to-container")
-int handle_to_container(struct __ctx_buff *ctx)
+int cil_to_container(struct __ctx_buff *ctx)
 {
 	enum trace_point trace = TRACE_FROM_STACK;
 	__u32 magic, identity = 0;

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -12,7 +12,7 @@
 #include "lib/encrypt.h"
 
 __section("from-network")
-int from_network(struct __ctx_buff *ctx)
+int cil_from_network(struct __ctx_buff *ctx)
 {
 	int ret = CTX_ACT_OK;
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -432,7 +432,7 @@ static __always_inline bool is_esp(struct __ctx_buff *ctx, __u16 proto)
  * entering the node via the tunnel.
  */
 __section("from-overlay")
-int from_overlay(struct __ctx_buff *ctx)
+int cil_from_overlay(struct __ctx_buff *ctx)
 {
 	__u16 proto;
 	int ret;
@@ -530,7 +530,7 @@ out:
  * leaving the node via the tunnel.
  */
 __section("to-overlay")
-int to_overlay(struct __ctx_buff *ctx)
+int cil_to_overlay(struct __ctx_buff *ctx)
 {
 	int ret;
 

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -476,7 +476,7 @@ __sock4_health_fwd(struct bpf_sock_addr *ctx __maybe_unused)
 }
 
 __section("cgroup/connect4")
-int sock4_connect(struct bpf_sock_addr *ctx)
+int cil_sock4_connect(struct bpf_sock_addr *ctx)
 {
 	if (sock_is_health_check(ctx))
 		return __sock4_health_fwd(ctx);
@@ -520,7 +520,7 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 }
 
 __section("cgroup/post_bind4")
-int sock4_post_bind(struct bpf_sock *ctx)
+int cil_sock4_post_bind(struct bpf_sock *ctx)
 {
 	if (__sock4_post_bind(ctx, ctx) < 0)
 		return SYS_REJECT;
@@ -559,7 +559,7 @@ static __always_inline int __sock4_pre_bind(struct bpf_sock_addr *ctx,
 }
 
 __section("cgroup/bind4")
-int sock4_pre_bind(struct bpf_sock_addr *ctx)
+int cil_sock4_pre_bind(struct bpf_sock_addr *ctx)
 {
 	int ret = SYS_PROCEED;
 
@@ -611,21 +611,21 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 }
 
 __section("cgroup/sendmsg4")
-int sock4_sendmsg(struct bpf_sock_addr *ctx)
+int cil_sock4_sendmsg(struct bpf_sock_addr *ctx)
 {
 	__sock4_xlate_fwd(ctx, ctx, true);
 	return SYS_PROCEED;
 }
 
 __section("cgroup/recvmsg4")
-int sock4_recvmsg(struct bpf_sock_addr *ctx)
+int cil_sock4_recvmsg(struct bpf_sock_addr *ctx)
 {
 	__sock4_xlate_rev(ctx, ctx);
 	return SYS_PROCEED;
 }
 
 __section("cgroup/getpeername4")
-int sock4_getpeername(struct bpf_sock_addr *ctx)
+int cil_sock4_getpeername(struct bpf_sock_addr *ctx)
 {
 	__sock4_xlate_rev(ctx, ctx);
 	return SYS_PROCEED;
@@ -874,7 +874,7 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 }
 
 __section("cgroup/post_bind6")
-int sock6_post_bind(struct bpf_sock *ctx)
+int cil_sock6_post_bind(struct bpf_sock *ctx)
 {
 	if (__sock6_post_bind(ctx) < 0)
 		return SYS_REJECT;
@@ -944,7 +944,7 @@ static __always_inline int __sock6_pre_bind(struct bpf_sock_addr *ctx)
 }
 
 __section("cgroup/bind6")
-int sock6_pre_bind(struct bpf_sock_addr *ctx)
+int cil_sock6_pre_bind(struct bpf_sock_addr *ctx)
 {
 	int ret = SYS_PROCEED;
 
@@ -1089,7 +1089,7 @@ __sock6_health_fwd(struct bpf_sock_addr *ctx __maybe_unused)
 }
 
 __section("cgroup/connect6")
-int sock6_connect(struct bpf_sock_addr *ctx)
+int cil_sock6_connect(struct bpf_sock_addr *ctx)
 {
 	if (sock_is_health_check(ctx))
 		return __sock6_health_fwd(ctx);
@@ -1167,21 +1167,21 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 }
 
 __section("cgroup/sendmsg6")
-int sock6_sendmsg(struct bpf_sock_addr *ctx)
+int cil_sock6_sendmsg(struct bpf_sock_addr *ctx)
 {
 	__sock6_xlate_fwd(ctx, true);
 	return SYS_PROCEED;
 }
 
 __section("cgroup/recvmsg6")
-int sock6_recvmsg(struct bpf_sock_addr *ctx)
+int cil_sock6_recvmsg(struct bpf_sock_addr *ctx)
 {
 	__sock6_xlate_rev(ctx);
 	return SYS_PROCEED;
 }
 
 __section("cgroup/getpeername6")
-int sock6_getpeername(struct bpf_sock_addr *ctx)
+int cil_sock6_getpeername(struct bpf_sock_addr *ctx)
 {
 	__sock6_xlate_rev(ctx);
 	return SYS_PROCEED;

--- a/bpf/sockops/bpf_redir.c
+++ b/bpf/sockops/bpf_redir.c
@@ -39,7 +39,7 @@ static __always_inline void sk_msg_extract4_key(const struct sk_msg_md *msg,
 }
 
 __section("sk_msg")
-int bpf_redir_proxy(struct sk_msg_md *msg)
+int cil_redir_proxy(struct sk_msg_md *msg)
 {
 	struct remote_endpoint_info *info;
 	__u64 flags = BPF_F_INGRESS;

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -127,7 +127,7 @@ static inline void bpf_sock_ops_ipv6(struct bpf_sock_ops *skops)
 #endif /* ENABLE_IPV6 */
 
 __section("sockops")
-int bpf_sockmap(struct bpf_sock_ops *skops)
+int cil_sockops(struct bpf_sock_ops *skops)
 {
 	__u32 family, op;
 

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -17,7 +17,6 @@ CLANG_FLAGS += -Wall -Wextra -Werror -Wshadow
 CLANG_FLAGS += -Wno-address-of-packed-member
 CLANG_FLAGS += -Wno-unknown-warning-option
 CLANG_FLAGS += -Wno-gnu-variable-sized-type-not-at-end
-CLANG_FLAGS += -Wdeclaration-after-statement
 CLANG_FLAGS += -Wimplicit-int-conversion -Wenum-conversion
 LLC_FLAGS := -march=bpf -mattr=dwarfris
 # Mimics the mcpu values set by cilium-agent. See GetBPFCPU().

--- a/bpf/tests/hairpin_flow.c
+++ b/bpf/tests/hairpin_flow.c
@@ -40,7 +40,7 @@ struct {
 	__array(values, int());
 } entry_call_map __section(".maps") = {
 	.values = {
-		[0] = &handle_xgress,
+		[0] = &cil_from_container,
 	},
 };
 

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -143,17 +143,17 @@ func classifyProgramTypes(spec *ebpf.CollectionSpec) {
 	for name := range spec.Programs {
 		switch name {
 		// bpf_xdp.c
-		case "bpf_xdp_entry":
+		case "cil_xdp_entry":
 			t = ebpf.XDP
 		case
 			// bpf_lxc.c
-			"handle_xgress", "handle_to_container",
+			"cil_from_container", "cil_to_container",
 			// bpf_host.c
-			"from_netdev", "from_host", "to_netdev", "to_host",
+			"cil_from_netdev", "cil_from_host", "cil_to_netdev", "cil_to_host",
 			// bpf_network.c
-			"from_network",
+			"cil_from_network",
 			// bpf_overlay.c
-			"to_overlay", "from_overlay":
+			"cil_to_overlay", "cil_from_overlay":
 			t = ebpf.SchedCLS
 		default:
 			continue

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -32,16 +32,16 @@ import (
 const (
 	Subsystem = "datapath-loader"
 
-	symbolFromEndpoint = "handle_xgress"
-	symbolToEndpoint   = "handle_to_container"
-	symbolFromNetwork  = "from_network"
+	symbolFromEndpoint = "cil_from_container"
+	symbolToEndpoint   = "cil_to_container"
+	symbolFromNetwork  = "cil_from_network"
 
-	symbolFromHostNetdevEp = "from_netdev"
-	symbolToHostNetdevEp   = "to_netdev"
-	symbolFromHostEp       = "from_host"
-	symbolToHostEp         = "to_host"
+	symbolFromHostNetdevEp = "cil_from_netdev"
+	symbolToHostNetdevEp   = "cil_to_netdev"
+	symbolFromHostEp       = "cil_from_host"
+	symbolToHostEp         = "cil_to_host"
 
-	symbolFromHostNetdevXDP = "bpf_xdp_entry"
+	symbolFromHostNetdevXDP = "cil_xdp_entry"
 
 	dirIngress = "ingress"
 	dirEgress  = "egress"


### PR DESCRIPTION
First commit fixes a compile issue with clang 14 in bpf/tests (-Wdeclaration-after-statement only effective in newer clang) .

Second commit: 
Commit 6ed1fe52e6d6 introduced the renaming of bpf_xdp_entry to cil_xdp_entry.
This unfortunately missed the reference to bpf_xdp_entry in loader.go causing
the ci-l4lb test to fail.

This commit fixes this issue and does a pass to rename all BPF entrypoint program
names to use the cil_ prefix. All references to the old names were checked with
"git grep" and corrected.

Fixes: 6ed1fe52e6d6 ("cilium: Remove attached bpf_xdp upon "cilium cleanup"")
Fixes: https://github.com/cilium/cilium/issues/20725