### PR TITLE
v1.11 backport for BGP SVC announcement fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ replace (
 	github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3
 	github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
 
-	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d
+	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47
 
 	// Using private fork of controller-tools. See commit msg for more context
 	// as to why we are using a private fork.

--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ replace (
 	github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3
 	github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
 
-	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47
+	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220713202445-9066eee9e0be
 
 	// Using private fork of controller-tools. See commit msg for more context
 	// as to why we are using a private fork.

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyR
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
 github.com/cilium/lumberjack/v2 v2.2.1 h1:RO55E3EXM0tRI0rEnCSx7YQgG2XddTFNiwOgq6io+FU=
 github.com/cilium/lumberjack/v2 v2.2.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
-github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47 h1:re/GRXDuD+xOLrONyqf355ioO96AbozC7QUiFzL6bT4=
-github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
+github.com/cilium/metallb v0.1.1-0.20220713202445-9066eee9e0be h1:ZlvVOPr/etGVRFiiuXyZKCCKRRmeXVjgbK0nESEOQBg=
+github.com/cilium/metallb v0.1.1-0.20220713202445-9066eee9e0be/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
 github.com/cilium/proxy v0.0.0-20220202185058-28b3c32edfee h1:C8BQJ4s4O7O3beGzZIItO7EhWhCOvbRADzYAomBQ/Rc=
 github.com/cilium/proxy v0.0.0-20220202185058-28b3c32edfee/go.mod h1:ontBl/RX7G0GwcR38YQVp6d75MjIsL1FbBidVpn+F8I=
 github.com/cilium/workerpool v1.1.1 h1:OTs+dZBzYTP1XC9iO9SnTGaCSEI/Xs1Eohi/y0cGdDU=

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyR
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
 github.com/cilium/lumberjack/v2 v2.2.1 h1:RO55E3EXM0tRI0rEnCSx7YQgG2XddTFNiwOgq6io+FU=
 github.com/cilium/lumberjack/v2 v2.2.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
-github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d h1:skjwi8X3DdLWRI4AFmiAn83ruNoAw4f2kvdBlM8EI8c=
-github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
+github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47 h1:re/GRXDuD+xOLrONyqf355ioO96AbozC7QUiFzL6bT4=
+github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
 github.com/cilium/proxy v0.0.0-20220202185058-28b3c32edfee h1:C8BQJ4s4O7O3beGzZIItO7EhWhCOvbRADzYAomBQ/Rc=
 github.com/cilium/proxy v0.0.0-20220202185058-28b3c32edfee/go.mod h1:ontBl/RX7G0GwcR38YQVp6d75MjIsL1FbBidVpn+F8I=
 github.com/cilium/workerpool v1.1.1 h1:OTs+dZBzYTP1XC9iO9SnTGaCSEI/Xs1Eohi/y0cGdDU=

--- a/pkg/bgp/mock/mock.go
+++ b/pkg/bgp/mock/mock.go
@@ -16,9 +16,10 @@ import (
 // MockMetalLBSpeaker implements the speaker.Speaker interface by delegating to
 // a set of functions defined during test.
 type MockMetalLBSpeaker struct {
-	SetService_    func(name string, svc *metallbspr.Service, eps *metallbspr.Endpoints) types.SyncState
-	SetNodeLabels_ func(labels map[string]string) types.SyncState
-	PeerSession_   func() []metallbspr.Session
+	SetService_       func(name string, svc *metallbspr.Service, eps *metallbspr.Endpoints) types.SyncState
+	SetNodeLabels_    func(labels map[string]string) types.SyncState
+	PeerSession_      func() []metallbspr.Session
+	GetBGPController_ func() *metallbspr.BGPController
 }
 
 func (m *MockMetalLBSpeaker) SetService(name string, svc *metallbspr.Service, eps *metallbspr.Endpoints) types.SyncState {
@@ -31,6 +32,10 @@ func (m *MockMetalLBSpeaker) SetNodeLabels(labels map[string]string) types.SyncS
 
 func (m *MockMetalLBSpeaker) PeerSessions() []metallbspr.Session {
 	return m.PeerSession_()
+}
+
+func (m *MockMetalLBSpeaker) GetBGPController() *metallbspr.BGPController {
+	return m.GetBGPController_()
 }
 
 // MockEndpointGetter implements the method set for obtaining th endpoints

--- a/pkg/bgp/speaker/metallb.go
+++ b/pkg/bgp/speaker/metallb.go
@@ -14,6 +14,7 @@ import (
 	nodetypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 
+	"go.universe.tf/metallb/pkg/config"
 	"go.universe.tf/metallb/pkg/k8s/types"
 	metallbspr "go.universe.tf/metallb/pkg/speaker"
 )
@@ -37,6 +38,8 @@ type Speaker interface {
 	SetNodeLabels(labels map[string]string) types.SyncState
 	// PeerSessions returns any active BGP sessions.
 	PeerSessions() []metallbspr.Session
+	// GetBGPController returns the BGPController of the speaker
+	GetBGPController() *metallbspr.BGPController
 }
 
 // metalLBSpeaker implements the Speaker interface
@@ -98,4 +101,7 @@ func (m metalLBSpeaker) SetNodeLabels(labels map[string]string) types.SyncState 
 }
 func (m metalLBSpeaker) PeerSessions() []metallbspr.Session {
 	return m.C.PeerSessions()
+}
+func (m metalLBSpeaker) GetBGPController() *metallbspr.BGPController {
+	return m.C.Protocols[config.BGP].(*metallbspr.BGPController)
 }

--- a/pkg/bgp/speaker/pod_cidr.go
+++ b/pkg/bgp/speaker/pod_cidr.go
@@ -4,7 +4,6 @@
 package speaker
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -13,7 +12,6 @@ import (
 
 	metallbbgp "go.universe.tf/metallb/pkg/bgp"
 	metallbspr "go.universe.tf/metallb/pkg/speaker"
-	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -73,6 +71,9 @@ func (s *MetalLBSpeaker) withdraw() {
 //
 // returning an error from this method will requeue the event
 // which triggered the invocation.
+//
+// This function is not thread safe and should not be called while other functions that modify the underlying speaker
+// are being called.
 func (s *MetalLBSpeaker) announcePodCIDRs(cidrs CidrSlice) error {
 	var (
 		l = log.WithFields(logrus.Fields{
@@ -80,12 +81,7 @@ func (s *MetalLBSpeaker) announcePodCIDRs(cidrs CidrSlice) error {
 		})
 	)
 
-	sessions := s.speaker.PeerSessions()
-	if len(sessions) == 0 {
-		// no sessions available, returning this error will
-		// requeue the event.
-		return fmt.Errorf("no established BGP session")
-	}
+	ctl := s.speaker.GetBGPController()
 
 	// create advertisements
 	adverts := cidrs.ToAdvertisements()
@@ -97,20 +93,7 @@ func (s *MetalLBSpeaker) announcePodCIDRs(cidrs CidrSlice) error {
 	l.WithField("advertisements", cidrs).
 		Info("Advertising CIDRs to all available session")
 
-	var eg errgroup.Group
-	for _, session := range sessions {
-		func(s metallbspr.Session) { // Need an outer closure to capture session.
-			eg.Go(func() error {
-				// if node-selectors are on its possible to receive
-				// nil sessions. look for them here and send a debug
-				// log as this is normal behavior.
-				if s == nil {
-					l.Debug("Encountered nil session from MetalLB. If node-selector(s) are not configured this could be an error.")
-					return nil
-				}
-				return s.Set(adverts...)
-			})
-		}(session)
-	}
-	return eg.Wait()
+	ctl.SvcAds["podcidr"] = adverts
+
+	return ctl.UpdateAds()
 }

--- a/pkg/bgp/speaker/speaker_test.go
+++ b/pkg/bgp/speaker/speaker_test.go
@@ -368,9 +368,16 @@ func TestSpeakerOnUpdateNode(t *testing.T) {
 			atomic.AddInt32(&callCount, 1)
 			return types.SyncStateSuccess
 		},
-		PeerSession_: func() []metallbspr.Session {
+		GetBGPController_: func() *metallbspr.BGPController {
 			atomic.AddInt32(&callCount, 1)
-			return []metallbspr.Session{mockSession}
+			return &metallbspr.BGPController{
+				SvcAds: make(map[string][]*metallbbgp.Advertisement),
+				Peers: []*metallbspr.Peer{
+					{
+						BGP: mockSession,
+					},
+				},
+			}
 		},
 	}
 
@@ -465,6 +472,16 @@ func TestSpeakerOnDeleteNode(t *testing.T) {
 		PeerSession_: func() []metallbspr.Session {
 			atomic.AddInt32(&callCount, 1)
 			return []metallbspr.Session{mockSession}
+		},
+		GetBGPController_: func() *metallbspr.BGPController {
+			return &metallbspr.BGPController{
+				SvcAds: make(map[string][]*metallbbgp.Advertisement),
+				Peers: []*metallbspr.Peer{
+					{
+						BGP: mockSession,
+					},
+				},
+			}
 		},
 	}
 

--- a/vendor/go.universe.tf/metallb/pkg/speaker/bgp_controller.go
+++ b/vendor/go.universe.tf/metallb/pkg/speaker/bgp_controller.go
@@ -178,7 +178,7 @@ func (c *BGPController) syncPeers(l log.Logger) error {
 	}
 	if needUpdateAds {
 		// Some new sessions came up, resync advertisement state.
-		if err := c.updateAds(); err != nil {
+		if err := c.UpdateAds(); err != nil {
 			l.Log("op", "updateAds", "error", err, "msg", "failed to update BGP advertisements")
 			return err
 		}
@@ -207,7 +207,7 @@ func (c *BGPController) SetBalancer(l log.Logger, name string, lbIP net.IP, pool
 		c.SvcAds[name] = append(c.SvcAds[name], ad)
 	}
 
-	if err := c.updateAds(); err != nil {
+	if err := c.UpdateAds(); err != nil {
 		return err
 	}
 
@@ -216,7 +216,7 @@ func (c *BGPController) SetBalancer(l log.Logger, name string, lbIP net.IP, pool
 	return nil
 }
 
-func (c *BGPController) updateAds() error {
+func (c *BGPController) UpdateAds() error {
 	var allAds []*bgp.Advertisement
 	for _, ads := range c.SvcAds {
 		// This list might contain duplicates, but that's fine,
@@ -243,7 +243,7 @@ func (c *BGPController) DeleteBalancer(l log.Logger, name, reason string) error 
 		return nil
 	}
 	delete(c.SvcAds, name)
-	return c.updateAds()
+	return c.UpdateAds()
 }
 
 // Session gives access to the BGP session.

--- a/vendor/go.universe.tf/metallb/pkg/speaker/bgp_controller.go
+++ b/vendor/go.universe.tf/metallb/pkg/speaker/bgp_controller.go
@@ -32,49 +32,49 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
-type peer struct {
+type Peer struct {
 	cfg *config.Peer
-	bgp Session
+	BGP Session
 }
 
 type BGPController struct {
 	Logger     log.Logger
 	MyNode     string
 	nodeLabels labels.Set
-	peers      []*peer
+	Peers      []*Peer
 	SvcAds     map[string][]*bgp.Advertisement
 }
 
 func (c *BGPController) SetConfig(l log.Logger, cfg *config.Config) error {
-	newPeers := make([]*peer, 0, len(cfg.Peers))
+	newPeers := make([]*Peer, 0, len(cfg.Peers))
 newPeers:
 	for _, p := range cfg.Peers {
-		for i, ep := range c.peers {
+		for i, ep := range c.Peers {
 			if ep == nil {
 				continue
 			}
 			if reflect.DeepEqual(p, ep.cfg) {
 				newPeers = append(newPeers, ep)
-				c.peers[i] = nil
+				c.Peers[i] = nil
 				continue newPeers
 			}
 		}
 		// No existing peers match, create a new one.
-		newPeers = append(newPeers, &peer{
+		newPeers = append(newPeers, &Peer{
 			cfg: p,
 		})
 	}
 
-	oldPeers := c.peers
-	c.peers = newPeers
+	oldPeers := c.Peers
+	c.Peers = newPeers
 
 	for _, p := range oldPeers {
 		if p == nil {
 			continue
 		}
 		l.Log("event", "peerRemoved", "peer", p.cfg.Addr, "reason", "removedFromConfig", "msg", "peer deconfigured, closing BGP session")
-		if p.bgp != nil {
-			if err := p.bgp.Close(); err != nil {
+		if p.BGP != nil {
+			if err := p.BGP.Close(); err != nil {
 				l.Log("op", "setConfig", "error", err, "peer", p.cfg.Addr, "msg", "failed to shut down BGP session")
 			}
 		}
@@ -139,7 +139,7 @@ func (c *BGPController) syncPeers(l log.Logger) error {
 		errs          int
 		needUpdateAds bool
 	)
-	for _, p := range c.peers {
+	for _, p := range c.Peers {
 		// First, determine if the peering should be active for this
 		// node.
 		shouldRun := false
@@ -151,14 +151,14 @@ func (c *BGPController) syncPeers(l log.Logger) error {
 		}
 
 		// Now, compare current state to intended state, and correct.
-		if p.bgp != nil && !shouldRun {
+		if p.BGP != nil && !shouldRun {
 			// Oops, session is running but shouldn't be. Shut it down.
 			l.Log("event", "peerRemoved", "peer", p.cfg.Addr, "reason", "filteredByNodeSelector", "msg", "peer deconfigured, closing BGP session")
-			if err := p.bgp.Close(); err != nil {
+			if err := p.BGP.Close(); err != nil {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to shut down BGP session")
 			}
-			p.bgp = nil
-		} else if p.bgp == nil && shouldRun {
+			p.BGP = nil
+		} else if p.BGP == nil && shouldRun {
 			// Session doesn't exist, but should be running. Create
 			// it.
 			l.Log("event", "peerAdded", "peer", p.cfg.Addr, "msg", "peer configured, starting BGP session")
@@ -171,7 +171,7 @@ func (c *BGPController) syncPeers(l log.Logger) error {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++
 			} else {
-				p.bgp = s
+				p.BGP = s
 				needUpdateAds = true
 			}
 		}
@@ -268,9 +268,9 @@ func (c *BGPController) SetNodeLabels(l log.Logger, lbls map[string]string) erro
 
 // PeerSessions returns the underlying BGP sessions for direct use.
 func (c *BGPController) PeerSessions() []Session {
-	s := make([]Session, len(c.peers))
-	for i, peer := range c.peers {
-		s[i] = peer.bgp
+	s := make([]Session, len(c.Peers))
+	for i, peer := range c.Peers {
+		s[i] = peer.BGP
 	}
 	return s
 }

--- a/vendor/go.universe.tf/metallb/pkg/speaker/speaker.go
+++ b/vendor/go.universe.tf/metallb/pkg/speaker/speaker.go
@@ -38,7 +38,7 @@ func NewController(cfg ControllerConfig) (*Controller, error) {
 
 	ret := &Controller{
 		myNode:    cfg.MyNode,
-		protocols: protocols,
+		Protocols: protocols,
 		announced: map[string]config.Proto{},
 		svcIP:     map[string]net.IP{},
 	}
@@ -52,7 +52,7 @@ type Controller struct {
 	config *config.Config
 	Client service
 
-	protocols map[config.Proto]Protocol
+	Protocols map[config.Proto]Protocol
 	announced map[string]config.Proto // service name -> protocol advertising it
 	svcIP     map[string]net.IP       // service name -> assigned IP
 }
@@ -142,7 +142,7 @@ func (c *Controller) SetService(l gokitlog.Logger, name string, svc *Service, ep
 	}
 
 	l = gokitlog.With(l, "protocol", pool.Protocol)
-	handler := c.protocols[pool.Protocol]
+	handler := c.Protocols[pool.Protocol]
 	if handler == nil {
 		l.Log("bug", "true", "msg", "internal error: unknown balancer protocol!")
 		return c.deleteBalancer(l, name, "internalError")
@@ -179,7 +179,7 @@ func (c *Controller) deleteBalancer(l gokitlog.Logger, name, reason string) type
 		return types.SyncStateSuccess
 	}
 
-	if err := c.protocols[proto].DeleteBalancer(l, name, reason); err != nil {
+	if err := c.Protocols[proto].DeleteBalancer(l, name, reason); err != nil {
 		l.Log("op", "deleteBalancer", "error", err, "msg", "failed to clear balancer state")
 		return types.SyncStateError
 	}
@@ -225,7 +225,7 @@ func (c *Controller) SetConfig(l gokitlog.Logger, cfg *config.Config) types.Sync
 		}
 	}
 
-	for proto, handler := range c.protocols {
+	for proto, handler := range c.Protocols {
 		if err := handler.SetConfig(l, cfg); err != nil {
 			l.Log("op", "setConfig", "protocol", proto, "error", err, "msg", "applying new configuration to protocol handler failed")
 			return types.SyncStateError
@@ -242,7 +242,7 @@ func (c *Controller) SetNode(l gokitlog.Logger, node *v1.Node) types.SyncState {
 }
 
 func (c *Controller) SetNodeLabels(l gokitlog.Logger, labels map[string]string) types.SyncState {
-	for proto, handler := range c.protocols {
+	for proto, handler := range c.Protocols {
 		if err := handler.SetNodeLabels(l, labels); err != nil {
 			l.Log("op", "setNode", "error", err, "protocol", proto, "msg", "failed to propagate node info to protocol handler")
 			return types.SyncStateError
@@ -254,7 +254,7 @@ func (c *Controller) SetNodeLabels(l gokitlog.Logger, labels map[string]string) 
 // PeerSessions returns the underlying BGP sessions from the BGP controller. In
 // Layer2 mode only, this returns nil.
 func (c *Controller) PeerSessions() []Session {
-	if handler, ok := c.protocols[config.BGP]; ok {
+	if handler, ok := c.Protocols[config.BGP]; ok {
 		return handler.(*BGPController).PeerSessions()
 	}
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -815,7 +815,7 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 go.uber.org/zap/zapgrpc
-# go.universe.tf/metallb v0.11.0 => github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d
+# go.universe.tf/metallb v0.11.0 => github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47
 ## explicit; go 1.17
 go.universe.tf/metallb/pkg/allocator
 go.universe.tf/metallb/pkg/allocator/k8salloc
@@ -1486,5 +1486,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3
 # github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
-# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20210831235406-48667b93284d
+# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47
 # sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.6.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -815,7 +815,7 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 go.uber.org/zap/zapgrpc
-# go.universe.tf/metallb v0.11.0 => github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47
+# go.universe.tf/metallb v0.11.0 => github.com/cilium/metallb v0.1.1-0.20220713202445-9066eee9e0be
 ## explicit; go 1.17
 go.universe.tf/metallb/pkg/allocator
 go.universe.tf/metallb/pkg/allocator/k8salloc
@@ -1486,5 +1486,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/miekg/dns => github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3
 # github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
-# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220628131316-3c8101856f47
+# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220713202445-9066eee9e0be
 # sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.6.2


### PR DESCRIPTION
 * #20413 -- bgp: fixed PodCIDR announcement being overwritten by SVC announcement (@dylandreimerink)
 * #20521 -- bgp: Fixed broken bgp speaker unit tests (@dylandreimerink)
 
 Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20413 20521; do contrib/backporting/set-labels.py $pr done 1.11; done
```