### PR TITLE
doc: correct lock down network policy

### DIFF
--- a/examples/policies/host/lock-down-ingress.yaml
+++ b/examples/policies/host/lock-down-ingress.yaml
@@ -11,7 +11,7 @@ spec:
   - fromEntities:
     - remote-node
     - health
-  - toPorts:
+    toPorts:
     - ports:
       - port: "6443"
         protocol: TCP


### PR DESCRIPTION
Before it was 2 separate rules, where it was fromEntities have access OR all toPorts have access. Now it is an fromEntities AND toPorts.

Signed-off-by: Wouter van Os <wouter0100@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
