### PR TITLE
pkg/k8s: set the right IP addresses in log messages

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -245,10 +245,10 @@ func (k *K8sWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) error
 		logfields.K8sNamespace: newK8sPod.ObjectMeta.Namespace,
 		"new-podIP":            newK8sPod.Status.PodIP,
 		"new-podIPs":           newK8sPod.Status.PodIPs,
-		"new-hostIP":           newK8sPod.Status.PodIP,
+		"new-hostIP":           newK8sPod.Status.HostIP,
 		"old-podIP":            oldK8sPod.Status.PodIP,
 		"old-podIPs":           oldK8sPod.Status.PodIPs,
-		"old-hostIP":           oldK8sPod.Status.PodIP,
+		"old-hostIP":           oldK8sPod.Status.HostIP,
 	})
 
 	// In Kubernetes Jobs, Pods can be left in Kubernetes until the Job


### PR DESCRIPTION
The host-IPs being printed in the log messages were from the pod IP
addresses which is incorrect.

Fixes: e92dc6ac6b76 ("pkg/k8s: add pod IP event change")
Signed-off-by: André Martins <andre@cilium.io>