### PR TITLE
docs: Clarify identity table for reserved identities

### DIFF
--- a/Documentation/internals/security-identities.rst
+++ b/Documentation/internals/security-identities.rst
@@ -53,7 +53,8 @@ Overall, the following represents the different ranges:
 
 ::
 
-   0x00000001 - 0x0000FFFF (1           to 2^16 - 1)        => cluster-local identities
+   0x00000001 - 0x000000FF (1           to 2^8  - 1)        => reserved identities
+   0x00000100 - 0x0000FFFF (2^8         to 2^16 - 1)        => cluster-local identities
    0x00010000 - 0x00FFFFFF (2^16        to 2^24 - 1)        => identities for remote clusters
    0x01000000 - 0x0100FFFF (2^24        to 2^24 + 2^16 - 1) => identities for CIDRs (node-local)
    0x01010000 - 0xFFFFFFFF (2^24 + 2^16 to 2^32 - 1)        => reserved for future use


### PR DESCRIPTION
Reserved identities take up the first 255 values (per `pkg/identity/numericidentity.go`), as already described in this document. Add these to the table for completeness. I didn't bother to fully explain this point for clustermesh but in practice this range (`0x00xx0001`->`0x00xx00FF`) is reserved in each cluster. These are not synchronized across all clusters.
