### PR TITLE
operator: rename OperatorConfig member to match flag name

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -525,8 +525,8 @@ func OnOperatorStartLeading(ctx context.Context) {
 		RunCNPNodeStatusGC(ciliumNodeStore)
 	}
 
-	if operatorOption.Config.NodeGCInterval != 0 {
-		operatorWatchers.RunCiliumNodeGC(ctx, ciliumNodeStore, operatorOption.Config.NodeGCInterval)
+	if operatorOption.Config.NodesGCInterval != 0 {
+		operatorWatchers.RunCiliumNodeGC(ctx, ciliumNodeStore, operatorOption.Config.NodesGCInterval)
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMClusterPool || option.Config.IPAM == ipamOption.IPAMClusterPoolV2 {

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -263,8 +263,8 @@ type OperatorConfig struct {
 	// being sent to the K8s apiserver for a given CNP.
 	CNPStatusUpdateInterval time.Duration
 
-	// NodeGCInterval is the GC interval for CiliumNodes
-	NodeGCInterval time.Duration
+	// NodesGCInterval is the GC interval for CiliumNodes
+	NodesGCInterval time.Duration
 
 	// EnableMetrics enables prometheus metrics.
 	EnableMetrics bool
@@ -472,7 +472,7 @@ type OperatorConfig struct {
 func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.CNPNodeStatusGCInterval = vp.GetDuration(CNPNodeStatusGCInterval)
 	c.CNPStatusUpdateInterval = vp.GetDuration(CNPStatusUpdateInterval)
-	c.NodeGCInterval = vp.GetDuration(NodesGCInterval)
+	c.NodesGCInterval = vp.GetDuration(NodesGCInterval)
 	c.EnableMetrics = vp.GetBool(EnableMetrics)
 	c.EndpointGCInterval = vp.GetDuration(EndpointGCInterval)
 	c.IdentityGCInterval = vp.GetDuration(IdentityGCInterval)


### PR DESCRIPTION
We usually use the same name for the flag const and the option struct
member to make it easier to grep for option usage.

Fixes: edc1a0a0d268 ("operator: Add cilium node garbage collector")
