### PR TITLE
v1.12 backports 2022-08-29

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -296,6 +296,14 @@ the PRs they need to review by filtering by reviews requested.
 A good filter is provided in this `link <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+user-review-requested%3A%40me+sort%3Aupdated-asc>`_
 so make sure to bookmark it.
 
+Reviewers are expected to focus their review on the areas of the code where
+GitHub requested their review. For small PRs, it may make sense to simply
+review the entire PR. However, if the PR is quite large then it can help
+to narrow the area of focus to one particular aspect of the code. When leaving
+a review, share which areas you focused on and which areas you think that
+other reviewers should look into. This will help others to focus on aspects
+of review that have not been covered as deeply.
+
 Belonging to a team does not mean that a committer should know every single
 line of code the team is maintaining. For this reason it is recommended
 that once you have reviewed a PR, if you feel that another pair of eyes is

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -337,22 +337,20 @@ every week. The following steps describe how to perform those duties. Please
 submit changes to these steps if you have found a better way to perform each
 duty.
 
-* `People in a Janitor hat this week <https://github.com/orgs/cilium/teams/tophat/members>`_
-* `People in a Triage hat this week <https://github.com/orgs/cilium/teams/tophat/members>`_
-* `People in a Backport hat this week <https://github.com/orgs/cilium/teams/tophat/members>`_
+* `People with the top hat this week <https://github.com/orgs/cilium/teams/tophat/members>`_
 
-Pull request review process for Janitors team
----------------------------------------------
+Pull request review process
+---------------------------
 
 .. note::
 
    These instructions assume that whoever is reviewing is a member of the
-   Cilium GitHub organization or has the status of a contributor. This is
+   Cilium GitHub organization or has the status of a committer. This is
    required to obtain the privileges to modify GitHub labels on the pull
    request.
 
-Dedicated expectation time for each member of Janitors team: Follow the next
-steps 1 to 2 times per day. Works best if done first thing in the working day.
+Dedicated expectation time for review duties: Follow the next steps 1 to 2
+times per day.
 
 #. Review all PRs needing a review `from you <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+team-review-requested%3Acilium%2Ftophat+sort%3Aupdated-asc>`_;
 
@@ -438,17 +436,16 @@ steps 1 to 2 times per day. Works best if done first thing in the working day.
 #. If the PR is a backport PR, update the labels of cherry-picked PRs with the command included at the end of the original post. For example:
 
    .. code-block:: shell-session
-   
+
        $ for pr in 12589 12568; do contrib/backporting/set-labels.py $pr done 1.8; done
 
-Triage issues for Triage team
------------------------------
+Triage issues
+-------------
 
-Dedicated expectation time for each member of Triage team: 15/30 minutes per
+Dedicated expectation time for triage duties: 15/30 minutes per
 day. Works best if done first thing in the working day.
 
-#. Committers belonging to the `Triage team <https://github.com/orgs/cilium/teams/triage>`_
-   should make sure that:
+#. Ensure that:
 
    #. `Issues opened by community users are tracked down <https://github.com/cilium/cilium/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee+sort%3Aupdated-desc>`_:
 
@@ -472,10 +469,10 @@ day. Works best if done first thing in the working day.
        #. If the issue cannot be solved, bring the issue up in the weekly
           meeting.
 
-Backporting PR for Backport team
---------------------------------
+Backporting community PRs
+-------------------------
 
-Dedicated expectation time for each member of Backport team: 60 minutes per
+Dedicated expectation time for backporting duties: 60 minutes, twice per
 week depending on releases that need to be performed at the moment.
 
 Even if the next release is not imminently planned, it is still important to
@@ -483,11 +480,6 @@ perform backports to keep the process smooth and to catch potential regressions
 in stable branches as soon as possible. If backports are delayed, this can also
 delay releases which is important to avoid especially if there are
 security-sensitive bug fixes that require an immediate release.
-
-In addition, when a backport PR is open, the person opening it is responsible to
-drive it to completion, even if it stretches after the assigned week of
-backporting hat. If this is not feasible (e.g. PTO), you are responsible to
-initiate handover of the PR to the next week's backporters.
 
 If you can't backport a PR due technical constraints feel free to contact the
 original author of that PR directly so they can backport the PR themselves.
@@ -497,21 +489,17 @@ Follow the :ref:`backport_process` guide to know how to perform this task.
 Coordination
 ++++++++++++
 
-In general, coordinating in the #launchpad Slack channel with the other hat
-owner for the week is encouraged. It can reduce your workload and it will avoid
-backporting conflicts such as opening a PR with the same backports. Such
-discussions will typically revolve around which branches to tackle and which
-day of the week.
+In general, the committer with the top hat should coordinate with other core
+team members in the #launchpad Slack channel in order to understand the status
+of the review, triage and backport duties. This is especially important when
+the top hat is rotated from one committer to another, as well as when a release
+is planned for the upcoming week.
 
 An example interaction in #launchpad:
 
 ::
 
     Starting backport round for v1.7 and v1.8 now
-    cc @other-hat-wearer
-
-The other hat owner can then handle v1.9 and v1.10 backports the next day, for
-example.
 
 If there are many backports to be done, then splitting up the rounds can be
 beneficial. Typically, backporters opt to start a round in the beginning of the
@@ -521,7 +509,7 @@ By the start / end of the week, if there are other backport PRs that haven't
 been merged, then please coordinate with the previous / next backporter to
 check what the status is and establish who will work on getting the backports
 into the tree (for instance by investigating CI failures and addressing review
-feedback). There's leeway to negotiate depending on who has time available.
+feedback). Ensure that the responsibility for driving the PRs forward is clear.
 
 .. _dev_coo:
 

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -260,16 +260,29 @@ Handling large pull requests
 ----------------------------
 
 If the PR is considerably large (e.g. with more than 200 lines changed and/or
-more than 6 commits), consider creating a new commit for each review. This
-will make the review process smoother as GitHub has limitations that
-prevents reviewers from only seeing the new changes added since the last time
-they have reviewed a PR. Once all reviews are addressed those commits should
-be squashed against the commit that introduced those changes. This can be
-accomplished by the usage of ``git rebase -i upstream/master`` and in
-that windows, move these new commits below the commit that introduced the
-changes and replace the work ``pick`` with ``fixup``. In the following
-example, commit ``d2cb02265`` will be combined into ``9c62e62d8`` and commit
-``146829b59`` will be combined into ``9400fed20``.
+more than 6 commits), consider whether there is a good way to split the PR into
+smaller PRs that can be merged more incrementally. Reviewers are often more
+hesitant to review large PRs due to the level of complexity involved in
+understanding the changes and the amount of time required to provide
+constructive review comments. By making smaller logical PRs, this makes it
+easier for the reviewer to provide comments and to engage in dialogue on the
+PR, and also means there should be fewer overall pieces of feedback that you
+need to address as a contributor. Tighter feedback cycles like this then make
+it easier to get your contributions into the tree, which also helps with
+reducing conflicts with other contributions. Good candidates for smaller PRs
+may be individual bugfixes, or self-contained refactoring that adjusts the code
+in order to make it easier to build subsequent functionality on top.
+
+While handling review on larger PRs, consider creating a new commit to address
+feedback from each review that you receive on your PR. This will make the
+review process smoother as GitHub has limitations that prevents reviewers from
+only seeing the new changes added since the last time they have reviewed a PR.
+Once all reviews are addressed those commits should be squashed against the
+commit that introduced those changes. This can be accomplished by the usage of
+``git rebase -i upstream/master`` and in that windows, move these new commits
+below the commit that introduced the changes and replace the work ``pick`` with
+``fixup``. In the following example, commit ``d2cb02265`` will be combined into
+``9c62e62d8`` and commit ``146829b59`` will be combined into ``9400fed20``.
 
     ::
 

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -16,7 +16,7 @@ Clone and Provision Environment
 #. Make sure you have a `GitHub account <https://github.com/join>`_
 #. Fork the Cilium repository to your GitHub user or organization.
 #. Turn off GitHub actions for your fork as described in the `GitHub Docs <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository>`_.
-   #. This is recommended to avoid unnecessary CI notification failures on the fork.
+   This is recommended to avoid unnecessary CI notification failures on the fork.
 #. Clone your ``${YOUR_GITHUB_USERNAME_OR_ORG}/cilium`` fork into your ``GOPATH``, and setup the base repository as ``upstream`` remote:
 
    .. code-block:: shell-session
@@ -47,8 +47,14 @@ upstream GitHub repository at https://github.com/cilium/cilium.
 Before hitting the submit button, please make sure that the following
 requirements have been met:
 
-#. Each commit compiles and is functional on its own to allow for bisecting of
-   commits.
+#. Take some time to describe your change in the PR description! A well-written
+   description about the motivation of the change and choices you made during
+   the implementation can go a long way to help the reviewers understand why
+   you've made the change and why it's a good way to solve your problem. If
+   it helps you to explain something, use pictures or
+   `Mermaid diagrams <https://mermaid-js.github.io/>`_.
+#. Each commit must compile and be functional on its own to allow for
+   bisecting of commits in the event of a bug affecting the tree.
 #. All code is covered by unit and/or runtime tests where feasible.
 #. All changes have been tested and checked for regressions by running the
    existing testsuite against your changes. See the :ref:`testsuite` section
@@ -215,9 +221,9 @@ Getting a pull request merged
 #. As you submit the pull request as described in the section :ref:`submit_pr`.
    One of the reviewers will start a CI run by replying with a comment
    ``/test`` as described in :ref:`trigger_phrases`. If you are a core team
-   member, you may trigger the CI run yourself.
+   member, you may trigger the CI run yourself. CI consists of:
 
-   #. Basic static code analyzer by Github Action and Travis CI. Golang linter
+   #. Static code analysis by Github Actions and Travis CI. Golang linter
       suggestions are added in-line on PRs. For other failed jobs, please refer
       to build log for required action (e.g. Please run ``go mod tidy && go mod
       vendor`` and submit your changes, etc).
@@ -238,78 +244,82 @@ Getting a pull request merged
    #. Address any feedback received from the reviewers
    #. You can push individual commits to address feedback and then rebase your
       branch at the end before merging.
+   #. Once you have addressed the feedback, re-request a review from the
+      reviewers that provided feedback by clicking on the button next to their
+      name in the list of reviewers. This ensures that the reviewers are
+      notified again that your PR is ready for subsequent review.
 
 #. Owners of the repository will automatically adjust the labels on the pull
    request to track its state and progress towards merging.
 
 #. Once the PR has been reviewed and the CI tests have passed, the PR will be
    merged by one of the repository owners. In case this does not happen, ping
-   us on Slack.
+   us on Slack in the #development channel.
 
-#. If reviewers have requested changes and those changes have been addressed,
-   re-request a review for the reviewers that have requested changes. Otherwise,
-   those reviewers will not be notified and your PR will not receive any
-   reviews. If the PR is considerably large (e.g. with more than 200 lines
-   changed and/or more than 6 commits) create new commit for each review. This
-   will make the review process smoother as GitHub has limitations that
-   prevents reviewers from only seeing the new changes added since the last time
-   they have reviewed a PR. Once all reviews are addressed those commits should
-   be squashed against the commit that introduced those changes. This can be
-   easily accomplished by the usage of ``git rebase -i origin/master`` and in
-   that windows, move these new commits below the commit that introduced the
-   changes and replace the work ``pick`` with ``fixup``. In the following
-   example, commit ``d2cb02265`` will be meld into ``9c62e62d8`` and commit
-   ``146829b59`` will be meld into ``9400fed20``.
+Handling large pull requests
+----------------------------
 
-       ::
+If the PR is considerably large (e.g. with more than 200 lines changed and/or
+more than 6 commits), consider creating a new commit for each review. This
+will make the review process smoother as GitHub has limitations that
+prevents reviewers from only seeing the new changes added since the last time
+they have reviewed a PR. Once all reviews are addressed those commits should
+be squashed against the commit that introduced those changes. This can be
+accomplished by the usage of ``git rebase -i upstream/master`` and in
+that windows, move these new commits below the commit that introduced the
+changes and replace the work ``pick`` with ``fixup``. In the following
+example, commit ``d2cb02265`` will be combined into ``9c62e62d8`` and commit
+``146829b59`` will be combined into ``9400fed20``.
 
-           pick 9c62e62d8 docs: updating contribution guide process
-           fixup d2cb02265 joe + paul + chris changes
-           pick 9400fed20 docs: fixing typo
-           fixup 146829b59 Quetin and Maciej reviews
+    ::
 
-   Once this is done you can perform push force into your branch and request for
-   your PR to be merged.
+        pick 9c62e62d8 docs: updating contribution guide process
+        fixup d2cb02265 joe + paul + chris changes
+        pick 9400fed20 docs: fixing typo
+        fixup 146829b59 Quentin and Maciej reviews
+
+Once this is done you can perform push force into your branch and request for
+your PR to be merged.
 
 
 Pull requests review process for committers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. Every committer in the `committers team <https://github.com/orgs/cilium/teams/committers/members>`_
-   belongs to `one or more other teams in the Cilium organization <https://github.com/orgs/cilium/teams/team/teams>`_
-   if you would like to be added or removed from any team, please contact any
-   of the `maintainers <https://github.com/orgs/cilium/teams/cilium-maintainers/members>`_.
+Every committer in the `committers team <https://github.com/orgs/cilium/teams/committers/members>`_
+belongs to `one or more other teams in the Cilium organization <https://github.com/orgs/cilium/teams/team/teams>`_
+If you would like to be added or removed from any team, please contact any
+of the `maintainers <https://github.com/orgs/cilium/teams/cilium-maintainers/members>`_.
 
-#. Once a PR is open, GitHub will automatically pick which `teams <https://github.com/orgs/cilium/teams/team/teams>`_
-   should review the PR using the ``CODEOWNERS`` file. Each committer can see
-   the PRs they need to review by filtering by reviews requested.
-   A good filter is provided in this `link <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+user-review-requested%3A%40me+sort%3Aupdated-asc>`_
-   so make sure to bookmark it.
+Once a PR is opened by a contributor, GitHub will automatically pick which `teams <https://github.com/orgs/cilium/teams/team/teams>`_
+should review the PR using the ``CODEOWNERS`` file. Each committer can see
+the PRs they need to review by filtering by reviews requested.
+A good filter is provided in this `link <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+user-review-requested%3A%40me+sort%3Aupdated-asc>`_
+so make sure to bookmark it.
 
-#. Belonging to a team does not mean that a committer should know every single
-   line of code the team is maintaining. For this reason it is recommended
-   that once you have reviewed a PR, if you feel that another pair of eyes is
-   needed, you should re-request a review from the appropriate team. In the
-   example below, the committer belonging to the CI team is re-requesting a
-   review for other team members to review the PR. This allows other team
-   members belonging to the CI team to see the PR as part of the PRs that
-   require review in the `filter <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+review-requested%3A%40me+sort%3Aupdated-asc>`_
+Belonging to a team does not mean that a committer should know every single
+line of code the team is maintaining. For this reason it is recommended
+that once you have reviewed a PR, if you feel that another pair of eyes is
+needed, you should re-request a review from the appropriate team. In the
+example below, the committer belonging to the CI team is re-requesting a
+review for other team members to review the PR. This allows other team
+members belonging to the CI team to see the PR as part of the PRs that
+require review in the `filter <https://github.com/cilium/cilium/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+review-requested%3A%40me+sort%3Aupdated-asc>`_.
 
-   .. image:: ../../images/re-request-review.png
-      :align: center
-      :scale: 50%
+.. image:: ../../images/re-request-review.png
+   :align: center
+   :scale: 50%
 
-#. When all review objectives for all ``CODEOWNERS`` are met, all required CI
-   tests have passed and a proper release label as been set, you may set the
-   ``ready-to-merge`` label to indicate that all criteria have been met.
-   Maintainer's little helper might set this label automatically if the previous
-   requirements were met.
+When all review objectives for all ``CODEOWNERS`` are met, all required CI
+tests have passed and a proper release label as been set, you may set the
+``ready-to-merge`` label to indicate that all criteria have been met.
+Maintainer's little helper might set this label automatically if the previous
+requirements were met.
 
-   +--------------------------+---------------------------+
-   | Labels                   | When to set               |
-   +==========================+===========================+
-   | ``ready-to-merge``       | PR is ready to be merged  |
-   +--------------------------+---------------------------+
++--------------------------+---------------------------+
+| Labels                   | When to set               |
++==========================+===========================+
+| ``ready-to-merge``       | PR is ready to be merged  |
++--------------------------+---------------------------+
 
 Weekly duties
 ~~~~~~~~~~~~~

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -116,8 +116,6 @@ example patch that shows how this can be achieved.
 
                             //This test should run in each PR for now.
 
-.. _ci_failure_triage:
-
 Jobs Overview
 ~~~~~~~~~~~~~
 
@@ -276,6 +274,8 @@ always be found in the `Cilium CI matrix`_.
 .. _Cilium CI matrix: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0
 
 .. _trigger_phrases:
+
+.. _ci_failure_triage:
 
 CI Failure Triage
 ~~~~~~~~~~~~~~~~~

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -365,9 +365,6 @@ Triage process
       eventually deleted).
    #. Attach the zipfile downloaded from Jenkins with logs from the failing
       tests. A zipfile for all tests is also available.
-   #. Check how much time has passed since the last reported occurrence of this
-      failure and move this issue to the correct column in the `CI flakes
-      project`_ board.
 
 #. If no existing GitHub issue was found, file a `new GitHub issue <https://github.com/cilium/cilium/issues/new>`_:
 
@@ -385,7 +382,6 @@ Triage process
          eventually deleted).
       #. Attach zipfile downloaded from Jenkins with logs from failing test
       #. Include the test name and whole Stacktrace section to help others find this issue.
-      #. Add issue to `CI flakes project`_.
 
    .. note::
 
@@ -408,7 +404,7 @@ Triage process
 
       This step can only be performed with an account on Jenkins. If you are
       interested in CI failure reviews and do not have an account yet, ping us
-      on Slack.
+      on Slack in the ``#testing`` channel.
 
 **Examples:**
 
@@ -416,8 +412,6 @@ Triage process
 * ``Flake, DNS not ready, #3333``
 * ``CI-Bug, K8sValidatedPolicyTest: Namespaces, pod not ready, #9939``
 * ``Regression, k8s host policy, #1111``
-
-.. _CI flakes project: https://github.com/cilium/cilium/projects/8
 
 Bisect process
 ^^^^^^^^^^^^^^

--- a/Documentation/policy/caveats.rst
+++ b/Documentation/policy/caveats.rst
@@ -25,3 +25,23 @@ selected endpoint by the LB. If not, i.e., the request needs to be forwarded to
 another node after the service endpoint selection, then it will have the ``reserved:remote-node``.
 
 The latter traffic will match ``fromEntities: cluster`` policies.
+
+Differences From Kubernetes Network Policies
+============================================
+
+When creating Cilium Network Policies it is important to keep in mind that Cilium Network
+Policies do not perfectly replicate the functionality of `Kubernetes Network Policies <https://kubernetes.io/docs/concepts/services-networking/network-policies/>`_.
+
+There are two ways Cilium Network Policies do not overlap with existing Kubernetes Network
+Policy functionality:
+
+1. Cilium Network Policies that reference the Stream Control Transmission Protocol (SCTP)
+   will not work properly. Currently, Cilium does not support SCTP (see :gh-issue:`5719`).
+
+2. Cilium Network Policies that use CIDR blocks to define endpoints controlled by Cilium
+   (i.e. internal to the Kubernetes cluster) will not work properly. As stated under the
+   :ref:`policy_cidr` section of this documentation, CIDR policies in Cilium are used to
+   define policies to and from endpoints which are not managed by Cilium (i.e. external
+   to the Kubernetes cluster). This differs from Kubernetes Network Policies which **can**
+   use CIDR blocks to define policies to and from endpoints which are internal to the
+   Kubernetes cluster (i.e. managed by a CNI other than Cilium).

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -253,12 +253,12 @@ accessible from endpoints that have both labels ``env=prod`` and
 Services based
 --------------
 
-Services running in your cluster can be whitelisted in Egress rules.
-Currently Kubernetes `Services without a Selector
+Traffic from pods to services running in your cluster can be allowed via
+``toServices`` statements in Egress rules. Currently Kubernetes
+`Services without a Selector
 <https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors>`_
 are supported when defined by their name and namespace or label selector.
-Future versions of Cilium will support specifying non-Kubernetes services
-and Kubernetes services which are backed by pods.
+For services backed by pods, use `labels based` rules on the backend pod labels.
 
 This example shows how to allow all endpoints with the label ``id=app2``
 to talk to all endpoints of kubernetes service ``myservice`` in kubernetes
@@ -301,6 +301,11 @@ have ``head:none`` set as the label.
 
         .. literalinclude:: ../../examples/policies/l3/service/service-labels.json
 
+Limitations
+~~~~~~~~~~~
+
+``toServices`` statements cannot be combined with ``toPorts`` statements in the
+same rule.
 
 .. _Entities based:
 

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -372,9 +372,14 @@ func synchronizeIdentities() {
 	go identityInformer.Run(wait.NeverStop)
 }
 
-type nodeStub string
+type nodeStub struct {
+	cluster string
+	name    string
+}
 
-func (n nodeStub) GetKeyName() string { return string(n) }
+func (n *nodeStub) GetKeyName() string {
+	return nodeTypes.GetKeyNodeName(n.cluster, n.name)
+}
 
 func updateNode(obj interface{}) {
 	if ciliumNode, ok := obj.(*ciliumv2.CiliumNode); ok {
@@ -394,7 +399,11 @@ func updateNode(obj interface{}) {
 func deleteNode(obj interface{}) {
 	n, ok := obj.(*ciliumv2.CiliumNode)
 	if ok {
-		ciliumNodeStore.DeleteLocalKey(context.Background(), nodeStub(n.Name))
+		n := nodeStub{
+			cluster: cfg.clusterName,
+			name:    n.Name,
+		}
+		ciliumNodeStore.DeleteLocalKey(context.Background(), &n)
 	} else {
 		log.Warningf("Unknown CiliumNode object type %s received: %+v", reflect.TypeOf(obj), obj)
 	}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -52,8 +52,10 @@ spec:
         # in AppArmor.
         container.apparmor.security.beta.kubernetes.io/cilium-agent: "unconfined"
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: "unconfined"
+        {{- if .Values.cgroup.autoMount.enabled }}
         container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
         container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: "unconfined"
+        {{- end }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -333,5 +333,9 @@ func init() {
 	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")
 	option.BindEnv(operatorOption.SetCiliumIsUpCondition)
 
+	flags.Duration(option.KVstoreLeaseTTL, defaults.KVstoreLeaseTTL, "Time-to-live for the KVstore lease.")
+	flags.MarkHidden(option.KVstoreLeaseTTL)
+	option.BindEnv(option.KVstoreLeaseTTL)
+
 	viper.BindPFlags(flags)
 }

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -24,7 +24,7 @@ import (
 const (
 	EndpointPolicyStateEnforcing    cilium_v2.EndpointPolicyState = "enforcing"
 	EndpointPolicyStateNonEnforcing cilium_v2.EndpointPolicyState = "non-enforcing"
-	EndpointPolicyStateDisabled     cilium_v2.EndpointPolicyState = "disabled"
+	EndpointPolicyStateDisabled     cilium_v2.EndpointPolicyState = "<status disabled>"
 )
 
 func getEndpointStatusControllers(mdlControllers models.ControllerStatuses) (controllers cilium_v2.ControllerList) {

--- a/pkg/endpointmanager/host.go
+++ b/pkg/endpointmanager/host.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node"
 )
 
 // GetHostEndpoint returns the host endpoint.
@@ -51,6 +52,8 @@ func (mgr *EndpointManager) OnUpdateNode(oldNode, newNode *v1.Node,
 		log.Error("Host endpoint not found")
 		return nil
 	}
+
+	node.SetLabels(newNodeLabels)
 
 	err := nodeEP.UpdateLabelsFrom(oldNodeLabels, newNodeLabels, labels.LabelSourceK8s)
 	if err != nil {

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -571,7 +571,7 @@ func (e *etcdClient) renewSession(ctx context.Context) error {
 		return fmt.Errorf("unable to renew etcd session: %s", err)
 	}
 	sessionSuccess <- true
-	log.Infof("Got new lease ID %x", newSession.Lease())
+	log.Infof("Got new lease ID %x and the session TTL is %s", newSession.Lease(), option.Config.KVstoreLeaseTTL)
 
 	e.session = newSession
 	e.sessionCancel = sessionCancel
@@ -724,7 +724,7 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		ls = *lockSession
 		ec.RWMutex.Unlock()
 
-		log.Infof("Got lease ID %x", s.Lease())
+		log.Infof("Got lease ID %x and the session TTL is %s", s.Lease(), option.Config.KVstoreLeaseTTL)
 		log.Infof("Got lock lease ID %x", ls.Lease())
 		close(errorChan)
 	}()

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -297,7 +297,10 @@ func (n *NodeDiscovery) updateLocalNode() {
 			controller.NewManager().UpdateController("propagating local node change to kv-store",
 				controller.ControllerParams{
 					DoFunc: func(ctx context.Context) error {
-						err := n.Registrar.UpdateLocalKeySync(&n.localNode)
+						n.localNodeLock.Lock()
+						localNode := n.localNode.DeepCopy()
+						n.localNodeLock.Unlock()
+						err := n.Registrar.UpdateLocalKeySync(localNode)
 						if err != nil {
 							log.WithError(err).Error("Unable to propagate local node change to kvstore")
 						}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2958,6 +2958,9 @@ func (c *DaemonConfig) Populate() {
 
 	if c.TunnelPort == 0 {
 		switch c.Tunnel {
+		case TunnelDisabled:
+			// tunnel might still be used by eg. EgressGW
+			c.TunnelPort = defaults.TunnelPortVXLAN
 		case TunnelVXLAN:
 			c.TunnelPort = defaults.TunnelPortVXLAN
 		case TunnelGeneve:

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -654,9 +654,10 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 	// only contain local backends (i.e. it has externalTrafficPolicy=Local)
 	if option.Config.EnableHealthCheckNodePort {
 		if onlyLocalBackends && filterBackends {
-			localBackendCount := len(backendsCopy)
+			_, activeBackends, _ := segregateBackends(backendsCopy)
+
 			s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
-				localBackendCount, svc.svcHealthCheckNodePort)
+				len(activeBackends), svc.svcHealthCheckNodePort)
 		} else if svc.svcHealthCheckNodePort == 0 {
 			// Remove the health check server in case this service used to have
 			// externalTrafficPolicy=Local with HealthCheckNodePort in the previous

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -512,9 +512,11 @@ func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {
 	// Create two node-local backends
 	localBackend1 := *lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.1"), 8080)
 	localBackend2 := *lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080)
+	localTerminatingBackend3 := *lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.3"), 8080)
 	localBackend1.NodeName = nodeTypes.GetName()
 	localBackend2.NodeName = nodeTypes.GetName()
-	localBackends := []lb.Backend{localBackend1, localBackend2}
+	localTerminatingBackend3.NodeName = nodeTypes.GetName()
+	localActiveBackends := []lb.Backend{localBackend1, localBackend2}
 
 	// Create three remote backends
 	remoteBackend1 := *lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.3"), 8080)
@@ -525,7 +527,7 @@ func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {
 	remoteBackend3.NodeName = "not-" + nodeTypes.GetName()
 	remoteBackends := []lb.Backend{remoteBackend1, remoteBackend2, remoteBackend3}
 
-	allBackends := []lb.Backend{localBackend1, localBackend2, remoteBackend1, remoteBackend2, remoteBackend3}
+	allBackends := []lb.Backend{localBackend1, localBackend2, localTerminatingBackend3, remoteBackend1, remoteBackend2, remoteBackend3}
 
 	// Insert svc1 as type LoadBalancer with some local backends
 	p1 := &lb.SVC{
@@ -541,7 +543,10 @@ func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Name, Equals, "svc1")
 	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Namespace, Equals, "ns1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, len(localBackends))
+
+	p1.Backends[2].State = lb.BackendStateTerminating
+	_, _, _ = m.svc.UpsertService(p1)
+	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, len(localActiveBackends))
 
 	// Insert the the ClusterIP frontend of svc1
 	p2 := &lb.SVC{
@@ -557,7 +562,7 @@ func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Name, Equals, "svc1")
 	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Namespace, Equals, "ns1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, len(localBackends))
+	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, len(localActiveBackends))
 
 	// Update the HealthCheckNodePort for svc1
 	p1.HealthCheckNodePort = 32000
@@ -566,7 +571,7 @@ func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {
 	c.Assert(new, Equals, false)
 	c.Assert(m.svcHealth.ServiceByPort(32000).Service.Name, Equals, "svc1")
 	c.Assert(m.svcHealth.ServiceByPort(32000).Service.Namespace, Equals, "ns1")
-	c.Assert(m.svcHealth.ServiceByPort(32000).LocalEndpoints, Equals, len(localBackends))
+	c.Assert(m.svcHealth.ServiceByPort(32000).LocalEndpoints, Equals, len(localActiveBackends))
 	c.Assert(m.svcHealth.ServiceByPort(32001), IsNil)
 
 	// Update the externalTrafficPolicy for svc1
@@ -586,7 +591,7 @@ func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {
 	c.Assert(new, Equals, false)
 	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Name, Equals, "svc1")
 	c.Assert(m.svcHealth.ServiceByPort(32001).Service.Namespace, Equals, "ns1")
-	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, len(localBackends))
+	c.Assert(m.svcHealth.ServiceByPort(32001).LocalEndpoints, Equals, len(localActiveBackends))
 
 	// Upsert svc1 of type LoadBalancer with only remote backends
 	p1.Backends = remoteBackends


### PR DESCRIPTION
* #20780 -- datapath: avoid delete/add flap for cilium_vxlan on startup (@julianwiedmann)
 * #21003 -- pkg/endpoint: change CEP policy status message (@aanm)
 * #21006 -- add kvstore TTL flag in cilium-operator (@NikhilSharmaWe)
 * #21062 -- Do not enable health checks on Terminating backends (@zuzzas)
 * #21078 -- clustermesh-apiserver: fix key name for delete during k8s->kvstore sync (@tklauser)
 * #21008 -- helm: Add check for apparmor annotations (@sayboras)
 * #21056 -- Spring cleaning for the contributor guide (@joestringer)
 * #21052 -- docs: Update ToServices docs section (@joestringer)
 * #21086 -- pkg/nodediscovery: protect variable against concurrent access (@aanm)
 * #21087 -- pkg/endpoint: set labels for local node from k8s events (@aanm)
 * #21001 -- Highlight Non-Overlapping Functionality Between K8s and Cilium Network Policies (@nathanjsweet)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20780 21003 21006 21062 21078 21008 21056 21052 21086 21087 21001; do contrib/backporting/set-labels.py $pr done 1.12; done
```