### PR TITLE
Fix identity garbage collection in clustermesh

### DIFF
--- a/operator/identity_gc.go
+++ b/operator/identity_gc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 )
@@ -26,8 +27,17 @@ func startKvstoreIdentityGC() {
 	if err != nil {
 		log.WithError(err).Fatal("Unable to initialize kvstore backend for identity allocation")
 	}
+
+	identity.InitMinMaxIdentityAllocation(option.Config)
+
 	minID := idpool.ID(identity.MinimalAllocationIdentity)
 	maxID := idpool.ID(identity.MaximumAllocationIdentity)
+
+	log.WithFields(map[string]interface{}{
+		"min":        minID,
+		"max":        maxID,
+		"cluster-id": option.Config.ClusterID,
+	}).Info("Garbage Collecting identities between range")
 	a := allocator.NewAllocatorForGC(backend, allocator.WithMin(minID), allocator.WithMax(maxID))
 
 	successfulRuns := 0

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -184,6 +184,12 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 	minID := idpool.ID(identity.MinimalAllocationIdentity)
 	maxID := idpool.ID(identity.MaximumAllocationIdentity)
 
+	log.WithFields(map[string]interface{}{
+		"min":        minID,
+		"max":        maxID,
+		"cluster-id": option.Config.ClusterID,
+	}).Info("Allocating identities between range")
+
 	// Asynchronously set up the global identity allocator since it connects
 	// to the kvstore.
 	go func(owner IdentityAllocatorOwner, events allocator.AllocatorEventChan, minID, maxID idpool.ID) {

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -171,6 +171,7 @@ func (w wellKnownIdentities) lookupByNumericIdentity(identity NumericIdentity) *
 type Configuration interface {
 	LocalClusterName() string
 	CiliumNamespaceName() string
+	LocalClusterID() int
 }
 
 // InitWellKnownIdentities establishes all well-known identities. Returns the
@@ -311,16 +312,22 @@ func InitWellKnownIdentities(c Configuration) int {
 	WellKnown.add(ReservedCiliumEtcdOperator2, append(ciliumEtcdOperatorLabels,
 		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
 
-	if option.Config.ClusterID > 0 {
-		// For ClusterID > 0, the identity range just starts from cluster shift,
-		// no well-known-identities need to be reserved from the range.
-		MinimalAllocationIdentity = NumericIdentity((1 << ClusterIDShift) * option.Config.ClusterID)
-		// The maximum identity also needs to be recalculated as ClusterID
-		// may be overwritten by runtime parameters.
-		MaximumAllocationIdentity = NumericIdentity((1<<ClusterIDShift)*(option.Config.ClusterID+1) - 1)
-	}
+	InitMinMaxIdentityAllocation(c)
 
 	return len(WellKnown)
+}
+
+// InitMinMaxIdentityAllocation sets the minimal and maximum for identities that
+// should be allocated in the cluster.
+func InitMinMaxIdentityAllocation(c Configuration) {
+	if c.LocalClusterID() > 0 {
+		// For ClusterID > 0, the identity range just starts from cluster shift,
+		// no well-known-identities need to be reserved from the range.
+		MinimalAllocationIdentity = NumericIdentity((1 << ClusterIDShift) * c.LocalClusterID())
+		// The maximum identity also needs to be recalculated as ClusterID
+		// may be overwritten by runtime parameters.
+		MaximumAllocationIdentity = NumericIdentity((1<<ClusterIDShift)*(c.LocalClusterID()+1) - 1)
+	}
 }
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2317,6 +2317,11 @@ func (c *DaemonConfig) LocalClusterName() string {
 	return c.ClusterName
 }
 
+// LocalClusterID returns the ID of the cluster local to the Cilium agent.
+func (c *DaemonConfig) LocalClusterID() int {
+	return c.ClusterID
+}
+
 // K8sServiceProxyName returns the required value for the
 // service.kubernetes.io/service-proxy-name label in order for services to be
 // handled.

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -36,3 +36,8 @@ func (f *Config) EncryptionEnabled() bool {
 func (f *Config) NodeEncryptionEnabled() bool {
 	return true
 }
+
+// LocalClusterID returns a dummy cluster ID.
+func (f *Config) LocalClusterID() int {
+	return 5
+}


### PR DESCRIPTION
Since the identity.MinimalAllocationIdentity and
identity.MaximumAllocationIdentity variables are initialized before the
option.Config.ClusterID is set and their values will be 256 and 65535
respectively. This will prevent Cilium Operator from garbage collecting
identities in the clusters, in a clustermesh environment, where their
cluster-id is not 0.


```release-note
Fix identity garbage collection in clustermesh environments
```

Upstream PR https://github.com/cilium/cilium/pull/20931