### PR TITLE
operator: do not GC kvstore nodes if CiliumNodes are not available

### DIFF
--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -91,10 +91,16 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 			listOfCiliumNodes := ciliumNodeStore.ListKeys()
 
 			kvStoreNodes := ciliumNodeKVStore.SharedKeysMap()
+
 			for _, ciliumNode := range listOfCiliumNodes {
 				// The remaining kvStoreNodes are leftovers that need to be GCed
 				kvStoreNodeName := nodeTypes.GetKeyNodeName(option.Config.ClusterName, ciliumNode)
 				delete(kvStoreNodes, kvStoreNodeName)
+			}
+
+			if len(listOfCiliumNodes) == 0 && len(kvStoreNodes) != 0 {
+				log.Warn("Preventing GC of nodes in the KVStore due the nonexistence of any CiliumNodes in kube-apiserver")
+				return
 			}
 
 			for _, kvStoreNode := range kvStoreNodes {


### PR DESCRIPTION
If users deploy Cilium without creating any CiliumNodes, Cilium Operator
will GC all kvstore nodes once it starts. This commits adds a guardrail
to prevent such behavior.

Signed-off-by: André Martins <andre@cilium.io>