### PR TITLE
gh/workflows: Update L4LB 1.1{0,1,2} jobs

### DIFF
--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -61,6 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  cilium_cli_version: v0.12.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -118,9 +119,10 @@ jobs:
       )) ||
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
-    # We need nested virtualisation which is supported only by MacOS runner
-    runs-on: macos-10.15
-    timeout-minutes: 30
+    # Ubuntu 22.04 runner uses cgroup v2-only which is needed for some
+    # our LB functionality
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
     steps:
       - name: Set up job variables
         id: vars
@@ -147,19 +149,10 @@ jobs:
           state: pending
           target_url: ${{ env.check_url }}
 
-      - name: Install Docker Client
-        run: |
-          cd /tmp
-          curl -sOL https://download.docker.com/mac/static/stable/x86_64/docker-20.10.9.tgz
-          tar xzf docker-20.10.9.tgz
-          sudo xattr -rc docker
-          sudo cp docker/docker /usr/local/bin/docker
-          rm -r docker docker-20.10.9.tgz
-
-      - name: Checkout upstream for Vagrantfile
+      - name: Checkout upstream for test files
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
-          # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
+          # This is intentionally set to stable branch to avoid using test.sh from pull requests.
           ref: v1.10
           persist-credentials: false
 
@@ -170,28 +163,20 @@ jobs:
           persist-credentials: false
           path: pull-request
 
-      - name: Boot Fedora
-        run: |
-          ln -sf ./test/l4lb/Vagrantfile ./Vagrantfile
-          # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
-          # Spend up to 10 seconds on this
-          for i in {1..4}; do
-            if vagrant up --provision; then
-              break
-            fi
-            sleep $i
-          done
-          vagrant ssh-config >> ~/.ssh/config
-
       - name: Wait for image to be available
         timeout-minutes: 10
         shell: bash
         run: |
           until docker manifest inspect quay.io/${{ github.repository_owner }}/cilium-ci:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
 
-      - name: Run tests
+      - name: Run LoadBalancing test
         run: |
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} /vagrant/pull-request/install/kubernetes/cilium'"
+          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request/install/kubernetes/cilium
+
+      - name: Fetch cilium-sysdump
+        if: ${{ !success() }}
+        run: |
+          sudo cilium sysdump --output-filename cilium-sysdump-out
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -61,6 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  cilium_cli_version: v0.12.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -118,9 +119,10 @@ jobs:
       )) ||
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
-    # We need nested virtualisation which is supported only by MacOS runner
-    runs-on: macos-10.15
-    timeout-minutes: 30
+    # Ubuntu 22.04 runner uses cgroup v2-only which is needed for some
+    # our LB functionality
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
     steps:
       - name: Set up job variables
         id: vars
@@ -147,19 +149,18 @@ jobs:
           state: pending
           target_url: ${{ env.check_url }}
 
-      - name: Install Docker Client
+      - name: Install Cilium CLI
         run: |
-          cd /tmp
-          curl -sOL https://download.docker.com/mac/static/stable/x86_64/docker-20.10.9.tgz
-          tar xzf docker-20.10.9.tgz
-          sudo xattr -rc docker
-          sudo cp docker/docker /usr/local/bin/docker
-          rm -r docker docker-20.10.9.tgz
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
 
-      - name: Checkout upstream for Vagrantfile
+      - name: Checkout upstream for test files
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
-          # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
+          # This is intentionally set to stable branch to avoid using test.sh from pull requests.
           ref: v1.11
           persist-credentials: false
 
@@ -170,34 +171,20 @@ jobs:
           persist-credentials: false
           path: pull-request
 
-      - name: Boot Fedora
-        run: |
-          ln -sf ./test/l4lb/Vagrantfile ./Vagrantfile
-          # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
-          # Spend up to 10 seconds on this
-          for i in {1..4}; do
-            if vagrant up --provision; then
-              break
-            fi
-            sleep $i
-          done
-          vagrant ssh-config >> ~/.ssh/config
-
       - name: Wait for image to be available
         timeout-minutes: 10
         shell: bash
         run: |
           until docker manifest inspect quay.io/${{ github.repository_owner }}/cilium-ci:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
 
-      - name: Run tests
+      - name: Run LoadBalancing test
         run: |
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} /vagrant/pull-request/install/kubernetes/cilium'"
+          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request/install/kubernetes/cilium
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}
         run: |
-          ssh default "sudo /bin/sh -c 'cilium sysdump --output-filename cilium-sysdump-out; mv cilium-sysdump-out.zip /tmp'"
-          scp default:/tmp/cilium-sysdump-out.zip .
+          sudo cilium sysdump --output-filename cilium-sysdump-out
 
       - name: Upload cilium-sysdump
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8

--- a/.github/workflows/tests-l4lb-v1.12.yaml
+++ b/.github/workflows/tests-l4lb-v1.12.yaml
@@ -61,6 +61,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  cilium_cli_version: v0.12.1
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -118,8 +119,9 @@ jobs:
       )) ||
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
-    # We need nested virtualisation which is supported only by MacOS runner
-    runs-on: macos-10.15
+    # Ubuntu 22.04 runner uses cgroup v2-only which is needed for some
+    # our LB functionality
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - name: Set up job variables
@@ -147,19 +149,18 @@ jobs:
           state: pending
           target_url: ${{ env.check_url }}
 
-      - name: Install Docker Client
+      - name: Install Cilium CLI
         run: |
-          cd /tmp
-          curl -sOL https://download.docker.com/mac/static/stable/x86_64/docker-20.10.9.tgz
-          tar xzf docker-20.10.9.tgz
-          sudo xattr -rc docker
-          sudo cp docker/docker /usr/local/bin/docker
-          rm -r docker docker-20.10.9.tgz
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          cilium version
 
-      - name: Checkout upstream for Vagrantfile
+      - name: Checkout upstream for test files
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
-          # This is intentionally set to stable branch to avoid using Vagrantfile from pull requests.
+          # This is intentionally set to stable branch to avoid using test.sh from pull requests.
           ref: v1.12
           persist-credentials: false
 
@@ -170,35 +171,24 @@ jobs:
           persist-credentials: false
           path: pull-request
 
-      - name: Boot Fedora
-        run: |
-          ln -sf ./test/l4lb/Vagrantfile ./Vagrantfile
-          # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
-          # Spend up to 10 seconds on this
-          for i in {1..4}; do
-            if vagrant up --provision; then
-              break
-            fi
-            sleep $i
-          done
-          vagrant ssh-config >> ~/.ssh/config
-
       - name: Wait for image to be available
         timeout-minutes: 10
         shell: bash
         run: |
           until docker manifest inspect quay.io/${{ github.repository_owner }}/cilium-ci:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
 
-      - name: Run tests
+      - name: Run LoadBalancing test
         run: |
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/l4lb && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} /vagrant/pull-request/install/kubernetes/cilium'"
-          ssh default "sudo /bin/sh -c 'cd /vagrant/test/nat46x64 && ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} /vagrant/pull-request/install/kubernetes/cilium'"
+          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request/install/kubernetes/cilium
+
+      - name: Run NAT46x64 test
+        run: |
+          cd ${{ github.workspace }}/test/nat46x64 && sudo ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request/install/kubernetes/cilium
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}
         run: |
-          ssh default "sudo /bin/sh -c 'cilium sysdump --output-filename cilium-sysdump-out; mv cilium-sysdump-out.zip /tmp'"
-          scp default:/tmp/cilium-sysdump-out.zip .
+          sudo cilium sysdump --output-filename cilium-sysdump-out
 
       - name: Upload cilium-sysdump
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8


### PR DESCRIPTION
This commit is a partly backport of \[1\] to the v1.1{0,1,2} branches.
Switching the KIND image is done in the \[2\]\[3\]\[4\] PRs.

\[1\]: https://github.com/cilium/cilium/pull/20682/
\[2\]: https://github.com/cilium/cilium/pull/20918
\[3\]: https://github.com/cilium/cilium/pull/20919
\[4\]: https://github.com/cilium/cilium/pull/20920