### PR TITLE
helm: Refer to the correct Helm value

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -211,7 +211,7 @@ spec:
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
-      {{- else if .Values.dnsPolicy }}
+      {{- else if .Values.operator.dnsPolicy }}
       dnsPolicy: {{ .Values.operator.dnsPolicy }}
       {{- end }}
       restartPolicy: Always


### PR DESCRIPTION
The operator deployment template was incorrectly referring to dnsPolicy
instead of operator.dnsPolicy.

Fixes: 307df356c2 ("helm: Make DNS policy for agent and operator configurable")
Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

```release-note
Helm: Use the correct operator.dnsPolicy value for the operator deployment template
```
