### PR TITLE
datapath: avoid delete/add flap for cilium_vxlan on startup

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2973,6 +2973,9 @@ func (c *DaemonConfig) Populate() {
 
 	if c.TunnelPort == 0 {
 		switch c.Tunnel {
+		case TunnelDisabled:
+			// tunnel might still be used by eg. EgressGW
+			c.TunnelPort = defaults.TunnelPortVXLAN
 		case TunnelVXLAN:
 			c.TunnelPort = defaults.TunnelPortVXLAN
 		case TunnelGeneve:


### PR DESCRIPTION
In a configuration with EgressGW and direct-routing, cilium still uses a
cilium_vxlan interface to transport the EgressGW traffic between source
nodes and Gateway nodes.

If no --tunnel-port is configured we stick to the default value (0) instead
of using the VXLAN default port (8472), and when bpf/init.sh later tries to
create the interface with port 0 the kernel simply falls back to using
port 8472 instead.

But if cilium_vxlan already exists from a previous run, the corresponding
check in bpf/init.sh fails (as we look for dstport 0, but find cilium_vxlan
with dstport 8472). So we delete the interface, just to add it again in the
same effective configuration.

Avoid the overhead (and flapping ifindex) by initializing c.TunnelPort with
the VXLAN port, even when the user didn't select tunneling mode.

Fixes: 030077272e9c ("datapath: Add a flag to set VXLAN and Geneve ports")
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>

```release-note
For configurations with Egress Gateway and Direct-Routing, avoid recreating the cilium_vxlan interface on every restart.
```
