### PR TITLE
ipsec: Fix incorrect parsing of SPI from mark

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -254,7 +254,7 @@ func ipSecXfrmMarkSetSPI(markValue uint32, spi uint8) uint32 {
 
 // ipSecXfrmMarkGetSPI extracts from a XfrmMark value the encoded SPI
 func ipSecXfrmMarkGetSPI(markValue uint32) uint8 {
-	return uint8(markValue >> ipSecXfrmMarkSPIShift)
+	return uint8(markValue >> ipSecXfrmMarkSPIShift & 0xF)
 }
 
 func getSPIFromXfrmPolicy(policy *netlink.XfrmPolicy) uint8 {


### PR DESCRIPTION
Commit b2331289c70 introduced helpers to set and retrieve the SPI from the XFRM mark. The SPI number is encoded into 4 bits at positions 12-15 (LSB first).

However, function `ipSecXfrmMarkGetSPI` extracts 8 bits at positions 12-19 instead of 4. This pull request fixes it. This bug would only have an impact if some other software used the 4 upper bug; no such case is currently known.

Fixes: https://github.com/cilium/cilium/pull/19932.
cc @jibi 