### PR TITLE
v1.11 backports 2022-08-30

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       docs-tree: ${{ steps.docs-tree.outputs.src }}
     steps:
@@ -51,7 +51,7 @@ jobs:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.docs-tree == 'true' }}
     name: Validate & Build HTML
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:

--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -18,7 +18,7 @@ jobs:
   check_changes:
     name: Deduce required tests from code changes
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}
     steps:
@@ -36,7 +36,7 @@ jobs:
   analyze:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.go-changes == 'true' || github.event_name != 'pull_request' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
     steps:

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -253,12 +253,12 @@ accessible from endpoints that have both labels ``env=prod`` and
 Services based
 --------------
 
-Services running in your cluster can be whitelisted in Egress rules.
-Currently Kubernetes `Services without a Selector
+Traffic from pods to services running in your cluster can be allowed via
+``toServices`` statements in Egress rules. Currently Kubernetes
+`Services without a Selector
 <https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors>`_
 are supported when defined by their name and namespace or label selector.
-Future versions of Cilium will support specifying non-Kubernetes services
-and Kubernetes services which are backed by pods.
+For services backed by pods, use `labels based` rules on the backend pod labels.
 
 This example shows how to allow all endpoints with the label ``id=app2``
 to talk to all endpoints of kubernetes service ``myservice`` in kubernetes
@@ -301,6 +301,11 @@ have ``head:none`` set as the label.
 
         .. literalinclude:: ../../examples/policies/l3/service/service-labels.json
 
+Limitations
+~~~~~~~~~~~
+
+``toServices`` statements cannot be combined with ``toPorts`` statements in the
+same rule.
 
 .. _Entities based:
 

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -367,9 +367,14 @@ func synchronizeIdentities() {
 	go identityInformer.Run(wait.NeverStop)
 }
 
-type nodeStub string
+type nodeStub struct {
+	cluster string
+	name    string
+}
 
-func (n nodeStub) GetKeyName() string { return string(n) }
+func (n *nodeStub) GetKeyName() string {
+	return nodeTypes.GetKeyNodeName(n.cluster, n.name)
+}
 
 func updateNode(obj interface{}) {
 	if ciliumNode, ok := obj.(*ciliumv2.CiliumNode); ok {
@@ -389,7 +394,11 @@ func updateNode(obj interface{}) {
 func deleteNode(obj interface{}) {
 	n, ok := obj.(*ciliumv2.CiliumNode)
 	if ok {
-		ciliumNodeStore.DeleteLocalKey(context.Background(), nodeStub(n.Name))
+		n := nodeStub{
+			cluster: cfg.clusterName,
+			name:    n.Name,
+		}
+		ciliumNodeStore.DeleteLocalKey(context.Background(), &n)
 	} else {
 		log.Warningf("Unknown CiliumNode object type %s received: %+v", reflect.TypeOf(obj), obj)
 	}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -584,7 +584,8 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		d.k8sWatcher.NodeChain.Register(&d.k8sWatcher.K8sSvcCache)
 	}
 
-	d.k8sWatcher.NodeChain.Register(watchers.NewCiliumNodeUpdater(d.k8sWatcher, d.nodeDiscovery))
+	// watchers.NewCiliumNodeUpdater needs to be registered *after* d.endpointManager
+	d.k8sWatcher.NodeChain.Register(watchers.NewCiliumNodeUpdater(d.nodeDiscovery))
 
 	d.redirectPolicyManager.RegisterSvcCache(&d.k8sWatcher.K8sSvcCache)
 	d.redirectPolicyManager.RegisterGetStores(d.k8sWatcher)

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -329,5 +329,9 @@ func init() {
 	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")
 	option.BindEnv(operatorOption.SetCiliumIsUpCondition)
 
+	flags.Duration(option.KVstoreLeaseTTL, defaults.KVstoreLeaseTTL, "Time-to-live for the KVstore lease.")
+	flags.MarkHidden(option.KVstoreLeaseTTL)
+	option.BindEnv(option.KVstoreLeaseTTL)
+
 	viper.BindPFlags(flags)
 }

--- a/pkg/command/exec/exec.go
+++ b/pkg/command/exec/exec.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -51,8 +52,14 @@ func output(ctx context.Context, cmd *exec.Cmd, filters []string, scopedLog *log
 		scopedLog.WithError(err).WithField("cmd", cmd.Args).Error("Command execution failed")
 		return nil, fmt.Errorf("Command execution failed for %s: %s", cmd.Args, ctx.Err())
 	}
-	if err != nil && verbose {
-		warnToLog(cmd, filters, out, scopedLog, err)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			err = fmt.Errorf("%w stderr=%q", exitErr, exitErr.Stderr)
+		}
+		if verbose {
+			warnToLog(cmd, filters, out, scopedLog, err)
+		}
 	}
 	return out, err
 }

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -99,9 +99,9 @@ var ciliumChains = []customChain{
 func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 	args := []string{"-t", c.table, "-L", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
-		if strings.Contains(string(output), "No chain/target/match by that name.") {
+		if strings.Contains(err.Error(), "No chain/target/match by that name.") {
 			return false, nil
 		}
 
@@ -114,7 +114,7 @@ func (c *customChain) exists(prog iptablesInterface) (bool, error) {
 func (c *customChain) doAdd(prog iptablesInterface) error {
 	args := []string{"-t", c.table, "-N", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to add %s chain: %s (%w)", c.name, string(output), err)
 	}
@@ -146,7 +146,7 @@ func (c *customChain) doRename(prog iptablesInterface, newName string) error {
 
 	args := []string{"-t", c.table, "-E", c.name, newName}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to rename %s chain to %s: %s (%w)", c.name, newName, string(output), err)
 	}
@@ -178,14 +178,14 @@ func (c *customChain) doRemove(prog iptablesInterface) error {
 
 	args := []string{"-t", c.table, "-F", c.name}
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to flush %s chain: %s (%w)", c.name, string(output), err)
 	}
 
 	args = []string{"-t", c.table, "-X", c.name}
 
-	output, err = prog.runProgCombinedOutput(args)
+	output, err = prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to remove %s chain: %s (%w)", c.name, string(output), err)
 	}
@@ -226,7 +226,7 @@ func (c *customChain) doInstallFeeder(prog iptablesInterface, feedArgs string) e
 
 	args := append([]string{"-t", c.table, installMode, c.hook}, feedRule...)
 
-	output, err := prog.runProgCombinedOutput(args)
+	output, err := prog.runProgOutput(args)
 	if err != nil {
 		return fmt.Errorf("unable to install feeder rule for %s chain: %s (%w)", c.name, string(output), err)
 	}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -81,7 +81,7 @@ type iptablesInterface interface {
 	getProg() string
 	getIpset() string
 	getVersion() (semver.Version, error)
-	runProgCombinedOutput(args []string) (string, error)
+	runProgOutput(args []string) (string, error)
 	runProg(args []string) error
 }
 
@@ -131,7 +131,7 @@ func (ipt *ipt) getVersion() (semver.Version, error) {
 	return versioncheck.Version(vString[1])
 }
 
-func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
+func (ipt *ipt) runProgOutput(args []string) (string, error) {
 	fullCommand := fmt.Sprintf("%s %s", ipt.getProg(), strings.Join(args, " "))
 
 	log.Debugf("Running '%s' command", fullCommand)
@@ -140,19 +140,16 @@ func (ipt *ipt) runProgCombinedOutput(args []string) (string, error) {
 	iptArgs := make([]string, 0, len(ipt.waitArgs)+len(args))
 	iptArgs = append(iptArgs, ipt.waitArgs...)
 	iptArgs = append(iptArgs, args...)
-	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).CombinedOutput(log, false)
-
-	outStr := string(out)
+	out, err := exec.WithTimeout(defaults.ExecTimeout, ipt.prog, iptArgs...).Output(log, false)
 
 	if err != nil {
-		return outStr, fmt.Errorf("unable to run '%s' iptables command: %s (%w)", fullCommand, outStr, err)
+		return "", fmt.Errorf("unable to run '%s' iptables command: %w", fullCommand, err)
 	}
-
-	return outStr, nil
+	return string(out), nil
 }
 
 func (ipt *ipt) runProg(args []string) error {
-	_, err := ipt.runProgCombinedOutput(args)
+	_, err := ipt.runProgOutput(args)
 	return err
 }
 
@@ -217,7 +214,7 @@ func isDisabledChain(chain string) bool {
 }
 
 func (m *IptablesManager) removeCiliumRules(table string, prog iptablesInterface, match string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
 	if err != nil {
 		return err
 	}
@@ -619,7 +616,7 @@ func (m *IptablesManager) installStaticProxyRules() error {
 }
 
 func (m *IptablesManager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, match, oldChain, newChain string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", table, "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
 	if err != nil {
 		return err
 	}
@@ -672,7 +669,7 @@ func (m *IptablesManager) copyProxyRules(oldChain string, match string) error {
 // Redirect packets to the host proxy via TPROXY, as directed by the Cilium
 // datapath bpf programs via skb marks (egress) or DSCP (ingress).
 func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16, ingress bool, name string) error {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-S"})
+	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-S"})
 	if err != nil {
 		return err
 	}
@@ -902,7 +899,7 @@ func (m *IptablesManager) GetProxyPort(name string) uint16 {
 }
 
 func (m *IptablesManager) doGetProxyPort(prog iptablesInterface, name string) uint16 {
-	rules, err := prog.runProgCombinedOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
+	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-n", "-L", ciliumPreMangleChain})
 	if err != nil {
 		return 0
 	}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -55,7 +55,7 @@ func (ipt *mockIptables) getVersion() (semver.Version, error) {
 	return semver.Version{}, nil
 }
 
-func (ipt *mockIptables) runProgCombinedOutput(args []string) (out string, err error) {
+func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {
 	a := strings.Join(args, " ")
 	i := ipt.index
 	ipt.index++
@@ -75,7 +75,7 @@ func (ipt *mockIptables) runProgCombinedOutput(args []string) (out string, err e
 }
 
 func (ipt *mockIptables) runProg(args []string) error {
-	out, err := ipt.runProgCombinedOutput(args)
+	out, err := ipt.runProgOutput(args)
 	if len(out) > 0 {
 		ipt.c.Errorf("%d: Unexpected output for %s %s", ipt.index-1, ipt.prog, strings.Join(args, " "))
 	}

--- a/pkg/endpointmanager/host.go
+++ b/pkg/endpointmanager/host.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node"
 
 	v1 "k8s.io/api/core/v1"
 )
@@ -51,6 +52,8 @@ func (mgr *EndpointManager) OnUpdateNode(oldNode, newNode *v1.Node,
 		log.Error("Host endpoint not found")
 		return nil
 	}
+
+	node.SetLabels(newNodeLabels)
 
 	err := nodeEP.UpdateLabelsFrom(oldNodeLabels, newNodeLabels, labels.LabelSourceK8s)
 	if err != nil {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -394,6 +394,14 @@ func updateCiliumEndpointLabels(ep *endpoint.Endpoint, labels map[string]string)
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) (err error) {
 				pod := ep.GetPod()
+				if pod == nil {
+					err := errors.New("Skipping CiliumEndpoint update because it has no k8s pod")
+					scopedLog.WithFields(logrus.Fields{
+						logfields.EndpointID: ep.GetID(),
+						logfields.Labels:     logfields.Repr(labels),
+					}).Debug(err)
+					return err
+				}
 				ciliumClient := k8s.CiliumClient().CiliumV2()
 
 				replaceLabels := []k8s.JSONPatch{

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -571,7 +571,7 @@ func (e *etcdClient) renewSession(ctx context.Context) error {
 		return fmt.Errorf("unable to renew etcd session: %s", err)
 	}
 	sessionSuccess <- true
-	log.Infof("Got new lease ID %x", newSession.Lease())
+	log.Infof("Got new lease ID %x and the session TTL is %s", newSession.Lease(), option.Config.KVstoreLeaseTTL)
 
 	e.session = newSession
 	e.sessionCancel = sessionCancel
@@ -724,7 +724,7 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		ls = *lockSession
 		ec.RWMutex.Unlock()
 
-		log.Infof("Got lease ID %x", s.Lease())
+		log.Infof("Got lease ID %x and the session TTL is %s", s.Lease(), option.Config.KVstoreLeaseTTL)
 		log.Infof("Got lock lease ID %x", ls.Lease())
 		close(errorChan)
 	}()

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -59,12 +59,6 @@ type k8sNodeGetter interface {
 	GetK8sNode(ctx context.Context, nodeName string) (*corev1.Node, error)
 }
 
-// The KVStoreNodeUpdater interface is used to provide an abstraction for the
-// NodeStore object logic used to update a node entry in the KV store.
-type KVStoreNodeUpdater interface {
-	UpdateKVNodeEntry(node *nodeTypes.Node) error
-}
-
 // NodeDiscovery represents a node discovery action
 type NodeDiscovery struct {
 	Manager               *nodemanager.Manager
@@ -435,6 +429,9 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 
 	nodeResource.ObjectMeta.Labels = k8sNodeParsed.Labels
 
+	localCN := n.localNode.ToCiliumNode()
+	nodeResource.ObjectMeta.Annotations = localCN.Annotations
+
 	for _, k8sAddress := range k8sNodeAddresses {
 		k8sAddressStr := k8sAddress.IP.String()
 		nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
@@ -662,20 +659,4 @@ func (n *NodeDiscovery) RegisterK8sNodeGetter(k8sNodeGetter k8sNodeGetter) {
 
 func getInt(i int) *int {
 	return &i
-}
-
-func (nodeDiscovery *NodeDiscovery) UpdateKVNodeEntry(node *nodeTypes.Node) error {
-	if nodeDiscovery.Registrar.SharedStore == nil {
-		return nil
-	}
-
-	if err := nodeDiscovery.Registrar.UpdateLocalKeySync(node); err != nil {
-		return fmt.Errorf("failed to update KV node store entry: %w", err)
-	}
-
-	if err := nodeDiscovery.mutateNodeResource(node.ToCiliumNode()); err != nil {
-		return fmt.Errorf("failed to mutate node resource: %w", err)
-	}
-
-	return nil
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2762,6 +2762,9 @@ func (c *DaemonConfig) Populate() {
 
 	if c.TunnelPort == 0 {
 		switch c.Tunnel {
+		case TunnelDisabled:
+			// tunnel might still be used by eg. EgressGW
+			c.TunnelPort = defaults.TunnelPortVXLAN
 		case TunnelVXLAN:
 			c.TunnelPort = defaults.TunnelPortVXLAN
 		case TunnelGeneve:


### PR DESCRIPTION
* #20865 -- k8s/watchers: fix panic in CiliumEndpoint labels update (jaffcheng)
 * #20895 -- don't merge stderr into iptable stdout (liuyuan10)
 * #21015 -- gh/workflows: stop using ubuntu-18.04 runner (@julianwiedmann)
 * #20780 -- datapath: avoid delete/add flap for cilium_vxlan on startup (@julianwiedmann)
 * #21006 -- add kvstore TTL flag in cilium-operator (NikhilSharmaWe)
 * #21078 -- clustermesh-apiserver: fix key name for delete during k8s->kvstore sync (@tklauser)
 * #21052 -- docs: Update ToServices docs section (@joestringer)
 * #21087 -- pkg/endpoint: set labels for local node from k8s events (@aanm)
 * #21080 -- pkg/k8s: fix node update sync from k8s to kvstore (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20865 20895 21015 20780 21006 21078 21052 21087 21080; do contrib/backporting/set-labels.py $pr done 1.11; done
```