### PR TITLE
pkg/k8s/watcher: fix deadlock with service event handler & CES watcher.

### DIFF
--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -6,6 +6,7 @@
 package k8s
 
 import (
+	"net"
 	"sort"
 
 	. "gopkg.in/check.v1"
@@ -226,9 +227,9 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	}
 
 	translator := NewK8sTranslator(ipcache.NewIPCache(nil), serviceInfo, endpointInfo, false, map[string]string{}, false)
-	err := translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
+	prefixesToAllocate, err := translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
-
+	c.Assert(len(prefixesToAllocate), Equals, 0, Commentf("if allocatePrefixes is false, then it should return nothing"))
 	cidrs := rule.ToCIDRSet.StringSlice()
 	sort.Strings(cidrs)
 	c.Assert(len(cidrs), Equals, 2)
@@ -238,8 +239,15 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	})
 
 	// second run, to make sure there are no duplicates added
-	err = translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
+	prefixesToAllocate, err = translator.generateToCidrFromEndpoint(rule, endpointInfo, true)
 	c.Assert(err, IsNil)
+	c.Assert(len(prefixesToAllocate), Equals, 2, Commentf("if allocatePrefixes is true, then it should list of prefixes to allocate"))
+	_, epIP1Prefix, err := net.ParseCIDR(epIP1 + "/32")
+	c.Assert(err, IsNil)
+	_, epIP2Prefix, err := net.ParseCIDR(epIP2 + "/32")
+	c.Assert(err, IsNil)
+	c.Assert(prefixesToAllocate[0].String(), Equals, epIP1Prefix.String())
+	c.Assert(prefixesToAllocate[1].String(), Equals, epIP2Prefix.String())
 
 	cidrs = rule.ToCIDRSet.StringSlice()
 	sort.Strings(cidrs)
@@ -249,12 +257,12 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 		epIP2 + "/32",
 	})
 
-	err = translator.deleteToCidrFromEndpoint(rule, endpointInfo, false)
+	_, err = translator.deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 0)
 
 	// third run, to make sure there are no duplicates added
-	err = translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
+	_, err = translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	cidrs = rule.ToCIDRSet.StringSlice()
@@ -266,7 +274,7 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	})
 
 	// and one final delete
-	err = translator.deleteToCidrFromEndpoint(rule, endpointInfo, false)
+	_, err = translator.deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 0)
 }
@@ -367,20 +375,20 @@ func (s *K8sSuite) TestDontDeleteUserRules(c *C) {
 	}
 
 	translator := NewK8sTranslator(ipcache.NewIPCache(nil), serviceInfo, endpointInfo, false, map[string]string{}, false)
-	err := translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
+	_, err := translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 2)
 	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP+"/32")
 
 	// second run, to make sure there are no duplicates added
-	err = translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
+	_, err = translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 2)
 	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP+"/32")
 
-	err = translator.deleteToCidrFromEndpoint(rule, endpointInfo, false)
+	_, err = translator.deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, string(userCIDR))

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -591,6 +591,13 @@ func (k *K8sWatcher) k8sServiceHandler() {
 				break
 			} else if result.NumToServicesRules > 0 {
 				// Only trigger policy updates if ToServices rules are in effect
+				k.ipcache.ReleaseCIDRIdentitiesByCIDR(result.PrefixesToRelease)
+				_, err := k.ipcache.AllocateCIDRs(result.PrefixesToAdd, nil, nil)
+				if err != nil {
+					scopedLog.WithError(err).
+						Error("Unabled to allocate ipcache CIDR for toService rule")
+					break
+				}
 				k.policyManager.TriggerPolicyUpdates(true, "Kubernetes service endpoint added")
 			}
 
@@ -610,6 +617,7 @@ func (k *K8sWatcher) k8sServiceHandler() {
 				break
 			} else if result.NumToServicesRules > 0 {
 				// Only trigger policy updates if ToServices rules are in effect
+				k.ipcache.ReleaseCIDRIdentitiesByCIDR(result.PrefixesToRelease)
 				k.policyManager.TriggerPolicyUpdates(true, "Kubernetes service endpoint deleted")
 			}
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"sync"
 	"sync/atomic"
 
@@ -612,6 +613,14 @@ type TranslationResult struct {
 	// NumToServicesRules is the number of ToServices rules processed while
 	// translating the rules
 	NumToServicesRules int
+
+	// BackendPrefixes contains all egress CIDRs that are to be added
+	// for the translation.
+	PrefixesToAdd []*net.IPNet
+
+	// BackendPrefixes contains all egress CIDRs that are to be removed
+	// for the translation.
+	PrefixesToRelease []*net.IPNet
 }
 
 // TranslateRules traverses rules and applies provided translator to rules


### PR DESCRIPTION
There is a deadlock that can occur when a k8s service update and a
endpoint update occur at the same time. This can occur in the following situation:

1. CiliumEndpointSlice k8s watcher performs an update due to new watcher event.
   This triggers an endpoint regeneration which transitively holds a lock on the
   endpoint repository.
   At the same time, this goes to hold a lock on the ipcache.

2. The k8sServiceHandler control loop performs an update due to kube-apiserver
   service record change (i.e. this is common on EKS where the control plane IPs
   change often).
   This involves three steps:
   This is done in the policyRepository.TranslateRules(...) function, which would:
     i. Go to ipcache to find a list of CIDRs to be added (thus holding a lock on ipcache)
          and perform allocation of CIDRs on this list.
     ii. Translate the network policies in the policyRepo.
     iii. Repeat similar process in i/ii for CIDRs to be removed.
     iv. Trigger endpoint regeneration.

At this point, codepath #2 is holding a lock on ipcache and policyRepo (nested).
At the same time codepath #1 is holding locks on ipcache and policyRepo.
Codepath #2 cannot proceed to unlock the policyRepo lock until the lock on ipcache is released.
IPCache lock cannot be released endpoint update is complete.

This solve this situation by moving the IPCache allocation out of the TranslateRules
policy function. Now the CIDRs are computed in TranslateRules, but are passed back to the
service event handler to be added or released from IPCache.

Endpoint regeneration is then run async which eventually writes state to BPF maps.

```release-note
pkg/k8s/watcher: fix deadlock crash that occurs when handling endpoint and service updates.
```

CC @joestringer 