### PR TITLE
install: add TerminationMessagePolicy to cilium pods

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -297,6 +297,7 @@ spec:
             drop:
               - ALL
           {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         {{- if not .Values.securityContext.privileged }}
         # Unprivileged containers need to mount /proc/sys/net from the host
@@ -412,6 +413,7 @@ spec:
         {{- range $type := .Values.monitor.eventTypes -}}
           {{ " " }}--type={{ $type }}
         {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: cilium-run
           mountPath: /var/run/cilium
@@ -452,6 +454,7 @@ spec:
           mountPath: /hostproc
         - name: cni-path
           mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           {{- if .Values.securityContext.privileged }}
           privileged: true
@@ -495,6 +498,7 @@ spec:
           mountPath: /hostproc
         - name: cni-path
           mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           {{- if .Values.securityContext.privileged }}
           privileged: true
@@ -529,6 +533,7 @@ spec:
         - /bin/bash
         - -c
         - --
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           privileged: true
       {{- /* CRI-O already mounts the BPF filesystem */ -}}
@@ -551,6 +556,7 @@ spec:
             echo "Waiting on node-init to run...";
             sleep 1;
           done
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: cilium-bootstrap-file-dir
           mountPath: "/tmp/cilium-bootstrap.d"
@@ -584,6 +590,7 @@ spec:
         {{- with .Values.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           {{- if .Values.securityContext.privileged }}
           privileged: true
@@ -665,6 +672,7 @@ spec:
               echo "Waiting for kube-proxy to create iptables rules...";
               sleep 1;
             done
+        terminationMessagePolicy: FallbackToLogsOnError
       {{- end }} # wait-for-kube-proxy
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -91,6 +91,7 @@ spec:
           securityContext:
             {{- toYaml . | trim | nindent 12 }}
           {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
       {{- with .Values.nodeinit.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -206,6 +206,7 @@ spec:
         securityContext:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
       {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -35,6 +35,7 @@ spec:
           command: ["/bin/echo"]
           args:
           - "hello"
+          terminationMessagePolicy: FallbackToLogsOnError
       containers:
         - name: cilium-pre-flight-check
           image: {{ include "cilium.image" .Values.preflight.image | quote }}
@@ -82,6 +83,7 @@ spec:
           securityContext:
             {{- toYaml . | trim | nindent 14 }}
           {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
         {{- if ne .Values.preflight.tofqdnsPreCache "" }}
         - name: cilium-pre-flight-fqdn-precache
           image: {{ include "cilium.image" .Values.preflight.image | quote }}
@@ -140,6 +142,7 @@ spec:
           securityContext:
             {{- toYaml . | trim | nindent 14 }}
           {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
         {{- end }}
       hostNetwork: true
       # This is here to seamlessly allow migrate-identity to work with

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -72,6 +72,7 @@ spec:
           resources:
             {{- toYaml . | trim | nindent 12 }}
           {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.preflight.priorityClassName "system-cluster-critical") }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -71,6 +71,7 @@ spec:
         volumeMounts:
         - name: etcd-data-dir
           mountPath: /var/run/etcd
+        terminationMessagePolicy: FallbackToLogsOnError
       containers:
       - name: etcd
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
@@ -101,6 +102,7 @@ spec:
           readOnly: true
         - name: etcd-data-dir
           mountPath: /var/run/etcd
+        terminationMessagePolicy: FallbackToLogsOnError
       - name: apiserver
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
@@ -148,6 +150,7 @@ spec:
         - name: etcd-admin-client
           mountPath: /var/lib/cilium/etcd-secrets
           readOnly: true
+        terminationMessagePolicy: FallbackToLogsOnError
       volumes:
       - name: etcd-server-secrets
         secret:

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -89,6 +89,7 @@ spec:
         image: {{ .Values.etcd.image.repository }}:{{ .Values.etcd.image.tag }}
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
+        terminationMessagePolicy: FallbackToLogsOnError
       dnsPolicy: ClusterFirst
       hostNetwork: true
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.clustermesh.apiserver.priorityClassName "system-cluster-critical") }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -91,6 +91,7 @@ spec:
             mountPath: /var/lib/hubble-relay/tls
             readOnly: true
           {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
       restartPolicy: Always
       priorityClassName: {{ .Values.hubble.relay.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.relay.name | quote }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -65,6 +65,7 @@ spec:
             subPath: nginx.conf
           - name: tmp-dir
             mountPath: /tmp
+        terminationMessagePolicy: FallbackToLogsOnError
       - name: backend
         image: {{ include "cilium.image" .Values.hubble.ui.backend.image | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
@@ -104,6 +105,7 @@ spec:
           mountPath: /var/lib/hubble-ui/certs
           readOnly: true
         {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
       {{- with .Values.hubble.ui.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This "captures" the last few lines of logs and sets them as the TerminationMessage in the Status. This means that errors are preserved even if logs are lost (e.g. because of node restarts).

Signed-off-by: Casey Callendrello <cdc@isovalent.com>