### PR TITLE
go-mod: bump go mod version to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Azure/azure-sdk-for-go v66.0.0+incompatible


### PR DESCRIPTION
```release-note
Bump go.mod to v1.19 since build tags now require it.
```
