### PR TITLE
Switch to CNI v0.4.0

### DIFF
--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -18,7 +18,7 @@ case "$CILIUM_CNI_CHAINING_MODE" in
 	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
 	;;
 *)
-	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conf}
+	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
 	;;
 esac
 
@@ -142,7 +142,7 @@ case "$CILIUM_CNI_CHAINING_MODE" in
 "flannel")
 	cat > "${CNI_CONF_NAME}" <<EOF
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "name": "flannel",
   "plugins": [
     {
@@ -172,7 +172,7 @@ EOF
 "portmap")
 	cat > "${CNI_CONF_NAME}" <<EOF
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "name": "portmap",
   "plugins": [
     {
@@ -198,7 +198,7 @@ EOF
   else
     cat > "${CNI_CONF_NAME}" <<EOF
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "name": "aws-cni",
   "plugins": [
     {
@@ -229,11 +229,15 @@ EOF
 *)
 	cat > "${CNI_CONF_NAME}" <<EOF
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "name": "cilium",
-  "type": "cilium-cni",
-  "enable-debug": ${ENABLE_DEBUG},
-  "log-file": "${LOG_FILE}"
+  "plugins": [
+    {
+      "type": "cilium-cni",
+      "enable-debug": ${ENABLE_DEBUG},
+      "log-file": "${LOG_FILE}"
+    }
+  ]
 }
 EOF
 	;;

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -407,7 +407,7 @@ fi
 #     [ERROR SystemVerification]: unsupported kernel release: 5.0.0-rc6+
 case $K8S_VERSION in
     "1.16")
-        KUBERNETES_CNI_VERSION="0.7.5"
+        KUBERNETES_CNI_VERSION="0.8.7"
         K8S_FULL_VERSION="1.16.15"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri,swap"
         KUBEADM_WORKER_OPTIONS="--token=$TOKEN --discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification,swap"


### PR DESCRIPTION
(This is an un-revert of #20956)
Fixes: https://github.com/cilium/cilium/issues/17251

CNI v0.4.0 introduces CHECK, which we support. CNI v1.0.0 no longer supports single-plugin configs, so let's switch to
the list now.

This PR also bumps the CNI plugin version used in the kubernetes v1.16 tests to a version that supports v0.4.0. Kubelet itself supports v0.4.0.

```release-note
The default CNI version is now v0.4.0. Cilium now supports the CNI CHECK action.
```
