### PR TITLE
pkg/bgpv1/annotations: Optimize annotations Errors

### DIFF
--- a/pkg/bgpv1/annotations.go
+++ b/pkg/bgpv1/annotations.go
@@ -5,7 +5,6 @@ package bgpv1
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"net"
 	"strconv"
@@ -23,7 +22,7 @@ type ErrNotVRouterAnno struct {
 }
 
 func (e ErrNotVRouterAnno) Error() string {
-	return fmt.Sprintf("annotation %v is not a valid cilium.io/bgp-virtual-router annotation", e.a)
+	return "annotation " + e.a + " is not a valid cilium.io/bgp-virtual-router annotation"
 }
 
 // ErrNoASNAnno is an error returned from parseAnnotation() when the bgp-virtual-router
@@ -33,19 +32,19 @@ type ErrNoASNAnno struct {
 }
 
 func (e ErrNoASNAnno) Error() string {
-	return fmt.Sprintf("annotation %v provides no asn", e.a)
+	return "annotation " + e.a + " provides no asn"
 }
 
 // ErrASN is an error returned from parseAnnotation() when the bgp-virtual-router
 // annotation includes an ASN that cannot be parsed into an
 type ErrASNAnno struct {
-	err  error
+	err  string
 	asn  string
 	anno string
 }
 
 func (e ErrASNAnno) Error() string {
-	return fmt.Sprintf("ASN %v in annotation %v cannot be parsed into integer: %v", e.asn, e.anno, e.err)
+	return "ASN" + e.asn + " in annotation " + e.anno + " cannot be parsed into integer: " + e.err
 }
 
 // ErrAttrib is an error returned from parseAnnotation() when an attribute is
@@ -57,7 +56,7 @@ type ErrAttrib struct {
 }
 
 func (e ErrAttrib) Error() string {
-	return fmt.Sprintf("annotation %v failed to parse attribute %v: %v", e.anno, e.attr, e.err)
+	return "annotation " + e.anno + " failed to parse attribute " + e.attr + ":" + e.err
 }
 
 // The BGP control plane may need some node-specific configuration for

--- a/pkg/bgpv1/annotations_test.go
+++ b/pkg/bgpv1/annotations_test.go
@@ -5,7 +5,9 @@
 
 package bgpv1
 
-import "testing"
+import (
+	"testing"
+)
 
 // TestAnnotation performs a series of unit tests ensuring the parsing of
 // annotations works correctly.
@@ -49,5 +51,40 @@ func TestAnnotation(t *testing.T) {
 				t.Fatalf("got: %v, want: %v", err, tt.error)
 			}
 		})
+	}
+}
+
+func BenchmarkErrNotVRouterAnnoError(b *testing.B) {
+	e := &ErrNotVRouterAnno{
+		a: "foo error",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = e.Error()
+	}
+}
+
+func BenchmarkErrErrNoASNAnno(b *testing.B) {
+	e := &ErrNoASNAnno{
+		a: "foo error",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = e.Error()
+	}
+}
+
+func BenchmarkErrASNAnno(b *testing.B) {
+	e := &ErrASNAnno{
+		err:  "foo error",
+		asn:  "foo asn",
+		anno: "foo anno",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = e.Error()
 	}
 }


### PR DESCRIPTION
Avoiding to use  fmt.Sprintf() so that Go won't over-allocate the memory.

issue reference : cilium#19571

Result:

```
$ go test -v -benchmem -run=^$ -bench 'BenchmarkErrNotVRouterAnnoError' github.com/cilium/cilium/pkg/bgpv1 > BenchmarkErrNotVRouterAnnoError_old.txt
$ go test -v -benchmem -run=^$ -bench 'BenchmarkErrErrNoASNAnno' github.com/cilium/cilium/pkg/bgpv1 > BenchmarkErrErrNoASNAnno_old.txt
$ go test -v -benchmem -run=^$ -bench 'BenchmarkErrASNAnno' github.com/cilium/cilium/pkg/bgpv1 > BenchmarkErrASNAnno_old.txt
$ go test -v -benchmem -run=^$ -bench 'BenchmarkErrNotVRouterAnnoError' github.com/cilium/cilium/pkg/bgpv1 > BenchmarkErrNotVRouterAnnoError_new.txt
$ go test -v -benchmem -run=^$ -bench 'BenchmarkErrErrNoASNAnno' github.com/cilium/cilium/pkg/bgpv1 > BenchmarkErrErrNoASNAnno_new.txt
$ go test -v -benchmem -run=^$ -bench 'BenchmarkErrASNAnno' github.com/cilium/cilium/pkg/bgpv1 > BenchmarkErrASNAnno_new.txt
$ benchcmp BenchmarkErrNotVRouterAnnoError_old.txt BenchmarkErrNotVRouterAnnoError_new.txt
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                              old ns/op     new ns/op     delta
BenchmarkErrNotVRouterAnnoError-12     186           47.2          -74.67%

benchmark                              old allocs     new allocs     delta
BenchmarkErrNotVRouterAnnoError-12     2              1              -50.00%

benchmark                              old bytes     new bytes     delta
BenchmarkErrNotVRouterAnnoError-12     96            80            -16.67%
$ benchcmp BenchmarkErrErrNoASNAnno_old.txt BenchmarkErrErrNoASNAnno_new.txt
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                       old ns/op     new ns/op     delta
BenchmarkErrErrNoASNAnno-12     143           45.0          -68.49%

benchmark                       old allocs     new allocs     delta
BenchmarkErrErrNoASNAnno-12     2              1              -50.00%

benchmark                       old bytes     new bytes     delta
$ benchcmp BenchmarkErrASNAnno_old.txt BenchmarkErrASNAnno_new.txt
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                  old ns/op     new ns/op     delta
BenchmarkErrASNAnno-12     252           61.6          -75.59%

benchmark                  old allocs     new allocs     delta
BenchmarkErrASNAnno-12     3              1              -66.67%

benchmark                  old bytes     new bytes     delta
BenchmarkErrASNAnno-12     112           80            -28.57%
```

Signed-off-by: MikeLing <sabergeass@gmail.com>