### PR TITLE
cilium-cni: implement cni CHECK support

### DIFF
--- a/plugins/cilium-cni/chaining/api/api.go
+++ b/plugins/cilium-cni/chaining/api/api.go
@@ -53,6 +53,10 @@ type ChainingPlugin interface {
 	// ImplementsDelete returns true if the chaining plugin implements its
 	// own delete logic
 	ImplementsDelete() bool
+
+	// Check is called on CNI CHECK. The plugin should verify (to the best of its
+	// ability) that everything is reasonably configured, else return error.
+	Check(ctx context.Context, pluginContext PluginContext) error
 }
 
 // Register is called by chaining plugins to register themselves. After

--- a/plugins/cilium-cni/chaining/api/api_test.go
+++ b/plugins/cilium-cni/chaining/api/api_test.go
@@ -39,6 +39,10 @@ func (p *pluginTest) ImplementsDelete() bool {
 	return true
 }
 
+func (p *pluginTest) Check(ctx context.Context, pluginContext PluginContext) error {
+	return nil
+}
+
 func (a *APISuite) TestRegistration(c *check.C) {
 	err := Register("foo", &pluginTest{})
 	c.Assert(err, check.IsNil)

--- a/plugins/cilium-cni/chaining/portmap/portmap.go
+++ b/plugins/cilium-cni/chaining/portmap/portmap.go
@@ -29,6 +29,10 @@ func (p *portmapChainer) Delete(ctx context.Context, pluginCtx chainingapi.Plugi
 	return nil
 }
 
+func (p *portmapChainer) Check(ctx context.Context, pluginContext chainingapi.PluginContext) error {
+	return nil
+}
+
 func init() {
 	chainingapi.Register("portmap", &portmapChainer{})
 }

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -18,7 +18,7 @@ case "$CILIUM_CNI_CHAINING_MODE" in
 	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
 	;;
 *)
-	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conf}
+	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
 	;;
 esac
 
@@ -142,7 +142,7 @@ case "$CILIUM_CNI_CHAINING_MODE" in
 "flannel")
 	cat > "${CNI_CONF_NAME}" <<EOF
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "name": "flannel",
   "plugins": [
     {
@@ -172,7 +172,7 @@ EOF
 "portmap")
 	cat > "${CNI_CONF_NAME}" <<EOF
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "name": "portmap",
   "plugins": [
     {
@@ -198,7 +198,7 @@ EOF
   else
     cat > "${CNI_CONF_NAME}" <<EOF
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "name": "aws-cni",
   "plugins": [
     {
@@ -229,11 +229,15 @@ EOF
 *)
 	cat > "${CNI_CONF_NAME}" <<EOF
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "name": "cilium",
-  "type": "cilium-cni",
-  "enable-debug": ${ENABLE_DEBUG},
-  "log-file": "${LOG_FILE}"
+  "plugins": [
+    {
+      "type": "cilium-cni",
+      "enable-debug": ${ENABLE_DEBUG},
+      "log-file": "${LOG_FILE}"
+    }
+  ]
 }
 EOF
 	;;

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -106,3 +106,10 @@ type ArgsSpec struct {
 // Args contains arbitrary information a scheduler
 // can pass to the cni plugin
 type Args struct{}
+
+// CNI error codes
+// (error codes 100+ are allowed for plugin use)
+const (
+	CniErrHealthzGet uint = 100
+	CniErrUnhealthy       = iota
+)


### PR DESCRIPTION
Fixes: #17251

The cni CHECK action asks the plugin to ensure that the container's networking is configured as desired.

Fortunately, the agent already exposes a "healthz"-style api; all we need to do is call it. Also, verify that the veth interface exists and is configured correctly.


```release-note
The default CNI version is now v0.4.0. Cilium now supports the CNI CHECK action.
```

Note that, right now, very few runtimes actually call CNI CHECK. I tested this with a hacked version of containerd that called CNI CHECK periodically. Some of the other CNI maintainers are working on rolling out check support universally.
