### PR TITLE
k8s: optimize API calls made to kube-apiserver

### DIFF
--- a/cilium/cmd/preflight_identity_crd_migrate.go
+++ b/cilium/cmd/preflight_identity_crd_migrate.go
@@ -196,13 +196,21 @@ func migrateIdentities(clientset k8sClient.Clientset, shutdowner fx.Shutdowner) 
 	return nil
 }
 
+type NodeGetter struct {
+	*k8s.K8sClient
+	*k8s.K8sCiliumClient
+}
+
 // initK8s connects to k8s with a allocator.Backend and an initialized
 // allocator.Allocator, using the k8s config passed into the command.
 func initK8s(ctx context.Context, clientset k8sClient.Clientset) (crdBackend allocator.Backend, crdAllocator *allocator.Allocator) {
 	log.Info("Setting up kubernetes client")
 
 	k8s.SetClients(clientset, clientset.Slim(), clientset, clientset)
-	if err := k8s.WaitForNodeInformation(ctx, k8s.Client()); err != nil {
+	if err := k8s.WaitForNodeInformation(ctx, &NodeGetter{
+		K8sClient:       k8s.Client(),
+		K8sCiliumClient: k8s.CiliumClient(),
+	}); err != nil {
 		log.WithError(err).Fatal("Unable to connect to get node spec from apiserver")
 	}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -659,7 +659,7 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup,
 		option.Config,
 		d.ipcache,
 	)
-	nd.RegisterK8sNodeGetter(d.k8sWatcher)
+	nd.RegisterK8sGetters(d.k8sWatcher)
 	d.ipcache.RegisterK8sSyncedChecker(&d)
 
 	d.k8sWatcher.RegisterNodeSubscriber(d.endpointManager)

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/controller"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	slimclientset "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -150,4 +151,13 @@ func (k8sCli K8sClient) GetK8sNode(ctx context.Context, nodeName string) (*core_
 	}
 
 	return k8sCli.CoreV1().Nodes().Get(ctx, nodeName, v1.GetOptions{})
+}
+
+// GetCiliumNode returns the CiliumNode with the given nodeName.
+func (k8sCiliumCli K8sCiliumClient) GetCiliumNode(ctx context.Context, nodeName string) (*cilium_v2.CiliumNode, error) {
+	if k8sCiliumCli.Interface == nil {
+		return nil, fmt.Errorf("GetK8sNode: No k8s, cannot access k8s nodes")
+	}
+
+	return k8sCiliumCli.CiliumV2().CiliumNodes().Get(ctx, nodeName, v1.GetOptions{})
 }

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -4,8 +4,12 @@
 package watchers
 
 import (
+	"context"
 	"sync"
 
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/comparator"
@@ -140,4 +144,42 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 
 		log.Info("Disconnected from key-value store, restarting CiliumNode watcher")
 	}
+}
+
+// GetCiliumNode returns the CiliumNode "nodeName" from the local store. If the
+// local store is not initialized then it will fallback retrieving the node
+// from kube-apiserver.
+func (k *K8sWatcher) GetCiliumNode(ctx context.Context, nodeName string) (*cilium_v2.CiliumNode, error) {
+	var (
+		err                      error
+		nodeInterface            interface{}
+		exists, getFromAPIServer bool
+	)
+	k.ciliumNodeStoreMU.RLock()
+	// k.ciliumNodeStore might not be set in all invocations of GetCiliumNode,
+	// for example, during Cilium initialization GetCiliumNode is called from
+	// WaitForNodeInformation, which happens before ciliumNodeStore,
+	// so we will fallback to perform an API request to kube-apiserver.
+	if k.ciliumNodeStore == nil {
+		getFromAPIServer = true
+	} else {
+		nodeInterface, exists, err = k.ciliumNodeStore.GetByKey(nodeName)
+	}
+	k.ciliumNodeStoreMU.RUnlock()
+
+	if getFromAPIServer {
+		// fallback to using the kube-apiserver
+		return k8s.CiliumClient().CiliumV2().CiliumNodes().Get(ctx, nodeName, v1.GetOptions{})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, k8sErrors.NewNotFound(schema.GroupResource{
+			Group:    "cilium",
+			Resource: "CiliumNode",
+		}, nodeName)
+	}
+	return nodeInterface.(*cilium_v2.CiliumNode).DeepCopy(), nil
 }


### PR DESCRIPTION
With stores locally available we don't need to fetch the latest state
from kube-apiserver. Changed all calls to use the stores instead.

Signed-off-by: André Martins <andre@cilium.io>