### PR TITLE
if the user do not specify a proxy port and it fails to listen on the port, instead of retrying again for that specific one, increment it.

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/rand"
@@ -536,6 +537,9 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 		if nRetry > 0 {
 			// an error occurred and we can retry
 			scopedLog.WithError(err).Warningf("Unable to create %s proxy, retrying", ppName)
+			if option.Config.ToFQDNsProxyPort == 0 {
+				pp.proxyPort++
+			}
 		}
 
 		if !pp.configured {


### PR DESCRIPTION
This PR makes changes so that in case the user does not specify a proxy port and it fails to listen on the port, instead of retrying again for that specific one, increment it.

Fixes: #20732

```release-note
Ensure that the DNS proxy picks a new port if the previously-used port is unavailable.
```