### PR TITLE
add BGP route injection

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -63,6 +63,11 @@ The policy in ``yaml`` form is defined below:
       neighbors: # []CiliumBGPNeighbor
        - peerAddress: 'fc00:f853:ccd:e793::50/128'
          peerASN: 64512
+      additionalRoutes: # []CiliumBGPAdditionalRoutes
+      - afi: ipv4
+        safi: unicast
+        cidrs:
+        - '10.0.10.0/24'
 
 Fields
 ^^^^^^
@@ -82,6 +87,11 @@ Fields
        virtualRouters[*].neighbors: A list of neighbors to peer with
            neighbors[*].peerAddress: The address of the peer neighbor
            neighbors[*].peerASN: The ASN of the peer
+
+       virtualRouters[*].additionalRoutes: Additional user-specified routes for announcement
+           neighbors[*].additionalRoutes.afi: One of 'ipv4' or 'ipv6'
+           neighbors[*].additionalRoutes.safi: 'unicast'
+           neighbors[*].additionalRoutes.cidrs: List of cidrs to be announced
 
 .. note::
 

--- a/pkg/bgpv1/gobgp/server.go
+++ b/pkg/bgpv1/gobgp/server.go
@@ -64,6 +64,8 @@ type ServerWithConfig struct {
 	PodCIDRAnnouncements []Advertisement
 	// Holds any announced Service routes.
 	ServiceAnnouncements map[resource.Key][]Advertisement
+	// Holds additional user-specified routes
+	AdditionalRoutes []Advertisement
 }
 
 // NewServerWithConfig will start an underlying BgpServer utilizing startReq
@@ -102,6 +104,7 @@ func NewServerWithConfig(ctx context.Context, startReq *gobgp.StartBgpRequest) (
 		Config:               nil,
 		PodCIDRAnnouncements: []Advertisement{},
 		ServiceAnnouncements: make(map[resource.Key][]Advertisement),
+		AdditionalRoutes:     []Advertisement{},
 	}, nil
 }
 

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	gobgp "github.com/osrg/gobgp/v3/api"
 )
 
 // +genclient
@@ -107,4 +108,43 @@ type CiliumBGPVirtualRouter struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
 	Neighbors []CiliumBGPNeighbor `json:"neighbors"`
+	// AdditionalRoutes is a list of BGP Routes to be announced for this virtual router
+	//
+	// +kubebuilder:validation:Optional
+	AdditionalRoutes []CiliumBGPAdditionalRoutes `json:"additionalRoutes,omitempty"`
+}
+
+// these should likely be merged with gobgp.GoBGPIPv{4,6}Family
+// but are used slightly differently for CiliumBGPAdditionalRoutes
+var (
+	FamilyAfiMap = map[string]gobgp.Family_Afi{
+		"ipv4": gobgp.Family_AFI_IP,
+		"ipv6": gobgp.Family_AFI_IP6,
+	}
+
+	FamilySafiMap = map[string]gobgp.Family_Safi{
+		"unicast": gobgp.Family_SAFI_UNICAST,
+	}
+)
+
+// CiliumBGPAdditionalRoutes defines a manually injected route
+type CiliumBGPAdditionalRoutes struct {
+	// AFI is the Address Family Indicator, one of 'ipv4' or 'ipv6'
+	//
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=ipv4;ipv6
+	AFI string `json:"afi"`
+
+	// SAFI is the Subsequent Address Family Indicator, currently only 'unicast' is supported
+	//
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=unicast
+	SAFI string `json:"safi"`
+
+	// CIDRs is a list of Routes to be advertised
+	//
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Format=cidr
+	// +kubebuilder:validation:MinItems=1
+	CIDRs []string `json:"cidrs"`
 }


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.

<!-- Description of change -->

This allows the user the ability to advertise routes where the LoadBalancer pattern is not desired.  Additionally, allows the user to advertise ClusterIPs in cases where non-kubernetes workloads must access the cluster.
```release-note
Allow injecting routes to BGP control plane announcements.
```
