### PR TITLE
EgressGW: make logging less verbose

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -120,9 +120,9 @@ func (manager *Manager) OnAddEgressPolicy(config PolicyConfig) {
 	logger := log.WithField(logfields.CiliumEgressNATPolicyName, config.id.Name)
 
 	if _, ok := manager.policyConfigs[config.id]; !ok {
-		logger.Info("Added CiliumEgressNATPolicy")
+		logger.Debug("Added CiliumEgressNATPolicy")
 	} else {
-		logger.Info("Updated CiliumEgressNATPolicy")
+		logger.Debug("Updated CiliumEgressNATPolicy")
 	}
 
 	manager.policyConfigs[config.id] = &config
@@ -143,7 +143,7 @@ func (manager *Manager) OnDeleteEgressPolicy(configID policyID) {
 		return
 	}
 
-	logger.Info("Deleted CiliumEgressNATPolicy")
+	logger.Debug("Deleted CiliumEgressNATPolicy")
 
 	delete(manager.policyConfigs, configID)
 
@@ -172,7 +172,7 @@ func (manager *Manager) OnUpdateEndpoint(endpoint *k8sTypes.CiliumEndpoint) {
 
 	if identityLabels, err = manager.getIdentityLabels(uint32(endpoint.Identity.ID)); err != nil {
 		logger.WithError(err).
-			Error("Failed to get idenity labels for endpoint, skipping update to egress policy.")
+			Error("Failed to get identity labels for endpoint, skipping update to egress policy.")
 		return
 	}
 
@@ -256,14 +256,14 @@ func (manager *Manager) addMissingIpRulesAndRoutes(isRetry bool) (shouldRetry bo
 				shouldRetry = true
 			}
 		} else {
-			logger.Info("Added IP rule")
+			logger.Debug("Added IP rule")
 		}
 
 		if err := addEgressIpRoutes(gwc.egressIP, gwc.ifaceIndex); err != nil {
 			logger.WithError(err).Warn("Can't add IP routes")
 			return
 		}
-		logger.Info("Added IP routes")
+		logger.Debug("Added IP routes")
 	}
 
 	for _, policyConfig := range manager.policyConfigs {
@@ -354,7 +354,7 @@ func (manager *Manager) addMissingEgressRules() {
 		if err := egressmap.EgressPolicyMap.Update(endpointIP, *dstCIDR, gwc.egressIP.IP, gwc.gatewayIP); err != nil {
 			logger.WithError(err).Error("Error applying egress gateway policy")
 		} else {
-			logger.Info("Egress gateway policy applied")
+			logger.Debug("Egress gateway policy applied")
 		}
 	}
 
@@ -394,7 +394,7 @@ nextPolicyKey:
 		if err := egressmap.EgressPolicyMap.Delete(policyKey.GetSourceIP(), *policyKey.GetDestCIDR()); err != nil {
 			logger.WithError(err).Error("Error removing egress gateway policy")
 		} else {
-			logger.Info("Egress gateway policy removed")
+			logger.Debug("Egress gateway policy removed")
 		}
 	}
 }

--- a/pkg/egressgateway/net.go
+++ b/pkg/egressgateway/net.go
@@ -145,7 +145,7 @@ func addEgressIpRoutes(egressIP net.IPNet, ifaceIndex int) error {
 func deleteIpRule(ipRule netlink.Rule) {
 	logger := log.WithFields(logrus.Fields{})
 
-	logger.Info("Removing IP rule")
+	logger.Debug("Removing IP rule")
 	route.DeleteRule(route.Rule{
 		Priority: linux_defaults.RulePriorityEgressGateway,
 		From:     ipRule.Src,
@@ -170,7 +170,7 @@ func deleteIpRouteTable(tableIndex int) {
 func deleteIpRoute(ipRoute netlink.Route) {
 	logger := log.WithFields(logrus.Fields{})
 
-	logger.Info("Removing IP route")
+	logger.Debug("Removing IP route")
 
 	netlink.RouteDel(&ipRoute)
 }


### PR DESCRIPTION
@bmcustodio noticed that the EgressGW feature is producing a lot of logs, even from its good path. Change those paths to only log when in debug mode.