### PR TITLE
Coalesce of health endpoint CIDRs

### DIFF
--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -243,6 +243,15 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerI
 		}
 		routerIP = result.IP
 	}
+
+	// Coalescing multiple CIDRs. GH #18868
+	if option.Config.EnableIPv4Masquerade &&
+		option.Config.IPAM == ipamOption.IPAMENI &&
+		result != nil &&
+		len(result.CIDRs) > 0 {
+		result.CIDRs = coalesceCIDRs(result.CIDRs)
+	}
+
 	if (option.Config.IPAM == ipamOption.IPAMENI ||
 		option.Config.IPAM == ipamOption.IPAMAlibabaCloud ||
 		option.Config.IPAM == ipamOption.IPAMAzure) && result != nil {
@@ -257,10 +266,6 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerI
 		node.SetRouterInfo(routingInfo)
 	}
 
-	// Coalescing multiple CIDRs. GH #18868
-	if result != nil && len(result.CIDRs) > 0 {
-		result.CIDRs = coalesceCIDRs(result.CIDRs)
-	}
 	return
 }
 
@@ -274,7 +279,10 @@ func (d *Daemon) allocateHealthIPs() error {
 			}
 
 			// Coalescing multiple CIDRs. GH #18868
-			if result != nil && len(result.CIDRs) > 0 {
+			if option.Config.EnableIPv4Masquerade &&
+				option.Config.IPAM == ipamOption.IPAMENI &&
+				result != nil &&
+				len(result.CIDRs) > 0 {
 				result.CIDRs = coalesceCIDRs(result.CIDRs)
 			}
 
@@ -303,7 +311,10 @@ func (d *Daemon) allocateHealthIPs() error {
 			}
 
 			// Coalescing multiple CIDRs. GH #18868
-			if result != nil && len(result.CIDRs) > 0 {
+			if option.Config.EnableIPv6Masquerade &&
+				option.Config.IPAM == ipamOption.IPAMENI &&
+				result != nil &&
+				len(result.CIDRs) > 0 {
 				result.CIDRs = coalesceCIDRs(result.CIDRs)
 			}
 
@@ -339,6 +350,14 @@ func (d *Daemon) allocateIngressIPs() error {
 				if err != nil {
 					return fmt.Errorf("unable to allocate ingress IPs: %s, see https://cilium.link/ipam-range-full", err)
 				}
+			}
+
+			// Coalescing multiple CIDRs. GH #18868
+			if option.Config.EnableIPv4Masquerade &&
+				option.Config.IPAM == ipamOption.IPAMENI &&
+				result != nil &&
+				len(result.CIDRs) > 0 {
+				result.CIDRs = coalesceCIDRs(result.CIDRs)
 			}
 
 			node.SetIngressIPv4(result.IP)
@@ -388,6 +407,14 @@ func (d *Daemon) allocateIngressIPs() error {
 					}
 					return fmt.Errorf("unable to allocate ingress IPs: %s, see https://cilium.link/ipam-range-full", err)
 				}
+			}
+
+			// Coalescing multiple CIDRs. GH #18868
+			if option.Config.EnableIPv6Masquerade &&
+				option.Config.IPAM == ipamOption.IPAMENI &&
+				result != nil &&
+				len(result.CIDRs) > 0 {
+				result.CIDRs = coalesceCIDRs(result.CIDRs)
 			}
 
 			node.SetIngressIPv6(result.IP)

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
-	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -162,16 +161,6 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing types.NodeAddressi
 	routerIP := net.IPNet{
 		IP:   nodeAddressing.IPv4().Router(),
 		Mask: net.CIDRMask(32, 32),
-	}
-
-	cidrs2 := make([]*net.IPNet, 0, 0)
-	for i := range cidrs {
-		cidrs2 = append(cidrs2, &cidrs[i])
-	}
-	resultcidr, _ := iputil.CoalesceCIDRs(cidrs2)
-	cidrs = make([]net.IPNet, 0, len(resultcidr))
-	for _, cidr := range resultcidr {
-		cidrs = append(cidrs, *cidr)
 	}
 
 	for _, cidr := range cidrs {


### PR DESCRIPTION
Fixes: #18868. Multiple CIDRs are currently not coalesced for the health
endpoint when setting up routing the corresponding routing tables. This
results in orphaned routing entries that may conflict when IPs are
reused for workload pods after an agent restart.

Addresses comment https://github.com/cilium/cilium/pull/20112#issuecomment-1180343763

Signed-off-by: Simone Sciarrati <s.sciarrati@gmail.com>
Signed-off-by: Federico Hernandez <f@ederi.co>
