### PR TITLE
ip: Add a helper to assist net.IP -> netip.Addr conversion

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"fmt"
 	"net"
-	"net/netip"
 	"os"
 	"strings"
 	"time"
@@ -27,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
+	ippkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -293,7 +293,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 }
 
 func (d *Daemon) sourceByIP(ip net.IP, defaultSrc source.Source) source.Source {
-	if addr, ok := netip.AddrFromSlice(ip); ok {
+	if addr, ok := ippkg.AddrFromIP(ip); ok {
 		lbls := d.ipcache.GetIDMetadataByIP(addr)
 		if lbls.Has(labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer]) {
 			return source.KubeAPIServer

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -49,11 +49,14 @@ func PrefixToIPNet(prefix netip.Prefix) *net.IPNet {
 // IPNetToPrefix is a convenience helper for migrating from the older 'net'
 // standard library types to the newer 'netip' types. Use this to plug the
 // new types in newer code into older types in older code during the migration.
+//
+// Note: This function assumes given prefix.IP is not an IPv4 mapped IPv6
+// address. See the comment of AddrFromIP for more details.
 func IPNetToPrefix(prefix *net.IPNet) netip.Prefix {
 	if prefix == nil {
 		return netip.Prefix{}
 	}
-	ip, ok := netip.AddrFromSlice(prefix.IP)
+	ip, ok := AddrFromIP(prefix.IP)
 	if !ok {
 		return netip.Prefix{}
 	}
@@ -69,12 +72,10 @@ func IPNetToPrefix(prefix *net.IPNet) netip.Prefix {
 // standard library types to the newer 'netip' types. Use this to plug the new
 // types in newer code into older types in older code during the migration.
 //
-// Note: This function assumes that the result of net.IP.To4() or net.IP.To16()
-// are passed in. This is because the net package always creates net.IP with a
-// length of 16 (IPv6) which causes this function to return an IPv6
-// netip.Prefix.
+// Note: This function assumes given ip is not an IPv4 mapped IPv6 address.
+// See the comment of AddrFromIP for more details.
 func IPToNetPrefix(ip net.IP) netip.Prefix {
-	a, ok := netip.AddrFromSlice(ip)
+	a, ok := AddrFromIP(ip)
 	if !ok {
 		return netip.Prefix{}
 	}

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"math/big"
 	"net"
+	"net/netip"
 	"sort"
 )
 
@@ -917,4 +918,29 @@ func GetIPFromListByFamily(ipList []net.IP, v4Family bool) net.IP {
 	}
 
 	return nil
+}
+
+// AddrFromIP converts a net.IP to netip.Addr using netip.AddrFromSlice, but preserves
+// the original address family. It assumes given net.IP is not an IPv4 mapped IPv6
+// address.
+//
+// The problem behind this is that when we convert the IPv4 net.IP address with
+// netip.AddrFromSlice, the address is interpreted as an IPv4 mapped IPv6 address in some
+// cases.
+//
+// For example, when we do netip.AddrFromSlice(net.ParseIP("1.1.1.1")), it is interpreted
+// as an IPv6 address "::ffff:1.1.1.1". This is because 1) net.IP created with
+// net.ParseIP(IPv4 string) holds IPv4 address as an IPv4 mapped IPv6 address internally
+// and 2) netip.AddrFromSlice recognizes address family with length of the slice (4-byte =
+// IPv4 and 16-byte = IPv6).
+//
+// By using AddrFromIP, we can preserve the address family, but since we cannot distinguish
+// IPv4 and IPv4 mapped IPv6 address only from net.IP value (see #37921 on golang/go) we
+// need an assumption that given net.IP is not an IPv4 mapped IPv6 address.
+func AddrFromIP(ip net.IP) (netip.Addr, bool) {
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return addr, ok
+	}
+	return addr.Unmap(), ok
 }

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"math/rand"
 	"net"
+	"net/netip"
 	"sort"
 	"testing"
 
@@ -912,5 +913,41 @@ func (s *IPTestSuite) TestGetIPAtIndex(c *C) {
 			c.Errorf("GetIPAtIndex() = %v, want %v", got, tt.want)
 		}
 
+	}
+}
+
+func (s *IPTestSuite) TestAddrFromIP(c *C) {
+	type args struct {
+		ip       net.IP
+		wantAddr netip.Addr
+		wantOk   bool
+	}
+
+	tests := []args{
+		{
+			net.ParseIP("10.0.0.1"),
+			netip.MustParseAddr("10.0.0.1"),
+			true,
+		},
+		{
+			net.ParseIP("a::1"),
+			netip.MustParseAddr("a::1"),
+			true,
+		},
+		{
+			net.ParseIP("::ffff:10.0.0.1"),
+			netip.MustParseAddr("10.0.0.1"),
+			true,
+		},
+	}
+	for _, tt := range tests {
+		addr, ok := AddrFromIP(tt.ip)
+		if ok != tt.wantOk {
+			c.Errorf("AddrFromIP(net.IP(%v)) should success", []byte(tt.ip))
+		}
+
+		if addr != tt.wantAddr {
+			c.Errorf("AddrFromIP(net.IP(%v)) = %v want %v", []byte(tt.ip), addr, tt.wantAddr)
+		}
 	}
 }

--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
 )
 
@@ -94,7 +95,7 @@ func GetCIDRLabels(cidr *net.IPNet) labels.Labels {
 	// to generate the set of prefixes starting from the /0 up to the
 	// specified prefix length.
 	if ones > 0 {
-		ip, _ := netip.AddrFromSlice(cidr.IP)
+		ip, _ := ip.AddrFromIP(cidr.IP)
 		for i := 0; i <= ones; i++ {
 			prefix := netip.PrefixFrom(ip, i)
 			label := maskedIPToLabelString(prefix.Masked().Addr(), i)

--- a/test/controlplane/services/helpers/lbmap_validation.go
+++ b/test/controlplane/services/helpers/lbmap_validation.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/netip"
 	"os"
 	"sort"
 	"strconv"
@@ -20,6 +19,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/ip"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/testutils/mockmaps"
 	"github.com/cilium/cilium/test/controlplane/suite"
@@ -78,8 +78,8 @@ func diffStrings(file string, expected, actual string) (string, bool) {
 }
 
 func ipLess(a, b net.IP) bool {
-	nipA, _ := netip.AddrFromSlice(a)
-	nipB, _ := netip.AddrFromSlice(b)
+	nipA, _ := ip.AddrFromIP(a)
+	nipB, _ := ip.AddrFromIP(b)
 	return nipA.Compare(nipB) < 0
 }
 


### PR DESCRIPTION
Please see the commits for more details.

```release-note
Add a helper to assist net.IP -> netip.Addr conversion
```
