### PR TITLE
Fix ineffective post-start hook in ENI mode

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -41,25 +41,19 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      volumes:
-      # To access iptables concurrently with other processes (e.g. kube-proxy)
-      - hostPath:
-          path: /run/xtables.lock
-          type: FileOrCreate
-        name: xtables-lock
       containers:
         - name: node-init
           image: {{ include "cilium.image" .Values.nodeinit.image | quote }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
-          volumeMounts:
-            # To access iptables concurrently with other processes (e.g. kube-proxy)
-            - mountPath: /run/xtables.lock
-              name: xtables-lock
           lifecycle:
             {{- if .Values.eni.enabled }}
             postStart:
               exec:
                 command:
+                  - nsenter
+                  - --target=1
+                  - --mount
+                  - --
                   - "/bin/sh"
                   - "-c"
                   - |


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/16840 introduced code to remove
some SNAT-related iptables rules which are known to be problematic when
Cilium is running in ENI mode. However, said PR didn't account for the
fact that this needs to run from inside the host mount and network
namespaces (like the existing pre-stop hook does), and not from inside
the 'node-init' container itself. This commit fixes that by making the
script run with the right 'nsenter' magic.

As a result of this, the `xtables.lock` mount is no longer necessary and
can be removed.

Fixes: #19421

```release-note
Fix ineffective post-start hook in ENI mode
```