### PR TITLE
policy: Add type check to avoid panic

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -825,8 +825,8 @@ func (e *Endpoint) UpdateNoTrackRules(annoCB AnnotationsResolverCB) {
 	}
 
 	updateRes := <-ch
-	regenResult := updateRes.(*EndpointRegenerationResult)
-	if regenResult.err != nil {
+	regenResult, ok := updateRes.(*EndpointRegenerationResult)
+	if ok && regenResult.err != nil {
 		e.getLogger().WithError(regenResult.err).Error("EndpointNoTrackEvent event failed")
 	}
 }
@@ -847,8 +847,8 @@ func (e *Endpoint) UpdateVisibilityPolicy(annoCB AnnotationsResolverCB) {
 	}
 
 	updateRes := <-ch
-	regenResult := updateRes.(*EndpointRegenerationResult)
-	if regenResult.err != nil {
+	regenResult, ok := updateRes.(*EndpointRegenerationResult)
+	if ok && regenResult.err != nil {
 		e.getLogger().WithError(regenResult.err).Error("EndpointPolicyVisibilityEvent event failed")
 	}
 }
@@ -866,8 +866,8 @@ func (e *Endpoint) UpdateBandwidthPolicy(annoCB AnnotationsResolverCB) {
 	}
 
 	updateRes := <-ch
-	regenResult := updateRes.(*EndpointRegenerationResult)
-	if regenResult.err != nil {
+	regenResult, ok := updateRes.(*EndpointRegenerationResult)
+	if ok && regenResult.err != nil {
 		e.getLogger().WithError(regenResult.err).Error("EndpointPolicyBandwidthEvent event failed")
 	}
 }


### PR DESCRIPTION
This commit is to avoid the above panic in cilium, one of the scenario
could be that Event Queue channel is draining and closing while there
is one enqueuing attempt. Hence, it's better to add the type check
reading from event queue.

```
2022-08-04T10:28:40.671198616Z level=debug msg="Preparing to compile BPF" containerID=a32b452c7f datapathPolicyRevision=0 desiredPolicyRevision=1 endpointID=892 identity=24329 ipv4=10.0.0.244 ipv6="fd02::3c" k8sPodName=cilium-monitoring/prometheus-5c59d656f5-n6jt7 regeneration-level=rewrite+load subsys=endpoint
2022-08-04T10:28:40.678959713Z panic: interface conversion: interface {} is nil, not *endpoint.EndpointRegenerationResult
2022-08-04T10:28:40.679010841Z 
2022-08-04T10:28:40.679258530Z goroutine 332 [running]:
2022-08-04T10:28:40.679420447Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).UpdateVisibilityPolicy(0xc000acd180, 0xc001719620)
2022-08-04T10:28:40.679599044Z  /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:850 +0x426
2022-08-04T10:28:40.679789544Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).RunMetadataResolver.func2({0x34af2f0, 0xc001066840})
2022-08-04T10:28:40.679952198Z  /go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1603 +0x3cb
2022-08-04T10:28:40.680051632Z github.com/cilium/cilium/pkg/controller.(*Controller).runController(0xc0004126c0)
2022-08-04T10:28:40.680213852Z  /go/src/github.com/cilium/cilium/pkg/controller/controller.go:206 +0x1bb
2022-08-04T10:28:40.680335727Z created by github.com/cilium/cilium/pkg/controller.(*Manager).updateController
2022-08-04T10:28:40.680540502Z  /go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0xb45
```

Related: 0161dc4a32b0cdf04ae952347237d6f61cb16ca1
Co-authored-by: Tobias Klauser <tobias.klauser@gmail.com>
Signed-off-by: Tam Mach <tam.mach@cilium.io>

