### PR TITLE
daemon: Call initEnv from start hook to avoid data race

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1569,6 +1569,10 @@ func registerDaemonHooks(lc fx.Lifecycle, shutdowner fx.Shutdowner) error {
 	cleaner := NewDaemonCleanup()
 	lc.Append(fx.Hook{
 		OnStart: func(context.Context) error {
+			bootstrapStats.earlyInit.Start()
+			initEnv()
+			bootstrapStats.earlyInit.End(true)
+
 			// Start running the daemon in the background (blocks on API server's Serve()) to allow rest
 			// of the start hooks to run.
 			go runDaemon(ctx, cleaner, shutdowner)
@@ -1585,10 +1589,6 @@ func registerDaemonHooks(lc fx.Lifecycle, shutdowner fx.Shutdowner) error {
 
 // runDaemon runs the old unmodular part of the cilium-agent.
 func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner fx.Shutdowner) {
-	bootstrapStats.earlyInit.Start()
-	initEnv()
-	bootstrapStats.earlyInit.End(true)
-
 	datapathConfig := linuxdatapath.DatapathConfiguration{
 		HostDevice: defaults.HostDevice,
 		ProcFs:     option.Config.ProcFs,


### PR DESCRIPTION
The metrics logging hook was being added from initEnv while the FxLogger (pkg/logging/fx_logger.go) was using the logger to log fx events. This fixes the race by executing initEnv directly in the start hook preventing concurrent use of the logger.

Fixes: #21230
Fixes: 6b7c7b326995 ("daemon: Convert app.go to hive, add dump commands")
