### PR TITLE
pkg/endpoint: set namedPortsGetter interface on ParseEndpoint

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -51,6 +51,7 @@ type DaemonSuite struct {
 
 	// Owners interface mock
 	OnGetPolicyRepository  func() *policy.Repository
+	OnGetNamedPorts        func() (npm policy.NamedPortMultiMap)
 	OnQueueEndpointBuild   func(ctx context.Context, epID uint64) (func(), error)
 	OnGetCompilationLock   func() *lock.RWMutex
 	OnSendNotification     func(typ monitorAPI.AgentNotifyMessage) error
@@ -236,6 +237,13 @@ func (ds *DaemonSuite) GetPolicyRepository() *policy.Repository {
 		return ds.OnGetPolicyRepository()
 	}
 	panic("GetPolicyRepository should not have been called")
+}
+
+func (ds *DaemonSuite) GetNamedPorts() (npm policy.NamedPortMultiMap) {
+	if ds.OnGetNamedPorts != nil {
+		return ds.OnGetNamedPorts()
+	}
+	panic("GetNamedPorts should not have been called")
 }
 
 func (ds *DaemonSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -133,7 +133,7 @@ func (d *Daemon) fetchOldEndpoints(dir string) (*endpointRestoreState, error) {
 	}
 	eptsID := endpoint.FilterEPDir(dirFiles)
 
-	state.possible = endpoint.ReadEPsFromDirNames(d.ctx, d, d, dir, eptsID)
+	state.possible = endpoint.ReadEPsFromDirNames(d.ctx, d, d, d.ipcache, dir, eptsID)
 
 	if len(state.possible) == 0 {
 		log.Info("No old endpoints found.")

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -794,7 +794,7 @@ func FilterEPDir(dirFiles []os.DirEntry) []string {
 // common.CiliumCHeaderPrefix + common.Version + ":" + endpointBase64
 // Note that the parse'd endpoint's identity is only partially restored. The
 // caller must call `SetIdentity()` to make the returned endpoint's identity useful.
-func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter, bEp []byte) (*Endpoint, error) {
+func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter, namedPortsGetter namedPortsGetter, bEp []byte) (*Endpoint, error) {
 	// TODO: Provide a better mechanism to update from old version once we bump
 	// TODO: cilium version.
 	epSlice := bytes.Split(bEp, []byte{':'})
@@ -802,8 +802,9 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter p
 		return nil, fmt.Errorf("invalid format %q. Should contain a single ':'", bEp)
 	}
 	ep := Endpoint{
-		owner:        owner,
-		policyGetter: policyGetter,
+		owner:            owner,
+		namedPortsGetter: namedPortsGetter,
+		policyGetter:     policyGetter,
 	}
 
 	if err := parseBase64ToEndpoint(epSlice[1], &ep); err != nil {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -57,6 +57,7 @@ type EndpointSuite struct {
 
 	// Owners interface mock
 	OnGetPolicyRepository     func() *policy.Repository
+	OnGetNamedPorts           func() (npm policy.NamedPortMultiMap)
 	OnQueueEndpointBuild      func(ctx context.Context, epID uint64) (func(), error)
 	OnRemoveFromEndpointQueue func(epID uint64)
 	OnGetCompilationLock      func() *lock.RWMutex
@@ -93,6 +94,13 @@ func (s *EndpointSuite) TearDownSuite(c *C) {
 
 func (s *EndpointSuite) GetPolicyRepository() *policy.Repository {
 	return s.repo
+}
+
+func (s *EndpointSuite) GetNamedPorts() (npm policy.NamedPortMultiMap) {
+	if s.OnGetNamedPorts != nil {
+		return s.OnGetNamedPorts()
+	}
+	panic("GetNamedPorts should not have been called")
 }
 
 func (s *EndpointSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {
@@ -139,7 +147,7 @@ func NewCachingIdentityAllocator(owner cache.IdentityAllocatorOwner) fakeIdentit
 	}
 }
 
-//func (f *fakeIdentityAllocator)
+// func (f *fakeIdentityAllocator)
 
 func (s *EndpointSuite) SetUpTest(c *C) {
 	/* Required to test endpoint CEP policy model */

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -67,7 +67,9 @@ func hasHostObjectFile(epDir string) bool {
 
 // ReadEPsFromDirNames returns a mapping of endpoint ID to endpoint of endpoints
 // from a list of directory names that can possible contain an endpoint.
-func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter, basePath string, eptsDirNames []string) map[uint16]*Endpoint {
+func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter,
+	namedPortsGetter namedPortsGetter, basePath string, eptsDirNames []string) map[uint16]*Endpoint {
+
 	completeEPDirNames, incompleteEPDirNames := partitionEPDirNamesByRestoreStatus(eptsDirNames)
 
 	if len(incompleteEPDirNames) > 0 {
@@ -137,7 +139,7 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGe
 			scopedLog.WithError(err).Warn("Unable to read the C header file")
 			continue
 		}
-		ep, err := parseEndpoint(ctx, owner, policyGetter, bEp)
+		ep, err := parseEndpoint(ctx, owner, policyGetter, namedPortsGetter, bEp)
 		if err != nil {
 			scopedLog.WithError(err).Warn("Unable to parse the C header file")
 			continue

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -132,7 +132,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNames(c *C) {
 			epsNames = append(epsNames, ep.DirectoryPath())
 		}
 	}
-	eps := ReadEPsFromDirNames(context.TODO(), ds, ds, tmpDir, epsNames)
+	eps := ReadEPsFromDirNames(context.TODO(), ds, ds, ds, tmpDir, epsNames)
 	c.Assert(len(eps), Equals, len(epsWanted))
 
 	sort.Slice(epsWanted, func(i, j int) bool { return epsWanted[i].ID < epsWanted[j].ID })
@@ -198,7 +198,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNamesWithRestoreFailure(c *C) {
 		ep.DirectoryPath(), ep.NextDirectoryPath(),
 	}
 
-	epResult := ReadEPsFromDirNames(context.TODO(), ds, ds, tmpDir, epNames)
+	epResult := ReadEPsFromDirNames(context.TODO(), ds, ds, ds, tmpDir, epNames)
 	c.Assert(len(epResult), Equals, 1)
 
 	restoredEP := epResult[ep.ID]
@@ -254,7 +254,7 @@ func (ds *EndpointSuite) BenchmarkReadEPsFromDirNames(c *C) {
 	c.StartTimer()
 
 	for i := 0; i < c.N; i++ {
-		eps := ReadEPsFromDirNames(context.TODO(), ds, ds, tmpDir, epsNames)
+		eps := ReadEPsFromDirNames(context.TODO(), ds, ds, ds, tmpDir, epsNames)
 		c.Assert(len(eps), Equals, len(epsWanted))
 	}
 }


### PR DESCRIPTION
When restoring endpoints from the state directory we need to also
initialize their internal "getters" as they will not be initialized on
restore.

This prevents Cilium from crashing upon initialization when a CNP with a
named port is available on the cluster.

```
goroutine 827 [running]:
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).GetNamedPortLocked(0xc00024a000, 0x50?, {0xc000ba1cd0, 0x9}, 0xc0?)
 /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:68 +0x4f
github.com/cilium/cilium/pkg/policy.(*L4Filter).ToMapState(0xc001080000, {0x3434870, 0xc00024a000}, 0x1)
 /go/src/github.com/cilium/cilium/pkg/policy/l4.go:345 +0x2c3
github.com/cilium/cilium/pkg/policy.(*EndpointPolicy).computeDirectionL4PolicyMapEntries(0xc0019e8540, 0xc0019e8540?, 0xc0019e80d8?, 0x40?)
 /go/src/github.com/cilium/cilium/pkg/policy/resolve.go:171 +0xba
github.com/cilium/cilium/pkg/policy.(*EndpointPolicy).computeDesiredL4PolicyMapEntries(0xc0019e8540)
 /go/src/github.com/cilium/cilium/pkg/policy/resolve.go:164 +0x56
github.com/cilium/cilium/pkg/policy.(*selectorPolicy).DistillPolicy(0xc000d180c0, {0x3434870?, 0xc00024a000}, 0x0)
 /go/src/github.com/cilium/cilium/pkg/policy/resolve.go:141 +0x105
github.com/cilium/cilium/pkg/policy.(*cachedSelectorPolicy).Consume(0xc000123770?, {0x3434870?, 0xc00024a000?})
 /go/src/github.com/cilium/cilium/pkg/policy/distillery.go:202 +0x35
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regeneratePolicy(0xc00024a000)
 /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:234 +0x3f7
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).runPreCompilationSteps(0xc00024a000, 0xc000399400)
 /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:814 +0x2c5
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF(0xc00024a000, 0xc000399400)
 /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:584 +0x189
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerate(0xc00024a000, 0xc000399400)
 /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:398 +0x7a5
github.com/cilium/cilium/pkg/endpoint.(*EndpointRegenerationEvent).Handle(0xc0014a2b70, 0x29fef80?)
 /go/src/github.com/cilium/cilium/pkg/endpoint/events.go:53 +0x325
```

Example of such CNP:
```
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  namespace: cilium-test
  name: client-egress-to-echo-deny-named-port
spec:
  endpointSelector:
    matchLabels:
      kind: client
  egressDeny:
  - toPorts:
    - ports:
      - port: "http-8080"
        protocol: TCP
    toEndpoints:
    - matchLabels:
        io.kubernetes.pod.namespace: cilium-test
        kind: echo
```

Fixes: 6e7e9468be4b ("endpoint: Remove references to global ipcache")

Reported-by: Tam Mach <tam.mach@isovalent.com>
Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/20903

```release-note
Fix panic during Cilium initialization when a NetworkPolicy with a named-port selected an pod running on that node.
```