### PR TITLE
Support new hubble metrics context: "labelsContext"

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -650,13 +650,21 @@ This metric supports :ref:`Context Options<hubble_context_options>`.
 ``http``
 ~~~~~~~~
 
-================================= ============================= ========== ==============================================
-Name                              Labels                        Default     Description
-================================= ============================= ========== ==============================================
-``http_requests_total``           ``method``, ``protocol``      Disabled   Count of HTTP requests
-``http_responses_total``          ``method``, ``status``        Disabled   Count of HTTP responses
-``http_request_duration_seconds`` ``method``                    Disabled   Quantiles of HTTP request duration in seconds
-================================= ============================= ========== ==============================================
+================================= ======================================= ========== ==============================================
+Name                              Labels                                  Default     Description
+================================= ======================================= ========== ==============================================
+``http_requests_total``           ``method``, ``protocol``, ``reporter``  Disabled   Count of HTTP requests
+``http_responses_total``          ``method``, ``status``, ``reporter``    Disabled   Count of HTTP responses
+``http_request_duration_seconds`` ``method``, ``reporter``                Disabled   Quantiles of HTTP request duration in seconds
+================================= ======================================= ========== ==============================================
+
+Labels
+""""""
+
+- ``method`` is the HTTP method of the request/response.
+- ``protocol`` is the HTTP protocol of the request, (For example: ``HTTP/1.1``, ``HTTP/2``).
+- ``status`` is the HTTP status code of the response.
+- ``reporter`` identifies the origin of the request/response. It is set to ``client`` if it originated from the client, ``server`` if it originated from the server, or ``unknown`` if it's origin isn't known.
 
 Options
 """""""

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -496,9 +496,18 @@ and the ``http`` metric with the ``destinationContext=pod-short`` option.
 Context Options
 ^^^^^^^^^^^^^^^
 
+Hubble metrics support configuration via context options.
+Currently there are 3 supported context options for all metrics:
+
+- ``sourceContext`` - Configures the ``source`` label on metrics.
+- ``destinationContext`` - Configures the ``destination`` label on metrics.
+- ``labelsContext`` - Configures a list of labels to be enabled on metrics.
+
+See below for details on each of the different context options.
+
 Most Hubble metrics can be configured to add the source and/or destination
-context as a label. The options are called ``sourceContext`` and
-``destinationContext``. The possible values are:
+context as a label using the ``sourceContext`` and ``destinationContext``
+options. The possible values are:
 
 ===================== ===================================================================================
 Option Value          Description
@@ -529,6 +538,29 @@ and use the IP address of the target instead.
    3. ``reserved:kube-apiserver`` and ``reserved:world``
 
    In all of these 3 cases, ``reserved-identity`` context returns ``reserved:kube-apiserver``.
+
+Hubble metrics can also be configured with a ``labelsContext`` which allows providing a list of labels
+that should be added to the metric. Unlike ``sourceContext`` and ``destinationContext``, instead
+of different values being put into the same metric label, the ``labelsContext`` puts them into different label values.
+
+========================= ===============================================================================
+Option Value              Description
+========================= ===============================================================================
+``source_namespace``      The namespace of the pod if the flow source is from a Kubernetes pod.
+``source_pod``            The pod name if the flow source is from a Kubernetes pod.
+``source_workload``       The name of the source pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).
+``source_app``            The app name of the source pod, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
+``destination_namespace`` The namespace of the pod if the flow destination is from a Kubernetes pod.
+``destination_pod``       The pod name if the flow destination is from a Kubernetes pod.
+``destination_workload``  The name of the destination pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).
+``destination_app``       The app name of the source pod, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
+``traffic_direction``     Identifies the traffic direction of the flow. Possible values are ``ingress``, ``egress`` and ``unknown``.
+========================= ===============================================================================
+
+When specifying the flow context, multiple values can be specified by separating them via the ``,`` symbol.
+All labels listed are included in the metric, even if empty. For example, a metric configuration of
+``http:labelsContext=source_namespace,source_pod`` will add the ``source_namespace`` and ``source_pod``
+labels to all Hubble HTTP metrics.
 
 .. _hubble_exported_metrics:
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -581,6 +581,7 @@ kubeproxy
 kubernetes
 kubespray
 kvstore
+labelsContext
 latencies
 lbExternalClusterIP
 lbMapMax

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -111,7 +111,10 @@ func (d *Daemon) launchHubble() {
 
 		observerOpts = append(observerOpts,
 			observeroption.WithOnDecodedFlowFunc(func(ctx context.Context, flow *flowpb.Flow) (bool, error) {
-				metrics.ProcessFlow(ctx, flow)
+				err := metrics.ProcessFlow(ctx, flow)
+				if err != nil {
+					logger.WithError(err).Error("Failed to ProcessFlow in metrics handler")
+				}
 				return false, nil
 			}),
 		)

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -71,12 +71,12 @@ var (
 
 	podAppLabels = []string{
 		// k8s recommend app label
-		ciliumLabels.LabelSourceK8sKeyPrefix + k8sConst.AppKubernetes + "/name",
+		ciliumLabels.LabelSourceK8s + ":" + k8sConst.AppKubernetes + "/name",
 		// legacy k8s app label
-		ciliumLabels.LabelSourceK8sKeyPrefix + "k8s-app",
+		ciliumLabels.LabelSourceK8s + ":" + "k8s-app",
 		// app label that is often used before people realize there's a recommended
 		// label
-		ciliumLabels.LabelSourceK8sKeyPrefix + "app",
+		ciliumLabels.LabelSourceK8s + ":" + "app",
 	}
 )
 
@@ -401,12 +401,14 @@ func destinationIPContext(flow *pb.Flow) (context string) {
 }
 
 func getK8sAppFromLabels(labels []string) string {
-	ls := ciliumLabels.ParseLabelArrayFromArray(labels)
-	// Iterate over the set of pod app labels we source from and return the first
-	// app label that is non-empty.
-	for _, label := range podAppLabels {
-		if labelValue := ls.Get(label); labelValue != "" {
-			return labelValue
+	for _, label := range labels {
+		for _, appLabel := range podAppLabels {
+			if strings.HasPrefix(label, appLabel+"=") {
+				l := ciliumLabels.ParseLabel(label)
+				if l.Value != "" {
+					return l.Value
+				}
+			}
 		}
 	}
 	return ""

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -12,7 +12,8 @@ import (
 	"k8s.io/utils/strings/slices"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
-	"github.com/cilium/cilium/pkg/labels"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	ciliumLabels "github.com/cilium/cilium/pkg/labels"
 )
 
 // ContextIdentifier describes the identification method of a transmission or
@@ -43,14 +44,40 @@ const (
 
 // ContextOptionsHelp is the help text for context options
 const ContextOptionsHelp = `
- sourceContext          := identifier , { "|", identifier }
- destinationContext     := identifier , { "|", identifier }
- identifier             := identity | namespace | pod | pod-short | dns | ip | reserved-identity
+ sourceContext          ::= identifier , { "|", identifier }
+ destinationContext     ::= identifier , { "|", identifier }
+ labels                 ::= label , { ",", label }
+ identifier             ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity
+ label                  ::= source_pod | source_namespace | source_workload | source_app | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 
 var (
 	shortPodPattern    = regexp.MustCompile("^(.+?)(-[a-z0-9]+){1,2}$")
-	kubeAPIServerLabel = labels.LabelKubeAPIServer.String()
+	kubeAPIServerLabel = ciliumLabels.LabelKubeAPIServer.String()
+	// contextLabelsList defines available labels for the ContextLabels
+	// ContextIdentifier and the order of those labels for GetLabelNames and GetLabelValues.
+	contextLabelsList = []string{
+		"source_pod",
+		"source_namespace",
+		"source_workload",
+		"source_app",
+		"destination_pod",
+		"destination_namespace",
+		"destination_workload",
+		"destination_app",
+		"traffic_direction",
+	}
+	allowedContextLabels = newLabelsSet(contextLabelsList)
+
+	podAppLabels = []string{
+		// k8s recommend app label
+		ciliumLabels.LabelSourceK8sKeyPrefix + k8sConst.AppKubernetes + "/name",
+		// legacy k8s app label
+		ciliumLabels.LabelSourceK8sKeyPrefix + "k8s-app",
+		// app label that is often used before people realize there's a recommended
+		// label
+		ciliumLabels.LabelSourceK8sKeyPrefix + "app",
+	}
 )
 
 // String return the context identifier as string
@@ -72,7 +99,6 @@ func (c ContextIdentifier) String() string {
 		return "ip"
 	case ContextReservedIdentity:
 		return "reserved-identity"
-
 	}
 	return fmt.Sprintf("%d", c)
 }
@@ -94,6 +120,10 @@ type ContextOptions struct {
 	Destination ContextIdentifierList
 	// Source is the source context to include in metrics
 	Source ContextIdentifierList
+
+	// Labels is the full set of labels that have been allowlisted when using the
+	// ContextLabels ContextIdentifier.
+	Labels labelsSet
 }
 
 func parseContextIdentifier(s string) (ContextIdentifier, error) {
@@ -129,28 +159,117 @@ func parseContext(s string) (cs ContextIdentifierList, err error) {
 	return cs, nil
 }
 
+func parseLabels(s string) (labelsSet, error) {
+	labels := strings.Split(s, ",")
+	for _, label := range labels {
+		if !allowedContextLabels.HasLabel(label) {
+			return labelsSet{}, fmt.Errorf("invalid labelsContext value: %s", label)
+		}
+	}
+	ls := newLabelsSet(labels)
+	return ls, nil
+}
+
 // ParseContextOptions parses a set of options and extracts the context
 // relevant options
 func ParseContextOptions(options Options) (*ContextOptions, error) {
 	o := &ContextOptions{}
+	var err error
 	for key, value := range options {
 		switch strings.ToLower(key) {
 		case "destinationcontext":
-			c, err := parseContext(value)
+			o.Destination, err = parseContext(value)
 			if err != nil {
 				return nil, err
 			}
-			o.Destination = c
 		case "sourcecontext":
-			c, err := parseContext(value)
+			o.Source, err = parseContext(value)
 			if err != nil {
 				return nil, err
 			}
-			o.Source = c
+		case "labelscontext":
+			o.Labels, err = parseLabels(value)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	return o, nil
+}
+
+type labelsSet map[string]struct{}
+
+func newLabelsSet(labels []string) labelsSet {
+	m := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		m[label] = struct{}{}
+	}
+	return labelsSet(m)
+}
+
+func (ls labelsSet) HasLabel(label string) bool {
+	_, exists := ls[label]
+	return exists
+}
+
+func (ls labelsSet) String() string {
+	var b strings.Builder
+	// output the labels in a consistent order
+	for i, label := range contextLabelsList {
+		if ls.HasLabel(label) {
+			b.WriteString(label)
+			if i < len(ls)-1 {
+				b.WriteString(",")
+			}
+		}
+	}
+	return b.String()
+}
+
+func labelsContext(wantedLabels labelsSet, flow *pb.Flow) (outputLabels []string) {
+	// Iterate over contextLabelsList so that the label order is stable,
+	// otherwise GetLabelNames and GetLabelValues might be mismatched
+	for _, label := range contextLabelsList {
+		if wantedLabels.HasLabel(label) {
+			var labelValue string
+			switch label {
+			case "source_pod":
+				labelValue = flow.GetSource().GetPodName()
+			case "source_namespace":
+				labelValue = flow.GetSource().GetNamespace()
+			case "source_workload":
+				if workloads := flow.GetSource().GetWorkloads(); len(workloads) != 0 {
+					labelValue = workloads[0].Name
+				}
+			case "source_app":
+				labelValue = getK8sAppFromLabels(flow.GetSource().GetLabels())
+			case "destination_pod":
+				labelValue = flow.GetDestination().GetPodName()
+			case "destination_namespace":
+				labelValue = flow.GetDestination().GetNamespace()
+			case "destination_workload":
+				if workloads := flow.GetDestination().GetWorkloads(); len(workloads) != 0 {
+					labelValue = workloads[0].Name
+				}
+			case "destination_app":
+				labelValue = getK8sAppFromLabels(flow.GetDestination().GetLabels())
+			case "traffic_direction":
+				direction := flow.GetTrafficDirection()
+				if direction == pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN {
+					labelValue = "unknown"
+				} else {
+					labelValue = strings.ToLower(direction.String())
+				}
+			default:
+				// Label is in contextLabelsList but isn't handled in the switch
+				// statement. Programmer error.
+				panic(fmt.Sprintf("label %s not mapped in labelsContext, please update labelsContext", label))
+			}
+			outputLabels = append(outputLabels, labelValue)
+		}
+	}
+	return outputLabels
 }
 
 func sourceNamespaceContext(flow *pb.Flow) (context string) {
@@ -226,7 +345,7 @@ func handleReservedIdentityLabels(lbls []string) string {
 	}
 	// else return the first reserved label.
 	for _, label := range lbls {
-		if strings.HasPrefix(label, labels.LabelSourceReserved+":") {
+		if strings.HasPrefix(label, ciliumLabels.LabelSourceReserved+":") {
 			return label
 		}
 	}
@@ -281,10 +400,26 @@ func destinationIPContext(flow *pb.Flow) (context string) {
 	return
 }
 
+func getK8sAppFromLabels(labels []string) string {
+	ls := ciliumLabels.ParseLabelArrayFromArray(labels)
+	// Iterate over the set of pod app labels we source from and return the first
+	// app label that is non-empty.
+	for _, label := range podAppLabels {
+		if labelValue := ls.Get(label); labelValue != "" {
+			return labelValue
+		}
+	}
+	return ""
+}
+
 // GetLabelValues returns the values of the context relevant labels according
 // to the configured options. The order of the values is the same as the order
 // of the label names returned by GetLabelNames()
 func (o *ContextOptions) GetLabelValues(flow *pb.Flow) (labels []string) {
+	if len(o.Labels) != 0 {
+		labels = append(labels, labelsContext(o.Labels, flow)...)
+	}
+
 	if len(o.Source) != 0 {
 		var context string
 		for _, source := range o.Source {
@@ -345,6 +480,16 @@ func (o *ContextOptions) GetLabelValues(flow *pb.Flow) (labels []string) {
 // GetLabelNames returns a slice of label names required to fulfil the
 // configured context description requirements
 func (o *ContextOptions) GetLabelNames() (labels []string) {
+	if len(o.Labels) != 0 {
+		// We must iterate over contextLabelsList to ensure the order of the label
+		// names the same order as label values in GetLabelValues.
+		for _, label := range contextLabelsList {
+			if o.Labels.HasLabel(label) {
+				labels = append(labels, label)
+			}
+		}
+	}
+
 	if len(o.Source) != 0 {
 		labels = append(labels, "source")
 	}
@@ -360,6 +505,10 @@ func (o *ContextOptions) GetLabelNames() (labels []string) {
 // with Handler.Status
 func (o *ContextOptions) Status() string {
 	var status []string
+	if len(o.Labels) != 0 {
+		status = append(status, "labels="+o.Labels.String())
+	}
+
 	if len(o.Source) != 0 {
 		status = append(status, "source="+o.Source.String())
 	}

--- a/pkg/hubble/metrics/api/registry_test.go
+++ b/pkg/hubble/metrics/api/registry_test.go
@@ -41,8 +41,9 @@ func (t *testHandler) Status() string {
 	return ""
 }
 
-func (t *testHandler) ProcessFlow(ctx context.Context, p *pb.Flow) {
+func (t *testHandler) ProcessFlow(ctx context.Context, p *pb.Flow) error {
 	t.ProcessCalled++
+	return nil
 }
 
 func TestRegister(t *testing.T) {

--- a/pkg/hubble/metrics/flow/handler.go
+++ b/pkg/hubble/metrics/flow/handler.go
@@ -44,7 +44,11 @@ func (h *flowHandler) Status() string {
 	return h.context.Status()
 }
 
-func (h *flowHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) {
+func (h *flowHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+	labelValues, err := h.context.GetLabelValues(flow)
+	if err != nil {
+		return err
+	}
 	var typeName, subType string
 	eventType := flow.GetEventType().GetType()
 	switch eventType {
@@ -75,7 +79,8 @@ func (h *flowHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) {
 	}
 
 	labels := []string{v1.FlowProtocol(flow), typeName, subType, flow.GetVerdict().String()}
-	labels = append(labels, h.context.GetLabelValues(flow)...)
+	labels = append(labels, labelValues...)
 
 	h.flows.WithLabelValues(labels...).Inc()
+	return nil
 }

--- a/pkg/hubble/metrics/http/handler_test.go
+++ b/pkg/hubble/metrics/http/handler_test.go
@@ -42,6 +42,7 @@ func Test_httpHandler_ProcessFlow(t *testing.T) {
 	}})
 	// should count for request
 	handler.ProcessFlow(ctx, &pb.Flow{
+		TrafficDirection: pb.TrafficDirection_INGRESS,
 		L7: &pb.Layer7{
 			Type: pb.L7FlowType_REQUEST,
 			Record: &pb.Layer7_Http{Http: &pb.HTTP{
@@ -51,6 +52,7 @@ func Test_httpHandler_ProcessFlow(t *testing.T) {
 	})
 	// should count for response
 	handler.ProcessFlow(ctx, &pb.Flow{
+		TrafficDirection: pb.TrafficDirection_INGRESS,
 		L7: &pb.Layer7{
 			Type:      pb.L7FlowType_RESPONSE,
 			LatencyNs: 12345678,
@@ -63,33 +65,33 @@ func Test_httpHandler_ProcessFlow(t *testing.T) {
 	requestsExpected := `
         # HELP hubble_http_requests_total Count of HTTP requests
         # TYPE hubble_http_requests_total counter
-	hubble_http_requests_total{method="GET",protocol=""} 1
+	hubble_http_requests_total{method="GET",protocol="",reporter="server"} 1
 	`
 	require.NoError(t, testutil.CollectAndCompare(handler.(*httpHandler).requests, strings.NewReader(requestsExpected)))
 	responsesExpected := `
        # HELP hubble_http_responses_total Count of HTTP responses
        # TYPE hubble_http_responses_total counter
-       hubble_http_responses_total{method="GET",status="200"} 1
+       hubble_http_responses_total{method="GET",reporter="server",status="200"} 1
 	`
 	require.NoError(t, testutil.CollectAndCompare(handler.(*httpHandler).responses, strings.NewReader(responsesExpected)))
 
 	durationExpected := `
         # HELP hubble_http_request_duration_seconds Quantiles of HTTP request duration in seconds
         # TYPE hubble_http_request_duration_seconds histogram
-        hubble_http_request_duration_seconds_bucket{method="GET",le="0.005"} 0
-        hubble_http_request_duration_seconds_bucket{method="GET",le="0.01"} 0
-        hubble_http_request_duration_seconds_bucket{method="GET",le="0.025"} 1
-        hubble_http_request_duration_seconds_bucket{method="GET",le="0.05"} 1
-        hubble_http_request_duration_seconds_bucket{method="GET",le="0.1"} 1
-        hubble_http_request_duration_seconds_bucket{method="GET",le="0.25"} 1
-        hubble_http_request_duration_seconds_bucket{method="GET",le="0.5"} 1
-        hubble_http_request_duration_seconds_bucket{method="GET",le="1"} 1
-        hubble_http_request_duration_seconds_bucket{method="GET",le="2.5"} 1
-        hubble_http_request_duration_seconds_bucket{method="GET",le="5"} 1
-        hubble_http_request_duration_seconds_bucket{method="GET",le="10"} 1
-        hubble_http_request_duration_seconds_bucket{method="GET",le="+Inf"} 1
-        hubble_http_request_duration_seconds_sum{method="GET"} 0.012345678
-        hubble_http_request_duration_seconds_count{method="GET"} 1
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="0.005"} 0
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="0.01"} 0
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="0.025"} 1
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="0.05"} 1
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="0.1"} 1
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="0.25"} 1
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="0.5"} 1
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="1"} 1
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="2.5"} 1
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="5"} 1
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="10"} 1
+        hubble_http_request_duration_seconds_bucket{method="GET",reporter="server",le="+Inf"} 1
+        hubble_http_request_duration_seconds_sum{method="GET",reporter="server"} 0.012345678
+        hubble_http_request_duration_seconds_count{method="GET",reporter="server"} 1
 	`
 	require.NoError(t, testutil.CollectAndCompare(handler.(*httpHandler).duration, strings.NewReader(durationExpected)))
 }

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -22,9 +22,11 @@ Metrics:
   http_request_duration_seconds - Median, 90th and 99th percentile of request duration.
 
 Options:
- sourceContext          := identifier , { "|", identifier }
- destinationContext     := identifier , { "|", identifier }
- identifier             := identity | namespace | pod | pod-short | dns | ip | reserved-identity
+ sourceContext          ::= identifier , { "|", identifier }
+ destinationContext     ::= identifier , { "|", identifier }
+ labels                 ::= label , { ",", label }
+ identifier             ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity
+ label                  ::= source_pod | source_namespace | source_workload | source_app | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 	assert.Equal(t, expected, plugin.HelpText())
 }

--- a/pkg/hubble/metrics/icmp/handler.go
+++ b/pkg/hubble/metrics/icmp/handler.go
@@ -42,21 +42,28 @@ func (h *icmpHandler) Status() string {
 	return h.context.Status()
 }
 
-func (h *icmpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) {
+func (h *icmpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
 	l4 := flow.GetL4()
 	if l4 == nil {
-		return
+		return nil
+	}
+
+	labelValues, err := h.context.GetLabelValues(flow)
+	if err != nil {
+		return err
 	}
 
 	if icmp := l4.GetICMPv4(); icmp != nil {
 		labels := []string{"IPv4", layers.CreateICMPv4TypeCode(uint8(icmp.Type), uint8(icmp.Code)).String()}
-		labels = append(labels, h.context.GetLabelValues(flow)...)
+		labels = append(labels, labelValues...)
 		h.icmp.WithLabelValues(labels...).Inc()
 	}
 
 	if icmp := l4.GetICMPv6(); icmp != nil {
 		labels := []string{"IPv4", layers.CreateICMPv6TypeCode(uint8(icmp.Type), uint8(icmp.Code)).String()}
-		labels = append(labels, h.context.GetLabelValues(flow)...)
+		labels = append(labels, labelValues...)
 		h.icmp.WithLabelValues(labels...).Inc()
 	}
+
+	return nil
 }

--- a/pkg/hubble/metrics/metrics.go
+++ b/pkg/hubble/metrics/metrics.go
@@ -32,10 +32,11 @@ var (
 )
 
 // ProcessFlow processes a flow and updates metrics
-func ProcessFlow(ctx context.Context, flow *pb.Flow) {
+func ProcessFlow(ctx context.Context, flow *pb.Flow) error {
 	if enabledMetrics != nil {
-		enabledMetrics.ProcessFlow(ctx, flow)
+		return enabledMetrics.ProcessFlow(ctx, flow)
 	}
+	return nil
 }
 
 // initMetrics initialies the metrics system

--- a/pkg/hubble/metrics/policy/handler.go
+++ b/pkg/hubble/metrics/policy/handler.go
@@ -44,20 +44,25 @@ func (d *policyHandler) Status() string {
 	return d.context.Status()
 }
 
-func (d *policyHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) {
+func (d *policyHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
 	if flow.GetEventType().GetType() != monitorAPI.MessageTypePolicyVerdict {
-		return
+		return nil
 	}
 	// ignore verdict if the source is host since host is allowed to connect to any local endpoints.
 	if flow.GetSource().GetIdentity() == uint32(identity.ReservedIdentityHost) {
-		return
+		return nil
+	}
+	labelValues, err := d.context.GetLabelValues(flow)
+	if err != nil {
+		return err
 	}
 
 	direction := strings.ToLower(flow.GetTrafficDirection().String())
 	match := strings.ToLower(monitorAPI.PolicyMatchType(flow.GetPolicyMatchType()).String())
 	action := strings.ToLower(flow.Verdict.String())
 	labels := []string{direction, match, action}
-	labels = append(labels, d.context.GetLabelValues(flow)...)
+	labels = append(labels, labelValues...)
 
 	d.verdicts.WithLabelValues(labels...).Inc()
+	return nil
 }

--- a/pkg/hubble/metrics/tcp/handler.go
+++ b/pkg/hubble/metrics/tcp/handler.go
@@ -41,19 +41,23 @@ func (h *tcpHandler) Status() string {
 	return h.context.Status()
 }
 
-func (h *tcpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) {
+func (h *tcpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
 	if (flow.GetVerdict() != flowpb.Verdict_FORWARDED && flow.GetVerdict() != flowpb.Verdict_REDIRECTED) ||
 		flow.GetL4() == nil {
-		return
+		return nil
 	}
 
 	ip := flow.GetIP()
 	tcp := flow.GetL4().GetTCP()
 	if ip == nil || tcp == nil || tcp.Flags == nil {
-		return
+		return nil
 	}
 
-	labels := append([]string{"", ip.IpVersion.String()}, h.context.GetLabelValues(flow)...)
+	labels, err := h.context.GetLabelValues(flow)
+	if err != nil {
+		return err
+	}
+	labels = append(labels, "", ip.IpVersion.String())
 
 	if tcp.Flags.FIN {
 		labels[0] = "FIN"
@@ -74,4 +78,6 @@ func (h *tcpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) {
 		labels[0] = "RST"
 		h.tcpFlags.WithLabelValues(labels...).Inc()
 	}
+
+	return nil
 }


### PR DESCRIPTION
The new "labelsContext" metrics context differs from the existing
contexts in that instead of putting different values into the
source/destination labels, it accepts a list of predefined labels that
should be exposed, and maps the flow data into these different labels.

This PR, we add source/destination namespace, pod, workload, and app
labels as well as a reporter label which allow distinguishing where the
metric was counted (client vs server). By adding this `reporter` label,
we can avoid potentially double counting metrics when using both egress
and ingress policies with the same port, since the metric will be
produced on both sides of the connection. For more details on the new
labels, see the updated documentation.

For comparison, Istio documents the metrics and labels it exposes:
https://istio.io/latest/docs/reference/config/metrics/.

This makes the hubble metrics much easier to use as it now separates out
the different values into separate labels.

Here is an example query that illistrates using these new metrics,
enabling getting the total number of requests by the destination
workload, filtered to metrics reported the server side (as opposed to
the client).

```
sum(rate(hubble_http_requests_total{reporter="server"}[1m])) by (destination_workload, method)
```

Release note:

```release-note
Support new hubble metrics context: "labelsContext"
```
