### PR TITLE
v1.12 backports 2022-08-11

### DIFF
--- a/Documentation/internals/security-identities.rst
+++ b/Documentation/internals/security-identities.rst
@@ -53,7 +53,8 @@ Overall, the following represents the different ranges:
 
 ::
 
-   0x00000001 - 0x0000FFFF (1           to 2^16 - 1)        => cluster-local identities
+   0x00000001 - 0x000000FF (1           to 2^8  - 1)        => reserved identities
+   0x00000100 - 0x0000FFFF (2^8         to 2^16 - 1)        => cluster-local identities
    0x00010000 - 0x00FFFFFF (2^16        to 2^24 - 1)        => identities for remote clusters
    0x01000000 - 0x0100FFFF (2^24        to 2^24 + 2^16 - 1) => identities for CIDRs (node-local)
    0x01010000 - 0xFFFFFFFF (2^24 + 2^16 to 2^32 - 1)        => reserved for future use

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -241,13 +241,15 @@ func LaunchAsEndpoint(baseCtx context.Context,
 		ip4Address, ip6Address *net.IPNet
 	)
 
-	if healthIP = node.GetEndpointHealthIPv6(); healthIP != nil {
-		info.Addressing.IPV6 = healthIP.String()
-		ip6Address = &net.IPNet{IP: healthIP, Mask: defaults.ContainerIPv6Mask}
+	if healthIPv6 := node.GetEndpointHealthIPv6(); healthIPv6 != nil {
+		info.Addressing.IPV6 = healthIPv6.String()
+		ip6Address = &net.IPNet{IP: healthIPv6, Mask: defaults.ContainerIPv6Mask}
+		healthIP = healthIPv6
 	}
-	if healthIP = node.GetEndpointHealthIPv4(); healthIP != nil {
-		info.Addressing.IPV4 = healthIP.String()
-		ip4Address = &net.IPNet{IP: healthIP, Mask: defaults.ContainerIPv4Mask}
+	if healthIPv4 := node.GetEndpointHealthIPv4(); healthIPv4 != nil {
+		info.Addressing.IPV4 = healthIPv4.String()
+		ip4Address = &net.IPNet{IP: healthIPv4, Mask: defaults.ContainerIPv4Mask}
+		healthIP = healthIPv4
 	}
 
 	if option.Config.EnableEndpointRoutes {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -320,7 +321,11 @@ func (d *Daemon) restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
 // then it attempts to clear all IPs from the interface.
 func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 	l, err := netlink.LinkByName(defaults.HostDevice)
-	if err != nil {
+	if errors.As(err, &netlink.LinkNotFoundError{}) && restoredIP == nil {
+		// There's no old state remove as the host device doesn't exist and
+		// there's no restored IP anyway.
+		return nil
+	} else if err != nil {
 		return err
 	}
 

--- a/daemon/cmd/daemon_privileged_test.go
+++ b/daemon/cmd/daemon_privileged_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build privileged_tests
+
+package cmd
+
+import (
+	"net"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/loader"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/netns"
+)
+
+func Test_removeOldRouterState(t *testing.T) {
+	const netnsName = "test-daemon-priv-0"
+
+	t.Run("test-1", func(t *testing.T) {
+		netns0, clean := setupNetNS(t, netnsName)
+		defer clean()
+
+		netns0.Do(func(_ ns.NetNS) error {
+			createDevices(t)
+
+			// Assert that the old router IP (192.0.2.1) was removed because we are
+			// restoring a different one (10.0.0.1).
+			assert.NoError(t, removeOldRouterState(false, net.ParseIP("10.0.0.1")))
+			addrs, err := netlink.AddrList(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: defaults.HostDevice,
+				},
+			}, netlink.FAMILY_V4)
+			assert.NoError(t, err)
+			assert.Len(t, addrs, 0)
+
+			// Assert no errors in the case we have no IPs to remove from cilium_host.
+			assert.NoError(t, removeOldRouterState(false, nil))
+
+			return nil
+		})
+	})
+
+	t.Run("test-2", func(t *testing.T) {
+		netns0, clean := setupNetNS(t, netnsName)
+		defer clean()
+
+		netns0.Do(func(_ ns.NetNS) error {
+			createDevices(t)
+
+			// Remove the cilium_host device and assert no error on "link not found"
+			// error.
+			link, err := netlink.LinkByName(defaults.HostDevice)
+			assert.NoError(t, err)
+			assert.NotNil(t, link)
+			assert.NoError(t, netlink.LinkDel(link))
+			assert.NoError(t, removeOldRouterState(false, nil))
+
+			return nil
+		})
+	})
+}
+
+// createDevices creates the necessary devices for this test suite. Assumes it
+// is executing within the new network namespace.
+func createDevices(t *testing.T) {
+	t.Helper()
+
+	ciliumHost, ciliumNet, err := loader.SetupBaseDevice(1500)
+	assert.NoError(t, err)
+	assert.NotNil(t, ciliumHost)
+	assert.NotNil(t, ciliumNet)
+
+	_, ipnet, _ := net.ParseCIDR("192.0.2.1/32")
+	addr := &netlink.Addr{IPNet: ipnet}
+	assert.NoError(t, netlink.AddrAdd(ciliumHost, addr))
+}
+
+func setupNetNS(t *testing.T, netnsName string) (ns.NetNS, func()) {
+	t.Helper()
+
+	netns0, err := netns.ReplaceNetNSWithName(netnsName)
+	assert.NoError(t, err)
+	assert.NotNil(t, netns0)
+
+	return netns0, func() {
+		assert.NoError(t, netns.RemoveNetNSWithName(netnsName))
+	}
+}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -207,7 +207,7 @@ spec:
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
-      {{- else if .Values.dnsPolicy }}
+      {{- else if .Values.operator.dnsPolicy }}
       dnsPolicy: {{ .Values.operator.dnsPolicy }}
       {{- end }}
       restartPolicy: Always

--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -16,6 +16,7 @@ const (
 	TCPKeepAliveIdleAnnotation             = annotation.Prefix + "/tcp-keep-alive-idle"
 	TCPKeepAliveProbeIntervalAnnotation    = annotation.Prefix + "/tcp-keep-alive-probe-interval"
 	TCPKeepAliveProbeMaxFailuresAnnotation = annotation.Prefix + "/tcp-keep-alive-probe-max-failures"
+	WebsocketEnabledAnnotation             = annotation.Prefix + "/websocket"
 )
 
 const (
@@ -24,9 +25,10 @@ const (
 	defaultTCPKeepAliveInitialIdle   = 10 // in seconds
 	defaultTCPKeepAliveProbeInterval = 5  // in seconds
 	defaultTCPKeepAliveMaxProbeCount = 10
+	defaultWebsocketEnabled          = 0 // 1 - Enabled, 0 - Disabled
 )
 
-// GetAnnotationTCPKeepAliveEnabled returns 1 if enabled (default), 0 if disable
+// GetAnnotationTCPKeepAliveEnabled returns 1 if enabled (default), 0 if disabled
 func GetAnnotationTCPKeepAliveEnabled(ingress *slim_networkingv1.Ingress) int64 {
 	val, exists := ingress.GetAnnotations()[TCPKeepAliveEnabledAnnotation]
 	if !exists {
@@ -70,7 +72,7 @@ func GetAnnotationTCPKeepAliveProbeInterval(ingress *slim_networkingv1.Ingress) 
 	return intVal
 }
 
-// GetAnnotationTCPKeepAliveProbeMaxFailures return he maximum number of keepalive probes TCP
+// GetAnnotationTCPKeepAliveProbeMaxFailures returns the maximum number of keepalive probes TCP
 // should send before dropping the connection. Defaults to 10.
 // Related references:
 // 	- https://man7.org/linux/man-pages/man7/tcp.7.html
@@ -84,4 +86,16 @@ func GetAnnotationTCPKeepAliveProbeMaxFailures(ingress *slim_networkingv1.Ingres
 		return defaultTCPKeepAliveMaxProbeCount
 	}
 	return intVal
+}
+
+// GetAnnotationWebsocketEnabled returns 1 if enabled (default), 0 if disabled
+func GetAnnotationWebsocketEnabled(ingress *slim_networkingv1.Ingress) int64 {
+	val, exists := ingress.GetAnnotations()[WebsocketEnabledAnnotation]
+	if !exists {
+		return defaultWebsocketEnabled
+	}
+	if val == enabled {
+		return 1
+	}
+	return 0
 }

--- a/operator/pkg/ingress/ingress_test.go
+++ b/operator/pkg/ingress/ingress_test.go
@@ -14,9 +14,10 @@ var exactPathType = slim_networkingv1.PathTypeExact
 
 var baseIngress = &slim_networkingv1.Ingress{
 	ObjectMeta: slim_metav1.ObjectMeta{
-		Name:      "dummy-ingress",
-		Namespace: "dummy-namespace",
-		UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+		Name:        "dummy-ingress",
+		Namespace:   "dummy-namespace",
+		Annotations: map[string]string{},
+		UID:         "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
 	},
 	Spec: slim_networkingv1.IngressSpec{
 		IngressClassName: stringp("cilium"),

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -326,16 +326,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		args[initArgHostReachableServicesPeer] = "false"
 	}
 
-	devices := make([]netlink.Link, 0, len(option.Config.GetDevices()))
 	if len(option.Config.GetDevices()) != 0 {
-		for _, device := range option.Config.GetDevices() {
-			link, err := netlink.LinkByName(device)
-			if err != nil {
-				log.WithError(err).WithField("device", device).Warn("Link does not exist")
-				return err
-			}
-			devices = append(devices, link)
-		}
 		args[initArgDevices] = strings.Join(option.Config.GetDevices(), ";")
 	} else {
 		args[initArgDevices] = "<nil>"
@@ -406,7 +397,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	sysctl.ApplySettings(sysSettings)
 
 	// Datapath initialization
-	hostDev1, hostDev2, err := setupBaseDevice(devices, mode, deviceMTU)
+	hostDev1, hostDev2, err := setupBaseDevice(deviceMTU)
 	if err != nil {
 		return fmt.Errorf("failed to setup base devices in mode %s: %w", mode, err)
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -397,7 +397,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	sysctl.ApplySettings(sysSettings)
 
 	// Datapath initialization
-	hostDev1, hostDev2, err := setupBaseDevice(deviceMTU)
+	hostDev1, hostDev2, err := SetupBaseDevice(deviceMTU)
 	if err != nil {
 		return fmt.Errorf("failed to setup base devices in mode %s: %w", mode, err)
 	}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -220,7 +220,7 @@ func setupVethPair(name, peerName string) error {
 // the first step of datapath initialization, then performs the setup (and
 // creation, if needed) of those interfaces. It returns two links and an error.
 // By default, it sets up the veth pair - cilium_host and cilium_net.
-func setupBaseDevice(nativeDevs []netlink.Link, mode baseDeviceMode, mtu int) (netlink.Link, netlink.Link, error) {
+func setupBaseDevice(mtu int) (netlink.Link, netlink.Link, error) {
 	if err := setupVethPair(defaults.HostDevice, defaults.SecondHostDevice); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -216,11 +216,11 @@ func setupVethPair(name, peerName string) error {
 	return nil
 }
 
-// setupBaseDevice decides which and what kind of interfaces should be set up as
+// SetupBaseDevice decides which and what kind of interfaces should be set up as
 // the first step of datapath initialization, then performs the setup (and
 // creation, if needed) of those interfaces. It returns two links and an error.
 // By default, it sets up the veth pair - cilium_host and cilium_net.
-func setupBaseDevice(mtu int) (netlink.Link, netlink.Link, error) {
+func SetupBaseDevice(mtu int) (netlink.Link, netlink.Link, error) {
 	if err := setupVethPair(defaults.HostDevice, defaults.SecondHostDevice); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -220,7 +220,8 @@ func NewIPIdentityWatcher(ipc *IPCache, backend kvstore.BackendOperations) *IPId
 // automatically restart as required.
 func (iw *IPIdentityWatcher) Watch(ctx context.Context) {
 
-	var scopedLog *logrus.Entry
+	scopedLog := log
+
 restart:
 	watcher := iw.backend.ListAndWatch(ctx, "endpointIPWatcher", IPIdentitiesPath, 512)
 
@@ -276,7 +277,9 @@ restart:
 				}
 				ip := ipIDPair.PrefixString()
 				if ip == "<nil>" {
-					scopedLog.Debug("Ignoring entry with nil IP")
+					if option.Config.Debug {
+						scopedLog.Debug("Ignoring entry with nil IP")
+					}
 					continue
 				}
 				var k8sMeta *K8sMetadata

--- a/pkg/netns/netns.go
+++ b/pkg/netns/netns.go
@@ -47,9 +47,22 @@ func RemoveIfFromNetNSWithNameIfBothExist(netNSName, ifName string) error {
 	return RemoveIfFromNetNSIfExists(netNS, ifName)
 }
 
-// ReplaceNetNSWithName creates a network namespace with the given name.
-// If such netns already exists from a previous run, it will be removed
-// and then re-created to avoid any previous state of the netns.
+// ReplaceNetNSWithName creates a network namespace with the given name and
+// returns a handle to it. If such netns already exists from a previous run, it
+// will be removed and then re-created to avoid any previous state of the
+// netns.
+//
+// Example usage of this function:
+//
+//   netns0, err := netns.ReplaceNetNSWithName(netnsName)
+//   if err != nil {
+//     return err
+//   }
+//   defer netns.RemoveNetNSWithName(netnsName)
+//
+//   netns0.Do(func(_ ns.NetNS) error {
+//     <logic to be executed within the new netns>
+//   })
 //
 // FIXME: replace "ip-netns" invocations with native Go code
 func ReplaceNetNSWithName(netNSName string) (ns.NetNS, error) {

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -62,7 +62,6 @@ helm install cilium ${HELM_CHART_DIR} \
     --set loadBalancer.dsrDispatch=ipip \
     --set devices='{eth0,l4lb-veth1}' \
     --set nodePort.directRoutingDevice=eth0 \
-    --set ipv6.enabled=false \
     --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key="kubernetes.io/hostname" \
     --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In \
     --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=kind-control-plane


### PR DESCRIPTION
* #20608 -- ipvlan: clean up leftover  in setupBaseDevice() (@vincentmli)
 * #20734 -- Fix complaint about nil IP address on restore of cilium_host (@christarazi)
 * #20814 -- ingress: add websockets configuration (@nikhiljha)
 * #20821 -- CI: Enable IPv6 in the L4LB suite (@brb)
 * #20832 -- docs: Clarify identity table for reserved identities (@joestringer)
 * #20844 -- helm: Refer to the correct Helm value (@michi-covalent)
 * #20849 -- cilium-health: fix probing for IPv6-only clusters (@aanm)
 * #20706 -- ipcache/kvstore: fix panic when processing ip=<nil> entries (@ArthurChiao)

Skipped:
 * #20834 -- test: Switch back to official kind image (@brb)
   - Will be backported separately by @brb because it depends on bits of #20682, see
     https://github.com/cilium/cilium/pull/20834#issuecomment-1209435905

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20608 20734 20814 20821 20832 20844 20849 20706; do contrib/backporting/set-labels.py $pr done 1.12; done
```