### PR TITLE
datapath: tolerate missing ifaces when setting rp_filter sysctl

### DIFF
--- a/tools/sysctlfix/main.go
+++ b/tools/sysctlfix/main.go
@@ -38,8 +38,8 @@ var (
 
 var sysctlConfig = `
 # Disable rp_filter on Cilium interfaces since it may cause mangled packets to be dropped
-net.ipv4.conf.lxc*.rp_filter = 0
-net.ipv4.conf.cilium_*.rp_filter = 0
+-net.ipv4.conf.lxc*.rp_filter = 0
+-net.ipv4.conf.cilium_*.rp_filter = 0
 # The kernel uses max(conf.all, conf.{dev}) as its value, so we need to set .all. to 0 as well.
 # Otherwise it will overrule the device specific settings.
 net.ipv4.conf.all.rp_filter = 0


### PR DESCRIPTION
At the point where systemd-sysctl applies our rp_filter settings, the host
might not have any cilium_* and/or lxc_* interfaces yet. But systemd-sysctl
treats the failure to resolve these globs as an hard error:

  systemd-sysctl[9354]: Couldn't resolve glob 'net/ipv4/conf/lxc*/rp_filter': No such file or directory
  systemd[1]: systemd-sysctl.service: Main process exited, code=exited, status=1/FAILURE
  systemd[1]: systemd-sysctl.service: Failed with result 'exit-code'.

Adding the `-` option makes systemd-sysctl tolerate such errors.

```release-note
When systemd-sysctl sets the rp_filter sysctl, tolerate missing lxc_* / cilium_* interfaces.
```
