### PR TITLE
ci: Update docs-builder image for documentation workflow

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run pre-requisites for validation
         run: |
           make -C Documentation copy-api # necessary for check-build.sh
-      - uses: docker://cilium/docs-builder:2022-04-08@sha256:44f59d844a7e1162080e6fdd62c72a16fc268c893c6cb81e1fbd31cfa189e691
+      - uses: docker://cilium/docs-builder:2022-08-24@sha256:d62428f571eae01297eb58a7c11375bd2b33adec313213a6b8841a3a9c0f2959
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -12,6 +12,7 @@ set -o pipefail
 # times anyway.
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(dirname "${script_dir}")"
 
 build_dir="${script_dir}/_build"
 warnings="${build_dir}/warnings.txt"
@@ -76,7 +77,7 @@ build_with_spellchecker() {
     # If running in a container, tell Git that the repository is safe.
     set +o nounset
     if [[ -n "$MAKE_GIT_REPO_SAFE" ]]; then
-        git config --global --add safe.directory "${script_dir}/.."
+        git config --global --add safe.directory "${root_dir}"
     fi
     set -o nounset
 


### PR DESCRIPTION
We have recently upgraded Sphinx and some of its extensions used for building the docs. There should be nothing breaking, and the documentation should still build with the older image, but it's probably better to validate doc changes with a setup closer to what we're using to deploy the documentation. Joe [generated and tagged a new image](https://github.com/cilium/cilium/pull/20997#issuecomment-1223341138): let's use it.
