### PR TITLE
docs: Make external links in docs open in a new tab

### DIFF
--- a/Documentation/_exts/cilium_external_links.py
+++ b/Documentation/_exts/cilium_external_links.py
@@ -1,0 +1,20 @@
+from sphinx.writers.html import HTMLTranslator
+from sphinx.writers.html5 import HTML5Translator
+from sphinx.util.docutils import is_html5_writer_available
+
+# Make all external links open in new tabs
+class PatchedHTMLTranslator(
+    HTML5Translator if is_html5_writer_available() else HTMLTranslator
+): 
+    def starttag(self, node, tagname, *args, **attrs):
+        if (
+            tagname == "a"
+            and "target" not in attrs
+            and (
+                "external" in attrs.get("class", "")
+                or "external" in attrs.get("classes", [])
+            )
+        ):
+            attrs["target"] = "_blank"
+            attrs["ref"] = "noopener noreferrer"
+        return super().starttag(node, tagname, *args, **attrs)

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -24,7 +24,7 @@ import semver
 
 sys.path.insert(0, os.path.abspath('_exts'))
 import cilium_spellfilters
-
+import cilium_external_links
 
 # -- General configuration ------------------------------------------------
 
@@ -256,7 +256,6 @@ http_strict_mode = False
 # Try as hard as possible to find references
 default_role = 'any'
 
-
 def setup(app):
     app.add_css_file('parsed-literal.css')
     app.add_css_file('copybutton.css')
@@ -264,3 +263,5 @@ def setup(app):
     app.add_js_file('clipboardjs.min.js')
     app.add_js_file("copybutton.js")
     app.add_css_file('helm-reference.css')
+    # Patch HTML translator to open external links in new tabs
+    app.set_translator("html", cilium_external_links.PatchedHTMLTranslator)


### PR DESCRIPTION
For a better reading experience, this change makes all external links in the Cilium docs open in a new tab 