### PR TITLE
fqdn/metrics: Fix ProxyUpstreamTime error=timeout

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -424,7 +424,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		if errors.Is(stat.Err, dnsproxy.ErrFailedAcquireSemaphore{}) || errors.Is(stat.Err, dnsproxy.ErrTimedOutAcquireSemaphore{}) {
 			metrics.FQDNSemaphoreRejectedTotal.Add(1)
 		}
-		metrics.ProxyUpstreamTime.WithLabelValues(metrics.ErrorTimeout, metrics.L7DNS, upstream).Observe(
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, upstream).Observe(
 			stat.UpstreamTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(
 			stat.ProcessingTime.Total().Seconds())


### PR DESCRIPTION
Previously, regardless of whether there was an error or not, the proxy
upstream time metric would report "error=timeout". This was confusing,
since successful DNS transactions with the upstream server would be
reported with this timeout label.

Fix this by using the local metricError variable which reflects either
that the request was allowed ("error=allow"), or only if the upstream
request times out, error="timeout". This is at least more consistent
with the existing metrics.

We can follow up separately whether "allow" should be split from the
"error" label.
