### PR TITLE
pkg/nodediscovery: protect variable against concurrent access

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -297,7 +297,10 @@ func (n *NodeDiscovery) updateLocalNode() {
 			controller.NewManager().UpdateController("propagating local node change to kv-store",
 				controller.ControllerParams{
 					DoFunc: func(ctx context.Context) error {
-						err := n.Registrar.UpdateLocalKeySync(&n.localNode)
+						n.localNodeLock.Lock()
+						localNode := n.localNode.DeepCopy()
+						n.localNodeLock.Unlock()
+						err := n.Registrar.UpdateLocalKeySync(localNode)
 						if err != nil {
 							log.WithError(err).Error("Unable to propagate local node change to kvstore")
 						}


### PR DESCRIPTION
This variable can be accessed concurrently since controllers run on a
separate go routine. Using its mutex and performing a DeepCopy will
help protecting it against concurrent access.

Fixes: e52fe1d59d1c ("nodediscovery: Make LocalNode object private")
Signed-off-by: André Martins <andre@cilium.io>

Related to https://github.com/cilium/cilium/issues/21085