### PR TITLE
cni: Add generic-device chaining plugin

### DIFF
--- a/api/v1/models/endpoint_change_request.go
+++ b/api/v1/models/endpoint_change_request.go
@@ -64,6 +64,9 @@ type EndpointChangeRequest struct {
 	// MAC address
 	Mac string `json:"mac,omitempty"`
 
+	// Network Namespace
+	NetNs string `json:"net-ns,omitempty"`
+
 	// Process ID of the workload belonging to this endpoint
 	Pid int64 `json:"pid,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1149,6 +1149,9 @@ definitions:
       docker-network-id:
         description: Docker network ID
         type: string
+      net-ns:
+        description: Network Namespace
+        type: string
       interface-name:
         description: Name of network device
         type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2198,6 +2198,10 @@ func init() {
           "description": "MAC address",
           "type": "string"
         },
+        "net-ns": {
+          "description": "Network Namespace",
+          "type": "string"
+        },
         "pid": {
           "description": "Process ID of the workload belonging to this endpoint",
           "type": "integer"
@@ -6757,6 +6761,10 @@ func init() {
         },
         "mac": {
           "description": "MAC address",
+          "type": "string"
+        },
+        "net-ns": {
+          "description": "Network Namespace",
           "type": "string"
         },
         "pid": {

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -333,6 +333,9 @@ spec:
           mountPath: /host/opt/cni/bin
         - name: etc-cni-netd
           mountPath: {{ .Values.cni.hostConfDirMountPath }}
+        - name: netns
+          mountPath: /var/run/netns
+          mountPropagation: HostToContainer
         {{- if .Values.etcd.enabled }}
         - name: etcd-config-path
           mountPath: /var/lib/etcd-config
@@ -745,6 +748,10 @@ spec:
         hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
+      - name: netns
+        hostPath:
+          path: /var/run/netns
+          type: DirectoryOrCreate
       {{- if .Values.kubeConfigPath }}
       - name: kube-config
         hostPath:

--- a/pkg/datapath/endpoint.go
+++ b/pkg/datapath/endpoint.go
@@ -12,4 +12,5 @@ type Endpoint interface {
 	InterfaceName() string
 	Logger(subsystem string) *logrus.Entry
 	StateDir() string
+	NetNS() string
 }

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -62,6 +62,7 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 	ep.dockerEndpointID = base.DockerEndpointID
 	ep.K8sPodName = base.K8sPodName
 	ep.K8sNamespace = base.K8sNamespace
+	ep.netNS = base.NetNs
 
 	if base.Mac != "" {
 		m, err := mac.ParseMAC(base.Mac)

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -27,6 +27,7 @@ type epInfoCache struct {
 	epdir  string
 	id     uint64
 	ifName string
+	netNS  string
 
 	// For datapath.EndpointConfiguration
 	identity                               identity.NumericIdentity
@@ -80,6 +81,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		options:                e.Options.DeepCopy(),
 		lxcMAC:                 e.mac,
 		ifIndex:                e.ifIndex,
+		netNS:                  e.netNS,
 
 		endpoint: e,
 	}
@@ -98,6 +100,10 @@ func (ep *epInfoCache) LXCMac() mac.MAC {
 // communicating with the endpoint.
 func (ep *epInfoCache) InterfaceName() string {
 	return ep.ifName
+}
+
+func (ep *epInfoCache) NetNS() string {
+	return ep.netNS
 }
 
 // GetID returns the endpoint's ID.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -140,6 +140,9 @@ type Endpoint struct {
 	// libnetwork
 	dockerEndpointID string
 
+	// netNS is the network namespace of interface, veth doesn't need this
+	netNS string
+
 	// ifName is the name of the host facing interface (veth pair) which
 	// connects into the endpoint
 	ifName string

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -382,6 +382,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		ContainerID:           e.containerID,
 		DockerNetworkID:       e.dockerNetworkID,
 		DockerEndpointID:      e.dockerEndpointID,
+		NetNS:                 e.netNS,
 		IfName:                e.ifName,
 		IfIndex:               e.ifIndex,
 		OpLabels:              e.OpLabels,
@@ -427,6 +428,9 @@ type serializableEndpoint struct {
 	// dockerEndpointID is the Docker network endpoint ID if managed by
 	// libnetwork
 	DockerEndpointID string
+
+	// netNS is the network namespace of interface, veth doesn't need this
+	NetNS string
 
 	// ifName is the name of the host facing interface (veth pair) which
 	// connects into the endpoint
@@ -515,6 +519,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.containerID = r.ContainerID
 	ep.dockerNetworkID = r.DockerNetworkID
 	ep.dockerEndpointID = r.DockerEndpointID
+	ep.netNS = r.NetNS
 	ep.ifName = r.IfName
 	ep.ifIndex = r.IfIndex
 	ep.OpLabels = r.OpLabels

--- a/plugins/cilium-cni/chaining/generic-device/generic-device.go
+++ b/plugins/cilium-cni/chaining/generic-device/generic-device.go
@@ -1,0 +1,192 @@
+package genericdevice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/cilium/cilium/plugins/cilium-cni/types"
+	cniTypes "github.com/containernetworking/cni/pkg/types"
+
+	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
+	cniVersion "github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/api/v1/models"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
+)
+
+type GenericDeviceChainer struct{}
+
+func (f *GenericDeviceChainer) ImplementsAdd() bool {
+	return true
+}
+
+func (f *GenericDeviceChainer) Add(ctx context.Context, pluginCtx chainingapi.PluginContext) (res *cniTypesVer.Result, err error) {
+	err = cniVersion.ParsePrevResult(&pluginCtx.NetConf.NetConf)
+	if err != nil {
+		err = fmt.Errorf("unable to understand network config: %s", err)
+		return
+	}
+
+	var prevRes *cniTypesVer.Result
+	prevRes, err = cniTypesVer.NewResultFromResult(pluginCtx.NetConf.PrevResult)
+	if err != nil {
+		err = fmt.Errorf("unable to get previous network result: %s", err)
+		return
+	}
+
+	defer func() {
+		if err != nil {
+			pluginCtx.Logger.WithError(err).
+				WithFields(logrus.Fields{"cni-pre-result": pluginCtx.NetConf.PrevResult}).
+				Errorf("Unable to create endpoint")
+		}
+	}()
+	var (
+		deviceName, deviceMac, deviceIP, deviceIPv6 string
+		netNS                                       ns.NetNS
+	)
+
+	if pluginCtx.Args.Netns == "" {
+		err = errors.New("unable to determine Netns")
+		return
+	}
+	for _, inf := range prevRes.Interfaces {
+		if inf.Sandbox == pluginCtx.Args.Netns {
+			deviceName = inf.Name
+			break
+		}
+	}
+	if deviceName == "" {
+		err = fmt.Errorf("unable to find interface in network namespace %v", pluginCtx.Args.Netns)
+		return
+	}
+
+	netNS, err = ns.GetNS(pluginCtx.Args.Netns)
+	if err != nil {
+		err = fmt.Errorf("failed to open netns %q: %s", pluginCtx.Args.Netns, err)
+		return
+	}
+	defer netNS.Close()
+
+	if err = netNS.Do(func(_ ns.NetNS) error {
+		links, err := netlink.LinkList()
+		if err != nil {
+			return fmt.Errorf("failed to list link %s", pluginCtx.Args.Netns)
+		}
+		for _, link := range links {
+			if link.Attrs().Name != deviceName {
+				continue
+			}
+			deviceMac = link.Attrs().HardwareAddr.String()
+
+			addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+			if err != nil {
+				return fmt.Errorf("unable to list addresses for link %s: %s", link.Attrs().Name, err)
+			}
+			if len(addrs) < 1 {
+				return fmt.Errorf("no address configured inside container")
+			}
+
+			addrsv6, err := netlink.AddrList(link, netlink.FAMILY_V6)
+			if err == nil && len(addrsv6) > 0 {
+				deviceIPv6 = addrsv6[0].IPNet.IP.String()
+			} else if err != nil {
+				pluginCtx.Logger.WithError(err).WithFields(logrus.Fields{
+					logfields.Interface: link.Attrs().Name}).Warn("No valid IPv6 address found")
+			}
+
+			deviceIP = addrs[0].IPNet.IP.String()
+			return nil
+		}
+
+		return fmt.Errorf("no link found inside container")
+	}); err != nil {
+		return
+	}
+
+	switch {
+	case deviceMac == "":
+		err = errors.New("unable to determine device MAC address")
+		return
+	case deviceIP == "" && deviceIPv6 == "":
+		err = errors.New("unable to determine device IP address")
+		return
+	}
+
+	var disabled = false
+	ep := &models.EndpointChangeRequest{
+		Addressing: &models.AddressPair{
+			IPV4: deviceIP,
+			IPV6: deviceIPv6,
+		},
+		ContainerID:       pluginCtx.Args.ContainerID,
+		State:             models.EndpointStateWaitingForIdentity,
+		NetNs:             pluginCtx.Args.Netns,
+		Mac:               deviceMac,
+		HostMac:           deviceMac,
+		InterfaceName:     deviceName,
+		K8sPodName:        string(pluginCtx.CniArgs.K8S_POD_NAME),
+		K8sNamespace:      string(pluginCtx.CniArgs.K8S_POD_NAMESPACE),
+		SyncBuildEndpoint: true,
+		DatapathConfiguration: &models.EndpointDatapathConfiguration{
+			RequireArpPassthrough: true,
+			RequireEgressProg:     true,
+			ExternalIpam:          true,
+			RequireRouting:        &disabled,
+		},
+	}
+
+	err = pluginCtx.Client.EndpointCreate(ep)
+	if err != nil {
+		pluginCtx.Logger.WithError(err).WithFields(logrus.Fields{
+			logfields.ContainerID: ep.ContainerID}).Warn("Unable to create endpoint")
+		err = fmt.Errorf("unable to create endpoint: %s", err)
+		return
+	}
+
+	pluginCtx.Logger.WithFields(logrus.Fields{
+		logfields.ContainerID: ep.ContainerID}).Debug("Endpoint successfully created")
+
+	res = prevRes
+
+	return
+}
+
+func (f *GenericDeviceChainer) ImplementsDelete() bool {
+	return true
+}
+
+func (f *GenericDeviceChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext) (err error) {
+	id := endpointid.NewID(endpointid.ContainerIdPrefix, pluginCtx.Args.ContainerID)
+	if err := pluginCtx.Client.EndpointDelete(id); err != nil {
+		pluginCtx.Logger.WithError(err).Warning("Errors encountered while deleting endpoint")
+	}
+	return nil
+}
+
+func (f *GenericDeviceChainer) Check(ctx context.Context, pluginCtx chainingapi.PluginContext) error {
+	// Just confirm that the endpoint is healthy
+	eID := fmt.Sprintf("container-id:%s", pluginCtx.Args.ContainerID)
+	pluginCtx.Logger.Debugf("Asking agent for healthz for %s", eID)
+	epHealth, err := pluginCtx.Client.EndpointHealthGet(eID)
+	if err != nil {
+		return cniTypes.NewError(types.CniErrHealthzGet, "HealthzFailed",
+			fmt.Sprintf("failed to retrieve container health: %s", err))
+	}
+
+	if epHealth.OverallHealth == models.EndpointHealthStatusFailure {
+		return cniTypes.NewError(types.CniErrUnhealthy, "Unhealthy",
+			"container is unhealthy in agent")
+	}
+	pluginCtx.Logger.Debugf("Container %s has a healthy agent endpoint", pluginCtx.Args.ContainerID)
+	return nil
+}
+
+func init() {
+	chainingapi.Register("generic-device", &GenericDeviceChainer{})
+}

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/awscni"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/azure"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/flannel"
+	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-device"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/portmap"
 	"github.com/cilium/cilium/plugins/cilium-cni/types"


### PR DESCRIPTION
Some cni plugin doesn't use veth, such as [host-device](https://www.cni.dev/plugins/current/main/host-device/).
In TKE(Tencent Kubernetes Engine), for high permormance, we support per pod use a ENI, we just move ENI to Pod NetNS like [host-device](https://www.cni.dev/plugins/current/main/host-device/).
![image](https://user-images.githubusercontent.com/9653438/189265946-e1660ad6-9ea9-403d-a3f0-b3bfade536d6.png)
We hope use cilium provide Service and NetworkPolicy, so I implement a chining plugin called `generic-device`.
If use this plugin, cilium-agent will attach bpf program to pod netns interface instead of host veth interface.
