### PR TITLE
go.sum: run Go 1.19 `go mod tidy` after dependabot update

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,7 @@ github.com/go-openapi/runtime v0.24.1/go.mod h1:AKurw9fNre+h3ELZfk6ILsfvPN+bvvla
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/spec v0.19.5/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/spec v0.20.4/go.mod h1:faYFR1CvsJZ0mNsmsphTMSoRrNV3TEDoAM7FOEWeq8I=
+github.com/go-openapi/spec v0.20.6/go.mod h1:2OpW+JddWPrpXSCIX8eOx7lZ5iyuWj3RYR6VaaBKcWA=
 github.com/go-openapi/spec v0.20.7 h1:1Rlu/ZrOCCob0n+JKKJAWhNWMPW8bOZRg8FJaY+0SKI=
 github.com/go-openapi/spec v0.20.7/go.mod h1:2OpW+JddWPrpXSCIX8eOx7lZ5iyuWj3RYR6VaaBKcWA=
 github.com/go-openapi/strfmt v0.21.0/go.mod h1:ZRQ409bWMj+SOgXofQAGTIo2Ebu72Gs+WaRADcS5iNg=


### PR DESCRIPTION
Looks like commit dd4379e702a9 ("build(deps): bump
github.com/go-openapi/spec from 0.20.6 to 0.20.7") didn't properly run
`go mod tidy`. Run it using Go 1.19 to fix the go-mod check avoids
complaining about `go.sum`.

Fixes: dd4379e702a9 ("build(deps): bump github.com/go-openapi/spec from 0.20.6 to 0.20.7")
