### PR TITLE
v1.10 backports 2022-08-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Summary of Changes
 * helm: Guard apply sysctl init container (Backport PR #20838, Upstream PR #20643, @sayboras)
 * iptables: handle case where kernel IPv6 support is disabled (Backport PR #20838, Upstream PR #20680, @jibi)
 * pkg/k8s/version: Also set EndpointSlice when forcing version (Backport PR #20620, Upstream PR #20383, @joamaki)
+* Fix bug where Cilium would crash on startup with an error about being unable to delete iptables rules. (Backport PR #20892, Upstream PR #20885, @jibi)
 
 **CI Changes:**
 * ci: fix code changes detection on `push` events (Backport PR #20838, Upstream PR #20685, @nbusseneau)

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -234,6 +234,17 @@ func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface
 			continue
 		}
 
+		// Temporary fix while Iptables is upgraded to >= 1.8.5
+		// (See GH-20884).
+		//
+		// The version currently shipped with Cilium (1.8.4) does not
+		// support the deletion of NOTRACK rules, so we will just ignore
+		// them here and let the agent remove them when it deletes the
+		// entire chain.
+		if strings.Contains(rule, "-j NOTRACK") {
+			continue
+		}
+
 		// do not remove feeder for chains that are set to be disabled
 		// ie catch the beginning of the rule like -A POSTROUTING to match it against
 		// disabled chains


### PR DESCRIPTION
* #20885 -- iptables: skip NOTRACK rules deletion (@jibi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20885; do contrib/backporting/set-labels.py $pr done 1.10; done
```