### PR TITLE
CODEOWNERS: Add owner for ingress

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -171,6 +171,7 @@ jenkinsfiles @cilium/ci-structure
 /MAINTAINERS.md @cilium/contributing
 /netlify.toml @cilium/ci-structure
 /operator/ @cilium/operator
+/operator/pkg/ingress @cilium/operator @cilium/sig-servicemesh
 /pkg/ @cilium/tophat
 /pkg/annotation @cilium/sig-k8s
 /pkg/alibabacloud/ @cilium/alibabacloud


### PR DESCRIPTION
This commit is to add additional @cilium/sig-servicemesh for
operator/pkg/ingress package.

Signed-off-by: Tam Mach <tam.mach@cilium.io>