### PR TITLE
helm: Fix post-start and pre-stop hooks for cilium-nodeinit on Ubuntu EKS images

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
                   - --target=1
                   - --mount
                   - --
-                  - "/bin/sh"
+                  - "/bin/bash"
                   - "-c"
                   - |
                     {{- tpl (.Files.Get "files/nodeinit/poststart-eni.bash") . | nindent 20 }}
@@ -67,7 +67,7 @@ spec:
                   - --target=1
                   - --mount
                   - --
-                  - /bin/sh
+                  - /bin/bash
                   - -c
                   - |
                     {{- tpl (.Files.Get "files/nodeinit/prestop.bash") . | nindent 20 }}


### PR DESCRIPTION
Signed-off-by: John Watson <johnw@planetscale.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

If using Canonical's Ubuntu based EKS image, `/bin/sh` is `/bin/dash` by default. DASH does not support  things like `-o pipefail`. Rather than depending on `/bin/sh` being the expected shell, use  `/bin/bash` directly as that's what the scripts are expected to run under.
