### PR TITLE
Fix typos in FQDN semaphore metric enablement.

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1251,7 +1251,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			collectors = append(collectors, FQDNAliveZombieConnections)
 			c.FQDNActiveZombiesConnections = true
 
-		case metricName + "_" + SubsystemFQDN + "_sempaphore_rejected_total":
+		case Namespace + "_" + SubsystemFQDN + "_semaphore_rejected_total":
 			FQDNSemaphoreRejectedTotal = prometheus.NewCounter(prometheus.CounterOpts{
 				Namespace: Namespace,
 				Subsystem: SubsystemFQDN,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3248,11 +3248,11 @@ func (c *DaemonConfig) Populate() {
 
 func (c *DaemonConfig) additionalMetrics() []string {
 	addMetric := func(name string) string {
-		return "+" + metrics.Namespace + name
+		return "+" + metrics.Namespace + "_" + name
 	}
 	var m []string
 	if c.DNSProxyConcurrencyLimit > 0 {
-		m = append(m, addMetric(metrics.SubsystemFQDN+"_sempaphore_rejected_total"))
+		m = append(m, addMetric(metrics.SubsystemFQDN+"_semaphore_rejected_total"))
 	}
 	return m
 }


### PR DESCRIPTION
Signed-off-by: Rahul Joshi <rkjoshi@google.com>

```release-note
Fixes typos in enabling fqdn_semaphore_rejected_total metric
```
