### PR TITLE
Pr/v1.10 backport 2022 09 13

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -16,7 +16,9 @@ export LC_ALL=C
 
 get_schema_of_tag(){
    tag="${1}"
+   set +o pipefail
    git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${tag} -- pkg/k8s | head -n1 | sed 's/.*=\ "//;s/"//'
+   set -o pipefail
 }
 
 get_line_of_schema_version(){
@@ -26,7 +28,9 @@ get_line_of_schema_version(){
 
 get_schema_of_branch(){
    stable_branch="${1}"
-   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//' | uniq
+   set +o pipefail
+   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//' | uniq  | head -n1
+   set -o pipefail
 }
 
 get_stable_branches(){

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -51,7 +51,8 @@ Deploy Cilium via Helm:
      --set cni.chainingMode=aws-cni \\
      --set enableIPv4Masquerade=false \\
      --set tunnel=disabled \\
-     --set nodeinit.enabled=true
+     --set nodeinit.enabled=true \\
+     --set endpointRoutes.enabled=true
 
 This will enable chaining with the AWS VPC CNI plugin. It will also disable
 tunneling, as it's not required since ENI IP addresses can be directly routed

--- a/install/kubernetes/cilium/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl
+++ b/install/kubernetes/cilium/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl
@@ -38,6 +38,7 @@ spec:
             {{- if not (and .Values.clustermesh.apiserver.tls.remote.cert .Values.clustermesh.apiserver.tls.remote.key) }}
             - "--clustermesh-apiserver-remote-cert-generate"
             {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/install/kubernetes/cilium/templates/_hubble-generate-certs-job-spec.tpl
+++ b/install/kubernetes/cilium/templates/_hubble-generate-certs-job-spec.tpl
@@ -58,6 +58,7 @@ spec:
             - "--hubble-relay-server-cert-validity-duration={{ $certValiditySecondsStr }}"
             - "--hubble-relay-server-cert-secret-name=hubble-relay-server-certs"
             {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-daemonset.yaml
@@ -278,6 +278,7 @@ spec:
             - NET_ADMIN
             - SYS_MODULE
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
 {{- /* CRI-O already mounts the BPF filesystem */ -}}
 {{- if not (eq .Values.containerRuntime.integration "crio") }}
@@ -369,6 +370,7 @@ spec:
 {{- end }}
         image: "{{ if .Values.image.override }}{{ .Values.image.override }}{{ else }}{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}{{ end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
@@ -404,6 +406,7 @@ spec:
           - 'cp /usr/bin/cilium-mount /hostbin/cilium-mount && nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT; rm /hostbin/cilium-mount'
         image: "{{ if .Values.image.override }}{{ .Values.image.override }}{{ else }}{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}{{ end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
           - mountPath: /hostproc
             name: hostproc
@@ -429,6 +432,7 @@ spec:
           cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
           nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
           rm /hostbin/cilium-sysctlfix
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: hostproc
           mountPath: /hostproc
@@ -442,6 +446,7 @@ spec:
         command: ['sh', '-c', 'until test -s {{ (print "/tmp/cilium-bootstrap.d/" (.Values.nodeinit.bootstrapFile | base)) | quote }}; do echo "Waiting on node-init to run..."; sleep 1; done']
         image: "{{ if .Values.image.override }}{{ .Values.image.override }}{{ else }}{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}{{ end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: "/tmp/cilium-bootstrap.d"
           name: cilium-bootstrap-file-dir
@@ -480,6 +485,7 @@ spec:
             add:
             - NET_ADMIN
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
 {{- /* CRI-O already mounts the BPF filesystem */ -}}
 {{- if not (eq .Values.containerRuntime.integration "crio") }}

--- a/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-etcd-operator-deployment.yaml
@@ -93,6 +93,7 @@ spec:
         image: {{ if .Values.etcd.image.override }}{{ .Values.etcd.image.override }}{{ else }}{{ .Values.etcd.image.repository }}:{{ .Values.etcd.image.tag }}{{ end }}
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
+        terminationMessagePolicy: FallbackToLogsOnError
       dnsPolicy: ClusterFirst
       hostNetwork: true
 {{- if and (or (and (eq .Release.Namespace "kube-system") (gt $k8sMinor "10")) (ge $k8sMinor "17") (gt $k8sMajor "1")) .Values.enableCriticalPriorityClass }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit-daemonset.yaml
@@ -59,6 +59,7 @@ spec:
         - name: node-init
           image: {{ if .Values.nodeinit.image.override }}{{ .Values.nodeinit.image.override }}{{ else }}{{ .Values.nodeinit.image.repository }}:{{ .Values.nodeinit.image.tag }}{{ end }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
+          terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
             privileged: true
           lifecycle:

--- a/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator-deployment.yaml
@@ -203,6 +203,7 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path

--- a/install/kubernetes/cilium/templates/cilium-preflight-daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-daemonset.yaml
@@ -37,6 +37,7 @@ spec:
         - name: cilium-pre-flight-check
           image: "{{ if .Values.preflight.image.override }}{{ .Values.preflight.image.override }}{{ else }}{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}{{ end }}"
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
+          terminationMessagePolicy: FallbackToLogsOnError
           command: ["/bin/sh"]
           args:
           - -c
@@ -73,6 +74,7 @@ spec:
         - name: cilium-pre-flight-fqdn-precache
           image: "{{ if .Values.preflight.image.override }}{{ .Values.preflight.image.override }}{{ else }}{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}{{ end }}"
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
+          terminationMessagePolicy: FallbackToLogsOnError
           name: cilium-pre-flight-fqdn-precache
           command: ["/bin/sh"]
           args:

--- a/install/kubernetes/cilium/templates/cilium-preflight-deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight-deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - name: cnp-validator
           image: "{{ if .Values.preflight.image.override }}{{ .Values.preflight.image.override }}{{ else }}{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}{{ end }}"
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
+          terminationMessagePolicy: FallbackToLogsOnError
           command: ["/bin/sh"]
           args:
           - -c

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-deployment.yaml
@@ -73,6 +73,7 @@ spec:
       - name: etcd
         image: {{ if .Values.clustermesh.apiserver.etcd.image.override }}{{ .Values.clustermesh.apiserver.etcd.image.override }}{{ else }}{{ .Values.clustermesh.apiserver.etcd.image.repository }}:{{ .Values.clustermesh.apiserver.etcd.image.tag }}{{ end }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
+        terminationMessagePolicy: FallbackToLogsOnError
         env:
         - name: ETCDCTL_API
           value: "3"
@@ -102,6 +103,7 @@ spec:
       - name: "apiserver"
         image: "{{ if .Values.clustermesh.apiserver.image.override }}{{ .Values.clustermesh.apiserver.image.override }}{{ else }}{{ .Values.clustermesh.apiserver.image.repository }}:{{ .Values.clustermesh.apiserver.image.tag }}{{ if .Values.clustermesh.apiserver.image.useDigest }}@{{ .Values.clustermesh.apiserver.image.digest }}{{ end }}{{ end }}"
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
+        terminationMessagePolicy: FallbackToLogsOnError
         command:
           - /usr/bin/clustermesh-apiserver
         args:

--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -51,6 +51,7 @@ spec:
         - name: hubble-relay
           image: "{{ if .Values.hubble.relay.image.override }}{{ .Values.hubble.relay.image.override }}{{ else }}{{ .Values.hubble.relay.image.repository }}:{{ .Values.hubble.relay.image.tag }}{{ if .Values.hubble.relay.image.useDigest }}@{{ .Values.hubble.relay.image.digest }}{{ end }}{{ end }}"
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
+          terminationMessagePolicy: FallbackToLogsOnError
           command:
             - hubble-relay
           args:
@@ -71,6 +72,7 @@ spec:
           resources:
             {{- toYaml . | trim | nindent 12 }}
 {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
           {{- if $mountSocket }}
           - mountPath: {{ dir .Values.hubble.socketPath }}

--- a/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui-deployment.yaml
@@ -49,6 +49,7 @@ spec:
         - name: frontend
           image: "{{ if .Values.hubble.ui.frontend.image.override }}{{ .Values.hubble.ui.frontend.image.override }}{{ else }}{{ .Values.hubble.ui.frontend.image.repository }}:{{ .Values.hubble.ui.frontend.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
+          terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 8081
               name: http
@@ -61,6 +62,7 @@ spec:
         - name: backend
           image: "{{ if .Values.hubble.ui.backend.image.override }}{{ .Values.hubble.ui.backend.image.override }}{{ else }}{{ .Values.hubble.ui.backend.image.repository }}:{{ .Values.hubble.ui.backend.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: EVENTS_SERVER_PORT
               value: "8090"


### PR DESCRIPTION
v1.10 backports 2022-09-13

 * #21208 -- docs: fix check-crd-compat-table script (@aanm)
 * #21012 -- install: add TerminationMessagePolicy to cilium pods (@squeed)
 * #21276 -- Documentation: run with endpoint routes under aws-cni chaining (@ti-mo)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 21208 21012 21276; do contrib/backporting/set-labels.py $pr done 1.10; done
```