### PR TITLE
v1.10 backports 2022-08-23

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -406,6 +406,14 @@ func updateCiliumEndpointLabels(ep *endpoint.Endpoint, labels map[string]string)
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) (err error) {
 				pod := ep.GetPod()
+				if pod == nil {
+					err := errors.New("Skipping CiliumEndpoint update because it has no k8s pod")
+					scopedLog.WithFields(logrus.Fields{
+						logfields.EndpointID: ep.GetID(),
+						logfields.Labels:     logfields.Repr(labels),
+					}).Debug(err)
+					return err
+				}
 				ciliumClient := k8s.CiliumClient().CiliumV2()
 
 				replaceLabels := []k8s.JSONPatch{


### PR DESCRIPTION
* #20865 -- k8s/watchers: fix panic in CiliumEndpoint labels update (@jaffcheng)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20865; do contrib/backporting/set-labels.py $pr done 1.10; done
```