### PR TITLE
ci: use a script for check-preflight-clusterrole.sh

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -54,15 +54,7 @@ jobs:
           persist-credentials: false
 
       - name: Check pre-flight clusterrole
-        run: |
-          cd install/kubernetes/cilium/templates
-          echo "Checking for differences between preflight and agent clusterrole"
-          diff \
-             -I '^[ ]\{2\}name: cilium.*' \
-             -I '^Keep file in sync with.*' \
-             -I '{{- if.*' \
-             cilium-agent/clusterrole.yaml \
-             cilium-preflight/clusterrole.yaml
+        run: make check-k8s-clusterrole
 
   helm-charts:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -424,6 +424,9 @@ generate-k8s-api: ## Generate Cilium k8s API client, deepcopy and deepequal Go s
 	pkg:tuple\
 	pkg:recorder")
 
+check-k8s-clusterrole: ## Ensures there is no diff between preflight's clusterrole and runtime's clusterrole.
+	./contrib/scripts/check-preflight-clusterrole.sh
+
 ##@ Development
 vps: ## List all the running vagrant VMs.
 	VBoxManage list runningvms

--- a/contrib/scripts/check-preflight-clusterrole.sh
+++ b/contrib/scripts/check-preflight-clusterrole.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cd install/kubernetes/cilium/templates
+echo "Checking for differences between preflight and agent clusterrole"
+diff=$(diff \
+ -I '^[ ]\{2\}name: cilium.*' \
+ -I '^Keep file in sync with.*' \
+ -I '{{- if.*' \
+ cilium-agent/clusterrole.yaml \
+ cilium-preflight/clusterrole.yaml)
+
+if [ -n "$diff" ]; then
+	echo "A diff exists between cilium-agent/clusterrole.yaml and cilium-preflight/clusterrole.yaml"
+    echo ""
+	echo "$diff"
+    echo ""
+	echo "Please ensure both files are the same."
+	exit 1
+fi
+echo "cilium-agent/clusterrole.yaml and cilium-preflight/clusterrole.yaml clusterroles are in in sync"


### PR DESCRIPTION
it's not convenient to have inline scripts in github actions, as we
can't run the actions which fail a CI run, locally.

this commit moves the clusterrole preflight check into a script that can
be ran locally before pushing the branch up.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>

```release-note
Move the clusterrole precheck inline script to one that can be ran locally.
```
