### PR TITLE
kvstore/allocator: fix panic on receiving invalid identity entries

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -601,8 +601,17 @@ func (k *kvstoreBackend) ListAndWatch(ctx context.Context, handler allocator.Cac
 							fieldKey:   event.Key,
 							fieldValue: event.Value,
 						}).Warning("Unable to decode key value")
-					} else {
-						key = k.keyType.PutKey(string(s))
+						continue
+					}
+
+					key = k.keyType.PutKey(string(s))
+				} else {
+					if event.Typ != kvstore.EventTypeDelete {
+						log.WithFields(logrus.Fields{
+							fieldKey:       event.Key,
+							fieldEventType: event.Typ,
+						}).Error("Received a key with an empty value")
+						continue
 					}
 				}
 

--- a/pkg/kvstore/allocator/logfields.go
+++ b/pkg/kvstore/allocator/logfields.go
@@ -4,9 +4,10 @@
 package allocator
 
 const (
-	fieldID      = "id"
-	fieldKey     = "key"
-	fieldPrefix  = "prefix"
-	fieldValue   = "value"
-	fieldLeaseID = "leaseID"
+	fieldID        = "id"
+	fieldKey       = "key"
+	fieldPrefix    = "prefix"
+	fieldValue     = "value"
+	fieldLeaseID   = "leaseID"
+	fieldEventType = "eventType"
 )


### PR DESCRIPTION
This problem is triggered when the event type is "UPDATE" AND the value
is an empty string, resulting in the `key` variable uninitialized:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1cc4362]

goroutine 1430 [running]:
github.com/cilium/cilium/pkg/allocator.(*Allocator).encodeKey(0xc00f4fab00, 0x0, 0x0, 0xc0207a5838, 0x2ac8c01)
        /go/src/github.com/cilium/cilium/pkg/allocator/allocator.go:457 +0x22
github.com/cilium/cilium/pkg/allocator.(*cache).OnModify(0xc00f4fab98, 0x333f4, 0x2f28b38, 0xc03d7b2318)
        /go/src/github.com/cilium/cilium/pkg/allocator/cache.go:144 +0x22d
github.com/cilium/cilium/pkg/kvstore/allocator.(*kvstoreBackend).ListAndWatch(0xc005029e80, 0x2f1c088, 0xc0000c8008, 0x2f1c3d0, 0xc00f4fab98, 0xc00f5aaea0)
        /go/src/github.com/cilium/cilium/pkg/kvstore/allocator/allocator.go:624 +0x2a7
github.com/cilium/cilium/pkg/allocator.(*cache).start.func1(0xc00f4fab98)
        /go/src/github.com/cilium/cilium/pkg/allocator/cache.go:198 +0x73
created by github.com/cilium/cilium/pkg/allocator.(*cache).start
        /go/src/github.com/cilium/cilium/pkg/allocator/cache.go:197 +0xee
```

"CREATE" event handlings are not suffered previously as there is nil pointer
checking in `OnAdd()` handler.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>