### PR TITLE
mlh: update Jenkins jobs following 1.25 support

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -60,9 +60,10 @@ flake-tracker:
     - cilium-master-k8s-1.20-kernel-4.9
     - cilium-master-k8s-1.21-kernel-4.9
     - cilium-master-k8s-1.22-kernel-4.9
-    - cilium-master-k8s-1.22-kernel-5.4
-    - cilium-master-k8s-1.23-kernel-4.19
-    - cilium-master-k8s-1.24-kernel-net-next
+    - cilium-master-k8s-1.23-kernel-4.9
+    - cilium-master-k8s-1.23-kernel-5.4
+    - cilium-master-k8s-1.24-kernel-4.19
+    - cilium-master-k8s-1.25-kernel-net-next
     - cilium-master-k8s-upstream
     pr-jobs:
       Cilium-PR-K8s-1.16-kernel-4.9:
@@ -74,6 +75,7 @@ flake-tracker:
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
         - cilium-master-k8s-1.22-kernel-4.9
+        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.17-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -83,6 +85,7 @@ flake-tracker:
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
         - cilium-master-k8s-1.22-kernel-4.9
+        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.18-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -92,6 +95,7 @@ flake-tracker:
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
         - cilium-master-k8s-1.22-kernel-4.9
+        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.19-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -101,6 +105,7 @@ flake-tracker:
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
         - cilium-master-k8s-1.22-kernel-4.9
+        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.20-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -110,6 +115,7 @@ flake-tracker:
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
         - cilium-master-k8s-1.22-kernel-4.9
+        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.21-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -119,6 +125,7 @@ flake-tracker:
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
         - cilium-master-k8s-1.22-kernel-4.9
+        - cilium-master-k8s-1.23-kernel-4.9
       Cilium-PR-K8s-1.22-kernel-4.9:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.16-kernel-4.9
@@ -128,15 +135,26 @@ flake-tracker:
         - cilium-master-k8s-1.20-kernel-4.9
         - cilium-master-k8s-1.21-kernel-4.9
         - cilium-master-k8s-1.22-kernel-4.9
-      Cilium-PR-K8s-1.22-kernel-5.4:
+        - cilium-master-k8s-1.23-kernel-4.9
+      Cilium-PR-K8s-1.23-kernel-4.9:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.22-kernel-5.4
-      Cilium-PR-K8s-1.23-kernel-4.19:
+        - cilium-master-k8s-1.16-kernel-4.9
+        - cilium-master-k8s-1.17-kernel-4.9
+        - cilium-master-k8s-1.18-kernel-4.9
+        - cilium-master-k8s-1.19-kernel-4.9
+        - cilium-master-k8s-1.20-kernel-4.9
+        - cilium-master-k8s-1.21-kernel-4.9
+        - cilium-master-k8s-1.22-kernel-4.9
+        - cilium-master-k8s-1.23-kernel-4.9
+      Cilium-PR-K8s-1.23-kernel-5.4:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.23-kernel-4.19
-      Cilium-PR-K8s-1.24-kernel-net-next:
+        - cilium-master-k8s-1.23-kernel-5.4
+      Cilium-PR-K8s-1.24-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.24-kernel-net-next
+        - cilium-master-k8s-1.24-kernel-4.19
+      Cilium-PR-K8s-1.25-kernel-net-next:
+        correlate-with-stable-jobs:
+        - cilium-master-k8s-1.25-kernel-net-next
       Cilium-PR-K8s-GKE:
         correlate-with-stable-jobs:
         - cilium-master-gke


### PR DESCRIPTION
K8s 1.25 support was added in ce69afdc3ad196cf5b9f9093406f760433233329.

We have rotated / expanded the Jenkins test jobs as follow:

- Changed: Kernel 5.4 on K8s 1.23 (instead of 1.22, triggered on `/test`).
- Changed: Kernel 4.19 on K8s 1.24 (instead of 1.23, triggered on `/test`).
- Changed: Kernel net-next on K8s 1.25 (instead of 1.24, triggered on `/test`).
- Added: Kernel 4.9 on K8s 1.23 (triggered on `/test-missed-k8s`).

See the Table of Truth™️ for up to date status on all trigger phrases: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0/edit#gid=0