### PR TITLE
iptables: add support for iptables >= 1.8.7

### DIFF
--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -105,6 +105,18 @@ func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 			return false, nil
 		}
 
+		// with iptables-nft >= 1.8.7, when we try to list the rules of a non existing
+		// chain, the command will return an error in the format:
+		//
+		//     chain `$chain' in table `$chain' is incompatible, use 'nft' tool.
+		//
+		// rather than the usual one:
+		//
+		//     No chain/target/match by that name.
+		if strings.Contains(err.Error(), fmt.Sprintf("chain `%s' in table `%s' is incompatible, use 'nft' tool.", c.name, c.table)) {
+			return false, nil
+		}
+
 		return false, fmt.Errorf("unable to list %s chain: %s (%w)", c.name, string(output), err)
 	}
 


### PR DESCRIPTION
Starting from iptables-nft 1.8.7, whenever we try to list the rules of a
non existing chain, that command will return:

    chain `$chain' in table `$table' is incompatible, use 'nft' tool.

rather than the usual error:

    No chain/target/match by that name.

This commit adds support for iptables >= 1.8.7 by handling this special
case in the logic responsible for checking if a chain exists.