### PR TITLE
daemon: use netlink for managed neighbor support probe

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -402,7 +402,9 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup, epMgr *endpointmanag
 
 	// Check the kernel if we can make use of managed neighbor entries which
 	// simplifies and fully 'offloads' L2 resolution handling to the kernel.
-	probeManagedNeighborSupport()
+	if err := probeManagedNeighborSupport(); err != nil {
+		log.WithError(err).Warn("Unable to probe managed neighbor kernel support")
+	}
 
 	// Do the partial kube-proxy replacement initialization before creating BPF
 	// maps. Otherwise, some maps might not be created (e.g. session affinity).


### PR DESCRIPTION
With this commit we refactor the probe logic that checks for the existence of a certain helper as this could break on older distro kernel that have backported the commit we probed for.

Using actual netlink calls to probe for managed neighbor support will only succeed if the underlying kernel actually supports it.

Fixes #20694.

Signed-off-by: Robin Gögge <r.goegge@isovalent.com>
