### PR TITLE
ip: Add MustAddrFromIP

### DIFF
--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -944,3 +944,13 @@ func AddrFromIP(ip net.IP) (netip.Addr, bool) {
 	}
 	return addr.Unmap(), ok
 }
+
+// MustAddrFromIP is the same as AddrFromIP except that it assumes the input is
+// a valid IP address and always returns a valid netip.Addr.
+func MustAddrFromIP(ip net.IP) netip.Addr {
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		panic("addr is not a valid IP address")
+	}
+	return addr.Unmap()
+}


### PR DESCRIPTION
This function is the same as AddrFromIP() but assumes the input is
valid. It doesn't return an error and instead panics if assumptions are
not true.

This is useful to have a fast-path without error handling when we are
certain the input is valid.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
