### PR TITLE
v1.10 backports 2022-08-30

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -253,12 +253,12 @@ accessible from endpoints that have both labels ``env=prod`` and
 Services based
 --------------
 
-Services running in your cluster can be whitelisted in Egress rules.
-Currently Kubernetes `Services without a Selector
+Traffic from pods to services running in your cluster can be allowed via
+``toServices`` statements in Egress rules. Currently Kubernetes
+`Services without a Selector
 <https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors>`_
 are supported when defined by their name and namespace or label selector.
-Future versions of Cilium will support specifying non-Kubernetes services
-and Kubernetes services which are backed by pods.
+For services backed by pods, use `labels based` rules on the backend pod labels.
 
 This example shows how to allow all endpoints with the label ``id=app2``
 to talk to all endpoints of kubernetes service ``myservice`` in kubernetes
@@ -301,6 +301,11 @@ have ``head:none`` set as the label.
 
         .. literalinclude:: ../../examples/policies/l3/service/service-labels.json
 
+Limitations
+~~~~~~~~~~~
+
+``toServices`` statements cannot be combined with ``toPorts`` statements in the
+same rule.
 
 .. _Entities based:
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -332,5 +332,9 @@ func init() {
 	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")
 	option.BindEnv(operatorOption.SetCiliumIsUpCondition)
 
+	flags.Duration(option.KVstoreLeaseTTL, defaults.KVstoreLeaseTTL, "Time-to-live for the KVstore lease.")
+	flags.MarkHidden(option.KVstoreLeaseTTL)
+	option.BindEnv(option.KVstoreLeaseTTL)
+
 	viper.BindPFlags(flags)
 }

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -99,9 +99,9 @@ var ciliumChains = []customChain{
 func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 	args := []string{"-t", c.table, "-L", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
-		if strings.Contains(string(output), "No chain/target/match by that name.") {
+		if strings.Contains(err.Error(), "No chain/target/match by that name.") {
 			return false, nil
 		}
 
@@ -114,7 +114,7 @@ func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 func (c *customChain) doAdd(prog iptablesInterface) error {
 	args := []string{"-t", c.table, "-N", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to add %s chain: %s (%w)", c.name, string(output), err)
 	}
@@ -146,7 +146,7 @@ func (c *customChain) doRename(prog iptablesInterface, newName string) error {
 
 	args := []string{"-t", c.table, "-E", c.name, newName}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to rename %s chain to %s: %s (%w)", c.name, newName, string(output), err)
 	}
@@ -178,14 +178,14 @@ func (c *customChain) doRemove(prog iptablesInterface) error {
 
 	args := []string{"-t", c.table, "-F", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to flush %s chain: %s (%w)", c.name, string(output), err)
 	}
 
 	args = []string{"-t", c.table, "-X", c.name}
 
-	output, err = prog.runProgCombinedOutput(args)
+	output, err = prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to remove %s chain: %s (%w)", c.name, string(output), err)
 	}
@@ -226,7 +226,7 @@ func (c *customChain) doInstallFeeder(prog iptablesInterface, feedArgs string) e
 
 	args := append([]string{"-t", c.table, installMode, c.hook}, feedRule...)
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to install feeder rule for %s chain: %s (%w)", c.name, string(output), err)
 	}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -87,7 +87,7 @@ const (
 type iptablesInterface interface {
 	getProg() string
 	getVersion() (semver.Version, error)
-	runProgCombinedOutput(args []string) (string, error)
+	runProgOutput(args []string) (string, error)
 	runProg(args []string) error
 }
 
@@ -131,7 +131,7 @@ func (ipt *ipt) getVersion() (semver.Version, error) {
 	return versioncheck.Version(vString[1])
 }
 
-func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
+func (ipt *ipt) runProgOutput(args []string) (string, error) {
 	fullCommand := fmt.Sprintf("%s %s", ipt.getProg(), strings.Join(args, " "))
 
 	log.Debugf("Running '%s' command", fullCommand)
@@ -140,19 +140,16 @@ func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
 	iptArgs := make([]string, 0, len(ipt.waitArgs)+len(args))
 	iptArgs = append(iptArgs, ipt.waitArgs...)
 	iptArgs = append(iptArgs, args...)
-	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).CombinedOutput(log, false)
-
-	outStr := string(out)
+	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).Output(log, false)
 
 	if err != nil {
-		return outStr, fmt.Errorf("unable to run '%s' iptables command: %s (%w)", fullCommand, outStr, err)
+		return "", fmt.Errorf("unable to run '%s' iptables command: %w", fullCommand, err)
 	}
-
-	return outStr, nil
+	return string(out), nil
 }
 
 func (ipt *ipt) runProg(args []string) error {
-	_, err := ipt.runProgCombinedOutput(args)
+	_, err := ipt.runProgOutput(args)
 	return err
 }
 
@@ -217,7 +214,7 @@ func isDisabledChain(chain string) bool {
 }
 
 func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
 	if err != nil {
 		return err
 	}
@@ -607,7 +604,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 }
 
 func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, match, oldChain, newChain string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
 	if err != nil {
 		return err
 	}
@@ -660,7 +657,7 @@ func (m *IptablesManager) copyProxyRules(oldChain string, match string) error {
 // Redirect packets to the host proxy via TPROXY, as directed by the Cilium
 // datapath bpf programs via skb marks (egress) or DSCP (ingress).
 func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16, ingress bool, name string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-S"})
 	if err != nil {
 		return err
 	}
@@ -886,7 +883,7 @@ func (m *IptablesManager) GetProxyPort(name string) uint16 {
 }
 
 func (m *IptablesManager) doGetProxyPort(prog iptablesInterface, name string) uint16 {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
+	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
 	if err != nil {
 		return 0
 	}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -60,7 +60,7 @@ func (ipt *mockIptables) getVersion() (semver.Version, error) {
 	return semver.Version{}, nil
 }
 
-func (ipt *mockIptables) runProgCombinedOutput(args []string) (out string, err error) {
+func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {
 	a := strings.Join(args, " ")
 	i := ipt.index
 	ipt.index++
@@ -80,7 +80,7 @@ func (ipt *mockIptables) runProgCombinedOutput(args []string) (out string, err e
 }
 
 func (ipt *mockIptables) runProg(args []string) error {
-	out, err := ipt.runProgCombinedOutput(args)
+	out, err := ipt.runProgOutput(args)
 	if len(out) > 0 {
 		ipt.c.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
 	}

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -584,7 +584,7 @@ func (e *etcdClient) renewSession(ctx context.Context) error {
 		return fmt.Errorf("unable to renew etcd session: %s", err)
 	}
 	sessionSuccess <- true
-	log.Infof("Got new lease ID %x", newSession.Lease())
+	log.Infof("Got new lease ID %x and the session TTL is %s", newSession.Lease(), option.Config.KVstoreLeaseTTL)
 
 	e.session = newSession
 	e.sessionCancel = sessionCancel
@@ -737,7 +737,7 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		ls = *lockSession
 		ec.RWMutex.Unlock()
 
-		log.Infof("Got lease ID %x", s.Lease())
+		log.Infof("Got lease ID %x and the session TTL is %s", s.Lease(), option.Config.KVstoreLeaseTTL)
 		log.Infof("Got lock lease ID %x", ls.Lease())
 		close(errorChan)
 	}()


### PR DESCRIPTION
* #20895 -- don't merge stderr into iptable stdout (@liuyuan10)
 * #21006 -- add kvstore TTL flag in cilium-operator (@NikhilSharmaWe)
 * #21052 -- docs: Update ToServices docs section (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20895 21006 21052; do contrib/backporting/set-labels.py $pr done 1.10; done
```