### PR TITLE
Push workflow status to Loki

### DIFF
--- a/.github/workflows/loki.yaml
+++ b/.github/workflows/loki.yaml
@@ -1,0 +1,70 @@
+name: Push to Loki
+
+on:
+  workflow_run:
+    workflows:
+      - BPF checks
+      - Base Image Lint
+      - Base Image Release Build
+      - Beta Image Release Build
+      - CIFuzz
+      - CODEOWNERS checks
+      - Cilium L4LB XDP (ci-l4lb)
+      - Cilium L4LB XDP (ci-l4lb-1.10)
+      - Cilium L4LB XDP (ci-l4lb-1.11)
+      - Cilium L4LB XDP (ci-l4lb-1.12)
+      - Conformance AWS-CNI (ci-awscni)
+      - Conformance AWS-CNI (ci-awscni-1.10)
+      - Conformance AWS-CNI (ci-awscni-1.11)
+      - Conformance AWS-CNI (ci-awscni-1.12)
+      - ConformanceAKS (ci-aks)
+      - ConformanceAKS (ci-aks-1.10)
+      - ConformanceAKS (ci-aks-1.11)
+      - ConformanceAKS (ci-aks-1.12)
+      - ConformanceEKS (ci-eks)
+      - ConformanceEKS (ci-eks-1.10)
+      - ConformanceEKS (ci-eks-1.11)
+      - ConformanceEKS (ci-eks-1.12)
+      - ConformanceGKE (ci-gke)
+      - ConformanceGKE (ci-gke-1.10)
+      - ConformanceGKE (ci-gke-1.11)
+      - ConformanceGKE (ci-gke-1.12)
+      - ConformanceIngress
+      - ConformanceKind1.19
+      - Cyclonus network policy test
+      - Documentation Updates
+      - External workloads (ci-external-workloads)
+      - External workloads (ci-external-workloads-v1.10)
+      - External workloads (ci-external-workloads-v1.11)
+      - External workloads (ci-external-workloads-v1.12)
+      - Go-related checks
+      - Hot Fix Image Release Build
+      - Image CI Build
+      - Image CI Cache Cleaner
+      - Image Release Build
+      - Multicluster / Cluster mesh (ci-multicluster)
+      - Multicluster / Cluster mesh (ci-multicluster-1.10)
+      - Multicluster / Cluster mesh (ci-multicluster-1.11)
+      - Multicluster / Cluster mesh (ci-multicluster-1.12)
+      - Nightly
+      - Scruffy
+      - Smoke Test with IPv6
+      - Smoke test
+      - build-commits
+      - codeql
+    types:
+      - completed
+
+permissions:
+  actions: read
+
+jobs:
+  push-to-loki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push to Loki
+        uses: michi-covalent/push-to-loki@v0.2.0
+        with:
+          endpoint: https://logs-prod3.grafana.net/loki/api/v1/push
+          username: ${{ secrets.LOKI_USERNAME }}
+          password: ${{ secrets.LOKI_PASSWORD }}


### PR DESCRIPTION
Push workflow status to Loki to make it easier to monitor CI stability over time. Unfortunately there is no wildcard support for workflow_run trigger, so we need to explicitly list individual workflow names.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>