### PR TITLE
cilium-health: fix probing for IPv6-only clusters

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -243,13 +243,15 @@ func LaunchAsEndpoint(baseCtx context.Context,
 		ip4Address, ip6Address *net.IPNet
 	)
 
-	if healthIP = node.GetEndpointHealthIPv6(); healthIP != nil {
-		info.Addressing.IPV6 = healthIP.String()
-		ip6Address = &net.IPNet{IP: healthIP, Mask: defaults.ContainerIPv6Mask}
+	if healthIPv6 := node.GetEndpointHealthIPv6(); healthIPv6 != nil {
+		info.Addressing.IPV6 = healthIPv6.String()
+		ip6Address = &net.IPNet{IP: healthIPv6, Mask: defaults.ContainerIPv6Mask}
+		healthIP = healthIPv6
 	}
-	if healthIP = node.GetEndpointHealthIPv4(); healthIP != nil {
-		info.Addressing.IPV4 = healthIP.String()
-		ip4Address = &net.IPNet{IP: healthIP, Mask: defaults.ContainerIPv4Mask}
+	if healthIPv4 := node.GetEndpointHealthIPv4(); healthIPv4 != nil {
+		info.Addressing.IPV4 = healthIPv4.String()
+		ip4Address = &net.IPNet{IP: healthIPv4, Mask: defaults.ContainerIPv4Mask}
+		healthIP = healthIPv4
 	}
 
 	if option.Config.EnableEndpointRoutes {


### PR DESCRIPTION
Due some refactoring done in ed934cb958c5, a bug was introduced in the
code that overwrote the IP address used to perform health checks.
In IPv6-only clusters, this IP address was overwritten by an empty IPv4
address which would then be used to perform health checks. Obviously
failing to perform such health checks since the address was "<nil>",
Cilium would report that `cilium-health-ep` controllers were failing.

Fixes: ed934cb958c5 ("health: Move endpoint IP to node package")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/20796

```release-note
Fix regression with cilium-health-probe controller in IPv6-only clusters
```
