### PR TITLE
docs: Clarify KPR requirements for Kind

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -348,6 +348,7 @@ dns
 dnsPolicy
 dnsProxy
 dnsRejectResponseCode
+dockerd
 dockerhub
 dpaa
 dports


### PR DESCRIPTION
- Only Socket LB depends on cgroup v2 ns.
- systemd.unified_cgroup_hierarchy=1 is used to enable cgroup v2, but not necessary cgroup ns.
- Make it more clear that there are two requirements (cgroup v2 ns and cgroup v1 disablement).