### PR TITLE
v1.11 backports 2022-08-17

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -163,7 +163,7 @@ if ! git diff --quiet ${last_cilium_release}..${remote}/${release_version} $crd_
   if [[ "${current_release_version}" != "${expected_version}" ]]; then
     >&2 echo "Current version for branch ${release_version} should be ${expected_version}, not ${current_release_version}, please run the following command to fix it:"
     >&2 echo "git checkout ${remote}/${release_version} && \\"
-    >&2 echo "sed -i 's+${current_release_version}+${expected_version}+' $(get_line_of_schema_version ${release_version})"
+    >&2 echo "sed -i 's+${current_release_version}+${expected_version}+' $(get_line_of_schema_version ${release_version} | tr '\n' ' ')"
     exit 1
   fi
 fi

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -6,6 +6,7 @@ dst_file="${dir}/concepts/kubernetes/compatibility-table.rst"
 . "${dir}/../contrib/backporting/common.sh"
 remote="$(get_remote)"
 
+set -e
 set -o nounset
 set -o pipefail
 

--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-dst_file="${dir}/concepts/kubernetes/compatibility-table.rst"
+dst_file="${PWD}/$(basename ${dir})/concepts/kubernetes/compatibility-table.rst"
 
 . "${dir}/../contrib/backporting/common.sh"
 remote="$(get_remote)"
@@ -21,7 +21,7 @@ get_schema_of_tag(){
 
 get_line_of_schema_version(){
    tag="${1}"
-   git grep -H 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${tag} -- pkg/k8s | sed "s+${remote}/${tag}:++;s+.go:.*+.go+"
+   git grep -H 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${tag} -- pkg/k8s | sed "s+${remote}/${tag}:++;s+.go:.*+.go+;s+^+${PWD}/+"
 }
 
 get_schema_of_branch(){

--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -168,6 +168,12 @@ the ``netperf-server`` Pod):
 Each Pod is represented in Cilium as an :ref:`endpoint` which has an identity. The above
 identity can then be correlated with the ``cilium endpoint list`` command.
 
+.. note::
+
+   Bandwidth limits apply on a per-Pod scope. In our example, if multiple
+   replicas of the Pod are created, then each of the Pod instances receives
+   a 10M bandwidth limit.
+
 Limitations
 ###########
 

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -244,13 +244,15 @@ func LaunchAsEndpoint(baseCtx context.Context,
 		ip4Address, ip6Address *net.IPNet
 	)
 
-	if healthIP = node.GetEndpointHealthIPv6(); healthIP != nil {
-		info.Addressing.IPV6 = healthIP.String()
-		ip6Address = &net.IPNet{IP: healthIP, Mask: defaults.ContainerIPv6Mask}
+	if healthIPv6 := node.GetEndpointHealthIPv6(); healthIPv6 != nil {
+		info.Addressing.IPV6 = healthIPv6.String()
+		ip6Address = &net.IPNet{IP: healthIPv6, Mask: defaults.ContainerIPv6Mask}
+		healthIP = healthIPv6
 	}
-	if healthIP = node.GetEndpointHealthIPv4(); healthIP != nil {
-		info.Addressing.IPV4 = healthIP.String()
-		ip4Address = &net.IPNet{IP: healthIP, Mask: defaults.ContainerIPv4Mask}
+	if healthIPv4 := node.GetEndpointHealthIPv4(); healthIPv4 != nil {
+		info.Addressing.IPV4 = healthIPv4.String()
+		ip4Address = &net.IPNet{IP: healthIPv4, Mask: defaults.ContainerIPv4Mask}
+		healthIP = healthIPv4
 	}
 
 	if option.Config.EnableEndpointRoutes {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -297,7 +298,11 @@ func (d *Daemon) restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
 // then it attempts to clear all IPs from the interface.
 func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 	l, err := netlink.LinkByName(defaults.HostDevice)
-	if err != nil {
+	if errors.As(err, &netlink.LinkNotFoundError{}) && restoredIP == nil {
+		// There's no old state remove as the host device doesn't exist and
+		// there's no restored IP anyway.
+		return nil
+	} else if err != nil {
 		return err
 	}
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -241,7 +241,7 @@ func ipSecXfrmMarkSetSPI(markValue uint32, spi uint8) uint32 {
 
 // ipSecXfrmMarkGetSPI extracts from a XfrmMark value the encoded SPI
 func ipSecXfrmMarkGetSPI(markValue uint32) uint8 {
-	return uint8(markValue >> ipSecXfrmMarkSPIShift)
+	return uint8(markValue >> ipSecXfrmMarkSPIShift & 0xF)
 }
 
 func getSPIFromXfrmPolicy(policy *netlink.XfrmPolicy) uint8 {

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -217,7 +217,8 @@ func NewIPIdentityWatcher(backend kvstore.BackendOperations) *IPIdentityWatcher 
 // automatically restart as required.
 func (iw *IPIdentityWatcher) Watch(ctx context.Context) {
 
-	var scopedLog *logrus.Entry
+	scopedLog := log
+
 restart:
 	watcher := iw.backend.ListAndWatch(ctx, "endpointIPWatcher", IPIdentitiesPath, 512)
 
@@ -273,7 +274,9 @@ restart:
 				}
 				ip := ipIDPair.PrefixString()
 				if ip == "<nil>" {
-					scopedLog.Debug("Ignoring entry with nil IP")
+					if option.Config.Debug {
+						scopedLog.Debug("Ignoring entry with nil IP")
+					}
 					continue
 				}
 				var k8sMeta *K8sMetadata

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1237,7 +1237,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			collectors = append(collectors, FQDNAliveZombieConnections)
 			c.FQDNActiveZombiesConnections = true
 
-		case metricName + "_" + SubsystemFQDN + "_sempaphore_rejected_total":
+		case Namespace + "_" + SubsystemFQDN + "_semaphore_rejected_total":
 			FQDNSemaphoreRejectedTotal = prometheus.NewCounter(prometheus.CounterOpts{
 				Namespace: Namespace,
 				Subsystem: SubsystemFQDN,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3003,11 +3003,11 @@ func (c *DaemonConfig) Populate() {
 
 func (c *DaemonConfig) additionalMetrics() []string {
 	addMetric := func(name string) string {
-		return "+" + metrics.Namespace + name
+		return "+" + metrics.Namespace + "_" + name
 	}
 	var m []string
 	if c.DNSProxyConcurrencyLimit > 0 {
-		m = append(m, addMetric(metrics.SubsystemFQDN+"_sempaphore_rejected_total"))
+		m = append(m, addMetric(metrics.SubsystemFQDN+"_semaphore_rejected_total"))
 	}
 	return m
 }

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -515,7 +515,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "without native routing cidr and tunnel enabled",
+			name: "without native routing cidr and tunnel disabled",
 			d: &DaemonConfig{
 				EnableIPv4Masquerade: true,
 				EnableIPv6Masquerade: true,

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -543,6 +543,8 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			err := tt.d.checkIPv4NativeRoutingCIDR()
 			if tt.wantErr && err == nil {
 				t.Error("expected error, but got nil")
+			} else if !tt.wantErr && err != nil {
+				t.Errorf("expected no error, but got %q", err)
 			}
 		})
 	}

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -63,7 +63,6 @@ helm install cilium ${HELM_CHART_DIR} \
     --set loadBalancer.dsrDispatch=ipip \
     --set devices='{eth0,l4lb-veth1}' \
     --set nodePort.directRoutingDevice=eth0 \
-    --set ipv6.enabled=false \
     --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key="kubernetes.io/hostname" \
     --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In \
     --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=kind-control-plane


### PR DESCRIPTION
* #20473 -- config: Fix unit tests for native routing CIDR (@pchaigno)
   * Minor conflict due to TestCheckIPv6NativeRoutingCIDR not being present on v1.11 branch. Skipped
     that hunk of the patch.
 * #20734 -- Fix complaint about nil IP address on restore of cilium_host (@christarazi)
   * Only backported the first commit 08205dde0f6d ("daemon/cmd: Fix complaint about nil IP address
     on restore of cilium_host") which seems to be the main fix in this PR. The second commit caused
     merge conflicts because it releias on changes from #20453 which we don't backport.
 * #20821 -- CI: Enable IPv6 in the L4LB suite (@brb)
 * #20849 -- cilium-health: fix probing for IPv6-only clusters (@aanm)
 * #20706 -- ipcache/kvstore: fix panic when processing ip=<nil> entries (@ArthurChiao)
 * #20875 -- Improve CRD schema update automation during release process (@joestringer)
   * Skipped the last commit d9a14a007a1c ("contrib: Fix CRD schema gen when it needs updating")
     because it would require additional backports (see
     https://github.com/cilium/cilium/pull/20700#issuecomment-1217721443) and maintainers seem to be
     using these scripts from `master` branch only anyway.
 * #20916 -- docs(bandwidth-manager): add note on per-pod limits (@raphink)
 * #20900 -- ipsec: Fix incorrect parsing of SPI from mark (@pchaigno)
 * #20893 -- Fix typos in FQDN semaphore metric enablement. (@rahulkjoshi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20473 20734 20821 20849 20706 20875 20916 20900 20893; do contrib/backporting/set-labels.py $pr done 1.11; done
```