### PR TITLE
clustermesh: explicitly report zero remote nodes on connection release

### DIFF
--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -129,7 +129,7 @@ func (rc *remoteCluster) releaseOldConnection() {
 	backend := rc.backend
 	rc.backend = nil
 
-	rc.metricTotalNodes.WithLabelValues(rc.mesh.conf.Name, rc.mesh.conf.NodeName, rc.name).Set(float64(rc.remoteNodes.NumEntries()))
+	rc.metricTotalNodes.WithLabelValues(rc.mesh.conf.Name, rc.mesh.conf.NodeName, rc.name).Set(0.0)
 	rc.metricReadinessStatus.WithLabelValues(rc.mesh.conf.Name, rc.mesh.conf.NodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
 
 	rc.mutex.Unlock()


### PR DESCRIPTION
rc.remoteNodes is set to nil a few lines above [1], thus calling
NumEntries will always return 0 and will thus set the
clustermesh_remote_cluster_nodes metric to zero. Make that explicit
instead of relying on ((*store.SharedStore)nil).NumEntries() to return
0.

[1] https://github.com/cilium/cilium/blob/ab21ecbd53546abbc8d472498f1bbfae22842ee5/pkg/clustermesh/remote_cluster.go#L120-L121