### PR TITLE
agent: Stop serving DNS before shutdown

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -836,6 +836,11 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup, epMgr *endpointmanag
 		bootstrapStats.fqdn.EndError(err)
 		return nil, restoredEndpoints, err
 	}
+	// This is done in preCleanup so that proxy stops serving DNS traffic before shutdown
+	cleaner.preCleanupFuncs.Add(func() {
+		proxy.DefaultDNSProxy.Cleanup()
+	})
+
 	bootstrapStats.fqdn.End(true)
 
 	if k8s.IsEnabled() {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -452,6 +452,12 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		EnableIPv4, EnableIPv6 = option.Config.EnableIPv4, option.Config.EnableIPv6
 	)
 
+	// Bind the DNS forwarding clients on UDP and TCP
+	// Note: SingleInFlight should remain disabled. When enabled it folds DNS
+	// retries into the previous lookup, suppressing them.
+	p.UDPClient = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: false}
+	p.TCPClient = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: false}
+
 	start := time.Now()
 	for time.Since(start) < ProxyBindTimeout {
 		UDPConn, TCPListener, err = bindToAddr(address, port, EnableIPv4, EnableIPv6)
@@ -487,12 +493,6 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 			log.Fatalf("Failed to start %s DNS Proxy on %s", server.Net, server.Addr)
 		}(s)
 	}
-
-	// Bind the DNS forwarding clients on UDP and TCP
-	// Note: SingleInFlight should remain disabled. When enabled it folds DNS
-	// retries into the previous lookup, suppressing them.
-	p.UDPClient = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: false}
-	p.TCPClient = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: false}
 
 	return p, nil
 }

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -16,6 +16,7 @@ type DNSProxier interface {
 	GetBindPort() uint16
 	SetRejectReply(string)
 	RestoreRules(op *endpoint.Endpoint)
+	Cleanup()
 }
 
 type MockFQDNProxy struct{}
@@ -41,5 +42,9 @@ func (m MockFQDNProxy) SetRejectReply(s string) {
 }
 
 func (m MockFQDNProxy) RestoreRules(op *endpoint.Endpoint) {
+	return
+}
+
+func (m MockFQDNProxy) Cleanup() {
 	return
 }


### PR DESCRIPTION
This PR affects DNS proxy startup, as we have started proxy without populating proxy DNS clients which might have caused some DNS messages to get to proxy before it had DNS clients set.

 It also adds a cleanup step that causes the proxy to unbind from the socket so that it doesn't get served DNS traffic while it's shutting down. This should decrease amount of in-flight DNS messages that are lost because proxy is being shut down.

```release-note
dnsproxy: stop serving DNS traffic before agent shutdown
```
