### PR TITLE
metrics: fix ts_events API timestamp and scope label cardinality

### DIFF
--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -53,14 +53,16 @@ func getShortPath(s string) string {
 // ServeHTTP implements the http.Handler interface. It records the timestamp
 // this API call began at, then chains to the next handler.
 func (m *APIEventTSHelper) ServeHTTP(r http.ResponseWriter, req *http.Request) {
-	if req != nil {
-		m.TSGauge.WithLabelValues(LabelEventSourceAPI, req.URL.Path, req.Method)
+	reqOk := req != nil && req.URL != nil && req.URL.Path != ""
+	var path string
+	if reqOk {
+		path = getShortPath(req.URL.Path)
+		m.TSGauge.WithLabelValues(LabelEventSourceAPI, path, req.Method).SetToCurrentTime()
 	}
 	duration := spanstat.Start()
 	rw := &responderWrapper{ResponseWriter: r}
 	m.Next.ServeHTTP(rw, req)
-	if req != nil && req.URL != nil && req.URL.Path != "" {
-		path := getShortPath(req.URL.Path)
+	if reqOk {
 		took := float64(duration.End(true).Total().Seconds())
 		m.Histogram.WithLabelValues(path, req.Method, strconv.Itoa(rw.code)).Observe(took)
 	}

--- a/pkg/spanstat/spanstat_test.go
+++ b/pkg/spanstat/spanstat_test.go
@@ -66,7 +66,8 @@ func (s *SpanStatTestSuite) TestSpanStat(c *C) {
 	c.Assert(span1.FailureTotal(), Equals, spanFailureTotal1)
 
 	span1.Start()
-	span1.End(false)
+	time.Sleep(time.Millisecond * 100)
+	span1.End(false) // ensure second measure is different from first.
 	c.Assert(span1.Total(), Not(Equals), spanTotal1)
 	c.Assert(span1.SuccessTotal(), Equals, spanSuccessTotal1)
 	c.Assert(span1.FailureTotal(), Not(Equals), spanFailureTotal1)


### PR DESCRIPTION
Regression caused ts_events gauge to be scoped with url path including url parameter causing high cardinality metrics.
This fixes that to follow the same scoping as the API metrics middleware histogram metrics.

As well fixes API type ts_events metrics only ever being reported as 0 due to not setting the metric timestamp upon emit.

Also adds unit test for metrics middleware.

Fixes: #20967

Signed-off-by: Tom Hadlaw <tom.hadlaw@isovalent.com>

```release-note
metrics: fix ts_events API timestamp only emitting zero and unbounded scope label cardinality issue. 
```
