### PR TITLE
operator: rename (*OperatorConfig).Populate parameter

### DIFF
--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -469,42 +469,42 @@ type OperatorConfig struct {
 }
 
 // Populate sets all options with the values from viper.
-func (c *OperatorConfig) Populate(Vp *viper.Viper) {
-	c.CNPNodeStatusGCInterval = Vp.GetDuration(CNPNodeStatusGCInterval)
-	c.CNPStatusUpdateInterval = Vp.GetDuration(CNPStatusUpdateInterval)
-	c.NodeGCInterval = Vp.GetDuration(NodesGCInterval)
-	c.EnableMetrics = Vp.GetBool(EnableMetrics)
-	c.EndpointGCInterval = Vp.GetDuration(EndpointGCInterval)
-	c.IdentityGCInterval = Vp.GetDuration(IdentityGCInterval)
-	c.IdentityGCRateInterval = Vp.GetDuration(IdentityGCRateInterval)
-	c.IdentityGCRateLimit = Vp.GetInt64(IdentityGCRateLimit)
-	c.IdentityHeartbeatTimeout = Vp.GetDuration(IdentityHeartbeatTimeout)
-	c.OperatorAPIServeAddr = Vp.GetString(OperatorAPIServeAddr)
-	c.OperatorPrometheusServeAddr = Vp.GetString(OperatorPrometheusServeAddr)
-	c.PProf = Vp.GetBool(PProf)
-	c.PProfPort = Vp.GetInt(PProfPort)
-	c.SyncK8sServices = Vp.GetBool(SyncK8sServices)
-	c.SyncK8sNodes = Vp.GetBool(SyncK8sNodes)
-	c.UnmanagedPodWatcherInterval = Vp.GetInt(UnmanagedPodWatcherInterval)
-	c.NodeCIDRMaskSizeIPv4 = Vp.GetInt(NodeCIDRMaskSizeIPv4)
-	c.NodeCIDRMaskSizeIPv6 = Vp.GetInt(NodeCIDRMaskSizeIPv6)
-	c.ClusterPoolIPv4CIDR = Vp.GetStringSlice(ClusterPoolIPv4CIDR)
-	c.ClusterPoolIPv6CIDR = Vp.GetStringSlice(ClusterPoolIPv6CIDR)
-	c.LeaderElectionLeaseDuration = Vp.GetDuration(LeaderElectionLeaseDuration)
-	c.LeaderElectionRenewDeadline = Vp.GetDuration(LeaderElectionRenewDeadline)
-	c.LeaderElectionRetryPeriod = Vp.GetDuration(LeaderElectionRetryPeriod)
-	c.BGPAnnounceLBIP = Vp.GetBool(BGPAnnounceLBIP)
-	c.BGPConfigPath = Vp.GetString(BGPConfigPath)
-	c.SkipCRDCreation = Vp.GetBool(SkipCRDCreation)
-	c.EnableIngressController = Vp.GetBool(EnableIngressController)
-	c.EnforceIngressHTTPS = Vp.GetBool(EnforceIngressHttps)
-	c.IngressSecretsNamespace = Vp.GetString(IngressSecretsNamespace)
-	c.EnableIngressSecretsSync = Vp.GetBool(EnableIngressSecretsSync)
-	c.CiliumPodLabels = Vp.GetString(CiliumPodLabels)
-	c.RemoveCiliumNodeTaints = Vp.GetBool(RemoveCiliumNodeTaints)
-	c.SetCiliumIsUpCondition = Vp.GetBool(SetCiliumIsUpCondition)
+func (c *OperatorConfig) Populate(vp *viper.Viper) {
+	c.CNPNodeStatusGCInterval = vp.GetDuration(CNPNodeStatusGCInterval)
+	c.CNPStatusUpdateInterval = vp.GetDuration(CNPStatusUpdateInterval)
+	c.NodeGCInterval = vp.GetDuration(NodesGCInterval)
+	c.EnableMetrics = vp.GetBool(EnableMetrics)
+	c.EndpointGCInterval = vp.GetDuration(EndpointGCInterval)
+	c.IdentityGCInterval = vp.GetDuration(IdentityGCInterval)
+	c.IdentityGCRateInterval = vp.GetDuration(IdentityGCRateInterval)
+	c.IdentityGCRateLimit = vp.GetInt64(IdentityGCRateLimit)
+	c.IdentityHeartbeatTimeout = vp.GetDuration(IdentityHeartbeatTimeout)
+	c.OperatorAPIServeAddr = vp.GetString(OperatorAPIServeAddr)
+	c.OperatorPrometheusServeAddr = vp.GetString(OperatorPrometheusServeAddr)
+	c.PProf = vp.GetBool(PProf)
+	c.PProfPort = vp.GetInt(PProfPort)
+	c.SyncK8sServices = vp.GetBool(SyncK8sServices)
+	c.SyncK8sNodes = vp.GetBool(SyncK8sNodes)
+	c.UnmanagedPodWatcherInterval = vp.GetInt(UnmanagedPodWatcherInterval)
+	c.NodeCIDRMaskSizeIPv4 = vp.GetInt(NodeCIDRMaskSizeIPv4)
+	c.NodeCIDRMaskSizeIPv6 = vp.GetInt(NodeCIDRMaskSizeIPv6)
+	c.ClusterPoolIPv4CIDR = vp.GetStringSlice(ClusterPoolIPv4CIDR)
+	c.ClusterPoolIPv6CIDR = vp.GetStringSlice(ClusterPoolIPv6CIDR)
+	c.LeaderElectionLeaseDuration = vp.GetDuration(LeaderElectionLeaseDuration)
+	c.LeaderElectionRenewDeadline = vp.GetDuration(LeaderElectionRenewDeadline)
+	c.LeaderElectionRetryPeriod = vp.GetDuration(LeaderElectionRetryPeriod)
+	c.BGPAnnounceLBIP = vp.GetBool(BGPAnnounceLBIP)
+	c.BGPConfigPath = vp.GetString(BGPConfigPath)
+	c.SkipCRDCreation = vp.GetBool(SkipCRDCreation)
+	c.EnableIngressController = vp.GetBool(EnableIngressController)
+	c.EnforceIngressHTTPS = vp.GetBool(EnforceIngressHttps)
+	c.IngressSecretsNamespace = vp.GetString(IngressSecretsNamespace)
+	c.EnableIngressSecretsSync = vp.GetBool(EnableIngressSecretsSync)
+	c.CiliumPodLabels = vp.GetString(CiliumPodLabels)
+	c.RemoveCiliumNodeTaints = vp.GetBool(RemoveCiliumNodeTaints)
+	c.SetCiliumIsUpCondition = vp.GetBool(SetCiliumIsUpCondition)
 
-	c.CiliumK8sNamespace = Vp.GetString(CiliumK8sNamespace)
+	c.CiliumK8sNamespace = vp.GetString(CiliumK8sNamespace)
 	if c.CiliumK8sNamespace == "" {
 		if option.Config.K8sNamespace == "" {
 			c.CiliumK8sNamespace = metav1.NamespaceDefault
@@ -521,54 +521,54 @@ func (c *OperatorConfig) Populate(Vp *viper.Viper) {
 
 	// AWS options
 
-	c.AWSReleaseExcessIPs = Vp.GetBool(AWSReleaseExcessIPs)
-	c.AWSEnablePrefixDelegation = Vp.GetBool(AWSEnablePrefixDelegation)
-	c.AWSUsePrimaryAddress = Vp.GetBool(AWSUsePrimaryAddress)
-	c.UpdateEC2AdapterLimitViaAPI = Vp.GetBool(UpdateEC2AdapterLimitViaAPI)
-	c.EC2APIEndpoint = Vp.GetString(EC2APIEndpoint)
-	c.ExcessIPReleaseDelay = Vp.GetInt(ExcessIPReleaseDelay)
+	c.AWSReleaseExcessIPs = vp.GetBool(AWSReleaseExcessIPs)
+	c.AWSEnablePrefixDelegation = vp.GetBool(AWSEnablePrefixDelegation)
+	c.AWSUsePrimaryAddress = vp.GetBool(AWSUsePrimaryAddress)
+	c.UpdateEC2AdapterLimitViaAPI = vp.GetBool(UpdateEC2AdapterLimitViaAPI)
+	c.EC2APIEndpoint = vp.GetString(EC2APIEndpoint)
+	c.ExcessIPReleaseDelay = vp.GetInt(ExcessIPReleaseDelay)
 
 	// Azure options
 
-	c.AzureSubscriptionID = Vp.GetString(AzureSubscriptionID)
-	c.AzureResourceGroup = Vp.GetString(AzureResourceGroup)
-	c.AzureUsePrimaryAddress = Vp.GetBool(AzureUsePrimaryAddress)
-	c.AzureUserAssignedIdentityID = Vp.GetString(AzureUserAssignedIdentityID)
+	c.AzureSubscriptionID = vp.GetString(AzureSubscriptionID)
+	c.AzureResourceGroup = vp.GetString(AzureResourceGroup)
+	c.AzureUsePrimaryAddress = vp.GetBool(AzureUsePrimaryAddress)
+	c.AzureUserAssignedIdentityID = vp.GetString(AzureUserAssignedIdentityID)
 
 	// AlibabaCloud options
 
-	c.AlibabaCloudVPCID = Vp.GetString(AlibabaCloudVPCID)
-	c.AlibabaCloudReleaseExcessIPs = Vp.GetBool(AlibabaCloudReleaseExcessIPs)
+	c.AlibabaCloudVPCID = vp.GetString(AlibabaCloudVPCID)
+	c.AlibabaCloudReleaseExcessIPs = vp.GetBool(AlibabaCloudReleaseExcessIPs)
 
 	// CiliumEndpointSlice options
-	c.CESMaxCEPsInCES = Vp.GetInt(CESMaxCEPsInCES)
-	c.CESSlicingMode = Vp.GetString(CESSlicingMode)
+	c.CESMaxCEPsInCES = vp.GetInt(CESMaxCEPsInCES)
+	c.CESSlicingMode = vp.GetString(CESSlicingMode)
 
 	// Option maps and slices
 
-	if m := Vp.GetStringSlice(IPAMSubnetsIDs); len(m) != 0 {
+	if m := vp.GetStringSlice(IPAMSubnetsIDs); len(m) != 0 {
 		c.IPAMSubnetsIDs = m
 	}
 
-	if m, err := command.GetStringMapStringE(Vp, IPAMSubnetsTags); err != nil {
+	if m, err := command.GetStringMapStringE(vp, IPAMSubnetsTags); err != nil {
 		log.Fatalf("unable to parse %s: %s", IPAMSubnetsTags, err)
 	} else {
 		c.IPAMSubnetsTags = m
 	}
 
-	if m, err := command.GetStringMapStringE(Vp, IPAMInstanceTags); err != nil {
+	if m, err := command.GetStringMapStringE(vp, IPAMInstanceTags); err != nil {
 		log.Fatalf("unable to parse %s: %s", IPAMInstanceTags, err)
 	} else {
 		c.IPAMInstanceTags = m
 	}
 
-	if m, err := command.GetStringMapStringE(Vp, AWSInstanceLimitMapping); err != nil {
+	if m, err := command.GetStringMapStringE(vp, AWSInstanceLimitMapping); err != nil {
 		log.Fatalf("unable to parse %s: %s", AWSInstanceLimitMapping, err)
 	} else {
 		c.AWSInstanceLimitMapping = m
 	}
 
-	if m, err := command.GetStringMapStringE(Vp, ENITags); err != nil {
+	if m, err := command.GetStringMapStringE(vp, ENITags); err != nil {
 		log.Fatalf("unable to parse %s: %s", ENITags, err)
 	} else {
 		c.ENITags = m


### PR DESCRIPTION
Stick to the convention of lower-case parameter names. Also, Vp already
is the package-level var holding the Viper instance.

Fixes: 2bea69a54a00 ("option: remove usage of Viper singleton")
