### PR TITLE
backport v1.11: test: Switch to kindest/node:v1.24.3

### DIFF
--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -15,6 +15,8 @@ HELM_CHART_DIR=${3:-/vagrant/install/kubernetes/cilium}
 # the container netns, forwards a LB request with XDP_TX, the request needs to
 # be picked in the host netns by a NAPI handler. To register the handler, we
 # attach the dummy program.
+apt-get update
+apt-get install -y gcc-multilib libbpf-dev
 clang -O2 -Wall -target bpf -c bpf_xdp_veth_host.c -o bpf_xdp_veth_host.o
 
 # The worker (aka backend node) will receive IPIP packets from the LB node.
@@ -31,7 +33,7 @@ clang -O2 -Wall -target bpf -c test_tc_tunnel.c -o test_tc_tunnel.o
 #
 # The LB cilium does not connect to the kube-apiserver. For now we use Kind
 # just to create Docker-in-Docker containers.
-kind create cluster --config kind-config.yaml
+kind create cluster --config kind-config.yaml --image=kindest/node:v1.24.3
 
 # Create additional veth pair which is going to be used to test XDP_REDIRECT.
 ip l a l4lb-veth0 type veth peer l4lb-veth1


### PR DESCRIPTION
```
See [1] and [2] for motivation.

[1]: https://github.com/cilium/cilium/pull/20682
[2]: https://github.com/cilium/cilium/pull/20834
```