### PR TITLE
test/controlplane: Add tests for upstream k8s polices

### DIFF
--- a/test/controlplane/controlplane_test.go
+++ b/test/controlplane/controlplane_test.go
@@ -8,6 +8,7 @@ import (
 
 	_ "github.com/cilium/cilium/test/controlplane/node"
 	_ "github.com/cilium/cilium/test/controlplane/node/ciliumnodes"
+	_ "github.com/cilium/cilium/test/controlplane/policies/k8s"
 	_ "github.com/cilium/cilium/test/controlplane/services/dualstack"
 	_ "github.com/cilium/cilium/test/controlplane/services/graceful-termination"
 	_ "github.com/cilium/cilium/test/controlplane/services/nodeport"

--- a/test/controlplane/policies/k8s/README.md
+++ b/test/controlplane/policies/k8s/README.md
@@ -1,0 +1,8 @@
+
+# Control-plane test for k8s Network Policies
+
+This test case checks that upstream k8s NetworkPolicies are created and mapped
+correctly to Cilium policy internal representation.
+
+The test inputs, 'vX.XX/init.yaml' and 'vX.XXX/state1.yaml' were generated using
+the 'generate.sh' script.

--- a/test/controlplane/policies/k8s/generate.sh
+++ b/test/controlplane/policies/k8s/generate.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Generate the golden test files for the NodePort test.
+# Reuses kind configs from the dual-stack test.
+#
+
+set -eux
+
+export KUBECONFIG=kubeconfig
+
+resources="services,endpoints,endpointslices,pods,networkpolicies,ciliumnetworkpolicies"
+versions=(1.20 1.22 1.24)
+
+for version in ${versions[*]}; do
+    mkdir -p v${version}
+
+    : Start a kind cluster
+    kind create cluster --config manifests/kind-config-${version}.yaml --name policy
+
+    : Wait for service account to be created
+    until kubectl get serviceaccount/default; do
+        sleep 5
+    done
+
+    : Install cilium
+    cilium install --wait
+
+    : Dump the initial state
+    kubectl get nodes,ciliumnodes,$resources -o yaml > v${version}/init.yaml
+
+    : Apply the manifest and dump the final state
+    kubectl create namespace policy1
+    kubectl apply -n policy1 -f manifests/knp-default-allow-egress.yaml
+    kubectl get -n policy1 $resources -o yaml > v${version}/state1.yaml
+
+    kubectl create namespace policy2
+    kubectl apply -n policy2 -f manifests/knp-default-allow-ingress.yaml
+    kubectl get -n policy2 $resources -o yaml > v${version}/state2.yaml
+
+    kubectl create namespace policy3
+    kubectl apply -n policy3 -f manifests/knp-default-deny-egress.yaml
+    kubectl get -n policy3 $resources -o yaml > v${version}/state3.yaml
+
+    kubectl create namespace policy4
+    kubectl apply -n policy4 -f manifests/knp-default-deny-ingress.yaml
+    kubectl get -n policy4 $resources -o yaml > v${version}/state4.yaml
+
+    kubectl create namespace policy5
+    kubectl apply -n policy5 -f manifests/knp-default-deny-ingress-egress.yaml
+    kubectl get -n policy5 $resources -o yaml > v${version}/state5.yaml
+
+    : Tear down the cluster
+    kind delete clusters policy
+    rm -f kubeconfig
+
+done

--- a/test/controlplane/policies/k8s/manifests/kind-config-1.20.yaml
+++ b/test/controlplane/policies/k8s/manifests/kind-config-1.20.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+    - role: control-plane
+      image: kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
+    - role: worker
+      image: kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
+      kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "cilium.io/ci-node=k8s1"
+networking:
+    disableDefaultCNI: true

--- a/test/controlplane/policies/k8s/manifests/kind-config-1.22.yaml
+++ b/test/controlplane/policies/k8s/manifests/kind-config-1.22.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+    - role: control-plane
+      image: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+    - role: worker
+      image: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+      kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "cilium.io/ci-node=k8s1"
+networking:
+    disableDefaultCNI: true

--- a/test/controlplane/policies/k8s/manifests/kind-config-1.24.yaml
+++ b/test/controlplane/policies/k8s/manifests/kind-config-1.24.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+    - role: control-plane
+      image: kindest/node:v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1
+    - role: worker
+      image: kindest/node:v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1
+      kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "cilium.io/ci-node=k8s1"
+networking:
+    disableDefaultCNI: true

--- a/test/controlplane/policies/k8s/manifests/knp-default-allow-egress.yaml
+++ b/test/controlplane/policies/k8s/manifests/knp-default-allow-egress.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "knp-default-allow-egress"
+spec:
+  podSelector: {}
+  egress:
+  - {}
+  policyTypes:
+  - Egress

--- a/test/controlplane/policies/k8s/manifests/knp-default-allow-ingress.yaml
+++ b/test/controlplane/policies/k8s/manifests/knp-default-allow-ingress.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "knp-default-allow-ingress"
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  policyTypes:
+  - Ingress

--- a/test/controlplane/policies/k8s/manifests/knp-default-deny-egress.yaml
+++ b/test/controlplane/policies/k8s/manifests/knp-default-deny-egress.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "knp-default-deny-egress"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress

--- a/test/controlplane/policies/k8s/manifests/knp-default-deny-ingress-egress.yaml
+++ b/test/controlplane/policies/k8s/manifests/knp-default-deny-ingress-egress.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "knp-default-deny-ingress-egress"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/test/controlplane/policies/k8s/manifests/knp-default-deny-ingress.yaml
+++ b/test/controlplane/policies/k8s/manifests/knp-default-deny-ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "knp-default-deny-ingress"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress

--- a/test/controlplane/policies/k8s/policy.go
+++ b/test/controlplane/policies/k8s/policy.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/test/controlplane/suite"
+)
+
+func init() {
+	suite.AddTestCase("Policies/k8s", testK8SNetworkPolicy)
+}
+
+type direction int
+
+const (
+	egress = direction(iota)
+	ingress
+	both
+)
+
+type step struct {
+	filename         string
+	namespace        string
+	direction        direction
+	expectedDecision api.Decision
+}
+
+var steps = []step{
+	{
+		filename:         "state1.yaml",
+		namespace:        "policy1",
+		direction:        egress,
+		expectedDecision: api.Allowed,
+	},
+	{
+		filename:         "state2.yaml",
+		namespace:        "policy2",
+		direction:        ingress,
+		expectedDecision: api.Allowed,
+	},
+	{
+		filename:         "state3.yaml",
+		namespace:        "policy3",
+		direction:        egress,
+		expectedDecision: api.Denied,
+	},
+	{
+		filename:         "state4.yaml",
+		namespace:        "policy4",
+		direction:        ingress,
+		expectedDecision: api.Denied,
+	},
+	{
+		filename:         "state5.yaml",
+		namespace:        "policy5",
+		direction:        both,
+		expectedDecision: api.Denied,
+	},
+}
+
+func testK8SNetworkPolicy(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modConfig := func(c *option.DaemonConfig) {
+		c.Debug = true
+	}
+
+	for _, version := range []string{"1.20", "1.22", "1.24"} {
+		abs := func(f string) string { return path.Join(cwd, "policies", "k8s", "v"+version, f) }
+
+		t.Run("v"+version, func(t *testing.T) {
+			test := suite.NewControlPlaneTest(t, "policy-control-plane", version)
+
+			// Feed in initial state and start the agent.
+			test.UpdateObjectsFromFile(abs("init.yaml")).StartAgent(modConfig)
+
+			// Run through the test steps
+			for _, step := range steps {
+				test.UpdateObjectsFromFile(abs(step.filename))
+				test.Eventually(func() error { return validate(test, step) })
+			}
+
+			test.StopAgent()
+		})
+	}
+}
+
+func validate(test *suite.ControlPlaneTest, step step) error {
+	sc := &policy.SearchContext{
+		From: labels.LabelArray{
+			labels.NewLabel(k8sConst.PodNamespaceLabel, step.namespace, labels.LabelSourceK8s),
+		},
+		To: labels.LabelArray{
+			labels.NewLabel(k8sConst.PodNamespaceLabel, step.namespace, labels.LabelSourceK8s),
+		},
+	}
+
+	repo := test.GetAgent().GetPolicyRepository()
+
+	repo.Mutex.RLock()
+	ingressDecision := test.GetAgent().GetPolicyRepository().AllowsIngressRLocked(sc)
+	egressDecision := test.GetAgent().GetPolicyRepository().AllowsEgressRLocked(sc)
+	repo.Mutex.RUnlock()
+
+	if (step.direction == egress || step.direction == both) && egressDecision != step.expectedDecision {
+		return fmt.Errorf("failed to verify egress %s, expected: %s, actual: %s",
+			step.filename, step.expectedDecision, egressDecision)
+	}
+	if (step.direction == ingress || step.direction == both) && ingressDecision != step.expectedDecision {
+		return fmt.Errorf("failed to verify ingress %s, expected: %s, actual: %s",
+			step.filename, step.expectedDecision, egressDecision)
+	}
+
+	return nil
+}

--- a/test/controlplane/policies/k8s/v1.20/init.yaml
+++ b/test/controlplane/policies/k8s/v1.20/init.yaml
@@ -1,0 +1,403 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-03T14:32:20Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+    name: policy-control-plane
+    resourceVersion: "751"
+    uid: eab36f43-a69b-4dda-a0b4-9877c18bad5d
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/policy/policy-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: policy-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    capacity:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-03T14:33:30Z"
+      lastTransitionTime: "2022-08-03T14:33:30Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-03T14:33:30Z"
+      lastTransitionTime: "2022-08-03T14:32:18Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-03T14:33:30Z"
+      lastTransitionTime: "2022-08-03T14:32:18Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-03T14:33:30Z"
+      lastTransitionTime: "2022-08-03T14:32:18Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-03T14:33:30Z"
+      lastTransitionTime: "2022-08-03T14:33:10Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:079baa4fa1b9fe638f96084f4e0297c84dd4fb215d29d2321dcbe54273f63ade
+      sizeBytes: 166660061
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
+      - k8s.gcr.io/kube-proxy:v1.20.15
+      sizeBytes: 101468763
+    - names:
+      - k8s.gcr.io/etcd:3.4.13-0
+      sizeBytes: 86742272
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
+      - k8s.gcr.io/kube-apiserver:v1.20.15
+      sizeBytes: 69805873
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
+      - k8s.gcr.io/kube-controller-manager:v1.20.15
+      sizeBytes: 63301443
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
+      - k8s.gcr.io/kube-scheduler:v1.20.15
+      sizeBytes: 48523057
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns:1.7.0
+      sizeBytes: 13982350
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: c7cd173c-f3ec-42d9-afc4-b2b2ca4c34cd
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.13-200.fc36.x86_64
+      kubeProxyVersion: v1.20.15
+      kubeletVersion: v1.20.15
+      machineID: 54174bfaffd54a619999cdb4c916a25b
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 0553bb27-000d-4d1a-9a74-e4e32429d827
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-03T14:32:44Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-worker
+      kubernetes.io/os: linux
+    name: policy-worker
+    resourceVersion: "755"
+    uid: b424cb12-e575-4f2b-8c40-bdbb209b3d6c
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/policy/policy-worker
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: policy-worker
+      type: Hostname
+    allocatable:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    capacity:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-03T14:33:31Z"
+      lastTransitionTime: "2022-08-03T14:33:31Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-03T14:33:14Z"
+      lastTransitionTime: "2022-08-03T14:32:44Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-03T14:33:14Z"
+      lastTransitionTime: "2022-08-03T14:32:44Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-03T14:33:14Z"
+      lastTransitionTime: "2022-08-03T14:32:44Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-03T14:33:14Z"
+      lastTransitionTime: "2022-08-03T14:33:14Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:079baa4fa1b9fe638f96084f4e0297c84dd4fb215d29d2321dcbe54273f63ade
+      sizeBytes: 166660061
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:7962cd2a34ae337f56bc841a5c0cf896ec116a721ca983bbefc302c32cd5c1bb
+      - k8s.gcr.io/kube-proxy:v1.20.15
+      sizeBytes: 101468763
+    - names:
+      - k8s.gcr.io/etcd:3.4.13-0
+      sizeBytes: 86742272
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c37ad6940632d8bcbf52df4ce5e8724343b154b0c6a1def65d6f1e2137bdc5d7
+      - k8s.gcr.io/kube-apiserver:v1.20.15
+      sizeBytes: 69805873
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:8c0e8f18ad72ccc5a2dbb7c0035fccca03a940344c89da11240107ddadc58e41
+      - k8s.gcr.io/kube-controller-manager:v1.20.15
+      sizeBytes: 63301443
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:a0da6981c92f5499921ab1bf71a1faed8366bdffb65816ca9fdd31a2a8d92d2f
+      - k8s.gcr.io/kube-scheduler:v1.20.15
+      sizeBytes: 48523057
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - quay.io/cilium/operator-generic@sha256:bb2a42eda766e5d4a87ee8a5433f089db81b72dd04acf6b59fcbb445a95f9410
+      sizeBytes: 18766988
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns:1.7.0
+      sizeBytes: 13982350
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: c7cd173c-f3ec-42d9-afc4-b2b2ca4c34cd
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.13-200.fc36.x86_64
+      kubeProxyVersion: v1.20.15
+      kubeletVersion: v1.20.15
+      machineID: b2c1f8ddc2e54afc8f8b8b8e6e838fb4
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: c0fcd69c-8ee2-4173-9015-40dbe89d4a4d
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-03T14:33:10Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+    name: policy-control-plane
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: policy-control-plane
+      uid: eab36f43-a69b-4dda-a0b4-9877c18bad5d
+    resourceVersion: "655"
+    uid: f54fde37-fad8-46cf-a53a-034c1d518059
+  spec:
+    addresses:
+    - ip: 172.18.0.3
+      type: InternalIP
+    - ip: 10.244.0.206
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.0.164
+    ingress: {}
+    ipam:
+      podCIDRs:
+      - 10.244.0.0/24
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-03T14:33:10Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-worker
+      kubernetes.io/os: linux
+    name: policy-worker
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: policy-worker
+      uid: b424cb12-e575-4f2b-8c40-bdbb209b3d6c
+    resourceVersion: "656"
+    uid: fd2bc352-0a03-40dc-b4e6-bdeb17495695
+  spec:
+    addresses:
+    - ip: 172.18.0.2
+      type: InternalIP
+    - ip: 10.244.1.190
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.1.222
+    ingress: {}
+    ipam:
+      podCIDRs:
+      - 10.244.1.0/24
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: "2022-08-03T14:32:22Z"
+    labels:
+      component: apiserver
+      provider: kubernetes
+    name: kubernetes
+    namespace: default
+    resourceVersion: "211"
+    uid: 0223a4c5-a9f0-4558-ac69-5102348b0c93
+  spec:
+    clusterIP: 10.96.0.1
+    clusterIPs:
+    - 10.96.0.1
+    ipFamilies:
+    - IPv4
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 6443
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Endpoints
+  metadata:
+    creationTimestamp: "2022-08-03T14:32:22Z"
+    labels:
+      endpointslice.kubernetes.io/skip-mirror: "true"
+    name: kubernetes
+    namespace: default
+    resourceVersion: "213"
+    uid: a5849606-7a52-4314-9794-1ad49d53794f
+  subsets:
+  - addresses:
+    - ip: 172.18.0.3
+    ports:
+    - name: https
+      port: 6443
+      protocol: TCP
+- addressType: IPv4
+  apiVersion: discovery.k8s.io/v1beta1
+  endpoints:
+  - addresses:
+    - 172.18.0.3
+    conditions:
+      ready: true
+  kind: EndpointSlice
+  metadata:
+    creationTimestamp: "2022-08-03T14:32:22Z"
+    generation: 1
+    labels:
+      kubernetes.io/service-name: kubernetes
+    name: kubernetes
+    namespace: default
+    resourceVersion: "214"
+    uid: 7551dcc9-3683-4f53-9be1-ed1cefc4199b
+  ports:
+  - name: https
+    port: 6443
+    protocol: TCP
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.20/state1.yaml
+++ b/test/controlplane/policies/k8s/v1.20/state1.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-allow-egress","namespace":"policy1"},"spec":{"egress":[{}],"podSelector":{},"policyTypes":["Egress"]}}
+    creationTimestamp: "2022-08-03T14:33:33Z"
+    generation: 1
+    name: knp-default-allow-egress
+    namespace: policy1
+    resourceVersion: "766"
+    uid: bfe85d53-8237-4220-ac3c-1ac23b563cac
+  spec:
+    egress:
+    - {}
+    podSelector: {}
+    policyTypes:
+    - Egress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.20/state2.yaml
+++ b/test/controlplane/policies/k8s/v1.20/state2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-allow-ingress","namespace":"policy2"},"spec":{"ingress":[{}],"podSelector":{},"policyTypes":["Ingress"]}}
+    creationTimestamp: "2022-08-03T14:33:33Z"
+    generation: 1
+    name: knp-default-allow-ingress
+    namespace: policy2
+    resourceVersion: "772"
+    uid: d4e4432a-d0bd-4d79-be47-c22cb2ecd99a
+  spec:
+    ingress:
+    - {}
+    podSelector: {}
+    policyTypes:
+    - Ingress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.20/state3.yaml
+++ b/test/controlplane/policies/k8s/v1.20/state3.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-deny-egress","namespace":"policy3"},"spec":{"podSelector":{},"policyTypes":["Egress"]}}
+    creationTimestamp: "2022-08-03T14:33:33Z"
+    generation: 1
+    name: knp-default-deny-egress
+    namespace: policy3
+    resourceVersion: "778"
+    uid: 7352b261-e910-4675-91e1-9f1b0d533b7c
+  spec:
+    podSelector: {}
+    policyTypes:
+    - Egress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.20/state4.yaml
+++ b/test/controlplane/policies/k8s/v1.20/state4.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-deny-ingress","namespace":"policy4"},"spec":{"podSelector":{},"policyTypes":["Ingress"]}}
+    creationTimestamp: "2022-08-03T14:33:33Z"
+    generation: 1
+    name: knp-default-deny-ingress
+    namespace: policy4
+    resourceVersion: "785"
+    uid: d76506f0-f9d7-44d9-8085-43aca7fe0f19
+  spec:
+    podSelector: {}
+    policyTypes:
+    - Ingress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.20/state5.yaml
+++ b/test/controlplane/policies/k8s/v1.20/state5.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-deny-ingress-egress","namespace":"policy5"},"spec":{"podSelector":{},"policyTypes":["Ingress","Egress"]}}
+    creationTimestamp: "2022-08-03T14:33:34Z"
+    generation: 1
+    name: knp-default-deny-ingress-egress
+    namespace: policy5
+    resourceVersion: "791"
+    uid: 45664b0c-9fe2-4adf-bae4-e7d87d18c48d
+  spec:
+    podSelector: {}
+    policyTypes:
+    - Ingress
+    - Egress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.22/init.yaml
+++ b/test/controlplane/policies/k8s/v1.22/init.yaml
@@ -1,0 +1,406 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-03T14:33:46Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: policy-control-plane
+    resourceVersion: "739"
+    uid: 778d88db-ad99-4d9b-9579-5987682eaf1b
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/policy/policy-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: policy-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    capacity:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-03T14:34:39Z"
+      lastTransitionTime: "2022-08-03T14:34:39Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-03T14:34:50Z"
+      lastTransitionTime: "2022-08-03T14:33:44Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-03T14:34:50Z"
+      lastTransitionTime: "2022-08-03T14:33:44Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-03T14:34:50Z"
+      lastTransitionTime: "2022-08-03T14:33:44Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-03T14:34:50Z"
+      lastTransitionTime: "2022-08-03T14:34:40Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:079baa4fa1b9fe638f96084f4e0297c84dd4fb215d29d2321dcbe54273f63ade
+      sizeBytes: 166660061
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
+    - names:
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: c7cd173c-f3ec-42d9-afc4-b2b2ca4c34cd
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.13-200.fc36.x86_64
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: 2607cba09bf24d9e9c674f4ac3a4cf06
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: e389ccb2-80ce-412e-8fa7-6d29b496ed5d
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-03T14:34:11Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-worker
+      kubernetes.io/os: linux
+    name: policy-worker
+    resourceVersion: "741"
+    uid: 21abf46b-bf9a-40d8-a9c0-85ec50869408
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/policy/policy-worker
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: policy-worker
+      type: Hostname
+    allocatable:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    capacity:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-03T14:34:46Z"
+      lastTransitionTime: "2022-08-03T14:34:46Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-03T14:34:51Z"
+      lastTransitionTime: "2022-08-03T14:34:11Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-03T14:34:51Z"
+      lastTransitionTime: "2022-08-03T14:34:11Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-03T14:34:51Z"
+      lastTransitionTime: "2022-08-03T14:34:11Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-03T14:34:51Z"
+      lastTransitionTime: "2022-08-03T14:34:51Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:079baa4fa1b9fe638f96084f4e0297c84dd4fb215d29d2321dcbe54273f63ade
+      sizeBytes: 166660061
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:c363d7be64b689eaa72045ed44383a5fc7123459efc8dd7a6bb9dda64dc6d78c
+      - k8s.gcr.io/kube-proxy:v1.22.9
+      sizeBytes: 105463291
+    - names:
+      - k8s.gcr.io/etcd:3.5.0-0
+      sizeBytes: 99868722
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:20d6fca8758f609d79c1be5475e8853d0638939dfd63dd5dbb1de9d8002d5495
+      - k8s.gcr.io/kube-apiserver:v1.22.9
+      sizeBytes: 74678750
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:365cc86bcfaf48766348e393f6b43a947094028df6c9e2bd948804280851d630
+      - k8s.gcr.io/kube-controller-manager:v1.22.9
+      sizeBytes: 67530868
+    - names:
+      - docker.io/library/import-2022-05-19@sha256:66a8e762e940cabe0c832fb4c9eb34802923b59ae77c839cbdf7d2f4107791d8
+      - k8s.gcr.io/kube-scheduler:v1.22.9
+      sizeBytes: 53928052
+    - names:
+      - docker.io/kindest/kindnetd:v20220510-4929dd75
+      sizeBytes: 45239873
+    - names:
+      - quay.io/cilium/operator-generic@sha256:bb2a42eda766e5d4a87ee8a5433f089db81b72dd04acf6b59fcbb445a95f9410
+      sizeBytes: 18766988
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.4
+      sizeBytes: 13707249
+    - names:
+      - docker.io/kindest/local-path-helper:v20220512-507ff70b
+      sizeBytes: 2859518
+    - names:
+      - k8s.gcr.io/pause:3.6
+      sizeBytes: 301773
+    nodeInfo:
+      architecture: amd64
+      bootID: c7cd173c-f3ec-42d9-afc4-b2b2ca4c34cd
+      containerRuntimeVersion: containerd://1.6.4
+      kernelVersion: 5.18.13-200.fc36.x86_64
+      kubeProxyVersion: v1.22.9
+      kubeletVersion: v1.22.9
+      machineID: c84c01b62ee14f0f8f6cd653e5022e87
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 7e7dec16-a2ba-4360-8788-831957a81d69
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-03T14:34:37Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: policy-control-plane
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: policy-control-plane
+      uid: 778d88db-ad99-4d9b-9579-5987682eaf1b
+    resourceVersion: "635"
+    uid: 077f75f6-5ec2-4181-8327-5ae5f9fc9659
+  spec:
+    addresses:
+    - ip: 172.18.0.3
+      type: InternalIP
+    - ip: 10.244.0.13
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.0.71
+    ingress: {}
+    ipam:
+      podCIDRs:
+      - 10.244.0.0/24
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-03T14:34:44Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-worker
+      kubernetes.io/os: linux
+    name: policy-worker
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: policy-worker
+      uid: 21abf46b-bf9a-40d8-a9c0-85ec50869408
+    resourceVersion: "724"
+    uid: 58b144ae-c1dd-44e2-8a50-b763ba11c69b
+  spec:
+    addresses:
+    - ip: 172.18.0.2
+      type: InternalIP
+    - ip: 10.244.1.80
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.1.64
+    ingress: {}
+    ipam:
+      podCIDRs:
+      - 10.244.1.0/24
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: "2022-08-03T14:33:49Z"
+    labels:
+      component: apiserver
+      provider: kubernetes
+    name: kubernetes
+    namespace: default
+    resourceVersion: "208"
+    uid: 0179a832-4713-4f06-9eb6-ee4dc8b0ff92
+  spec:
+    clusterIP: 10.96.0.1
+    clusterIPs:
+    - 10.96.0.1
+    internalTrafficPolicy: Cluster
+    ipFamilies:
+    - IPv4
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 6443
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Endpoints
+  metadata:
+    creationTimestamp: "2022-08-03T14:33:49Z"
+    labels:
+      endpointslice.kubernetes.io/skip-mirror: "true"
+    name: kubernetes
+    namespace: default
+    resourceVersion: "210"
+    uid: a9117f78-3fc3-449d-afcb-296d9744d483
+  subsets:
+  - addresses:
+    - ip: 172.18.0.3
+    ports:
+    - name: https
+      port: 6443
+      protocol: TCP
+- addressType: IPv4
+  apiVersion: discovery.k8s.io/v1
+  endpoints:
+  - addresses:
+    - 172.18.0.3
+    conditions:
+      ready: true
+  kind: EndpointSlice
+  metadata:
+    creationTimestamp: "2022-08-03T14:33:49Z"
+    generation: 1
+    labels:
+      kubernetes.io/service-name: kubernetes
+    name: kubernetes
+    namespace: default
+    resourceVersion: "211"
+    uid: 8c53b7eb-2e63-4a73-b089-2faf4755f2f6
+  ports:
+  - name: https
+    port: 6443
+    protocol: TCP
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.22/state1.yaml
+++ b/test/controlplane/policies/k8s/v1.22/state1.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-allow-egress","namespace":"policy1"},"spec":{"egress":[{}],"podSelector":{},"policyTypes":["Egress"]}}
+    creationTimestamp: "2022-08-03T14:34:53Z"
+    generation: 1
+    name: knp-default-allow-egress
+    namespace: policy1
+    resourceVersion: "755"
+    uid: d8590798-9f8b-4b5c-9c28-d423b7bf8e58
+  spec:
+    egress:
+    - {}
+    podSelector: {}
+    policyTypes:
+    - Egress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.22/state2.yaml
+++ b/test/controlplane/policies/k8s/v1.22/state2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-allow-ingress","namespace":"policy2"},"spec":{"ingress":[{}],"podSelector":{},"policyTypes":["Ingress"]}}
+    creationTimestamp: "2022-08-03T14:34:53Z"
+    generation: 1
+    name: knp-default-allow-ingress
+    namespace: policy2
+    resourceVersion: "761"
+    uid: 9413b35c-6cdd-4aa6-9a9d-33c05fbaa5ce
+  spec:
+    ingress:
+    - {}
+    podSelector: {}
+    policyTypes:
+    - Ingress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.22/state3.yaml
+++ b/test/controlplane/policies/k8s/v1.22/state3.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-deny-egress","namespace":"policy3"},"spec":{"podSelector":{},"policyTypes":["Egress"]}}
+    creationTimestamp: "2022-08-03T14:34:54Z"
+    generation: 1
+    name: knp-default-deny-egress
+    namespace: policy3
+    resourceVersion: "767"
+    uid: 28f3560e-0bd8-4108-a473-9c6ba9db709f
+  spec:
+    podSelector: {}
+    policyTypes:
+    - Egress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.22/state4.yaml
+++ b/test/controlplane/policies/k8s/v1.22/state4.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-deny-ingress","namespace":"policy4"},"spec":{"podSelector":{},"policyTypes":["Ingress"]}}
+    creationTimestamp: "2022-08-03T14:34:54Z"
+    generation: 1
+    name: knp-default-deny-ingress
+    namespace: policy4
+    resourceVersion: "774"
+    uid: 0ca0cd9a-d00d-4064-ab62-f64f6a01800b
+  spec:
+    podSelector: {}
+    policyTypes:
+    - Ingress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.22/state5.yaml
+++ b/test/controlplane/policies/k8s/v1.22/state5.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-deny-ingress-egress","namespace":"policy5"},"spec":{"podSelector":{},"policyTypes":["Ingress","Egress"]}}
+    creationTimestamp: "2022-08-03T14:34:54Z"
+    generation: 1
+    name: knp-default-deny-ingress-egress
+    namespace: policy5
+    resourceVersion: "780"
+    uid: 9515aa4c-47e5-41f6-b542-dad4c45cd0cc
+  spec:
+    podSelector: {}
+    policyTypes:
+    - Ingress
+    - Egress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.24/init.yaml
+++ b/test/controlplane/policies/k8s/v1.24/init.yaml
@@ -1,0 +1,403 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-03T14:35:09Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: policy-control-plane
+    resourceVersion: "622"
+    uid: 4e131cce-2b13-4705-bc26-9d6a387eaede
+  spec:
+    podCIDR: 10.244.0.0/24
+    podCIDRs:
+    - 10.244.0.0/24
+    providerID: kind://docker/policy/policy-control-plane
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+  status:
+    addresses:
+    - address: 172.18.0.3
+      type: InternalIP
+    - address: policy-control-plane
+      type: Hostname
+    allocatable:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    capacity:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-03T14:36:01Z"
+      lastTransitionTime: "2022-08-03T14:36:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-03T14:36:03Z"
+      lastTransitionTime: "2022-08-03T14:35:05Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-03T14:36:03Z"
+      lastTransitionTime: "2022-08-03T14:35:05Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-03T14:36:03Z"
+      lastTransitionTime: "2022-08-03T14:35:05Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-03T14:36:03Z"
+      lastTransitionTime: "2022-08-03T14:36:03Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
+    - names:
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
+    - names:
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
+    - names:
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
+    - names:
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
+    nodeInfo:
+      architecture: amd64
+      bootID: c7cd173c-f3ec-42d9-afc4-b2b2ca4c34cd
+      containerRuntimeVersion: containerd://1.6.6
+      kernelVersion: 5.18.13-200.fc36.x86_64
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: 2423870458e24cc687ae7797a9e265a4
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 6e21abea-318b-49f4-a0de-3444eb8aebb5
+- apiVersion: v1
+  kind: Node
+  metadata:
+    annotations:
+      kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
+      node.alpha.kubernetes.io/ttl: "0"
+      volumes.kubernetes.io/controller-managed-attach-detach: "true"
+    creationTimestamp: "2022-08-03T14:35:27Z"
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-worker
+      kubernetes.io/os: linux
+    name: policy-worker
+    resourceVersion: "603"
+    uid: cffdd08e-8721-418b-a429-58841b8d65fa
+  spec:
+    podCIDR: 10.244.1.0/24
+    podCIDRs:
+    - 10.244.1.0/24
+    providerID: kind://docker/policy/policy-worker
+  status:
+    addresses:
+    - address: 172.18.0.2
+      type: InternalIP
+    - address: policy-worker
+      type: Hostname
+    allocatable:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    capacity:
+      cpu: "32"
+      ephemeral-storage: 952244Mi
+      hugepages-1Gi: "0"
+      hugepages-2Mi: "0"
+      memory: 131608772Ki
+      pods: "110"
+    conditions:
+    - lastHeartbeatTime: "2022-08-03T14:36:01Z"
+      lastTransitionTime: "2022-08-03T14:36:01Z"
+      message: Cilium is running on this node
+      reason: CiliumIsUp
+      status: "False"
+      type: NetworkUnavailable
+    - lastHeartbeatTime: "2022-08-03T14:35:59Z"
+      lastTransitionTime: "2022-08-03T14:35:27Z"
+      message: kubelet has sufficient memory available
+      reason: KubeletHasSufficientMemory
+      status: "False"
+      type: MemoryPressure
+    - lastHeartbeatTime: "2022-08-03T14:35:59Z"
+      lastTransitionTime: "2022-08-03T14:35:27Z"
+      message: kubelet has no disk pressure
+      reason: KubeletHasNoDiskPressure
+      status: "False"
+      type: DiskPressure
+    - lastHeartbeatTime: "2022-08-03T14:35:59Z"
+      lastTransitionTime: "2022-08-03T14:35:27Z"
+      message: kubelet has sufficient PID available
+      reason: KubeletHasSufficientPID
+      status: "False"
+      type: PIDPressure
+    - lastHeartbeatTime: "2022-08-03T14:35:59Z"
+      lastTransitionTime: "2022-08-03T14:35:59Z"
+      message: kubelet is posting ready status
+      reason: KubeletReady
+      status: "True"
+      type: Ready
+    daemonEndpoints:
+      kubeletEndpoint:
+        Port: 10250
+    images:
+    - names:
+      - quay.io/cilium/cilium@sha256:079baa4fa1b9fe638f96084f4e0297c84dd4fb215d29d2321dcbe54273f63ade
+      sizeBytes: 166660061
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:12e698e531ca89a461810a15d012fd4c2ea8d61bd7064aa25ea39ea31f737889
+      - k8s.gcr.io/kube-proxy:v1.24.2
+      sizeBytes: 111851370
+    - names:
+      - k8s.gcr.io/etcd:3.5.3-0
+      sizeBytes: 102143581
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:2ce9254eb0b0054762a7fb1e9f29eef8a45a6e7a737d52f58182bcbe74dbe572
+      - k8s.gcr.io/kube-apiserver:v1.24.2
+      sizeBytes: 77277666
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:4e74736c8ae3b791ae5a5e3e910a8065e4ac56a9767a18b6c3a8ac56b4534bd4
+      - k8s.gcr.io/kube-controller-manager:v1.24.2
+      sizeBytes: 65554548
+    - names:
+      - docker.io/library/import-2022-06-23@sha256:0097dd48241a96bccd82270ac6c811c8cf34f929aaeffb61fb73097b6c455890
+      - k8s.gcr.io/kube-scheduler:v1.24.2
+      sizeBytes: 52333172
+    - names:
+      - docker.io/kindest/kindnetd:v20220607-9a4d8d2a
+      sizeBytes: 45255283
+    - names:
+      - quay.io/cilium/operator-generic@sha256:bb2a42eda766e5d4a87ee8a5433f089db81b72dd04acf6b59fcbb445a95f9410
+      sizeBytes: 18766988
+    - names:
+      - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
+      sizeBytes: 17375346
+    - names:
+      - k8s.gcr.io/coredns/coredns:v1.8.6
+      sizeBytes: 13585107
+    - names:
+      - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
+      sizeBytes: 2859509
+    - names:
+      - registry.k8s.io/pause:3.7
+      sizeBytes: 311278
+    nodeInfo:
+      architecture: amd64
+      bootID: c7cd173c-f3ec-42d9-afc4-b2b2ca4c34cd
+      containerRuntimeVersion: containerd://1.6.6
+      kernelVersion: 5.18.13-200.fc36.x86_64
+      kubeProxyVersion: v1.24.2
+      kubeletVersion: v1.24.2
+      machineID: 876c612460ed46dd9c4200219433b1b6
+      operatingSystem: linux
+      osImage: Ubuntu 21.10
+      systemUUID: 7ff1d6dd-a57a-4af9-8ab0-6bc503ef2ae5
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-03T14:35:54Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-control-plane
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
+      node.kubernetes.io/exclude-from-external-load-balancers: ""
+    name: policy-control-plane
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: policy-control-plane
+      uid: 4e131cce-2b13-4705-bc26-9d6a387eaede
+    resourceVersion: "557"
+    uid: 3b0c304b-b08a-4630-87e5-9a8eeb1f3e2c
+  spec:
+    addresses:
+    - ip: 172.18.0.3
+      type: InternalIP
+    - ip: 10.244.0.1
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.0.163
+    ingress: {}
+    ipam:
+      podCIDRs:
+      - 10.244.0.0/24
+- apiVersion: cilium.io/v2
+  kind: CiliumNode
+  metadata:
+    creationTimestamp: "2022-08-03T14:35:58Z"
+    generation: 1
+    labels:
+      beta.kubernetes.io/arch: amd64
+      beta.kubernetes.io/os: linux
+      cilium.io/ci-node: k8s1
+      kubernetes.io/arch: amd64
+      kubernetes.io/hostname: policy-worker
+      kubernetes.io/os: linux
+    name: policy-worker
+    ownerReferences:
+    - apiVersion: v1
+      kind: Node
+      name: policy-worker
+      uid: cffdd08e-8721-418b-a429-58841b8d65fa
+    resourceVersion: "579"
+    uid: 2f0d0343-11e0-4e49-a30e-cb4af9d20dd8
+  spec:
+    addresses:
+    - ip: 172.18.0.2
+      type: InternalIP
+    - ip: 10.244.1.91
+      type: CiliumInternalIP
+    alibaba-cloud: {}
+    azure: {}
+    encryption: {}
+    eni: {}
+    health:
+      ipv4: 10.244.1.224
+    ingress: {}
+    ipam:
+      podCIDRs:
+      - 10.244.1.0/24
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: "2022-08-03T14:35:11Z"
+    labels:
+      component: apiserver
+      provider: kubernetes
+    name: kubernetes
+    namespace: default
+    resourceVersion: "201"
+    uid: 7763d983-112f-4783-b0d9-1a16109b446e
+  spec:
+    clusterIP: 10.96.0.1
+    clusterIPs:
+    - 10.96.0.1
+    internalTrafficPolicy: Cluster
+    ipFamilies:
+    - IPv4
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 6443
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Endpoints
+  metadata:
+    creationTimestamp: "2022-08-03T14:35:11Z"
+    labels:
+      endpointslice.kubernetes.io/skip-mirror: "true"
+    name: kubernetes
+    namespace: default
+    resourceVersion: "203"
+    uid: b35e2d1a-5baf-41da-963d-5f1686ebde7a
+  subsets:
+  - addresses:
+    - ip: 172.18.0.3
+    ports:
+    - name: https
+      port: 6443
+      protocol: TCP
+- addressType: IPv4
+  apiVersion: discovery.k8s.io/v1
+  endpoints:
+  - addresses:
+    - 172.18.0.3
+    conditions:
+      ready: true
+  kind: EndpointSlice
+  metadata:
+    creationTimestamp: "2022-08-03T14:35:11Z"
+    generation: 1
+    labels:
+      kubernetes.io/service-name: kubernetes
+    name: kubernetes
+    namespace: default
+    resourceVersion: "204"
+    uid: c5bd61b5-5e70-4214-9962-ad689e872d1a
+  ports:
+  - name: https
+    port: 6443
+    protocol: TCP
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.24/state1.yaml
+++ b/test/controlplane/policies/k8s/v1.24/state1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-allow-egress","namespace":"policy1"},"spec":{"egress":[{}],"podSelector":{},"policyTypes":["Egress"]}}
+    creationTimestamp: "2022-08-03T14:36:05Z"
+    generation: 1
+    name: knp-default-allow-egress
+    namespace: policy1
+    resourceVersion: "651"
+    uid: 8a57dce7-0352-4b57-9f4c-9db36b860fa0
+  spec:
+    egress:
+    - {}
+    podSelector: {}
+    policyTypes:
+    - Egress
+  status: {}
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.24/state2.yaml
+++ b/test/controlplane/policies/k8s/v1.24/state2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-allow-ingress","namespace":"policy2"},"spec":{"ingress":[{}],"podSelector":{},"policyTypes":["Ingress"]}}
+    creationTimestamp: "2022-08-03T14:36:05Z"
+    generation: 1
+    name: knp-default-allow-ingress
+    namespace: policy2
+    resourceVersion: "656"
+    uid: eef3bd7b-9da8-4b87-bf68-f99b57333cb8
+  spec:
+    ingress:
+    - {}
+    podSelector: {}
+    policyTypes:
+    - Ingress
+  status: {}
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.24/state3.yaml
+++ b/test/controlplane/policies/k8s/v1.24/state3.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-deny-egress","namespace":"policy3"},"spec":{"podSelector":{},"policyTypes":["Egress"]}}
+    creationTimestamp: "2022-08-03T14:36:06Z"
+    generation: 1
+    name: knp-default-deny-egress
+    namespace: policy3
+    resourceVersion: "660"
+    uid: 4234973e-2ce6-44c3-a9f2-d1a98995836e
+  spec:
+    podSelector: {}
+    policyTypes:
+    - Egress
+  status: {}
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.24/state4.yaml
+++ b/test/controlplane/policies/k8s/v1.24/state4.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-deny-ingress","namespace":"policy4"},"spec":{"podSelector":{},"policyTypes":["Ingress"]}}
+    creationTimestamp: "2022-08-03T14:36:06Z"
+    generation: 1
+    name: knp-default-deny-ingress
+    namespace: policy4
+    resourceVersion: "664"
+    uid: ace041eb-425b-43d9-b063-39b731faadc2
+  spec:
+    podSelector: {}
+    policyTypes:
+    - Ingress
+  status: {}
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/policies/k8s/v1.24/state5.yaml
+++ b/test/controlplane/policies/k8s/v1.24/state5.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"annotations":{},"name":"knp-default-deny-ingress-egress","namespace":"policy5"},"spec":{"podSelector":{},"policyTypes":["Ingress","Egress"]}}
+    creationTimestamp: "2022-08-03T14:36:06Z"
+    generation: 1
+    name: knp-default-deny-ingress-egress
+    namespace: policy5
+    resourceVersion: "668"
+    uid: e9d67774-4f1c-4f5b-85ec-caa6e168f1f9
+  spec:
+    podSelector: {}
+    policyTypes:
+    - Ingress
+    - Egress
+  status: {}
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	k8sTesting "k8s.io/client-go/testing"
 
+	"github.com/cilium/cilium/daemon/cmd"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	fakeCilium "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
@@ -90,6 +91,10 @@ func (cpt *ControlPlaneTest) StartAgent(modConfig func(*option.DaemonConfig)) *C
 	cpt.agentHandle = &agentHandle
 	cpt.Datapath = datapath
 	return cpt
+}
+
+func (cpt *ControlPlaneTest) GetAgent() *cmd.Daemon {
+	return cpt.agentHandle.d
 }
 
 func (cpt *ControlPlaneTest) StopAgent() {


### PR DESCRIPTION
# Description
    
This commit is to make sure that upstream k8s NetworkPolicies are working
as expected. The manifests are from upstream examples.

Signed-off-by: Tam Mach <tam.mach@cilium.io>

## Note

- [x] This is done on top of https://github.com/cilium/cilium/pull/20760, so I will wait for this PR to land in first.
