### PR TITLE
Adding/fixing DNSProxy metrics

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -43,11 +43,13 @@ import (
 )
 
 const (
-	upstream        = "upstreamTime"
+	upstreamTime    = "upstreamTime"
 	processingTime  = "processingTime"
 	semaphoreTime   = "semaphoreTime"
 	policyCheckTime = "policyCheckTime"
+	policyGenTime   = "policyGenerationTime"
 	dataplaneTime   = "dataplaneTime"
+	totalTime       = "totalTime"
 
 	metricErrorTimeout = "timeout"
 	metricErrorProxy   = "proxyErr"
@@ -423,15 +425,20 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 	endMetric := func() {
 		stat.DataplaneTime.End(true)
 		stat.ProcessingTime.End(true)
-		if errors.Is(stat.Err, dnsproxy.ErrFailedAcquireSemaphore{}) || errors.Is(stat.Err, dnsproxy.ErrTimedOutAcquireSemaphore{}) {
-			metrics.FQDNSemaphoreRejectedTotal.Add(1)
+		stat.TotalTime.End(true)
+		if errors.As(stat.Err, &dnsproxy.ErrFailedAcquireSemaphore{}) || errors.As(stat.Err, &dnsproxy.ErrTimedOutAcquireSemaphore{}) {
+			metrics.FQDNSemaphoreRejectedTotal.Inc()
 		}
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, upstream).Observe(
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, totalTime).Observe(
+			stat.TotalTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, upstreamTime).Observe(
 			stat.UpstreamTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(
 			stat.ProcessingTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, semaphoreTime).Observe(
 			stat.SemaphoreAcquireTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyGenTime).Observe(
+			stat.PolicyGenerationTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyCheckTime).Observe(
 			stat.PolicyCheckTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, dataplaneTime).Observe(
@@ -525,7 +532,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 	record.Log()
 
 	if msg.Response && msg.Rcode == dns.RcodeSuccess && len(responseIPs) > 0 {
-		stat.DataplaneTime.Start()
+		stat.PolicyGenerationTime.Start()
 		// This must happen before the NameManager update below, to ensure that
 		// this data is included in the serialized Endpoint object.
 		// We also need to add to the cache before we purge any matching zombies
@@ -557,6 +564,8 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 			log.WithError(err).Error("error updating internal DNS cache for rule generation")
 		}
 
+		stat.PolicyGenerationTime.End(true)
+		stat.DataplaneTime.Start()
 		updateComplete := make(chan struct{})
 		go func(wg *sync.WaitGroup, done chan struct{}) {
 			wg.Wait()


### PR DESCRIPTION
A few changes are made here:
- `cilium_fqdn_semaphore_rejected_total` wasn't being updated correctly, due to an incorrect error check. This is fixed now.
- Based on the discussion [here](https://github.com/cilium/cilium/pull/19992/commits/403790a7a9b778eebca1605856a8919bcae60812#r936034590), the field `scope:datapathTime` in `cilium_proxy_upstream_reply_seconds` was split into two different scopes: `policyGenerationTime` (for updating the DNS caches and policy caches) and `datapathTime` (which include the async policy map updates and the identity cache updates).

```release-note
Fixes `semaphore_rejected_total` metric and adds new `scope` to `proxy_upstream_reply_seconds` metric.
```

Signed-off-by: Rahul Joshi <rkjoshi@google.com>
