### PR TITLE
Update wrk2 repository

### DIFF
--- a/test/k8sT/manifests/http-clients.yaml
+++ b/test/k8sT/manifests/http-clients.yaml
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
       - name: http-client
-        image: quay.io/isovalent/wrk2:1.0
+        image: quay.io/isovalent-dev/wrk2:1.0
         ports:
         - containerPort: 80


### PR DESCRIPTION
It's been moved to quay.io/isovalent-dev/wrk2.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>