### PR TITLE
ipam/allocator/podcidr: remove unused CIDRAllocator.IsIPv6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/cilium/customvet v0.0.0-20201209211516-9852765c1ac4
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
 	github.com/cilium/ebpf v0.9.1
-	github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c
+	github.com/cilium/ipam v0.0.0-20220824141044-46ef3d556735
 	github.com/cilium/lumberjack/v2 v2.2.2
 	github.com/cilium/proxy v0.0.0-20220803100640-5739e4be8ae7
 	github.com/cilium/workerpool v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/cilium/dns v1.1.51-0.20220729113855-5b94b11b46fc/go.mod h1:e3IlAVfNqA
 github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
 github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
-github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c h1:BNplQ8/gUxxF3ISPjM5h6+e/r1lld3VhGEjj2S02/7c=
-github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c/go.mod h1:Ascfar4FtgB+K+mwqbZpSb3WVZ5sPFIarg+iAOXNZqI=
+github.com/cilium/ipam v0.0.0-20220824141044-46ef3d556735 h1:zVAyMgk50mGdTozg5aTQd9QKHlmQmQY5onmO1NqGrZ0=
+github.com/cilium/ipam v0.0.0-20220824141044-46ef3d556735/go.mod h1:Ascfar4FtgB+K+mwqbZpSb3WVZ5sPFIarg+iAOXNZqI=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyRem1awcpz3icz/HoL8Dxg/m6a4=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
 github.com/cilium/lumberjack/v2 v2.2.2 h1:RKTdhb63DY0Xu7pE1pipMj7Zq28LyvBGSrCneHiKm4A=

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -184,7 +184,6 @@ type CIDRAllocator interface {
 	AllocateNext() (*net.IPNet, error)
 	Release(cidr *net.IPNet) error
 	IsAllocated(cidr *net.IPNet) (bool, error)
-	IsIPv6() bool
 	IsFull() bool
 	InRange(cidr *net.IPNet) bool
 }

--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -79,7 +79,6 @@ type mockCIDRAllocator struct {
 	OnAllocateNext func() (*net.IPNet, error)
 	OnRelease      func(cidr *net.IPNet) error
 	OnIsAllocated  func(cidr *net.IPNet) (bool, error)
-	OnIsIPv6       func() bool
 	OnIsFull       func() bool
 	OnInRange      func(cidr *net.IPNet) bool
 }
@@ -114,13 +113,6 @@ func (d *mockCIDRAllocator) IsAllocated(cidr *net.IPNet) (bool, error) {
 		return d.OnIsAllocated(cidr)
 	}
 	panic("d.IsAllocated should not have been called!")
-}
-
-func (d *mockCIDRAllocator) IsIPv6() bool {
-	if d.OnIsIPv6 != nil {
-		return d.OnIsIPv6()
-	}
-	panic("d.IsIPv6 should not have been called!")
 }
 
 func (d *mockCIDRAllocator) IsFull() bool {

--- a/vendor/github.com/cilium/ipam/cidrset/cidr_set.go
+++ b/vendor/github.com/cilium/ipam/cidrset/cidr_set.go
@@ -30,7 +30,6 @@ import (
 // CidrSet manages a set of CIDR ranges from which blocks of IPs can
 // be allocated from.
 type CidrSet struct {
-	isV6 bool
 	sync.Mutex
 	clusterCIDR     *net.IPNet
 	clusterIP       net.IP
@@ -77,9 +76,8 @@ func NewCIDRSet(clusterCIDR *net.IPNet, subNetMaskSize int) (*CidrSet, error) {
 	clusterMask := clusterCIDR.Mask
 	clusterMaskSize, _ := clusterMask.Size()
 
-	isV6 := clusterCIDR.IP.To4() == nil
 	var maxCIDRs int
-	if isV6 {
+	if clusterCIDR.IP.To4() == nil {
 		if subNetMaskSize > maxSubNetMaskSizeIPv6 {
 			return nil, ErrSubNetMaskSizeInvalid
 		}
@@ -96,7 +94,6 @@ func NewCIDRSet(clusterCIDR *net.IPNet, subNetMaskSize int) (*CidrSet, error) {
 		clusterMaskSize: clusterMaskSize,
 		maxCIDRs:        maxCIDRs,
 		subNetMaskSize:  subNetMaskSize,
-		isV6:            isV6,
 	}, nil
 }
 
@@ -157,11 +154,6 @@ func (s *CidrSet) indexToCIDRBlock(index int) *net.IPNet {
 		IP:   ip,
 		Mask: net.CIDRMask(s.subNetMaskSize, mask),
 	}
-}
-
-// IsIPv6 returns true if CidrSet only allocates IPv6 CIDRs.
-func (s *CidrSet) IsIPv6() bool {
-	return s.isV6
 }
 
 // IsFull returns true if CidrSet does not have any more available CIDRs.

--- a/vendor/github.com/cilium/ipam/service/allocator/utils.go
+++ b/vendor/github.com/cilium/ipam/service/allocator/utils.go
@@ -24,8 +24,8 @@ import (
 // countBits returns the number of set bits in n
 func countBits(n *big.Int) int {
 	var count int = 0
-	for _, b := range n.Bytes() {
-		count += bits.OnesCount8(uint8(b))
+	for _, w := range n.Bits() {
+		count += bits.OnesCount64(uint64(w))
 	}
 	return count
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,7 +178,7 @@ github.com/cilium/ebpf/internal/sys
 github.com/cilium/ebpf/internal/unix
 github.com/cilium/ebpf/perf
 github.com/cilium/ebpf/rlimit
-# github.com/cilium/ipam v0.0.0-20211026130907-54a76012817c
+# github.com/cilium/ipam v0.0.0-20220824141044-46ef3d556735
 ## explicit; go 1.14
 github.com/cilium/ipam/cidrset
 github.com/cilium/ipam/service/allocator


### PR DESCRIPTION
The `CIDRAllocator` interface's `IsIPv6` method is unused across the entire
Cilium code base since it was added in commit 513296652c02 ("add
Cilium-operator podCIDR allocator"). This change would allow to also
drop it from `github.com/cilium/ipam/cidrset.CidrSet` which was forked
from `k8s.io/kubernetes/pkg/controller/nodeipam/ipam/cidrset` and amended
with the `IsIPv6` method.
