### PR TITLE
test: Switch back to official kind image

### DIFF
--- a/test/bigtcp/test.sh
+++ b/test/bigtcp/test.sh
@@ -18,7 +18,7 @@ HELM_CHART_DIR=${3:-/vagrant/kubernetes/cilium}
 # * "kind-worker2" runs a netperf server.
 #
 
-kind create cluster --config kind-config.yaml --image=brb0/kindest-node:v1.23.3-ubuntu-22.04
+kind create cluster --config kind-config.yaml --image=kindest/node:v1.24.3
 
 # Install Cilium with IPv6 BIG TCP enabled
 helm install cilium ${HELM_CHART_DIR} \

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -35,7 +35,7 @@ clang -O2 -Wall -target bpf -c test_tc_tunnel.c -o test_tc_tunnel.o
 #
 # The LB cilium does not connect to the kube-apiserver. For now we use Kind
 # just to create Docker-in-Docker containers.
-kind create cluster --config kind-config.yaml --image=brb0/kindest-node:v1.23.3-ubuntu-22.04
+kind create cluster --config kind-config.yaml --image=kindest/node:v1.24.3
 
 # Create additional veth pair which is going to be used to test XDP_REDIRECT.
 ip l a l4lb-veth0 type veth peer l4lb-veth1

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -14,7 +14,7 @@ HELM_CHART_DIR=${3:-/vagrant/install/kubernetes/cilium}
 #
 # The LB cilium does not connect to the kube-apiserver. For now we use Kind
 # just to create Docker-in-Docker containers.
-kind create cluster --config kind-config.yaml --image=brb0/kindest-node:v1.23.3-ubuntu-22.04
+kind create cluster --config kind-config.yaml --image=kindest/node:v1.24.3
 
 # Install Cilium as standalone L4LB: tc/Maglev/SNAT
 helm install cilium ${HELM_CHART_DIR} \


### PR DESCRIPTION
The `kindest/node:v1.24.3` has been recently released, and it contains the Ubuntu base distro switch \[1\]. Therefore, we no longer need to use my custom image.

\[1\]: https://github.com/kubernetes-sigs/kind/pull/2838

The CI has passed https://github.com/cilium/cilium/runs/7741071236?check_suite_focus=true.
