### PR TITLE
v1.10 backports 2022-09-07

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -57,6 +57,7 @@ cilium-agent [flags]
       --cluster-id int                                          Unique identifier of the cluster
       --cluster-name string                                     Name of the cluster (default "default")
       --clustermesh-config string                               Path to the ClusterMesh configuration directory
+      --cni-chaining-mode string                                Enable CNI chaining with the specified plugin
       --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                                       Configuration directory that contains a file for each option
       --conntrack-gc-interval duration                          Overwrite the connection-tracking garbage collection interval

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -132,7 +132,7 @@
    * - clustermesh.apiserver.image
      - Clustermesh API server image.
      - object
-     - ``{"digest":"sha256:0dd9df6e4b20f7120f10ddee560e0c285875657f0db0e2a18bc0cd748f86a84c","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/clustermesh-apiserver","tag":"v1.10.12","useDigest":true}``
+     - ``{"digest":"sha256:ebd5c66c7ed9bbab7634263b9f5a38008827648be30cb8334aa3353aaaac8f48","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/clustermesh-apiserver","tag":"v1.10.14","useDigest":true}``
    * - clustermesh.apiserver.nodeSelector
      - Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object
@@ -612,7 +612,7 @@
    * - hubble.relay.image
      - Hubble-relay container image.
      - object
-     - ``{"digest":"sha256:fd3829bf67f2f3d3471da6ded9c636b22feb9a31feaac4509a295043e93af169","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.10.12","useDigest":true}``
+     - ``{"digest":"sha256:a6d131f1eb66c950712d2faf8ca788ac4b81353f5b0884f31a3fa9dee82e33c9","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.10.14","useDigest":true}``
    * - hubble.relay.listenHost
      - Host to listen to. Specify an empty string to bind to all the interfaces.
      - string
@@ -721,10 +721,14 @@
      - base64 encoded PEM values for the Hubble server certificate and private key
      - object
      - ``{"cert":"","key":""}``
+   * - hubble.ui.backend.extraEnv
+     - Additional hubble-ui backend environment variables.
+     - list
+     - ``[]``
    * - hubble.ui.backend.image
      - Hubble-ui backend image.
      - object
-     - ``{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-ui-backend","tag":"v0.9.0@sha256:000df6b76719f607a9edefb9af94dfd1811a6f1b6a8a9c537cba90bf12df474b"}``
+     - ``{"override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7"}``
    * - hubble.ui.backend.resources
      - Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
      - object
@@ -733,14 +737,22 @@
      - Whether to enable the Hubble UI.
      - bool
      - ``false``
+   * - hubble.ui.frontend.extraEnv
+     - Additional hubble-ui frontend environment variables.
+     - list
+     - ``[]``
    * - hubble.ui.frontend.image
      - Hubble-ui frontend image.
      - object
-     - ``{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-ui","tag":"v0.9.0@sha256:0ef04e9a29212925da6bdfd0ba5b581765e41a01f1cc30563cef9b30b457fea0"}``
+     - ``{"override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui","tag":"v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e"}``
    * - hubble.ui.frontend.resources
      - Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
      - object
      - ``{}``
+   * - hubble.ui.frontend.server.ipv6
+     - Controls server listener for ipv6
+     - object
+     - ``{"enabled":true}``
    * - hubble.ui.ingress
      - hubble-ui ingress configuration.
      - object
@@ -784,7 +796,7 @@
    * - image
      - Agent container image.
      - object
-     - ``{"digest":"sha256:6a119c4f249d42df0d5654295ac9466da117f9b838ff48b4bc64234f7ab20b80","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.10.12","useDigest":true}``
+     - ``{"digest":"sha256:65c78132e247c72c396ef2e02375665d0d0b05850ddfe4fa978fe8ac194a2149","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.10.14","useDigest":true}``
    * - imagePullSecrets
      - Configure image pull secrets for pulling container images
      - string
@@ -1020,7 +1032,7 @@
    * - operator.image
      - cilium-operator image.
      - object
-     - ``{"alibabacloudDigest":"sha256:72de09e0e7a17de8e61e03f251d698c68e2e8e1f1fa1ada67200920a6cad6d0a","awsDigest":"sha256:06b31f3d9baa2be911b90ab933bb8dc08a1bd5e3104f5e90b9cb51a9dd9142f6","azureDigest":"sha256:7c920352c82cd10b402d14902f119d75e45f6faa103f2ea89f760cf5de5301f3","genericDigest":"sha256:35288de36cd1b6fe65e55a9b878100c2ab92ac88ed6a3ab04326e00326cff3f7","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.10.12","useDigest":true}``
+     - ``{"alibabacloudDigest":"sha256:fafc53bfa40ed47befdd5b9b28d68b33bde04d00b3a277ed15a59ab829bdb2be","awsDigest":"sha256:6e54d5d670e32d0854c774934b3094e5fda514a96dc923f1140e0b119bbf8be4","azureDigest":"sha256:cf3400449d0e883d7338f08a55e29fed2872add031be655824bc012446bf1633","genericDigest":"sha256:fff61fed88fe07fe5e67eb51d2eb4297a65a51b0c367046ceb9c928b70443c6b","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.10.14","useDigest":true}``
    * - operator.nodeGCInterval
      - Interval for cilium node garbage collection.
      - string
@@ -1152,7 +1164,7 @@
    * - preflight.image
      - Cilium pre-flight image.
      - object
-     - ``{"digest":"sha256:6a119c4f249d42df0d5654295ac9466da117f9b838ff48b4bc64234f7ab20b80","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.10.12","useDigest":true}``
+     - ``{"digest":"sha256:65c78132e247c72c396ef2e02375665d0d0b05850ddfe4fa978fe8ac194a2149","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.10.14","useDigest":true}``
    * - preflight.nodeSelector
      - Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
      - object

--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -191,7 +191,7 @@ func (m *VMManager) OnUpdate(k store.Key) {
 				nk.IPAddresses = nil
 
 				// Update the registration, now with the node identity and overridden fields
-				if err := ciliumNodeRegisterStore.UpdateKeySync(context.Background(), nk); err != nil {
+				if err := ciliumNodeRegisterStore.UpdateKeySync(context.Background(), nk, true); err != nil {
 					log.WithError(err).Warning("CEW: Unable to update register node in etcd")
 				} else {
 					log.Debugf("CEW: Updated register node in etcd (nid: %d): %v", nid, nk)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -676,6 +676,10 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		bootstrapStats.fqdn.EndError(err)
 		return nil, restoredEndpoints, err
 	}
+	cleaner.cleanupFuncs.Add(func() {
+		proxy.DefaultDNSProxy.Cleanup()
+	})
+
 	bootstrapStats.fqdn.End(true)
 
 	if k8s.IsEnabled() {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -476,6 +476,9 @@ func initializeFlags() {
 	flags.String(option.IPAM, ipamOption.IPAMClusterPool, "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
 
+	flags.String(option.CNIChainingMode, "", "Enable CNI chaining with the specified plugin")
+	option.BindEnv(option.CNIChainingMode)
+
 	flags.String(option.IPv4Range, AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	option.BindEnv(option.IPv4Range)
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -254,6 +254,15 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 		}
 		routerIP = result.IP
 	}
+
+	// Coalescing multiple CIDRs. GH #18868
+	if option.Config.EnableIPv4Masquerade &&
+		option.Config.IPAM == ipamOption.IPAMENI &&
+		result != nil &&
+		len(result.CIDRs) > 0 {
+		result.CIDRs = coalesceCIDRs(result.CIDRs)
+	}
+
 	if (option.Config.IPAM == ipamOption.IPAMENI ||
 		option.Config.IPAM == ipamOption.IPAMAlibabaCloud ||
 		option.Config.IPAM == ipamOption.IPAMAzure) && result != nil {
@@ -268,10 +277,6 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 		node.SetRouterInfo(routingInfo)
 	}
 
-	// Coalescing multiple CIDRs. GH #18868
-	if result != nil && len(result.CIDRs) > 0 {
-		result.CIDRs = coalesceCIDRs(result.CIDRs)
-	}
 	return
 }
 
@@ -285,7 +290,10 @@ func (d *Daemon) allocateHealthIPs() error {
 			}
 
 			// Coalescing multiple CIDRs. GH #18868
-			if result != nil && len(result.CIDRs) > 0 {
+			if option.Config.EnableIPv4Masquerade &&
+				option.Config.IPAM == ipamOption.IPAMENI &&
+				result != nil &&
+				len(result.CIDRs) > 0 {
 				result.CIDRs = coalesceCIDRs(result.CIDRs)
 			}
 
@@ -313,7 +321,10 @@ func (d *Daemon) allocateHealthIPs() error {
 			}
 
 			// Coalescing multiple CIDRs. GH #18868
-			if result != nil && len(result.CIDRs) > 0 {
+			if option.Config.EnableIPv6Masquerade &&
+				option.Config.IPAM == ipamOption.IPAMENI &&
+				result != nil &&
+				len(result.CIDRs) > 0 {
 				result.CIDRs = coalesceCIDRs(result.CIDRs)
 			}
 

--- a/daemon/cmd/ipam_test.go
+++ b/daemon/cmd/ipam_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+// +build !privileged_tests
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestCoalesceCIDRs(t *testing.T) {
+	CIDR := []string{"10.0.0.0/8"}
+	expectedCIDR := []string{"10.0.0.0/8"}
+	newCIDR := coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"10.105.0.0/16", "10.0.0.0/8"}
+	expectedCIDR = []string{"10.0.0.0/8"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"10.105.0.0/16", "10.104.0.0/19", "10.0.0.0/8"}
+	expectedCIDR = []string{"10.0.0.0/8"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
+	expectedCIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
+	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8", "f00d::a0f:0:0:0/96"}
+	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"f00d::a0f:0:0:0/96", "10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
+	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+
+	CIDR = []string{"f00d::a0f:0:0:0/96"}
+	expectedCIDR = []string{"f00d::a0f:0:0:0/96"}
+	newCIDR = coalesceCIDRs(CIDR)
+	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	}
+}

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -3,8 +3,9 @@
 
 include Makefile.digests ../../Makefile.defs
 
-HUBBLE_UI_VERSION := "v0.9.0@sha256:0ef04e9a29212925da6bdfd0ba5b581765e41a01f1cc30563cef9b30b457fea0"
-HUBBLE_UI_BACKEND_VERSION := "v0.9.0@sha256:000df6b76719f607a9edefb9af94dfd1811a6f1b6a8a9c537cba90bf12df474b"
+HUBBLE_UI_VERSION := "v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e"
+HUBBLE_UI_BACKEND_VERSION := "v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7"
+
 MANAGED_ETCD_VERSION := "v2.0.7"
 ETCD_VERSION := "v3.4.13"
 NODEINIT_VERSION := "62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8"
@@ -67,9 +68,9 @@ update-versions:
 		# image.tag operator.image.tag preflight.image.tag hubble.relay.image.tag;					\
 		sed -i 's/tag: .*/tag: '$$cilium_version'/g' $(CILIUM_VALUES);							\
 		# hubble.ui.frontend.image.tag;											\
-		sed -i '/repository.*hubble-ui$$/{!b;n;s/tag.*/tag: '$$hubble_version'/}' $(CILIUM_VALUES);			\
+		sed -i '/repository.*"*.*hubble-ui"*$$/{!b;n;s/tag.*/tag: '$$hubble_version'/}' $(CILIUM_VALUES);			\
 		# hubble.ui.backend.image.tag;											\
-		sed -i '/repository.*hubble-ui-backend.*/{!b;n;s/tag.*/tag: '$$hubble_backend_version'/}' $(CILIUM_VALUES);	\
+		sed -i '/repository.*"*.*hubble-ui-backend.*"*/{!b;n;s/tag.*/tag: '$$hubble_backend_version'/}' $(CILIUM_VALUES);	\
 		# etcd.image.tag												\
 		sed -i '/repository.*etcd-operator.*/{!b;n;s/tag.*/tag: '$(MANAGED_ETCD_VERSION)'/}' $(CILIUM_VALUES)		\
 		# clustermesh.apiserver.etcd.image.tag										\

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -231,11 +231,14 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.tls.ca.key | string | `""` | The CA private key (optional). If it is provided, then it will be used by hubble.tls.auto.method=cronJob to generate all other certificates. Otherwise, a ephemeral CA is generated if hubble.tls.auto.enabled=true. |
 | hubble.tls.enabled | bool | `true` | Enable mutual TLS for listenAddress. Setting this value to false is highly discouraged as the Hubble API provides access to potentially sensitive network flow metadata and is exposed on the host network. |
 | hubble.tls.server | object | `{"cert":"","key":""}` | base64 encoded PEM values for the Hubble server certificate and private key |
-| hubble.ui.backend.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-ui-backend","tag":"v0.9.0@sha256:000df6b76719f607a9edefb9af94dfd1811a6f1b6a8a9c537cba90bf12df474b"}` | Hubble-ui backend image. |
+| hubble.ui.backend.extraEnv | list | `[]` | Additional hubble-ui backend environment variables. |
+| hubble.ui.backend.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-ui-backend","tag":"v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7"}` | Hubble-ui backend image. |
 | hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
 | hubble.ui.enabled | bool | `false` | Whether to enable the Hubble UI. |
-| hubble.ui.frontend.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-ui","tag":"v0.9.0@sha256:0ef04e9a29212925da6bdfd0ba5b581765e41a01f1cc30563cef9b30b457fea0"}` | Hubble-ui frontend image. |
+| hubble.ui.frontend.extraEnv | list | `[]` | Additional hubble-ui frontend environment variables. |
+| hubble.ui.frontend.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-ui","tag":"v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e"}` | Hubble-ui frontend image. |
 | hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
+| hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |
 | hubble.ui.ingress | object | `{"annotations":{},"enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.nodeSelector | object | `{}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |

--- a/install/kubernetes/cilium/templates/hubble-ui/_nginx.tpl
+++ b/install/kubernetes/cilium/templates/hubble-ui/_nginx.tpl
@@ -1,7 +1,9 @@
 {{- define "hubble-ui.nginx.conf" }}
 server {
     listen       8081;
+{{- if .Values.hubble.ui.frontend.server.ipv6.enabled }}
     listen       [::]:8081;
+{{- end }}
     server_name  localhost;
     root /app;
     index index.html;

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -775,37 +775,45 @@ hubble:
       # -- Hubble-ui backend image.
       image:
         override: ~
-        repository: quay.io/cilium/hubble-ui-backend
-        tag: v0.9.0@sha256:000df6b76719f607a9edefb9af94dfd1811a6f1b6a8a9c537cba90bf12df474b
+        repository: "quay.io/cilium/hubble-ui-backend"
+        tag: v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7
         pullPolicy: IfNotPresent
-      # [Example]
-      # resources:
+
+      # -- Additional hubble-ui backend environment variables.
+      extraEnv: []
+
+      # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
+      resources: {}
       #   limits:
       #     cpu: 1000m
       #     memory: 1024M
       #   requests:
       #     cpu: 100m
       #     memory: 64Mi
-      # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
-      resources: {}
 
     frontend:
       # -- Hubble-ui frontend image.
       image:
         override: ~
-        repository: quay.io/cilium/hubble-ui
-        tag: v0.9.0@sha256:0ef04e9a29212925da6bdfd0ba5b581765e41a01f1cc30563cef9b30b457fea0
+        repository: "quay.io/cilium/hubble-ui"
+        tag: v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e
         pullPolicy: IfNotPresent
-      # [Example]
-      # resources:
+
+      # -- Additional hubble-ui frontend environment variables.
+      extraEnv: []
+
+      # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
+      resources: {}
       #   limits:
       #     cpu: 1000m
       #     memory: 1024M
       #   requests:
       #     cpu: 100m
       #     memory: 64Mi
-      # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
-      resources: {}
+      server:
+        # -- Controls server listener for ipv6
+        ipv6:
+          enabled: true
 
     # -- The number of replicas of Hubble UI to deploy.
     replicas: 1

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -107,6 +107,11 @@ func runNodeWatcher(nodeManager *allocator.NodeEventHandler) error {
 			delete(kvStoreNodes, kvStoreNodeName)
 		}
 
+		if len(listOfCiliumNodes) == 0 && len(kvStoreNodes) != 0 {
+			log.Warn("Preventing GC of nodes in the KVStore due the nonexistence of any CiliumNodes in kube-apiserver")
+			return
+		}
+
 		for _, kvStoreNode := range kvStoreNodes {
 			// Only delete the nodes that belong to our cluster
 			if strings.HasPrefix(kvStoreNode.GetKeyName(), option.Config.ClusterName) {

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -62,7 +62,7 @@ func runNodeWatcher(nodeManager *allocator.NodeEventHandler) error {
 			AddFunc: func(obj interface{}) {
 				if ciliumNode := k8s.ObjToCiliumNode(obj); ciliumNode != nil {
 					nodeNew := nodeTypes.ParseCiliumNode(ciliumNode)
-					ciliumNodeKVStore.UpdateKeySync(context.TODO(), &nodeNew)
+					ciliumNodeKVStore.UpdateKeySync(context.TODO(), &nodeNew, false)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
@@ -73,7 +73,7 @@ func runNodeWatcher(nodeManager *allocator.NodeEventHandler) error {
 						}
 
 						nodeNew := nodeTypes.ParseCiliumNode(newNode)
-						ciliumNodeKVStore.UpdateKeySync(context.TODO(), &nodeNew)
+						ciliumNodeKVStore.UpdateKeySync(context.TODO(), &nodeNew, false)
 					}
 				}
 			},

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -905,11 +905,21 @@ func (m *IptablesManager) doGetProxyPort(prog iptablesInterface, name string) ui
 }
 
 func getDeliveryInterface(ifName string) string {
-	deliveryInterface := ifName
-	if option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAlibabaCloud || option.Config.EnableEndpointRoutes {
-		deliveryInterface = "lxc+"
+	switch {
+	case option.Config.EnableEndpointRoutes:
+		// aws-cni creates container interfaces with names like eni621c0fc8425.
+		if option.Config.CNIChainingMode == "aws-cni" {
+			return "eni+"
+		}
+		return "lxc+"
+
+	case option.Config.IPAM == ipamOption.IPAMENI ||
+		option.Config.IPAM == ipamOption.IPAMAlibabaCloud:
+		return "lxc+"
+
+	default:
+		return ifName
 	}
-	return deliveryInterface
 }
 
 func (m *IptablesManager) installForwardChainRules(ifName, localDeliveryInterface, forwardChain string) error {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -37,7 +37,6 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
-	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -167,16 +166,6 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing datapath.NodeAddre
 	routerIP := net.IPNet{
 		IP:   nodeAddressing.IPv4().Router(),
 		Mask: net.CIDRMask(32, 32),
-	}
-
-	cidrs2 := make([]*net.IPNet, 0, 0)
-	for i := range cidrs {
-		cidrs2 = append(cidrs2, &cidrs[i])
-	}
-	resultcidr, _ := iputil.CoalesceCIDRs(cidrs2)
-	cidrs = make([]net.IPNet, 0, len(resultcidr))
-	for _, cidr := range resultcidr {
-		cidrs = append(cidrs, *cidr)
 	}
 
 	for _, cidr := range cidrs {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -37,6 +37,7 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -167,6 +168,17 @@ func addENIRules(sysSettings []sysctl.Setting, nodeAddressing datapath.NodeAddre
 		IP:   nodeAddressing.IPv4().Router(),
 		Mask: net.CIDRMask(32, 32),
 	}
+
+	cidrs2 := make([]*net.IPNet, 0, 0)
+	for i := range cidrs {
+		cidrs2 = append(cidrs2, &cidrs[i])
+	}
+	resultcidr, _ := iputil.CoalesceCIDRs(cidrs2)
+	cidrs = make([]net.IPNet, 0, len(resultcidr))
+	for _, cidr := range resultcidr {
+		cidrs = append(cidrs, *cidr)
+	}
+
 	for _, cidr := range cidrs {
 		if err = linuxrouting.SetupRules(&routerIP, &cidr, info.GetMac().String(), info.GetInterfaceNumber()); err != nil {
 			return nil, fmt.Errorf("unable to install ip rule for cilium_host: %w", err)

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -464,6 +464,12 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		EnableIPv4, EnableIPv6 = option.Config.EnableIPv4, option.Config.EnableIPv6
 	)
 
+	// Bind the DNS forwarding clients on UDP and TCP
+	// Note: SingleInFlight should remain disabled. When enabled it folds DNS
+	// retries into the previous lookup, suppressing them.
+	p.UDPClient = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: false}
+	p.TCPClient = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: false}
+
 	start := time.Now()
 	for time.Since(start) < ProxyBindTimeout {
 		UDPConn, TCPListener, err = bindToAddr(address, port, EnableIPv4, EnableIPv6)
@@ -499,12 +505,6 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 			log.Fatalf("Failed to start %s DNS Proxy on %s", server.Net, server.Addr)
 		}(s)
 	}
-
-	// Bind the DNS forwarding clients on UDP and TCP
-	// Note: SingleInFlight should remain disabled. When enabled it folds DNS
-	// retries into the previous lookup, suppressing them.
-	p.UDPClient = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: false}
-	p.TCPClient = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: false}
 
 	return p, nil
 }

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -16,6 +16,7 @@ type DNSProxier interface {
 	GetBindPort() uint16
 	SetRejectReply(string)
 	RestoreRules(op *endpoint.Endpoint)
+	Cleanup()
 }
 
 type MockFQDNProxy struct{}
@@ -41,5 +42,9 @@ func (m MockFQDNProxy) SetRejectReply(s string) {
 }
 
 func (m MockFQDNProxy) RestoreRules(op *endpoint.Endpoint) {
+	return
+}
+
+func (m MockFQDNProxy) Cleanup() {
 	return
 }

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1412,9 +1412,7 @@ func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, 
 	}
 
 	if lease {
-		e.RWMutex.RLock()
-		leaseID := e.session.Lease()
-		e.RWMutex.RUnlock()
+		leaseID := e.GetSessionLeaseID()
 		if getR.Kvs[0].Lease != int64(leaseID) {
 			return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
 		}
@@ -1446,9 +1444,7 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 		return true, e.Update(ctx, key, value, lease)
 	}
 	if lease {
-		e.RWMutex.RLock()
-		leaseID := e.session.Lease()
-		e.RWMutex.RUnlock()
+		leaseID := e.GetSessionLeaseID()
 		if getR.Kvs[0].Lease != int64(leaseID) {
 			return true, e.Update(ctx, key, value, lease)
 		}

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -375,8 +375,8 @@ func (s *SharedStore) UpdateLocalKeySync(ctx context.Context, key LocalKey) erro
 }
 
 // UpdateKeySync synchronously synchronizes a key with the kvstore.
-func (s *SharedStore) UpdateKeySync(ctx context.Context, key LocalKey) error {
-	return s.syncLocalKey(ctx, key, true)
+func (s *SharedStore) UpdateKeySync(ctx context.Context, key LocalKey, lease bool) error {
+	return s.syncLocalKey(ctx, key, lease)
 }
 
 // DeleteLocalKey removes a key from being synchronized with the kvstore

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -224,7 +224,7 @@ func JoinSharedStore(c Configuration) (*SharedStore, error) {
 	controllers.UpdateController(s.controllerName,
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				return s.syncLocalKeys(ctx)
+				return s.syncLocalKeys(ctx, true)
 			},
 			RunInterval: s.conf.SynchronizationInterval,
 		},
@@ -288,15 +288,15 @@ func (s *SharedStore) keyPath(key NamedKey) string {
 }
 
 // syncLocalKey synchronizes a key to the kvstore
-func (s *SharedStore) syncLocalKey(ctx context.Context, key LocalKey) error {
+func (s *SharedStore) syncLocalKey(ctx context.Context, key LocalKey, lease bool) error {
 	jsonValue, err := key.Marshal()
 	if err != nil {
 		return err
 	}
 
-	// Update key in kvstore, overwrite an eventual existing key, attach
+	// Update key in kvstore, overwrite an eventual existing key. If requested, attach
 	// lease to expire entry when agent dies and never comes back up.
-	if _, err := s.backend.UpdateIfDifferent(ctx, s.keyPath(key), jsonValue, true); err != nil {
+	if _, err := s.backend.UpdateIfDifferent(ctx, s.keyPath(key), jsonValue, lease); err != nil {
 		return err
 	}
 
@@ -304,7 +304,7 @@ func (s *SharedStore) syncLocalKey(ctx context.Context, key LocalKey) error {
 }
 
 // syncLocalKeys synchronizes all local keys with the kvstore
-func (s *SharedStore) syncLocalKeys(ctx context.Context) error {
+func (s *SharedStore) syncLocalKeys(ctx context.Context, lease bool) error {
 	// Create a copy of all local keys so we can unlock and sync to kvstore
 	// without holding the lock
 	s.mutex.RLock()
@@ -315,7 +315,7 @@ func (s *SharedStore) syncLocalKeys(ctx context.Context) error {
 	s.mutex.RUnlock()
 
 	for _, key := range keys {
-		if err := s.syncLocalKey(ctx, key); err != nil {
+		if err := s.syncLocalKey(ctx, key, lease); err != nil {
 			return err
 		}
 	}
@@ -367,7 +367,7 @@ func (s *SharedStore) SharedKeysMap() map[string]Key {
 func (s *SharedStore) UpdateLocalKeySync(ctx context.Context, key LocalKey) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	err := s.syncLocalKey(ctx, key)
+	err := s.syncLocalKey(ctx, key, true)
 	if err == nil {
 		s.localKeys[key.GetKeyName()] = key.DeepKeyCopy()
 	}
@@ -376,7 +376,7 @@ func (s *SharedStore) UpdateLocalKeySync(ctx context.Context, key LocalKey) erro
 
 // UpdateKeySync synchronously synchronizes a key with the kvstore.
 func (s *SharedStore) UpdateKeySync(ctx context.Context, key LocalKey) error {
-	return s.syncLocalKey(ctx, key)
+	return s.syncLocalKey(ctx, key, true)
 }
 
 // DeleteLocalKey removes a key from being synchronized with the kvstore
@@ -521,7 +521,7 @@ func (s *SharedStore) watcher(listDone chan struct{}) {
 			if localKey := s.lookupLocalKey(keyName); localKey != nil {
 				logger.Warning("Received delete event for local key. Re-creating the key in the kvstore")
 
-				s.syncLocalKey(s.conf.Context, localKey)
+				s.syncLocalKey(s.conf.Context, localKey, true)
 			} else {
 				s.deleteSharedKey(keyName)
 			}

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -361,13 +361,6 @@ func (s *SharedStore) SharedKeysMap() map[string]Key {
 	return sharedKeysCopy
 }
 
-// UpdateLocalKey adds a key to be synchronized with the kvstore
-func (s *SharedStore) UpdateLocalKey(key LocalKey) {
-	s.mutex.Lock()
-	s.localKeys[key.GetKeyName()] = key.DeepKeyCopy()
-	s.mutex.Unlock()
-}
-
 // UpdateLocalKeySync synchronously synchronizes a local key with the kvstore
 // and adds it to the list of local keys to be synchronized if the initial
 // synchronous synchronization was successful

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -525,6 +525,9 @@ const (
 	// ClusterMeshConfigName is the name of the ClusterMeshConfig option
 	ClusterMeshConfigName = "clustermesh-config"
 
+	// CNIChainingMode configures which CNI plugin Cilium is chained with.
+	CNIChainingMode = "cni-chaining-mode"
+
 	// BPFCompileDebugName is the name of the option to enable BPF compiliation debugging
 	BPFCompileDebugName = "bpf-compile-debug"
 
@@ -1857,6 +1860,9 @@ type DaemonConfig struct {
 	// IPAM is the IPAM method to use
 	IPAM string
 
+	// Enable chaining with another CNI plugin.
+	CNIChainingMode string
+
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource bool
@@ -2480,6 +2486,7 @@ func (c *DaemonConfig) Populate() {
 	c.ClusterID = viper.GetInt(ClusterIDName)
 	c.ClusterName = viper.GetString(ClusterName)
 	c.ClusterMeshConfig = viper.GetString(ClusterMeshConfigName)
+	c.CNIChainingMode = viper.GetString(CNIChainingMode)
 	c.DatapathMode = viper.GetString(DatapathMode)
 	c.Debug = viper.GetBool(DebugArg)
 	c.DebugVerbose = viper.GetStringSlice(DebugVerbose)

--- a/tools/sysctlfix/main.go
+++ b/tools/sysctlfix/main.go
@@ -38,8 +38,8 @@ var (
 
 var sysctlConfig = `
 # Disable rp_filter on Cilium interfaces since it may cause mangled packets to be dropped
-net.ipv4.conf.lxc*.rp_filter = 0
-net.ipv4.conf.cilium_*.rp_filter = 0
+-net.ipv4.conf.lxc*.rp_filter = 0
+-net.ipv4.conf.cilium_*.rp_filter = 0
 # The kernel uses max(conf.all, conf.{dev}) as its value, so we need to set .all. to 0 as well.
 # Otherwise it will overrule the device specific settings.
 net.ipv4.conf.all.rp_filter = 0


### PR DESCRIPTION
 * #20112 -- Fix conflicting routes for multiple ENIs in IPAM mode (@recollir)
 * #20795 -- agent: Stop serving DNS before shutdown (@nebril)
 * #21133 -- operator: do not GC kvstore nodes if CiliumNodes are not available (@aanm)
 * #21146 -- datapath: tolerate missing ifaces when setting rp_filter sysctl (@julianwiedmann)
 * #21126 -- datapath: allow local NodePort traffic for `eni+` container interfaces with CNI chaining (@ti-mo)
 * #20848 -- Coalesce of health endpoint CIDRs (@dezmodue)
 * #21127 -- hubble-ui: release v0.9.2 (@geakstr)
 * #21202 -- operator: update CiliumNode in kvstore without lease (@tklauser)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20112 20795 21133 21146 21126 20848 21127 21202; do contrib/backporting/set-labels.py $pr done 1.10; done
```
or with
```
$ make add-label BRANCH=v1.10 ISSUES=20112,20795,21133,21146,21126,20848,21127,21202
```