### PR TITLE
Fix off-by-one-byte multi-node-port mark and mask

### DIFF
--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -55,11 +55,11 @@ const (
 	// MarkMultinodeNodeport is used for AWS ENI to mark traffic from
 	// another node, so that it gets routed back through the relevant
 	// interface.
-	MarkMultinodeNodeport = 0x80
+	MarkMultinodeNodeport = 0x8000
 
 	// MaskMultinodeNodeport is the mask associated with the
 	// RouterMarkNodePort
-	MaskMultinodeNodeport = 0x80
+	MaskMultinodeNodeport = 0x8000
 
 	// IPSecProtocolID IP protocol ID for IPSec defined in RFC4303
 	RouteProtocolIPSec = 50


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #20797

See detailed explanation in issue [20797](https://github.com/cilium/cilium/issues/20797).

The `MarkMultinodeNodeport` and `MaskMultinodeNodeport` values of `0x80` appear to be incorrect as this targets the 
leftmost bit of the cluster id of the identity serialised in the mark. This results in corrupting the leftmost cluster id bit and ingress denials in network policies as the full source identity fails to match.

Instead these constants should be `0x8000` in order to target the 2nd byte of the mark that is reserved by Cilium for the purpose of encoding non-identity information in the mark.
