### PR TITLE
ci: Add go build tag for labels_test.go file

### DIFF
--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
+//go:build !privileged_tests
+
 package k8s
 
 import (


### PR DESCRIPTION
This commit is to go build tag to fix the below issue in master.

```
Test file(s) does not contain a tag privileged_tests or !privileged_tests tags:
./pkg/k8s/labels_test.go
```

Signed-off-by: Tam Mach <tam.mach@cilium.io>
