### PR TITLE
datapath: allow local NodePort traffic for `eni+` container interfaces with CNI chaining

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -61,6 +61,7 @@ cilium-agent [flags]
       --cluster-id int                                          Unique identifier of the cluster
       --cluster-name string                                     Name of the cluster (default "default")
       --clustermesh-config string                               Path to the ClusterMesh configuration directory
+      --cni-chaining-mode string                                Enable CNI chaining with the specified plugin
       --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                                       Configuration directory that contains a file for each option
       --conntrack-gc-interval duration                          Overwrite the connection-tracking garbage collection interval

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -407,6 +407,9 @@ func initializeFlags() {
 	flags.String(option.IPAM, ipamOption.IPAMClusterPool, "Backend to use for IPAM")
 	option.BindEnv(Vp, option.IPAM)
 
+	flags.String(option.CNIChainingMode, "", "Enable CNI chaining with the specified plugin")
+	option.BindEnv(Vp, option.CNIChainingMode)
+
 	flags.String(option.IPv4Range, AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	option.BindEnv(Vp, option.IPv4Range)
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -203,8 +202,7 @@ func (d *Daemon) getClockSourceStatus() *models.ClockSource {
 }
 
 func (d *Daemon) getCNIChainingStatus() *models.CNIChainingStatus {
-	// CNI chaining is enabled only from CILIUM_CNI_CHAINING_MODE env
-	mode := os.Getenv("CILIUM_CNI_CHAINING_MODE")
+	mode := option.Config.CNIChainingMode
 	if len(mode) == 0 {
 		mode = models.CNIChainingStatusModeNone
 	}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -956,11 +956,21 @@ func (m *IptablesManager) doGetProxyPort(prog iptablesInterface, name string) ui
 }
 
 func getDeliveryInterface(ifName string) string {
-	deliveryInterface := ifName
-	if option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAlibabaCloud || option.Config.EnableEndpointRoutes {
-		deliveryInterface = "lxc+"
+	switch {
+	case option.Config.EnableEndpointRoutes:
+		// aws-cni creates container interfaces with names like eni621c0fc8425.
+		if option.Config.CNIChainingMode == "aws-cni" {
+			return "eni+"
+		}
+		return "lxc+"
+
+	case option.Config.IPAM == ipamOption.IPAMENI ||
+		option.Config.IPAM == ipamOption.IPAMAlibabaCloud:
+		return "lxc+"
+
+	default:
+		return ifName
 	}
-	return deliveryInterface
 }
 
 func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterface, forwardChain string) error {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -543,6 +543,9 @@ const (
 	// ClusterMeshConfigName is the name of the ClusterMeshConfig option
 	ClusterMeshConfigName = "clustermesh-config"
 
+	// CNIChainingMode configures which CNI plugin Cilium is chained with.
+	CNIChainingMode = "cni-chaining-mode"
+
 	// CTMapEntriesGlobalTCPDefault is the default maximum number of entries
 	// in the TCP CT table.
 	CTMapEntriesGlobalTCPDefault = 2 << 18 // 512Ki
@@ -1963,6 +1966,9 @@ type DaemonConfig struct {
 	// IPAM is the IPAM method to use
 	IPAM string
 
+	// Enable chaining with another CNI plugin.
+	CNIChainingMode string
+
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource bool
@@ -2768,6 +2774,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.ClusterID = vp.GetUint32(ClusterIDName)
 	c.ClusterName = vp.GetString(ClusterName)
 	c.ClusterMeshConfig = vp.GetString(ClusterMeshConfigName)
+	c.CNIChainingMode = vp.GetString(CNIChainingMode)
 	c.DatapathMode = vp.GetString(DatapathMode)
 	c.Debug = vp.GetBool(DebugArg)
 	c.DebugVerbose = vp.GetStringSlice(DebugVerbose)


### PR DESCRIPTION
AWS CNI chaining yields container interface names like 'eni621c0fc8425', not the usual 'lxcXYZ'. This causes packets for local endpoints to be dropped in CILIUM_FORWARD when they are called through a NodePort.

Before the patch, the CILIUM_FORWARD chain looks like this:

```
-A CILIUM_FORWARD -o cilium_host -m comment --comment "cilium: any->cluster on cilium_host forward accept" -j ACCEPT
-A CILIUM_FORWARD -i cilium_host -m comment --comment "cilium: cluster->any on cilium_host forward accept (nodeport)" -j ACCEPT
-A CILIUM_FORWARD -i lxc+ -m comment --comment "cilium: cluster->any on lxc+ forward accept" -j ACCEPT
-A CILIUM_FORWARD -i cilium_net -m comment --comment "cilium: cluster->any on cilium_net forward accept (nodeport)" -j ACCEPT
-A CILIUM_FORWARD -o lxc+ -m comment --comment "cilium: any->cluster on lxc+ forward accept" -j ACCEPT
-A CILIUM_FORWARD -i lxc+ -m comment --comment "cilium: cluster->any on lxc+ forward accept (nodeport)" -j ACCEPT
```

This doesn't match any packets to or from `eni+` container interfaces, letting them fall through to the `KUBE-FORWARD` chain instead:

```
-A FORWARD -m comment --comment "cilium-feeder: CILIUM_FORWARD" -j CILIUM_FORWARD
-A FORWARD -m comment --comment "kubernetes forwarding rules" -j KUBE-FORWARD
...
-A KUBE-FORWARD -m conntrack --ctstate INVALID -j DROP
```

Initial SYN packets go through to the Pod, SYN-ACK responses from local NodePort services are bpf_redirect'ed back out the physical interface to the client, but any follow-up packets from the client arriving at the node are considered invalid by netfilter's conntrack since the reply packet bypassed the stack, and thus dropped.

This commit takes care of adding `-i eni+` and `-o eni+` iptables rules to make sure world->container packets are never dropped in the stack.

```release-note
datapath: allow local NodePort traffic for `eni+` container interfaces with CNI chaining
```