### PR TITLE
images: Fix image build for qemu workflow

### DIFF
--- a/images/cilium-test/Dockerfile
+++ b/images/cilium-test/Dockerfile
@@ -37,7 +37,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
   env GOARCH=arm64 CC=aarch64-linux-gnu-gcc \
     /out/linux/amd64/usr/local/bin/ginkgo build ./ && mv test.test /out/linux/arm64/usr/local/bin/cilium-test
 
-FROM scratch
+FROM scratch as release
 ARG TARGETPLATFORM
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=rootfs / /


### PR DESCRIPTION
This image doesn't really have a "release" version so the earlier commit
that added release targets didn't add the target here. However, the CI
workflows expect that all the dockerfiles have a release target now. We
could make a special case in the workflows, but that might get broken
again in future. Instead, just add a 'release' target to the final image
defined in the dockerfile here.

Fixes: fdf4f7ee3ed1 ("images: Name final docker target as 'release'")
Reported-by: Nicolas Busseneau <nicolas@isovalent.com>
