### PR TITLE
ip: rename IsExcluded() to ListContainsIP()

### DIFF
--- a/pkg/datapath/linux/node_addressing.go
+++ b/pkg/datapath/linux/node_addressing.go
@@ -32,7 +32,7 @@ func listLocalAddresses(family int) ([]net.IP, error) {
 		if addr.Scope > option.Config.AddressScopeMax {
 			continue
 		}
-		if ip.IsExcluded(ipsToExclude, addr.IP) {
+		if ip.ListContainsIP(ipsToExclude, addr.IP) {
 			continue
 		}
 		if addr.IP.IsLoopback() || addr.IP.IsLinkLocalUnicast() {

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -799,17 +799,6 @@ func init() {
 	initPrivatePrefixes()
 }
 
-// IsExcluded returns whether a given IP is must be excluded
-// due to coming from blacklisted device.
-func IsExcluded(excludeList []net.IP, ip net.IP) bool {
-	for _, e := range excludeList {
-		if e.Equal(ip) {
-			return true
-		}
-	}
-	return false
-}
-
 // IsPublicAddr returns whether a given global IP is from
 // a public range.
 func IsPublicAddr(ip net.IP) bool {
@@ -855,6 +844,16 @@ func IsIPv4(ip net.IP) bool {
 // IsIPv6 returns if netIP is IPv6.
 func IsIPv6(ip net.IP) bool {
 	return ip != nil && ip.To4() == nil
+}
+
+// ListContainsIP returns whether a list of IPs contains a given IP.
+func ListContainsIP(ipList []net.IP, ip net.IP) bool {
+	for _, e := range ipList {
+		if e.Equal(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // SortIPList sorts the provided net.IP slice in place.

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -53,7 +53,7 @@ retryScope:
 
 	for _, a := range addr {
 		if a.Scope <= linkScopeMax {
-			if ip.IsExcluded(ipsToExclude, a.IP) {
+			if ip.ListContainsIP(ipsToExclude, a.IP) {
 				continue
 			}
 			if len(a.IP) >= ipLen {


### PR DESCRIPTION
Apply a trivial cleanup, originating from review of related work. No functional change.