### PR TITLE
envoy: Support LB capability for existing k8s Service

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1405,6 +1405,18 @@
      - interval between checks of the liveness probe
      - int
      - ``30``
+   * - loadBalancer
+     - Configure service load balancing
+     - object
+     - ``{"l7":{"backend":"disabled"}}``
+   * - loadBalancer.l7
+     - L7 LoadBalancer
+     - object
+     - ``{"backend":"disabled"}``
+   * - loadBalancer.l7.backend
+     - Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. io.cilium.service/lb-protocol, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration. Applicable values: - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well. - disabled: Disable L7 load balancing.
+     - string
+     - ``"disabled"``
    * - localRedirectPolicy
      - Enable Local Redirect Policy.
      - bool

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1408,11 +1408,15 @@
    * - loadBalancer
      - Configure service load balancing
      - object
-     - ``{"l7":{"backend":"disabled","ports":[]}}``
+     - ``{"l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}``
    * - loadBalancer.l7
      - L7 LoadBalancer
      - object
-     - ``{"backend":"disabled","ports":[]}``
+     - ``{"algorithm":"round_robin","backend":"disabled","ports":[]}``
+   * - loadBalancer.l7.algorithm
+     - Default LB algorithm The default LB algorithm to be used for services, which can be overridden by the service annotation (e.g. io.cilium.service/lb-algorithm) Applicable values: round_robin, least_request, random
+     - string
+     - ``"round_robin"``
    * - loadBalancer.l7.backend
      - Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. io.cilium.service/lb-protocol, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration.  Applicable values:   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.   - disabled: Disable L7 load balancing.
      - string

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1408,15 +1408,19 @@
    * - loadBalancer
      - Configure service load balancing
      - object
-     - ``{"l7":{"backend":"disabled"}}``
+     - ``{"l7":{"backend":"disabled","ports":[]}}``
    * - loadBalancer.l7
      - L7 LoadBalancer
      - object
-     - ``{"backend":"disabled"}``
+     - ``{"backend":"disabled","ports":[]}``
    * - loadBalancer.l7.backend
-     - Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. io.cilium.service/lb-protocol, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration. Applicable values: - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well. - disabled: Disable L7 load balancing.
+     - Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. io.cilium.service/lb-protocol, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration.  Applicable values:   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.   - disabled: Disable L7 load balancing.
      - string
      - ``"disabled"``
+   * - loadBalancer.l7.ports
+     - List of ports from service to be automatically redirected to above backend. Any service exposing one of these ports will be automatically redirected. Fine-grained control can be achieved by using the service annotation.
+     - list
+     - ``[]``
    * - localRedirectPolicy
      - Enable Local Redirect Policy.
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -402,6 +402,9 @@ contributors across the globe, there is almost always someone available to help.
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
+| loadBalancer | object | `{"l7":{"backend":"disabled"}}` | Configure service load balancing |
+| loadBalancer.l7 | object | `{"backend":"disabled"}` | L7 LoadBalancer |
+| loadBalancer.l7.backend | string | `"disabled"` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. io.cilium.service/lb-protocol, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration. Applicable values: - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well. - disabled: Disable L7 load balancing. |
 | localRedirectPolicy | bool | `false` | Enable Local Redirect Policy. |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -402,9 +402,16 @@ contributors across the globe, there is almost always someone available to help.
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
+<<<<<<< HEAD
 | loadBalancer | object | `{"l7":{"backend":"disabled"}}` | Configure service load balancing |
 | loadBalancer.l7 | object | `{"backend":"disabled"}` | L7 LoadBalancer |
 | loadBalancer.l7.backend | string | `"disabled"` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. io.cilium.service/lb-protocol, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration. Applicable values: - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well. - disabled: Disable L7 load balancing. |
+=======
+| loadBalancer | object | `{"envoy":{"enabled":false,"ports":[]}}` | Configure service load balancing |
+| loadBalancer.envoy | object | `{"enabled":false,"ports":[]}` | LoadBalancer with envoy proxy |
+| loadBalancer.envoy.enabled | bool | `false` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. io.cilium/lb-protocol, will be forwarded to the local envoy proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for configuring the envoy proxy. This will automatically set enable-envoy-config as well. |
+| loadBalancer.envoy.ports | list | `[]` | List of ports from service to be automatically redirected to envoy proxy. Any service exposing one of these ports will be automatically redirected to envoy proxy. Fine-grained control can be achieved by using the service annotation. |
+>>>>>>> b06076c98a (envoy: Support list of global ports for redirect)
 | localRedirectPolicy | bool | `false` | Enable Local Redirect Policy. |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -402,16 +402,11 @@ contributors across the globe, there is almost always someone available to help.
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
-<<<<<<< HEAD
-| loadBalancer | object | `{"l7":{"backend":"disabled"}}` | Configure service load balancing |
-| loadBalancer.l7 | object | `{"backend":"disabled"}` | L7 LoadBalancer |
-| loadBalancer.l7.backend | string | `"disabled"` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. io.cilium.service/lb-protocol, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration. Applicable values: - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well. - disabled: Disable L7 load balancing. |
-=======
-| loadBalancer | object | `{"envoy":{"enabled":false,"ports":[]}}` | Configure service load balancing |
-| loadBalancer.envoy | object | `{"enabled":false,"ports":[]}` | LoadBalancer with envoy proxy |
-| loadBalancer.envoy.enabled | bool | `false` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. io.cilium/lb-protocol, will be forwarded to the local envoy proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for configuring the envoy proxy. This will automatically set enable-envoy-config as well. |
-| loadBalancer.envoy.ports | list | `[]` | List of ports from service to be automatically redirected to envoy proxy. Any service exposing one of these ports will be automatically redirected to envoy proxy. Fine-grained control can be achieved by using the service annotation. |
->>>>>>> b06076c98a (envoy: Support list of global ports for redirect)
+| loadBalancer | object | `{"l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}` | Configure service load balancing |
+| loadBalancer.l7 | object | `{"algorithm":"round_robin","backend":"disabled","ports":[]}` | L7 LoadBalancer |
+| loadBalancer.l7.algorithm | string | `"round_robin"` | Default LB algorithm The default LB algorithm to be used for services, which can be overridden by the service annotation (e.g. io.cilium.service/lb-algorithm) Applicable values: round_robin, least_request, random |
+| loadBalancer.l7.backend | string | `"disabled"` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. io.cilium.service/lb-protocol, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration.  Applicable values:   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.   - disabled: Disable L7 load balancing. |
+| loadBalancer.l7.ports | list | `[]` | List of ports from service to be automatically redirected to above backend. Any service exposing one of these ports will be automatically redirected. Fine-grained control can be achieved by using the service annotation. |
 | localRedirectPolicy | bool | `false` | Enable Local Redirect Policy. |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -224,6 +224,7 @@ data:
   loadbalancer-l7: "envoy"
   enable-envoy-config: "true"
   loadbalancer-l7-ports: {{ .Values.loadBalancer.l7.ports | join " " | quote }}
+  loadbalancer-l7-algorithm: {{ .Values.loadBalancer.l7.algorithm | quote }}
 {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -219,6 +219,13 @@ data:
   gateway-api-secrets-namespace: {{ .Values.gatewayAPI.secretsNamespace.name | quote }}
 {{- end }}
 
+{{- if hasKey .Values "loadBalancer" }}
+{{- if eq .Values.loadBalancer.l7.backend "envoy" }}
+  loadbalancer-l7: "envoy"
+  enable-envoy-config: "true"
+{{- end }}
+{{- end }}
+
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
   # address.
   enable-ipv4: {{ .Values.ipv4.enabled | quote }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -223,6 +223,7 @@ data:
 {{- if eq .Values.loadBalancer.l7.backend "envoy" }}
   loadbalancer-l7: "envoy"
   enable-envoy-config: "true"
+  loadbalancer-l7-ports: {{ .Values.loadBalancer.l7.ports | join " " | quote }}
 {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1520,6 +1520,11 @@ loadBalancer:
     # Any service exposing one of these ports will be automatically redirected.
     # Fine-grained control can be achieved by using the service annotation.
     ports: []
+    # -- Default LB algorithm
+    # The default LB algorithm to be used for services, which can be overridden by the
+    # service annotation (e.g. io.cilium.service/lb-algorithm)
+    # Applicable values: round_robin, least_request, random
+    algorithm: round_robin
 
 # -- Configure N-S k8s service loadbalancing
 nodePort:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1480,7 +1480,7 @@ monitor:
   enabled: false
 
 # -- Configure service load balancing
-# loadBalancer:
+loadBalancer:
   # -- standalone enables the standalone L4LB which does not connect to
   # kube-apiserver.
   # standalone: false
@@ -1504,6 +1504,18 @@ monitor:
   # -- serviceTopology enables K8s Topology Aware Hints -based service
   # endpoints filtering
   # serviceTopology: false
+
+  # -- L7 LoadBalancer
+  l7:
+    # -- Enable L7 service load balancing via envoy proxy.
+    # The request to a k8s service, which has specific annotation e.g. io.cilium.service/lb-protocol,
+    # will be forwarded to the local backend proxy to be load balanced to the service endpoints.
+    # Please refer to docs for supported annotations for more configuration.
+    #
+    # Applicable values:
+    #   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.
+    #   - disabled: Disable L7 load balancing.
+    backend: disabled
 
 # -- Configure N-S k8s service loadbalancing
 nodePort:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1516,6 +1516,10 @@ loadBalancer:
     #   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.
     #   - disabled: Disable L7 load balancing.
     backend: disabled
+    # -- List of ports from service to be automatically redirected to above backend.
+    # Any service exposing one of these ports will be automatically redirected.
+    # Fine-grained control can be achieved by using the service annotation.
+    ports: []
 
 # -- Configure N-S k8s service loadbalancing
 nodePort:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1477,7 +1477,7 @@ monitor:
   enabled: false
 
 # -- Configure service load balancing
-# loadBalancer:
+loadBalancer:
   # -- standalone enables the standalone L4LB which does not connect to
   # kube-apiserver.
   # standalone: false
@@ -1501,6 +1501,18 @@ monitor:
   # -- serviceTopology enables K8s Topology Aware Hints -based service
   # endpoints filtering
   # serviceTopology: false
+
+  # -- L7 LoadBalancer
+  l7:
+    # -- Enable L7 service load balancing via envoy proxy.
+    # The request to a k8s service, which has specific annotation e.g. io.cilium.service/lb-protocol,
+    # will be forwarded to the local backend proxy to be load balanced to the service endpoints.
+    # Please refer to docs for supported annotations for more configuration.
+    #
+    # Applicable values:
+    #   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.
+    #   - disabled: Disable L7 load balancing.
+    backend: disabled
 
 # -- Configure N-S k8s service loadbalancing
 nodePort:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1517,6 +1517,11 @@ loadBalancer:
     # Any service exposing one of these ports will be automatically redirected.
     # Fine-grained control can be achieved by using the service annotation.
     ports: []
+    # -- Default LB algorithm
+    # The default LB algorithm to be used for services, which can be overridden by the
+    # service annotation (e.g. io.cilium.service/lb-algorithm)
+    # Applicable values: round_robin, least_request, random
+    algorithm: round_robin
 
 # -- Configure N-S k8s service loadbalancing
 nodePort:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1513,6 +1513,10 @@ loadBalancer:
     #   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.
     #   - disabled: Disable L7 load balancing.
     backend: disabled
+    # -- List of ports from service to be automatically redirected to above backend.
+    # Any service exposing one of these ports will be automatically redirected.
+    # Fine-grained control can be achieved by using the service annotation.
+    ports: []
 
 # -- Configure N-S k8s service loadbalancing
 nodePort:

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -706,7 +706,7 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 
 	if operatorOption.Config.LoadBalancerL7 == "envoy" {
 		log.Info("Starting Envoy load balancer controller")
-		operatorWatchers.StartCECController(legacy.ctx, legacy.clientset, legacy.resources.Services)
+		operatorWatchers.StartCECController(legacy.ctx, legacy.clientset, legacy.resources.Services, operatorOption.Config.LoadBalancerL7Ports)
 	}
 
 	log.Info("Initialization complete")

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cilium/cilium/operator/pkg/ingress"
 	"github.com/cilium/cilium/operator/pkg/lbipam"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
-
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
@@ -703,6 +702,11 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 				"Failed to create gateway controller")
 		}
 		go gatewayController.Run()
+	}
+
+	if operatorOption.Config.LoadBalancerL7 == "envoy" {
+		log.Info("Starting Envoy load balancer controller")
+		operatorWatchers.StartCECController(legacy.ctx, legacy.clientset, legacy.resources.Services)
 	}
 
 	log.Info("Initialization complete")

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -706,7 +706,9 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 
 	if operatorOption.Config.LoadBalancerL7 == "envoy" {
 		log.Info("Starting Envoy load balancer controller")
-		operatorWatchers.StartCECController(legacy.ctx, legacy.clientset, legacy.resources.Services, operatorOption.Config.LoadBalancerL7Ports)
+		operatorWatchers.StartCECController(legacy.ctx, legacy.clientset, legacy.resources.Services,
+			operatorOption.Config.LoadBalancerL7Ports,
+			operatorOption.Config.LoadBalancerL7Algorithm)
 	}
 
 	log.Info("Initialization complete")

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -251,6 +251,9 @@ const (
 	// CESSlicingMode instructs how CEPs are grouped in a CES.
 	CESSlicingMode = "ces-slice-mode"
 
+	// LoadBalancerL7 enables loadbalancer capabilities for services via envoy proxy
+	LoadBalancerL7 = "loadbalancer-l7"
+
 	// EnableIngressController enables cilium ingress controller
 	// This must be enabled along with enable-envoy-config in cilium agent.
 	EnableIngressController = "enable-ingress-controller"
@@ -519,6 +522,9 @@ type OperatorConfig struct {
 	// CESSlicingMode instructs how CEPs are grouped in a CES.
 	CESSlicingMode string
 
+	// LoadBalancerL7 enables loadbalancer capabilities for services.
+	LoadBalancerL7 string
+
 	// EnableIngressController enables cilium ingress controller
 	EnableIngressController bool
 
@@ -603,6 +609,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.BGPAnnounceLBIP = vp.GetBool(BGPAnnounceLBIP)
 	c.BGPConfigPath = vp.GetString(BGPConfigPath)
 	c.SkipCRDCreation = vp.GetBool(SkipCRDCreation)
+	c.LoadBalancerL7 = vp.GetString(LoadBalancerL7)
 	c.EnableIngressController = vp.GetBool(EnableIngressController)
 	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)
 	c.EnforceIngressHTTPS = vp.GetBool(EnforceIngressHttps)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -254,6 +254,9 @@ const (
 	// LoadBalancerL7 enables loadbalancer capabilities for services via envoy proxy
 	LoadBalancerL7 = "loadbalancer-l7"
 
+	// LoadBalancerL7Ports is a list of service ports that will be automatically redirected to backend.
+	LoadBalancerL7Ports = "loadbalancer-l7-ports"
+
 	// EnableIngressController enables cilium ingress controller
 	// This must be enabled along with enable-envoy-config in cilium agent.
 	EnableIngressController = "enable-ingress-controller"
@@ -525,6 +528,9 @@ type OperatorConfig struct {
 	// LoadBalancerL7 enables loadbalancer capabilities for services.
 	LoadBalancerL7 string
 
+	// EnvoyLoadBalancerPorts is a list of service ports that will be automatically redirected to Envoy
+	LoadBalancerL7Ports []string
+
 	// EnableIngressController enables cilium ingress controller
 	EnableIngressController bool
 
@@ -610,6 +616,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.BGPConfigPath = vp.GetString(BGPConfigPath)
 	c.SkipCRDCreation = vp.GetBool(SkipCRDCreation)
 	c.LoadBalancerL7 = vp.GetString(LoadBalancerL7)
+	c.LoadBalancerL7Ports = vp.GetStringSlice(LoadBalancerL7Ports)
 	c.EnableIngressController = vp.GetBool(EnableIngressController)
 	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)
 	c.EnforceIngressHTTPS = vp.GetBool(EnforceIngressHttps)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -257,6 +257,9 @@ const (
 	// LoadBalancerL7Ports is a list of service ports that will be automatically redirected to backend.
 	LoadBalancerL7Ports = "loadbalancer-l7-ports"
 
+	// LoadBalancerL7Algorithm is a default LB algorithm for services that do not specify related annotation
+	LoadBalancerL7Algorithm = "loadbalancer-l7-algorithm"
+
 	// EnableIngressController enables cilium ingress controller
 	// This must be enabled along with enable-envoy-config in cilium agent.
 	EnableIngressController = "enable-ingress-controller"
@@ -531,6 +534,9 @@ type OperatorConfig struct {
 	// EnvoyLoadBalancerPorts is a list of service ports that will be automatically redirected to Envoy
 	LoadBalancerL7Ports []string
 
+	// LoadBalancerL7Algorithm is a default LB algorithm for services that do not specify related annotation
+	LoadBalancerL7Algorithm string
+
 	// EnableIngressController enables cilium ingress controller
 	EnableIngressController bool
 
@@ -617,6 +623,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.SkipCRDCreation = vp.GetBool(SkipCRDCreation)
 	c.LoadBalancerL7 = vp.GetString(LoadBalancerL7)
 	c.LoadBalancerL7Ports = vp.GetStringSlice(LoadBalancerL7Ports)
+	c.LoadBalancerL7Algorithm = vp.GetString(LoadBalancerL7Algorithm)
 	c.EnableIngressController = vp.GetBool(EnableIngressController)
 	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)
 	c.EnforceIngressHTTPS = vp.GetBool(EnforceIngressHttps)

--- a/operator/pkg/ciliumenvoyconfig/annotations.go
+++ b/operator/pkg/ciliumenvoyconfig/annotations.go
@@ -4,6 +4,10 @@
 package ciliumenvoyconfig
 
 import (
+	envoy_config_cluster_v3 "github.com/cilium/proxy/go/envoy/config/cluster/v3"
+	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
+	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
+	http_connection_manager_v3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/pkg/annotation"
@@ -14,6 +18,13 @@ const (
 	lbEnabledAnnotation     = servicePrefixAnnotation + "/lb-l7"
 	lbModeAnnotation        = servicePrefixAnnotation + "/lb-l7-algorithm"
 )
+
+type clusterMutator func(*envoy_config_cluster_v3.Cluster) *envoy_config_cluster_v3.Cluster
+type httpConnectionManagerMutator func(*http_connection_manager_v3.HttpConnectionManager) *http_connection_manager_v3.HttpConnectionManager
+type listenerMutator func(*envoy_config_listener.Listener) *envoy_config_listener.Listener
+type routeMutator func(route *envoy_config_route_v3.Route) *envoy_config_route_v3.Route
+type routeConfigMutator func(*envoy_config_route_v3.RouteConfiguration) *envoy_config_route_v3.RouteConfiguration
+type virtualHostMutator func(*envoy_config_route_v3.VirtualHost) *envoy_config_route_v3.VirtualHost
 
 // IsLBProtocolAnnotationEnabled returns true if the load balancer protocol is enabled
 func IsLBProtocolAnnotationEnabled(obj metav1.Object) bool {

--- a/operator/pkg/ciliumenvoyconfig/annotations.go
+++ b/operator/pkg/ciliumenvoyconfig/annotations.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/pkg/annotation"
+)
+
+const (
+	servicePrefixAnnotation = annotation.Prefix + ".service"
+	lbEnabledAnnotation     = servicePrefixAnnotation + "/lb-l7"
+	lbModeAnnotation        = servicePrefixAnnotation + "/lb-l7-algorithm"
+)
+
+// IsLBProtocolAnnotationEnabled returns true if the load balancer protocol is enabled
+func IsLBProtocolAnnotationEnabled(obj metav1.Object) bool {
+	return obj.GetAnnotations()[lbEnabledAnnotation] == "enabled"
+}
+
+// GetLBProtocolModelAnnotation returns the load balancer mode
+func GetLBProtocolModelAnnotation(obj metav1.Object) string {
+	return obj.GetAnnotations()[lbModeAnnotation]
+}

--- a/operator/pkg/ciliumenvoyconfig/annotations.go
+++ b/operator/pkg/ciliumenvoyconfig/annotations.go
@@ -4,6 +4,8 @@
 package ciliumenvoyconfig
 
 import (
+	"strings"
+
 	envoy_config_cluster_v3 "github.com/cilium/proxy/go/envoy/config/cluster/v3"
 	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
@@ -39,6 +41,19 @@ func GetLBProtocolModelAnnotation(obj metav1.Object) string {
 //
 // ClusterMutator functions
 //
+
+// grpcHttpConnectionManagerMutator returns a function that mutates the upgradeConfigs for grpc protocol
+func lbModeClusterMutator(obj metav1.Object) clusterMutator {
+	return func(cluster *envoy_config_cluster_v3.Cluster) *envoy_config_cluster_v3.Cluster {
+		lbMode := GetLBProtocolModelAnnotation(obj)
+		if lbMode == "" {
+			return cluster
+		}
+
+		cluster.LbPolicy = envoy_config_cluster_v3.Cluster_LbPolicy(envoy_config_cluster_v3.Cluster_LbPolicy_value[strings.ToUpper(lbMode)])
+		return cluster
+	}
+}
 
 //
 // HTTPConnectionManagerMutator functions

--- a/operator/pkg/ciliumenvoyconfig/annotations.go
+++ b/operator/pkg/ciliumenvoyconfig/annotations.go
@@ -35,3 +35,21 @@ func IsLBProtocolAnnotationEnabled(obj metav1.Object) bool {
 func GetLBProtocolModelAnnotation(obj metav1.Object) string {
 	return obj.GetAnnotations()[lbModeAnnotation]
 }
+
+//
+// ClusterMutator functions
+//
+
+//
+// HTTPConnectionManagerMutator functions
+//
+
+// grpcHttpConnectionManagerMutator returns a function that mutates the upgradeConfigs for grpc protocol
+func grpcHttpConnectionManagerMutator(_ metav1.Object) httpConnectionManagerMutator {
+	return func(manager *http_connection_manager_v3.HttpConnectionManager) *http_connection_manager_v3.HttpConnectionManager {
+		manager.UpgradeConfigs = []*http_connection_manager_v3.HttpConnectionManager_UpgradeConfig{
+			{UpgradeType: "websocket"},
+		}
+		return manager
+	}
+}

--- a/operator/pkg/ciliumenvoyconfig/annotations_test.go
+++ b/operator/pkg/ciliumenvoyconfig/annotations_test.go
@@ -6,6 +6,7 @@ package ciliumenvoyconfig
 import (
 	"testing"
 
+	envoy_config_cluster "github.com/cilium/proxy/go/envoy/config/cluster/v3"
 	http_connection_manager_v3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/stretchr/testify/require"
 
@@ -22,5 +23,39 @@ func Test_grpcHttpConnectionManagerMutator(t *testing.T) {
 		})(input)
 		require.NotNil(t, res)
 		require.NotNil(t, res.UpgradeConfigs)
+	})
+}
+
+func Test_lbModeClusterMutator(t *testing.T) {
+	input := &envoy_config_cluster.Cluster{}
+
+	t.Run("no ops", func(t *testing.T) {
+		res := lbModeClusterMutator(&slim_corev1.Service{})(input)
+		require.NotNil(t, res)
+		require.Equal(t, envoy_config_cluster.Cluster_LbPolicy(0), res.LbPolicy)
+	})
+
+	t.Run("mutate lb policy to round robin", func(t *testing.T) {
+		res := lbModeClusterMutator(&slim_corev1.Service{
+			ObjectMeta: slim_metav1.ObjectMeta{
+				Annotations: map[string]string{
+					lbModeAnnotation: "round_robin",
+				},
+			},
+		})(input)
+		require.NotNil(t, res)
+		require.NotNil(t, res.LbPolicy, envoy_config_cluster.Cluster_ROUND_ROBIN)
+	})
+
+	t.Run("mutate lb policy to least request", func(t *testing.T) {
+		res := lbModeClusterMutator(&slim_corev1.Service{
+			ObjectMeta: slim_metav1.ObjectMeta{
+				Annotations: map[string]string{
+					lbModeAnnotation: "least_request",
+				},
+			},
+		})(input)
+		require.NotNil(t, res)
+		require.NotNil(t, res.LbPolicy, envoy_config_cluster.Cluster_LEAST_REQUEST)
 	})
 }

--- a/operator/pkg/ciliumenvoyconfig/annotations_test.go
+++ b/operator/pkg/ciliumenvoyconfig/annotations_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"testing"
+
+	http_connection_manager_v3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/stretchr/testify/require"
+
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func Test_grpcHttpConnectionManagerMutator(t *testing.T) {
+	input := &http_connection_manager_v3.HttpConnectionManager{}
+
+	t.Run("mutate upgradeConfigs", func(t *testing.T) {
+		res := grpcHttpConnectionManagerMutator(&slim_corev1.Service{
+			ObjectMeta: slim_metav1.ObjectMeta{},
+		})(input)
+		require.NotNil(t, res)
+		require.NotNil(t, res.UpgradeConfigs)
+	})
+}

--- a/operator/pkg/ciliumenvoyconfig/doc.go
+++ b/operator/pkg/ciliumenvoyconfig/doc.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package service contains the logic for Cilium Load Balancer Controller via envoy config
+package ciliumenvoyconfig
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const Subsys = "envoy-lb-controller"
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, Subsys)

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -6,13 +6,26 @@ package ciliumenvoyconfig
 import (
 	"fmt"
 
+	envoy_config_cluster_v3 "github.com/cilium/proxy/go/envoy/config/cluster/v3"
+	envoy_config_core_v3 "github.com/cilium/proxy/go/envoy/config/core/v3"
+	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
+	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
+	envoy_extensions_filters_network_http_connection_manager_v3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoy_config_upstream "github.com/cilium/proxy/go/envoy/extensions/upstreams/http/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 
-	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/envoy"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 )
 
@@ -30,8 +43,8 @@ func newEnvoyConfigManager(client client.Clientset, maxRetries int) (*envoyConfi
 	}
 
 	manager.store, manager.informer = informer.NewInformer(
-		utils.ListerWatcherFromTyped[*v2.CiliumEnvoyConfigList](client.CiliumV2().CiliumEnvoyConfigs(corev1.NamespaceAll)),
-		&v2.CiliumEnvoyConfig{},
+		utils.ListerWatcherFromTyped[*ciliumv2.CiliumEnvoyConfigList](client.CiliumV2().CiliumEnvoyConfigs(corev1.NamespaceAll)),
+		&ciliumv2.CiliumEnvoyConfig{},
 		0,
 		cache.ResourceEventHandlerFuncs{},
 		nil,
@@ -45,12 +58,12 @@ func newEnvoyConfigManager(client client.Clientset, maxRetries int) (*envoyConfi
 }
 
 // getByKey is a wrapper of Store.GetByKey but with concrete CiliumEnvoyConfig object
-func (em *envoyConfigManager) getByKey(key string) (*v2.CiliumEnvoyConfig, bool, error) {
+func (em *envoyConfigManager) getByKey(key string) (*ciliumv2.CiliumEnvoyConfig, bool, error) {
 	objFromCache, exists, err := em.store.GetByKey(key)
 	if objFromCache == nil || !exists || err != nil {
 		return nil, exists, err
 	}
-	envoyConfig, ok := objFromCache.(*v2.CiliumEnvoyConfig)
+	envoyConfig, ok := objFromCache.(*ciliumv2.CiliumEnvoyConfig)
 	if !ok {
 		return nil, exists, fmt.Errorf("got invalid object from cache")
 	}
@@ -59,4 +72,260 @@ func (em *envoyConfigManager) getByKey(key string) (*v2.CiliumEnvoyConfig, bool,
 
 func (em *envoyConfigManager) MarkSynced() {
 	em.informer.HasSynced()
+}
+
+func getEnvoyConfigForService(svc *slim_corev1.Service) (*ciliumv2.CiliumEnvoyConfig, error) {
+	resources, err := getResources(svc)
+	if err != nil {
+		return nil, err
+	}
+	return &ciliumv2.CiliumEnvoyConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.CECKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", ciliumEnvoyLBPrefix, svc.GetName()),
+			Namespace: svc.GetNamespace(),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: slim_corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+					Name:       svc.GetName(),
+					UID:        svc.GetUID(),
+				},
+			},
+		},
+		Spec: ciliumv2.CiliumEnvoyConfigSpec{
+			Services: []*ciliumv2.ServiceListener{
+				{
+					Name:      svc.GetName(),
+					Namespace: svc.GetNamespace(),
+				},
+			},
+			Resources: resources,
+		},
+	}, nil
+}
+
+func getResources(svc *slim_corev1.Service) ([]ciliumv2.XDSResource, error) {
+	var resources []ciliumv2.XDSResource
+	listener, err := getListenerResource(svc)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, listener)
+
+	routeConfig, err := getRouteConfigurationResource(svc)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, routeConfig)
+
+	clusters, err := getClusterResources(svc)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, clusters...)
+	return resources, nil
+}
+
+func getClusterResources(svc *slim_corev1.Service) ([]ciliumv2.XDSResource, error) {
+	cluster := &envoy_config_cluster_v3.Cluster{
+		Name:           getName(svc),
+		ConnectTimeout: &durationpb.Duration{Seconds: 5},
+		LbPolicy:       envoy_config_cluster_v3.Cluster_ROUND_ROBIN,
+		TypedExtensionProtocolOptions: map[string]*anypb.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": toAny(&envoy_config_upstream.HttpProtocolOptions{
+				UpstreamProtocolOptions: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamProtocolConfig{
+					UseDownstreamProtocolConfig: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamHttpConfig{
+						Http2ProtocolOptions: &envoy_config_core_v3.Http2ProtocolOptions{},
+					},
+				},
+			}),
+		},
+		OutlierDetection: &envoy_config_cluster_v3.OutlierDetection{
+			SplitExternalLocalOriginErrors: true,
+			// The number of consecutive locally originated failures before ejection occurs.
+			ConsecutiveLocalOriginFailure: &wrapperspb.UInt32Value{Value: 2},
+		},
+		ClusterDiscoveryType: &envoy_config_cluster_v3.Cluster_Type{
+			Type: envoy_config_cluster_v3.Cluster_EDS,
+		},
+	}
+
+	var mutatorFuncs = []clusterMutator{}
+	for _, fn := range mutatorFuncs {
+		cluster = fn(cluster)
+	}
+
+	clusterBytes, err := proto.Marshal(cluster)
+	if err != nil {
+		return nil, err
+	}
+	return []ciliumv2.XDSResource{
+		{
+			Any: &anypb.Any{
+				TypeUrl: envoy.ClusterTypeURL,
+				Value:   clusterBytes,
+			},
+		},
+	}, nil
+}
+
+func getRouteConfigurationResource(svc *slim_corev1.Service) (ciliumv2.XDSResource, error) {
+	routeConfig := &envoy_config_route_v3.RouteConfiguration{
+		Name:         getName(svc),
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{getVirtualHost(svc)},
+	}
+
+	var mutatorFuncs = []routeConfigMutator{}
+	for _, fn := range mutatorFuncs {
+		routeConfig = fn(routeConfig)
+	}
+
+	routeBytes, err := proto.Marshal(routeConfig)
+	if err != nil {
+		return ciliumv2.XDSResource{}, err
+	}
+	return ciliumv2.XDSResource{
+		Any: &anypb.Any{
+			TypeUrl: envoy.RouteTypeURL,
+			Value:   routeBytes,
+		},
+	}, nil
+}
+
+func getListenerResource(svc *slim_corev1.Service) (ciliumv2.XDSResource, error) {
+	defaultHttpConnectionManager, err := getConnectionManager(svc)
+	if err != nil {
+		return ciliumv2.XDSResource{}, nil
+	}
+
+	var filterChains []*envoy_config_listener.FilterChain
+	filterChains = []*envoy_config_listener.FilterChain{
+		{
+			FilterChainMatch: &envoy_config_listener.FilterChainMatch{
+				TransportProtocol: "raw_buffer",
+			},
+			Filters: []*envoy_config_listener.Filter{
+				{
+					Name: "envoy.filters.network.http_connection_manager",
+					ConfigType: &envoy_config_listener.Filter_TypedConfig{
+						TypedConfig: defaultHttpConnectionManager.Any,
+					},
+				},
+			},
+		},
+	}
+
+	listener := &envoy_config_listener.Listener{
+		Name:         getName(svc),
+		FilterChains: filterChains,
+		ListenerFilters: []*envoy_config_listener.ListenerFilter{
+			{
+				Name: "envoy.filters.listener.tls_inspector",
+			},
+		},
+	}
+
+	var mutatorFuncs = []listenerMutator{}
+	for _, fn := range mutatorFuncs {
+		listener = fn(listener)
+	}
+
+	listenerBytes, err := proto.Marshal(listener)
+	if err != nil {
+		return ciliumv2.XDSResource{}, err
+	}
+	return ciliumv2.XDSResource{
+		Any: &anypb.Any{
+			TypeUrl: envoy.ListenerTypeURL,
+			Value:   listenerBytes,
+		},
+	}, nil
+}
+
+func getConnectionManager(svc *slim_corev1.Service) (ciliumv2.XDSResource, error) {
+	connectionManager := &envoy_extensions_filters_network_http_connection_manager_v3.HttpConnectionManager{
+		StatPrefix: getName(svc),
+		RouteSpecifier: &envoy_extensions_filters_network_http_connection_manager_v3.HttpConnectionManager_Rds{
+			Rds: &envoy_extensions_filters_network_http_connection_manager_v3.Rds{
+				RouteConfigName: getName(svc),
+			},
+		},
+		HttpFilters: []*envoy_extensions_filters_network_http_connection_manager_v3.HttpFilter{
+			{Name: "envoy.filters.http.router"},
+		},
+	}
+
+	var mutatorFuncs = []httpConnectionManagerMutator{}
+	for _, fn := range mutatorFuncs {
+		connectionManager = fn(connectionManager)
+	}
+
+	connectionManagerBytes, err := proto.Marshal(connectionManager)
+	if err != nil {
+		return ciliumv2.XDSResource{}, err
+	}
+
+	return ciliumv2.XDSResource{
+		Any: &anypb.Any{
+			TypeUrl: envoy.HttpConnectionManagerTypeURL,
+			Value:   connectionManagerBytes,
+		},
+	}, nil
+}
+
+func getVirtualHost(svc *slim_corev1.Service) *envoy_config_route_v3.VirtualHost {
+	route := &envoy_config_route_v3.Route{
+		Match: &envoy_config_route_v3.RouteMatch{
+			PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+				Prefix: "/",
+			},
+		},
+		Action: &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{
+				ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
+					Cluster: getName(svc),
+				},
+				MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
+					MaxStreamDuration: &durationpb.Duration{
+						Seconds: 0,
+					},
+				},
+			},
+		},
+	}
+
+	var routeMutatorFuncs = []routeMutator{}
+	for _, fn := range routeMutatorFuncs {
+		route = fn(route)
+	}
+
+	virtualHost := &envoy_config_route_v3.VirtualHost{
+		Name:    getName(svc),
+		Domains: []string{"*"},
+		Routes:  []*envoy_config_route_v3.Route{route},
+	}
+
+	var mutatorFuncs = []virtualHostMutator{}
+	for _, fn := range mutatorFuncs {
+		virtualHost = fn(virtualHost)
+	}
+
+	return virtualHost
+}
+
+func getName(obj metav1.Object) string {
+	return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
+}
+
+func toAny(message proto.Message) *anypb.Any {
+	a, err := anypb.New(message)
+	if err != nil {
+		log.WithError(err).Errorf("invalid message %s", message)
+		return nil
+	}
+	return a
 }

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/informer"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+)
+
+type envoyConfigManager struct {
+	client     client.Clientset
+	informer   cache.Controller
+	store      cache.Store
+	maxRetries int
+}
+
+func newEnvoyConfigManager(client client.Clientset, maxRetries int) (*envoyConfigManager, error) {
+	manager := &envoyConfigManager{
+		client:     client,
+		maxRetries: maxRetries,
+	}
+
+	manager.store, manager.informer = informer.NewInformer(
+		utils.ListerWatcherFromTyped[*v2.CiliumEnvoyConfigList](client.CiliumV2().CiliumEnvoyConfigs(corev1.NamespaceAll)),
+		&v2.CiliumEnvoyConfig{},
+		0,
+		cache.ResourceEventHandlerFuncs{},
+		nil,
+	)
+
+	go manager.informer.Run(wait.NeverStop)
+	if !cache.WaitForCacheSync(wait.NeverStop, manager.informer.HasSynced) {
+		return manager, fmt.Errorf("unable to sync envoy configs")
+	}
+	return manager, nil
+}
+
+// getByKey is a wrapper of Store.GetByKey but with concrete CiliumEnvoyConfig object
+func (em *envoyConfigManager) getByKey(key string) (*v2.CiliumEnvoyConfig, bool, error) {
+	objFromCache, exists, err := em.store.GetByKey(key)
+	if objFromCache == nil || !exists || err != nil {
+		return nil, exists, err
+	}
+	envoyConfig, ok := objFromCache.(*v2.CiliumEnvoyConfig)
+	if !ok {
+		return nil, exists, fmt.Errorf("got invalid object from cache")
+	}
+	return envoyConfig, exists, err
+}

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -259,7 +259,9 @@ func getConnectionManager(svc *slim_corev1.Service) (ciliumv2.XDSResource, error
 		},
 	}
 
-	var mutatorFuncs = []httpConnectionManagerMutator{}
+	var mutatorFuncs = []httpConnectionManagerMutator{
+		grpcHttpConnectionManagerMutator(svc),
+	}
 	for _, fn := range mutatorFuncs {
 		connectionManager = fn(connectionManager)
 	}

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -56,3 +56,7 @@ func (em *envoyConfigManager) getByKey(key string) (*v2.CiliumEnvoyConfig, bool,
 	}
 	return envoyConfig, exists, err
 }
+
+func (em *envoyConfigManager) MarkSynced() {
+	em.informer.HasSynced()
+}

--- a/operator/pkg/ciliumenvoyconfig/envoy_config_test.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config_test.go
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig

--- a/operator/pkg/ciliumenvoyconfig/envoy_config_test.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 func Test_getClusterResources(t *testing.T) {
-	res, err := getClusterResources(&slim_corev1.Service{
+	m := &Manager{}
+	res, err := m.getClusterResources(&slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "dummy-service",
 			Namespace: "dummy-namespace",
@@ -39,7 +40,8 @@ func Test_getClusterResources(t *testing.T) {
 }
 
 func Test_getRouteConfigurationResource(t *testing.T) {
-	res, err := getRouteConfigurationResource(&slim_corev1.Service{
+	m := &Manager{}
+	res, err := m.getRouteConfigurationResource(&slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "dummy-service",
 			Namespace: "dummy-namespace",
@@ -58,7 +60,8 @@ func Test_getRouteConfigurationResource(t *testing.T) {
 }
 
 func Test_getListenerResource(t *testing.T) {
-	res, err := getListenerResource(&slim_corev1.Service{
+	m := &Manager{}
+	res, err := m.getListenerResource(&slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "dummy-service",
 			Namespace: "dummy-namespace",

--- a/operator/pkg/ciliumenvoyconfig/envoy_config_test.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config_test.go
@@ -2,3 +2,76 @@
 // Copyright Authors of Cilium
 
 package ciliumenvoyconfig
+
+import (
+	"testing"
+
+	envoy_config_cluster_v3 "github.com/cilium/proxy/go/envoy/config/cluster/v3"
+	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
+	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func Test_getClusterResources(t *testing.T) {
+	res, err := getClusterResources(&slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-service",
+			Namespace: "dummy-namespace",
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, res, 1)
+
+	cluster := &envoy_config_cluster_v3.Cluster{}
+	err = proto.Unmarshal(res[0].Value, cluster)
+	require.NoError(t, err)
+
+	require.Equal(t, "dummy-namespace/dummy-service", cluster.Name)
+	require.Equal(t, envoy_config_cluster_v3.Cluster_ROUND_ROBIN, cluster.LbPolicy)
+	require.Equal(t, &envoy_config_cluster_v3.Cluster_Type{
+		Type: envoy_config_cluster_v3.Cluster_EDS,
+	}, cluster.ClusterDiscoveryType)
+}
+
+func Test_getRouteConfigurationResource(t *testing.T) {
+	res, err := getRouteConfigurationResource(&slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-service",
+			Namespace: "dummy-namespace",
+		},
+	})
+
+	require.NoError(t, err)
+	routeConfig := &envoy_config_route_v3.RouteConfiguration{}
+	err = proto.Unmarshal(res.Value, routeConfig)
+	require.NoError(t, err)
+
+	require.Len(t, routeConfig.VirtualHosts, 1)
+	require.Equal(t, "dummy-namespace/dummy-service", routeConfig.VirtualHosts[0].Name)
+	require.Equal(t, []string{"*"}, routeConfig.VirtualHosts[0].Domains)
+	require.Len(t, routeConfig.VirtualHosts[0].Routes, 1)
+}
+
+func Test_getListenerResource(t *testing.T) {
+	res, err := getListenerResource(&slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-service",
+			Namespace: "dummy-namespace",
+		},
+	})
+	require.NoError(t, err)
+
+	listener := &envoy_config_listener.Listener{}
+	err = proto.Unmarshal(res.Value, listener)
+	require.NoError(t, err)
+
+	require.Len(t, listener.ListenerFilters, 1)
+	require.Len(t, listener.FilterChains, 1)
+	require.Len(t, listener.FilterChains[0].Filters, 1)
+	require.IsType(t, &envoy_config_listener.Filter_TypedConfig{}, listener.FilterChains[0].Filters[0].ConfigType)
+}

--- a/operator/pkg/ciliumenvoyconfig/manager.go
+++ b/operator/pkg/ciliumenvoyconfig/manager.go
@@ -5,17 +5,26 @@ package ciliumenvoyconfig
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
 	ciliumEnvoyLBPrefix = "cilium-envoy-lb"
 )
+
+type svcEvent string
 
 type Manager struct {
 	envoyConfigManager *envoyConfigManager
@@ -46,15 +55,41 @@ func New(client client.Clientset, indexer cache.Store) (*Manager, error) {
 }
 
 func (m *Manager) OnAddService(service *slim_corev1.Service) error {
+	var (
+		svcName   = service.Name
+		scopedLog = log.WithField(logfields.ServiceName, svcName)
+	)
+	key, err := cache.MetaNamespaceKeyFunc(service)
+	if err != nil {
+		return err
+	}
 
+	if !IsLBProtocolAnnotationEnabled(service) {
+		return nil
+	}
+
+	scopedLog.Debug("adding event to queue")
+	m.queue.Add(svcEvent(key))
 	return nil
 }
 
-func (m *Manager) OnUpdateService(oldObj, newObj *slim_corev1.Service) error {
+func (m *Manager) OnUpdateService(_, newObj *slim_corev1.Service) error {
+	var (
+		svcName   = newObj.Name
+		scopedLog = log.WithField(logfields.ServiceName, svcName)
+	)
+	key, err := cache.MetaNamespaceKeyFunc(newObj)
+	if err != nil {
+		return err
+	}
+
+	scopedLog.Debug("adding event to queue")
+	m.queue.Add(svcEvent(key))
 	return nil
 }
 
-func (m *Manager) OnDeleteService(service *slim_corev1.Service) error {
+func (m *Manager) OnDeleteService(_ *slim_corev1.Service) error {
+	// Doing nothing here as clean up should be done via k8s OwnerReferences
 	return nil
 }
 
@@ -85,6 +120,106 @@ func (m *Manager) Run(ctx context.Context) {
 	}
 }
 
-func (m *Manager) processEvent(ctx context.Context, ev interface{}) error {
+func (m *Manager) processEvent(ctx context.Context, event interface{}) error {
+	switch k := event.(type) {
+	case svcEvent:
+		n := string(k) // service namespace/name
+
+		objFromCache, exists, err := m.serviceStore.GetByKey(n)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("service %s does not exist", n)
+		}
+
+		service, ok := objFromCache.(*slim_corev1.Service)
+		if !ok {
+			return fmt.Errorf("got invalid object from cache: %T", objFromCache)
+		}
+		if IsLBProtocolAnnotationEnabled(service) {
+			return m.createEnvoyConfig(ctx, service)
+		}
+		return m.deleteEnvoyConfig(ctx, service)
+	default:
+		log.Debugf("Encountered an unknown key type %T in CEC controller", k)
+		return fmt.Errorf("unknown key type %T", k)
+	}
+}
+
+func (m *Manager) createEnvoyConfig(ctx context.Context, svc *slim_corev1.Service) error {
+	desired, err := getEnvoyConfigForService(svc)
+	if err != nil {
+		return err
+	}
+
+	// check if the CiliumEnvoyConfig resource already exists
+	key, err := cache.MetaNamespaceKeyFunc(desired)
+	if err != nil {
+		log.WithError(err).Warn("MetaNamespaceKeyFunc returned an error")
+		return err
+	}
+	existingEnvoyConfig, exists, err := m.envoyConfigManager.getByKey(key)
+	if err != nil {
+		log.WithError(err).Warn("CiliumEnvoyConfig lookup failed")
+		return err
+	}
+
+	scopedLog := log.WithField(logfields.ServiceKey, getName(svc))
+	if exists {
+		if desired.DeepEqual(existingEnvoyConfig) {
+			log.WithField(logfields.CiliumEnvoyConfigName, key).Debug("No change for existing CiliumEnvoyConfig")
+			return nil
+		}
+		// Update existing CEC
+		newEnvoyConfig := existingEnvoyConfig.DeepCopy()
+		newEnvoyConfig.Spec = desired.Spec
+
+		c, err := json.Marshal(existingEnvoyConfig)
+		if err != nil {
+			return err
+		}
+		d, err := json.Marshal(newEnvoyConfig)
+		if err != nil {
+			return nil
+		}
+		patch, err := strategicpatch.CreateTwoWayMergePatch(c, d, ciliumv2.CiliumEnvoyConfig{})
+		if err != nil {
+			return err
+		}
+		_, err = m.client.CiliumV2().CiliumEnvoyConfigs(svc.Namespace).Patch(ctx, newEnvoyConfig.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{
+			FieldManager: Subsys,
+		})
+		if err != nil {
+			scopedLog.WithError(err).Error("Failed to update CiliumEnvoyConfig for service")
+			return err
+		}
+		scopedLog.Debug("Updated CiliumEnvoyConfig for service")
+		return nil
+	}
+
+	_, err = m.client.CiliumV2().CiliumEnvoyConfigs(svc.Namespace).Create(ctx, desired, metav1.CreateOptions{
+		FieldManager: Subsys,
+	})
+	if err != nil {
+		scopedLog.WithError(err).Error("Failed to create CiliumEnvoyConfig for service")
+		return err
+	}
+	scopedLog.Debug("Created CiliumEnvoyConfig for service")
+	return nil
+}
+
+func (m *Manager) deleteEnvoyConfig(ctx context.Context, svc *slim_corev1.Service) error {
+	cecName := fmt.Sprintf("%s-%s", ciliumEnvoyLBPrefix, svc.GetName())
+	// check if the CiliumEnvoyConfig resource already exists
+	_, exist, err := m.envoyConfigManager.getByKey(fmt.Sprintf("%s/%s", svc.Namespace, cecName))
+	if !exist || err != nil {
+		return err
+	}
+	err = m.client.CiliumV2().CiliumEnvoyConfigs(svc.Namespace).Delete(ctx, cecName, metav1.DeleteOptions{})
+	if err != nil {
+		log.WithField(logfields.ServiceKey, getName(svc)).WithError(err).Error("Failed to delete CiliumEnvoyConfig for service")
+		return err
+	}
 	return nil
 }

--- a/operator/pkg/ciliumenvoyconfig/manager.go
+++ b/operator/pkg/ciliumenvoyconfig/manager.go
@@ -58,6 +58,10 @@ func (m *Manager) OnDeleteService(service *slim_corev1.Service) error {
 	return nil
 }
 
+func (m *Manager) MarkSynced() {
+	m.envoyConfigManager.MarkSynced()
+}
+
 // Run kicks off the controlled loop
 func (m *Manager) Run(ctx context.Context) {
 	defer m.queue.ShutDown()

--- a/operator/pkg/ciliumenvoyconfig/manager.go
+++ b/operator/pkg/ciliumenvoyconfig/manager.go
@@ -36,16 +36,18 @@ type Manager struct {
 	client       client.Clientset
 	serviceStore cache.Store
 	ports        []string
+	algorithm    string
 }
 
 // New returns a new Manager for CiliumEnvoyConfig
-func New(client client.Clientset, indexer cache.Store, ports []string) (*Manager, error) {
+func New(client client.Clientset, indexer cache.Store, ports []string, algorithm string) (*Manager, error) {
 	manager := &Manager{
 		queue:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		client:       client,
 		serviceStore: indexer,
 		maxRetries:   10,
 		ports:        ports,
+		algorithm:    algorithm,
 	}
 
 	envoyConfigManager, err := newEnvoyConfigManager(client, manager.maxRetries)

--- a/operator/pkg/ciliumenvoyconfig/manager.go
+++ b/operator/pkg/ciliumenvoyconfig/manager.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"context"
+
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/cilium/cilium/pkg/k8s/client"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+)
+
+const (
+	ciliumEnvoyLBPrefix = "cilium-envoy-lb"
+)
+
+type Manager struct {
+	envoyConfigManager *envoyConfigManager
+
+	queue      workqueue.RateLimitingInterface
+	maxRetries int
+
+	client       client.Clientset
+	serviceStore cache.Store
+}
+
+// New returns a new Manager for CiliumEnvoyConfig
+func New(client client.Clientset, indexer cache.Store) (*Manager, error) {
+	manager := &Manager{
+		queue:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		client:       client,
+		serviceStore: indexer,
+		maxRetries:   10,
+	}
+
+	envoyConfigManager, err := newEnvoyConfigManager(client, manager.maxRetries)
+	if err != nil {
+		return nil, err
+	}
+	manager.envoyConfigManager = envoyConfigManager
+
+	return manager, nil
+}
+
+func (m *Manager) OnAddService(service *slim_corev1.Service) error {
+
+	return nil
+}
+
+func (m *Manager) OnUpdateService(oldObj, newObj *slim_corev1.Service) error {
+	return nil
+}
+
+func (m *Manager) OnDeleteService(service *slim_corev1.Service) error {
+	return nil
+}
+
+// Run kicks off the controlled loop
+func (m *Manager) Run(ctx context.Context) {
+	defer m.queue.ShutDown()
+	for {
+		ev, quit := m.queue.Get()
+		if quit {
+			return
+		}
+		err := m.processEvent(ctx, ev)
+		if err != nil {
+			if m.queue.NumRequeues(ev) < m.maxRetries {
+				log.WithError(err).Warning("Error while processing event, retrying")
+				m.queue.AddRateLimited(ev)
+				continue
+			} else {
+				log.WithError(err).Warning("Error while processing event, no more retries")
+				m.queue.Forget(ev)
+			}
+		}
+		m.queue.Done(ev)
+	}
+}
+
+func (m *Manager) processEvent(ctx context.Context, ev interface{}) error {
+	return nil
+}

--- a/operator/pkg/ciliumenvoyconfig/manager.go
+++ b/operator/pkg/ciliumenvoyconfig/manager.go
@@ -148,7 +148,7 @@ func (m *Manager) processEvent(ctx context.Context, event interface{}) error {
 }
 
 func (m *Manager) createEnvoyConfig(ctx context.Context, svc *slim_corev1.Service) error {
-	desired, err := getEnvoyConfigForService(svc)
+	desired, err := m.getEnvoyConfigForService(svc)
 	if err != nil {
 		return err
 	}

--- a/operator/watchers/cec.go
+++ b/operator/watchers/cec.go
@@ -15,14 +15,14 @@ import (
 // StartCECController starts the service watcher if it hasn't already and looks
 // for service of type with envoy enabled LB annotation. Once such service is
 // found, it will try to create one CEC associated with the service.
-func StartCECController(ctx context.Context, clientset k8sClient.Clientset, services resource.Resource[*slim_corev1.Service], ports []string) {
+func StartCECController(ctx context.Context, clientset k8sClient.Clientset, services resource.Resource[*slim_corev1.Service], ports []string, defaultAlgorithm string) {
 	go func() {
 		store, err := services.Store(ctx)
 		if err != nil {
 			log.WithError(err).Fatal("Failed to retrieve service store")
 		}
 
-		m, err := ciliumenvoyconfig.New(clientset, store.CacheStore(), ports )
+		m, err := ciliumenvoyconfig.New(clientset, store.CacheStore(), ports, defaultAlgorithm)
 		if err != nil {
 			log.WithError(err).Fatal("Error creating CiliumEnvoyConfiguration manager")
 		}

--- a/operator/watchers/cec.go
+++ b/operator/watchers/cec.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/operator/pkg/ciliumenvoyconfig"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+)
+
+// StartCECController starts the service watcher if it hasn't already and looks
+// for service of type with envoy enabled LB annotation. Once such service is
+// found, it will try to create one CEC associated with the service.
+func StartCECController(ctx context.Context, clientset k8sClient.Clientset, services resource.Resource[*slim_corev1.Service]) {
+	go func() {
+		store, err := services.Store(ctx)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to retrieve service store")
+		}
+
+		m, err := ciliumenvoyconfig.New(clientset, store.CacheStore())
+		if err != nil {
+			log.WithError(err).Fatal("Error creating CiliumEnvoyConfiguration manager")
+		}
+		go m.Run(ctx)
+
+		services.Observe(
+			ctx,
+			func(ev resource.Event[*slim_corev1.Service]) {
+				ev.Handle(
+					func() error {
+						m.MarkSynced()
+						return nil
+					},
+					func(_ resource.Key, svc *slim_corev1.Service) error {
+						return m.OnUpdateService(nil, svc)
+					},
+					func(_ resource.Key, svc *slim_corev1.Service) error {
+						return m.OnDeleteService(svc)
+					},
+				)
+			},
+			func(error) { /* only completes when stopping */ },
+		)
+	}()
+}

--- a/operator/watchers/cec.go
+++ b/operator/watchers/cec.go
@@ -15,14 +15,14 @@ import (
 // StartCECController starts the service watcher if it hasn't already and looks
 // for service of type with envoy enabled LB annotation. Once such service is
 // found, it will try to create one CEC associated with the service.
-func StartCECController(ctx context.Context, clientset k8sClient.Clientset, services resource.Resource[*slim_corev1.Service]) {
+func StartCECController(ctx context.Context, clientset k8sClient.Clientset, services resource.Resource[*slim_corev1.Service], ports []string) {
 	go func() {
 		store, err := services.Store(ctx)
 		if err != nil {
 			log.WithError(err).Fatal("Failed to retrieve service store")
 		}
 
-		m, err := ciliumenvoyconfig.New(clientset, store.CacheStore())
+		m, err := ciliumenvoyconfig.New(clientset, store.CacheStore(), ports )
 		if err != nil {
 			log.WithError(err).Fatal("Error creating CiliumEnvoyConfiguration manager")
 		}


### PR DESCRIPTION
### Description

Please refer to individual commit for more details

### Checklist

- [x] Add mutation functions based on annotation for customized and advanced use cases
- [x] Unit test
- [x] Different service types
    - [x] Node port
    - [x] LB
    - [x] ClusterIP
- [x] Support gRPC load-balancing
- [x] Integration with clustermesh
- [x] Getting started guide and docs, this can be done after first round or review or just subsequent PR. _Done as part of https://github.com/cilium/cilium/pull/23100_

### Testing

Please find below one of test cases with ClusterIP

<details>
<summary>Deployment manifest used for testing</summary>

```
$ cat temp.yaml
---
apiVersion: v1
kind: Service
metadata:
  name: rebel-base
spec:
  type: ClusterIP
  ports:
    - port: 80
  selector:
    name: rebel-base
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: rebel-base
spec:
  selector:
    matchLabels:
      name: rebel-base
  replicas: 2
  template:
    metadata:
      labels:
        name: rebel-base
    spec:
      containers:
        - name: rebel-base
          image: docker.io/nginx:1.15.8
          volumeMounts:
            - name: html
              mountPath: /usr/share/nginx/html/
          livenessProbe:
            httpGet:
              path: /
              port: 80
            periodSeconds: 1
          readinessProbe:
            httpGet:
              path: /
              port: 80
      volumes:
        - name: html
          configMap:
            name: rebel-base-response
            items:
              - key: message
                path: index.html
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: rebel-base-response
data:
  message: "{\"Galaxy\": \"Alderaan\", \"Cluster\": \"Cluster-1\"}\n"
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: x-wing
spec:
  selector:
    matchLabels:
      name: x-wing
  replicas: 1
  template:
    metadata:
      labels:
        name: x-wing
    spec:
      containers:
        - name: x-wing-container
          image: docker.io/cilium/json-mock:1.2
          livenessProbe:
            exec:
              command:
                - curl
                - -sS
                - -o
                - /dev/null
                - localhost
          readinessProbe:
            exec:
              command:
                - curl
                - -sS
                - -o
                - /dev/null
                - localhost

```

</details>


<details>
<summary>No L7 LB annotation</summary>

```
# Before apply L7 LB annotation, request is going directly to backend
$ kex deployment/x-wing -- curl -v http://rebel-base:80/
*   Trying 10.110.111.135...
* TCP_NODELAY set
* Connected to rebel-base (10.110.111.135) port 80 (#0)
> GET / HTTP/1.1
> Host: rebel-base
> User-Agent: curl/7.52.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: nginx/1.15.8
< Date: Mon, 12 Sep 2022 14:37:44 GMT
< Content-Type: text/html
< Content-Length: 47
< Last-Modified: Mon, 12 Sep 2022 14:37:40 GMT
< Connection: keep-alive
< ETag: "631f4434-2f"
< Accept-Ranges: bytes
< 
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
* Curl_http_done: called premature == 0
* Connection #0 to host rebel-base left intact

```

</details>


<details>
<summary>With L7 LB annotation</summary>

```
# After apply L7 LB annotation, request is redirected to envoy and then follow LB policy configured
$ kg service rebel-base -o json | jq .metadata.annotations
{
  "io.cilium/global-service": "true",
  "io.cilium.service/lb-l7": "enabled",
...
}

$ kex deployment/x-wing -- curl -v http://rebel-base:80/
*   Trying 10.103.190.27...
* TCP_NODELAY set
* Connected to rebel-base (10.103.190.27) port 80 (#0)
> GET / HTTP/1.1
> Host: rebel-base
> User-Agent: curl/7.52.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< server: envoy
< date: Wed, 21 Dec 2022 05:03:24 GMT
< content-type: text/html
< content-length: 47
< last-modified: Wed, 21 Dec 2022 04:59:15 GMT
< etag: "63a292a3-2f"
< accept-ranges: bytes
< x-envoy-upstream-service-time: 0
< 
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}

```

</details>


<details>
<summary>global ports</summary>

```
$ kg cec
NAME                              AGE
cilium-envoy-lb-rebel-base-8080   36s

# No annotation
$ kg services rebel-base-8080 -o json | jq .metadata.annotations
{
  "io.cilium/global-service": "true",
}

$ kex deployment/x-wing -- curl -v http://rebel-base-8080:8080
* Rebuilt URL to: http://rebel-base-8080:8080/
*   Trying 10.107.97.254...
* TCP_NODELAY set
* Connected to rebel-base-8080 (10.107.97.254) port 8080 (#0)
> GET / HTTP/1.1
> Host: rebel-base-8080:8080
> User-Agent: curl/7.52.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< server: envoy
< date: Sun, 18 Sep 2022 12:15:11 GMT
< content-type: text/html
< content-length: 47
< last-modified: Sun, 18 Sep 2022 12:13:37 GMT
< etag: "63270b71-2f"
< accept-ranges: bytes
< x-envoy-upstream-service-time: 0
< 
{"Galaxy": "Alderaan", "Cluster": "Cluster-1"}
* Curl_http_done: called premature == 0
* Connection #0 to host rebel-base-8080 left intact

```

</details>