### PR TITLE
v1.12 backports 2022-09-07 (for ingress)

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -42,6 +42,7 @@ cilium-operator-alibabacloud [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "alibabacloud")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -42,7 +42,7 @@ cilium-operator-alibabacloud [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-lb-annotation-prefixes strings    IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "alibabacloud")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -48,6 +48,7 @@ cilium-operator-aws [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "eni")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -48,7 +48,7 @@ cilium-operator-aws [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-lb-annotation-prefixes strings    IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "eni")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -45,6 +45,7 @@ cilium-operator-azure [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "azure")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -45,7 +45,7 @@ cilium-operator-azure [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-lb-annotation-prefixes strings    IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "azure")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -41,6 +41,7 @@ cilium-operator-generic [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -41,7 +41,7 @@ cilium-operator-generic [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-lb-annotation-prefixes strings    IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -53,6 +53,7 @@ cilium-operator [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -53,7 +53,7 @@ cilium-operator [flags]
       --identity-gc-rate-interval duration        Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration       Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --ingress-lb-annotations strings            IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-lb-annotation-prefixes strings    IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                  EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                               Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                     Kubernetes API server URL

--- a/Documentation/gettingstarted/servicemesh/ingress.rst
+++ b/Documentation/gettingstarted/servicemesh/ingress.rst
@@ -50,6 +50,10 @@ Supported Ingress Annotations
      - Enable websocket
      - 0 (disabled)
 
+Additionally, cloud-provider specific annotations for the LoadBalancer service
+are supported. Please refer to the `Kubernetes documentation <https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer>`_
+for more details.
+
 Examples
 ########
 

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1077,6 +1077,10 @@
      - Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header.
      - bool
      - ``true``
+   * - ingressController.ingressLBAnnotations
+     - IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer
+     - list
+     - ``["service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]``
    * - ingressController.secretsNamespace
      - SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1077,8 +1077,8 @@
      - Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header.
      - bool
      - ``true``
-   * - ingressController.ingressLBAnnotations
-     - IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer
+   * - ingressController.ingressLBAnnotationPrefixes
+     - IngressLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate from Ingress to the Load Balancer service
      - list
      - ``["service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]``
    * - ingressController.secretsNamespace

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -499,6 +499,7 @@ imagePullSecrets
 incrementing
 indices
 ingressController
+ingressLBAnnotations
 ingressing
 init
 initContainer

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -499,7 +499,7 @@ imagePullSecrets
 incrementing
 indices
 ingressController
-ingressLBAnnotations
+ingressLBAnnotationPrefixes
 ingressing
 init
 initContainer

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -320,6 +320,7 @@ contributors across the globe, there is almost always someone available to help.
 | imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
 | ingressController.enabled | bool | `false` | Enable cilium ingress controller This will automatically set enable-envoy-config as well. |
 | ingressController.enforceHttps | bool | `true` | Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. |
+| ingressController.ingressLBAnnotations | list | `["service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]` | IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer |
 | ingressController.secretsNamespace | object | `{"create":true,"name":"cilium-secrets","sync":true}` | SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from. |
 | ingressController.secretsNamespace.create | bool | `true` | Create secrets namespace for Ingress. |
 | ingressController.secretsNamespace.name | string | `"cilium-secrets"` | Name of Ingress secret namespace. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -320,7 +320,7 @@ contributors across the globe, there is almost always someone available to help.
 | imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
 | ingressController.enabled | bool | `false` | Enable cilium ingress controller This will automatically set enable-envoy-config as well. |
 | ingressController.enforceHttps | bool | `true` | Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. |
-| ingressController.ingressLBAnnotations | list | `["service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]` | IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer |
+| ingressController.ingressLBAnnotationPrefixes | list | `["service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]` | IngressLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate from Ingress to the Load Balancer service |
 | ingressController.secretsNamespace | object | `{"create":true,"name":"cilium-secrets","sync":true}` | SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from. |
 | ingressController.secretsNamespace.create | bool | `true` | Create secrets namespace for Ingress. |
 | ingressController.secretsNamespace.name | string | `"cilium-secrets"` | Name of Ingress secret namespace. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -213,6 +213,7 @@ data:
   enforce-ingress-https: {{ .Values.ingressController.enforceHttps | quote }}
   enable-ingress-secrets-sync: {{ .Values.ingressController.secretsNamespace.sync | quote }}
   ingress-secrets-namespace: {{ .Values.ingressController.secretsNamespace.name | quote }}
+  ingress-lb-annotations: {{ .Values.ingressController.ingressLBAnnotations | join " " | quote }}
 {{- end }}
 
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -213,7 +213,7 @@ data:
   enforce-ingress-https: {{ .Values.ingressController.enforceHttps | quote }}
   enable-ingress-secrets-sync: {{ .Values.ingressController.secretsNamespace.sync | quote }}
   ingress-secrets-namespace: {{ .Values.ingressController.secretsNamespace.name | quote }}
-  ingress-lb-annotations: {{ .Values.ingressController.ingressLBAnnotations | join " " | quote }}
+  ingress-lb-annotation-prefixes: {{ .Values.ingressController.ingressLBAnnotationPrefixes | join " " | quote }}
 {{- end }}
 
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -481,6 +481,10 @@ ingressController:
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
 
+  # -- IngressLBAnnotations are the annotations which are needed to propagate
+  # from Ingress to the Load Balancer
+  ingressLBAnnotations: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
+  
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
     # -- Create secrets namespace for Ingress.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -481,10 +481,10 @@ ingressController:
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
 
-  # -- IngressLBAnnotations are the annotations which are needed to propagate
-  # from Ingress to the Load Balancer
-  ingressLBAnnotations: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
-  
+  # -- IngressLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate
+  # from Ingress to the Load Balancer service
+  ingressLBAnnotationPrefixes: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
+
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
     # -- Create secrets namespace for Ingress.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -478,10 +478,10 @@ ingressController:
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
 
-  # -- IngressLBAnnotations are the annotations which are needed to propagate
-  # from Ingress to the Load Balancer
-  ingressLBAnnotations: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
-  
+  # -- IngressLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate
+  # from Ingress to the Load Balancer service
+  ingressLBAnnotationPrefixes: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
+
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
     # -- Create secrets namespace for Ingress.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -478,6 +478,10 @@ ingressController:
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
 
+  # -- IngressLBAnnotations are the annotations which are needed to propagate
+  # from Ingress to the Load Balancer
+  ingressLBAnnotations: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
+  
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
     # -- Create secrets namespace for Ingress.

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -338,8 +338,8 @@ func init() {
 	option.BindEnv(option.KVstoreLeaseTTL)
 
 	viper.BindPFlags(flags)
-	flags.StringSlice(operatorOption.IngressLBAnnotations, operatorOption.IngressLBAnnotationsDefault, "IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer")
-	option.BindEnv(operatorOption.IngressLBAnnotations)
+	flags.StringSlice(operatorOption.IngressLBAnnotationPrefixes, operatorOption.IngressLBAnnotationsDefault, "IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer")
+	option.BindEnv(operatorOption.IngressLBAnnotationPrefixes)
 
 	viper.BindPFlags(flags)
 }

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -338,4 +338,8 @@ func init() {
 	option.BindEnv(option.KVstoreLeaseTTL)
 
 	viper.BindPFlags(flags)
+	flags.StringSlice(operatorOption.IngressLBAnnotations, operatorOption.IngressLBAnnotationsDefault, "IngressLBAnnotations are the annotations which are needed to propagate from Ingress to the Load Balancer")
+	option.BindEnv(operatorOption.IngressLBAnnotations)
+
+	viper.BindPFlags(flags)
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -583,7 +583,7 @@ func onOperatorStartLeading(ctx context.Context) {
 			ingress.WithHTTPSEnforced(operatorOption.Config.EnforceIngressHTTPS),
 			ingress.WithSecretsSyncEnabled(operatorOption.Config.EnableIngressSecretsSync),
 			ingress.WithSecretsNamespace(operatorOption.Config.IngressSecretsNamespace),
-			ingress.WithLBAnnotations(operatorOption.Config.IngressLBAnnotations))
+			ingress.WithLBAnnotationPrefixes(operatorOption.Config.IngressLBAnnotationPrefixes))
 		if err != nil {
 			log.WithError(err).WithField(logfields.LogSubsys, ingress.Subsys).Fatal(
 				"Failed to start ingress controller")

--- a/operator/main.go
+++ b/operator/main.go
@@ -582,7 +582,8 @@ func onOperatorStartLeading(ctx context.Context) {
 		ingressController, err := ingress.NewIngressController(
 			ingress.WithHTTPSEnforced(operatorOption.Config.EnforceIngressHTTPS),
 			ingress.WithSecretsSyncEnabled(operatorOption.Config.EnableIngressSecretsSync),
-			ingress.WithSecretsNamespace(operatorOption.Config.IngressSecretsNamespace))
+			ingress.WithSecretsNamespace(operatorOption.Config.IngressSecretsNamespace),
+			ingress.WithLBAnnotations(operatorOption.Config.IngressLBAnnotations))
 		if err != nil {
 			log.WithError(err).WithField(logfields.LogSubsys, ingress.Subsys).Fatal(
 				"Failed to start ingress controller")

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -253,9 +253,9 @@ const (
 	// nodes.
 	SetCiliumIsUpCondition = "set-cilium-is-up-condition"
 
-	// IngressLBAnnotations are the annotations which are needed to propagate
+	// IngressLBAnnotationPrefixes are the annotations which are needed to propagate
 	// from Ingress to the Load Balancer
-	IngressLBAnnotations = "ingress-lb-annotations"
+	IngressLBAnnotationPrefixes = "ingress-lb-annotation-prefixes"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -473,9 +473,9 @@ type OperatorConfig struct {
 	// nodes.
 	SetCiliumIsUpCondition bool
 
-	// IngressLBAnnotations are the annotations which are needed to propagate
-	// from Ingress to the Load Balancer
-	IngressLBAnnotations []string
+	// IngressLBAnnotationPrefixes IngressLBAnnotations are the annotation prefixes,
+	// which are used to filter annotations to propagate from Ingress to the Load Balancer
+	IngressLBAnnotationPrefixes []string
 }
 
 // Populate sets all options with the values from viper.
@@ -513,7 +513,7 @@ func (c *OperatorConfig) Populate() {
 	c.CiliumPodLabels = viper.GetString(CiliumPodLabels)
 	c.RemoveCiliumNodeTaints = viper.GetBool(RemoveCiliumNodeTaints)
 	c.SetCiliumIsUpCondition = viper.GetBool(SetCiliumIsUpCondition)
-	c.IngressLBAnnotations = viper.GetStringSlice(IngressLBAnnotations)
+	c.IngressLBAnnotationPrefixes = viper.GetStringSlice(IngressLBAnnotationPrefixes)
 
 	c.CiliumK8sNamespace = viper.GetString(CiliumK8sNamespace)
 	if c.CiliumK8sNamespace == "" {

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -17,6 +17,8 @@ import (
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "option")
 
+var IngressLBAnnotationsDefault = []string{"service.beta.kubernetes.io", "service.kubernetes.io", "cloud.google.com"}
+
 const (
 	// EndpointGCIntervalDefault is the default time for the CEP GC
 	EndpointGCIntervalDefault = 5 * time.Minute
@@ -250,6 +252,10 @@ const (
 	// SetCiliumIsUpCondition sets the CiliumIsUp node condition in Kubernetes
 	// nodes.
 	SetCiliumIsUpCondition = "set-cilium-is-up-condition"
+
+	// IngressLBAnnotations are the annotations which are needed to propagate
+	// from Ingress to the Load Balancer
+	IngressLBAnnotations = "ingress-lb-annotations"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -466,6 +472,10 @@ type OperatorConfig struct {
 	// SetCiliumIsUpCondition sets the CiliumIsUp node condition in Kubernetes
 	// nodes.
 	SetCiliumIsUpCondition bool
+
+	// IngressLBAnnotations are the annotations which are needed to propagate
+	// from Ingress to the Load Balancer
+	IngressLBAnnotations []string
 }
 
 // Populate sets all options with the values from viper.
@@ -503,6 +513,7 @@ func (c *OperatorConfig) Populate() {
 	c.CiliumPodLabels = viper.GetString(CiliumPodLabels)
 	c.RemoveCiliumNodeTaints = viper.GetBool(RemoveCiliumNodeTaints)
 	c.SetCiliumIsUpCondition = viper.GetBool(SetCiliumIsUpCondition)
+	c.IngressLBAnnotations = viper.GetStringSlice(IngressLBAnnotations)
 
 	c.CiliumK8sNamespace = viper.GetString(CiliumK8sNamespace)
 	if c.CiliumK8sNamespace == "" {

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -69,10 +69,10 @@ type IngressController struct {
 	queue      workqueue.RateLimitingInterface
 	maxRetries int
 
-	enforcedHTTPS      bool
-	enabledSecretsSync bool
-	secretsNamespace   string
-	lbAnnotations      []string
+	enforcedHTTPS        bool
+	enabledSecretsSync   bool
+	secretsNamespace     string
+	lbAnnotationPrefixes []string
 }
 
 // NewIngressController returns a controller for ingress objects having ingressClassName as cilium
@@ -85,12 +85,12 @@ func NewIngressController(options ...Option) (*IngressController, error) {
 	}
 
 	ic := &IngressController{
-		queue:              workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		maxRetries:         opts.MaxRetries,
-		enforcedHTTPS:      opts.EnforcedHTTPS,
-		enabledSecretsSync: opts.EnabledSecretsSync,
-		secretsNamespace:   opts.SecretsNamespace,
-		lbAnnotations:      opts.LBAnnotations,
+		queue:                workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		maxRetries:           opts.MaxRetries,
+		enforcedHTTPS:        opts.EnforcedHTTPS,
+		enabledSecretsSync:   opts.EnabledSecretsSync,
+		secretsNamespace:     opts.SecretsNamespace,
+		lbAnnotationPrefixes: opts.LBAnnotationPrefixes,
 	}
 	ic.ingressStore, ic.ingressInformer = informer.NewInformer(
 		cache.NewListWatchFromClient(k8s.WatcherClient().NetworkingV1().RESTClient(), "ingresses", corev1.NamespaceAll, fields.Everything()),
@@ -329,7 +329,7 @@ func getIngressKeyForService(service *slim_corev1.Service) string {
 }
 
 func (ic *IngressController) createLoadBalancer(ingress *slim_networkingv1.Ingress) error {
-	svc := getServiceForIngress(ingress, ic.lbAnnotations)
+	svc := getServiceForIngress(ingress, ic.lbAnnotationPrefixes)
 	svcKey, err := cache.MetaNamespaceKeyFunc(svc)
 	if err != nil {
 		log.Warn("Failed to get service key for ingress")

--- a/operator/pkg/ingress/ingress_options.go
+++ b/operator/pkg/ingress/ingress_options.go
@@ -9,6 +9,7 @@ type Options struct {
 	EnforcedHTTPS      bool
 	EnabledSecretsSync bool
 	SecretsNamespace   string
+	LBAnnotations      []string
 }
 
 // DefaultIngressOptions specifies default values for cilium ingress controller.
@@ -16,6 +17,7 @@ var DefaultIngressOptions = Options{
 	MaxRetries:         10,
 	EnforcedHTTPS:      true,
 	EnabledSecretsSync: true,
+	LBAnnotations:      []string{},
 }
 
 // Option customizes the configuration of cilium ingress controller
@@ -49,6 +51,14 @@ func WithSecretsSyncEnabled(enabledSecretsSync bool) Option {
 func WithSecretsNamespace(secretsNamespace string) Option {
 	return func(o *Options) error {
 		o.SecretsNamespace = secretsNamespace
+		return nil
+	}
+}
+
+// WithLBAnnotations configures LB annotations to be used for LB service
+func WithLBAnnotations(lbAnnotations []string) Option {
+	return func(o *Options) error {
+		o.LBAnnotations = lbAnnotations
 		return nil
 	}
 }

--- a/operator/pkg/ingress/ingress_options.go
+++ b/operator/pkg/ingress/ingress_options.go
@@ -5,19 +5,19 @@ package ingress
 
 // Options stores all the configurations values for cilium ingress controller.
 type Options struct {
-	MaxRetries         int
-	EnforcedHTTPS      bool
-	EnabledSecretsSync bool
-	SecretsNamespace   string
-	LBAnnotations      []string
+	MaxRetries           int
+	EnforcedHTTPS        bool
+	EnabledSecretsSync   bool
+	SecretsNamespace     string
+	LBAnnotationPrefixes []string
 }
 
 // DefaultIngressOptions specifies default values for cilium ingress controller.
 var DefaultIngressOptions = Options{
-	MaxRetries:         10,
-	EnforcedHTTPS:      true,
-	EnabledSecretsSync: true,
-	LBAnnotations:      []string{},
+	MaxRetries:           10,
+	EnforcedHTTPS:        true,
+	EnabledSecretsSync:   true,
+	LBAnnotationPrefixes: []string{},
 }
 
 // Option customizes the configuration of cilium ingress controller
@@ -55,10 +55,10 @@ func WithSecretsNamespace(secretsNamespace string) Option {
 	}
 }
 
-// WithLBAnnotations configures LB annotations to be used for LB service
-func WithLBAnnotations(lbAnnotations []string) Option {
+// WithLBAnnotationPrefixes configures LB annotations to be used for LB service
+func WithLBAnnotationPrefixes(lbAnnotationPrefixes []string) Option {
 	return func(o *Options) error {
-		o.LBAnnotations = lbAnnotations
+		o.LBAnnotationPrefixes = lbAnnotationPrefixes
 		return nil
 	}
 }

--- a/operator/pkg/ingress/ingress_test.go
+++ b/operator/pkg/ingress/ingress_test.go
@@ -12,11 +12,17 @@ import (
 
 var exactPathType = slim_networkingv1.PathTypeExact
 
+var testAnnotations = map[string]string{
+	"service.beta.kubernetes.io/dummy-load-balancer-backend-protocol":    "http",
+	"service.beta.kubernetes.io/dummy-load-balancer-access-log-enabled":  "true",
+	"service.alpha.kubernetes.io/dummy-load-balancer-access-log-enabled": "true",
+}
+
 var baseIngress = &slim_networkingv1.Ingress{
 	ObjectMeta: slim_metav1.ObjectMeta{
 		Name:        "dummy-ingress",
 		Namespace:   "dummy-namespace",
-		Annotations: map[string]string{},
+		Annotations: testAnnotations,
 		UID:         "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
 	},
 	Spec: slim_networkingv1.IngressSpec{

--- a/operator/pkg/ingress/service.go
+++ b/operator/pkg/ingress/service.go
@@ -5,6 +5,7 @@ package ingress
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -183,7 +184,15 @@ func (sm *serviceManager) notify(service *slim_corev1.Service) {
 	}
 }
 
-func getServiceForIngress(ingress *slim_networkingv1.Ingress) *v1.Service {
+func getServiceForIngress(ingress *slim_networkingv1.Ingress, lbAnnotations []string) *v1.Service {
+	annotations := make(map[string]string)
+	for annotationKey, annotationValue := range ingress.ObjectMeta.Annotations {
+		for _, annotationPrefix := range lbAnnotations {
+			if strings.HasPrefix(annotationKey, annotationPrefix) {
+				annotations[annotationKey] = annotationValue
+			}
+		}
+	}
 	ports := []v1.ServicePort{
 		{
 			Name:     "http",
@@ -200,9 +209,10 @@ func getServiceForIngress(ingress *slim_networkingv1.Ingress) *v1.Service {
 	}
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getServiceNameForIngress(ingress),
-			Namespace: ingress.Namespace,
-			Labels:    map[string]string{ciliumIngressLabelKey: "true"},
+			Name:        getServiceNameForIngress(ingress),
+			Namespace:   ingress.Namespace,
+			Labels:      map[string]string{ciliumIngressLabelKey: "true"},
+			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: slim_networkingv1.SchemeGroupVersion.String(),

--- a/operator/pkg/ingress/service.go
+++ b/operator/pkg/ingress/service.go
@@ -184,10 +184,10 @@ func (sm *serviceManager) notify(service *slim_corev1.Service) {
 	}
 }
 
-func getServiceForIngress(ingress *slim_networkingv1.Ingress, lbAnnotations []string) *v1.Service {
+func getServiceForIngress(ingress *slim_networkingv1.Ingress, lbAnnotationPrefixes []string) *v1.Service {
 	annotations := make(map[string]string)
-	for annotationKey, annotationValue := range ingress.ObjectMeta.Annotations {
-		for _, annotationPrefix := range lbAnnotations {
+	for annotationKey, annotationValue := range ingress.GetAnnotations() {
+		for _, annotationPrefix := range lbAnnotationPrefixes {
 			if strings.HasPrefix(annotationKey, annotationPrefix) {
 				annotations[annotationKey] = annotationValue
 			}

--- a/operator/pkg/ingress/service_test.go
+++ b/operator/pkg/ingress/service_test.go
@@ -136,7 +136,7 @@ func Test_getServiceForIngress(t *testing.T) {
 		ingress := baseIngress.DeepCopy()
 		ingress.Spec.TLS = nil
 
-		res := getServiceForIngress(ingress)
+		res := getServiceForIngress(ingress, []string{"service.beta.kubernetes.io", "service.kubernetes.io", "cloud.google.com"})
 		assert.Equal(t, "cilium-ingress-dummy-ingress", res.Name)
 		assert.Equal(t, "dummy-namespace", res.Namespace)
 		assert.Equal(t, []metav1.OwnerReference{
@@ -158,6 +158,10 @@ func Test_getServiceForIngress(t *testing.T) {
 			},
 			Type: v1.ServiceTypeLoadBalancer,
 		}, res.Spec)
+		assert.Equal(t, map[string]string{
+			"service.beta.kubernetes.io/dummy-load-balancer-backend-protocol":   "http",
+			"service.beta.kubernetes.io/dummy-load-balancer-access-log-enabled": "true",
+		}, res.Annotations)
 	})
 
 	t.Run("with TLS", func(t *testing.T) {
@@ -169,7 +173,7 @@ func Test_getServiceForIngress(t *testing.T) {
 			},
 		}
 
-		res := getServiceForIngress(ingress)
+		res := getServiceForIngress(ingress, []string{"service.beta.kubernetes.io", "service.kubernetes.io", "cloud.google.com"})
 		assert.Equal(t, "cilium-ingress-dummy-ingress", res.Name)
 		assert.Equal(t, "dummy-namespace", res.Namespace)
 		assert.Equal(t, []metav1.OwnerReference{
@@ -196,6 +200,10 @@ func Test_getServiceForIngress(t *testing.T) {
 			},
 			Type: v1.ServiceTypeLoadBalancer,
 		}, res.Spec)
+		assert.Equal(t, map[string]string{
+			"service.beta.kubernetes.io/dummy-load-balancer-backend-protocol":   "http",
+			"service.beta.kubernetes.io/dummy-load-balancer-access-log-enabled": "true",
+		}, res.Annotations)
 	})
 }
 


### PR DESCRIPTION
* #20860 -- ingress: Propagate required annotations from Ingress to LB Service (@NikhilSharmaWe)
* #21222 --ingress: Rename LB annotation to annotation prefixes (@sayboras )

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20860 21222; do contrib/backporting/set-labels.py $pr done 1.12; done
```