### PR TITLE
Adjust pkg/netns go formatting to make Go1.19 happy

### DIFF
--- a/pkg/netns/netns.go
+++ b/pkg/netns/netns.go
@@ -54,15 +54,15 @@ func RemoveIfFromNetNSWithNameIfBothExist(netNSName, ifName string) error {
 //
 // Example usage of this function:
 //
-//   netns0, err := netns.ReplaceNetNSWithName(netnsName)
-//   if err != nil {
-//     return err
-//   }
-//   defer netns.RemoveNetNSWithName(netnsName)
+//	netns0, err := netns.ReplaceNetNSWithName(netnsName)
+//	if err != nil {
+//	  return err
+//	}
+//	defer netns.RemoveNetNSWithName(netnsName)
 //
-//   netns0.Do(func(_ ns.NetNS) error {
-//     <logic to be executed within the new netns>
-//   })
+//	netns0.Do(func(_ ns.NetNS) error {
+//	  <logic to be executed within the new netns>
+//	})
 //
 // FIXME: replace "ip-netns" invocations with native Go code
 func ReplaceNetNSWithName(netNSName string) (ns.NetNS, error) {


### PR DESCRIPTION
Fix a go 1.19 format warning (which breaks many tests)