### PR TITLE
eni: refactor(metrics) IPAM related metrics

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -461,9 +461,12 @@ IPAM
 Name                                     Labels                                                            Default    Description
 ======================================== ================================================================= ========== ========================================================
 ``ipam_ips``                             ``type``                                                          Enabled    Number of IPs allocated
-``ipam_allocation_ops``                  ``subnet_id``                                                     Enabled    Number of IP allocation operations.
-``ipam_interface_creation_ops``          ``subnet_id``, ``status``                                         Enabled    Number of interfaces creation operations.
-``ipam_available``                                                                                         Enabled    Number of interfaces with addresses available
+``ipam_ip_allocation_ops``               ``subnet_id``                                                     Enabled    Number of IP allocation operations.
+``ipam_ip_release_ops``                  ``subnet_id``                                                     Enabled    Number of IP release operations.
+``ipam_interface_creation_ops``          ``subnet_id``                                                     Enabled    Number of interfaces creation operations.
+``ipam_release_duration_seconds``        ``type``, ``status``, ``subnet_id``                               Enabled    Release ip or interface latency in seconds
+``ipam_allocation_duration_seconds``     ``type``, ``status``, ``subnet_id``                               Enabled    Allocation ip or interface latency in seconds
+``ipam_available_interfaces``                                                                              Enabled    Number of interfaces with addresses available
 ``ipam_nodes_at_capacity``                                                                                 Enabled    Number of nodes unable to allocate more addresses
 ``ipam_resync_total``                                                                                      Enabled    Number of synchronization operations with external IPAM API
 ``ipam_api_duration_seconds``            ``operation``, ``response_code``                                  Enabled    Duration of interactions with external IPAM API.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -307,6 +307,25 @@ Annotations:
 
 .. _current_release_required_changes:
 
+.. _1.13_upgrade_notes:
+
+1.13 Upgrade Notes
+------------------
+
+Added Metrics
+~~~~~~~~~~~~~
+
+* ``cilium_operator_allocation_duration_seconds``
+* ``cilium_operator_release_duration_seconds``
+
+Removed Metrics/Labels
+~~~~~~~~~~~~~~~~~~~~~~
+
+* ``cilium_operator_ipam_available`` is removed. Please use ``cilium_operator_ipam_available_interfaces`` instead.
+* ``cilium_operator_ipam_allocation_ops`` is removed. Please use ``cilium_operator_ipam_ip_allocation_ops`` instead.
+* ``cilium_operator_ipam_release_ops`` is removed. Please use ``cilium_operator_ipam_ip_release_ops`` instead.
+* The label of ``status`` in ``cilium_operator_ipam_interface_creation_ops`` is removed.
+
 .. _1.12_upgrade_notes:
 
 1.12 Upgrade Notes

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -356,12 +356,16 @@ func (n *Node) findNextIndex(index int32) int32 {
 // CreateInterface without additional context embedded in order to make them
 // usable for metrics accounting purposes.
 const (
-	errUnableToDetermineLimits    = "unable to determine limits"
-	errUnableToGetSecurityGroups  = "unable to get security groups"
-	errUnableToCreateENI          = "unable to create ENI"
-	errUnableToAttachENI          = "unable to attach ENI"
-	errUnableToMarkENIForDeletion = "unable to mark ENI for deletion"
-	errUnableToFindSubnet         = "unable to find matching subnet"
+	errUnableToDetermineLimits   = "unable to determine limits"
+	unableToDetermineLimits      = "unableToDetermineLimits"
+	errUnableToGetSecurityGroups = "unable to get security groups"
+	unableToGetSecurityGroups    = "unableToGetSecurityGroups"
+	errUnableToCreateENI         = "unable to create ENI"
+	unableToCreateENI            = "unableToCreateENI"
+	errUnableToAttachENI         = "unable to attach ENI"
+	unableToAttachENI            = "unableToAttachENI"
+	unableToMarkENIForDeletion   = "unableToMarkENIForDeletion"
+	unableToFindSubnet           = "unableToFindSubnet"
 )
 
 // CreateInterface creates an additional interface with the instance and
@@ -371,7 +375,7 @@ const (
 func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationAction, scopedLog *logrus.Entry) (int, string, error) {
 	limits, limitsAvailable := n.getLimits()
 	if !limitsAvailable {
-		return 0, errUnableToDetermineLimits, fmt.Errorf(errUnableToDetermineLimits)
+		return 0, unableToDetermineLimits, fmt.Errorf(errUnableToDetermineLimits)
 	}
 
 	n.mutex.RLock()
@@ -388,7 +392,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 
 	if bestSubnet == nil {
 		return 0,
-			errUnableToFindSubnet,
+			unableToFindSubnet,
 			fmt.Errorf(
 				"No matching subnet available for interface creation (VPC=%s AZ=%s SubnetIDs=%v SubnetTags=%s)",
 				resource.Spec.ENI.VpcID,
@@ -402,7 +406,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 	securityGroupIDs, err := n.getSecurityGroupIDs(ctx, resource.Spec.ENI)
 	if err != nil {
 		return 0,
-			errUnableToGetSecurityGroups,
+			unableToGetSecurityGroups,
 			fmt.Errorf("%s %s", errUnableToGetSecurityGroups, err)
 	}
 
@@ -427,7 +431,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 
 	eniID, eni, err := n.manager.api.CreateNetworkInterface(ctx, int32(toAllocate), bestSubnet.ID, desc, securityGroupIDs, isPrefixDelegated)
 	if err != nil {
-		return 0, errUnableToCreateENI, fmt.Errorf("%s %s", errUnableToCreateENI, err)
+		return 0, unableToCreateENI, fmt.Errorf("%s %s", errUnableToCreateENI, err)
 	}
 
 	scopedLog = scopedLog.WithField(fieldEniID, eniID)
@@ -458,7 +462,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 		}
 
 		return 0,
-			errUnableToAttachENI,
+			unableToAttachENI,
 			fmt.Errorf("%s at index %d: %s", errUnableToAttachENI, index, err)
 	}
 
@@ -485,7 +489,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 				return toAllocate, "", nil
 			}
 
-			return 0, errUnableToMarkENIForDeletion, fmt.Errorf("unable to mark ENI for deletion on termination: %s", err)
+			return 0, unableToMarkENIForDeletion, fmt.Errorf("unable to mark ENI for deletion on termination: %s", err)
 		}
 	}
 

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -761,7 +761,7 @@ func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
 
 	// All subnets must have been used for allocation
 	for _, subnet := range subnets {
-		c.Assert(metricsapi.AllocationAttempts("success", subnet.ID), check.Not(check.Equals), 0)
+		c.Assert(metricsapi.GetAllocationAttempts("createInterfaceAndAllocateIP", "success", subnet.ID), check.Not(check.Equals), 0)
 		c.Assert(metricsapi.IPAllocations(subnet.ID), check.Not(check.Equals), 0)
 	}
 
@@ -801,7 +801,7 @@ func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
 	}, 5*time.Second), check.IsNil)
 
 	// Metric should not indicate failure
-	c.Assert(metricsMock.AllocationAttempts("ENI attachment failed", testSubnet.ID), check.Equals, int64(0))
+	c.Assert(metricsMock.GetAllocationAttempts("createInterfaceAndAllocateIP", "unableToAttachENI", testSubnet.ID), check.Equals, int64(0))
 
 	node := mngr.Get("node1")
 	c.Assert(node, check.Not(check.IsNil))

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -343,7 +343,7 @@ func (e *IPAMSuite) TestIpamManyNodes(c *check.C) {
 	}
 
 	// The above check returns as soon as the address requirements are met.
-	// The metrics may still be oudated, resync all nodes to update
+	// The metrics may still be outdated, resync all nodes to update
 	// metrics.
 	mngr.Resync(context.TODO(), time.Now())
 
@@ -357,7 +357,7 @@ func (e *IPAMSuite) TestIpamManyNodes(c *check.C) {
 
 	// All subnets must have been used for allocation
 	for _, subnet := range subnets {
-		c.Assert(metrics.AllocationAttempts("success", subnet.ID), check.Not(check.Equals), 0)
+		c.Assert(metrics.GetAllocationAttempts("createInterfaceAndAllocateIP", "success", subnet.ID), check.Not(check.Equals), 0)
 		c.Assert(metrics.IPAllocations(subnet.ID), check.Not(check.Equals), 0)
 	}
 

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -72,23 +72,8 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 			return fmt.Errorf("invalid interface object")
 		}
 
-		if requiredIfaceName != "" {
-			if iface.Name != requiredIfaceName {
-				scopedLog.WithFields(logrus.Fields{
-					"ifaceName":    iface.Name,
-					"requiredName": requiredIfaceName,
-				}).Debug("Not considering interface for allocation since it does not match the required name")
-				return nil
-			}
-		}
-
-		scopedLog.WithFields(logrus.Fields{
-			"id":           iface.ID,
-			"numAddresses": len(iface.Addresses),
-		}).Debug("Considering interface for allocation")
-
-		availableOnInterface := math.IntMax(types.InterfaceAddressLimit-len(iface.Addresses), 0)
-		if availableOnInterface <= 0 {
+		availableOnInterface, available := isAvailableInterface(requiredIfaceName, iface, scopedLog)
+		if !available {
 			return nil
 		}
 
@@ -148,15 +133,15 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 
 // ResyncInterfacesAndIPs is called to retrieve and interfaces and IPs as known
 // to the Azure API and return them
-func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (ipamTypes.AllocationMap, error) {
+func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (available ipamTypes.AllocationMap, remainingAvailableInterfaceCount int, err error) {
 	if n.node.InstanceID() == "" {
-		return nil, nil
+		return nil, -1, nil
 	}
 
-	available := ipamTypes.AllocationMap{}
+	available = ipamTypes.AllocationMap{}
 	n.manager.mutex.RLock()
 	defer n.manager.mutex.RUnlock()
-	n.manager.instances.ForeachAddress(n.node.InstanceID(), func(instanceID, interfaceID, ip, poolID string, addressObj ipamTypes.Address) error {
+	err = n.manager.instances.ForeachAddress(n.node.InstanceID(), func(instanceID, interfaceID, ip, poolID string, addressObj ipamTypes.Address) error {
 		address, ok := addressObj.(types.AzureAddress)
 		if !ok {
 			scopedLog.WithField("ip", ip).Warning("Not an Azure address object, ignoring IP")
@@ -173,8 +158,28 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, -1, err
+	}
 
-	return available, nil
+	requiredIfaceName := n.k8sObj.Spec.Azure.InterfaceName
+	err = n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.InterfaceRevision) error {
+		iface, ok := interfaceObj.Resource.(*types.AzureInterface)
+		if !ok {
+			return fmt.Errorf("invalid interface object")
+		}
+
+		_, available := isAvailableInterface(requiredIfaceName, iface, scopedLog)
+		if available {
+			remainingAvailableInterfaceCount++
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, -1, err
+	}
+
+	return available, remainingAvailableInterfaceCount, nil
 }
 
 // GetMaximumAllocatableIPv4 returns the maximum amount of IPv4 addresses
@@ -200,4 +205,28 @@ func (n *Node) GetUsedIPWithPrefixes() int {
 		return 0
 	}
 	return len(n.k8sObj.Status.IPAM.Used)
+}
+
+// isAvailableInterface returns whether interface is available and the number of available IPs to allocate in interface
+func isAvailableInterface(requiredIfaceName string, iface *types.AzureInterface, scopedLog *logrus.Entry) (availableOnInterface int, available bool) {
+	if requiredIfaceName != "" {
+		if iface.Name != requiredIfaceName {
+			scopedLog.WithFields(logrus.Fields{
+				"ifaceName":    iface.Name,
+				"requiredName": requiredIfaceName,
+			}).Debug("Not considering interface as available since it does not match the required name")
+			return 0, false
+		}
+	}
+
+	scopedLog.WithFields(logrus.Fields{
+		"id":           iface.ID,
+		"numAddresses": len(iface.Addresses),
+	}).Debug("Considering interface as available")
+
+	availableOnInterface = math.IntMax(types.InterfaceAddressLimit-len(iface.Addresses), 0)
+	if availableOnInterface <= 0 {
+		return 0, false
+	}
+	return availableOnInterface, true
 }

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -15,6 +15,8 @@ const ipamSubsystem = "ipam"
 
 type prometheusMetrics struct {
 	registry              *prometheus.Registry
+	Allocation            *prometheus.HistogramVec
+	Release               *prometheus.HistogramVec
 	AllocateInterfaceOps  *prometheus.CounterVec
 	AllocateIpOps         *prometheus.CounterVec
 	ReleaseIpOps          *prometheus.CounterVec
@@ -45,14 +47,14 @@ func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prom
 	m.AllocateIpOps = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: ipamSubsystem,
-		Name:      "allocation_ops",
+		Name:      "ip_allocation_ops",
 		Help:      "Number of IP allocation operations",
 	}, []string{"subnet_id"})
 
 	m.ReleaseIpOps = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: ipamSubsystem,
-		Name:      "release_ops",
+		Name:      "ip_release_ops",
 		Help:      "Number of IP release operations",
 	}, []string{"subnet_id"})
 
@@ -61,12 +63,12 @@ func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prom
 		Subsystem: ipamSubsystem,
 		Name:      "interface_creation_ops",
 		Help:      "Number of interfaces allocated",
-	}, []string{"subnet_id", "status"})
+	}, []string{"subnet_id"})
 
 	m.AvailableInterfaces = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Subsystem: ipamSubsystem,
-		Name:      "available",
+		Name:      "available_interfaces",
 		Help:      "Number of interfaces with addresses available",
 	})
 
@@ -91,6 +93,28 @@ func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prom
 		Help:      "Number of resync operations to synchronize and resolve IP deficit of nodes",
 	})
 
+	m.Allocation = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Subsystem: ipamSubsystem,
+		Name:      "allocation_duration_seconds",
+		Help:      "Allocation ip or interface latency in seconds",
+		Buckets: merge(
+			prometheus.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
+			prometheus.LinearBuckets(1, 1, 60),      // 1s, 2s, 3s, ... 60s,
+		),
+	}, []string{"type", "status", "subnet_id"})
+
+	m.Release = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Subsystem: ipamSubsystem,
+		Name:      "release_duration_seconds",
+		Help:      "Release ip or interface latency in seconds",
+		Buckets: merge(
+			prometheus.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
+			prometheus.LinearBuckets(1, 1, 60),      // 1s, 2s, 3s, ... 60s,
+		),
+	}, []string{"type", "status", "subnet_id"})
+
 	// pool_maintainer is a more generic name, but for backward compatibility
 	// of dashboard, keep the metric name deficit_resolver unchanged
 	m.poolMaintainer = NewTriggerMetrics(namespace, "deficit_resolver")
@@ -105,6 +129,8 @@ func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prom
 	registry.MustRegister(m.AvailableIPsPerSubnet)
 	registry.MustRegister(m.Nodes)
 	registry.MustRegister(m.Resync)
+	registry.MustRegister(m.Allocation)
+	registry.MustRegister(m.Release)
 	m.poolMaintainer.Register(registry)
 	m.k8sSync.Register(registry)
 	m.resync.Register(registry)
@@ -124,8 +150,8 @@ func (p *prometheusMetrics) ResyncTrigger() trigger.MetricsObserver {
 	return p.resync
 }
 
-func (p *prometheusMetrics) IncAllocationAttempt(status, subnetID string) {
-	p.AllocateInterfaceOps.WithLabelValues(subnetID, status).Inc()
+func (p *prometheusMetrics) IncInterfaceAllocation(subnetID string) {
+	p.AllocateInterfaceOps.WithLabelValues(subnetID).Inc()
 }
 
 func (p *prometheusMetrics) AddIPAllocation(subnetID string, allocated int64) {
@@ -154,6 +180,14 @@ func (p *prometheusMetrics) SetNodes(label string, nodes int) {
 
 func (p *prometheusMetrics) IncResyncCount() {
 	p.Resync.Inc()
+}
+
+func (p *prometheusMetrics) AllocationAttempt(typ, status, subnetID string, observe float64) {
+	p.Allocation.WithLabelValues(typ, status, subnetID).Observe(observe)
+}
+
+func (p *prometheusMetrics) ReleaseAttempt(typ, status, subnetID string, observe float64) {
+	p.Release.WithLabelValues(typ, status, subnetID).Observe(observe)
 }
 
 type triggerMetrics struct {
@@ -219,7 +253,9 @@ func (m *NoOpMetricsObserver) QueueEvent(reason string)                         
 // NoOpMetrics is a no-operation implementation of the metrics
 type NoOpMetrics struct{}
 
-func (m *NoOpMetrics) IncAllocationAttempt(status, subnetID string)                              {}
+func (m *NoOpMetrics) AllocationAttempt(typ, status, subnetID string, observe float64)           {}
+func (m *NoOpMetrics) ReleaseAttempt(typ, status, subnetID string, observe float64)              {}
+func (m *NoOpMetrics) IncInterfaceAllocation(subnetID string)                                    {}
 func (m *NoOpMetrics) AddIPAllocation(subnetID string, allocated int64)                          {}
 func (m *NoOpMetrics) AddIPRelease(subnetID string, released int64)                              {}
 func (m *NoOpMetrics) SetAllocatedIPs(typ string, allocated int)                                 {}
@@ -230,3 +266,16 @@ func (m *NoOpMetrics) IncResyncCount()                                          
 func (m *NoOpMetrics) PoolMaintainerTrigger() trigger.MetricsObserver                            { return &NoOpMetricsObserver{} }
 func (m *NoOpMetrics) K8sSyncTrigger() trigger.MetricsObserver                                   { return &NoOpMetricsObserver{} }
 func (m *NoOpMetrics) ResyncTrigger() trigger.MetricsObserver                                    { return &NoOpMetricsObserver{} }
+
+func merge(slices ...[]float64) []float64 {
+	result := make([]float64, 1)
+	for _, s := range slices {
+		result = append(result, s...)
+	}
+	return result
+}
+
+// SinceInSeconds gets the time since the specified start in seconds.
+func SinceInSeconds(start time.Time) float64 {
+	return time.Since(start).Seconds()
+}

--- a/pkg/ipam/metrics/mock/mock.go
+++ b/pkg/ipam/metrics/mock/mock.go
@@ -12,9 +12,11 @@ import (
 
 type mockMetrics struct {
 	mutex                 lock.RWMutex
-	allocationAttempts    map[string]int64
+	allocationAttempts    map[string]histogram
+	releaseAttempts       map[string]histogram
 	ipAllocations         map[string]int64
 	ipReleases            map[string]int64
+	interfaceAllocations  map[string]int64
 	allocatedIPs          map[string]int
 	availableInterfaces   int
 	availableIPsPerSubnet map[string]int
@@ -22,10 +24,17 @@ type mockMetrics struct {
 	resyncCount           int64
 }
 
+type histogram struct {
+	count int64
+	sum   float64
+}
+
 // NewMockMetrics returns a new metrics implementation with a mocked backend
 func NewMockMetrics() *mockMetrics {
 	return &mockMetrics{
-		allocationAttempts:    map[string]int64{},
+		allocationAttempts:    map[string]histogram{},
+		releaseAttempts:       map[string]histogram{},
+		interfaceAllocations:  map[string]int64{},
 		ipAllocations:         map[string]int64{},
 		ipReleases:            map[string]int64{},
 		allocatedIPs:          map[string]int{},
@@ -34,15 +43,35 @@ func NewMockMetrics() *mockMetrics {
 	}
 }
 
-func (m *mockMetrics) AllocationAttempts(status, subnetID string) int64 {
+func (m *mockMetrics) GetAllocationAttempts(typ, status, subnetID string) int64 {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-	return m.allocationAttempts[fmt.Sprintf("status=%s, subnetId=%s", status, subnetID)]
+	return m.allocationAttempts[fmt.Sprintf("type=%s, status=%s, subnetId=%s", typ, status, subnetID)].count
 }
 
-func (m *mockMetrics) IncAllocationAttempt(status, subnetID string) {
+func (m *mockMetrics) AllocationAttempt(typ, status, subnetID string, observer float64) {
 	m.mutex.Lock()
-	m.allocationAttempts[fmt.Sprintf("status=%s, subnetId=%s", status, subnetID)]++
+	defer m.mutex.Unlock()
+	key := fmt.Sprintf("type=%s, status=%s, subnetId=%s", typ, status, subnetID)
+	value := m.allocationAttempts[key]
+	value.count++
+	value.sum += observer
+	m.allocationAttempts[key] = value
+}
+
+func (m *mockMetrics) ReleaseAttempt(typ, status, subnetID string, observer float64) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	key := fmt.Sprintf("type=%s, status=%s, subnetId=%s", typ, status, subnetID)
+	value := m.releaseAttempts[key]
+	value.count++
+	value.sum += observer
+	m.releaseAttempts[key] = value
+}
+
+func (m *mockMetrics) IncInterfaceAllocation(subnetID string) {
+	m.mutex.Lock()
+	m.interfaceAllocations[fmt.Sprintf("subnetId=%s", subnetID)]++
 	m.mutex.Unlock()
 }
 

--- a/pkg/ipam/metrics/mock/mock_test.go
+++ b/pkg/ipam/metrics/mock/mock_test.go
@@ -21,8 +21,8 @@ var _ = check.Suite(&MockSuite{})
 
 func (e *MockSuite) TestMock(c *check.C) {
 	api := NewMockMetrics()
-	api.IncAllocationAttempt("foo", "s-1")
-	c.Assert(api.AllocationAttempts("foo", "s-1"), check.Equals, int64(1))
+	api.AllocationAttempt("createInterfaceAndAllocateIP", "foo", "s-1", 0)
+	c.Assert(api.GetAllocationAttempts("createInterfaceAndAllocateIP", "foo", "s-1"), check.Equals, int64(1))
 	api.AddIPAllocation("s-1", 10)
 	api.AddIPAllocation("s-1", 20)
 	c.Assert(api.IPAllocations("s-1"), check.Equals, int64(30))

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -119,7 +119,9 @@ type AllocationImplementation interface {
 
 // MetricsAPI represents the metrics being maintained by a NodeManager
 type MetricsAPI interface {
-	IncAllocationAttempt(status, subnetID string)
+	AllocationAttempt(typ, status, subnetID string, observe float64)
+	ReleaseAttempt(typ, status, subnetID string, observe float64)
+	IncInterfaceAllocation(subnetID string)
 	AddIPAllocation(subnetID string, allocated int64)
 	AddIPRelease(subnetID string, released int64)
 	SetAllocatedIPs(typ string, allocated int)

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -58,7 +58,10 @@ type NodeOperations interface {
 	// interfaces and IPs associated with the node. This function is called
 	// sparingly as this information is kept in sync based on the success
 	// of the functions AllocateIPs(), ReleaseIPs() and CreateInterface().
-	ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (ipamTypes.AllocationMap, error)
+	// It returns all available ip in node and remaining available interfaces
+	// that can either be allocated or have not yet exhausted the instance specific quota of addresses
+	// and error occurred during execution.
+	ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (ipamTypes.AllocationMap, int, error)
 
 	// PrepareIPAllocation is called to calculate the number of IPs that
 	// can be allocated on the node and whether a new network interface

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -80,14 +80,14 @@ func (n *nodeOperationsMock) CreateInterface(ctx context.Context, allocation *Al
 	return 0, "operation not supported", fmt.Errorf("operation not supported")
 }
 
-func (n *nodeOperationsMock) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (ipamTypes.AllocationMap, error) {
+func (n *nodeOperationsMock) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (ipamTypes.AllocationMap, int, error) {
 	available := ipamTypes.AllocationMap{}
 	n.mutex.RLock()
 	for _, ip := range n.allocatedIPs {
 		available[ip] = ipamTypes.AllocationIP{}
 	}
 	n.mutex.RUnlock()
-	return available, nil
+	return available, 0, nil
 }
 
 func (n *nodeOperationsMock) PrepareIPAllocation(scopedLog *logrus.Entry) (*AllocationAction, error) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
1. fix `cilium_operator_ipam_available` is zero when all node are no need ip.
2. refactor ipam allocation and release metrics.
  2.1 add `cilium_operator_allocation_duration_seconds` and `cilium_operator_release_duration_seconds`
3. rename metrics name
    3.1 `cilium_operator_ipam_available` to `cilium_operator_ipam_available_interfaces`
    3.2 `cilium_operator_ipam_allocation_ops` to `cilium_operator_ipam_ip_allocation_ops`
    3.3 `cilium_operator_ipam_release_ops` to `cilium_operator_ipam_ip_release_ops`

Fixes: #20704
Fixes: #20384

```release-note
Add new ENI IPAM metrics for allocation, release
```
