### PR TITLE
pkg/endpoint: set labels for local node from k8s events

### DIFF
--- a/pkg/endpointmanager/host.go
+++ b/pkg/endpointmanager/host.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node"
 )
 
 // GetHostEndpoint returns the host endpoint.
@@ -51,6 +52,8 @@ func (mgr *EndpointManager) OnUpdateNode(oldNode, newNode *v1.Node,
 		log.Error("Host endpoint not found")
 		return nil
 	}
+
+	node.SetLabels(newNodeLabels)
 
 	err := nodeEP.UpdateLabelsFrom(oldNodeLabels, newNodeLabels, labels.LabelSourceK8s)
 	if err != nil {


### PR DESCRIPTION
Not setting these labels in the local node can cause the node to be
out-of-sync in the KVStore.

When IPSec configuration changes, Cilium will propagate these changes
into the KVStore by executing [1] which eventually calls [2]. If the
node labels are not up to date, Cilium will never be able to have this
information in the KVStore as it will always re-use the labels fetched
when Cilium started.

[1] https://github.com/cilium/cilium/blob/dc0f7aa7687bf37078bc3db93161e936efb9cb94/pkg/datapath/linux/ipsec/ipsec_linux.go#L698
[2] https://github.com/cilium/cilium/blob/9fd55dd7e849ee5edaf72d75d339213e10b97940/pkg/nodediscovery/nodediscovery.go#L247

Fixes: 8d0211c37537 ("pkg/identity: Watch and update labels for the host")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix node label synchronization in the KVStore when IPSec configuration changes
```
