### PR TITLE
tooling: add gitignore entry for clangd's cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ images/*/Dockerfile.dockerignore
 
 # Local Emacs files
 .dir-locals.el
+
+# Clangd cache for indexed bpf code
+bpf/.cache


### PR DESCRIPTION
its possible to use clangd to parse the bpf code with the make target
`make -C bpf gen_compile_commands`.

once compile commands are present clangd will create a cache folder in
/bpf/.cache.

we don't ever want to check this in, and we don't need it showing up in
"git status".

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Gitignore clangd cache folder for bpf code.
```
