### PR TITLE
trace: fix unknown dst security identity in to-overlay

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -299,7 +299,7 @@ skip_host_firewall:
 	info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN);
 	if (info != NULL && info->tunnel_endpoint != 0) {
 		ret = encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
-						     info->key, secctx, &trace);
+						     info->key, secctx, info->sec_label, &trace);
 
 		/* If IPSEC is needed recirc through ingress to use xfrm stack
 		 * and then result will routed back through bpf_netdev on egress
@@ -603,7 +603,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 			if (eth_store_daddr(ctx, (__u8 *)&vtep->vtep_mac, 0) < 0)
 				return DROP_WRITE_ERROR;
 			return __encap_and_redirect_with_nodeid(ctx, vtep->tunnel_endpoint,
-								secctx, WORLD_ID, &trace);
+								secctx, WORLD_ID, WORLD_ID, &trace);
 		}
 	}
 skip_vtep:
@@ -613,7 +613,7 @@ skip_vtep:
 	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
 	if (info != NULL && info->tunnel_endpoint != 0) {
 		ret = encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
-						     info->key, secctx, &trace);
+						     info->key, secctx, info->sec_label, &trace);
 
 		if (ret == IPSEC_ENDPOINT)
 			return CTX_ACT_OK;
@@ -892,7 +892,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 
 	bpf_clear_meta(ctx);
 	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, src_id,
-						NOT_VTEP_DST, &trace);
+						0, NOT_VTEP_DST, &trace);
 }
 
 static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto __maybe_unused,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -509,7 +509,7 @@ ct_recreate6:
 		 * (c) packet was redirected to tunnel device so return.
 		 */
 		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
-					     &key, SECLABEL, &trace);
+					     &key, SECLABEL, *dst_id, &trace);
 		if (ret == IPSEC_ENDPOINT)
 			goto encrypt_to_stack;
 		else if (ret != DROP_NO_TUNNEL_ENDPOINT)
@@ -1034,7 +1034,7 @@ ct_recreate4:
 		 * node through a tunnel.
 		 */
 		ret = encap_and_redirect_lxc(ctx, egress_gw_policy->gateway_ip, encrypt_key,
-					     &key, SECLABEL, &trace);
+					     &key, SECLABEL, *dst_id, &trace);
 		if (ret == IPSEC_ENDPOINT)
 			goto encrypt_to_stack;
 		else
@@ -1062,7 +1062,8 @@ skip_egress_gateway:
 			if (eth_store_daddr(ctx, (__u8 *)&vtep->vtep_mac, 0) < 0)
 				return DROP_WRITE_ERROR;
 			return __encap_and_redirect_with_nodeid(ctx, vtep->tunnel_endpoint,
-								SECLABEL, WORLD_ID, &trace);
+								SECLABEL, WORLD_ID,
+								WORLD_ID, &trace);
 		}
 	}
 skip_vtep:
@@ -1082,7 +1083,7 @@ skip_vtep:
 		key.family = ENDPOINT_KEY_IPV4;
 
 		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
-					     &key, SECLABEL, &trace);
+					     &key, SECLABEL, *dst_id, &trace);
 		if (ret == DROP_NO_TUNNEL_ENDPOINT)
 			goto pass_to_stack;
 		/* If not redirected noteably due to IPSEC then pass up to stack

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -382,7 +382,8 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 	if (info->tunnel_endpoint)
 		return __encap_and_redirect_with_nodeid(ctx,
 							info->tunnel_endpoint,
-							SECLABEL,
+							LOCAL_NODE_ID,
+							WORLD_ID,
 							WORLD_ID,
 							&trace);
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -651,6 +651,7 @@ int tail_nodeport_nat_ipv6_egress(struct __ctx_buff *ctx)
 	if (info && info->tunnel_endpoint != 0) {
 		ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 					  WORLD_ID,
+					  info->sec_label,
 					  NOT_VTEP_DST,
 					  (enum trace_reason)CT_NEW,
 					  TRACE_PAYLOAD_LEN);
@@ -949,6 +950,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex
 			if (info != NULL && info->tunnel_endpoint != 0) {
 				ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 							  SECLABEL,
+							  info->sec_label,
 							  NOT_VTEP_DST,
 							  TRACE_REASON_CT_REPLY,
 							  TRACE_PAYLOAD_LEN);
@@ -1734,6 +1736,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 		 */
 		ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 					  WORLD_ID,
+					  info->sec_label,
 					  NOT_VTEP_DST,
 					  (enum trace_reason)CT_NEW,
 					  TRACE_PAYLOAD_LEN);
@@ -1999,6 +2002,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 	__u32 monitor = TRACE_PAYLOAD_LEN;
 	bool l2_hdr_required = true;
 	__u32 tunnel_endpoint __maybe_unused = 0;
+	__u32 dst_id __maybe_unused = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -2035,6 +2039,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 			info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
 			if (info && info->tunnel_endpoint != 0) {
 				tunnel_endpoint = info->tunnel_endpoint;
+				dst_id = info->sec_label;
 				goto encap_redirect;
 			}
 		}
@@ -2064,6 +2069,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 			info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
 			if (info != NULL && info->tunnel_endpoint != 0) {
 				tunnel_endpoint = info->tunnel_endpoint;
+				dst_id = info->sec_label;
 				goto encap_redirect;
 			}
 		}
@@ -2141,8 +2147,8 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex
 #if (defined(ENABLE_EGRESS_GATEWAY) || defined(TUNNEL_MODE)) && \
 	__ctx_is != __ctx_xdp
 encap_redirect:
-	ret = __encap_with_nodeid(ctx, tunnel_endpoint, SECLABEL, NOT_VTEP_DST,
-				  reason, monitor);
+	ret = __encap_with_nodeid(ctx, tunnel_endpoint, SECLABEL, dst_id,
+				  NOT_VTEP_DST, reason, monitor);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
Reported in https://github.com/cilium/cilium/issues/20169
send_trace_notify() in __encap_with_nodeid() set destination
security identity to unknown and result in trace log below:

to-overlay: ...SNIP... interface cilium_vxlan, , identity 83809->unknown,

now after the fix

to-overlay: ...SNIP... interface cilium_vxlan, , identity 83809->126447,

Fix: #20169

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #20169

```release-note
trace: fix unknown dst security identity in to-overlay
```
