### PR TITLE
gha: Add images dir for l4lb jobs

### DIFF
--- a/.github/workflows/tests-l4lb-v1.10.yaml
+++ b/.github/workflows/tests-l4lb-v1.10.yaml
@@ -106,6 +106,7 @@ jobs:
               - 'daemon/**'
               - 'bpf/**'
               - 'test/l4lb/**'
+              - 'images/**'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -106,6 +106,7 @@ jobs:
               - 'daemon/**'
               - 'bpf/**'
               - 'test/l4lb/**'
+              - 'images/**'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.

--- a/.github/workflows/tests-l4lb-v1.12.yaml
+++ b/.github/workflows/tests-l4lb-v1.12.yaml
@@ -106,6 +106,7 @@ jobs:
               - 'daemon/**'
               - 'bpf/**'
               - 'test/l4lb/**'
+              - 'images/**'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -109,6 +109,7 @@ jobs:
               - 'bpf/**'
               - 'test/l4lb/**'
               - 'test/nat46x64/**'
+              - 'images/**'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.


### PR DESCRIPTION
The previous PR #20943, which upgrades all docker images, breaks
this test job. However, it was skipped due to path filtering, this
commit is to add images dir to avoid similar issue in the future.

Signed-off-by: Tam Mach <tam.mach@cilium.io>