### PR TITLE
docs: Add available options for Ingress Controller annotations

### DIFF
--- a/Documentation/installation/servicemesh/ingress.rst
+++ b/Documentation/installation/servicemesh/ingress.rst
@@ -24,6 +24,32 @@ an existing K8s cluster with Cilium installed.
 
 .. include:: installation.rst
 
+Supported Ingress Annotations
+#############################
+
+.. list-table:: 
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Default Value
+   * - ``io.cilium/tcp-keep-alive``
+     - Enable TCP keep-alive
+     - 1 (enabled)
+   * - ``io.cilium/tcp-keep-alive-idle``
+     - TCP keep-alive idle time (in seconds)
+     - 10s
+   * - ``io.cilium/tcp-keep-alive-probe-interval``
+     - TCP keep-alive probe intervals (in seconds)
+     - 5s
+   * - ``io.cilium/tcp-keep-alive-probe-max-failures``
+     - TCP keep-alive probe max failures
+     - 10
+   * - ``io.cilium/websocket``
+     - Enable websocket
+     - 0 (disabled)
+
 Examples
 ########
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -1006,6 +1006,7 @@ wakeup
 walkthrough
 webhook
 webservice
+websocket
 wellKnownIdentities
 whitelist
 whitelisted


### PR DESCRIPTION
This PR documents all available options for annotations in ingress implementation in [Documentation/installation/servicemesh/ingress.rst](https://github.com/cilium/cilium/blob/master/Documentation/installation/servicemesh/ingress.rst)
Fixes: #20902