### PR TITLE
operator: update CiliumNode in kvstore without lease

### DIFF
--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -136,7 +136,7 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 			},
 			func(node *cilium_v2.CiliumNode) {
 				nodeNew := nodeTypes.ParseCiliumNode(node)
-				ciliumNodeKVStore.UpdateKeySync(ctx, &nodeNew)
+				ciliumNodeKVStore.UpdateKeySync(ctx, &nodeNew, false)
 			})
 	}
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1400,9 +1400,7 @@ func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, 
 	}
 
 	if lease {
-		e.RWMutex.RLock()
-		leaseID := e.session.Lease()
-		e.RWMutex.RUnlock()
+		leaseID := e.GetSessionLeaseID()
 		if getR.Kvs[0].Lease != int64(leaseID) {
 			return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
 		}
@@ -1434,9 +1432,7 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 		return true, e.Update(ctx, key, value, lease)
 	}
 	if lease {
-		e.RWMutex.RLock()
-		leaseID := e.session.Lease()
-		e.RWMutex.RUnlock()
+		leaseID := e.GetSessionLeaseID()
 		if getR.Kvs[0].Lease != int64(leaseID) {
 			return true, e.Update(ctx, key, value, lease)
 		}

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -364,8 +364,8 @@ func (s *SharedStore) UpdateLocalKeySync(ctx context.Context, key LocalKey) erro
 }
 
 // UpdateKeySync synchronously synchronizes a key with the kvstore.
-func (s *SharedStore) UpdateKeySync(ctx context.Context, key LocalKey) error {
-	return s.syncLocalKey(ctx, key, true)
+func (s *SharedStore) UpdateKeySync(ctx context.Context, key LocalKey, lease bool) error {
+	return s.syncLocalKey(ctx, key, lease)
 }
 
 // DeleteLocalKey removes a key from being synchronized with the kvstore

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -213,7 +213,7 @@ func JoinSharedStore(c Configuration) (*SharedStore, error) {
 	controllers.UpdateController(s.controllerName,
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				return s.syncLocalKeys(ctx)
+				return s.syncLocalKeys(ctx, true)
 			},
 			RunInterval: s.conf.SynchronizationInterval,
 		},
@@ -277,15 +277,15 @@ func (s *SharedStore) keyPath(key NamedKey) string {
 }
 
 // syncLocalKey synchronizes a key to the kvstore
-func (s *SharedStore) syncLocalKey(ctx context.Context, key LocalKey) error {
+func (s *SharedStore) syncLocalKey(ctx context.Context, key LocalKey, lease bool) error {
 	jsonValue, err := key.Marshal()
 	if err != nil {
 		return err
 	}
 
-	// Update key in kvstore, overwrite an eventual existing key, attach
+	// Update key in kvstore, overwrite an eventual existing key. If requested, attach
 	// lease to expire entry when agent dies and never comes back up.
-	if _, err := s.backend.UpdateIfDifferent(ctx, s.keyPath(key), jsonValue, true); err != nil {
+	if _, err := s.backend.UpdateIfDifferent(ctx, s.keyPath(key), jsonValue, lease); err != nil {
 		return err
 	}
 
@@ -293,7 +293,7 @@ func (s *SharedStore) syncLocalKey(ctx context.Context, key LocalKey) error {
 }
 
 // syncLocalKeys synchronizes all local keys with the kvstore
-func (s *SharedStore) syncLocalKeys(ctx context.Context) error {
+func (s *SharedStore) syncLocalKeys(ctx context.Context, lease bool) error {
 	// Create a copy of all local keys so we can unlock and sync to kvstore
 	// without holding the lock
 	s.mutex.RLock()
@@ -304,7 +304,7 @@ func (s *SharedStore) syncLocalKeys(ctx context.Context) error {
 	s.mutex.RUnlock()
 
 	for _, key := range keys {
-		if err := s.syncLocalKey(ctx, key); err != nil {
+		if err := s.syncLocalKey(ctx, key, lease); err != nil {
 			return err
 		}
 	}
@@ -356,7 +356,7 @@ func (s *SharedStore) SharedKeysMap() map[string]Key {
 func (s *SharedStore) UpdateLocalKeySync(ctx context.Context, key LocalKey) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	err := s.syncLocalKey(ctx, key)
+	err := s.syncLocalKey(ctx, key, true)
 	if err == nil {
 		s.localKeys[key.GetKeyName()] = key.DeepKeyCopy()
 	}
@@ -365,7 +365,7 @@ func (s *SharedStore) UpdateLocalKeySync(ctx context.Context, key LocalKey) erro
 
 // UpdateKeySync synchronously synchronizes a key with the kvstore.
 func (s *SharedStore) UpdateKeySync(ctx context.Context, key LocalKey) error {
-	return s.syncLocalKey(ctx, key)
+	return s.syncLocalKey(ctx, key, true)
 }
 
 // DeleteLocalKey removes a key from being synchronized with the kvstore
@@ -480,7 +480,7 @@ func (s *SharedStore) watcher(listDone chan struct{}) {
 			if localKey := s.lookupLocalKey(keyName); localKey != nil {
 				logger.Warning("Received delete event for local key. Re-creating the key in the kvstore")
 
-				s.syncLocalKey(s.conf.Context, localKey)
+				s.syncLocalKey(s.conf.Context, localKey, true)
 			} else {
 				s.deleteSharedKey(keyName)
 			}

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -350,13 +350,6 @@ func (s *SharedStore) SharedKeysMap() map[string]Key {
 	return sharedKeysCopy
 }
 
-// UpdateLocalKey adds a key to be synchronized with the kvstore
-func (s *SharedStore) UpdateLocalKey(key LocalKey) {
-	s.mutex.Lock()
-	s.localKeys[key.GetKeyName()] = key.DeepKeyCopy()
-	s.mutex.Unlock()
-}
-
 // UpdateLocalKeySync synchronously synchronizes a local key with the kvstore
 // and adds it to the list of local keys to be synchronized if the initial
 // synchronous synchronization was successful


### PR DESCRIPTION
The first three commits are cleanups and refactoring in preparation for the 4th commit which contains the actual change:

Under normal circumstances, the agents should keep their own CiliumNode
up to date in the kvstore. In case of an agent restarting or otherwise
failing to renew the lease, the operator's sync logic might take over
and update the key with its own lease. This could lead to problems when
the respective agent comes back up and tries to renew the lease for its
own CiliumNode entry. To prevent this situation, let the operator
k8s->kvstore sync logic for CiliumNodes update the entries without
taking a lease.