### PR TITLE
docs(bandwidth-manager): add note on per-pod limits

### DIFF
--- a/Documentation/installation/bandwidth-manager.rst
+++ b/Documentation/installation/bandwidth-manager.rst
@@ -170,6 +170,12 @@ the ``netperf-server`` Pod):
 Each Pod is represented in Cilium as an :ref:`endpoint` which has an identity. The above
 identity can then be correlated with the ``cilium endpoint list`` command.
 
+.. note::
+
+   Bandwidth limits apply on a per-Pod scope. In our example, if multiple
+   replicas of the Pod are created, then each of the Pod instances receives
+   a 10M bandwidth limit.
+
 .. _BBR Pods:
 
 BBR for Pods


### PR DESCRIPTION
Signed-off-by: Raphaël Pinson <raphael@isovalent.com>