### PR TITLE
ingress: Propagate required annotations from Ingress to LB Service

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -42,6 +42,7 @@ cilium-operator-alibabacloud [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "alibabacloud")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -48,6 +48,7 @@ cilium-operator-aws [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "eni")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -45,6 +45,7 @@ cilium-operator-azure [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "azure")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -41,6 +41,7 @@ cilium-operator-generic [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -53,6 +53,7 @@ cilium-operator [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1109,6 +1109,10 @@
      - Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header.
      - bool
      - ``true``
+   * - ingressController.ingressLBAnnotations
+     - IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer
+     - list
+     - ``["service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]``
    * - ingressController.secretsNamespace
      - SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -496,6 +496,7 @@ imagePullSecrets
 incrementing
 indices
 ingressController
+ingressLBAnnotations
 ingressing
 init
 initContainer

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -328,6 +328,7 @@ contributors across the globe, there is almost always someone available to help.
 | imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
 | ingressController.enabled | bool | `false` | Enable cilium ingress controller This will automatically set enable-envoy-config as well. |
 | ingressController.enforceHttps | bool | `true` | Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. |
+| ingressController.ingressLBAnnotations | list | `["service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]` | IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer |
 | ingressController.secretsNamespace | object | `{"create":true,"name":"cilium-secrets","sync":true}` | SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from. |
 | ingressController.secretsNamespace.create | bool | `true` | Create secrets namespace for Ingress. |
 | ingressController.secretsNamespace.name | string | `"cilium-secrets"` | Name of Ingress secret namespace. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -213,6 +213,7 @@ data:
   enforce-ingress-https: {{ .Values.ingressController.enforceHttps | quote }}
   enable-ingress-secrets-sync: {{ .Values.ingressController.secretsNamespace.sync | quote }}
   ingress-secrets-namespace: {{ .Values.ingressController.secretsNamespace.name | quote }}
+  ingress-lb-annotations: {{ .Values.ingressController.ingressLBAnnotations | join " " | quote }}
 {{- end }}
 
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -484,6 +484,10 @@ ingressController:
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
 
+  # -- IngressLBAnnotations are the annotations which are needed to propagate
+  # from Ingress to the Load Balancer
+  ingressLBAnnotations: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
+  
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
     # -- Create secrets namespace for Ingress.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -481,6 +481,10 @@ ingressController:
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
 
+  # -- IngressLBAnnotations are the annotations which are needed to propagate
+  # from Ingress to the Load Balancer
+  ingressLBAnnotations: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
+  
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
     # -- Create secrets namespace for Ingress.

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -342,5 +342,8 @@ func init() {
 	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")
 	regOpts.BindEnv(operatorOption.SetCiliumIsUpCondition)
 
+	flags.StringSlice(operatorOption.IngressLBAnnotations, operatorOption.IngressLBAnnotationsDefault, "IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer")
+	regOpts.BindEnv(operatorOption.IngressLBAnnotations)
+
 	Vp.BindPFlags(flags)
 }

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -595,7 +595,8 @@ func OnOperatorStartLeading(ctx context.Context) {
 		ingressController, err := ingress.NewIngressController(
 			ingress.WithHTTPSEnforced(operatorOption.Config.EnforceIngressHTTPS),
 			ingress.WithSecretsSyncEnabled(operatorOption.Config.EnableIngressSecretsSync),
-			ingress.WithSecretsNamespace(operatorOption.Config.IngressSecretsNamespace))
+			ingress.WithSecretsNamespace(operatorOption.Config.IngressSecretsNamespace),
+			ingress.WithLBAnnotations(operatorOption.Config.IngressLBAnnotations))
 		if err != nil {
 			log.WithError(err).WithField(logfields.LogSubsys, ingress.Subsys).Fatal(
 				"Failed to start ingress controller")

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -17,6 +17,8 @@ import (
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "option")
 
+var IngressLBAnnotationsDefault = []string{"service.beta.kubernetes.io", "service.kubernetes.io", "cloud.google.com"}
+
 const (
 	// EndpointGCIntervalDefault is the default time for the CEP GC
 	EndpointGCIntervalDefault = 5 * time.Minute
@@ -250,6 +252,10 @@ const (
 	// SetCiliumIsUpCondition sets the CiliumIsUp node condition in Kubernetes
 	// nodes.
 	SetCiliumIsUpCondition = "set-cilium-is-up-condition"
+
+	// IngressLBAnnotations are the annotations which are needed to propagate
+	// from Ingress to the Load Balancer
+	IngressLBAnnotations = "ingress-lb-annotations"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -466,6 +472,10 @@ type OperatorConfig struct {
 	// SetCiliumIsUpCondition sets the CiliumIsUp node condition in Kubernetes
 	// nodes.
 	SetCiliumIsUpCondition bool
+
+	// IngressLBAnnotations are the annotations which are needed to propagate
+	// from Ingress to the Load Balancer
+	IngressLBAnnotations []string
 }
 
 // Populate sets all options with the values from viper.
@@ -503,8 +513,10 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.CiliumPodLabels = vp.GetString(CiliumPodLabels)
 	c.RemoveCiliumNodeTaints = vp.GetBool(RemoveCiliumNodeTaints)
 	c.SetCiliumIsUpCondition = vp.GetBool(SetCiliumIsUpCondition)
+	c.IngressLBAnnotations = vp.GetStringSlice(IngressLBAnnotations)
 
 	c.CiliumK8sNamespace = vp.GetString(CiliumK8sNamespace)
+
 	if c.CiliumK8sNamespace == "" {
 		if option.Config.K8sNamespace == "" {
 			c.CiliumK8sNamespace = metav1.NamespaceDefault

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -72,6 +72,7 @@ type IngressController struct {
 	enforcedHTTPS      bool
 	enabledSecretsSync bool
 	secretsNamespace   string
+	lbAnnotations      []string
 }
 
 // NewIngressController returns a controller for ingress objects having ingressClassName as cilium
@@ -89,6 +90,7 @@ func NewIngressController(options ...Option) (*IngressController, error) {
 		enforcedHTTPS:      opts.EnforcedHTTPS,
 		enabledSecretsSync: opts.EnabledSecretsSync,
 		secretsNamespace:   opts.SecretsNamespace,
+		lbAnnotations:      opts.LBAnnotations,
 	}
 	ic.ingressStore, ic.ingressInformer = informer.NewInformer(
 		utils.ListerWatcherFromTyped[*slim_networkingv1.IngressList](k8s.WatcherClient().NetworkingV1().Ingresses(corev1.NamespaceAll)),
@@ -327,7 +329,7 @@ func getIngressKeyForService(service *slim_corev1.Service) string {
 }
 
 func (ic *IngressController) createLoadBalancer(ingress *slim_networkingv1.Ingress) error {
-	svc := getServiceForIngress(ingress)
+	svc := getServiceForIngress(ingress, ic.lbAnnotations)
 	svcKey, err := cache.MetaNamespaceKeyFunc(svc)
 	if err != nil {
 		log.Warn("Failed to get service key for ingress")

--- a/operator/pkg/ingress/ingress_options.go
+++ b/operator/pkg/ingress/ingress_options.go
@@ -9,6 +9,7 @@ type Options struct {
 	EnforcedHTTPS      bool
 	EnabledSecretsSync bool
 	SecretsNamespace   string
+	LBAnnotations      []string
 }
 
 // DefaultIngressOptions specifies default values for cilium ingress controller.
@@ -16,6 +17,7 @@ var DefaultIngressOptions = Options{
 	MaxRetries:         10,
 	EnforcedHTTPS:      true,
 	EnabledSecretsSync: true,
+	LBAnnotations:      []string{},
 }
 
 // Option customizes the configuration of cilium ingress controller
@@ -49,6 +51,14 @@ func WithSecretsSyncEnabled(enabledSecretsSync bool) Option {
 func WithSecretsNamespace(secretsNamespace string) Option {
 	return func(o *Options) error {
 		o.SecretsNamespace = secretsNamespace
+		return nil
+	}
+}
+
+// WithLBAnnotations configures LB annotations to be used for LB service
+func WithLBAnnotations(lbAnnotations []string) Option {
+	return func(o *Options) error {
+		o.LBAnnotations = lbAnnotations
 		return nil
 	}
 }

--- a/operator/pkg/ingress/ingress_test.go
+++ b/operator/pkg/ingress/ingress_test.go
@@ -12,11 +12,17 @@ import (
 
 var exactPathType = slim_networkingv1.PathTypeExact
 
+var testAnnotations = map[string]string{
+	"service.beta.kubernetes.io/dummy-load-balancer-backend-protocol":    "http",
+	"service.beta.kubernetes.io/dummy-load-balancer-access-log-enabled":  "true",
+	"service.alpha.kubernetes.io/dummy-load-balancer-access-log-enabled": "true",
+}
+
 var baseIngress = &slim_networkingv1.Ingress{
 	ObjectMeta: slim_metav1.ObjectMeta{
 		Name:        "dummy-ingress",
 		Namespace:   "dummy-namespace",
-		Annotations: map[string]string{},
+		Annotations: testAnnotations,
 		UID:         "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
 	},
 	Spec: slim_networkingv1.IngressSpec{

--- a/operator/pkg/ingress/service_test.go
+++ b/operator/pkg/ingress/service_test.go
@@ -136,7 +136,7 @@ func Test_getServiceForIngress(t *testing.T) {
 		ingress := baseIngress.DeepCopy()
 		ingress.Spec.TLS = nil
 
-		res := getServiceForIngress(ingress)
+		res := getServiceForIngress(ingress, []string{"service.beta.kubernetes.io", "service.kubernetes.io", "cloud.google.com"})
 		assert.Equal(t, "cilium-ingress-dummy-ingress", res.Name)
 		assert.Equal(t, "dummy-namespace", res.Namespace)
 		assert.Equal(t, []metav1.OwnerReference{
@@ -158,6 +158,10 @@ func Test_getServiceForIngress(t *testing.T) {
 			},
 			Type: v1.ServiceTypeLoadBalancer,
 		}, res.Spec)
+		assert.Equal(t, map[string]string{
+			"service.beta.kubernetes.io/dummy-load-balancer-backend-protocol":   "http",
+			"service.beta.kubernetes.io/dummy-load-balancer-access-log-enabled": "true",
+		}, res.Annotations)
 	})
 
 	t.Run("with TLS", func(t *testing.T) {
@@ -169,7 +173,7 @@ func Test_getServiceForIngress(t *testing.T) {
 			},
 		}
 
-		res := getServiceForIngress(ingress)
+		res := getServiceForIngress(ingress, []string{"service.beta.kubernetes.io", "service.kubernetes.io", "cloud.google.com"})
 		assert.Equal(t, "cilium-ingress-dummy-ingress", res.Name)
 		assert.Equal(t, "dummy-namespace", res.Namespace)
 		assert.Equal(t, []metav1.OwnerReference{
@@ -196,6 +200,10 @@ func Test_getServiceForIngress(t *testing.T) {
 			},
 			Type: v1.ServiceTypeLoadBalancer,
 		}, res.Spec)
+		assert.Equal(t, map[string]string{
+			"service.beta.kubernetes.io/dummy-load-balancer-backend-protocol":   "http",
+			"service.beta.kubernetes.io/dummy-load-balancer-access-log-enabled": "true",
+		}, res.Annotations)
 	})
 }
 


### PR DESCRIPTION
This PR adds the required annotations from Ingress to Load Balancer Service.
Fixes: #20646


