### PR TITLE
Documention: fix crd-compat-table script

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-dst_file="${PWD}/$(basename ${dir})/concepts/kubernetes/compatibility-table.rst"
+dst_file="${PWD}/$(basename ${dir})/network/kubernetes/compatibility-table.rst"
 
 . "${dir}/../contrib/backporting/common.sh"
 remote="$(get_remote)"


### PR DESCRIPTION
The file was moved but the script path was not updated which is
preventing the release script from function properly.

Fixes: 05252d181074 ("docs: Update Networking, Contributor Guides and Reference sections")
Signed-off-by: André Martins <andre@cilium.io>