### PR TITLE
fix error when add new service with two same backends

### DIFF
--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -60,10 +60,6 @@ func (m *LBMockMap) UpsertService(p *datapathTypes.UpsertServiceParams) error {
 	if !found {
 		frontend := lb.NewL3n4AddrID(lb.NONE, cmtypes.MustAddrClusterFromIP(p.IP), p.Port, p.Scope, lb.ID(p.ID))
 		svc = &lb.SVC{Frontend: *frontend}
-	} else {
-		if p.PrevBackendsCount != len(svc.Backends) {
-			return fmt.Errorf("Invalid backends count: %d vs %d", p.PrevBackendsCount, len(svc.Backends))
-		}
 	}
 	svc.Backends = backendsList
 	svc.SessionAffinity = p.SessionAffinity


### PR DESCRIPTION
fix error when add new service with two same backends


### As-Is: can't delete a service in lb-only mode.
   After create a service with two backend with same ip address and port, 
   deleting that service fails because serviceKey of bpf map cilium_lb4_services_v2  with  **slot 2 backend**  does not exist.
   Also  after pod restarts and restores service from bpf,  service have only one backend


```
/home/cilium# cilium service update  --id=101  --frontend=3.3.3.3:80 --backends=1.1.1.1:80,1.1.1.1:80    --k8s-external
Creating new service with id '101'
Added service with 2 backends
/home/cilium# cilium service list
ID    Frontend     Service Type   Backend
101   3.3.3.3:80   ExternalIPs    1 => 1.1.1.1:80 (active)
                                  2 => 1.1.1.1:80 (active)
/home/cilium# cilium service delete 101
Error: [DELETE /service/{id}][500] deleteServiceIdFailure  Unable to delete service entry 3.3.3.3:20480: unable to delete element 3.3.3.3:80 from map cilium_lb4_services_v2: no such file or directory
```

> Error: [DELETE /service/{id}][500] deleteServiceIdFailure  Unable to delete service entry 3.3.3.3:20480: slot 2, unable to delete element 3.3.3.3:80 from map cilium_lb4_services_v2: no such file or directory
   
   - when pod is restarting and restoring from bpf map without deleting service, a backend disappears.

```
/home/cilium#  cilium service list
ID    Frontend     Service Type   Backend
101   3.3.3.3:80   ExternalIPs    1 => 1.1.1.1:80 (active)
```   

### To-Be
   - disallow creating a service with same backends with same ip address and port

```
# cilium service update  --id=101  --frontend=3.3.3.3:80 --backends=1.1.1.1:80,1.1.1.1:80    --k8s-external
Creating new service with id '101'
Error: Cannot add/update service: [PUT /service/{id}][500] putServiceIdFailure  duplicated backends are not allowed
```
