### PR TITLE
dnsproxy: introduce cache to reference count regexes

### DIFF
--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -4,11 +4,14 @@
 package dnsproxy
 
 import (
+	"regexp"
 	"testing"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy"
@@ -24,34 +27,188 @@ func TestNonPrivileged(t *testing.T) {
 	TestingT(t)
 }
 
-func (s *DNSProxyHelperTestSuite) TestGetSelectorRegexMap(c *C) {
-	selector := MockCachedSelector{}
-
-	dnsName := "example.name."
-
-	l7 := policy.L7DataMap{
-		selector: &policy.PerSelectorPolicy{
-			L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{
-				{
-					MatchName: dnsName,
-				},
-			}},
+func (s *DNSProxyHelperTestSuite) TestSetPortRulesForID(c *C) {
+	re.InitRegexCompileLRU(1)
+	rules := policy.L7DataMap{}
+	epID := uint64(1)
+	pea := perEPAllow{}
+	cache := make(regexCache)
+	rules[new(MockCachedSelector)] = &policy.PerSelectorPolicy{
+		L7Rules: api.L7Rules{
+			DNS: []api.PortRuleDNS{
+				{MatchName: "cilium.io."},
+				{MatchPattern: "*.cilium.io."},
+			},
 		},
 	}
-	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
-	m, err := GetSelectorRegexMap(l7)
-
+	err := pea.setPortRulesForID(cache, epID, 8053, rules)
 	c.Assert(err, Equals, nil)
+	c.Assert(len(cache), Equals, 1)
 
-	regex, ok := m[selector]
+	selector2 := new(MockCachedSelector)
+	rules[selector2] = &policy.PerSelectorPolicy{
+		L7Rules: api.L7Rules{
+			DNS: []api.PortRuleDNS{
+				{MatchName: "cilium2.io."},
+				{MatchPattern: "*.cilium2.io."},
+				{MatchPattern: "*.cilium3.io."},
+			},
+		},
+	}
+	err = pea.setPortRulesForID(cache, epID, 8053, rules)
+	c.Assert(err, Equals, nil)
+	c.Assert(len(cache), Equals, 2)
 
-	c.Assert(ok, Equals, true)
+	delete(rules, selector2)
+	err = pea.setPortRulesForID(cache, epID, 8053, rules)
+	c.Assert(err, Equals, nil)
+	c.Assert(len(cache), Equals, 1)
 
-	c.Assert(regex.MatchString(dnsName), Equals, true)
-	c.Assert(regex.MatchString(dnsName+"trolo"), Equals, false)
+	err = pea.setPortRulesForID(cache, epID, 8053, nil)
+	c.Assert(err, Equals, nil)
+	c.Assert(len(cache), Equals, 0)
+
+	rules[selector2] = &policy.PerSelectorPolicy{
+		L7Rules: api.L7Rules{
+			DNS: []api.PortRuleDNS{
+				{MatchName: "cilium2.io."},
+				{MatchPattern: "*.cilium2.io."},
+				{MatchPattern: "-invalid-pattern("},
+				{MatchPattern: "*.cilium3.io."},
+			},
+		},
+	}
+	err = pea.setPortRulesForID(cache, epID, 8053, rules)
+
+	c.Assert(err, NotNil)
+	c.Assert(len(cache), Equals, 0)
 }
 
-type MockCachedSelector struct{}
+func (s *DNSProxyHelperTestSuite) TestSetPortRulesForIDFromUnifiedFormat(c *C) {
+	re.InitRegexCompileLRU(1)
+	rules := make(CachedSelectorREEntry)
+	epID := uint64(1)
+	pea := perEPAllow{}
+	cache := make(regexCache)
+	rules[new(MockCachedSelector)] = regexp.MustCompile("^.*[.]cilium[.]io$")
+	rules[new(MockCachedSelector)] = regexp.MustCompile("^.*[.]cilium[.]io$")
+
+	err := pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	c.Assert(err, Equals, nil)
+	c.Assert(len(cache), Equals, 1)
+
+	selector2 := new(MockCachedSelector)
+	rules[selector2] = regexp.MustCompile("^sub[.]cilium[.]io")
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	c.Assert(err, Equals, nil)
+	c.Assert(len(cache), Equals, 2)
+
+	delete(rules, selector2)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	c.Assert(err, Equals, nil)
+	c.Assert(len(cache), Equals, 1)
+
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, nil)
+	c.Assert(err, Equals, nil)
+	c.Assert(len(cache), Equals, 0)
+
+	delete(rules, selector2)
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, rules)
+	c.Assert(err, Equals, nil)
+	c.Assert(len(cache), Equals, 1)
+
+	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, 8053, nil)
+	c.Assert(err, Equals, nil)
+	c.Assert(len(cache), Equals, 0)
+}
+
+func (s *DNSProxyHelperTestSuite) TestGeneratePattern(c *C) {
+	l7 := &policy.PerSelectorPolicy{
+		L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{
+			{MatchName: "example.name."},
+			{MatchName: "example.com."},
+			{MatchName: "demo.io."},
+			{MatchName: "demoo.tld."},
+			{MatchPattern: "*pattern.com"},
+			{MatchPattern: "*.*.*middle.*"},
+		}},
+	}
+	matching := []string{"example.name.", "example.com.", "demo.io.", "demoo.tld.", "testpattern.com.", "pattern.com.", "a.b.cmiddle.io."}
+	notMatching := []string{"eexample.name.", "eexample.com.", "vdemo.io.", "demo.ioo.", "emoo.tld.", "test.ppattern.com.", "b.cmiddle.io."}
+
+	re.InitRegexCompileLRU(defaults.FQDNRegexCompileLRUSize)
+	pattern := GeneratePattern(l7)
+
+	regex, err := re.CompileRegex(pattern)
+	c.Assert(err, Equals, nil)
+
+	for _, fqdn := range matching {
+		c.Assert(regex.MatchString(fqdn), Equals, true, Commentf("expected fqdn %q to match, but it did not", fqdn))
+	}
+	for _, fqdn := range notMatching {
+		c.Assert(regex.MatchString(fqdn), Equals, false, Commentf("expected fqdn %q to not match, but it did", fqdn))
+	}
+
+	pattern = GeneratePattern(
+		&policy.PerSelectorPolicy{
+			L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{
+				{MatchPattern: "domo.io."},
+				{MatchPattern: "*"},
+			}},
+		})
+
+	regex, err = re.CompileRegex(pattern)
+	c.Assert(err, Equals, nil)
+
+	// Ensure all fqdns match a policy with a wildcard
+	for _, fqdn := range append(matching, notMatching...) {
+		c.Assert(regex.MatchString(fqdn), Equals, true, Commentf("expected fqdn %q to match with wildcard policy, but it did not", fqdn))
+	}
+
+	pattern = GeneratePattern(&policy.PerSelectorPolicy{
+		L7Rules: api.L7Rules{},
+	})
+
+	regex, err = re.CompileRegex(pattern)
+	c.Assert(err, Equals, nil)
+
+	// Ensure all fqdns match a policy without any dns-rules
+	for _, fqdn := range append(matching, notMatching...) {
+		c.Assert(regex.MatchString(fqdn), Equals, true, Commentf("expected fqdn %q to match with wildcard policy, but it did not", fqdn))
+	}
+
+	pattern = GeneratePattern(&policy.PerSelectorPolicy{
+		L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{}},
+	})
+	regex, err = re.CompileRegex(pattern)
+	c.Assert(err, Equals, nil)
+
+	// Ensure all fqdns match a policy without any dns-rules
+	for _, fqdn := range append(matching, notMatching...) {
+		c.Assert(regex.MatchString(fqdn), Equals, true, Commentf("expected fqdn %q to match with wildcard policy, but it did not", fqdn))
+	}
+}
+
+func (s *DNSProxyHelperTestSuite) TestGeneratePatternTrailingDot(c *C) {
+	dnsName := "example.name"
+	dnsPattern := "*.example.name"
+	generatePattern := func(name, pattern string) string {
+		l7 := &policy.PerSelectorPolicy{
+			L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{
+				{MatchName: name},
+				{MatchPattern: pattern},
+			}},
+		}
+		return GeneratePattern(l7)
+
+	}
+	c.Assert(generatePattern(dnsPattern, dnsName), checker.DeepEquals, generatePattern(dns.FQDN(dnsPattern), dns.FQDN(dnsName)))
+
+}
+
+type MockCachedSelector struct {
+	key string
+}
 
 func (m MockCachedSelector) GetSelections() []identity.NumericIdentity {
 	return nil
@@ -70,5 +227,5 @@ func (m MockCachedSelector) IsNone() bool {
 }
 
 func (m MockCachedSelector) String() string {
-	return "string"
+	return m.key
 }

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -138,7 +138,6 @@ type DNSProxy struct {
 	// allowed tracks all allowed L7 DNS rules by endpointID, destination port,
 	// and L3 Selector. All must match for a query to be allowed.
 	//
-	// matchNames with no regexp wildcards are still compiled, internally.
 	// Note: Simple DNS names, e.g. bar.foo.com, will treat the "." as a literal.
 	allowed perEPAllow
 
@@ -146,6 +145,11 @@ type DNSProxy struct {
 	// used until 'allowed' rules for an endpoint are first initialized after
 	// a restart
 	restored perEPRestored
+
+	// cache is an internal structure to keep track of all the in use DNS rules. We do that
+	// so that we avoid storing multiple similar versions of the same rules, so that we can improve
+	// performance and reduce memory consumption when multiple endpoints or ports have similar rules.
+	cache regexCache
 
 	// mapping restored endpoint IP (both IPv4 and IPv6) to *Endpoint
 	restoredEPs restoredEPs
@@ -158,6 +162,17 @@ type DNSProxy struct {
 	unbindAddress func()
 }
 
+// regexCacheEntry is a lookup entry used to cache a compiled regex
+// and how many references it has
+type regexCacheEntry struct {
+	regex          *regexp.Regexp
+	referenceCount int
+}
+
+// regexCache is a reference counted cache used for reusing the compiled regex when multiple policies
+// have the same set of rules, or the same rule applies to multiple endpoints.
+type regexCache map[string]*regexCacheEntry
+
 // perEPAllow maps EndpointIDs to ports + selectors + rules
 type perEPAllow map[uint64]portToSelectorAllow
 
@@ -165,14 +180,27 @@ type perEPAllow map[uint64]portToSelectorAllow
 type portToSelectorAllow map[uint16]CachedSelectorREEntry
 
 // CachedSelectorREEntry maps port numbers to selectors to rules, mirroring
-// policy.L7DataMap but the DNS rules are compiled into a single regexp
+// policy.L7DataMap but the DNS rules are compiled into a regex
 type CachedSelectorREEntry map[policy.CachedSelector]*regexp.Regexp
 
 // structure for restored rules that can be used while Cilium agent is restoring endpoints
 type perEPRestored map[uint64]restore.DNSRules
 
+// restoredIPRule is the dnsproxy internal way of representing a restored IPRule
+// where we also store the actual compiled regular expression as a, as well
+// as the original restored IPRule
+type restoredIPRule struct {
+	restore.IPRule
+	regex *regexp.Regexp
+}
+
 // map from EP IPs to *Endpoint
 type restoredEPs map[string]*endpoint.Endpoint
+
+// asIPRule returns a new restore.IPRule representing the rules, including the provided IP map.
+func asIPRule(r *regexp.Regexp, IPs map[string]struct{}) restore.IPRule {
+	return restore.IPRule{IPs: IPs, Re: restore.RuleRegex{Regexp: r}}
+}
 
 // CheckRestored checks endpointID, destPort, destIP, and name against the restored rules,
 // and only returns true if a restored rule matches.
@@ -230,7 +258,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 					}
 				}
 			}
-			ipRules = append(ipRules, restore.IPRule{IPs: IPs, Re: restore.RuleRegex{Regexp: regex}})
+			ipRules = append(ipRules, asIPRule(regex, IPs))
 		}
 		restored[port] = ipRules
 	}
@@ -275,55 +303,133 @@ func (p *DNSProxy) RemoveRestoredRules(endpointID uint16) {
 	p.removeRestoredRulesLocked(uint64(endpointID))
 }
 
-// setPortRulesForID sets the matching rules for endpointID and destPort for
-// later lookups. It converts newRules into a unified regexp that can be reused
-// later.
-func (allow perEPAllow) setPortRulesForID(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
-	// This is the delete case
-	if len(newRules) == 0 {
-		epPorts := allow[endpointID]
-		delete(epPorts, destPort)
-		if len(epPorts) == 0 {
-			delete(allow, endpointID)
-		}
+// lookupOrCompileRegex will check if the pattern is already compiled and present in another policy, and
+// will reuse it in order to reduce memory consumption. The usage is reference counted, so all calls where
+// lookupOrCompileRegex returns no error, a subsequent call to release it via releaseRegex has to
+// be done when it's no longer being used by the policy.
+func (c regexCache) lookupOrCompileRegex(pattern string) (*regexp.Regexp, error) {
+	if entry, ok := c[pattern]; ok {
+		entry.referenceCount += 1
+		return entry.regex, nil
+	}
+	regex, err := re.CompileRegex(pattern)
+	if err != nil {
+		return nil, err
+	}
+	c[pattern] = &regexCacheEntry{regex: regex, referenceCount: 1}
+	return regex, nil
+}
+
+// lookupOrInsertRegex is equivalent to lookupOrCompileRegex, but a compiled regex is provided
+// instead of the pattern. In case a compiled regex with the same pattern as the provided regex is already present in
+// the cache, the already present regex will be returned. By doing that, the duplicate can be garbage collected in case
+// there are no other references to it. Trying to insert a nil value is a noop and will return nil
+func (c regexCache) lookupOrInsertRegex(regex *regexp.Regexp) *regexp.Regexp {
+	if regex == nil {
 		return nil
 	}
+	pattern := regex.String()
+	if entry, ok := c[pattern]; ok {
+		entry.referenceCount += 1
+		return entry.regex
+	}
+	c[pattern] = &regexCacheEntry{regex: regex, referenceCount: 1}
+	return regex
+}
 
-	newRE, err := GetSelectorRegexMap(newRules)
+// releaseRegex releases the provided regex. In case there are no longer any references to it,
+// it will be freed. Running release on a nil value is a noop.
+func (c regexCache) releaseRegex(regex *regexp.Regexp) {
+	if regex == nil {
+		return
+	}
+	pattern := regex.String()
+	if indexEntry, ok := c[pattern]; ok {
+		switch indexEntry.referenceCount {
+		case 1:
+			delete(c, pattern)
+		default:
+			indexEntry.referenceCount -= 1
+		}
+	}
+}
+
+// removeAndReleasePortRulesForID removes the old port rules for the given destPort on the given endpointID. It also
+// releases the regexes so that unused regex can be freed from memory.
+func (allow perEPAllow) removeAndReleasePortRulesForID(cache regexCache, endpointID uint64, destPort uint16) {
+	epPorts, hasEpPorts := allow[endpointID]
+	if !hasEpPorts {
+		return
+	}
+	for _, m := range epPorts[destPort] {
+		cache.releaseRegex(m)
+	}
+	delete(epPorts, destPort)
+	if len(epPorts) == 0 {
+		delete(allow, endpointID)
+	}
+}
+
+// setPortRulesForID sets the matching rules for endpointID and destPort for
+// later lookups. It converts newRules into a compiled regex
+func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
+	if len(newRules) == 0 {
+		allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
+		return nil
+	}
+	cse := make(CachedSelectorREEntry, len(newRules))
+	var err error
+	for selector, newRuleset := range newRules {
+		pattern := GeneratePattern(newRuleset)
+
+		var regex *regexp.Regexp
+		regex, err = cache.lookupOrCompileRegex(pattern)
+		if err != nil {
+			break
+		}
+		cse[selector] = regex
+	}
 	if err != nil {
+		// Unregister the registered regexes before returning the error to avoid
+		// leaving unused references in the cache
+		for k, regex := range cse {
+			cache.releaseRegex(regex)
+			delete(cse, k)
+		}
 		return err
 	}
-
+	allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
 	epPorts, exist := allow[endpointID]
 	if !exist {
 		epPorts = make(portToSelectorAllow)
 		allow[endpointID] = epPorts
 	}
-
-	epPorts[destPort] = newRE
+	epPorts[destPort] = cse
 	return nil
 }
 
 // setPortRulesForIDFromUnifiedFormat sets the matching rules for endpointID and destPort for
-// later lookups.
-func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(endpointID uint64, destPort uint16, newRules CachedSelectorREEntry) error {
-	// This is the delete case
+// later lookups. It does not guarantee it will reuse all the provided regexes, since it will reuse
+// already existing regexes with the same pattern in case they are already in use.
+func (allow perEPAllow) setPortRulesForIDFromUnifiedFormat(cache regexCache, endpointID uint64, destPort uint16, newRules CachedSelectorREEntry) error {
 	if len(newRules) == 0 {
-		epPorts := allow[endpointID]
-		delete(epPorts, destPort)
-		if len(epPorts) == 0 {
-			delete(allow, endpointID)
-		}
+		allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
 		return nil
 	}
+	cse := make(CachedSelectorREEntry, len(newRules))
+	for selector, providedRegex := range newRules {
+		// In case the regex is already compiled and in use in another regex, lookupOrInsertRegex
+		// will return a ref. to the existing regex, and use that one.
+		cse[selector] = cache.lookupOrInsertRegex(providedRegex)
+	}
 
+	allow.removeAndReleasePortRulesForID(cache, endpointID, destPort)
 	epPorts, exist := allow[endpointID]
 	if !exist {
 		epPorts = make(portToSelectorAllow)
 		allow[endpointID] = epPorts
 	}
-
-	epPorts[destPort] = newRules
+	epPorts[destPort] = cse
 	return nil
 }
 
@@ -458,6 +564,7 @@ func StartDNSProxy(
 		allowed:                  make(perEPAllow),
 		restored:                 make(perEPRestored),
 		restoredEPs:              make(restoredEPs),
+		cache:                    make(regexCache),
 		EnableDNSCompression:     enableDNSCompression,
 		maxIPsPerRestoredDNSRule: maxRestoreDNSIPs,
 	}
@@ -546,7 +653,7 @@ func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules po
 	p.Lock()
 	defer p.Unlock()
 
-	err := p.allowed.setPortRulesForID(endpointID, destPort, newRules)
+	err := p.allowed.setPortRulesForID(p.cache, endpointID, destPort, newRules)
 	if err == nil {
 		// Rules were updated based on policy, remove restored rules
 		p.removeRestoredRulesLocked(endpointID)
@@ -559,7 +666,7 @@ func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPort 
 	p.Lock()
 	defer p.Unlock()
 
-	err := p.allowed.setPortRulesForIDFromUnifiedFormat(endpointID, destPort, newRules)
+	err := p.allowed.setPortRulesForIDFromUnifiedFormat(p.cache, endpointID, destPort, newRules)
 	if err == nil {
 		// Rules were updated based on policy, remove restored rules
 		p.removeRestoredRulesLocked(endpointID)
@@ -580,9 +687,9 @@ func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID ident
 		return p.checkRestored(endpointID, destPort, destIP.String(), name), nil
 	}
 
-	for selector, re := range epAllow {
+	for selector, regex := range epAllow {
 		// The port was matched in getPortRulesForID, above.
-		if selector.Selects(destID) && re.MatchString(name) {
+		if regex != nil && selector.Selects(destID) && regex.MatchString(name) {
 			return true, nil
 		}
 	}
@@ -978,34 +1085,26 @@ func shouldCompressResponse(request, response *dns.Msg) bool {
 	return false
 }
 
-func GetSelectorRegexMap(l7 policy.L7DataMap) (CachedSelectorREEntry, error) {
-	newRE := make(CachedSelectorREEntry)
-	for selector, l7Rules := range l7 {
-		if l7Rules == nil {
-			l7Rules = &policy.PerSelectorPolicy{L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{{MatchPattern: "*"}}}}
+// GeneratePattern takes a set of l7Rules and returns a regular expression pattern for matching the
+// provided l7 rules.
+func GeneratePattern(l7Rules *policy.PerSelectorPolicy) (pattern string) {
+	if l7Rules == nil {
+		l7Rules = &policy.PerSelectorPolicy{L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{{MatchPattern: "*"}}}}
+	}
+	reStrings := make([]string, 0, len(l7Rules.DNS))
+	for _, dnsRule := range l7Rules.DNS {
+		if len(dnsRule.MatchName) > 0 {
+			dnsRuleName := strings.ToLower(dns.Fqdn(dnsRule.MatchName))
+			reStrings = append(reStrings, "("+matchpattern.ToRegexp(dnsRuleName)+")")
 		}
-		reStrings := make([]string, 0, len(l7Rules.DNS))
-		for _, dnsRule := range l7Rules.DNS {
-			if len(dnsRule.MatchName) > 0 {
-				dnsRuleName := strings.ToLower(dns.Fqdn(dnsRule.MatchName))
-				dnsPatternAsRE := matchpattern.ToRegexp(dnsRuleName)
-				reStrings = append(reStrings, "("+dnsPatternAsRE+")")
-			}
-			if len(dnsRule.MatchPattern) > 0 {
-				dnsPattern := matchpattern.Sanitize(dnsRule.MatchPattern)
-				dnsPatternAsRE := matchpattern.ToRegexp(dnsPattern)
-				reStrings = append(reStrings, "("+dnsPatternAsRE+")")
-			}
+		if len(dnsRule.MatchPattern) > 0 {
+			dnsPattern := matchpattern.Sanitize(dnsRule.MatchPattern)
+			dnsPatternAsRE := matchpattern.ToRegexp(dnsPattern)
+			reStrings = append(reStrings, "("+dnsPatternAsRE+")")
 		}
-		mp := strings.Join(reStrings, "|")
-		rei, err := re.CompileRegex(mp)
-		if err != nil {
-			return nil, err
-		}
-		newRE[selector] = rei
 	}
 
-	return newRE, nil
+	return strings.Join(reStrings, "|")
 }
 
 func (p *DNSProxy) Cleanup() {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -249,7 +250,17 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 }
 
 func (s *DNSProxyTestSuite) TearDownTest(c *C) {
-	s.proxy.allowed = make(perEPAllow)
+	for epID := range s.proxy.allowed {
+		for port := range s.proxy.allowed[epID] {
+			s.proxy.UpdateAllowed(epID, port, nil)
+		}
+	}
+	for epID := range s.proxy.restored {
+		s.proxy.RemoveRestoredRules(uint16(epID))
+	}
+	if len(s.proxy.cache) > 0 {
+		c.Error("cache not fully empty after removing all rules. Possible memory leak found.")
+	}
 	s.proxy.SetRejectReply(option.FQDNProxyDenyWithRefused)
 	s.dnsServer.Listener.Close()
 	s.proxy.UDPServer.Shutdown()
@@ -437,6 +448,37 @@ func (s *DNSProxyTestSuite) TestRespondMixedCaseInRequestResponse(c *C) {
 	c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed"))
 	c.Assert(len(response.Answer), Equals, 1, Commentf("Proxy returned incorrect number of answer RRs %+v", response.Answer))
 	c.Assert(response.Answer[0].String(), Equals, "ciliuM.io.\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
+}
+func (s *DNSProxyTestSuite) TestCheckNoRules(c *C) {
+	name := "cilium.io."
+	l7map := policy.L7DataMap{
+		cachedDstID1Selector: &policy.PerSelectorPolicy{
+			L7Rules: api.L7Rules{},
+		},
+	}
+	query := name
+
+	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	c.Assert(err, Equals, nil, Commentf("Error when inserting rules"))
+
+	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+
+	l7map = policy.L7DataMap{
+		cachedDstID1Selector: &policy.PerSelectorPolicy{
+			L7Rules: api.L7Rules{
+				DNS: []api.PortRuleDNS{},
+			},
+		},
+	}
+	err = s.proxy.UpdateAllowed(epID1, dstPort, l7map)
+	c.Assert(err, Equals, nil, Commentf("Error when inserting rules"))
+
+	allowed, err = s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
+	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
 }
 
 func (s *DNSProxyTestSuite) TestCheckAllowedTwiceRemovedOnce(c *C) {
@@ -629,16 +671,13 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 
 	// Get rules for restoration
 	expected1 := restore.DNSRules{
-		53: restore.IPRules{{
-			IPs: map[string]struct{}{"::": {}},
-			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID1Selector]},
-		}, {
-			IPs: map[string]struct{}{"127.0.0.1": {}, "127.0.0.2": {}},
-			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID2Selector]},
-		}}.Sort(),
-		54: restore.IPRules{{
-			Re: restore.RuleRegex{Regexp: s.proxy.allowed[epID1][54][cachedWildcardSelector]},
-		}},
+		53: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID1][53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
+			asIPRule(s.proxy.allowed[epID1][53][cachedDstID2Selector], map[string]struct{}{"127.0.0.1": {}, "127.0.0.2": {}}),
+		}.Sort(),
+		54: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID1][54][cachedWildcardSelector], nil),
+		},
 	}
 	restored1, _ := s.proxy.GetRules(uint16(epID1))
 	restored1.Sort()
@@ -650,16 +689,11 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	c.Assert(restored2, checker.DeepEquals, expected2)
 
 	expected3 := restore.DNSRules{
-		53: restore.IPRules{{
-			IPs: map[string]struct{}{"::": {}},
-			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID3][53][cachedDstID1Selector]},
-		}, {
-			IPs: map[string]struct{}{},
-			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID3][53][cachedDstID3Selector]},
-		}, {
-			IPs: map[string]struct{}{},
-			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID3][53][cachedDstID4Selector]},
-		}}.Sort(),
+		53: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID3][53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
+			asIPRule(s.proxy.allowed[epID3][53][cachedDstID3Selector], map[string]struct{}{}),
+			asIPRule(s.proxy.allowed[epID3][53][cachedDstID4Selector], map[string]struct{}{}),
+		}.Sort(),
 	}
 	restored3, _ := s.proxy.GetRules(uint16(epID3))
 	restored3.Sort()
@@ -670,16 +704,13 @@ func (s *DNSProxyTestSuite) TestFullPathDependence(c *C) {
 	s.proxy.usedServers = map[string]struct{}{"127.0.0.2": {}}
 
 	expected1b := restore.DNSRules{
-		53: restore.IPRules{{
-			IPs: map[string]struct{}{},
-			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID1Selector]},
-		}, {
-			IPs: map[string]struct{}{"127.0.0.2": {}},
-			Re:  restore.RuleRegex{Regexp: s.proxy.allowed[epID1][53][cachedDstID2Selector]},
-		}}.Sort(),
-		54: restore.IPRules{{
-			Re: restore.RuleRegex{Regexp: s.proxy.allowed[epID1][54][cachedWildcardSelector]},
-		}},
+		53: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID1][53][cachedDstID1Selector], map[string]struct{}{}),
+			asIPRule(s.proxy.allowed[epID1][53][cachedDstID2Selector], map[string]struct{}{"127.0.0.2": {}}),
+		}.Sort(),
+		54: restore.IPRules{
+			asIPRule(s.proxy.allowed[epID1][54][cachedWildcardSelector], nil),
+		},
 	}
 	restored1b, _ := s.proxy.GetRules(uint16(epID1))
 	restored1b.Sort()
@@ -921,28 +952,43 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	// connet with TCP, and the server only listens on TCP.
 
 	name := "cilium.io."
+	pattern := "*.cilium.com."
 	l7map := policy.L7DataMap{
 		cachedDstID1Selector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
-				DNS: []api.PortRuleDNS{{MatchName: name}},
+				DNS: []api.PortRuleDNS{{MatchName: name}, {MatchPattern: pattern}},
 			},
 		},
 	}
-	query := name
+	queries := []string{name, strings.ReplaceAll(pattern, "*", "sub")}
 
+	c.TestName()
 	err := s.proxy.UpdateAllowed(epID1, dstPort, l7map)
 	c.Assert(err, Equals, nil, Commentf("Could not update with rules"))
-	allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
-	c.Assert(err, Equals, nil, Commentf("Error when checking allowed"))
-	c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed"))
+	for _, query := range queries {
+		allowed, err := s.proxy.CheckAllowed(epID1, dstPort, dstID1, nil, query)
+		c.Assert(err, Equals, nil, Commentf("Error when checking allowed query: %q", query))
+		c.Assert(allowed, Equals, true, Commentf("request was rejected when it should be allowed for query: %q", query))
+	}
 
 	// 1st request
-	request := new(dns.Msg)
-	request.SetQuestion(query, dns.TypeA)
-	response, rtt, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
-	c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed (RTT: %v)", rtt))
-	c.Assert(len(response.Answer), Equals, 1, Commentf("Proxy returned incorrect number of answer RRs %s", response))
-	c.Assert(response.Answer[0].String(), Equals, "cilium.io.\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
+	for _, query := range queries {
+		request := new(dns.Msg)
+		request.SetQuestion(query, dns.TypeA)
+		response, rtt, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+		c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed (RTT: %v) (query: %q)", rtt, query))
+		c.Assert(len(response.Answer), Equals, 1, Commentf("Proxy returned incorrect number of answer RRs %s (query: %q)", response, query))
+		c.Assert(response.Answer[0].String(), Equals, query+"\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
+	}
+
+	for _, query := range queries {
+		request := new(dns.Msg)
+		request.SetQuestion(query, dns.TypeA)
+		response, rtt, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+		c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed (RTT: %v) (query: %q)", rtt, query))
+		c.Assert(len(response.Answer), Equals, 1, Commentf("Proxy returned incorrect number of answer RRs %s (query: %q)", response, query))
+		c.Assert(response.Answer[0].String(), Equals, query+"\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
+	}
 
 	// Get restored rules
 	restored, _ := s.proxy.GetRules(uint16(epID1))
@@ -953,12 +999,14 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	c.Assert(err, Equals, nil, Commentf("Could not remove rules"))
 
 	// 2nd request, refused due to no rules
-	request = new(dns.Msg)
-	request.SetQuestion(query, dns.TypeA)
-	response, rtt, err = s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
-	c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed (RTT: %v)", rtt))
-	c.Assert(len(response.Answer), Equals, 0, Commentf("Proxy returned incorrect number of answer RRs %s", response))
-	c.Assert(response.Rcode, Equals, dns.RcodeRefused, Commentf("DNS request from test client was not rejected when it should be blocked"))
+	for _, query := range queries {
+		request := new(dns.Msg)
+		request.SetQuestion(query, dns.TypeA)
+		response, rtt, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+		c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed (RTT: %v) (query: %q)", rtt, query))
+		c.Assert(len(response.Answer), Equals, 0, Commentf("Proxy returned incorrect number of answer RRs %s (query: %q)", response, query))
+		c.Assert(response.Rcode, Equals, dns.RcodeRefused, Commentf("DNS request from test client was not rejected when it should be blocked (query: %q)", query))
+	}
 
 	// restore rules, set the mock to restoring state
 	s.restoring = true
@@ -971,13 +1019,14 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 	c.Assert(exists, Equals, true)
 
 	// 3nd request, answered due to restored Endpoint and rules being found
-	request = new(dns.Msg)
-	request.SetQuestion(query, dns.TypeA)
-	response, rtt, err = s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
-	c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed (RTT: %v)", rtt))
-	c.Assert(len(response.Answer), Equals, 1, Commentf("Proxy returned incorrect number of answer RRs %s", response))
-	c.Assert(response.Answer[0].String(), Equals, "cilium.io.\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
-
+	for _, query := range queries {
+		request := new(dns.Msg)
+		request.SetQuestion(query, dns.TypeA)
+		response, rtt, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+		c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed (RTT: %v) (query: %q)", rtt, query))
+		c.Assert(len(response.Answer), Equals, 1, Commentf("Proxy returned incorrect number of answer RRs %s (query: %q)", response, query))
+		c.Assert(response.Answer[0].String(), Equals, query+"\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
+	}
 	// cleanup
 	s.proxy.RemoveRestoredRules(uint16(epID1))
 	_, exists = s.proxy.restored[epID1]
@@ -1068,20 +1117,21 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	}
 
 	pea := perEPAllow{}
+	c := regexCache{}
 	b.ReportAllocs()
 	b.StopTimer()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		re.InitRegexCompileLRU(cacheSize)
 		for epID := uint64(0); epID < nEPs; epID++ {
-			pea.setPortRulesForID(epID, 8053, nil)
+			pea.setPortRulesForID(c, epID, 8053, nil)
 		}
 		b.StartTimer()
 		for epID, rules := range rulesPerEP {
 			if epID >= nEPsAtOnce {
-				pea.setPortRulesForID(uint64(epID)-nEPsAtOnce, 8053, nil)
+				pea.setPortRulesForID(c, uint64(epID)-nEPsAtOnce, 8053, nil)
 			}
-			pea.setPortRulesForID(uint64(epID), 8053, rules)
+			pea.setPortRulesForID(c, uint64(epID), 8053, rules)
 		}
 		b.StopTimer()
 	}
@@ -1091,9 +1141,17 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	b.ReportMetric(float64(getMemStats().HeapInuse-initialHeap), "B(HeapInUse)/op")
 
 	for epID := uint64(0); epID < nEPs; epID++ {
-		pea.setPortRulesForID(epID, 8053, nil)
+		pea.setPortRulesForID(c, epID, 8053, nil)
 	}
 	if len(pea) > 0 {
+		b.Fail()
+	}
+	b.StopTimer()
+	// Remove all the inserted rules to ensure the cache goes down to zero entries
+	for epID := uint64(0); epID < 20; epID++ {
+		pea.setPortRulesForID(c, epID, 8053, nil)
+	}
+	if len(pea) > 0 || len(c) > 0 {
 		b.Fail()
 	}
 }
@@ -1183,11 +1241,12 @@ func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
 	fmt.Printf("\tNumGC = %v\n", m.NumGC)
 
 	pea := perEPAllow{}
+	c := regexCache{}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for epID := uint64(0); epID < numEPs; epID++ {
-			pea.setPortRulesForID(epID, 8053, rules)
+			pea.setPortRulesForID(c, epID, 8053, rules)
 		}
 	}
 	b.StopTimer()
@@ -1207,6 +1266,13 @@ func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
 	fmt.Printf("\tHeapInuse = %v MiB", bToMb(m.HeapInuse))
 	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
 	fmt.Printf("\tNumGC = %v\n", m.NumGC)
+	// Remove all the inserted rules to ensure both indexes go to zero entries
+	for epID := uint64(0); epID < numEPs; epID++ {
+		pea.setPortRulesForID(c, epID, 8053, nil)
+	}
+	if len(pea) > 0 || len(c) > 0 {
+		b.Fail()
+	}
 }
 
 //nolint:unused // Used in benchmark above, false-positive in golangci-lint v1.48.0.

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"golang.org/x/exp/maps"
 	. "gopkg.in/check.v1"
 	"sigs.k8s.io/yaml"
 
@@ -1027,6 +1028,40 @@ func (s *DNSProxyTestSuite) TestRestoredEndpoint(c *C) {
 		c.Assert(len(response.Answer), Equals, 1, Commentf("Proxy returned incorrect number of answer RRs %s (query: %q)", response, query))
 		c.Assert(response.Answer[0].String(), Equals, query+"\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
 	}
+	// cleanup
+	s.proxy.RemoveRestoredRules(uint16(epID1))
+	_, exists = s.proxy.restored[epID1]
+	c.Assert(exists, Equals, false)
+
+	invalidRePattern := "invalid-re-pattern((*"
+	validRePattern := "^this[.]domain[.]com[.]$"
+
+	// extract the port the DNS-server is listening on by looking at the restored rules. The port is non-deterministic
+	// since it's listening on :0
+	c.Assert(len(restored), Equals, 1, Commentf("GetRules is expected to return rules for one port but returned for %d", len(restored)))
+	port := maps.Keys(restored)[0]
+
+	// Insert one valid and one invalid pattern and ensure that the valid one works
+	// and that the invalid one doesn't interfere with the other rules.
+	restored[port] = append(restored[port],
+		restore.IPRule{Re: restore.RuleRegex{Pattern: &invalidRePattern}},
+		restore.IPRule{Re: restore.RuleRegex{Pattern: &validRePattern}},
+	)
+	ep1.DNSRules = restored
+	s.proxy.RestoreRules(ep1)
+	_, exists = s.proxy.restored[epID1]
+	c.Assert(exists, Equals, true)
+
+	// 4nd request, answered due to restored Endpoint and rules being found, including domain matched by new regex
+	for _, query := range append(queries, "this.domain.com.") {
+		request := new(dns.Msg)
+		request.SetQuestion(query, dns.TypeA)
+		response, rtt, err := s.dnsTCPClient.Exchange(request, s.proxy.TCPServer.Listener.Addr().String())
+		c.Assert(err, IsNil, Commentf("DNS request from test client failed when it should succeed (RTT: %v) (query: %q)", rtt, query))
+		c.Assert(len(response.Answer), Equals, 1, Commentf("Proxy returned incorrect number of answer RRs %s (query: %q)", response, query))
+		c.Assert(response.Answer[0].String(), Equals, query+"\t60\tIN\tA\t1.1.1.1", Commentf("Proxy returned incorrect RRs"))
+	}
+
 	// cleanup
 	s.proxy.RemoveRestoredRules(uint16(epID1))
 	_, exists = s.proxy.restored[epID1]


### PR DESCRIPTION
This introduce a reference counted cache/index for regexes, and is ready for supporting other caches as well. This means that policies with the same set of rules can reuse the underlying matcher saving, since long regex tends to occupy a lot of memory.

This also makes the LRU cache for compiled regexes more or less redundant, mitigating the drawbacks of that cache. Having a large LRU cache is useful when a lot of similar policies are in use at the same time, but in case a node have a small set of policies inserted at the same time, but the churn makes new and distinct policies come and go, the LRU cache will use a lot more memory than the benefit it gives.

benchmark TL;DR: Heap usage compared to a LRU size of 128 is down by ~99%, and ~92% with a LRU size of 1024, with the given test data*.

* defining heap usage as (HeapInuse after test) - (HeapInuse before setup)
```
$ go test -tags privileged_tests -v -run '^$' -bench Benchmark_perEPAllow_setPortRulesForID_large -benchmem -benchtime 1x ./pkg/fqdn/dnsproxy

// With this change;

go test -tags privileged_tests -v -run '^$' -bench Benchmark_perEPAllow_setPortRulesForID_large -benchmem -benchtime 1x -memprofile memprofile.out ./pkg/fqdn/dnsproxy goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/fqdn/dnsproxy
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Benchmark_perEPAllow_setPortRulesForID_large
Before Setup (N=1,EPs=20,cache=128)
Alloc = 3 MiB   HeapInuse = 5 MiB       Sys = 20 MiB    NumGC = 6
Before Test (N=1,EPs=20,cache=128)
Alloc = 37 MiB  HeapInuse = 49 MiB      Sys = 1031 MiB  NumGC = 18
After Test (N=1,EPs=20,cache=128)
Alloc = 52 MiB  HeapInuse = 62 MiB      Sys = 1031 MiB  NumGC = 53
Benchmark_perEPAllow_setPortRulesForID_large-7                 1        4289436000 ns/op        2559832616 B/op 34303565 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/fqdn/dnsproxy      12.574s

// Baseline with LRU size of 1024

goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/fqdn/dnsproxy
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Benchmark_perEPAllow_setPortRulesForID_large
Before Setup (N=1,EPs=20,cache=1024)
Alloc = 3 MiB   HeapInuse = 5 MiB       Sys = 20 MiB    NumGC = 6
Before Test (N=1,EPs=20,cache=1024)
Alloc = 37 MiB  HeapInuse = 49 MiB      Sys = 969 MiB   NumGC = 18
After Test (N=1,EPs=20,cache=1024)
Alloc = 312 MiB HeapInuse = 357 MiB     Sys = 969 MiB   NumGC = 46
Benchmark_perEPAllow_setPortRulesForID_large-7                 1        5990697400 ns/op        3470756528 B/op 36068464 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/fqdn/dnsproxy      11.813s

// Baseline with LRU size of 128
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/fqdn/dnsproxy
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Benchmark_perEPAllow_setPortRulesForID_large
Before Setup (N=1,EPs=20,cache=128)
Alloc = 3 MiB   HeapInuse = 5 MiB       Sys = 19 MiB    NumGC = 5
Before Test (N=1,EPs=20,cache=128)
Alloc = 38 MiB  HeapInuse = 49 MiB      Sys = 1047 MiB  NumGC = 17
After Test (N=1,EPs=20,cache=128)
Alloc = 1763 MiB        HeapInuse = 1907 MiB    Sys = 2918 MiB  NumGC = 44
Benchmark_perEPAllow_setPortRulesForID_large-7                 1        81058653300 ns/op       10328100808 B/op        46896658 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/fqdn/dnsproxy      93.574s
```

```release-note
Introduce smarter internal cache to reduce memory consumption for FQDN / DNS policy usage, especially in environment with heavy FQDN / DNS policy usage
```
