### PR TITLE
v1.11 backports 2022-09-13

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -16,7 +16,9 @@ export LC_ALL=C
 
 get_schema_of_tag(){
    tag="${1}"
+   set +o pipefail
    git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${tag} -- pkg/k8s | head -n1 | sed 's/.*=\ "//;s/"//'
+   set -o pipefail
 }
 
 get_line_of_schema_version(){
@@ -26,7 +28,9 @@ get_line_of_schema_version(){
 
 get_schema_of_branch(){
    stable_branch="${1}"
-   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//' | uniq
+   set +o pipefail
+   git grep -o 'CustomResourceDefinitionSchemaVersion =.*' ${remote}/${stable_branch} -- pkg/k8s | sed 's/.*=\ "//;s/"//' | uniq  | head -n1
+   set -o pipefail
 }
 
 get_stable_branches(){

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -60,7 +60,8 @@ Deploy Cilium via Helm:
      --namespace kube-system \\
      --set cni.chainingMode=aws-cni \\
      --set enableIPv4Masquerade=false \\
-     --set tunnel=disabled
+     --set tunnel=disabled \\
+     --set endpointRoutes.enabled=true
 
 This will enable chaining with the AWS VPC CNI plugin. It will also disable
 tunneling, as it's not required since ENI IP addresses can be directly routed

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -246,6 +246,7 @@ spec:
         {{- end }}
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         {{- /* CRI-O already mounts the BPF filesystem */ -}}
         {{- if not (eq .Values.containerRuntime.integration "crio") }}
@@ -333,6 +334,7 @@ spec:
         {{- range $type := .Values.monitor.eventTypes }}
         - --type={{ $type }}
         {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: cilium-run
           mountPath: /var/run/cilium
@@ -378,6 +380,7 @@ spec:
           mountPath: /hostproc
         - name: cni-path
           mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           privileged: true
       - name: apply-sysctl-overwrites
@@ -403,6 +406,7 @@ spec:
           mountPath: /hostproc
         - name: cni-path
           mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           privileged: true
       {{- end }}
@@ -418,6 +422,7 @@ spec:
             echo "Waiting on node-init to run...";
             sleep 1;
           done
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: cilium-bootstrap-file-dir
           mountPath: "/tmp/cilium-bootstrap.d"
@@ -451,6 +456,7 @@ spec:
         {{- with .Values.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           privileged: true
         volumeMounts:
@@ -500,6 +506,7 @@ spec:
               echo "Waiting for kube-proxy to create iptables rules...";
               sleep 1;
             done
+        terminationMessagePolicy: FallbackToLogsOnError
       {{- end }} # wait-for-kube-proxy
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -75,4 +75,5 @@ spec:
           - name: STARTUP_SCRIPT
             value: |
               {{- tpl (.Files.Get "files/nodeinit/startup.bash") . | nindent 14 }}
+          terminationMessagePolicy: FallbackToLogsOnError
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -200,6 +200,7 @@ spec:
         resources:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
       {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -33,6 +33,7 @@ spec:
           command: ["/bin/echo"]
           args:
           - "hello"
+          terminationMessagePolicy: FallbackToLogsOnError
       containers:
         - name: cilium-pre-flight-check
           image: {{ include "cilium.image" .Values.preflight.image | quote }}
@@ -68,6 +69,7 @@ spec:
             readOnly: true
           {{- end }}
           {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
         {{- if ne .Values.preflight.tofqdnsPreCache "" }}
         - name: cilium-pre-flight-fqdn-precache
           image: {{ include "cilium.image" .Values.preflight.image | quote }}
@@ -115,6 +117,7 @@ spec:
             readOnly: true
           {{- end }}
           {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
         {{- end }}
       hostNetwork: true
       # This is here to seamlessly allow migrate-identity to work with

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -70,6 +70,7 @@ spec:
           - name: KUBERNETES_SERVICE_PORT
             value: {{ .Values.k8sServicePort | quote }}
           {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.preflight.priorityClassName "system-cluster-critical") }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -67,6 +67,7 @@ spec:
         volumeMounts:
         - name: etcd-data-dir
           mountPath: /var/run/etcd
+        terminationMessagePolicy: FallbackToLogsOnError
       containers:
       - name: etcd
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
@@ -97,6 +98,7 @@ spec:
           readOnly: true
         - name: etcd-data-dir
           mountPath: /var/run/etcd
+        terminationMessagePolicy: FallbackToLogsOnError
       - name: apiserver
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
@@ -141,6 +143,7 @@ spec:
         - name: etcd-admin-client
           mountPath: /var/lib/cilium/etcd-secrets
           readOnly: true
+        terminationMessagePolicy: FallbackToLogsOnError
       volumes:
       - name: etcd-server-secrets
         secret:

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -73,6 +73,7 @@ spec:
         image: {{ .Values.etcd.image.repository }}:{{ .Values.etcd.image.tag }}
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
+        terminationMessagePolicy: FallbackToLogsOnError
       dnsPolicy: ClusterFirst
       hostNetwork: true
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.clustermesh.apiserver.priorityClassName "system-cluster-critical") }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -84,6 +84,7 @@ spec:
             mountPath: /var/lib/hubble-relay/tls
             readOnly: true
           {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
       restartPolicy: Always
       priorityClassName: {{ .Values.hubble.relay.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.relay.name | quote }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -63,6 +63,7 @@ spec:
           - name: hubble-ui-nginx-conf
             mountPath: /etc/nginx/conf.d/default.conf
             subPath: nginx.conf
+        terminationMessagePolicy: FallbackToLogsOnError
       - name: backend
         image: {{ include "cilium.image" .Values.hubble.ui.backend.image | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
@@ -99,6 +100,7 @@ spec:
           mountPath: /var/lib/hubble-ui/certs
           readOnly: true
         {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
       volumes:
       - configMap:
           defaultMode: 420

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -600,8 +600,17 @@ func (k *kvstoreBackend) ListAndWatch(ctx context.Context, handler allocator.Cac
 							fieldKey:   event.Key,
 							fieldValue: event.Value,
 						}).Warning("Unable to decode key value")
-					} else {
-						key = k.keyType.PutKey(string(s))
+						continue
+					}
+
+					key = k.keyType.PutKey(string(s))
+				} else {
+					if event.Typ != kvstore.EventTypeDelete {
+						log.WithFields(logrus.Fields{
+							fieldKey:       event.Key,
+							fieldEventType: event.Typ,
+						}).Error("Received a key with an empty value")
+						continue
 					}
 				}
 

--- a/pkg/kvstore/allocator/logfields.go
+++ b/pkg/kvstore/allocator/logfields.go
@@ -4,9 +4,10 @@
 package allocator
 
 const (
-	fieldID      = "id"
-	fieldKey     = "key"
-	fieldPrefix  = "prefix"
-	fieldValue   = "value"
-	fieldLeaseID = "leaseID"
+	fieldID        = "id"
+	fieldKey       = "key"
+	fieldPrefix    = "prefix"
+	fieldValue     = "value"
+	fieldLeaseID   = "leaseID"
+	fieldEventType = "eventType"
 )


### PR DESCRIPTION
 * [ ] #21220 -- k8s: fix test flake in TestGenerateToCIDRFromEndpoint. (@tommyp1ckles)
 * [x] #21208 -- docs: fix check-crd-compat-table script (@aanm)
 * [ ] #21012 -- install: add TerminationMessagePolicy to cilium pods (@squeed)
 * [ ] #21213 -- kvstore/allocator: fix panic on receiving invalid identity entries (@ArthurChiao)
 * [ ] #21276 -- Documentation: run with endpoint routes under aws-cni chaining (@ti-mo)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 21220 21208 21012 21213 21276; do contrib/backporting/set-labels.py $pr done 1.11; done
```
or with
```
$ make add-label BRANCH=v1.11 ISSUES=21220,21208,21012,21213,21276
```