### PR TITLE
metrics: Add label type for errors_warnings_total metric

### DIFF
--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -66,7 +66,7 @@ func (h *LoggingHook) Fire(entry *logrus.Entry) error {
 	}
 
 	// Increment the metric.
-	h.metric.WithLabelValues(entry.Level.String(), subsystem).Inc()
+	h.metric.WithLabelValues(entry.Level.String(), subsystem, entry.Level.String()).Inc()
 
 	return nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1042,7 +1042,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Namespace: Namespace,
 				Name:      "errors_warnings_total",
 				Help:      "Number of total errors in cilium-agent instances",
-			}, []string{"level", "subsystem"})
+			}, []string{"level", "subsystem", LabelType})
 
 			collectors = append(collectors, ErrorsWarnings)
 			c.ErrorsWarningsEnabled = true


### PR DESCRIPTION
This commit is to add label type{error,warning} to the existing metric
cilium_errors_warnings_total. This will help to segregate warning and
error details.

Relates: #20909

Signed-off-by: Tam Mach <tam.mach@cilium.io>
