### PR TITLE
Consider `$GO` environment variable `make precheck` checks

### DIFF
--- a/contrib/scripts/check-fmt.sh
+++ b/contrib/scripts/check-fmt.sh
@@ -3,13 +3,15 @@
 set -e
 set -o pipefail
 
+_goroot=$(${GO:-go} env GOROOT)
+
 diff="$(find . ! \( -path './contrib' -prune \) \
         ! \( -path './vendor' -prune \) \
         ! \( -path './_build' -prune \) \
         ! \( -path './.git' -prune \) \
         ! \( -path '*.validate.go' -prune \) \
         -type f -name '*.go' | grep -Ev "(pkg/k8s/apis/cilium.io/v2/client/bindata.go)" | \
-        xargs gofmt -d -l -s )"
+        xargs $_goroot/bin/gofmt -d -l -s )"
 
 if [ -n "$diff" ]; then
 	echo "Unformatted Go source code:"

--- a/tools/customvet
+++ b/tools/customvet
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-go run ${SCRIPTPATH}/../vendor/github.com/cilium/customvet/main.go $@
+${GO:-go} run ${SCRIPTPATH}/../vendor/github.com/cilium/customvet/main.go $@


### PR DESCRIPTION
For backports it's usually convenient to be able to set the `$GO`
environment variable to the version used in the particular stable
branch, e.g. on v1.10 we'd set `GO=go1.16.15`. However, that setting is
currently not considered in all check scripts invoked by `make precheck`.

See individual commit messages for details.
