### PR TITLE
probe: fix kernel config probe log

### DIFF
--- a/pkg/datapath/linux/probes/probes_test.go
+++ b/pkg/datapath/linux/probes/probes_test.go
@@ -4,7 +4,6 @@
 package probes
 
 import (
-	"errors"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -242,9 +241,6 @@ func (s *ProbesTestSuite) TestSystemConfigProbes(c *C) {
 			features: Features{SystemConfig: tc.systemConfig},
 		}
 		err := manager.SystemConfigProbes()
-		if errors.Is(err, ErrKernelConfigNotFound) {
-			return
-		}
 		if tc.expectErr {
 			c.Assert(err, NotNil)
 		} else {

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -139,10 +139,9 @@ func CheckMinRequirements() {
 		}
 		if err := probeManager.SystemConfigProbes(); err != nil {
 			errMsg := "BPF system config check: NOT OK."
-			// TODO(brb) warn after GH#14314 has been resolved
-			if !errors.Is(err, probes.ErrKernelConfigNotFound) {
-				log.WithError(err).Warn(errMsg)
-			}
+			// TODO(vincentmli): revisit log when GH#14314 has been resolved
+			// Warn missing required kernel config option
+			log.WithError(err).Warn(errMsg)
 		}
 		if err := probeManager.CreateHeadersFile(); err != nil {
 			log.WithError(err).Fatal("BPF check: NOT OK.")


### PR DESCRIPTION
In https://github.com/cilium/cilium/issues/20858 and my lab,
I tested kernel with

    1 missing kernel config file /boot/config-xxx and /proc/config.gz
    2 missing required kernel config option CONFIG_NET_CLS_ACT
    
    when both condition 1 and 2 are met, the cilium agent does not log
    missing kernel config file, and missing required kernel config option.
    
    The reason is when missing kernel config file, SystemConfigProbes()
    returns ErrKernelConfigNotFound, but SystemConfigProbes() caller
    only logs error when SystemConfigProbes() detect missing required
    kernel config option which would never happen because SystemConfigProbes()
    returned already and kernel config option check is skipped.
    
      Warn missing kernel config file if cilium agent fail to start
    
    After the fix:
    
    level=info msg="clang (10.0.0) and kernel (5.18.0) versions: OK!" subsys=linux-datapath
    level=info msg="linking environment: OK!" subsys=linux-datapath
    level=warning msg="Kernel Config file not found: Check required kernel config parameter \
            if cilium agent fail to start!" subsys=probes
    …SNIP…
    level=warning msg="+ tc qdisc replace dev cilium_vxlan clsact" subsys=datapath-loader
    level=warning msg="Error: Cannot find ingress queue for specified device." subsys=datapath-loader


Fix: #20858

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #20858
```release-note
fix kernel config file and config option probe log
```
