### PR TITLE
client-go latency metrics use the host of the url only

### DIFF
--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -287,7 +287,7 @@ func NewK8sWatcher(
 type k8sMetrics struct{}
 
 func (*k8sMetrics) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
-	metrics.KubernetesAPIInteractions.WithLabelValues(u.Path, verb).Observe(latency.Seconds())
+	metrics.KubernetesAPIInteractions.WithLabelValues(u.Host, verb).Observe(latency.Seconds())
 }
 
 func (*k8sMetrics) Increment(_ context.Context, code string, method string, host string) {


### PR DESCRIPTION
Kubernetes client-go LatencyMetrics used to get the URL
as label, templating the name and namespaces to avoid
cardinality explosion. However, URLs path are unbounded,
and templating wasn't enough, so only the Host part of
the URL is used, since this is usually static with the
apiserver address.

In order to keep backwards compatibility the Interface
maintains the url as paramter, but the adapter only
uses the host.

Signed-off-by: Antonio Ojea <antonio.ojea.garcia@gmail.com>

Fixes: #208010
```release-note
latency metrics only uses the host of the URL as label
```
