### PR TITLE
contrib/cherry-pick: parameterize the source branch

### DIFF
--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -7,6 +7,7 @@ require_linux
 
 ORG=${ORG:-"cilium"}
 REPO=${REPO:-"cilium"}
+BRANCH=${BRANCH:-"master"}
 
 cleanup () {
   if [ -n "$TMPF" ]; then
@@ -18,8 +19,8 @@ trap cleanup EXIT
 
 cherry_pick () {
   CID=$1
-  if ! commit_in_upstream "$CID" "master" "${ORG}" "${REPO}"; then
-    echo "Commit $CID not in $REM/master!"
+  if ! commit_in_upstream "$CID" "$BRANCH" "${ORG}" "${REPO}"; then
+    echo "Commit $CID not in $REM/$BRANCH!"
     exit 1
   fi
   TMPF=`mktemp cp.XXXXXX`


### PR DESCRIPTION
In rare cases we want to cherry-pick a branch-specific fix that doesn't
have an upstream equivalent. Improve the cherry-pick script to allow such
usage:

ORG=... REPO=... BRANCH=... ./contrib/backporting/cherry-pick $SHA