### PR TITLE
Minor cleanups in FQDN name manager

### DIFF
--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -150,7 +150,7 @@ func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Tim
 		}).Debug("Updated FQDN with new IPs")
 	}
 
-	namesMissingIPs, selectorIPMapping := n.generateSelectorUpdates(fqdnSelectorsToUpdate)
+	namesMissingIPs, selectorIPMapping := n.MapSelectorsToIPsLocked(fqdnSelectorsToUpdate)
 	if len(namesMissingIPs) != 0 {
 		log.WithField(logfields.DNSName, namesMissingIPs).
 			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
@@ -235,14 +235,6 @@ func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[strin
 	}
 
 	return affectedSelectors, updatedNames
-}
-
-// generateSelectorUpdates iterates over all names in the DNS cache managed by
-// gen and figures out to which FQDNSelectors managed by the cache these names
-// map. Returns the set of FQDNSelectors which map to no IPs, and a mapping
-// of FQDNSelectors to IPs.
-func (n *NameManager) generateSelectorUpdates(fqdnSelectors map[api.FQDNSelector]struct{}) (namesMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
-	return n.MapSelectorsToIPsLocked(fqdnSelectors)
 }
 
 // updateIPsName will update the IPs for dnsName. It always retains a copy of

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -204,7 +204,6 @@ func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[strin
 	updatedNames = make(map[string][]net.IP, len(updatedDNSIPs))
 	affectedSelectors = make(map[api.FQDNSelector]struct{}, len(updatedDNSIPs))
 
-perDNSName:
 	for dnsName, lookupIPs := range updatedDNSIPs {
 		updated := n.updateIPsForName(lookupTime, dnsName, lookupIPs.IPs, lookupIPs.TTL)
 
@@ -214,7 +213,7 @@ perDNSName:
 				"dnsName":   dnsName,
 				"lookupIPs": lookupIPs,
 			}).Debug("FQDN: IPs didn't change for DNS name")
-			continue perDNSName
+			continue
 		}
 
 		// record the IPs that were different


### PR DESCRIPTION
This PR introduces a couple of minor cleanups in the FQDN Name Manager code.
Refer to the individual commits for more details.