### PR TITLE
hive: Add Validate to CellConfig

### DIFF
--- a/pkg/gops/cell.go
+++ b/pkg/gops/cell.go
@@ -20,8 +20,9 @@ import (
 
 // Gops runs the gops agent, a tool to list and diagnose Go processes.
 // See https://github.com/google/gops.
-var Cell = hive.NewCellWithConfig[GopsConfig](
+var Cell = hive.NewCellWithConfig(
 	"gops",
+	GopsConfig{},
 	fx.Invoke(registerGopsHooks),
 )
 
@@ -29,8 +30,12 @@ type GopsConfig struct {
 	GopsPort uint16 // Port for gops server to listen on
 }
 
-func (GopsConfig) CellFlags(flags *pflag.FlagSet) {
+func (GopsConfig) Flags(flags *pflag.FlagSet) {
 	flags.Uint16(option.GopsPort, defaults.GopsPortAgent, "Port for gops server to listen on")
+}
+
+func (GopsConfig) Validate() error {
+	return nil
 }
 
 func registerGopsHooks(lc fx.Lifecycle, log logrus.FieldLogger, cfg GopsConfig) {

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -3,23 +3,30 @@
 
 //go:build !privileged_tests
 
-package hive
+package hive_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/fx"
+
+	"github.com/cilium/cilium/pkg/hive"
 )
 
 type Config struct {
 	Hello string
 }
 
-func (Config) CellFlags(flags *pflag.FlagSet) {
+func (Config) Flags(flags *pflag.FlagSet) {
 	flags.String("hello", "hello world", "sets the greeting")
+}
+
+func (Config) Validate() error {
+	return nil
 }
 
 func TestHive(t *testing.T) {
@@ -27,12 +34,13 @@ func TestHive(t *testing.T) {
 	viper := viper.New()
 
 	var cfg Config
-	cell := NewCellWithConfig[Config](
+	cell := hive.NewCellWithConfig(
 		"test-cell",
+		Config{},
 		fx.Populate(&cfg),
 	)
 
-	hive := New(viper, flags, cell)
+	hive := hive.New(viper, flags, cell)
 
 	flags.Set("hello", "test")
 
@@ -64,8 +72,12 @@ type BadConfig struct {
 	Bar string
 }
 
-func (BadConfig) CellFlags(flags *pflag.FlagSet) {
+func (BadConfig) Flags(flags *pflag.FlagSet) {
 	flags.String("foo", "foobar", "foo")
+}
+
+func (BadConfig) Validate() error {
+	return nil
 }
 
 func TestHiveBadConfig(t *testing.T) {
@@ -73,21 +85,104 @@ func TestHiveBadConfig(t *testing.T) {
 	viper := viper.New()
 
 	var cfg BadConfig
-	cell := NewCellWithConfig[BadConfig](
+	cell := hive.NewCellWithConfig(
 		"test-cell",
+		BadConfig{},
 		fx.Populate(&cfg),
 	)
 
-	hive := New(viper, flags, cell)
+	hive := hive.New(viper, flags, cell)
 	_, err := hive.TestApp(t)
 	if err == nil {
 		t.Fatal("Expected TestApp() to fail")
 	}
 
-	if !strings.Contains(err.Error(), "has invalid keys: foo") {
-		t.Fatalf("Expected 'invalid keys' error, got: %s", err)
+	if !strings.Contains(err.Error(), ": Bar") {
+		t.Fatalf("Expected 'unused keys' error, got: %s", err)
 	}
-	if !strings.Contains(err.Error(), "has unset fields: Bar") {
+	if !strings.Contains(err.Error(), ": foo") {
 		t.Fatalf("Expected 'unset fields' error, got: %s", err)
+	}
+}
+
+type BadConfig2 struct {
+	Foo string
+}
+
+func (BadConfig2) Flags(flags *pflag.FlagSet) {
+	flags.String("foo", "foobar", "foo")
+}
+
+var validateErr = errors.New("fail")
+
+func (BadConfig2) Validate() error {
+	return validateErr
+}
+
+func TestHiveValidateConfig(t *testing.T) {
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	viper := viper.New()
+
+	var cfg BadConfig2
+	cell := hive.NewCellWithConfig(
+		"test-cell",
+		BadConfig2{},
+		fx.Populate(&cfg),
+	)
+
+	hive := hive.New(viper, flags, cell)
+	_, err := hive.TestApp(t)
+	if err == nil {
+		t.Fatal("Expected TestApp() to fail")
+	}
+
+	if !errors.Is(err, validateErr) {
+		t.Fatalf("Expected config validation error, got: %s", err)
+	}
+}
+
+type MutConfig struct {
+	Foo int
+
+	derivedFoo int
+}
+
+func (m *MutConfig) GetDerived() int {
+	return m.derivedFoo
+}
+
+func (*MutConfig) Flags(flags *pflag.FlagSet) {
+	flags.Int("foo", 0, "foo")
+}
+
+func (m *MutConfig) Validate() error {
+	m.Foo = 123
+	m.derivedFoo = m.Foo * 2
+	return nil
+}
+
+func TestHiveValidateMutates(t *testing.T) {
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	viper := viper.New()
+
+	var cfg MutConfig
+	cell := hive.NewCellWithConfig(
+		"test-cell",
+		&MutConfig{},
+		fx.Populate(&cfg),
+	)
+
+	hive := hive.New(viper, flags, cell)
+	_, err := hive.TestApp(t)
+	if err != nil {
+		t.Fatalf("Expected TestApp() to succeed, got %s", err)
+	}
+
+	if cfg.Foo != 123 {
+		t.Fatalf("expected Foo=123, got Foo=%d", cfg.Foo)
+	}
+
+	if cfg.GetDerived() != 246 {
+		t.Fatalf("expected derivedFoo=246, got %d", cfg.GetDerived())
 	}
 }


### PR DESCRIPTION
To support validation and modification of configurations, this commit
extends CellConfig interface with Validate() and adapts the cell
constructors to allow implementing Validate() as a pointer receiver.

CellFlags is renamed to just Flags.

I tried bunch of approaches to getting Validate as pointer receiver
working. Using a type parameter works, but requires rather ugly
constraints: `[T CellConfig, P interface { *T; CellConfigValidator }]`,
so I ended up with just passing the value in and reflecting on it to
figure out whether it's a struct or pointer to a struct.

This way we can implement a mutating Validate that populates private
fields by implementing it as pointer receiver and passing a pointer to the config:
```
type MyConfig struct {
  Foo int
  twoFoo int
}
func (*MyConfig) Flags(flags *pflag.FlagSet) { ... }

func (m *MyConfig) Validate() error {
  m.Foo += m.Foo
  m.twoFoo = m.Foo * 2
  return nil
}

func (m *MyConfig) TwoFoo() int {
  return m.twoFoo
}

var myConfigCell = hive.NewConfigCell(&MyConfig{})
```

This is useful when pflags does not provide the parsing primitives out of the box
for a specific option.
