### PR TITLE
Fix improper regex in check-sources.sh awk command

### DIFF
--- a/pkg/datapath/loader/check-sources.sh
+++ b/pkg/datapath/loader/check-sources.sh
@@ -9,7 +9,7 @@ defined_files=$(
 	awk -F: '/^__source_file_name_to_id/{found=1; next}
 		/return 0/{exit}
 		{if (!found || !/_strcase_/) next}
-		{gsub(/.* |"|)|;/, "", $1); print $1}
+		{gsub(/.* |"|\)|;/, "", $1); print $1}
 		' bpf/source_names_to_ids.h
 )
 


### PR DESCRIPTION
Parens need to be escaped with `\` in regex. Some versions of awk will fail without it.

Fixes: #21284
Fixes: bb5e3fef6f0e
Signed-off-by: Nathan Perkins <nperkins487@gmail.com>