### PR TITLE
don't merge stderr into iptable stdout

### DIFF
--- a/pkg/command/exec/exec.go
+++ b/pkg/command/exec/exec.go
@@ -56,8 +56,14 @@ func output(ctx context.Context, cmd *exec.Cmd, filters []string, scopedLog *log
 		}
 		return nil, fmt.Errorf("Command execution failed for %s: %w", cmd.Args, ctx.Err())
 	}
-	if err != nil && verbose {
-		warnToLog(cmd, filters, out, scopedLog, err)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			err = fmt.Errorf("%w stderr=%q", exitErr, exitErr.Stderr)
+		}
+		if verbose {
+			warnToLog(cmd, filters, out, scopedLog, err)
+		}
 	}
 	return out, err
 }

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -99,9 +99,9 @@ var ciliumChains = []customChain{
 func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 	args := []string{"-t", c.table, "-L", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
-		if strings.Contains(string(output), "No chain/target/match by that name.") {
+		if strings.Contains(err.Error(), "No chain/target/match by that name.") {
 			return false, nil
 		}
 
@@ -114,7 +114,7 @@ func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 func (c *customChain) doAdd(prog iptablesInterface) error {
 	args := []string{"-t", c.table, "-N", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to add %s chain: %s (%w)", c.name, string(output), err)
 	}
@@ -146,7 +146,7 @@ func (c *customChain) doRename(prog iptablesInterface, newName string) error {
 
 	args := []string{"-t", c.table, "-E", c.name, newName}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to rename %s chain to %s: %s (%w)", c.name, newName, string(output), err)
 	}
@@ -178,14 +178,14 @@ func (c *customChain) doRemove(prog iptablesInterface) error {
 
 	args := []string{"-t", c.table, "-F", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to flush %s chain: %s (%w)", c.name, string(output), err)
 	}
 
 	args = []string{"-t", c.table, "-X", c.name}
 
-	output, err = prog.runProgCombinedOutput(args)
+	output, err = prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to remove %s chain: %s (%w)", c.name, string(output), err)
 	}
@@ -226,7 +226,7 @@ func (c *customChain) doInstallFeeder(prog iptablesInterface, feedArgs string) e
 
 	args := append([]string{"-t", c.table, installMode, c.hook}, feedRule...)
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to install feeder rule for %s chain: %s (%w)", c.name, string(output), err)
 	}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -81,7 +81,7 @@ type iptablesInterface interface {
 	getProg() string
 	getIpset() string
 	getVersion() (semver.Version, error)
-	runProgCombinedOutput(args []string) (string, error)
+	runProgOutput(args []string) (string, error)
 	runProg(args []string) error
 }
 
@@ -131,7 +131,7 @@ func (ipt *ipt) getVersion() (semver.Version, error) {
 	return versioncheck.Version(vString[1])
 }
 
-func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
+func (ipt *ipt) runProgOutput(args []string) (string, error) {
 	fullCommand := fmt.Sprintf("%s %s", ipt.getProg(), strings.Join(args, " "))
 
 	log.Debugf("Running '%s' command", fullCommand)
@@ -140,19 +140,16 @@ func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
 	iptArgs := make([]string, 0, len(ipt.waitArgs)+len(args))
 	iptArgs = append(iptArgs, ipt.waitArgs...)
 	iptArgs = append(iptArgs, args...)
-	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).CombinedOutput(log, false)
-
-	outStr := string(out)
+	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).Output(log, false)
 
 	if err != nil {
-		return outStr, fmt.Errorf("unable to run '%s' iptables command: %s (%w)", fullCommand, outStr, err)
+		return "", fmt.Errorf("unable to run '%s' iptables command: %w", fullCommand, err)
 	}
-
-	return outStr, nil
+	return string(out), nil
 }
 
 func (ipt *ipt) runProg(args []string) error {
-	_, err := ipt.runProgCombinedOutput(args)
+	_, err := ipt.runProgOutput(args)
 	return err
 }
 
@@ -217,7 +214,7 @@ func isDisabledChain(chain string) bool {
 }
 
 func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
 	if err != nil {
 		return err
 	}
@@ -654,7 +651,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 }
 
 func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, match, oldChain, newChain string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
 	if err != nil {
 		return err
 	}
@@ -707,7 +704,7 @@ func (m *IptablesManager) copyProxyRules(oldChain string, match string) error {
 // Redirect packets to the host proxy via TPROXY, as directed by the Cilium
 // datapath bpf programs via skb marks (egress) or DSCP (ingress).
 func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16, ingress bool, name string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-S"})
 	if err != nil {
 		return err
 	}
@@ -937,7 +934,7 @@ func (m *IptablesManager) GetProxyPort(name string) uint16 {
 }
 
 func (m *IptablesManager) doGetProxyPort(prog iptablesInterface, name string) uint16 {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
+	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
 	if err != nil {
 		return 0
 	}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -54,7 +54,7 @@ func (ipt *mockIptables) getVersion() (semver.Version, error) {
 	return semver.Version{}, nil
 }
 
-func (ipt *mockIptables) runProgCombinedOutput(args []string) (out string, err error) {
+func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {
 	a := strings.Join(args, " ")
 	i := ipt.index
 	ipt.index++
@@ -74,7 +74,7 @@ func (ipt *mockIptables) runProgCombinedOutput(args []string) (out string, err e
 }
 
 func (ipt *mockIptables) runProg(args []string) error {
-	out, err := ipt.runProgCombinedOutput(args)
+	out, err := ipt.runProgOutput(args)
 	if len(out) > 0 {
 		ipt.c.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
 	}


### PR DESCRIPTION
runProgCombinedOutput merges stdout and stderr of iptables into a single
string and parse iptables rules out from it. But stderr is never rules but warnings/errors. For example, stderr can be "# Warning: iptables-legacy
tables present, use iptables-legacy-save to see them"

This commit changes it to use exec.Output but merge stderr into err.

Fixes: #20894

Signed-off-by: Yuan Liu <liuyuan@google.com>

```release-note
put stderr of iptables command into error instead of merging into stdout
```
