### PR TITLE
ipcache: Fix lock leak

### DIFF
--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -64,6 +64,7 @@ func (ipc *IPCache) AllocateCIDRs(
 		id, isNew, err := ipc.allocate(p, lbls, oldNID)
 		if err != nil {
 			ipc.IdentityAllocator.ReleaseSlice(context.Background(), nil, usedIdentities)
+			ipc.Unlock()
 			return nil, err
 		}
 


### PR DESCRIPTION
Commit 40e13ea2a5a9 ("ipcache: Fix race in identity/ipcache release")
unintentionally took the lock on the IPCache and failed to release it if
the loop returned in the middle. This case is a bit unusual given that
allocation fails in this case. Fix it.

Found by inspection. This wasn't yet included in an official release.

Fixes: #20721
Fixes: 40e13ea2a5a9 ("ipcache: Fix race in identity/ipcache release")
