### PR TITLE
operator, kvstore: don't add/update CiliumNode from operator

### DIFF
--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -128,8 +128,8 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 				ciliumNodeKVStore.DeleteLocalKey(ctx, &nodeDel)
 			},
 			func(node *cilium_v2.CiliumNode) {
-				nodeNew := nodeTypes.ParseCiliumNode(node)
-				ciliumNodeKVStore.UpdateKeySync(ctx, &nodeNew)
+				// Ignored because the agent running on that particular node will
+				// take care of adding/updating its CiliumNode in the kvstore.
 			})
 	}
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1400,9 +1400,7 @@ func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, 
 	}
 
 	if lease {
-		e.RWMutex.RLock()
-		leaseID := e.session.Lease()
-		e.RWMutex.RUnlock()
+		leaseID := e.GetSessionLeaseID()
 		if getR.Kvs[0].Lease != int64(leaseID) {
 			return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
 		}
@@ -1434,9 +1432,7 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 		return true, e.Update(ctx, key, value, lease)
 	}
 	if lease {
-		e.RWMutex.RLock()
-		leaseID := e.session.Lease()
-		e.RWMutex.RUnlock()
+		leaseID := e.GetSessionLeaseID()
 		if getR.Kvs[0].Lease != int64(leaseID) {
 			return true, e.Update(ctx, key, value, lease)
 		}

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -350,13 +350,6 @@ func (s *SharedStore) SharedKeysMap() map[string]Key {
 	return sharedKeysCopy
 }
 
-// UpdateLocalKey adds a key to be synchronized with the kvstore
-func (s *SharedStore) UpdateLocalKey(key LocalKey) {
-	s.mutex.Lock()
-	s.localKeys[key.GetKeyName()] = key.DeepKeyCopy()
-	s.mutex.Unlock()
-}
-
 // UpdateLocalKeySync synchronously synchronizes a local key with the kvstore
 // and adds it to the list of local keys to be synchronized if the initial
 // synchronous synchronization was successful

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -363,11 +363,6 @@ func (s *SharedStore) UpdateLocalKeySync(ctx context.Context, key LocalKey) erro
 	return err
 }
 
-// UpdateKeySync synchronously synchronizes a key with the kvstore.
-func (s *SharedStore) UpdateKeySync(ctx context.Context, key LocalKey) error {
-	return s.syncLocalKey(ctx, key)
-}
-
 // DeleteLocalKey removes a key from being synchronized with the kvstore
 func (s *SharedStore) DeleteLocalKey(ctx context.Context, key NamedKey) {
 	name := key.GetKeyName()


### PR DESCRIPTION
The first two commits are cleanups and refactoring in preparation for the 3rd commit which contains the actual change:

It is not possible to run the agent without kvstore and the agent with
kvstore simultaneously. Due to this, the agent running on each node will
always take care of adding/updating its own CiliumNode in the kvstore.
Thus it is safe to remove this part of the synchronization in the
operator (enabled by the  --synchronize-k8s-nodes flag). This also
avoids potential issues with leases attached to the CiliumNode entry,
where the operator would overwrite the lease which was previously owned
by the respective node's agent.