### PR TITLE
controlplane: use right node name in tests

### DIFF
--- a/test/controlplane/node/ciliumnodes/ciliumnodes.go
+++ b/test/controlplane/node/ciliumnodes/ciliumnodes.go
@@ -94,7 +94,7 @@ func init() {
 			abs := func(f string) string { return path.Join(cwd, "node", "ciliumnodes", "v"+version, f) }
 
 			t.Run("v"+version, func(t *testing.T) {
-				test := suite.NewControlPlaneTest(t, "cilium-nodes-control-plane", version)
+				test := suite.NewControlPlaneTest(t, "cilium-nodes-worker", version)
 
 				// Feed in initial state and start the agent.
 				test.


### PR DESCRIPTION
The node that is being tested is "cilium-nodes-worker" so we should
define that name when creating a new control plane test.

Fixes: 896aba311809 ("test/controlplane: Switch to imperative API and rewrite tests")
Signed-off-by: André Martins <andre@cilium.io>