### PR TITLE
daemon: Eliminate dry-mode option

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -83,7 +83,6 @@ func TestMain(m *testing.M) {
 	// run.
 	option.Config.Populate(Vp)
 	option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore
-	option.Config.DryMode = true
 	option.Config.Opts = option.NewIntOptions(&option.DaemonMutableOptionLibrary)
 	// GetConfig the default labels prefix filter
 	err := labelsfilter.ParseLabelPrefixCfg(nil, "")

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -168,10 +168,6 @@ func endParallelMapMode() {
 // ipcache, if needed, and also notifies the daemon and network policy
 // hosts cache if changes were made.
 func (d *Daemon) syncEndpointsAndHostIPs() error {
-	if option.Config.DryMode {
-		return nil
-	}
-
 	specialIdentities := []identity.IPIdentityPair{}
 
 	if option.Config.EnableIPv4 {
@@ -310,10 +306,6 @@ func (d *Daemon) sourceByIP(ip net.IP, defaultSrc source.Source) source.Source {
 // must be done *before* any operations which read BPF maps, especially
 // restoring endpoints and services.
 func (d *Daemon) initMaps() error {
-	if option.Config.DryMode {
-		return nil
-	}
-
 	if _, err := lxcmap.LXCMap.OpenOrCreate(); err != nil {
 		return err
 	}

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -325,7 +325,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	// Do not start the proxy in dry mode or if L7 proxy is disabled.
 	// The proxy would not get any traffic in the dry mode anyway, and some of the socket
 	// operations require privileges not available in all unit tests.
-	if option.Config.DryMode || !option.Config.EnableL7Proxy {
+	if !option.Config.EnableL7Proxy {
 		return nil
 	}
 

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -166,11 +166,9 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState, clean bool) er
 		err               error
 	)
 
-	if !option.Config.DryMode {
-		existingEndpoints, err = lxcmap.DumpToMap()
-		if err != nil {
-			log.WithError(err).Warning("Unable to open endpoint map while restoring. Skipping cleanup of endpoint map on startup")
-		}
+	existingEndpoints, err = lxcmap.DumpToMap()
+	if err != nil {
+		log.WithError(err).Warning("Unable to open endpoint map while restoring. Skipping cleanup of endpoint map on startup")
 	}
 
 	for _, ep := range state.possible {

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -38,10 +38,6 @@ func GetBytesPerSec(bandwidth string) (uint64, error) {
 }
 
 func ProbeBandwidthManager() {
-	if option.Config.DryMode {
-		return
-	}
-
 	// We at least need 5.1 kernel for native TCP EDT integration
 	// and writable queue_mapping that we use. Below helper is
 	// available for 5.1 kernels and onwards.
@@ -75,7 +71,7 @@ func ProbeBandwidthManager() {
 }
 
 func InitBandwidthManager() {
-	if option.Config.DryMode || !option.Config.EnableBandwidthManager {
+	if !option.Config.EnableBandwidthManager {
 		return
 	}
 

--- a/pkg/datapath/linux/bigtcp/bigtcp.go
+++ b/pkg/datapath/linux/bigtcp/bigtcp.go
@@ -79,10 +79,6 @@ func setGROGSOMaxSize(device string, GROMaxSize, GSOMaxSize int) error {
 func InitBIGTCP(bigTCPConfig *Configuration) {
 	var err error
 
-	if option.Config.DryMode {
-		return
-	}
-
 	if len(option.Config.GetDevices()) == 0 {
 		if option.Config.EnableIPv6BIGTCP {
 			log.Warn("IPv6 BIG TCP could not detect host devices. Disabling the feature.")

--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -87,7 +87,7 @@ func (dm *DeviceManager) Detect() ([]string, error) {
 	}
 
 	l3DevOK := true
-	if !option.Config.EnableHostLegacyRouting && !option.Config.DryMode {
+	if !option.Config.EnableHostLegacyRouting {
 		// Probe whether BPF host routing is supported for L3 devices. This will
 		// invoke bpftool and requires root privileges, so we're only probing
 		// when necessary.
@@ -405,10 +405,6 @@ func (dm *DeviceManager) Listen(ctx context.Context) (chan []string, error) {
 }
 
 func (dm *DeviceManager) AreDevicesRequired() bool {
-	if option.Config.DryMode {
-		return false
-	}
-
 	return option.Config.EnableNodePort ||
 		option.Config.EnableHostFirewall ||
 		option.Config.EnableBandwidthManager

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -133,24 +133,22 @@ func CheckMinRequirements() {
 	}
 
 	// bpftool checks
-	if !option.Config.DryMode {
-		probeManager := probes.NewProbeManager()
+	probeManager := probes.NewProbeManager()
 
-		// VTEP integration feature requires kernel 1m large instruction support
-		if option.Config.EnableVTEP {
-			if probes.HaveLargeInstructionLimit() != nil {
-				log.Fatalf("VXLAN Tunnel Endpoint (VTEP) Integration: requires support for large programs (Linux 5.2.0 or newer)")
-			}
+	// VTEP integration feature requires kernel 1m large instruction support
+	if option.Config.EnableVTEP {
+		if probes.HaveLargeInstructionLimit() != nil {
+			log.Fatalf("VXLAN Tunnel Endpoint (VTEP) Integration: requires support for large programs (Linux 5.2.0 or newer)")
 		}
-		if err := probeManager.SystemConfigProbes(); err != nil {
-			errMsg := "BPF system config check: NOT OK."
-			// TODO(brb) warn after GH#14314 has been resolved
-			if !errors.Is(err, probes.ErrKernelConfigNotFound) {
-				log.WithError(err).Warn(errMsg)
-			}
+	}
+	if err := probeManager.SystemConfigProbes(); err != nil {
+		errMsg := "BPF system config check: NOT OK."
+		// TODO(brb) warn after GH#14314 has been resolved
+		if !errors.Is(err, probes.ErrKernelConfigNotFound) {
+			log.WithError(err).Warn(errMsg)
 		}
-		if err := probeManager.CreateHeadersFile(); err != nil {
-			log.WithError(err).Fatal("BPF check: NOT OK.")
-		}
+	}
+	if err := probeManager.CreateHeadersFile(); err != nil {
+		log.WithError(err).Fatal("BPF check: NOT OK.")
 	}
 }

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -159,23 +159,21 @@ var (
 // GetBPFCPU returns the BPF CPU for this host.
 func GetBPFCPU() string {
 	probeCPUOnce.Do(func() {
-		if !option.Config.DryMode {
-			// We can probe the availability of BPF instructions indirectly
-			// based on what kernel helpers are available when both were
-			// added in the same release.
-			// We want to enable v3 only on kernels 5.10+ where we have
-			// tested it and need it to work around complexity issues.
-			if probes.HaveV3ISA() == nil {
-				if probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnRedirectNeigh) == nil {
-					nameBPFCPU = "v3"
-					return
-				}
+		// We can probe the availability of BPF instructions indirectly
+		// based on what kernel helpers are available when both were
+		// added in the same release.
+		// We want to enable v3 only on kernels 5.10+ where we have
+		// tested it and need it to work around complexity issues.
+		if probes.HaveV3ISA() == nil {
+			if probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnRedirectNeigh) == nil {
+				nameBPFCPU = "v3"
+				return
 			}
-			// We want to enable v2 on all kernels that support it, that is,
-			// kernels 4.14+.
-			if probes.HaveV2ISA() == nil {
-				nameBPFCPU = "v2"
-			}
+		}
+		// We want to enable v2 on all kernels that support it, that is,
+		// kernels 4.14+.
+		if probes.HaveV2ISA() == nil {
+			nameBPFCPU = "v2"
 		}
 	})
 	return nameBPFCPU

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1095,9 +1095,7 @@ type DeleteConfig struct {
 func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf DeleteConfig) []error {
 	errors := []error{}
 
-	if !option.Config.DryMode {
-		e.owner.Datapath().Loader().Unload(e.createEpInfoCache(""))
-	}
+	e.owner.Datapath().Loader().Unload(e.createEpInfoCache(""))
 
 	// Remove policy references from shared policy structures
 	e.desiredPolicy.Detach()
@@ -1149,7 +1147,7 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 
 	if e.ConntrackLocalLocked() {
 		ctmap.CloseLocalMaps(e.conntrackName())
-	} else if !option.Config.DryMode {
+	} else {
 		e.scrubIPsInConntrackTableLocked()
 	}
 
@@ -2148,15 +2146,12 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 	}
 	e.setState(StateDisconnecting, "Deleting endpoint")
 
-	// If dry mode is enabled, no changes to BPF maps are performed
-	if !option.Config.DryMode {
-		if errs2 := lxcmap.DeleteElement(e); errs2 != nil {
-			errs = append(errs, errs2...)
-		}
+	if errs2 := lxcmap.DeleteElement(e); errs2 != nil {
+		errs = append(errs, errs2...)
+	}
 
-		if errs2 := e.deleteMaps(); errs2 != nil {
-			errs = append(errs, errs2...)
-		}
+	if errs2 := e.deleteMaps(); errs2 != nil {
+		errs = append(errs, errs2...)
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure || option.Config.IPAM == ipamOption.IPAMAlibabaCloud {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -645,12 +645,9 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponStop(c *C) {
 	// Need to modify global configuration (hooray!), change back when test is
 	// done.
 	oldQueueSize := option.Config.EndpointQueueSize
-	oldDryMode := option.Config.DryMode
 	option.Config.EndpointQueueSize = 1
-	option.Config.DryMode = true
 	defer func() {
 		option.Config.EndpointQueueSize = oldQueueSize
-		option.Config.DryMode = oldDryMode
 	}()
 
 	oldDatapath := s.datapath

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -438,9 +438,7 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 	}
 
 	// Keep PolicyMap for this endpoint in sync with desired / realized state.
-	if !option.Config.DryMode {
-		e.syncPolicyMapController()
-	}
+	e.syncPolicyMapController()
 
 	if e.desiredPolicy != e.realizedPolicy {
 		// Remove references to the old policy

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -181,9 +181,6 @@ func (mgr *EndpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync
 // InitMetrics hooks the EndpointManager into the metrics subsystem. This can
 // only be done once, globally, otherwise the metrics library will panic.
 func (mgr *EndpointManager) InitMetrics() {
-	if option.Config.DryMode {
-		return
-	}
 	metricsOnce.Do(func() { // Endpoint is a function used to collect this metric. We cannot
 		// increment/decrement a gauge since we invoke Remove gratuitously and that
 		// would result in negative counts.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1307,8 +1307,6 @@ type DaemonConfig struct {
 	Tunnel       string // Tunnel mode
 	TunnelPort   int    // Tunnel port
 
-	DryMode bool // Do not create BPF maps, devices, ..
-
 	// RestoreState enables restoring the state from previous running daemons.
 	RestoreState bool
 

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -113,7 +113,6 @@ func (cpt *ControlPlaneTest) SetupEnvironment(modConfig func(*agentOption.Daemon
 
 	agentOption.Config.Populate(agentCmd.Vp)
 	agentOption.Config.IdentityAllocationMode = agentOption.IdentityAllocationModeCRD
-	agentOption.Config.DryMode = true
 	agentOption.Config.IPAM = ipamOption.IPAMKubernetes
 	agentOption.Config.Opts = agentOption.NewIntOptions(&agentOption.DaemonMutableOptionLibrary)
 	agentOption.Config.Opts.SetBool(agentOption.DropNotify, true)


### PR DESCRIPTION
Remove `option.Config.DryMode` to improve code readability and future development.

Fixes: #18489