### PR TITLE
test: add external_endpoints file for v1beta1

### DIFF
--- a/test/k8s/manifests/1.18/external_endpoint.yaml
+++ b/test/k8s/manifests/1.18/external_endpoint.yaml
@@ -1,0 +1,16 @@
+apiVersion: discovery.k8s.io/v1beta1
+kind: EndpointSlice
+addressType: IPv4
+endpoints:
+- addresses:
+  - 198.49.23.144
+  conditions:
+    ready: true
+metadata:
+  name: external-service
+  namespace: default
+  labels:
+    kubernetes.io/service-name: external-service
+ports:
+- port: 80
+  protocol: TCP

--- a/test/k8s/manifests/1.19/external_endpoint.yaml
+++ b/test/k8s/manifests/1.19/external_endpoint.yaml
@@ -1,0 +1,16 @@
+apiVersion: discovery.k8s.io/v1beta1
+kind: EndpointSlice
+addressType: IPv4
+endpoints:
+- addresses:
+  - 198.49.23.144
+  conditions:
+    ready: true
+metadata:
+  name: external-service
+  namespace: default
+  labels:
+    kubernetes.io/service-name: external-service
+ports:
+- port: 80
+  protocol: TCP


### PR DESCRIPTION
Although EndpointSlices were made GA in K8s 1.21, we have been enabling them in our CI since 1.18. However, between 1.18 and 1.20 EndpointSlices are part of the discovery.k8s.io/v1beta1 and not discovery.k8s.io/v1 so we need specific files for these versions.

Fixes: ce69afdc3ad1 ("add support for k8s 1.25.0")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/21231