### PR TITLE
ci: bump external workloads workflow timeouts

### DIFF
--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -119,7 +119,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Set up job variables
         id: vars

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -119,7 +119,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Set up job variables
         id: vars

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -122,7 +122,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Set up job variables
         id: vars


### PR DESCRIPTION
After commit 233cec30270e ("gha: Bump cilium cli to v1.12.2") the
external workloads workflow started timing out occasionally because
more tests were added in cilium-cli v0.12.2 and thus run times
increased. Bump the workflow timeouts to avoid this.

Follows cilium/cilium-cli#1067
