### PR TITLE
Add workload name and kind into L7 flows

### DIFF
--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -47,7 +47,7 @@ func New(
 		return nil, err
 	}
 
-	l7, err := seven.New(log, dnsGetter, ipGetter, serviceGetter, opts...)
+	l7, err := seven.New(log, dnsGetter, ipGetter, serviceGetter, endpointGetter, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add workload name and kind into L7 flows. This was previously done for L3/L4 flows in #16514, and this PR aims to get L7 flows aligned in this regard.

This information would be very useful for L7 metrics provided by the L7 visibility filters in cilium. This is to make our metrics more generally useful, as currently it would be quite challenging to query prometheus metrics based on eg: deployment, statefulset, or daemonset name.

For comparison https://istio.io/latest/docs/reference/config/metrics/#labels has a good set of labels.

A follow up PR will be made to support exposing these in hubble metrics.
Additionally, more consideration is needed for Deployments and ReplicaSets. Currently this only extracts the ReplicaSet name, which isn't as useful as the Deployment name, but that can be improved incrementally. This just makes L7 flows aligned with L3L4 flows.

```release-note
Add workload name and kind into L7 flows
```
