### PR TITLE
Add Cilium debugger images and default debugging configuration for kind, vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,9 @@ bpf-coverage.cover
 
 .DS_Store
 .idea/
-.vscode/
+.vscode/*
+!.vscode/launch.json
+!.vscode/extensions.json
 *.plist
 
 *_bash_completion

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"golang.go",
+		"ms-vscode.cpptools",
+		"timonwong.shellcheck",
+		"idanp.checkpatch",
+		"redhat.vscode-yaml"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,47 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+		{
+			"name": "Attach to kind-control-plane-1",
+			"type": "go",
+			"request": "attach",
+			"mode": "remote",
+			"remotePath": "",
+			"port":23401,
+			"host":"127.0.0.1",
+			"showLog": true,
+			"trace": "log",
+			"logOutput": "rpc",
+			"substitutePath": [{"from": "${workspaceFolder}", "to": "/go/src/github.com/cilium/cilium"}],
+		},
+		{
+			"name": "Attach to kind-worker-1",
+			"type": "go",
+			"request": "attach",
+			"mode": "remote",
+			"remotePath": "",
+			"port":23411,
+			"host":"127.0.0.1",
+			"showLog": true,
+			"trace": "log",
+			"logOutput": "rpc",
+			"substitutePath": [{"from": "${workspaceFolder}", "to": "/go/src/github.com/cilium/cilium"}],
+		},
+		{
+			"name": "Attach to kind-worker-2",
+			"type": "go",
+			"request": "attach",
+			"mode": "remote",
+			"remotePath": "",
+			"port":23412,
+			"host":"127.0.0.1",
+			"showLog": true,
+			"trace": "log",
+			"logOutput": "rpc",
+			"substitutePath": [{"from": "${workspaceFolder}", "to": "/go/src/github.com/cilium/cilium"}],
+		},
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -519,7 +519,7 @@ kind-image: export LOCAL_OPERATOR_IMAGE=$(DOCKER_REGISTRY)/$(DOCKER_DEV_ACCOUNT)
 kind-image: ## Build cilium-dev docker image and import it into kind.
 	@$(ECHO_CHECK) kind is ready...
 	@kind get clusters >/dev/null
-	$(QUIET)$(MAKE) dev-docker-image DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
+	$(QUIET)$(MAKE) dev-docker-image$(DEBUGGER_SUFFIX) DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
 	@echo "  DEPLOY image to kind ($(LOCAL_AGENT_IMAGE))"
 	$(QUIET)$(CONTAINER_ENGINE) push $(LOCAL_AGENT_IMAGE)
 	$(QUIET)kind load docker-image $(LOCAL_AGENT_IMAGE)
@@ -527,6 +527,11 @@ kind-image: ## Build cilium-dev docker image and import it into kind.
 	@echo "  DEPLOY image to kind ($(LOCAL_OPERATOR_IMAGE))"
 	$(QUIET)$(CONTAINER_ENGINE) push $(LOCAL_OPERATOR_IMAGE)
 	$(QUIET)kind load docker-image $(LOCAL_OPERATOR_IMAGE)
+
+kind-image-debug: export DEBUGGER_SUFFIX=-debug
+kind-image-debug: export NOSTRIP=1
+kind-image-debug: ## Build cilium-dev docker image with a dlv debugger wrapper and import it into kind.
+	$(MAKE) kind-image
 
 precheck: check-go-version logging-subsys-field ## Peform build precheck for the source code.
 ifeq ($(SKIP_K8S_CODE_GEN_CHECK),"false")

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -81,6 +81,9 @@ define DOCKER_IMAGE_TEMPLATE
 $(1): GIT_VERSION $(2) $(2).dockerignore GIT_VERSION builder-info
 	$(ECHO_DOCKER)$(2) $(IMAGE_REPOSITORY)/$(IMAGE_NAME)$${UNSTRIPPED}:$(4)
 	$(eval IMAGE_NAME := $(subst %,$$$$*,$(3)))
+ifeq ($(5),debug)
+	@export NOSTRIP=1
+endif
 	$(QUIET) $(CONTAINER_ENGINE) buildx build -f $(subst %,$$*,$(2)) \
 		$(DOCKER_BUILD_FLAGS) $(DOCKER_FLAGS) \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
@@ -112,6 +115,9 @@ $(eval $(call DOCKER_IMAGE_TEMPLATE,docker-cilium-image,images/cilium/Dockerfile
 
 # dev-docker-image
 $(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-image,images/cilium/Dockerfile,cilium-dev,$(DOCKER_IMAGE_TAG),release))
+
+# dev-docker-image-debug
+$(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-image-debug,images/cilium/Dockerfile,cilium-dev,$(DOCKER_IMAGE_TAG),debug))
 
 # docker-plugin-image
 $(eval $(call DOCKER_IMAGE_TEMPLATE,docker-plugin-image,images/cilium-docker-plugin/Dockerfile,docker-plugin,$(DOCKER_IMAGE_TAG),release))

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -74,6 +74,7 @@ endif
 # $(2) Dockerfile path
 # $(3) image name stem (e.g., cilium, cilium-operator, etc)
 # $(4) image tag
+# $(5) target
 #
 define DOCKER_IMAGE_TEMPLATE
 .PHONY: $(1)
@@ -91,6 +92,7 @@ $(1): GIT_VERSION $(2) $(2).dockerignore GIT_VERSION builder-info
 		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		--build-arg OPERATOR_VARIANT=$(IMAGE_NAME) \
+		--target $(5) \
 		-t $(IMAGE_REPOSITORY)/$(IMAGE_NAME)$${UNSTRIPPED}:$(4) .
 ifeq ($(findstring --push,$(DOCKER_FLAGS)),)
 	@echo 'Define "DOCKER_FLAGS=--push" to push the build results.'
@@ -106,25 +108,25 @@ $(1)-unstripped: $(1)
 endef
 
 # docker-cilium-image
-$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-cilium-image,images/cilium/Dockerfile,cilium,$(DOCKER_IMAGE_TAG)))
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-cilium-image,images/cilium/Dockerfile,cilium,$(DOCKER_IMAGE_TAG),release))
 
 # dev-docker-image
-$(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-image,images/cilium/Dockerfile,cilium-dev,$(DOCKER_IMAGE_TAG)))
+$(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-image,images/cilium/Dockerfile,cilium-dev,$(DOCKER_IMAGE_TAG),release))
 
 # docker-plugin-image
-$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-plugin-image,images/cilium-docker-plugin/Dockerfile,docker-plugin,$(DOCKER_IMAGE_TAG)))
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-plugin-image,images/cilium-docker-plugin/Dockerfile,docker-plugin,$(DOCKER_IMAGE_TAG),release))
 
 # docker-hubble-relay-image
-$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-hubble-relay-image,images/hubble-relay/Dockerfile,hubble-relay,$(DOCKER_IMAGE_TAG)))
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-hubble-relay-image,images/hubble-relay/Dockerfile,hubble-relay,$(DOCKER_IMAGE_TAG),release))
 
 # docker-clustermesh-apiserver-image
-$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-clustermesh-apiserver-image,images/clustermesh-apiserver/Dockerfile,clustermesh-apiserver,$(DOCKER_IMAGE_TAG)))
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-clustermesh-apiserver-image,images/clustermesh-apiserver/Dockerfile,clustermesh-apiserver,$(DOCKER_IMAGE_TAG),release))
 
 # docker-operator-images.
 # We eat the ending of "operator" in to the stem ('%') to allow this pattern
 # to build also 'docker-operator-image', where the stem would be empty otherwise.
-$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-opera%-image,images/operator/Dockerfile,opera%,$(DOCKER_IMAGE_TAG)))
-$(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-opera%-image,images/operator/Dockerfile,opera%,$(DOCKER_IMAGE_TAG)))
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-opera%-image,images/operator/Dockerfile,opera%,$(DOCKER_IMAGE_TAG),release))
+$(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-opera%-image,images/operator/Dockerfile,opera%,$(DOCKER_IMAGE_TAG),release))
 
 #
 # docker-*-all targets are mainly used from the CI

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -63,21 +63,33 @@ if [[ -n "${image}" ]]; then
   kind_cmd+=" --image ${image}"
 fi
 
-control_planes() {
-  for _ in $(seq 1 "${controlplanes}"); do
-    echo "- role: control-plane"
+node_config() {
+    local port="234$1$2"
+    local max="$3"
+
     echo "  extraMounts:"
     echo "  - hostPath: $CILIUM_ROOT"
     echo "    containerPath: /home/vagrant/go/src/github.com/cilium/cilium"
+    if [[ "${max}" -lt 10 ]]; then
+        echo "  extraPortMappings:"
+        echo "  - containerPort: 2345"
+        echo "    hostPort: $port"
+        echo "    listenAddress: \"127.0.0.1\""
+        echo "    protocol: TCP"
+    fi
+}
+
+control_planes() {
+  for i in $(seq 1 "${controlplanes}"); do
+    echo "- role: control-plane"
+    node_config "0" "$i" "${controlplanes}"
   done
 }
 
 workers() {
-  for _ in $(seq 1 "${workers}"); do
+  for i in $(seq 1 "${workers}"); do
     echo "- role: worker"
-    echo "  extraMounts:"
-    echo "  - hostPath: $CILIUM_ROOT"
-    echo "    containerPath: /home/vagrant/go/src/github.com/cilium/cilium"
+    node_config "1" "$i" "${workers}"
   done
 }
 

--- a/images/cilium-docker-plugin/Dockerfile
+++ b/images/cilium-docker-plugin/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
     make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} \
     && mkdir -p /out/${TARGETOS}/${TARGETARCH}/usr/bin && mv cilium-docker /out/${TARGETOS}/${TARGETARCH}/usr/bin
 
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} as release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -74,7 +74,7 @@ COPY images/cilium/init-container.sh \
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM ${CILIUM_RUNTIME_IMAGE}
+FROM ${CILIUM_RUNTIME_IMAGE} as release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -93,3 +93,23 @@ WORKDIR /home/cilium
 
 ENV INITSYSTEM="SYSTEMD"
 CMD ["/usr/bin/cilium"]
+
+#
+# Cilium debug image.
+#
+# Typical image bulids will stop above at the 'release' target, but
+# developers follow this Dockerfile to the end. Starting from a release
+# image, install delve debugger and wrap the cilium-agent binary calls
+# with a script that automatically provisions the debugger on a
+# dedicated port.
+FROM golang:1.19 as dlv
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+FROM release as debug
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+COPY --from=dlv /go/bin/dlv /usr/bin/dlv
+RUN mv /usr/bin/cilium-agent /usr/bin/cilium-agent-bin
+COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent

--- a/images/clustermesh-apiserver/Dockerfile
+++ b/images/clustermesh-apiserver/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y binutils-aarch64-linux-gnu binutils-x86
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     ./build-gops.sh
 
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} as release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y binutils-aarch64-linux-gnu binutils-x86
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     ./build-gops.sh
 
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} as release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -57,7 +57,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
     --mount=type=cache,target=/go/pkg \
     ./build-gops.sh
 
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} as release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/images/scripts/debug-wrapper.sh
+++ b/images/scripts/debug-wrapper.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+/usr/bin/dlv \
+    --listen=:2345 \
+    --headless=true \
+    --log=true \
+    --log-output=debugger,debuglineerr,gdbwire,lldbout,rpc \
+    --accept-multiclient \
+    --api-version=2 \
+    exec $0-bin -- "$@"


### PR DESCRIPTION
This target wraps the Cilium image with a dlv debugger wrapper,
allowing live debug of the container image after you deploy it.

Usage:
* Start a kind cluster with `make kind`
* Install Cilium
* `make kind-image-debug` & update the Cilium pods' image
* restart target Cilium pods
* attach the debugger to the target node on port 2345 and proceed
  * If you are using vscode then the .vscode/launch.json will automatically provide attach targets in your vscode debugger UI. Just pick your node target:
    ![image](https://user-images.githubusercontent.com/1243336/186947762-427b97fe-ea7c-4cd1-898f-fecd88cd5799.png)


Note that the Cilium pods will pause immediately on startup until you
have connected the debugger.

This PR exposes the debugger port on each kind node as well, which is enabled by loading an image using `make kind-image-debug`.

Port allocations:
- 23401: First control plane node
- 2340*: Subsequent kind-control-plane nodes (if defined)
- 23411: First kind-worker node
- 2341*: Subsequent kind-worker nodes (if defined)