### PR TITLE
hive: Make cell config decoding strict

### DIFF
--- a/pkg/hive/cell.go
+++ b/pkg/hive/cell.go
@@ -35,6 +35,7 @@ type Cell struct {
 	registerFlags func(*pflag.FlagSet)
 	name          string
 	opts          []fx.Option
+	flags         []string // Flags registered for the cell. Populated after call to registerFlags().
 }
 
 // NewCell constructs a new cell with the given name and options.


### PR DESCRIPTION
To keep things clean, this enforces that:

- All flags declared by CellFlags() must be used in the config struct
- Fields in the config struct must have a matching flag in CellFlags().
- The fields are populated only from flags declared by CellFlags().

For example:
```
type MyConfig struct {
  Bar string
}

func (MyConfig) CellFlags(flags *pflag.FlagSet) {
  flags.String("foo", "", "foo flag")
}
```

The above has two errors, "Bar" does not match with any declared flag, and "foo" does not
match with any field in MyConfig.