### PR TITLE
k8s/watchers: fix panic in CiliumEndpoint labels update

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -396,6 +396,14 @@ func updateCiliumEndpointLabels(ep *endpoint.Endpoint, labels map[string]string)
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) (err error) {
 				pod := ep.GetPod()
+				if pod == nil {
+					err := errors.New("Skipping CiliumEndpoint update because it has no k8s pod")
+					scopedLog.WithFields(logrus.Fields{
+						logfields.EndpointID: ep.GetID(),
+						logfields.Labels:     logfields.Repr(labels),
+					}).Debug(err)
+					return err
+				}
 				ciliumClient := k8s.CiliumClient().CiliumV2()
 
 				replaceLabels := []k8s.JSONPatch{


### PR DESCRIPTION
Cilium agent would panic if the assiciated k8s pod of CiliumEndpoint is nil:

panic: runtime error: invalid memory address or nil pointer dereference

[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x2154821]

goroutine 1499073313 [running]:

github.com/cilium/cilium/pkg/k8s/watchers.updateCiliumEndpointLabels.func1(0x2f1c050, 0xc0346c6a40, 0x428e6e0, 0x455600)
 /go/src/github.com/cilium/cilium/pkg/k8s/watchers/pod.go:483 +0x341
github.com/cilium/cilium/pkg/controller.(*Controller).runController(0xc0299d3d40)
 /go/src/github.com/cilium/cilium/pkg/controller/controller.go:217 +0xb29
created by github.com/cilium/cilium/pkg/controller.(*Manager).updateController
 /go/src/github.com/cilium/cilium/pkg/controller/manager.go:122 +0xbd2

This patch adds a check for the pod.

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>


```release-note
k8s/watchers: fix panic in CiliumEndpoint labels update
```
