### PR TITLE
v1.10 backports 2022-08-17

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -163,7 +163,7 @@ if ! git diff --quiet ${last_cilium_release}..${remote}/${release_version} $crd_
   if [[ "${current_release_version}" != "${expected_version}" ]]; then
     >&2 echo "Current version for branch ${release_version} should be ${expected_version}, not ${current_release_version}, please run the following command to fix it:"
     >&2 echo "git checkout ${remote}/${release_version} && \\"
-    >&2 echo "sed -i 's+${current_release_version}+${expected_version}+' $(get_line_of_schema_version ${release_version})"
+    >&2 echo "sed -i 's+${current_release_version}+${expected_version}+' $(get_line_of_schema_version ${release_version} | tr '\n' ' ')"
     exit 1
   fi
 fi

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -6,6 +6,7 @@ dst_file="${dir}/concepts/kubernetes/compatibility-table.rst"
 . "${dir}/../contrib/backporting/common.sh"
 remote="$(get_remote)"
 
+set -e
 set -o nounset
 set -o pipefail
 

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-dst_file="${dir}/concepts/kubernetes/compatibility-table.rst"
+dst_file="${PWD}/$(basename ${dir})/concepts/kubernetes/compatibility-table.rst"
 
 . "${dir}/../contrib/backporting/common.sh"
 remote="$(get_remote)"
@@ -21,7 +21,7 @@ get_schema_of_tag(){
 
 get_line_of_schema_version(){
    tag="${1}"
-   git grep -H 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${tag} -- pkg/k8s | sed "s+${remote}/${tag}:++;s+.go:.*+.go+"
+   git grep -H 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${tag} -- pkg/k8s | sed "s+${remote}/${tag}:++;s+.go:.*+.go+;s+^+${PWD}/+"
 }
 
 get_schema_of_branch(){

--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -168,6 +168,12 @@ the ``netperf-server`` Pod):
 Each Pod is represented in Cilium as an :ref:`endpoint` which has an identity. The above
 identity can then be correlated with the ``cilium endpoint list`` command.
 
+.. note::
+
+    Bandwidth limits apply on a per-Pod scope. In our example, if multiple
+    replicas of the Pod are created, then each of the Pod instances receives
+    a 10M bandwidth limit.
+
 Limitations
 ###########
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -308,7 +309,11 @@ func (d *Daemon) restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
 // then it attempts to clear all IPs from the interface.
 func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 	l, err := netlink.LinkByName(defaults.HostDevice)
-	if err != nil {
+	if errors.As(err, &netlink.LinkNotFoundError{}) && restoredIP == nil {
+		// There's no old state remove as the host device doesn't exist and
+		// there's no restored IP anyway.
+		return nil
+	} else if err != nil {
 		return err
 	}
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -251,7 +251,7 @@ func ipSecXfrmMarkSetSPI(markValue uint32, spi uint8) uint32 {
 
 // ipSecXfrmMarkGetSPI extracts from a XfrmMark value the encoded SPI
 func ipSecXfrmMarkGetSPI(markValue uint32) uint8 {
-	return uint8(markValue >> ipSecXfrmMarkSPIShift)
+	return uint8(markValue >> ipSecXfrmMarkSPIShift & 0xF)
 }
 
 func getSPIFromXfrmPolicy(policy *netlink.XfrmPolicy) uint8 {

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -228,7 +228,8 @@ func NewIPIdentityWatcher(backend kvstore.BackendOperations) *IPIdentityWatcher 
 // automatically restart as required.
 func (iw *IPIdentityWatcher) Watch(ctx context.Context) {
 
-	var scopedLog *logrus.Entry
+	scopedLog := log
+
 restart:
 	watcher := iw.backend.ListAndWatch(ctx, "endpointIPWatcher", IPIdentitiesPath, 512)
 
@@ -284,7 +285,9 @@ restart:
 				}
 				ip := ipIDPair.PrefixString()
 				if ip == "<nil>" {
-					scopedLog.Debug("Ignoring entry with nil IP")
+					if option.Config.Debug {
+						scopedLog.Debug("Ignoring entry with nil IP")
+					}
 					continue
 				}
 				var k8sMeta *K8sMetadata


### PR DESCRIPTION
* #20734 -- Fix complaint about nil IP address on restore of cilium_host (@christarazi)
   * Only backported the first commit 08205dde0f6d ("daemon/cmd: Fix complaint about nil IP address
     on restore of cilium_host") which seems to be the main fix in this PR. The second commit caused
     merge conflicts because it releias on changes from #20453 which we don't backport.
 * #20706 -- ipcache/kvstore: fix panic when processing ip=<nil> entries (@ArthurChiao)
 * #20875 -- Improve CRD schema update automation during release process (@joestringer)
   * Skipped the last commit d9a14a007a1c ("contrib: Fix CRD schema gen when it needs updating")
     because it would require additional backports (see
     https://github.com/cilium/cilium/pull/20700#issuecomment-1217721443) and maintainers seem to be
     using these scripts from `master` branch only anyway.
 * #20916 -- docs(bandwidth-manager): add note on per-pod limits (@raphink)
 * #20900 -- ipsec: Fix incorrect parsing of SPI from mark (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20734 20706 20875 20916 20900; do contrib/backporting/set-labels.py $pr done 1.10; done
```