### PR TITLE
docs: Mark Git repo as safe in docs-builder, for GitHub workflow too

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -38,4 +38,9 @@ RUN install -m 0777 -d /usr/local/lib/python3.10/site-packages/versionwarning/_s
 ## in the container). We pass --user "uid:gid" to have the "install" command
 ## work in the workaround for versionwarning above.
 ## Tell Git that this repository is safe.
+##
+## Use both the mountpoints used with docs' Makefile and with GitHub workflow.
+## Ideally we would like to make the mountpoint safe at runtime, but I don't
+## know an easy way to do so.
 RUN  git config --global --add safe.directory /src
+RUN  git config --global --add safe.directory /github/workspace


### PR DESCRIPTION
In the docs-builder image, we marked /src as a safe GitHub repository for running Git command in it from a non-root user. This works well when building the documentation locally, but this is not enough to make the GitHub workflow run Git commands in the directory where it mounts the Cilium repository ("/github/workspace").

When [trying to update to a recent docs-builder image][0], and because [the spelling extensions needs to run some Git commands][1], this has led to spell checks failing with an error, blocking the build. Let's mark /github/workspace as a safe Git repository, too.

Ideally, we would declare the repository as safe when launching the container, but given that its owner is root but we're running with a different user (to work around some other issue), I don't see an easy way to do that.

[0]: https://github.com/cilium/cilium/pull/21040#issuecomment-1223873462
[1]: https://github.com/sphinx-contrib/spelling/commit/82fbe4a9308470a2d0be1c18bd5dda636a49c12e

@joestringer: We would need to tag and push a new docs-builder image with this change, so we can use it in the CI workflow (the last one I had you build cannot be used -- apologies!)
