### PR TITLE
Documentation: run with endpoint routes under aws-cni chaining

### DIFF
--- a/Documentation/installation/cni-chaining-aws-cni.rst
+++ b/Documentation/installation/cni-chaining-aws-cni.rst
@@ -67,7 +67,8 @@ Deploy Cilium via Helm:
      --namespace kube-system \\
      --set cni.chainingMode=aws-cni \\
      --set enableIPv4Masquerade=false \\
-     --set tunnel=disabled
+     --set tunnel=disabled \\
+     --set endpointRoutes.enabled=true
 
 This will enable chaining with the AWS VPC CNI plugin. It will also disable
 tunneling, as it's not required since ENI IP addresses can be directly routed


### PR DESCRIPTION
Similar to #19088, endpoint routes are also required for some features like NodePort-type services to work under aws-cni chaining. This commit adds the endpointRoutes.enabled setting to the Helm snippet in the docs.

Related: #21126

```release-note
Document per-endpoint route requirement in aws-cni Helm snippet
```
