### PR TITLE
mount host /boot into cilium-agent container

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -85,6 +85,10 @@
      - Enable BPF clock source probing for more efficient tick retrieval.
      - bool
      - ``false``
+   * - bpf.hostBoot
+     - Configure the path to the host boot directory
+     - string
+     - ``"/boot"``
    * - bpf.lbExternalClusterIP
      - Allow cluster external access to ClusterIP services.
      - bool
@@ -105,6 +109,10 @@
      - Configure the typical time between monitor notifications for active connections.
      - string
      - ``"5s"``
+   * - bpf.mountHostBoot
+     - Enable host boot directory mount for BPF clock source probing
+     - bool
+     - ``true``
    * - bpf.policyMapMax
      - Configure the maximum number of entries in endpoint policy map (per endpoint).
      - int

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -470,6 +470,7 @@ herokuapp
 hexData
 hoc
 hostAliases
+hostBoot
 hostConfDirMountPath
 hostFirewall
 hostNetwork
@@ -664,6 +665,7 @@ mlx
 monitorAggregation
 monitorFlags
 monitorInterval
+mountHostBoot
 mountPath
 mov
 mul

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -72,11 +72,13 @@ contributors across the globe, there is almost always someone available to help.
 | bgpControlPlane | object | `{"enabled":false}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
 | bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |
 | bpf.clockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
+| bpf.hostBoot | string | `"/boot"` | Configure the path to the host boot directory |
 | bpf.lbExternalClusterIP | bool | `false` | Allow cluster external access to ClusterIP services. |
 | bpf.lbMapMax | int | `65536` | Configure the maximum number of service entries in the load balancer maps. |
 | bpf.monitorAggregation | string | `"medium"` | Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum. |
 | bpf.monitorFlags | string | `"all"` | Configure which TCP flags trigger notifications when seen for the first time in a connection. |
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
+| bpf.mountHostBoot | bool | `true` | Enable host boot directory mount for BPF clock source probing |
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -309,6 +309,13 @@ spec:
         - mountPath: /host/proc/sys/kernel
           name: host-proc-sys-kernel
         {{- end}}
+        {{- if .Values.bpf.mountHostBoot }}
+        # Required to run 'bpftool -j feature probe'
+        # during kernel feature probing
+        - mountPath: /boot
+          name: host-boot
+          readOnly: true
+        {{- end}}
         {{- /* CRI-O already mounts the BPF filesystem */ -}}
         {{- if not (eq .Values.containerRuntime.integration "crio") }}
         - name: bpf-maps
@@ -828,6 +835,12 @@ spec:
       - name: host-proc-sys-kernel
         hostPath:
           path: /proc/sys/kernel
+          type: Directory
+      {{- end }}
+      {{- if .Values.bpf.mountHostBoot }}
+      - name: host-boot
+        hostPath:
+          path: {{ .Values.bpf.hostBoot }}
           type: Directory
       {{- end }}
       {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -265,6 +265,12 @@ bpf:
   # -- Enable BPF clock source probing for more efficient tick retrieval.
   clockProbe: false
 
+  # -- Configure the path to the host boot directory
+  hostBoot: /boot
+
+  # -- Enable host boot directory mount for BPF clock source probing
+  mountHostBoot: true
+
   # -- Enables pre-allocation of eBPF map values. This increases
   # memory usage but can reduce latency.
   preallocateMaps: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -262,6 +262,12 @@ bpf:
   # -- Enable BPF clock source probing for more efficient tick retrieval.
   clockProbe: false
 
+  # -- Configure the path to the host boot directory
+  hostBoot: /boot
+
+  # -- Enable host boot directory mount for BPF clock source probing
+  mountHostBoot: true
+
   # -- Enables pre-allocation of eBPF map values. This increases
   # memory usage but can reduce latency.
   preallocateMaps: false


### PR DESCRIPTION
mount host /boot into cilium-agent container, as it required to run `bpftool -j feature probe` during kernel feature probing

Fixes: #20981

Signed-off-by: Alexey Grevtcev [alexey@grevtcev.ru](mailto:alexey@grevtcev.ru)