### PR TITLE
gha: Remove debug logs in conformance tests

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -110,8 +110,6 @@ jobs:
             --set operator.image.tag=${{ steps.vars.outputs.sha }} \
             --set operator.image.pullPolicy=IfNotPresent \
             --set operator.image.useDigest=false \
-            --set debug.enabled=true \
-            --set debug.verbose=flow \
             --set securityContext.privileged=true \
             --set ingressController.enabled=true
 

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -52,7 +52,6 @@ jobs:
             --helm-set=clustermesh.apiserver.image.useDigest=false \
             --helm-set=hubble.relay.image.repository=quay.io/${{ github.repository_owner }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${SHA} \
-            --helm-set=debug.enabled=true \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \


### PR DESCRIPTION
The previous PR #19825 set log level as debug mainly for debugging newly
added Ingress Conformance. Considered that this test is pretty much
stable, so debug logs can be removed.

Signed-off-by: Tam Mach <tam.mach@cilium.io>
