### PR TITLE
ingress: add websockets configuration

### DIFF
--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -16,6 +16,7 @@ const (
 	TCPKeepAliveIdleAnnotation             = annotation.Prefix + "/tcp-keep-alive-idle"
 	TCPKeepAliveProbeIntervalAnnotation    = annotation.Prefix + "/tcp-keep-alive-probe-interval"
 	TCPKeepAliveProbeMaxFailuresAnnotation = annotation.Prefix + "/tcp-keep-alive-probe-max-failures"
+	WebsocketEnabledAnnotation             = annotation.Prefix + "/websocket"
 )
 
 const (
@@ -24,9 +25,10 @@ const (
 	defaultTCPKeepAliveInitialIdle   = 10 // in seconds
 	defaultTCPKeepAliveProbeInterval = 5  // in seconds
 	defaultTCPKeepAliveMaxProbeCount = 10
+	defaultWebsocketEnabled          = 0 // 1 - Enabled, 0 - Disabled
 )
 
-// GetAnnotationTCPKeepAliveEnabled returns 1 if enabled (default), 0 if disable
+// GetAnnotationTCPKeepAliveEnabled returns 1 if enabled (default), 0 if disabled
 func GetAnnotationTCPKeepAliveEnabled(ingress *slim_networkingv1.Ingress) int64 {
 	val, exists := ingress.GetAnnotations()[TCPKeepAliveEnabledAnnotation]
 	if !exists {
@@ -70,7 +72,7 @@ func GetAnnotationTCPKeepAliveProbeInterval(ingress *slim_networkingv1.Ingress) 
 	return intVal
 }
 
-// GetAnnotationTCPKeepAliveProbeMaxFailures return he maximum number of keepalive probes TCP
+// GetAnnotationTCPKeepAliveProbeMaxFailures returns the maximum number of keepalive probes TCP
 // should send before dropping the connection. Defaults to 10.
 // Related references:
 // 	- https://man7.org/linux/man-pages/man7/tcp.7.html
@@ -84,4 +86,16 @@ func GetAnnotationTCPKeepAliveProbeMaxFailures(ingress *slim_networkingv1.Ingres
 		return defaultTCPKeepAliveMaxProbeCount
 	}
 	return intVal
+}
+
+// GetAnnotationWebsocketEnabled returns 1 if enabled (default), 0 if disabled
+func GetAnnotationWebsocketEnabled(ingress *slim_networkingv1.Ingress) int64 {
+	val, exists := ingress.GetAnnotations()[WebsocketEnabledAnnotation]
+	if !exists {
+		return defaultWebsocketEnabled
+	}
+	if val == enabled {
+		return 1
+	}
+	return 0
 }

--- a/operator/pkg/ingress/ingress_test.go
+++ b/operator/pkg/ingress/ingress_test.go
@@ -14,9 +14,10 @@ var exactPathType = slim_networkingv1.PathTypeExact
 
 var baseIngress = &slim_networkingv1.Ingress{
 	ObjectMeta: slim_metav1.ObjectMeta{
-		Name:      "dummy-ingress",
-		Namespace: "dummy-namespace",
-		UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+		Name:        "dummy-ingress",
+		Namespace:   "dummy-namespace",
+		Annotations: map[string]string{},
+		UID:         "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
 	},
 	Spec: slim_networkingv1.IngressSpec{
 		IngressClassName: stringp("cilium"),


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible. -> Does this need to be tested? I feel like this is an Envoy thing.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Some popular web software (e.x. Jupyterhub, Home Assistant) requires websocket support from the ingress. This commit provides an annotation to enable this support in Envoy. It is disabled by default.

Fixes: #20427