### PR TITLE
Add Cilium debugger images and default debugging configuration for kind, vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,9 @@ bpf-coverage.cover
 
 .DS_Store
 .idea/
-.vscode/
+.vscode/*
+!.vscode/launch.json
+!.vscode/extensions.json
 *.plist
 
 *_bash_completion

--- a/.nvim/README.md
+++ b/.nvim/README.md
@@ -1,0 +1,46 @@
+# Configuring Neovim for Cilium Debugging
+
+Cilium provides an instrumented Kind deployment which binds DAP debugging ports
+to the localhost.
+
+The `vscode` editor will discover a file named `.vscode/launch.json` in a project's
+root directory and configure `vscode`'s debugger panel with the necessary information
+to connect to these ports for debugging without any configuration needed by the
+user.
+
+We've devised a way for this to seamlessly work with Neovim as well.
+
+The following plugins are required:
+
+[nvim-dap](https://github.com/mfussenegger/nvim-dap) - the DAP client
+
+[nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui) - the UI elements for interfacing
+with nvim-dap
+
+[nvim-dap-projects](https://github.com/ldelossa/nvim-dap-projects) - a configuration
+discovery mechanism for nvim-dap configuration.
+
+You can use your favorite plugin manager but here is an example configuration
+using Plug
+
+```
+call plug#begin('~/.config/nvim/plugins')
+    Plug 'mfussenegger/nvim-dap'
+    Plug 'rcarriga/nvim-dap-ui'
+    Plug 'ldelossa/nvim-dap-projects'
+call plug#end()
+lua require('nvim-dap-projects').search_project_config()
+```
+
+Once all three plugins are installed you should make a call to
+`lua require('nvim-dap-projects').search_project_config()`.
+
+This function will find the `nvim-dap.lua` file in the Cilium repository and
+load it.
+
+You can now use nvim-dap as normal.
+
+This README will not be a nvim-dap tutorial but for a quick test you can create
+a breakpoint in your Cilium source code with the command `DapToggleBreakpoint`
+and then issue the command `DapContinue`. A UI should pop up asking you to select
+one of several Kind nodes to connect to for debugging.

--- a/.nvim/nvim-dap.lua
+++ b/.nvim/nvim-dap.lua
@@ -1,0 +1,60 @@
+local dap = require('dap')
+
+dap.adapters.cilium_kind_control_plane_1 = {
+    type = "server",
+    host = "127.0.0.1",
+    port = 23401,
+}
+dap.adapters.cilium_kind_worker_1 = {
+    type = "server",
+    host = "127.0.0.1",
+    port = 23411
+}
+dap.adapters.cilium_kind_worker_2 = {
+    type = "server",
+    host = "127.0.0.1",
+    port = 23412
+}
+dap.adapters.cilium_kind_worker_1 = {
+    type = "server",
+    host = "127.0.0.1",
+    port = 23411
+}
+dap.configurations.go = {
+    {
+        type = "cilium_kind_control_plane_1",
+        request = "attach",
+        name = "Attach to kind-control-plane-1",
+        mode = "remote",
+        substitutePath = {
+            {
+                from = "${workspaceFolder}",
+                to = "/go/src/github.com/cilium/cilium"
+            }
+        }
+    },
+    {
+        type = "cilium_kind_worker_1",
+        request = "attach",
+        name = "Attach to kind-worker-1",
+        mode = "remote",
+        substitutePath = {
+            {
+                from = "${workspaceFolder}",
+                to = "/go/src/github.com/cilium/cilium"
+            }
+        }
+    },
+    {
+        type = "cilium_kind_worker_2",
+        request = "attach",
+        name = "Attach to kind-worker-2",
+        mode = "remote",
+        substitutePath = {
+            {
+                from = "${workspaceFolder}",
+                to = "/go/src/github.com/cilium/cilium"
+            }
+        }
+    }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"golang.go",
+		"ms-vscode.cpptools",
+		"timonwong.shellcheck",
+		"idanp.checkpatch",
+		"redhat.vscode-yaml"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,51 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+		{
+			"name": "Launch test for current package",
+			"type": "go",
+			"request": "launch",
+			"mode": "test",
+			"program": "${relativeFileDirname}",
+		},
+		{
+			"name": "Attach to kind-control-plane-1",
+			"type": "go",
+			"request": "attach",
+			"mode": "remote",
+			"port":23401,
+			"host":"127.0.0.1",
+			"showLog": true,
+			"trace": "log",
+			"logOutput": "rpc",
+			"substitutePath": [{"from": "${workspaceFolder}", "to": "/go/src/github.com/cilium/cilium"}],
+		},
+		{
+			"name": "Attach to kind-worker-1",
+			"type": "go",
+			"request": "attach",
+			"mode": "remote",
+			"port":23411,
+			"host":"127.0.0.1",
+			"showLog": true,
+			"trace": "log",
+			"logOutput": "rpc",
+			"substitutePath": [{"from": "${workspaceFolder}", "to": "/go/src/github.com/cilium/cilium"}],
+		},
+		{
+			"name": "Attach to kind-worker-2",
+			"type": "go",
+			"request": "attach",
+			"mode": "remote",
+			"port":23412,
+			"host":"127.0.0.1",
+			"showLog": true,
+			"trace": "log",
+			"logOutput": "rpc",
+			"substitutePath": [{"from": "${workspaceFolder}", "to": "/go/src/github.com/cilium/cilium"}],
+		},
+    ]
+}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -50,6 +50,7 @@
 /.mailmap @cilium/tophat
 /.travis/ @cilium/ci-structure
 /.travis.yml @cilium/ci-structure
+/.vscode @cilium/contributing
 /api/ @cilium/api
 /api/v1/flow/ @cilium/api @cilium/sig-hubble
 /api/v1/health/ @cilium/api @cilium/health

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,6 +48,7 @@
 /.gitignore @cilium/tophat
 /.golangci.yaml @cilium/ci-structure
 /.mailmap @cilium/tophat
+/.nvim @cilium/contributing
 /.travis/ @cilium/ci-structure
 /.travis.yml @cilium/ci-structure
 /.vscode @cilium/contributing

--- a/Makefile
+++ b/Makefile
@@ -516,7 +516,8 @@ kind-down: ## Destroy a kind cluster for Cilium development.
 .PHONY: kind-ready
 kind-ready:
 	@$(ECHO_CHECK) kind is ready...
-	@kind get clusters >/dev/null
+	@kind get clusters 2>&1 | grep "No kind clusters found." \
+		&& exit 1 || exit 0
 
 .PHONY: kind-image-agent
 kind-image-agent: export DOCKER_REGISTRY=localhost:5000

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -81,6 +81,9 @@ define DOCKER_IMAGE_TEMPLATE
 $(1): GIT_VERSION $(2) $(2).dockerignore GIT_VERSION builder-info
 	$(ECHO_DOCKER)$(2) $(IMAGE_REPOSITORY)/$(IMAGE_NAME)$${UNSTRIPPED}:$(4)
 	$(eval IMAGE_NAME := $(subst %,$$$$*,$(3)))
+ifeq ($(5),debug)
+	@export NOSTRIP=1
+endif
 	$(QUIET) $(CONTAINER_ENGINE) buildx build -f $(subst %,$$*,$(2)) \
 		$(DOCKER_BUILD_FLAGS) $(DOCKER_FLAGS) \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
@@ -112,6 +115,9 @@ $(eval $(call DOCKER_IMAGE_TEMPLATE,docker-cilium-image,images/cilium/Dockerfile
 
 # dev-docker-image
 $(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-image,images/cilium/Dockerfile,cilium-dev,$(DOCKER_IMAGE_TAG),release))
+
+# dev-docker-image-debug
+$(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-image-debug,images/cilium/Dockerfile,cilium-dev,$(DOCKER_IMAGE_TAG),debug))
 
 # docker-plugin-image
 $(eval $(call DOCKER_IMAGE_TEMPLATE,docker-plugin-image,images/cilium-docker-plugin/Dockerfile,docker-plugin,$(DOCKER_IMAGE_TAG),release))

--- a/api/v1/Makefile
+++ b/api/v1/Makefile
@@ -3,7 +3,7 @@
 include ../../Makefile.defs
 
 # Update this via images/scripts/update-cilium-builder-image.sh
-CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:d1290e43e11d57e210b135cfa10f8754bf1717e1@sha256:0ce2c8206ada06b534b3b81e19bfb48cceefb605217e0d3ad2a242fd07cc7a10
+CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:26b92edac2234150255c9ae4673870128e724ee7@sha256:0beba252a18c77564afdf78f2116bb6c4a1b32cd8e32afbd6edcd76165d561f5
 
 .PHONY: proto
 proto:

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -63,21 +63,33 @@ if [[ -n "${image}" ]]; then
   kind_cmd+=" --image ${image}"
 fi
 
-control_planes() {
-  for _ in $(seq 1 "${controlplanes}"); do
-    echo "- role: control-plane"
+node_config() {
+    local port="234$1$2"
+    local max="$3"
+
     echo "  extraMounts:"
     echo "  - hostPath: $CILIUM_ROOT"
     echo "    containerPath: /home/vagrant/go/src/github.com/cilium/cilium"
+    if [[ "${max}" -lt 10 ]]; then
+        echo "  extraPortMappings:"
+        echo "  - containerPort: 2345"
+        echo "    hostPort: $port"
+        echo "    listenAddress: \"127.0.0.1\""
+        echo "    protocol: TCP"
+    fi
+}
+
+control_planes() {
+  for i in $(seq 1 "${controlplanes}"); do
+    echo "- role: control-plane"
+    node_config "0" "$i" "${controlplanes}"
   done
 }
 
 workers() {
-  for _ in $(seq 1 "${workers}"); do
+  for i in $(seq 1 "${workers}"); do
     echo "- role: worker"
-    echo "  extraMounts:"
-    echo "  - hostPath: $CILIUM_ROOT"
-    echo "    containerPath: /home/vagrant/go/src/github.com/cilium/cilium"
+    node_config "1" "$i" "${workers}"
   done
 }
 

--- a/contrib/testing/kind-values.yaml
+++ b/contrib/testing/kind-values.yaml
@@ -1,0 +1,17 @@
+debug:
+  enabled: true
+image:
+  override: "localhost:5000/cilium/cilium-dev:local"
+operator:
+  image:
+    override: "localhost:5000/cilium/operator-generic:local"
+    suffix: ""
+ipam:
+  mode: kubernetes
+monitor-aggregation: none
+livenessProbe:
+  failureThreshold: 9999
+readinessProbe:
+  failureThreshold: 9999
+startupProbe:
+  failureThreshold: 9999

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -56,6 +56,8 @@ ENV GOROOT /usr/local/go
 ENV GOPATH /go
 ENV PATH "${GOROOT}/bin:${GOPATH}/bin:${PATH}"
 
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
 WORKDIR /go/src/github.com/cilium/cilium/images/builder
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium/images/builder \
     ./install-protoc.sh

--- a/images/cilium-test/Dockerfile
+++ b/images/cilium-test/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:d1290e43e11d57e210b135cfa10f8754bf1717e1@sha256:0ce2c8206ada06b534b3b81e19bfb48cceefb605217e0d3ad2a242fd07cc7a10
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:26b92edac2234150255c9ae4673870128e724ee7@sha256:0beba252a18c77564afdf78f2116bb6c4a1b32cd8e32afbd6edcd76165d561f5
 ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
 
 FROM ${UBUNTU_IMAGE} as rootfs

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -93,3 +93,20 @@ WORKDIR /home/cilium
 
 ENV INITSYSTEM="SYSTEMD"
 CMD ["/usr/bin/cilium"]
+
+#
+# Cilium debug image.
+#
+# Typical image bulids will stop above at the 'release' target, but
+# developers follow this Dockerfile to the end. Starting from a release
+# image, install delve debugger and wrap the cilium-agent binary calls
+# with a script that automatically provisions the debugger on a
+# dedicated port.
+FROM release as debug
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+COPY --from=builder /go/bin/dlv /usr/bin/dlv
+RUN mv /usr/bin/cilium-agent /usr/bin/cilium-agent-bin
+COPY images/scripts/debug-wrapper.sh /usr/bin/cilium-agent

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:d1290e43e11d57e210b135cfa10f8754bf1717e1@sha256:0ce2c8206ada06b534b3b81e19bfb48cceefb605217e0d3ad2a242fd07cc7a10
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:26b92edac2234150255c9ae4673870128e724ee7@sha256:0beba252a18c77564afdf78f2116bb6c4a1b32cd8e32afbd6edcd76165d561f5
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:1d9a09fa9d641346b0fac05b7d9bc620cd52e044@sha256:fc2d789ed6631d447f886164da4667592394babf2f8e9da8eb2b2dcfb9b2279b
 
 # cilium-envoy from github.com/cilium/proxy

--- a/images/scripts/debug-wrapper.sh
+++ b/images/scripts/debug-wrapper.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+/usr/bin/dlv \
+    --listen=:2345 \
+    --headless=true \
+    --log=true \
+    --log-output=debugger,debuglineerr,gdbwire,lldbout,rpc \
+    --accept-multiclient \
+    --api-version=2 \
+    exec "${0}-bin" -- "$@"

--- a/test/k8s/manifests/demo-customcalls.yaml
+++ b/test/k8s/manifests/demo-customcalls.yaml
@@ -99,7 +99,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:d1290e43e11d57e210b135cfa10f8754bf1717e1@sha256:0ce2c8206ada06b534b3b81e19bfb48cceefb605217e0d3ad2a242fd07cc7a10
+    image: quay.io/cilium/cilium-builder:26b92edac2234150255c9ae4673870128e724ee7@sha256:0beba252a18c77564afdf78f2116bb6c4a1b32cd8e32afbd6edcd76165d561f5
     workingDir: /cilium
     command: ["sleep"]
     args:


### PR DESCRIPTION
Review commit by commit.

A new `make kind-image-debug` target wraps the Cilium image with a dlv debugger wrapper,
allowing live debug of the container image after you deploy it.

New make targets introduced:
- `kind-debug-agent` - Bootstrap kind, install cilium, build the cilium-agent and run it
- `kind-image-agent-debug` - Build cilium-agent image with a debugger wrapper that pauses on startup. Loads it into kind but does not restart the pods.
- `kind-install-cilium` - Install cilium into the kind cluster, pointing to locally built kind images.

Usage:
* `make kind-debug-agent`
* attach the debugger to the target node on port 2345 and proceed
  * If you are using vscode then the .vscode/launch.json will automatically provide attach targets in your vscode debugger UI. Just pick your node target:
    ![image](https://user-images.githubusercontent.com/1243336/186947762-427b97fe-ea7c-4cd1-898f-fecd88cd5799.png)

Note that the Cilium pods will pause immediately on startup until you
have connected the debugger.

This PR exposes the debugger port for cilium-agent on each kind node as well, which is enabled by loading an image using `make kind-image-debug`.

Port allocations:
- 23401: First control plane node
- 2340*: Subsequent kind-control-plane nodes (if defined)
- 23411: First kind-worker node
- 2341*: Subsequent kind-worker nodes (if defined)

Delve should be listening on this port with multiprotocol support, so any IDEs or debugger frontends that understand either DAP or delve API v2 should be compatible with this approach.