### PR TITLE
docs: Mark Git repository as safe, at runtime, if in a container

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -30,12 +30,3 @@ ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION
 ## write runtime data inside a system directory.
 ## We do rely on this extension, so we cannot just drop it.
 RUN install -m 0777 -d /usr/local/lib/python3.10/site-packages/versionwarning/_static/data
-
-## Recent Git versions refuse to work by default if the repository owner is
-## different from the user. This is the case on macOS, because we run the
-## container with --user "uid:gid", and they differ from what Linux is used to
-## (The gid from macOS seems to be 20, which corresponds to the "dialout" group
-## in the container). We pass --user "uid:gid" to have the "install" command
-## work in the workaround for versionwarning above.
-## Tell Git that this repository is safe.
-RUN  git config --global --add safe.directory /src

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -38,9 +38,4 @@ RUN install -m 0777 -d /usr/local/lib/python3.10/site-packages/versionwarning/_s
 ## in the container). We pass --user "uid:gid" to have the "install" command
 ## work in the workaround for versionwarning above.
 ## Tell Git that this repository is safe.
-##
-## Use both the mountpoints used with docs' Makefile and with GitHub workflow.
-## Ideally we would like to make the mountpoint safe at runtime, but I don't
-## know an easy way to do so.
 RUN  git config --global --add safe.directory /src
-RUN  git config --global --add safe.directory /github/workspace

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -25,6 +25,7 @@ RUN pip install -r /tmp/requirements.txt
 
 ENV HOME=/tmp
 ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION
+ENV MAKE_GIT_REPO_SAFE=1
 
 ## Workaround odd behaviour of sphinx versionwarning extension. It wants to
 ## write runtime data inside a system directory.

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -62,6 +62,24 @@ describe_spelling_errors() {
 }
 
 build_with_spellchecker() {
+    # The spell checker runs some Git commands to retreive the name of authors
+    # and consider them as acceptable words.
+    #
+    # Recent Git versions refuse to work by default if the repository owner is
+    # different from the user. This is the case when we run this script in a
+    # container on macOS, because pass --user "uid:gid", and these values
+    # differ from what Linux is used to (The gid from macOS seems to be 20,
+    # which corresponds to the "dialout" group in the container). We pass
+    # --user "uid:gid" to have the "install" command work in the workaround for
+    # versionwarning above.
+    #
+    # If running in a container, tell Git that the repository is safe.
+    set +o nounset
+    if [[ -n "$MAKE_GIT_REPO_SAFE" ]]; then
+        git config --global --add safe.directory "${script_dir}/.."
+    fi
+    set -o nounset
+
     rm -rf "${spelldir}"
     # Call with -q -W --keep-going: suppresses regular output (keeps warning;
     # -Q would suppress warnings as well including those we write to a file),


### PR DESCRIPTION
Trials and experiments... This is a follow-up to https://github.com/cilium/cilium/pull/21043, which sadly was not enough to fix the issue faced in https://github.com/cilium/cilium/pull/21040 to update the CI image.

The reason is that the GitHub workflow passes `-e HOME` when running the container, overwriting the home directory, making Git fail to find its `.gitconfig` where the directives for marking the repo as safe were stored.

Instead, let's declare the repo as safe at runtime, if running from a container.

Alas, this will require yet another image. I have not found a clean solution to detect whether we run from a container without passing a dedicated variable through the Dockerfile (and we don't want to mark the repo as safe if not in a container, because this would edit the user's `.gitconfig`).
