### PR TITLE
promise: Add promise package

### DIFF
--- a/pkg/promise/promise.go
+++ b/pkg/promise/promise.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package promise
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// A promise for a future value.
+type Promise[T any] interface {
+	// Await blocks until the value is resolved or rejected.
+	Await(context.Context) (T, error)
+}
+
+// Resolver can resolve or reject a promise.
+// These methods are separate from 'Promise' to make it clear where the promise is resolved
+// from.
+type Resolver[T any] interface {
+	// Resolve a promise. Unblocks all Await()s. Future calls of Await()
+	// return the resolved value immediately.
+	//
+	// Only the first call to resolve (or reject) has an effect and
+	// further calls are ignored.
+	Resolve(T)
+
+	// Reject a promise with an error.
+	Reject(error)
+}
+
+// New creates a new promise for value T.
+// Returns a resolver and the promise.
+func New[T any]() (Resolver[T], Promise[T]) {
+	promise := &promise[T]{}
+	promise.cond = sync.NewCond(promise)
+	return promise, promise
+}
+
+const (
+	promiseUnresolved = iota
+	promiseResolved
+	promiseRejected
+)
+
+type promise[T any] struct {
+	lock.Mutex
+	cond  *sync.Cond
+	state int
+	value T
+	err   error
+}
+
+func (p *promise[T]) Resolve(value T) {
+	p.Lock()
+	defer p.Unlock()
+	if p.state != promiseUnresolved {
+		return
+	}
+	p.state = promiseResolved
+	p.value = value
+	p.cond.Broadcast()
+}
+
+func (p *promise[T]) Reject(err error) {
+	p.Lock()
+	defer p.Unlock()
+	if p.state != promiseUnresolved {
+		return
+	}
+	p.state = promiseRejected
+	p.err = err
+	p.cond.Broadcast()
+}
+
+// Await blocks until the promise has been resolved, rejected or context cancelled.
+func (p *promise[T]) Await(ctx context.Context) (value T, err error) {
+	// Fork off a goroutine to wait for cancellation and wake up.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		<-ctx.Done()
+		p.cond.Broadcast()
+	}()
+
+	p.Lock()
+	defer p.Unlock()
+
+	// Wait until the promise is resolved or context cancelled.
+	for p.state == promiseUnresolved && (ctx == nil || ctx.Err() == nil) {
+		p.cond.Wait()
+	}
+
+	if ctx.Err() != nil {
+		err = ctx.Err()
+	} else if p.state == promiseResolved {
+		value = p.value
+	} else {
+		err = p.err
+	}
+	return
+}
+
+type wrappedPromise[T any] func(context.Context) (T, error)
+
+func (await wrappedPromise[T]) Await(ctx context.Context) (T, error) {
+	return await(ctx)
+}
+
+// Map transforms the value of a promise with the provided function.
+func Map[A, B any](p Promise[A], transform func(A) B) Promise[B] {
+	return wrappedPromise[B](func(ctx context.Context) (out B, err error) {
+		v, err := p.Await(ctx)
+		if err != nil {
+			return out, err
+		}
+		return transform(v), nil
+	})
+}

--- a/pkg/promise/promise_test.go
+++ b/pkg/promise/promise_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package promise
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestPromiseResolve(t *testing.T) {
+	resolver, promiseI := New[int]()
+
+	promiseU := Map(promiseI, func(n int) uint64 { return uint64(n) * 2 })
+
+	go func() {
+		resolver.Resolve(123)
+		resolver.Resolve(256)
+	}()
+
+	i, err := promiseI.Await(context.TODO())
+	if err != nil {
+		t.Fatalf("expected nil error, got %s", err)
+	}
+	if i != 123 {
+		t.Fatalf("expected 123, got %d", i)
+	}
+
+	u, err := promiseU.Await(context.TODO())
+	if err != nil {
+		t.Fatalf("expected nil error, got %s", err)
+	}
+	if u != 2*123 {
+		t.Fatalf("expected 2*123, got %d", u)
+	}
+}
+
+func TestPromiseReject(t *testing.T) {
+	resolver, promise := New[int]()
+
+	expectedError := errors.New("rejected")
+
+	go resolver.Reject(expectedError)
+
+	i, err := promise.Await(context.TODO())
+	if err != expectedError {
+		t.Fatalf("expected %s error, got %s", expectedError, err)
+	}
+	if i != 0 {
+		t.Fatalf("expected zero value, got %d", i)
+	}
+}
+
+func TestPromiseCancelled(t *testing.T) {
+	_, promise := New[int]()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go cancel()
+	_, err := promise.Await(ctx)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected %s error, got %s", context.Canceled, err)
+	}
+}


### PR DESCRIPTION
A simple implementation of promises. This can be used in situations where a value is not available immediately, and where we have multiple consumers (so a channel is not enough). The immediate use case will be to provide access to "*Daemon" and its fields as we transition into a more modular construction.

Example usage:

```
type Foo struct { ... }

func getFoo() promise.Promise[*Foo] {
    resolve, p := promise.New[*Foo]()
    go func() {
	// long operation to construct *Foo
	resolve(&foo{...})
    }()
    return p
}

func useFoo(p promise.Promise[*Foo]) {
	foo := p.Await()
	...
}
```