### PR TITLE
v1.10 backports 2022-08-09

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -30,6 +30,9 @@ jobs:
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: docs-tree
         with:
+          # For `push` events, compare against the `ref` base branch
+          # For `pull_request` events, this is ignored and will compare against the pull request base branch
+          base: ${{ github.ref }}
           filters: |
             src:
               - .github/workflows/documentation.yaml

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -31,7 +31,9 @@ jobs:
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: changes
         with:
-          base: ${{ github.event.pull_request.base.sha || github.event.before }}
+          # For `push` events, compare against the `ref` base branch
+          # For `pull_request` events, this is ignored and will compare against the pull request base branch
+          base: ${{ github.ref }}
           filters: |
             bpf-tree:
               - 'bpf/**'

--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -22,17 +22,10 @@ jobs:
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}
     steps:
-      - name: Checkout code
-        if: ${{ !github.event.pull_request }}
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-        with:
-          persist-credentials: false
       - name: Check code changes
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: go-changes
         with:
-          base: ${{ github.event.pull_request.base.sha }}
-          ref: ${{ github.event.pull_request.head.sha }}
           filters: |
             src:
               - .github/workflows/lint-codeql.yaml

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -38,6 +38,9 @@ jobs:
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: tested-tree
         with:
+          # For `push` events, compare against the `ref` base branch
+          # For `pull_request` events, this is ignored and will compare against the pull request base branch
+          base: ${{ github.ref }}
           filters: |
             src:
               - '!(test|Documentation)/**'

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -37,6 +37,9 @@ jobs:
         uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: tested-tree
         with:
+          # For `push` events, compare against the `ref` base branch
+          # For `pull_request` events, this is ignored and will compare against the pull request base branch
+          base: ${{ github.ref }}
           filters: |
             src:
               - '!(test|Documentation)/**'

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -1571,8 +1571,8 @@ The cilium preflight manifest requires etcd support and can be built with:
       --set agent.enabled=false \
       --set config.enabled=false \
       --set operator.enabled=false \
-      --set global.etcd.enabled=true \
-      --set global.etcd.ssl=true \
+      --set etcd.enabled=true \
+      --set etcd.ssl=true \
       > cilium-preflight.yaml
     kubectl create -f cilium-preflight.yaml
 
@@ -1582,7 +1582,7 @@ Example migration
 
 .. code-block:: shell-session
 
-      $ kubectl exec -n kube-system cilium-preflight-1234 -- cilium preflight migrate-identity
+      $ kubectl exec -n kube-system cilium-pre-flight-check-1234 -- cilium preflight migrate-identity
       INFO[0000] Setting up kvstore client
       INFO[0000] Connecting to etcd server...                  config=/var/lib/cilium/etcd-config.yml endpoints="[https://192.168.33.11:2379]" subsys=kvstore
       INFO[0000] Setting up kubernetes client
@@ -1618,6 +1618,13 @@ Example migration
   .. code-block:: shell-session
 
         cilium preflight migrate-identity --k8s-kubeconfig-path /var/lib/cilium/cilium.kubeconfig --kvstore etcd --kvstore-opt etcd.config=/var/lib/cilium/etcd-config.yml
+
+Once the migration is complete, confirm the endpoint identities match by listing the endpoints stored in CRDs and in etcd:
+
+.. code-block:: shell-session
+
+      $ kubectl get ciliumendpoints -A # new CRD-backed endpoints
+      $ kubectl exec -n kube-system cilium-1234 -- cilium endpoint list # existing etcd-backed endpoints
 
 Clearing CRD identities
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -233,6 +233,9 @@ func runApiserver() error {
 	flags.Duration(option.AllocatorListTimeoutName, defaults.AllocatorListTimeout, "Timeout for listing allocator state before exiting")
 	option.BindEnv(option.AllocatorListTimeoutName)
 
+	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enable support of Kubernetes EndpointSlice")
+	option.BindEnv(option.K8sEnableEndpointSlice)
+
 	viper.BindPFlags(flags)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -69,6 +69,7 @@ main() {
     old_proj=$(grep "projects" $ACTS_YAML | sed "$PROJECTS_REGEX")
     sed -i 's/\(projects\/\)[0-9]\+/\1'$new_proj'/g' $ACTS_YAML
 
+    $DIR/../../Documentation/check-crd-compat-table.sh "$branch"
     $DIR/prep-changelog.sh "$old_version" "$version"
 
     logecho "Next steps:"

--- a/contrib/scripts/check-fmt.sh
+++ b/contrib/scripts/check-fmt.sh
@@ -3,13 +3,15 @@
 set -e
 set -o pipefail
 
+_goroot=$(${GO:-go} env GOROOT)
+
 diff="$(find . ! \( -path './contrib' -prune \) \
         ! \( -path './vendor' -prune \) \
         ! \( -path './_build' -prune \) \
         ! \( -path './.git' -prune \) \
         ! \( -path '*.validate.go' -prune \) \
         -type f -name '*.go' | grep -Ev "(pkg/k8s/apis/cilium.io/v2/client/bindata.go)" | \
-        xargs gofmt -d -l -s )"
+        xargs $_goroot/bin/gofmt -d -l -s )"
 
 if [ -n "$diff" ]; then
 	echo "Unformatted Go source code:"

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -504,7 +504,9 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		// asserted via ep != nil here and msg.Response && msg.Rcode ==
 		// dns.RcodeSuccess below).
 		err := errors.New("DNS request cannot be associated with an existing endpoint")
-		log.WithError(err).Error("cannot find matching endpoint")
+		log.WithFields(logrus.Fields{
+			logfields.L3n4Addr: epIPPort,
+		}).WithError(err).Error("cannot find matching endpoint")
 		endMetric()
 		return err
 	}

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -411,7 +411,6 @@ spec:
             name: cni-path
         securityContext:
           privileged: true
-{{- end }}
       - name: apply-sysctl-overwrites
         image: "{{ if .Values.image.override }}{{ .Values.image.override }}{{ else }}{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}{{ end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -437,6 +436,7 @@ spec:
           mountPath: /hostbin
         securityContext:
           privileged: true
+{{- end }}
 {{- if and .Values.nodeinit.enabled (not (eq .Values.nodeinit.bootstrapFile "")) }}
       - name: wait-for-node-init
         command: ['sh', '-c', 'until test -s {{ (print "/tmp/cilium-bootstrap.d/" (.Values.nodeinit.bootstrapFile | base)) | quote }}; do echo "Waiting on node-init to run..."; sleep 1; done']

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -55,27 +55,21 @@ spec:
       imagePullSecrets:
         {{ toYaml .Values.imagePullSecrets | indent 6 }}
 {{- end }}
-      volumes:
-      # To access iptables concurrently with other processes (e.g. kube-proxy)
-      - hostPath:
-          path: /run/xtables.lock
-          type: FileOrCreate
-        name: xtables-lock
       containers:
         - name: node-init
           image: {{ if .Values.nodeinit.image.override }}{{ .Values.nodeinit.image.override }}{{ else }}{{ .Values.nodeinit.image.repository }}:{{ .Values.nodeinit.image.tag }}{{ end }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           securityContext:
             privileged: true
-          volumeMounts:
-            # To access iptables concurrently with other processes (e.g. kube-proxy)
-            - mountPath: /run/xtables.lock
-              name: xtables-lock
           lifecycle:
 {{- if .Values.eni.enabled }}
             postStart:
               exec:
                 command:
+                  - nsenter
+                  - --target=1
+                  - --mount
+                  - --
                   - "/bin/sh"
                   - "-c"
                   - |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
@@ -129,6 +129,12 @@ spec:
             configMapKeyRef:
               key: identity-allocation-mode
               name: cilium-config
+        - name: ENABLE_K8S_ENDPOINT_SLICE
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: enable-k8s-endpoint-slice
+              optional: true
 {{- with .Values.clustermesh.apiserver.resources }}
         resources: {{- toYaml . | nindent 10 }}
 {{- end }}

--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -127,6 +127,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 				resource.Spec.AlibabaCloud.VSwitchTags,
 			)
 	}
+	allocation.PoolID = ipamTypes.PoolID(bestSubnet.ID)
 
 	securityGroupIDs, err := n.getSecurityGroupIDs(ctx, resource.Spec.AlibabaCloud)
 	if err != nil {

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -373,6 +373,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 				resource.Spec.ENI.SubnetTags,
 			)
 	}
+	allocation.PoolID = ipamTypes.PoolID(bestSubnet.ID)
 
 	securityGroupIDs, err := n.getSecurityGroupIDs(ctx, resource.Spec.ENI)
 	if err != nil {

--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -66,7 +66,7 @@ func GetStringMapStringE(vp *viper.Viper, key string) (map[string]string, error)
 			for _, kv := range kvs {
 				temp := strings.Split(kv, string(equal))
 				if len(temp) != 2 {
-					return map[string]string{}, fmt.Errorf("'%s' is not formatted as key=value,key1=value1", s)
+					return map[string]string{}, fmt.Errorf("'%s' in '%s' is not formatted as key=value,key1=value1", kv, s)
 				}
 				v[temp[0]] = temp[1]
 			}
@@ -110,8 +110,12 @@ func splitKeyValue(str string, sep rune, keyValueSep rune) []string {
 
 	var res []string
 	var start = 0
-	for i := 0; i < len(sepIndexes)-1; i++ {
-		if strings.Contains(str[sepIndexes[i]:sepIndexes[i+1]], string(keyValueSep)) {
+	for i := 0; i < len(sepIndexes); i++ {
+		last := len(str)
+		if i < len(sepIndexes)-1 {
+			last = sepIndexes[i+1]
+		}
+		if strings.ContainsRune(str[sepIndexes[i]:last], keyValueSep) {
 			res = append(res, str[start:sepIndexes[i]])
 			start = sepIndexes[i] + 1
 		}

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -115,10 +115,11 @@ func TestGetStringMapString(t *testing.T) {
 			name: "another valid kv format with comma in value",
 			args: args{
 				key:   "AWS_INSTANCE_LIMIT_MAPPING",
-				value: "c6a.2xlarge=4,15,15",
+				value: "c6a.2xlarge=4,15,15,m4.large=1,5,10",
 			},
 			want: map[string]string{
 				"c6a.2xlarge": "4,15,15",
+				"m4.large":    "1,5,10",
 			},
 			wantErr: assert.NoError,
 		},
@@ -142,6 +143,20 @@ func TestGetStringMapString(t *testing.T) {
 			},
 			want: map[string]string{
 				"cluster": "my-cluster",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "valid kv format from issue #20666",
+			args: args{
+				key:   "FOO_BAR",
+				value: "a=b,c=d,E=F,G=h",
+			},
+			want: map[string]string{
+				"a": "b",
+				"c": "d",
+				"E": "F",
+				"G": "h",
 			},
 			wantErr: assert.NoError,
 		},
@@ -270,7 +285,6 @@ func Test_isValidKeyValuePair(t *testing.T) {
 			},
 			want: true,
 		},
-
 		{
 			name: "valid format with multiple pairs",
 			args: args{

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -297,6 +298,22 @@ func (m *IptablesManager) Init() {
 			"ip6tables kernel modules could not be loaded, so IPv6 cannot be used")
 		haveIp6tables = false
 	}
+
+	ipv6Disabled, err := os.ReadFile("/sys/module/ipv6/parameters/disable")
+	if err != nil {
+		if option.Config.EnableIPv6 {
+			log.WithError(err).Fatal(
+				"IPv6 is enabled but IPv6 kernel support could not be probed")
+		}
+		log.WithError(err).Warning(
+			"Unable to read /sys/module/ipv6/parameters/disable, disabling IPv6 iptables support")
+		haveIp6tables = false
+	} else if strings.TrimSuffix(string(ipv6Disabled), "\n") == "1" {
+		log.Debug(
+			"Kernel does not support IPv6, disabling IPv6 iptables support")
+		haveIp6tables = false
+	}
+
 	m.haveIp6tables = haveIp6tables
 
 	if err := modulesManager.FindOrLoadModules("xt_socket"); err != nil {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -255,10 +255,10 @@ func (k *K8sWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) error
 		logfields.K8sNamespace: newK8sPod.ObjectMeta.Namespace,
 		"new-podIP":            newK8sPod.Status.PodIP,
 		"new-podIPs":           newK8sPod.Status.PodIPs,
-		"new-hostIP":           newK8sPod.Status.PodIP,
+		"new-hostIP":           newK8sPod.Status.HostIP,
 		"old-podIP":            oldK8sPod.Status.PodIP,
 		"old-podIPs":           oldK8sPod.Status.PodIPs,
-		"old-hostIP":           oldK8sPod.Status.PodIP,
+		"old-hostIP":           oldK8sPod.Status.HostIP,
 	})
 
 	// In Kubernetes Jobs, Pods can be left in Kubernetes until the Job

--- a/tools/customvet
+++ b/tools/customvet
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-go run ${SCRIPTPATH}/../vendor/github.com/cilium/customvet/main.go $@
+${GO:-go} run ${SCRIPTPATH}/../vendor/github.com/cilium/customvet/main.go $@


### PR DESCRIPTION
* #20624 -- docs: update etcd kvstore migration instructions (@hhoover)
 * #20564 -- contrib: Add CRD generation to release process (@joestringer)
 * #20649 -- daemon: Improve dnsproxy error when EP not found (@joestringer)
 * #20643 -- helm: Guard apply sysctl init container (@sayboras)
 * #20673 -- command: fix parsing of string map strings with multiple separators (@tklauser)
 * #20697 -- clustermesh: Add EndpointSlice support for API server (@YutaroHayakawa)
 * #20685 -- ci: fix code changes detection on `push` events (@nbusseneau)
 * #20680 -- iptables: handle case where kernel IPv6 support is disabled (@jibi)
 * #20449 -- fix subnet_id label value is empty (@wu0407)
 * #20741 -- Fix ineffective post-start hook in ENI mode (@bmcustodio)
 * #20757 -- pkg/k8s: set the right IP addresses in log messages (@aanm)
 * #20750 -- Consider `$GO` environment variable `make precheck` checks (@tklauser)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20624 20564 20649 20643 20673 20697 20685 20680 20449 20741 20757 20750; do contrib/backporting/set-labels.py $pr done 1.10; done
```