### PR TITLE
eni: sync all nodes on operator starting

### DIFF
--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -217,6 +217,9 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 
 	go func() {
 		cache.WaitForCacheSync(wait.NeverStop, ciliumNodeInformer.HasSynced)
+		if nodeManager != nil {
+			nodeManager.SyncNodes(ciliumNodeStore)
+		}
 		close(k8sCiliumNodesCacheSynced)
 		log.Info("CiliumNodes caches synced with Kubernetes")
 		// Only handle events if nodeManagerSyncHandler is not nil. If it is nil

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -409,7 +409,7 @@ func OnOperatorStartLeading(ctx context.Context) {
 			log.WithError(err).Fatalf("Unable to init %s allocator", ipamMode)
 		}
 
-		nm, err := alloc.Start(ctx, &ciliumNodeUpdateImplementation{})
+		nm, err := alloc.Start(ctx, &ciliumNodeUpdateImplementation{}, k8sCiliumNodesCacheSynced)
 		if err != nil {
 			log.WithError(err).Fatalf("Unable to start %s allocator", ipamMode)
 		}

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -63,7 +63,7 @@ func (a *AllocatorAWS) Init(ctx context.Context) error {
 // Start kicks of ENI allocation, the initial connection to AWS
 // APIs is done in a blocking manner, given that is successful, a controller is
 // started to manage allocation based on CiliumNode custom resources
-func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
+func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, k8sCiliumNodesCacheSynced chan struct{}) (allocator.NodeEventHandler, error) {
 	var iMetrics ipam.MetricsAPI
 
 	log.Info("Starting ENI allocator...")
@@ -81,9 +81,12 @@ func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 		return nil, fmt.Errorf("unable to initialize ENI node manager: %w", err)
 	}
 
-	if err := nodeManager.Start(ctx); err != nil {
-		return nil, err
-	}
+	go func() {
+		<-k8sCiliumNodesCacheSynced
+		if err := nodeManager.Start(ctx); err != nil {
+			log.WithError(err).Fatal("Unable to start node manager")
+		}
+	}()
 
 	return nodeManager, nil
 }

--- a/pkg/ipam/allocator/clusterpool/clusterpool.go
+++ b/pkg/ipam/allocator/clusterpool/clusterpool.go
@@ -83,7 +83,7 @@ func (a *AllocatorOperator) Init(ctx context.Context) error {
 }
 
 // Start kicks of Operator allocation.
-func (a *AllocatorOperator) Start(ctx context.Context, updater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
+func (a *AllocatorOperator) Start(ctx context.Context, updater ipam.CiliumNodeGetterUpdater, k8sCiliumNodesCacheSynced chan struct{}) (allocator.NodeEventHandler, error) {
 	log.WithFields(logrus.Fields{
 		logfields.IPv4CIDRs: operatorOption.Config.ClusterPoolIPv4CIDR,
 		logfields.IPv6CIDRs: operatorOption.Config.ClusterPoolIPv6CIDR,

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/controller"
@@ -938,3 +939,6 @@ func allocateFirstFreeCIDR(cidrAllocators []CIDRAllocator) (revertFunc revert.Re
 	})
 	return revertStack.Revert, cidr, err
 }
+
+// SyncNodes do nothing
+func (n *NodesPodCIDRManager) SyncNodes(cache.Store) {}

--- a/pkg/ipam/allocator/provider.go
+++ b/pkg/ipam/allocator/provider.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"time"
 
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/cilium/cilium/pkg/ipam"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
@@ -15,7 +17,7 @@ import (
 // these are implemented by e.g. pkg/ipam/allocator/{aws,azure}.
 type AllocatorProvider interface {
 	Init(ctx context.Context) error
-	Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater) (NodeEventHandler, error)
+	Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, k8sCiliumNodesCacheSynced chan struct{}) (NodeEventHandler, error)
 }
 
 // NodeEventHandler should implement the behavior to handle CiliumNode
@@ -24,4 +26,5 @@ type NodeEventHandler interface {
 	Update(resource *v2.CiliumNode) bool
 	Delete(resource *v2.CiliumNode)
 	Resync(context.Context, time.Time)
+	SyncNodes(cache.Store)
 }


### PR DESCRIPTION
Set all nodes on the field `NodeManager.nodes` before `NodeManager.Start` , that
fix `NodeManager.Resync` not resync immediately all nodes  reconciling the IP resource pool  and metrics `cilium_operator_ipam_nodes` and
`cilium_operator_ipam_available_interfaces` not corrected.


Signed-off-by: xiaoqing <xiaoqingnb@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #20815

```release-note
sync all nodes on operator starting
```
