### PR TITLE
make: fix kind-image-operator target to build the operator-generic image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -537,7 +537,7 @@ kind-image-agent: kind-ready ## Build cilium-dev docker image and import it into
 
 $(eval $(call KIND_ENV,kind-image-operator))
 kind-image-operator: kind-ready ## Build cilium-operator-dev docker image and import it into kind.
-	$(QUIET)$(MAKE) dev-docker-operator-image DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
+	$(QUIET)$(MAKE) dev-docker-operator-generic-image DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
 	@echo "  DEPLOY image to kind ($(LOCAL_OPERATOR_IMAGE))"
 	$(QUIET)$(CONTAINER_ENGINE) push $(LOCAL_OPERATOR_IMAGE)
 	$(QUIET)kind load docker-image $(LOCAL_OPERATOR_IMAGE)


### PR DESCRIPTION
Build the cilium/operator-generic instead of the cilium/operator (all-in-one) image in the kind-image-operator. Otherwise loading the image will fail with:

      DEPLOY image to kind (localhost:5000/cilium/operator-generic:local)
    docker push localhost:5000/cilium/operator-generic:local
    The push refers to repository [localhost:5000/cilium/operator-generic]
    An image does not exist locally with the tag: localhost:5000/cilium/operator-generic
    make[1]: *** [Makefile:542: kind-image-operator] Error 1
    make[1]: Leaving directory '/home/tklauser/go/src/github.com/cilium/cilium'
    make: *** [Makefile:548: kind-image] Error 2

Fixes: a94382782e42 ("Makefile: Split agent and operator kind targets")
