### PR TITLE
CI: Add AKS helm overrides for E2E test

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -525,6 +525,24 @@ cluster.
           versions between 1.16 and 1.23. Version should match the server
           version reported by ``kubectl version``.
 
+AKS (experimental)
+^^^^^^^^^^^^^^^^^^
+
+.. note:: The tests require the ``NATIVE_CIDR`` environment variable to be set to
+          the value of the cluster IPv4 CIDR.
+
+1. Setup a cluster as in :ref:`k8s_install_quick` or utilize an existing
+   cluster. You do not need to deploy Cilium in this step, as the End-To-End
+   Testing Framework handles the deployment of Cilium.
+
+2. Invoke the tests from ``cilium/test`` with options set as explained in
+`Running End-To-End Tests In Other Environments via kubeconfig`_
+
+.. code-block:: shell-session
+
+    export NATIVE_CIDR="10.241.0.0/16"
+    CNI_INTEGRATION=aks K8S_VERSION=1.17 ginkgo --focus="K8s" --tags=integration_tests -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.passCLIEnvironment=true -cilium.image="mcr.microsoft.com/oss/cilium/cilium" -cilium.tag="1.12.1" -cilium.operator-image="mcr.microsoft.com/oss/cilium/operator" -cilium.operator-suffix=""  -cilium.operator-tag="1.12.1"
+
 AWS EKS (experimental)
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -56,6 +56,9 @@ const (
 	// CIIntegrationGKE contains the constants to be used when running tests on GKE.
 	CIIntegrationGKE = "gke"
 
+	// CIIntegrationAKS contains the constants to be used when running tests on AKS.
+	CIIntegrationAKS = "aks"
+
 	// CIIntegrationKind contains the constant to be used when running tests on kind.
 	CIIntegrationKind = "kind"
 
@@ -153,6 +156,26 @@ var (
 		"devices":                     "", // Override "eth0 eth0\neth0"
 	}
 
+	aksHelmOverrides = map[string]string{
+		"ipam.mode":                           "delegated-plugin",
+		"tunnel":                              "disabled",
+		"endpointRoutes.enabled":              "true",
+		"extraArgs":                           "{--local-router-ipv4=169.254.23.0}",
+		"k8s.requireIPv4PodCIDR":              "false",
+		"ipv6.enabled":                        "false",
+		"ipv4NativeRoutingCIDR":               AKSNativeRoutingCIDR(),
+		"enableIPv4Masquerade":                "false",
+		"install-no-conntrack-iptables-rules": "false",
+		"installIptablesRules":                "true",
+		"l7Proxy":                             "false",
+		"hubble.enabled":                      "false",
+		"kubeProxyReplacement":                "strict",
+		"endpointHealthChecking.enabled":      "false",
+		"cni.install":                         "true",
+		"cni.customConf":                      "true",
+		"cni.configMap":                       "cni-configuration",
+	}
+
 	microk8sHelmOverrides = map[string]string{
 		"cni.confPath":      "/var/snap/microk8s/current/args/cni-network",
 		"cni.binPath":       "/var/snap/microk8s/current/opt/cni/bin",
@@ -179,6 +202,7 @@ var (
 		CIIntegrationEKSChaining: eksChainingHelmOverrides,
 		CIIntegrationEKS:         eksHelmOverrides,
 		CIIntegrationGKE:         gkeHelmOverrides,
+		CIIntegrationAKS:         aksHelmOverrides,
 		CIIntegrationKind:        kindHelmOverrides,
 		CIIntegrationMicrok8s:    microk8sHelmOverrides,
 		CIIntegrationMinikube:    minikubeHelmOverrides,

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -518,6 +518,10 @@ func GKENativeRoutingCIDR() string {
 	return os.Getenv("NATIVE_CIDR")
 }
 
+func AKSNativeRoutingCIDR() string {
+	return os.Getenv("NATIVE_CIDR")
+}
+
 // DoesNotRunOn419Kernel is the complement function of RunsOn419Kernel.
 func DoesNotRunOn419Kernel() bool {
 	return !RunsOn419Kernel()
@@ -552,6 +556,16 @@ func RunsOnGKE() bool {
 // DoesNotRunOnGKE is the complement function of DoesNotRunOnGKE.
 func DoesNotRunOnGKE() bool {
 	return !RunsOnGKE()
+}
+
+// RunsOnAKS returns true if the tests are running on AKS.
+func RunsOnAKS() bool {
+	return GetCurrentIntegration() == CIIntegrationAKS
+}
+
+// DoesNotRunOnAKS is the complement function of DoesNotRunOnAKS.
+func DoesNotRunOnAKS() bool {
+	return !RunsOnAKS()
 }
 
 // RunsOnEKS returns true if the tests are running on EKS.
@@ -741,6 +755,11 @@ func DualStackSupported() bool {
 		return false
 	}
 
+	// AKS does not support dual stack yet
+	if IsIntegration(CIIntegrationAKS) {
+		return false
+	}
+
 	// We only have DualStack enabled in Vagrant test env or on KIND.
 	return (GetCurrentIntegration() == "" || IsIntegration(CIIntegrationKind)) &&
 		supportedVersions(k8sVersion)
@@ -756,6 +775,11 @@ func DualStackSupportBeta() bool {
 	supportedVersions := versioncheck.MustCompile(">=1.20.0")
 	k8sVersion, err := versioncheck.Version(GetCurrentK8SEnv())
 	if err != nil {
+		return false
+	}
+
+	// AKS does not support dual stack yet
+	if IsIntegration(CIIntegrationAKS) {
 		return false
 	}
 

--- a/test/k8s/cli.go
+++ b/test/k8s/cli.go
@@ -12,7 +12,7 @@ import (
 
 var _ = Describe("K8sDatapathCLI", func() {
 	SkipContextIf(func() bool {
-		return helpers.DoesNotRunOnGKE() && helpers.DoesNotRunOnEKS()
+		return helpers.DoesNotRunOnGKE() && helpers.DoesNotRunOnEKS() && helpers.DoesNotRunOnAKS()
 	}, "CLI", func() {
 		var kubectl *helpers.Kubectl
 		var ciliumFilename string

--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -244,7 +244,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 		connectivityTest()
 	})
 
-	It("Validate that multiple specs are working correctly", func() {
+	SkipItIf(helpers.RunsOnAKS, "Validate that multiple specs are working correctly", func() {
 		// To make sure that UUID in multiple specs are plumbed correctly to
 		// Cilium Policy
 		fqdnPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs.yaml")
@@ -280,7 +280,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 		res.ExpectFail("Can connect to a valid target when it should NOT work")
 	})
 
-	It("Validate that FQDN policy continues to work after being updated", func() {
+	SkipItIf(helpers.RunsOnAKS, "Validate that FQDN policy continues to work after being updated", func() {
 		// To make sure that UUID in multiple specs are plumbed correctly to
 		// Cilium Policy
 		fqdnPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs.yaml")

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -26,7 +26,9 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 	// We want to run Hubble tests both with and without our kube-proxy
 	// replacement, as the trace events depend on it. We thus run the tests
 	// on GKE and our 4.9 pipeline.
-	SkipContextIf(helpers.RunsOn419OrLaterKernel, "Hubble Observe", func() {
+	SkipContextIf(func() bool {
+		return helpers.RunsOn419OrLaterKernel() || helpers.RunsOnAKS()
+	}, "Hubble Observe", func() {
 		var (
 			kubectl        *helpers.Kubectl
 			ciliumFilename string

--- a/test/k8s/istio.go
+++ b/test/k8s/istio.go
@@ -296,7 +296,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentIstioTest", func() {
 			return true
 		}
 
-		It("Tests bookinfo inter-service connectivity", func() {
+		SkipItIf(helpers.RunsOnAKS, "Tests bookinfo inter-service connectivity", func() {
 			var err error
 			version := "version"
 			v1 := "v1"

--- a/test/k8s/kafka_policies.go
+++ b/test/k8s/kafka_policies.go
@@ -53,7 +53,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 	})
 
 	// Tests involving the L7 proxy do not work when built with -race, see issue #13757.
-	SkipContextIf(helpers.SkipRaceDetectorEnabled, "Kafka Policy Tests", func() {
+	SkipContextIf(func() bool { return helpers.SkipRaceDetectorEnabled() || helpers.RunsOnAKS() }, "Kafka Policy Tests", func() {
 		createTopicCmd := func(topic string) string {
 			return fmt.Sprintf("/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh --create "+
 				"--zookeeper localhost:2181 --replication-factor 1 "+

--- a/test/k8s/lrp.go
+++ b/test/k8s/lrp.go
@@ -18,7 +18,7 @@ import (
 
 // The 5.4 CI job is intended to catch BPF complexity regressions and as such
 // doesn't need to execute this test suite.
-var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathLRPTests", func() {
+var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() && helpers.DoesNotRunOnAKS() }, "K8sDatapathLRPTests", func() {
 	var (
 		kubectl        *helpers.Kubectl
 		ciliumFilename string
@@ -42,7 +42,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathLRPTests", func() {
 		kubectl.CiliumReport("cilium lrp list", "cilium service list")
 	})
 
-	SkipContextIf(func() bool { return !helpers.RunsOn419OrLaterKernel() }, "Checks local redirect policy", func() {
+	SkipContextIf(func() bool { return !helpers.RunsOn419OrLaterKernel() && helpers.DoesNotRunOnAKS() }, "Checks local redirect policy", func() {
 		const (
 			lrpServiceName = "lrp-demo-service"
 			be1Name        = "k8s1-backend"

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -29,7 +29,7 @@ var _ = SkipDescribeIf(func() bool {
 	// code coverage.
 	//
 	// For GKE coverage, see the K8sPolicyTestExtended Describe block below.
-	return helpers.RunsOnGKE() || helpers.RunsOn419Kernel() || helpers.RunsOn54Kernel()
+	return helpers.RunsOnGKE() || helpers.RunsOn419Kernel() || helpers.RunsOn54Kernel() || helpers.RunsOnAKS()
 }, "K8sAgentPolicyTest", func() {
 
 	var (

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -149,7 +149,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 				testFailBind(kubectl, ni)
 			})
 
-			Context("with L7 policy", func() {
+			SkipContextIf(helpers.RunsOnAKS, "with L7 policy", func() {
 				AfterAll(func() {
 					kubectl.Delete(demoPolicyL7)
 					// Remove CT entries to avoid packet drops which could happen
@@ -219,7 +219,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 			})
 		})
 
-		SkipContextIf(helpers.RunsWithKubeProxyReplacement, "TFTP with DNS Proxy port collision", func() {
+		SkipContextIf(func() bool { return helpers.RunsWithKubeProxyReplacement() || helpers.RunsOnAKS() }, "TFTP with DNS Proxy port collision", func() {
 			var (
 				demoPolicy    string
 				ciliumPodK8s1 string
@@ -313,7 +313,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 		})
 
 		SkipContextIf(func() bool {
-			return helpers.RunsWithKubeProxyReplacement()
+			return helpers.RunsWithKubeProxyReplacement() || helpers.RunsOnAKS()
 		}, "with L7 policy", func() {
 			var demoPolicyL7 string
 

--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -48,6 +48,8 @@ var _ = Describe("K8sUpdates", func() {
 	)
 
 	BeforeAll(func() {
+
+		SkipIfIntegration(helpers.CIIntegrationAKS)
 		canRun, err := helpers.CanRunK8sVersion(helpers.CiliumStableVersion, helpers.GetCurrentK8SEnv())
 		ExpectWithOffset(1, err).To(BeNil(), "Unable to get k8s constraints for %s", helpers.CiliumStableVersion)
 		if !canRun {

--- a/test/k8s/verifier.go
+++ b/test/k8s/verifier.go
@@ -111,6 +111,7 @@ var _ = Describe("K8sDatapathVerifier", func() {
 
 	BeforeAll(func() {
 		SkipIfIntegration(helpers.CIIntegrationGKE)
+		SkipIfIntegration(helpers.CIIntegrationAKS)
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		// We don't check the returned error because Cilium could


### PR DESCRIPTION
AKS does not have the E2E integration enabled for AKS. This PR adds `aks` as a valid `CNI_INTEGRATION` attribute. The change includes the helm overrides and the test that should be skipped for AKS.