### PR TITLE
add kvstore TTL flag in cilium-operator

### DIFF
--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -345,5 +345,9 @@ func init() {
 	flags.StringSlice(operatorOption.IngressLBAnnotations, operatorOption.IngressLBAnnotationsDefault, "IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer")
 	regOpts.BindEnv(operatorOption.IngressLBAnnotations)
 
+	flags.Duration(option.KVstoreLeaseTTL, defaults.KVstoreLeaseTTL, "Time-to-live for the KVstore lease.")
+	flags.MarkHidden(option.KVstoreLeaseTTL)
+	regOpts.BindEnv(option.KVstoreLeaseTTL)
+
 	Vp.BindPFlags(flags)
 }

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -571,7 +571,7 @@ func (e *etcdClient) renewSession(ctx context.Context) error {
 		return fmt.Errorf("unable to renew etcd session: %s", err)
 	}
 	sessionSuccess <- true
-	log.Infof("Got new lease ID %x", newSession.Lease())
+	log.Infof("Got new lease ID %x and the session TTL is %s", newSession.Lease(), option.Config.KVstoreLeaseTTL)
 
 	e.session = newSession
 	e.sessionCancel = sessionCancel
@@ -724,7 +724,7 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		ls = *lockSession
 		ec.RWMutex.Unlock()
 
-		log.Infof("Got lease ID %x", s.Lease())
+		log.Infof("Got lease ID %x and the session TTL is %s", s.Lease(), option.Config.KVstoreLeaseTTL)
 		log.Infof("Got lock lease ID %x", ls.Lease())
 		close(errorChan)
 	}()


### PR DESCRIPTION
This PR adds a kvstore TTL flag for `cilium-operator`
Fixes: #20958