### PR TITLE
pkg/endpoint: change CEP policy status message

### DIFF
--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -24,7 +24,7 @@ import (
 const (
 	EndpointPolicyStateEnforcing    cilium_v2.EndpointPolicyState = "enforcing"
 	EndpointPolicyStateNonEnforcing cilium_v2.EndpointPolicyState = "non-enforcing"
-	EndpointPolicyStateDisabled     cilium_v2.EndpointPolicyState = "disabled"
+	EndpointPolicyStateDisabled     cilium_v2.EndpointPolicyState = "<status disabled>"
 )
 
 func getEndpointStatusControllers(mdlControllers models.ControllerStatuses) (controllers cilium_v2.ControllerList) {


### PR DESCRIPTION
To make it clear to users that only the status of the policy enforcement
is not enabled this commit changes the message wording from "disabled"
to "\<status disabled>".

Fixes: 5452034199d2 ("kubectl get cep returns empty columns of policies statuses")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Change message for the status of the policy enforcement in CEPs to be more accurate.
```
