### PR TITLE
Compress CiliumEndpointSlices when moving from Identity to FCFS

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -169,6 +169,11 @@ func (c *CiliumEndpointSliceController) Run(ces cache.Indexer, stopCh chan struc
 		defer utilruntime.HandleCrash()
 	}()
 
+	if c.slicingMode != cesIdentityBasedSlicing {
+		// Process CES updates required to reach the desired CES state for FCFS.
+		go c.Manager.CompressCESsOnFCFSStartUp()
+	}
+
 	<-stopCh
 
 	return


### PR DESCRIPTION
CiliumEndpointSlice compression is required when changing the batching
mode from Identity to FCFS (First come, first served), to ensure the
expected performance of FCFS, which is achieved when CiliumEndpointSlices
are fully packed, instead of distributed by Identities.

_Example:_
Using many small K8s deployments might cause slow propagation of
CilumEndpointSlices while having Identity batching mode on. The reason
is that there are many CiliumEndpointSlices that need to be distributed
to all of the nodes, while there is rate limiting of CiliumEndpointSlice
updates. Switching to FCFS batching mode allows the same information
about CiliumEndpoints to be propagated through the cluster much faster, as
the number of slices will be reduced, since FCFS uses fully packed
slices. This change covers the compression of CiliumEndpointSlices in
case of changing the batching mode from Identity to FCFS.

Signed-off-by: Dorde Lapcevic [dordel@google.com](mailto:dordel@google.com)