### PR TITLE
bpf: grow verifier log buffer to 10MiB to prevent truncation

### DIFF
--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -108,11 +108,8 @@ func LoadCollection(spec *ebpf.CollectionSpec, opts ebpf.CollectionOptions) (*eb
 		return nil, errors.New("can't load nil CollectionSpec")
 	}
 
-	// By default, allocate a 1MiB verifier log buffer if first load attempt
-	// fails. This was adjusted around Cilium 1.11 for fitting bpf_lxc insn
-	// limit messages.
 	if opts.Programs.LogSize == 0 {
-		opts.Programs.LogSize = 1 << 20
+		opts.Programs.LogSize = 10_000_000
 	}
 
 	// Copy spec so the modifications below don't affect the input parameter,

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -119,6 +119,11 @@ func replaceDatapath(ctx context.Context, ifName, objPath, progName, direction s
 		l.Debug("Retrying loading Collection into kernel after map migration")
 		coll, err = bpf.LoadCollection(spec, opts)
 	}
+	var ve *ebpf.VerifierError
+	if errors.As(err, &ve) {
+		//TODO: Write this to a file in endpoint directory instead.
+		l.Debugf("Got verifier error: %+v", ve)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("error loading eBPF collection into the kernel: %w", err)
 	}


### PR DESCRIPTION
Just having seen a 4,6MB log from a bpf_host complexity issue, I started work on automatically growing the log buffer instead of hardcoding a size here, but hit a small bug in the lib. A possible solution is out, but still needs review: https://github.com/cilium/ebpf/pull/756.

Grow the buffer to 10MiB to at least get access to the full contents so a correct summary is generated.

Fixes: #20738

~@pchaigno This should unblock https://github.com/cilium/cilium/pull/18694 for now, but you'll still need to print the verifier error with `%+v` locally if you want to see it in full.~ Verifier logs are now logged as debug. A follow-up PR will write the buffer to a file in the endpoint dir so we can retrieve them from sysdumps.

```release-note
Allocate 10MiB verifier buffer to prevent truncation
```
