### PR TITLE
metrics: Split DNS upstream, processing time

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -310,14 +310,15 @@ Name                                       Labels                               
 ``policy_endpoint_enforcement_status``                                                        Number of endpoints labeled by policy enforcement status
 ========================================== ================================================== ========================================================
 
-Policy L7 (HTTP/Kafka)
-~~~~~~~~~~~~~~~~~~~~~~
+Policy L7 (DNS/HTTP/Kafka)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ======================================== ================================================== ========================================================
 Name                                     Labels                                             Description
 ======================================== ================================================== ========================================================
 ``proxy_redirects``                      ``protocol``                                       Number of redirects installed for endpoints
-``proxy_upstream_reply_seconds``                                                            Seconds waited for upstream server to reply to a request
+``proxy_processing_duration_seconds``    ``error``, ``protocol_l7``, ``scope``              Seconds spent processing Layer 7 traffic
+``proxy_upstream_reply_seconds``         ``error``, ``protocol_l7``                         Seconds waited for upstream server to reply to a request
 ``proxy_datapath_update_timeout_total``                                                     Number of total datapath update timeouts due to FQDN IP updates
 ``policy_l7_total``                      ``type``                                           Number of total L7 requests/responses
 ======================================== ================================================== ========================================================

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -316,6 +316,7 @@ Metrics/Labels
 ~~~~~~~~~~~~~~
 
 * ``proxy_upstream_reply_seconds`` no longer has the ``scope`` label. All scopes unrelated to upstream responses are moved to a new metric ``proxy_processing_duration_seconds``.
+* ``proxy_upstream_reply_seconds`` is now a Summary type with 50th, 90th and 99th percentile buckets.
 
 .. _1.12_upgrade_notes:
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -307,6 +307,16 @@ Annotations:
 
 .. _current_release_required_changes:
 
+.. _1.13_upgrade_notes:
+
+1.13 Upgrade Notes
+------------------
+
+Metrics/Labels
+~~~~~~~~~~~~~~
+
+* ``proxy_upstream_reply_seconds`` no longer has the ``scope`` label. All scopes unrelated to upstream responses are moved to a new metric ``proxy_processing_duration_seconds``.
+
 .. _1.12_upgrade_notes:
 
 1.12 Upgrade Notes

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -424,15 +424,15 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		if errors.Is(stat.Err, dnsproxy.ErrFailedAcquireSemaphore{}) || errors.Is(stat.Err, dnsproxy.ErrTimedOutAcquireSemaphore{}) {
 			metrics.FQDNSemaphoreRejectedTotal.Add(1)
 		}
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, upstream).Observe(
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS).Observe(
 			stat.UpstreamTime.Total().Seconds())
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(
+		metrics.ProxyProcessingTime.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(
 			stat.ProcessingTime.Total().Seconds())
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, semaphoreTime).Observe(
+		metrics.ProxyProcessingTime.WithLabelValues(metricError, metrics.L7DNS, semaphoreTime).Observe(
 			stat.SemaphoreAcquireTime.Total().Seconds())
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyCheckTime).Observe(
+		metrics.ProxyProcessingTime.WithLabelValues(metricError, metrics.L7DNS, policyCheckTime).Observe(
 			stat.PolicyCheckTime.Total().Seconds())
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, dataplaneTime).Observe(
+		metrics.ProxyProcessingTime.WithLabelValues(metricError, metrics.L7DNS, dataplaneTime).Observe(
 			stat.DataplaneTime.Total().Seconds())
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -215,6 +215,12 @@ const (
 var (
 	registry = prometheus.NewPedanticRegistry()
 
+	defaultSummaryObjectives = map[float64]float64{
+		0.5:  0.05,  // 50th percentile +/- 5%
+		0.9:  0.01,  // 90th percentile +/- 1%
+		0.99: 0.001, // 99th percentile +/- 0.1%
+	}
+
 	// APIInteractions is the total time taken to process an API call made
 	// to the cilium-agent
 	APIInteractions = NoOpObserverVec
@@ -875,20 +881,22 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			c.ProxyReceivedEnabled = true
 
 		case Namespace + "_proxy_processing_duration_seconds":
-			ProxyUpstreamTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Name:      "proxy_processing_duration_seconds",
-				Help:      "Seconds spent processing Layer 7 traffic",
+			ProxyUpstreamTime = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+				Namespace:  Namespace,
+				Name:       "proxy_processing_duration_seconds",
+				Help:       "Seconds spent processing Layer 7 traffic",
+				Objectives: defaultSummaryObjectives,
 			}, []string{"error", LabelProtocolL7, LabelScope})
 
 			collectors = append(collectors, ProxyUpstreamTime)
 			c.NoOpObserverVecEnabled = true
 
 		case Namespace + "_proxy_upstream_reply_seconds":
-			ProxyUpstreamTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Name:      "proxy_upstream_reply_seconds",
-				Help:      "Seconds waited to get a reply from a upstream server",
+			ProxyUpstreamTime = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+				Namespace:  Namespace,
+				Name:       "proxy_upstream_reply_seconds",
+				Help:       "Seconds waited to get a reply from a upstream server",
+				Objectives: defaultSummaryObjectives,
 			}, []string{"error", LabelProtocolL7})
 
 			collectors = append(collectors, ProxyUpstreamTime)


### PR DESCRIPTION
Split the `proxy_upstream_reply_seconds` metric into two:
* `upstream_duration`: Time spent waiting for an upstream DNS server to
  respond to a DNS request.
* `processing_duration`: Time spent handling a request and a response,
  not including the time spent waiting for upstream response.

This way, the "upstream" part of the metric name makes more sense
(referring to the server that handles the actual request), and "scope"
can more narrowly describe the different aspects of Cilium's own
handling of the L7 traffic.

These are currently restricted to DNS proxying, but I left the labels in
place to support other `protocol_l7 `in future if that makes sense.

While we're at it, Swap these metrics over to Summary, which does a better
job of tracking percentiles and is lower cost on the prometheus server.

This includes https://github.com/cilium/cilium/pull/20752. If @cilium/metrics agree with the change here, I can rebase this PR once the other PR goes in.