### PR TITLE
docs: Remove RancherOS

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -66,7 +66,6 @@ LinuxKit_                  all
 `RedHat Enterprise Linux`_ >= 8.0
 Ubuntu_                    >= 16.04.1 (Azure), >= 16.04.2 (Canonical), >= 16.10
 Opensuse_                  Tumbleweed, >=Leap 15.0
-RancherOS_                 >= 1.5.5
 ========================== ====================
 
 .. _Amazon Linux 2: https://aws.amazon.com/amazon-linux-2/
@@ -79,7 +78,6 @@ RancherOS_                 >= 1.5.5
 .. _RedHat Enterprise Linux: https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux
 .. _Ubuntu: https://wiki.ubuntu.com/YakketyYak/ReleaseNotes#Linux_kernel_4.8
 .. _Opensuse: https://www.opensuse.org/
-.. _RancherOS: https://rancher.com/rancher-os/
 
 .. [#centos_foot] CentOS 7 requires a third-party kernel provided by `ElRepo <http://elrepo.org/tiki/tiki-index.php>`_
     whereas CentOS 8 ships with a supported kernel. Note that some more advanced features may not be available on CentOS 7 even with a third-party kernel. For full details on which kernel config options must be enabled in order to use various features, see the section on :ref:`admin_kernel_version` requirements below.


### PR DESCRIPTION
RancherOS is now in "maintain-only-as-essential" mode, no longer
actively maintained. The URL here is a dead link. Reference:

https://rancher.com/docs/os/v1.x/en/support/
