### PR TITLE
Warn if a node contains multiple IP addresses of the same Kuberentes address type

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -337,6 +337,9 @@ const (
 	// Tunnel is the tunnel name
 	Tunnel = "tunnel"
 
+	// Type is the address type
+	Type = "type"
+
 	// Selector is a selector of any sort: endpoint, CIDR, toFQDNs
 	Selector = "Selector"
 


### PR DESCRIPTION
### Description
This PR is made to handle when K8s Nodes have more than one IP address per address type in their status field.

Fixes: #20787
```release-note
Warn if a node contains multiple IP addresses of the same Kuberentes address type
```
