### PR TITLE
node: Fix incorrect code comment

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -374,8 +374,8 @@ func (m *Manager) legacyNodeIpBehavior() bool {
 	if m.conf.NodeEncryptionEnabled() {
 		return false
 	}
-	// Needed to store the SPI for pod->remote node in the ipcache since
-	// that path goes through the tunnel.
+	// Needed to store the tunnel endpoint for pod->remote node in the
+	// ipcache so that this traffic goes through the tunnel.
 	if m.conf.EncryptionEnabled() && m.conf.TunnelingEnabled() {
 		return false
 	}


### PR DESCRIPTION
The code comment was incorrect. We won't even add an SPI for pod->remote node unless node encryption is enabled. The reason we care about that case is because we want such traffic to go through the tunnel, hence to have a tunnel endpoint in the ipcache.

Fixes: https://github.com/cilium/cilium/pull/17511.