### PR TITLE
additional print columns for ciliumnodes

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -21,7 +21,20 @@ spec:
     singular: ciliumnode
   scope: Cluster
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - description: Cilium internal IP for this node
+      jsonPath: .spec.addresses[?(@.type=="CiliumInternalIP")].ip
+      name: CiliumInternalIP
+      type: string
+    - description: IP of the node
+      jsonPath: .spec.addresses[?(@.type=="InternalIP")].ip
+      name: InternalIP
+      type: string
+    - description: Time duration since creation of Ciliumnode
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v2
     schema:
       openAPIV3Schema:
         description: CiliumNode represents a node managed by Cilium. It contains a

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -23,7 +23,7 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.26.0"
+	CustomResourceDefinitionSchemaVersion = "1.26.1"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -311,6 +311,9 @@ type CiliumEndpointList struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories={cilium},singular="ciliumnode",path="ciliumnodes",scope="Cluster",shortName={cn,ciliumn}
+// +kubebuilder:printcolumn:JSONPath=".spec.addresses[?(@.type==\"CiliumInternalIP\")].ip",description="Cilium internal IP for this node",name="CiliumInternalIP",type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.addresses[?(@.type==\"InternalIP\")].ip",description="IP of the node",name="InternalIP",type=string
+// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Ciliumnode",name="Age",type=date
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 


### PR DESCRIPTION
add details about the InternalIP and CiliumInternalIP to the print columns when running kubectl get ciliumnode

```
NAME                                CILIUMINTERNALIP   INTERNALIP   AGE
control-plane-9e2fc530-2wgbj        10.0.5.141         10.6.0.105   22d
control-plane-9e2fc530-8nv4n        10.0.4.246         10.6.0.76    22d
control-plane-9e2fc530-gc47f        10.0.0.148         10.6.0.171   22d
worker-node-2ef62be2-dxjp9          10.0.3.42          10.6.0.221   27d
worker-node-2ef62be2-jldhp          10.0.1.60          10.6.0.156   27d
worker-node-2ef62be2-xpfc2          10.0.2.253         10.6.0.153   27d
```

Signed-off-by: Mario Constanti <mario@constanti.de>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Add the additional print columns `CiliumInternalIP` and `InternalIP` for `kubectl get ciliumnode` command.
```
