### PR TITLE
v1.12 backports 2022-08-23

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       docs-tree: ${{ steps.docs-tree.outputs.src }}
     steps:
@@ -51,7 +51,7 @@ jobs:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.docs-tree == 'true' }}
     name: Validate & Build HTML
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:

--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -18,7 +18,7 @@ jobs:
   check_changes:
     name: Deduce required tests from code changes
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}
     steps:
@@ -36,7 +36,7 @@ jobs:
   analyze:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.go-changes == 'true' || github.event_name != 'pull_request' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:

--- a/Documentation/configuration/argocd-issues.rst
+++ b/Documentation/configuration/argocd-issues.rst
@@ -1,0 +1,95 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _argocd_issues:
+
+********************************************
+Troubleshooting Cilium deployed with Argo CD
+********************************************
+
+There have been reports from users hitting issues with Argo CD. This documentation 
+page outlines some of the known issues and their solutions.
+
+Argo CD deletes CustomResourceDefinitions
+=========================================
+
+When deploying Cilium with Argo CD, some users have reported that Cilium-generated custom resources disappear,
+causing one or more of the following issues:
+
+- ``ciliumid`` not found (:gh-issue:`17614`)
+- Argo CD Out-of-sync issues for hubble-generate-certs (:gh-issue:`14550`)
+- Out-of-sync issues for Cilium using Argo CD (:gh-issue:`18298`)
+
+Solution
+--------
+
+To prevent these issues, declare resource exclusions in the Argo CD ``ConfigMap`` by following `these instructions <https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#resource-exclusioninclusion>`__.
+
+Here is an example snippet:
+
+.. code-block:: yaml
+
+    resource.exclusions: |
+     - apiGroups:
+         - cilium.io
+       kinds:
+         - CiliumIdentity
+       clusters:
+         - "*"
+
+
+Also, it has been reported that the problem may affect all workloads you deploy with Argo CD in a cluster running Cilium, not just Cilium itself.
+If so, you will need the following exclusions in your Argo CD application definition to avoid getting “out of sync” when Hubble rotates its certificates.
+
+.. code-block:: yaml
+
+    ignoreDifferences:
+      - group: ""
+        kind: ConfigMap
+        name: hubble-ca-cert
+        jsonPointers:
+        - /data/ca.crt
+      - group: ""
+        kind: Secret
+        name: hubble-relay-client-certs
+        jsonPointers:
+        - /data/ca.crt
+        - /data/tls.crt
+        - /data/tls.key
+      - group: ""
+        kind: Secret
+        name: hubble-server-certs
+        jsonPointers:
+        - /data/ca.crt
+        - /data/tls.crt
+        - /data/tls.key
+
+
+.. note::
+    After applying the above configurations, for the settings to take effect, you will need to restart the Argo CD deployments.
+
+Helm template with serviceMonitor enabled fails
+===============================================
+
+Some users have reported that when they install Cilium using Argo CD and run ``helm template`` with ``serviceMonitor`` enabled, it fails.
+It fails because Argo CD CLI doesn't pass the ``--api-versions`` flag to Helm upon deployment.
+
+Solution
+--------
+
+This `pull request <https://github.com/argoproj/argo-cd/pull/8371>`__ fixed this issue in Argo CD's `v2.3.0 release <https://github.com/argoproj/argo-cd/releases/tag/v2.3.0>`__.
+Upgrade your Argo CD and check if ``helm template`` with ``serviceMonitor`` enabled still fails.
+
+
+.. note::
+    Note that when using ``helm template``, it is highly recommended you set ``--kube-version`` and ``--api-versions`` with the values matching your target Kubernetes cluster.
+    Helm charts such as Cilium's often conditionally enable certain Kubernetes features based on their availability (beta vs stable) on the target cluster.
+    
+    By specifying ``--api-versions=monitoring.coreos.com/v1`` you should be able to pass validation with ``helm template``.
+
+    
+If you have an issue with Argo CD that's not outlined above, check this `list of Argo CD related issues on GitHub <https://github.com/cilium/cilium/issues?q=is%3Aissue+argocd>`__.
+If you can't find an issue that relates to yours, create one and/or seek help on the :term:`Slack channel`.

--- a/Documentation/configuration/index.rst
+++ b/Documentation/configuration/index.rst
@@ -17,3 +17,4 @@ Core Agent
 
    api-rate-limiting
    vlan-802.1q
+   argocd-issues

--- a/Documentation/gettingstarted/bandwidth-manager.rst
+++ b/Documentation/gettingstarted/bandwidth-manager.rst
@@ -248,3 +248,8 @@ Limitations
     * Bandwidth enforcement doesn't work with nested network namespace environments like Kind. This is because
       they typically don't have access to the global sysctl under ``/proc/sys/net/core`` and the
       bandwidth enforcement depends on them.
+
+.. admonition:: Video
+  :class: attention
+
+  For more insights on Cilium's bandwidth manager, check out this `KubeCon talk on Better Bandwidth Management with eBPF <https://www.youtube.com/watch?v=QTSS6ktK8hY>`__.

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -20,6 +20,13 @@ and provide encryption.
 
 .. include:: cni-chaining-limitations.rst
 
+.. admonition:: Video
+  :class: attention
+
+  If you require advanced features of Cilium, consider migrating fully to Cilium.
+  To help you with the process, you can watch two Principal Engineers at Meltwater talk about `how they migrated
+  Meltwater's production Kubernetes clusters - from the AWS VPC CNI plugin to Cilium <https://www.youtube.com/watch?v=w6S6baRHHu8&list=PLDg_GiBbAx-kDXqDYimwytMLh2kAHyMPd&t=182s>`__.
+
 .. important::
 
    Please ensure that you are running version `1.7.9 <https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.7.9>`_

--- a/Documentation/gettingstarted/host-firewall.rst
+++ b/Documentation/gettingstarted/host-firewall.rst
@@ -13,6 +13,12 @@ Host Firewall
 This document serves as an introduction to Cilium's host firewall, to enforce
 security policies for Kubernetes nodes.
 
+.. admonition:: Video
+  :class: attention
+  
+  You can also watch a video of Cilium's host firewall in action on
+  `eCHO Episode 40: Cilium Host Firewall <https://www.youtube.com/watch?v=GLLLcz398K0&t=288s>`__.
+
 Enable the Host Firewall in Cilium
 ==================================
 

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -214,6 +214,11 @@ Install the Cilium CLI
 
   To learn more about the Cilium CLI, check out `eCHO episode 8: Exploring the Cilium CLI <https://www.youtube.com/watch?v=ndjmaM1i0WQ&t=1136s>`__.
 
+.. admonition:: Video
+  :class: attention
+
+  To learn more about the Cilium CLI, check out `eCHO episode 8: Exploring the Cilium CLI <https://www.youtube.com/watch?v=ndjmaM1i0WQ&t=1136s>`__.
+
 Install Cilium
 ==============
 

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -209,6 +209,11 @@ Install the Cilium CLI
 
 .. include:: cli-download.rst
 
+.. admonition:: Video
+  :class: attention
+
+  To learn more about the Cilium CLI, check out `eCHO episode 8: Exploring the Cilium CLI <https://www.youtube.com/watch?v=ndjmaM1i0WQ&t=1136s>`__.
+
 Install Cilium
 ==============
 

--- a/Documentation/gettingstarted/local-redirect-policy.rst
+++ b/Documentation/gettingstarted/local-redirect-policy.rst
@@ -16,6 +16,11 @@ or Kubernetes service to be redirected locally to backend pod(s) within a node,
 using eBPF. The namespace of backend pod(s) need to match with that of the policy.
 The CiliumLocalRedirectPolicy is configured as a ``CustomResourceDefinition``.
 
+.. admonition:: Video
+  :class: attention
+
+  Aside from this document, you can watch a video explanation of Cilium's Local Redirect Policy on `eCHO episode 39: Local Redirect Policy <https://www.youtube.com/watch?v=BT_gdlhjiQc&t=176s>`__.
+
 There are two types of Local Redirect Policies supported. When traffic for a
 Kubernetes service needs to be redirected, use the `ServiceMatcher` type. The
 service needs to be of type ``clusterIP``.

--- a/Documentation/gettingstarted/servicemesh/ingress.rst
+++ b/Documentation/gettingstarted/servicemesh/ingress.rst
@@ -24,6 +24,32 @@ an existing K8s cluster with Cilium installed.
 
 .. include:: installation.rst
 
+Supported Ingress Annotations
+#############################
+
+.. list-table:: 
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Default Value
+   * - ``io.cilium/tcp-keep-alive``
+     - Enable TCP keep-alive
+     - 1 (enabled)
+   * - ``io.cilium/tcp-keep-alive-idle``
+     - TCP keep-alive idle time (in seconds)
+     - 10s
+   * - ``io.cilium/tcp-keep-alive-probe-interval``
+     - TCP keep-alive probe intervals (in seconds)
+     - 5s
+   * - ``io.cilium/tcp-keep-alive-probe-max-failures``
+     - TCP keep-alive probe max failures
+     - 10
+   * - ``io.cilium/websocket``
+     - Enable websocket
+     - 0 (disabled)
+
 Examples
 ########
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -1005,6 +1005,7 @@ wakeup
 walkthrough
 webhook
 webservice
+websocket
 wellKnownIdentities
 whitelist
 whitelisted

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -31,6 +31,7 @@ DNS
 DSR
 DTrace
 Dangaard
+Datadog
 Datapath
 Dataplane
 Deathstar
@@ -73,6 +74,7 @@ KV
 KVstore
 Kata
 Kicinski
+Klusters
 Kops
 KubeVersion
 Kubernetes
@@ -101,6 +103,8 @@ Netronome
 NewProto
 Nic
 O'Reilly
+PaaS
+Palantir
 Pepelnjak
 Pfaff
 PodCIDR
@@ -113,6 +117,7 @@ Redis
 RuleParser
 SIG
 SR-IOV
+SRv
 Sharma
 Shirokov
 Shortnames
@@ -125,6 +130,7 @@ Suchakra
 Suricata
 TCP
 TLS
+Telco
 Terraform
 Tierney
 Tu
@@ -752,6 +758,7 @@ prepend
 prepended
 prepulls
 prerequirement
+printf
 priori
 priorityClassName
 procfs

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -89,6 +89,7 @@ Marek
 MaskSize
 Mbit
 Mellanox
+Meltwater
 Menlo
 Mesos
 MiB

--- a/FURTHER_READINGS.rst
+++ b/FURTHER_READINGS.rst
@@ -17,8 +17,28 @@ Related Material
 Presentations
 -------------
 
+* Kubernetes on Edge Day, Europe 2022 - Connecting Klusters on the Edge with Deep Dive into Cilium Cluster Mesh:
+  `Video <https://www.youtube.com/watch?v=UcsEVnFtrLY>`__
+* Cloud Native Telco Day, Europe 2022 - Leveraging Cilium and SRv6 for Telco Networking:
+  `Video <https://www.youtube.com/watch?v=vJaOKGWiyvU>`__
+* KubeCon, Europe 2022 - A Guided Tour of Cilium Service Mesh:
+  `Video <https://www.youtube.com/watch?v=e10kDBEsZw4>`__
+* eBPF Day, Europe, 2022 - IKEA Private Cloud, eBPF Based Networking, Load Balancing, and Observability with Cilium:
+  `Video <https://www.youtube.com/watch?v=sg-F_R-ZVNc>`__
+* KubeCon, North America 2021 - Beyond printf & tcpdump: Debugging Kubernetes Networking with eBPF:
+  `Video <https://www.youtube.com/watch?v=vqx-hLYfCYE>`__
+* eBPF Summit, Virtual 2020 - Our eBPF Journey at Datadog:
+  `Video <https://www.youtube.com/watch?v=6mTVuZUHLBg>`__
+* eBPF Summit, Virtual 2020 - Building a Secure and Maintainable PaaS Leveraging Cilium:
+  `Video <https://www.youtube.com/watch?v=hwOpCKBaJ-w>`__
+* eBPF Summit, Virtual 2020 - The Past, Present and Future of Cilium and Hubble at Palantir:
+  `Video <https://www.youtube.com/watch?v=3K5WJ_h5PhI>`__
+* KubeCon, Europe 2020 - Hubble - eBPF Based Observability for Kubernetes:
+  `Video <https://www.youtube.com/watch?v=8WCbGSCyDSo>`__
 * Fosdem, Brussels, 2020 - BPF as a revolutionary technology for the container landscape:
   `Slides <https://docs.google.com/presentation/d/1VOUcoIxgM_c6M_zAV1dLlRCjyYCMdR3tJv6CEdfLMh8/edit#slide=id.g7055f48ba8_0_0>`__, `Video <https://fosdem.org/2020/schedule/event/containers_bpf/>`__
+* KubeCon, North America 2019 - Understanding and Troubleshooting the eBPF Datapath in Cilium:
+  `Video <https://www.youtube.com/watch?v=Kmm8Hl57WDU>`__
 * KubeCon, North America 2019 - Liberating Kubernetes from kube-proxy and iptables:
   `Slides <https://docs.google.com/presentation/d/1cZJ-pcwB9WG88wzhDm2jxQY4Sh8adYg0-N3qWQ8593I/edit#slide=id.g7055f48ba8_0_0>`__, `Video <https://www.youtube.com/watch?v=bIRwSIwNHC0>`__
 * KubeCon, Europe 2019 - Using eBPF to Bring Kubernetes-Aware Security to the Linux Kernel:

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -49,6 +49,7 @@ type DaemonSuite struct {
 
 	// Owners interface mock
 	OnGetPolicyRepository  func() *policy.Repository
+	OnGetNamedPorts        func() (npm policy.NamedPortMultiMap)
 	OnQueueEndpointBuild   func(ctx context.Context, epID uint64) (func(), error)
 	OnGetCompilationLock   func() *lock.RWMutex
 	OnSendNotification     func(typ monitorAPI.AgentNotifyMessage) error
@@ -232,6 +233,13 @@ func (ds *DaemonSuite) GetPolicyRepository() *policy.Repository {
 		return ds.OnGetPolicyRepository()
 	}
 	panic("GetPolicyRepository should not have been called")
+}
+
+func (ds *DaemonSuite) GetNamedPorts() (npm policy.NamedPortMultiMap) {
+	if ds.OnGetNamedPorts != nil {
+		return ds.OnGetNamedPorts()
+	}
+	panic("GetNamedPorts should not have been called")
 }
 
 func (ds *DaemonSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -132,7 +132,7 @@ func (d *Daemon) fetchOldEndpoints(dir string) (*endpointRestoreState, error) {
 	}
 	eptsID := endpoint.FilterEPDir(dirFiles)
 
-	state.possible = endpoint.ReadEPsFromDirNames(d.ctx, d, d, dir, eptsID)
+	state.possible = endpoint.ReadEPsFromDirNames(d.ctx, d, d, d.ipcache, dir, eptsID)
 
 	if len(state.possible) == 0 {
 		log.Info("No old endpoints found.")

--- a/pkg/command/exec/exec.go
+++ b/pkg/command/exec/exec.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -51,8 +52,14 @@ func output(ctx context.Context, cmd *exec.Cmd, filters []string, scopedLog *log
 		scopedLog.WithError(err).WithField("cmd", cmd.Args).Error("Command execution failed")
 		return nil, fmt.Errorf("Command execution failed for %s: %s", cmd.Args, ctx.Err())
 	}
-	if err != nil && verbose {
-		warnToLog(cmd, filters, out, scopedLog, err)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			err = fmt.Errorf("%w stderr=%q", exitErr, exitErr.Stderr)
+		}
+		if verbose {
+			warnToLog(cmd, filters, out, scopedLog, err)
+		}
 	}
 	return out, err
 }

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -99,9 +99,9 @@ var ciliumChains = []customChain{
 func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 	args := []string{"-t", c.table, "-L", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
-		if strings.Contains(string(output), "No chain/target/match by that name.") {
+		if strings.Contains(err.Error(), "No chain/target/match by that name.") {
 			return false, nil
 		}
 
@@ -114,7 +114,7 @@ func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 func (c *customChain) doAdd(prog iptablesInterface) error {
 	args := []string{"-t", c.table, "-N", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to add %s chain: %s (%w)", c.name, string(output), err)
 	}
@@ -146,7 +146,7 @@ func (c *customChain) doRename(prog iptablesInterface, newName string) error {
 
 	args := []string{"-t", c.table, "-E", c.name, newName}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to rename %s chain to %s: %s (%w)", c.name, newName, string(output), err)
 	}
@@ -178,14 +178,14 @@ func (c *customChain) doRemove(prog iptablesInterface) error {
 
 	args := []string{"-t", c.table, "-F", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to flush %s chain: %s (%w)", c.name, string(output), err)
 	}
 
 	args = []string{"-t", c.table, "-X", c.name}
 
-	output, err = prog.runProgCombinedOutput(args)
+	output, err = prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to remove %s chain: %s (%w)", c.name, string(output), err)
 	}
@@ -226,7 +226,7 @@ func (c *customChain) doInstallFeeder(prog iptablesInterface, feedArgs string) e
 
 	args := append([]string{"-t", c.table, installMode, c.hook}, feedRule...)
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to install feeder rule for %s chain: %s (%w)", c.name, string(output), err)
 	}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -81,7 +81,7 @@ type iptablesInterface interface {
 	getProg() string
 	getIpset() string
 	getVersion() (semver.Version, error)
-	runProgCombinedOutput(args []string) (string, error)
+	runProgOutput(args []string) (string, error)
 	runProg(args []string) error
 }
 
@@ -131,7 +131,7 @@ func (ipt *ipt) getVersion() (semver.Version, error) {
 	return versioncheck.Version(vString[1])
 }
 
-func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
+func (ipt *ipt) runProgOutput(args []string) (string, error) {
 	fullCommand := fmt.Sprintf("%s %s", ipt.getProg(), strings.Join(args, " "))
 
 	log.Debugf("Running '%s' command", fullCommand)
@@ -140,19 +140,16 @@ func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
 	iptArgs := make([]string, 0, len(ipt.waitArgs)+len(args))
 	iptArgs = append(iptArgs, ipt.waitArgs...)
 	iptArgs = append(iptArgs, args...)
-	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).CombinedOutput(log, false)
-
-	outStr := string(out)
+	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).Output(log, false)
 
 	if err != nil {
-		return outStr, fmt.Errorf("unable to run '%s' iptables command: %s (%w)", fullCommand, outStr, err)
+		return "", fmt.Errorf("unable to run '%s' iptables command: %w", fullCommand, err)
 	}
-
-	return outStr, nil
+	return string(out), nil
 }
 
 func (ipt *ipt) runProg(args []string) error {
-	_, err := ipt.runProgCombinedOutput(args)
+	_, err := ipt.runProgOutput(args)
 	return err
 }
 
@@ -217,7 +214,7 @@ func isDisabledChain(chain string) bool {
 }
 
 func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
 	if err != nil {
 		return err
 	}
@@ -654,7 +651,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 }
 
 func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, match, oldChain, newChain string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
 	if err != nil {
 		return err
 	}
@@ -707,7 +704,7 @@ func (m *IptablesManager) copyProxyRules(oldChain string, match string) error {
 // Redirect packets to the host proxy via TPROXY, as directed by the Cilium
 // datapath bpf programs via skb marks (egress) or DSCP (ingress).
 func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16, ingress bool, name string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-S"})
 	if err != nil {
 		return err
 	}
@@ -937,7 +934,7 @@ func (m *IptablesManager) GetProxyPort(name string) uint16 {
 }
 
 func (m *IptablesManager) doGetProxyPort(prog iptablesInterface, name string) uint16 {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
+	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
 	if err != nil {
 		return 0
 	}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -54,7 +54,7 @@ func (ipt *mockIptables) getVersion() (semver.Version, error) {
 	return semver.Version{}, nil
 }
 
-func (ipt *mockIptables) runProgCombinedOutput(args []string) (out string, err error) {
+func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {
 	a := strings.Join(args, " ")
 	i := ipt.index
 	ipt.index++
@@ -74,7 +74,7 @@ func (ipt *mockIptables) runProgCombinedOutput(args []string) (out string, err e
 }
 
 func (ipt *mockIptables) runProg(args []string) error {
-	out, err := ipt.runProgCombinedOutput(args)
+	out, err := ipt.runProgOutput(args)
 	if len(out) > 0 {
 		ipt.c.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -794,7 +794,7 @@ func FilterEPDir(dirFiles []os.DirEntry) []string {
 // common.CiliumCHeaderPrefix + common.Version + ":" + endpointBase64
 // Note that the parse'd endpoint's identity is only partially restored. The
 // caller must call `SetIdentity()` to make the returned endpoint's identity useful.
-func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter, bEp []byte) (*Endpoint, error) {
+func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter, namedPortsGetter namedPortsGetter, bEp []byte) (*Endpoint, error) {
 	// TODO: Provide a better mechanism to update from old version once we bump
 	// TODO: cilium version.
 	epSlice := bytes.Split(bEp, []byte{':'})
@@ -802,8 +802,9 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter p
 		return nil, fmt.Errorf("invalid format %q. Should contain a single ':'", bEp)
 	}
 	ep := Endpoint{
-		owner:        owner,
-		policyGetter: policyGetter,
+		owner:            owner,
+		namedPortsGetter: namedPortsGetter,
+		policyGetter:     policyGetter,
 	}
 
 	if err := parseBase64ToEndpoint(epSlice[1], &ep); err != nil {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -57,6 +57,7 @@ type EndpointSuite struct {
 
 	// Owners interface mock
 	OnGetPolicyRepository     func() *policy.Repository
+	OnGetNamedPorts           func() (npm policy.NamedPortMultiMap)
 	OnQueueEndpointBuild      func(ctx context.Context, epID uint64) (func(), error)
 	OnRemoveFromEndpointQueue func(epID uint64)
 	OnGetCompilationLock      func() *lock.RWMutex
@@ -93,6 +94,13 @@ func (s *EndpointSuite) TearDownSuite(c *C) {
 
 func (s *EndpointSuite) GetPolicyRepository() *policy.Repository {
 	return s.repo
+}
+
+func (s *EndpointSuite) GetNamedPorts() (npm policy.NamedPortMultiMap) {
+	if s.OnGetNamedPorts != nil {
+		return s.OnGetNamedPorts()
+	}
+	panic("GetNamedPorts should not have been called")
 }
 
 func (s *EndpointSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {
@@ -139,7 +147,7 @@ func NewCachingIdentityAllocator(owner cache.IdentityAllocatorOwner) fakeIdentit
 	}
 }
 
-//func (f *fakeIdentityAllocator)
+// func (f *fakeIdentityAllocator)
 
 func (s *EndpointSuite) SetUpTest(c *C) {
 	/* Required to test endpoint CEP policy model */

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -67,7 +67,9 @@ func hasHostObjectFile(epDir string) bool {
 
 // ReadEPsFromDirNames returns a mapping of endpoint ID to endpoint of endpoints
 // from a list of directory names that can possible contain an endpoint.
-func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter, basePath string, eptsDirNames []string) map[uint16]*Endpoint {
+func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter,
+	namedPortsGetter namedPortsGetter, basePath string, eptsDirNames []string) map[uint16]*Endpoint {
+
 	completeEPDirNames, incompleteEPDirNames := partitionEPDirNamesByRestoreStatus(eptsDirNames)
 
 	if len(incompleteEPDirNames) > 0 {
@@ -137,7 +139,7 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGe
 			scopedLog.WithError(err).Warn("Unable to read the C header file")
 			continue
 		}
-		ep, err := parseEndpoint(ctx, owner, policyGetter, bEp)
+		ep, err := parseEndpoint(ctx, owner, policyGetter, namedPortsGetter, bEp)
 		if err != nil {
 			scopedLog.WithError(err).Warn("Unable to parse the C header file")
 			continue

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -132,7 +132,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNames(c *C) {
 			epsNames = append(epsNames, ep.DirectoryPath())
 		}
 	}
-	eps := ReadEPsFromDirNames(context.TODO(), ds, ds, tmpDir, epsNames)
+	eps := ReadEPsFromDirNames(context.TODO(), ds, ds, ds, tmpDir, epsNames)
 	c.Assert(len(eps), Equals, len(epsWanted))
 
 	sort.Slice(epsWanted, func(i, j int) bool { return epsWanted[i].ID < epsWanted[j].ID })
@@ -198,7 +198,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNamesWithRestoreFailure(c *C) {
 		ep.DirectoryPath(), ep.NextDirectoryPath(),
 	}
 
-	epResult := ReadEPsFromDirNames(context.TODO(), ds, ds, tmpDir, epNames)
+	epResult := ReadEPsFromDirNames(context.TODO(), ds, ds, ds, tmpDir, epNames)
 	c.Assert(len(epResult), Equals, 1)
 
 	restoredEP := epResult[ep.ID]
@@ -254,7 +254,7 @@ func (ds *EndpointSuite) BenchmarkReadEPsFromDirNames(c *C) {
 	c.StartTimer()
 
 	for i := 0; i < c.N; i++ {
-		eps := ReadEPsFromDirNames(context.TODO(), ds, ds, tmpDir, epsNames)
+		eps := ReadEPsFromDirNames(context.TODO(), ds, ds, ds, tmpDir, epsNames)
 		c.Assert(len(eps), Equals, len(epsWanted))
 	}
 }

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -396,6 +396,14 @@ func updateCiliumEndpointLabels(ep *endpoint.Endpoint, labels map[string]string)
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) (err error) {
 				pod := ep.GetPod()
+				if pod == nil {
+					err := errors.New("Skipping CiliumEndpoint update because it has no k8s pod")
+					scopedLog.WithFields(logrus.Fields{
+						logfields.EndpointID: ep.GetID(),
+						logfields.Labels:     logfields.Repr(labels),
+					}).Debug(err)
+					return err
+				}
 				ciliumClient := k8s.CiliumClient().CiliumV2()
 
 				replaceLabels := []k8s.JSONPatch{

--- a/pkg/spanstat/spanstat_test.go
+++ b/pkg/spanstat/spanstat_test.go
@@ -66,7 +66,8 @@ func (s *SpanStatTestSuite) TestSpanStat(c *C) {
 	c.Assert(span1.FailureTotal(), Equals, spanFailureTotal1)
 
 	span1.Start()
-	span1.End(false)
+	time.Sleep(time.Millisecond * 100)
+	span1.End(false) // ensure second measure is different from first.
 	c.Assert(span1.Total(), Not(Equals), spanTotal1)
 	c.Assert(span1.SuccessTotal(), Equals, spanSuccessTotal1)
 	c.Assert(span1.FailureTotal(), Not(Equals), spanFailureTotal1)


### PR DESCRIPTION
* ~#20853 -- ingress: Support clustermesh service affinity (@sayboras)~
 I tried resolving the conflicts, but it seems like there was a change that changed []backends to []*backends, and that wasn't backported. @sayboras I skipped it.
 * #20865 -- k8s/watchers: fix panic in CiliumEndpoint labels update (@jaffcheng)
 * #20911 -- pkg/endpoint: set namedPortsGetter interface on ParseEndpoint (@aanm)
 * #20313 -- Add ArgoCD issues notes in the official documentation (@Kikiodazie)
 * #20623 -- docs: second set of video contents added (@Kikiodazie)
 
 * #20895 -- don't merge stderr into iptable stdout (@liuyuan10)
Resolved minor conflict around imports.

 * #20973 -- docs: Add available options for Ingress Controller annotations (@NikhilSharmaWe)
* ~#20860 -- ingress: Propagate required annotations from Ingress to LB Service (@NikhilSharmaWe)~
I was able to resolve other conflicts, except the ones in cmd/root.go, looks like that file doesn't exist. I wasn't able to find the other variables from the file in v1.12 source code. @aanm/ @sayboras I skipped the backport for this PR. 

 * #21015 -- gh/workflows: stop using ubuntu-18.04 runner (@julianwiedmann)
 * #20977 -- metrics: fix ts_events API timestamp and scope label cardinality (@tommyp1ckles)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20865 20911 20313 20623 20895 20973 21015 20977; do contrib/backporting/set-labels.py $pr done 1.12; done
```