### PR TITLE
pkg/bgpv1/gobgp: Optimize reconcileDiff String()

### DIFF
--- a/pkg/bgpv1/gobgp/workdiff.go
+++ b/pkg/bgpv1/gobgp/workdiff.go
@@ -5,6 +5,8 @@ package gobgp
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -61,11 +63,41 @@ func (wd *reconcileDiff) diff(m LocalASNMap, policy *v2alpha1api.CiliumBGPPeerin
 
 // String provides a string representation of the reconcileDiff.
 func (wd *reconcileDiff) String() string {
-	return fmt.Sprintf("Registering: %v Withdrawing: %v Reconciling: %v",
-		wd.register,
-		wd.withdraw,
-		wd.reconcile,
-	)
+	var register, withdraw, reconcile strings.Builder
+	// The length of register will be len(wd.register) + 2 + len(wd.register) - 1
+	// e.g wd.register := []int{1,2,3,4}, then the length of register will be
+	// len([]int{1,2,3,4}) + len("[]") + len("[]string{" ", " ", " "}") like "[1 2 3 4]"
+	register.Grow(1 + 2*len(wd.register))
+	register.WriteRune('[')
+	for i, r := range wd.register {
+		if i != 0 {
+			register.WriteRune(' ')
+		}
+		register.WriteString(strconv.Itoa(r))
+	}
+	register.WriteRune(']')
+
+	withdraw.Grow(1 + 2*len(wd.withdraw))
+	withdraw.WriteRune('[')
+	for i, r := range wd.withdraw {
+		if i != 0 {
+			withdraw.WriteRune(' ')
+		}
+		withdraw.WriteString(strconv.Itoa(r))
+	}
+	withdraw.WriteRune(']')
+
+	reconcile.Grow(1 + 2*len(wd.reconcile))
+	reconcile.WriteRune('[')
+	for i, r := range wd.reconcile {
+		if i != 0 {
+			reconcile.WriteRune(' ')
+		}
+		reconcile.WriteString(strconv.Itoa(r))
+	}
+	reconcile.WriteRune(']')
+
+	return "Registering: " + register.String() + " Withdrawing: " + withdraw.String() + " Reconciling: " + reconcile.String()
 }
 
 // empty informs the caller whether the reconcileDiff contains any work to undertake.

--- a/pkg/bgpv1/gobgp/workdiff_test.go
+++ b/pkg/bgpv1/gobgp/workdiff_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+//go:build !privileged_tests
+
+package gobgp
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+)
+
+func BenchmarkReconcileDiffString(b *testing.B) {
+	r := &reconcileDiff{
+		seen:      make(map[int]*v2alpha1api.CiliumBGPVirtualRouter),
+		state:     &agent.ControlPlaneState{},
+		register:  []int{1, 2, 3},
+		withdraw:  []int{4, 5, 6, 7, 8},
+		reconcile: []int{11, 12, 13, 14, 15, 16},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.String()
+	}
+}


### PR DESCRIPTION
Avoiding to use  fmt.Sprintf() so that Go won't over-allocate the memory.

issue reference : cilium#19571

Result:

```
$ go test -benchmem -run=^$ -bench ^BenchmarkReconcileDiffString$ github.com/cilium/cilium/pkg/bgpv1/gobgp > BenchmarkReconcileDiffString_old.txt
$ go test -benchmem -run=^$ -bench ^BenchmarkReconcileDiffString$ github.com/cilium/cilium/pkg/bgpv1/gobgp > BenchmarkReconcileDiffString_new.txt
$ benchcmp  BenchmarkReconcileDiffString_old.txt BenchmarkReconcileDiffString_new.txt
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                           old ns/op     new ns/op     delta
BenchmarkReconcileDiffString-12     1592          350           -78.01%

benchmark                           old allocs     new allocs     delta
BenchmarkReconcileDiffString-12     18             5              -72.22%

benchmark                           old bytes     new bytes     delta
BenchmarkReconcileDiffString-12     264           152           -42.42%
```

Signed-off-by: MikeLing <sabergeass@gmail.com>
