### PR TITLE
Configure websocket UpgradeConfig in L7 http policies

### DIFF
--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -282,6 +282,9 @@ func (s *XDSServer) getHttpFilterChainProto(clusterName string, tls bool) *envoy
 				Name: "envoy.filters.http.router",
 			},
 		},
+		UpgradeConfigs: []*envoy_config_http.HttpConnectionManager_UpgradeConfig{
+			{UpgradeType: "websocket"},
+		},
 		StreamIdleTimeout: &durationpb.Duration{}, // 0 == disabled
 		RouteSpecifier: &envoy_config_http.HttpConnectionManager_RouteConfig{
 			RouteConfig: &envoy_config_route.RouteConfiguration{


### PR DESCRIPTION
This fixes an issue where enabling L7 policies prevents websockets from working.

This could also be exposed as a configuration option in the L7 policy, but it feels like "it should work by default" instead of having to opt in. However, we could also add an option to disable the behavior, in case it breaks something. Relates to #20814. Depending on what we do here, perhaps we can enable web socket support in Ingress by default, with an option to disable it instead?

Fixes: #11672

Tasks:
- [ ] Make this explicitly configurable, we cannot autoupgrade due to security concerns
- [ ] Fix egress

```release-note
Configure websocket UpgradeConfig in L7 http policies
```
