### PR TITLE
v1.12 backports 2022-08-09

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -512,8 +512,16 @@ ct_recreate6:
 			return ret;
 	}
 #endif
-	if (is_defined(ENABLE_HOST_ROUTING))
-		return redirect_direct_v6(ctx, ETH_HLEN, ip6);
+	if (is_defined(ENABLE_HOST_ROUTING)) {
+		int oif;
+
+		ret = redirect_direct_v6(ctx, ETH_HLEN, ip6, &oif);
+		if (likely(ret == CTX_ACT_REDIRECT))
+			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
+					  *dst_id, 0, oif,
+					  trace.reason, trace.monitor);
+		return ret;
+	}
 
 	goto pass_to_stack;
 
@@ -1093,8 +1101,16 @@ skip_vtep:
 			return ret;
 	}
 #endif /* TUNNEL_MODE */
-	if (is_defined(ENABLE_HOST_ROUTING))
-		return redirect_direct_v4(ctx, ETH_HLEN, ip4);
+	if (is_defined(ENABLE_HOST_ROUTING)) {
+		int oif;
+
+		ret = redirect_direct_v4(ctx, ETH_HLEN, ip4, &oif);
+		if (likely(ret == CTX_ACT_REDIRECT))
+			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
+					  *dst_id, 0, oif,
+					  trace.reason, trace.monitor);
+		return ret;
+	}
 
 	goto pass_to_stack;
 


### PR DESCRIPTION
* #20479 -- bpf: Add send_trace_notify hook for redirect_direct_{v4,v6} (@qmonnet)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20479; do contrib/backporting/set-labels.py $pr done 1.12; done
```