### PR TITLE
docs: fix check-crd-compat-table script

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -16,7 +16,9 @@ export LC_ALL=C
 
 get_schema_of_tag(){
    tag="${1}"
+   set +o pipefail
    git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${tag} -- pkg/k8s | head -n1 | sed 's/.*=\ "//;s/"//'
+   set -o pipefail
 }
 
 get_line_of_schema_version(){
@@ -26,7 +28,9 @@ get_line_of_schema_version(){
 
 get_schema_of_branch(){
    stable_branch="${1}"
-   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//' | uniq
+   set +o pipefail
+   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//' | uniq  | head -n1
+   set -o pipefail
 }
 
 get_stable_branches(){


### PR DESCRIPTION
Since `head` terminates its execution before reading the input from the
previous command, the previous command will receive a SIGPIPE signal.
This, together with the fact that the scripts are set with `set -o
pipeline` and `set -e`, makes the script to terminate abruptly causing
the CRD compatibility table to be incorrectly created.

For more information see:  https://www.greenend.org.uk/rjk/tech/shellmistakes.html#pipeerrors

Signed-off-by: André Martins <andre@cilium.io>