### PR TITLE
metallb: bump to latest metallb version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,7 @@ replace (
 	github.com/miekg/dns => github.com/cilium/dns v1.1.51-0.20220729113855-5b94b11b46fc
 	github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
 
-	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220713202445-9066eee9e0be
+	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7
 
 	k8s.io/client-go => github.com/cilium/client-go v0.0.0-20220824093223-b6557c021e53
 

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyR
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
 github.com/cilium/lumberjack/v2 v2.2.2 h1:RKTdhb63DY0Xu7pE1pipMj7Zq28LyvBGSrCneHiKm4A=
 github.com/cilium/lumberjack/v2 v2.2.2/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
-github.com/cilium/metallb v0.1.1-0.20220713202445-9066eee9e0be h1:ZlvVOPr/etGVRFiiuXyZKCCKRRmeXVjgbK0nESEOQBg=
-github.com/cilium/metallb v0.1.1-0.20220713202445-9066eee9e0be/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
+github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7 h1:ocC6/1Gz6LJd0XsJiwhcTlAy3yJrJruzh4sjRzUNvQs=
+github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
 github.com/cilium/proxy v0.0.0-20220803100640-5739e4be8ae7 h1:9bXF7c9aYzu1U0SthXXTBa5dLqGVmsnQ3iiNfvp6Kms=
 github.com/cilium/proxy v0.0.0-20220803100640-5739e4be8ae7/go.mod h1:ontBl/RX7G0GwcR38YQVp6d75MjIsL1FbBidVpn+F8I=
 github.com/cilium/workerpool v1.1.3 h1:GB5H495r6AXg8kYklLAOn7N4PDR/djeE4WYPbq8U+yY=

--- a/vendor/go.universe.tf/metallb/pkg/bgp/messages.go
+++ b/vendor/go.universe.tf/metallb/pkg/bgp/messages.go
@@ -190,7 +190,6 @@ func readOpen(r io.Reader) (*openResult, error) {
 	if err := binary.Read(lr, binary.BigEndian, &open); err != nil {
 		return nil, err
 	}
-	fmt.Printf("%#v\n", open)
 	if open.Version != 4 {
 		return nil, fmt.Errorf("wrong BGP version")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -898,7 +898,7 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 go.uber.org/zap/zapgrpc
-# go.universe.tf/metallb v0.11.0 => github.com/cilium/metallb v0.1.1-0.20220713202445-9066eee9e0be
+# go.universe.tf/metallb v0.11.0 => github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7
 ## explicit; go 1.17
 go.universe.tf/metallb/pkg/allocator
 go.universe.tf/metallb/pkg/allocator/k8salloc
@@ -1693,6 +1693,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/miekg/dns => github.com/cilium/dns v1.1.51-0.20220729113855-5b94b11b46fc
 # github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
-# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220713202445-9066eee9e0be
+# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7
 # k8s.io/client-go => github.com/cilium/client-go v0.0.0-20220824093223-b6557c021e53
 # sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.6.2


### PR DESCRIPTION
this commit bumps the metallb version to our latest forked patch set.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>
```
Bump metallb fork to remove plain logging from agent daemon.
```
