### PR TITLE
Create a composite action to define environment variables

### DIFF
--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -1,0 +1,9 @@
+name: Set environment variables
+description: Set environment variables
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        echo "QUAY_ORGANIZATION=cilium" >> $GITHUB_ENV
+        echo "QUAY_ORGANIZATION_DEV=cilium" >> $GITHUB_ENV


### PR DESCRIPTION
This makes it easier to share common environment variables across
workflows. To use this action, you can add a step like this:

    - name: Set Environment Variables
      uses: ./.github/actions/set-env-variables

In https://github.com/cilium/cilium/pull/21110 I attempted to use
secrets for this purpose, but secrets are not available for pull
requests from users without write access to cilium/cilium repo.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

```release-note
Create a composite action to define environment variables
```
