### PR TITLE
Object namespace for overriding the namespace in the helm chart added

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -132,3 +132,14 @@ and `commonCASecretName` variables.
     {{- $_ := set (set . "commonCA" $ca) "commonCASecretName" $secretName -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+overridde the release namespace for multi-namespace deployments in combined charts.
+*/}}
+{{- define "cilium.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -15,7 +15,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cilium
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: cilium
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/name: cilium-agent
     {{- if .Values.keepDeprecatedLabels }}
     kubernetes.io/cluster-service: "true"
-    {{- if and .Values.gke.enabled (eq .Release.Namespace "kube-system" ) }}
+    {{- if and .Values.gke.enabled (eq cilium.namespace "kube-system" ) }}
       {{- fail "Invalid configuration: Installing Cilium on GKE with 'kubernetes.io/cluster-service' labels on 'kube-system' namespace causes Cilium DaemonSet to be removed by GKE. Either install Cilium on a different Namespace or install with '--set keepDeprecatedLabels=false'" }}
     {{- end }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
@@ -11,5 +11,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccounts.cilium.name | quote }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ cilium.namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cilium-agent
-  namespace: {{ .Release.Namespace }}
+  namespace: {{cilium.namespace }}
   labels:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-agent
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cilium-agent
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.proxy.prometheus.port | quote }}

--- a/install/kubernetes/cilium/templates/cilium-agent/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   {{- if .Values.serviceAccounts.cilium.annotations }}
   annotations:
     {{- toYaml .Values.serviceAccounts.cilium.annotations | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: cilium-agent
-  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default cilium.namespace }}
   labels:
     app.kubernetes.io/part-of: cilium
     {{- with .Values.prometheus.serviceMonitor.labels }}
@@ -20,7 +20,7 @@ spec:
       k8s-app: cilium
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ cilium.namespace }}
   endpoints:
   - port: metrics
     interval: {{ .Values.prometheus.serviceMonitor.interval | quote }}

--- a/install/kubernetes/cilium/templates/cilium-ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ca-secret.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .commonCASecretName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   ca.crt: {{ .commonCA.Cert | b64enc }}
   ca.key: {{ .commonCA.Key  | b64enc }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -62,7 +62,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cilium-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
 {{- if .Values.etcd.enabled }}
   # The kvstore configuration is used to enable use of a kvstore for state
@@ -81,7 +81,7 @@ data:
     ---
     endpoints:
       {{- if .Values.etcd.managed }}
-      - https://cilium-etcd-client.{{ .Release.Namespace }}.svc:2379
+      - https://cilium-etcd-client.{{ cilium.namespace }}.svc:2379
       {{- else }}
       {{- range .Values.etcd.endpoints }}
       - {{ . }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -4,7 +4,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: cilium-node-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     app: cilium-node-init
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.operator.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cilium-operator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     io.cilium/app: operator
     name: cilium-operator

--- a/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: cilium-operator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     io.cilium/app: operator
     name: cilium-operator

--- a/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
@@ -11,5 +11,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccounts.operator.name | quote }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ cilium.namespacece }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cilium-azure
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: Opaque
 data:
   AZURE_CLIENT_ID: {{ default "" .Values.azure.clientID | b64enc | quote }}

--- a/install/kubernetes/cilium/templates/cilium-operator/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: cilium-operator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     io.cilium/app: operator
     name: cilium-operator

--- a/install/kubernetes/cilium/templates/cilium-operator/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/serviceaccount.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.operator.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   {{- if .Values.serviceAccounts.operator.annotations }}
   annotations:
     {{- toYaml .Values.serviceAccounts.operator.annotations | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: cilium-operator
-  namespace: {{ .Values.operator.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.operator.prometheus.serviceMonitor.namespace | default cilium.namespace }}
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
@@ -21,7 +21,7 @@ spec:
       name: cilium-operator
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ cilium.namespace }}
   endpoints:
   - port: metrics
     interval: {{ .Values.operator.prometheus.serviceMonitor.interval | quote }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.preflight.name | quote }} 
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cilium-pre-flight-check
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   selector:
     matchLabels:

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cilium-pre-flight-check
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-pre-flight-check

--- a/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: cilium-pre-flight-check
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: cilium-pre-flight-check-deployment
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/cilium-preflight/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.preflight.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   {{- if .Values.serviceAccounts.preflight.annotations }}
   annotations:
     {{ toYaml .Values.serviceAccounts.preflight.annotations | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
+++ b/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
@@ -1,10 +1,10 @@
-{{- if or .Values.resourceQuotas.enabled (and (ne .Release.Namespace "kube-system") .Values.gke.enabled) }}
+{{- if or .Values.resourceQuotas.enabled (and (ne cilium.namespace "kube-system") .Values.gke.enabled) }}
 {{- if .Values.agent }}
 apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: cilium-resource-quota
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   hard:
     pods: {{ .Values.resourceQuotas.cilium.hard.pods | quote }}
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: cilium-operator-resource-quota
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   hard:
     pods: {{ .Values.resourceQuotas.operator.hard.pods | quote }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: clustermesh-apiserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: clustermesh-apiserver
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: clustermesh-apiserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: clustermesh-apiserver
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: clustermesh-apiserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: clustermesh-apiserver
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   {{- with .Values.serviceAccounts.clustermeshApiserver.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: clustermesh-apiserver-admin-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   issuerRef:
     {{- include "clustermesh-apiserver-generate-certs.certmanager.issuer" . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: clustermesh-apiserver-client-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   issuerRef:
     {{- include "clustermesh-apiserver-generate-certs.certmanager.issuer" . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/clustermesh-apiserver-issuer.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/clustermesh-apiserver-issuer.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-ca-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   ca.crt: {{ .cmca.Cert | b64enc }}
   ca.key: {{ .cmca.Key  | b64enc }}
@@ -14,7 +14,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: clustermesh-apiserver-issuer
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   ca:
     secretName: clustermesh-apiserver-ca-cert

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: clustermesh-apiserver-remote-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   issuerRef:
     {{- include "clustermesh-apiserver-generate-certs.certmanager.issuer" . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: clustermesh-apiserver-server-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   issuerRef:
     {{- include "clustermesh-apiserver-generate-certs.certmanager.issuer" . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/ca-secret.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-ca-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   ca.crt: {{ $crt }}
   ca.key: {{ $key }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: clustermesh-apiserver-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: clustermesh-apiserver-generate-certs
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
@@ -13,7 +13,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: clustermesh-apiserver-generate-certs-{{$checkSum}}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: clustermesh-apiserver-generate-certs
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/role.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: clustermesh-apiserver-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 rules:
   - apiGroups:
       - ""

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: clustermesh-apiserver-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -11,5 +11,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace}}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   {{- with .Values.serviceAccounts.clustermeshcertgen.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-admin-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .cmca.Cert | b64enc }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/ca-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-ca-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   ca.crt: {{ .cmca.Cert | b64enc }}
   ca.key: {{ .cmca.Key  | b64enc }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/client-secret.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-client-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .cmca.Cert | b64enc }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-remote-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .cmca.Cert | b64enc }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-server-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .cmca.Cert | b64enc }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/admin-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-admin-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt: {{ .Values.clustermesh.apiserver.tls.ca.cert }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/ca-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-ca-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   ca.crt: {{ .Values.clustermesh.apiserver.tls.ca.cert }}
   {{- if .Values.clustermesh.apiserver.tls.ca.key }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/client-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-client-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt: {{ .Values.clustermesh.apiserver.tls.ca.cert }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/remote-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-remote-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt: {{ .Values.clustermesh.apiserver.tls.ca.cert }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/server-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-server-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt: {{ .Values.clustermesh.apiserver.tls.ca.cert }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cilium-clustermesh
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   {{- range .Values.clustermesh.config.clusters }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain) | b64enc }}

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.etcd.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: cilium-etcd-operator
     app.kubernetes.io/part-of: cilium
   name: cilium-etcd-operator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   replicas: 1
   selector:

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.etcd.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   {{- if .Values.serviceAccounts.etcd.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccounts.etcd.annotations | indent 4 }}

--- a/install/kubernetes/cilium/templates/etcd-operator/etcd-operator-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/etcd-operator-clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cilium-etcd-sa
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/etcd-operator/etcd-operator-serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/etcd-operator-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cilium-etcd-sa
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   {{- if .Values.serviceAccounts.etcd.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccounts.etcd.annotations | indent 4 }}

--- a/install/kubernetes/cilium/templates/etcd-operator/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: cilium-etcd-operator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     io.cilium/app: etcd-operator
     name: cilium-etcd-operator

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -8,12 +8,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hubble-relay-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   config.yaml: |
     cluster-name: {{ .Values.cluster.name }}
     {{- if and .Values.hubble.enabled .Values.hubble.peerService.enabled }}
-    peer-service: "hubble-peer.{{ .Release.Namespace }}.svc.{{ .Values.hubble.peerService.clusterDomain }}:{{ $peerSvcPort }}"
+    peer-service: "hubble-peer.{{ cilium.namespace }}.svc.{{ .Values.hubble.peerService.clusterDomain }}:{{ $peerSvcPort }}"
     {{- else }}
     peer-service: unix://{{ .Values.hubble.socketPath }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hubble-relay
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-relay/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/metrics-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: hubble-relay-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble-relay
 spec:

--- a/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: hubble-relay
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-relay/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: hubble-relay
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-relay/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.relay.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   {{- with .Values.serviceAccounts.relay.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: hubble-relay
-  namespace: {{ .Values.hubble.relay.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.hubble.relay.prometheus.serviceMonitor.namespace | default cilium.namespace }}
   labels:
     {{- with .Values.hubble.relay.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
@@ -18,7 +18,7 @@ spec:
       k8s-app: hubble-relay
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ cilium.namespace }}
   endpoints:
   - port: metrics
     interval: {{ .Values.hubble.relay.prometheus.serviceMonitor.interval | quote }}

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.ui.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hubble-ui-nginx
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   nginx.conf: {{ include "hubble-ui.nginx.conf" . | trim | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: hubble-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui

--- a/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: hubble-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui

--- a/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: hubble-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui

--- a/install/kubernetes/cilium/templates/hubble-ui/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: hubble-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui

--- a/install/kubernetes/cilium/templates/hubble-ui/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.ui.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   {{- with .Values.serviceAccounts.ui.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hubble-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble
     app.kubernetes.io/name: hubble

--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hubble-peer
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: cilium
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: hubble
-  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default cilium.namespace }}
   labels:
     app.kubernetes.io/part-of: cilium
     {{- with .Values.hubble.metrics.serviceMonitor.labels }}
@@ -19,7 +19,7 @@ spec:
       k8s-app: hubble
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ cilium.namespace }}
   endpoints:
   - port: hubble-metrics
     interval: {{ .Values.hubble.metrics.serviceMonitor.interval | quote }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/hubble-issuer.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/hubble-issuer.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-ca-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   ca.crt: {{ .ca.Cert | b64enc }}
   ca.key: {{ .ca.Key  | b64enc }}
@@ -14,7 +14,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: hubble-issuer
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   ca:
     secretName: hubble-ca-secret

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hubble-relay-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   issuerRef:
     {{- include "hubble-generate-certs.certmanager.issuer" . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hubble-relay-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   issuerRef:
     {{- include "hubble-generate-certs.certmanager.issuer" . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hubble-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   issuerRef:
     {{- include "hubble-generate-certs.certmanager.issuer" . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hubble-ui-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 spec:
   issuerRef:
     {{- include "hubble-generate-certs.certmanager.issuer" . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/ca-secret.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-ca-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   ca.crt: {{ $crt }}
   ca.key: {{ $key }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: hubble-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble-generate-certs
     app.kubernetes.io/name: hubble-generate-certs

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
@@ -13,7 +13,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: hubble-generate-certs-{{$checkSum}}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   labels:
     k8s-app: hubble-generate-certs
     app.kubernetes.io/name: hubble-generate-certs

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
   {{- with .Values.serviceAccounts.hubblecertgen.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/ca-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-ca-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   ca.crt: {{ .ca.Cert | b64enc }}
   ca.key: {{ .ca.Key  | b64enc }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/relay-client-secret.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-relay-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .ca.Cert | b64enc }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/relay-server-secret.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-relay-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .ca.Cert | b64enc }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .ca.Cert | b64enc }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/ui-client-certs.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-ui-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .ca.Cert | b64enc }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/ca-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-ca-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 data:
   ca.crt: {{ .Values.hubble.tls.ca.cert }}
   {{- if .Values.hubble.tls.ca.key }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/relay-client-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-relay-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .Values.hubble.tls.ca.cert }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/relay-server-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-relay-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .Values.hubble.tls.ca.cert }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .Values.hubble.tls.ca.cert }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/ui-client-certs.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-ui-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ cilium.namespace }}
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .Values.hubble.tls.ca.cert }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -32,7 +32,7 @@ cluster:
   # may be 0 if Cluster Mesh is not used.
   id: 0
 # This allows to define the namespace where services will get installed 
-namespace: ""
+namespaceOverride: ""
 # -- Define serviceAccount names for components.
 # @default -- Component's fully qualified name.
 serviceAccounts:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -31,7 +31,8 @@ cluster:
   # clusters and in the range of 1 to 255. Only required for Cluster Mesh,
   # may be 0 if Cluster Mesh is not used.
   id: 0
-
+# This allows to define the namespace where services will get installed 
+namespace: ""
 # -- Define serviceAccount names for components.
 # @default -- Component's fully qualified name.
 serviceAccounts:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -28,7 +28,7 @@ cluster:
   # clusters and in the range of 1 to 255. Only required for Cluster Mesh,
   # may be 0 if Cluster Mesh is not used.
   id: 0
-
+namespaceOverride: ""
 # -- Define serviceAccount names for components.
 # @default -- Component's fully qualified name.
 serviceAccounts:


### PR DESCRIPTION
Signed-off-by: Basit Hasan <hasanbasit13@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change --> Added namespace object to let helm support installation of services in other namespaces as well.  

Fixes: #20511 


