### PR TITLE
document all available options for annotations in ingress implementation

### DIFF
--- a/Documentation/installation/servicemesh/ingress.rst
+++ b/Documentation/installation/servicemesh/ingress.rst
@@ -24,6 +24,15 @@ an existing K8s cluster with Cilium installed.
 
 .. include:: installation.rst
 
+Supported Ingress Annotations
+########
+
+- io.cilium/tcp-keep-alive
+- io.cilium/tcp-keep-alive-idle
+- io.cilium/tcp-keep-alive-probe-interval
+- io.cilium/tcp-keep-alive-probe-max-failures
+- io.cilium/websocket
+
 Examples
 ########
 


### PR DESCRIPTION
This PR documents all available options for annotations in ingress implementation in [Documentation/installation/servicemesh/ingress.rst](https://github.com/cilium/cilium/blob/master/Documentation/installation/servicemesh/ingress.rst)
Fixes: #20902

