### PR TITLE
docs: Rework requirements.txt: Generate from minimal list

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.10.4-alpine3.15
+FROM docker.io/library/python:3.10.4-alpine3.15 AS docs-base
 
 LABEL maintainer="maintainer@cilium.io"
 
@@ -19,6 +19,7 @@ RUN apk add --no-cache --virtual --update \
     musl-dev \
     && true
 
+FROM docs-base AS docs-builder
 ADD ./requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
 

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -12,14 +12,21 @@ HELM_VALUES := helm-values.rst
 
 default: html
 
-DOCS_BUILDER_IMG ?= cilium/docs-builder
+define build_image
+  $(ECHO_DOCKER)
+  # Pre-pull FROM docker image due to Buildkit sometimes failing to pull them.
+  grep -m 1 "^FROM " $(1) | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
+  $(QUIET)tar c requirements.txt Dockerfile \
+    | $(CONTAINER_ENGINE) build $(DOCKER_BUILD_FLAGS) --target $(2) --tag $(3) -
+endef
 
+DOCS_BASE_IMG ?= cilium/docs-base
+base-image: Dockerfile ## Build the docs-base image for updating the requirements.txt file.
+	$(call build_image,$<,docs-base,$(DOCS_BASE_IMG))
+
+DOCS_BUILDER_IMG ?= cilium/docs-builder
 builder-image: Dockerfile requirements.txt ## Build the docs-builder image for rendering and checking the documentation.
-	$(ECHO_DOCKER)
-	# Pre-pull FROM docker images due to Buildkit sometimes failing to pull them.
-	grep "^FROM " $< | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
-	$(QUIET)tar c requirements.txt Dockerfile \
-	  | $(CONTAINER_ENGINE) build $(DOCKER_BUILD_FLAGS) --tag $(DOCS_BUILDER_IMG) -
+	$(call build_image,$<,docs-builder,$(DOCS_BUILDER_IMG))
 
 # cilium must have all build artifacts present for
 # documentation to be generated correctly.
@@ -28,9 +35,10 @@ cilium-build:
 
 READTHEDOCS_VERSION:=$(READTHEDOCS_VERSION)
 DOCKER_CTR_ROOT_DIR := /src
-DOCKER_CTR := $(CONTAINER_ENGINE) container run --rm \
+DOCKER_CTR_BASE := $(CONTAINER_ENGINE) container run --rm \
 		--workdir $(DOCKER_CTR_ROOT_DIR)/Documentation \
-		--volume $(CURDIR)/..:$(DOCKER_CTR_ROOT_DIR) \
+		--volume $(CURDIR)/..:$(DOCKER_CTR_ROOT_DIR)
+DOCKER_CTR := $(DOCKER_CTR_BASE) \
 		--env READTHEDOCS_VERSION=$(READTHEDOCS_VERSION) \
 		--env SKIP_LINT=$(SKIP_LINT) \
 		--user "$(shell id -u):$(shell id -g)"
@@ -103,6 +111,11 @@ live-preview: builder-image ## Build and serve the documentation locally.
 		--publish $(DOCS_PORT):8000 \
 			$(DOCS_BUILDER_IMG) \
 		sphinx-autobuild --open-browser --host 0.0.0.0 $(SPHINX_OPTS) --ignore *.swp -Q . _preview
+
+update-requirements: base-image requirements-min.txt
+	@echo '## Auto-generated from requirements-min.txt with "make update-requirements"' > requirements.txt
+	$(QUIET)$(DOCKER_CTR_BASE) $(DOCS_BASE_IMG) \
+		bash -c "pip install -r requirements-min.txt && pip freeze -r requirements-min.txt >> requirements.txt"
 
 clean: ## Clean up all artefacts from documentation.
 	-$(QUIET)rm -rf _build _api _exts/__pycache__ _preview Pipfile Pipfile.lock

--- a/Documentation/requirements-min.txt
+++ b/Documentation/requirements-min.txt
@@ -1,0 +1,21 @@
+Sphinx==4.5.0
+
+# Custom theme, forked from Read the Docs
+git+https://github.com/cilium/sphinx_rtd_theme.git@v1.0#egg=sphinx-rtd-theme-cilium
+
+# We use semver to parse Cilium's version in the config file
+semver==2.13.0
+
+# Sphinx extensions
+myst-parser==0.18.0
+# Fork openapi until it uses something newer than unmaintained m2r
+# (See git logs for details)
+git+https://github.com/cilium/openapi.git@mdinclude#egg=sphinxcontrib-openapi
+sphinx-tabs==3.3.1
+sphinx-version-warning==1.1.2
+sphinxcontrib-spelling==7.6.0
+sphinxcontrib-websupport==1.2.4
+
+# Linters
+rstcheck==3.3.1
+yamllint==1.27.1

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -1,36 +1,58 @@
-alabaster==0.7.12
-Babel==2.9.1
-certifi==2021.10.8
-chardet==4.0.0
-docutils==0.17
-idna==3.3
-imagesize==1.3.0
-Jinja2==3.0.3
-jsonschema==4.12.1
-mistune==2.0.3
-MarkupSafe==2.1.0
-myst-parser==0.17.0
-pyenchant==3.2.2
-Pygments==2.13.0
-pytz==2021.3
-PyYAML==6.0
-requests==2.28.1
-semver==2.13.0
-six==1.16.0
-snowballstemmer==2.2.0
+## Auto-generated from requirements-min.txt with "make update-requirements"
 Sphinx==4.5.0
-sphinx-autobuild==2021.3.14
-# forked read the docs themez
-git+https://github.com/cilium/sphinx_rtd_theme.git@v1.0
-sphinxcontrib-httpdomain==1.8.0
+
+# Custom theme, forked from Read the Docs
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@d607dabeb0a4af85c0364082789786534571aee1
+# We use semver to parse Cilium's version in the config file
+semver==2.13.0
+# Sphinx extensions
+myst-parser==0.18.0
 # Fork openapi until it uses something newer than unmaintained m2r
 # (See git logs for details)
-git+https://github.com/cilium/openapi.git@mdinclude
-sphinxcontrib-spelling==7.6.0
-sphinxcontrib-websupport==1.2.4
+sphinxcontrib-openapi @ git+https://github.com/cilium/openapi.git@a1d4fca2e7c3ae3cca69593baade1ebc297a12ff
 sphinx-tabs==3.3.1
 sphinx-version-warning==1.1.2
-typing==3.7.4.3
-urllib3==1.26.8
-yamllint==1.26.3
+sphinxcontrib-spelling==7.6.0
+sphinxcontrib-websupport==1.2.4
+# Linters
 rstcheck==3.3.1
+yamllint==1.27.1
+## The following requirements were added by pip freeze:
+alabaster==0.7.12
+attrs==22.1.0
+Babel==2.10.3
+certifi==2022.6.15
+charset-normalizer==2.1.0
+deepmerge==1.0.1
+docutils==0.17.1
+idna==3.3
+imagesize==1.4.1
+Jinja2==3.1.2
+jsonschema==4.12.1
+markdown-it-py==2.1.0
+MarkupSafe==2.1.1
+mdit-py-plugins==0.3.0
+mdurl==0.1.2
+mistune==2.0.4
+packaging==21.3
+pathspec==0.9.0
+picobox==2.2.0
+pyenchant==3.2.2
+Pygments==2.13.0
+pyparsing==3.0.9
+pyrsistent==0.18.1
+pytz==2022.2.1
+PyYAML==6.0
+requests==2.28.1
+six==1.16.0
+snowballstemmer==2.2.0
+sphinx_mdinclude==0.5.1
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-httpdomain==1.8.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
+typing_extensions==4.3.0
+urllib3==1.26.11


### PR DESCRIPTION
The requirements.txt was initially created from a `pip freeze` to pin all packages used for building the documentation. It has since received a number of manual updates, when adding new Sphinx extensions or when upgrading Sphinx (or other packages).

This raises several issues:

- We don't know what packages do. This is especially true for dependencies.

- We don't know which packages in the list are necessary to build the docs, and which are not. It is possible that some packages were initially pinned as dependencies, but are no longer necessary now that the dependent packages have been upgraded.

- Conversely, we are also missing some new dependencies, that are not pinned and that may not always come in the same version between two builds of the image.

Let's clean this up. We need to keep a minimal list of the packages that we need to build the docs: Sphinx and its extensions, semver, rstcheck. All other packages are dependencies.

Let's regenerate the requirements.txt file based on this shortlist. To do so, we "split" the build of the docs-builder image into two parts. The first image stops before installing the packages from requirements.txt, and can be used in a specific Makefile target for updating the list of requirements (instead of building the docs). In the future, it is possible to update requirements.txt in-place with:

    $ make update-requirements

Having run that command to update the current list, we get a number of updates for the packages in use:

- Babel: 2.9.1 -> 2.10.3
- certifi: 2021.10.8 -> 2022.6.15
- docutils: 0.17 -> 0.17.1
- imagesize: 1.3.0 -> 1.4.1
- Jingja2: 3.0.3 -> 3.1.2
- mistune: 2.0.3 -> 2.0.4
- MarkupSafe: 2.1.0 -> 2.1.1
- myst-parser: 0.17.0 -> 0.18.0
- pytz: 2021.3 -> 2022.2.1
- urllib3: 1.26.8 -> 1.26.11
- yamllint: 1.26.3 -> 1.27.1

These dependencies are no longer in use:

- chardet
- spinx-autobuild
- typing

These dependencies are new:

- attrs
- charset-normalizer
- deepmerge
- markdown-it-py
- mdit-py-plugins
- mdurl
- packaging
- pathspec
- picobox
- pyparsing
- pyrsistent
- sphinx_mdinclude
- sphinxcontrib-applehelp
- sphinxcontrib-devhelp
- sphinxcontrib-htmlhelp
- sphinxcontrib-jsmath
- sphinxcontrib-qthelp
- sphinxcontrib-serializinghtml
- typing_extensions

Note that in the new requirements.txt, the forked packages (theme and openapi extension) are now pinned to a commit instead of a Git branch. This means that they will no longer pull the latest commit for that branch, but instead they will keep using the same commit consistently. This is probably for the best.

There is no mechanism to automatically update either requirements-min.txt or requirements.txt on a regular basis, this is left at the discretion of the documentation maintainers. Dependabot will probably play a role here, but I am not sure yet whether it will detect the shortlist.