### PR TITLE
added a new bug-tool flag to remove object files from sysdump 

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -33,6 +33,7 @@ cilium-bugtool [OPTIONS] [flags]
       --config string             Configuration to decide what should be run (default "./.cilium-bugtool.config")
       --dry-run                   Create configuration file of all commands that would have been executed
       --enable-markdown           Dump output of commands in markdown format
+      --exclude-object-files      Exclude object files from sysdump
       --exec-timeout duration     The default timeout for any cmd execution in seconds (default 30s)
       --get-pprof                 When set, only gets the pprof traces from the cilium-agent binary
   -h, --help                      help for cilium-bugtool

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -419,6 +419,9 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 			kubectlArg := fmt.Sprintf("%s/%s:%s", k8sNamespace, pod, stateDir)
 			// kubectl cp kube-system/cilium-xrzwr:/var/run/cilium/state cilium-xrzwr-state
 			commands = append(commands, fmt.Sprintf("kubectl cp %s %s", kubectlArg, dst))
+			if excludeObjectFiles {
+				commands = append(commands, fmt.Sprintf("rm %s/*.o", dst))
+			}
 			for _, cmd := range ciliumCommands {
 				// Add the host flag if set
 				if len(host) > 0 {

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -56,22 +56,23 @@ for sensitive information.
 )
 
 var (
-	archive         bool
-	archiveType     string
-	k8s             bool
-	dumpPath        string
-	host            string
-	k8sNamespace    string
-	k8sLabel        string
-	execTimeout     time.Duration
-	configPath      string
-	dryRunMode      bool
-	enableMarkdown  bool
-	archivePrefix   string
-	getPProf        bool
-	pprofPort       int
-	traceSeconds    int
-	parallelWorkers int
+	archive            bool
+	archiveType        string
+	k8s                bool
+	dumpPath           string
+	host               string
+	k8sNamespace       string
+	k8sLabel           string
+	execTimeout        time.Duration
+	configPath         string
+	dryRunMode         bool
+	enableMarkdown     bool
+	archivePrefix      string
+	getPProf           bool
+	pprofPort          int
+	traceSeconds       int
+	parallelWorkers    int
+	excludeObjectFiles bool
 )
 
 func init() {
@@ -97,6 +98,7 @@ func init() {
 	BugtoolRootCmd.Flags().BoolVar(&enableMarkdown, "enable-markdown", false, "Dump output of commands in markdown format")
 	BugtoolRootCmd.Flags().StringVarP(&archivePrefix, "archive-prefix", "", "", "String to prefix to name of archive if created (e.g., with cilium pod-name)")
 	BugtoolRootCmd.Flags().IntVar(&parallelWorkers, "parallel-workers", 0, "Maximum number of parallel worker tasks, use 0 for number of CPUs")
+	BugtoolRootCmd.Flags().BoolVar(&excludeObjectFiles, "exclude-object-files", false, "Exclude object files from sysdump")
 }
 
 func getVerifyCiliumPods() (k8sPods []string) {


### PR DESCRIPTION
This PR adds a new bug-tool flag `--exclude-object-files` for removing the object files like `template.o` & `bpf_lxc.o` from sysdump by default.

Fixes: #20450