### PR TITLE
policy: use netip.Addr when constructing CIDR rules

### DIFF
--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -10,6 +10,8 @@ import (
 	"net"
 	"net/netip"
 	"sort"
+
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -762,6 +764,20 @@ func KeepUniqueIPs(ips []net.IP) []net.IP {
 	}
 
 	return returnIPs
+}
+
+// KeepUniqueAddrs transforms the provided multiset of IP addresses into a
+// single set, lexicographically sorted via comparison of the addresses using
+// netip.Addr.Compare (i.e. IPv4 addresses show up before IPv6).
+// The slice is manipulated in-place destructively; it does not create a new slice.
+func KeepUniqueAddrs(addrs []netip.Addr) []netip.Addr {
+	if len(addrs) == 0 {
+		return addrs
+	}
+	sort.Slice(addrs, func(i, j int) bool {
+		return addrs[i].Compare(addrs[j]) < 0
+	})
+	return slices.Compact(addrs)
 }
 
 var privateIPBlocks []*net.IPNet

--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"net"
+	"net/netip"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/ip"
@@ -154,16 +155,17 @@ func ComputeResultantCIDRSet(cidrs CIDRRuleSlice) CIDRSlice {
 	return allResultantAllowedCIDRs
 }
 
-// IPsToCIDRRules generates CIDRRules for the IPs passed in./
+// addrsToCIDRRules generates CIDRRules for the IPs passed in.
 // This function will mark the rule to Generated true by default.
-func IPsToCIDRRules(ips []net.IP) (cidrRules []CIDRRule) {
-	for _, ip := range ips {
+func addrsToCIDRRules(addrs []netip.Addr) []CIDRRule {
+	cidrRules := make([]CIDRRule, 0, len(addrs))
+	for _, addr := range addrs {
 		rule := CIDRRule{ExceptCIDRs: make([]CIDR, 0)}
 		rule.Generated = true
-		if ip.To4() != nil {
-			rule.Cidr = CIDR(ip.String() + "/32")
+		if addr.Is4() {
+			rule.Cidr = CIDR(addr.String() + "/32")
 		} else {
-			rule.Cidr = CIDR(ip.String() + "/128")
+			rule.Cidr = CIDR(addr.String() + "/128")
 		}
 		cidrRules = append(cidrRules, rule)
 	}

--- a/pkg/policy/api/egress_test.go
+++ b/pkg/policy/api/egress_test.go
@@ -8,7 +8,7 @@ package api
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 
 	. "gopkg.in/check.v1"
 
@@ -48,8 +48,8 @@ func (s *PolicyAPITestSuite) TestCreateDerivativeRuleWithoutToGroups(c *C) {
 }
 
 func (s *PolicyAPITestSuite) TestCreateDerivativeRuleWithToGroupsWitInvalidRegisterCallback(c *C) {
-	cb := func(ctx context.Context, group *ToGroups) ([]net.IP, error) {
-		return []net.IP{}, fmt.Errorf("Invalid error")
+	cb := func(ctx context.Context, group *ToGroups) ([]netip.Addr, error) {
+		return []netip.Addr{}, fmt.Errorf("Invalid error")
 	}
 	RegisterToGroupsProvider(AWSProvider, cb)
 

--- a/pkg/policy/groups/aws/aws.go
+++ b/pkg/policy/groups/aws/aws.go
@@ -6,7 +6,7 @@ package aws
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -27,8 +27,8 @@ func init() {
 }
 
 // GetIPsFromGroup will return the list of the ips for the given group filter
-func GetIPsFromGroup(ctx context.Context, group *api.ToGroups) ([]net.IP, error) {
-	result := []net.IP{}
+func GetIPsFromGroup(ctx context.Context, group *api.ToGroups) ([]netip.Addr, error) {
+	result := []netip.Addr{}
 	if group.AWS == nil {
 		return result, fmt.Errorf("no aws data available")
 	}
@@ -37,7 +37,7 @@ func GetIPsFromGroup(ctx context.Context, group *api.ToGroups) ([]net.IP, error)
 
 // getInstancesFromFilter returns the instances IPs in aws EC2 filter by the
 // given filter
-func getInstancesIpsFromFilter(ctx context.Context, filter *api.AWSGroup) ([]net.IP, error) {
+func getInstancesIpsFromFilter(ctx context.Context, filter *api.AWSGroup) ([]netip.Addr, error) {
 	var result []ec2_types.Reservation
 	input := &ec2.DescribeInstancesInput{}
 
@@ -80,15 +80,23 @@ func getInstancesIpsFromFilter(ctx context.Context, filter *api.AWSGroup) ([]net
 	return extractIPs(result), nil
 }
 
-func extractIPs(reservations []ec2_types.Reservation) []net.IP {
-	result := []net.IP{}
+func extractIPs(reservations []ec2_types.Reservation) []netip.Addr {
+	result := []netip.Addr{}
 	for _, reservation := range reservations {
 		for _, instance := range reservation.Instances {
 			for _, iface := range instance.NetworkInterfaces {
 				for _, ifaceIP := range iface.PrivateIpAddresses {
-					result = append(result, net.ParseIP(aws.ToString(ifaceIP.PrivateIpAddress)))
+					addr, err := netip.ParseAddr(aws.ToString(ifaceIP.PrivateIpAddress))
+					if err != nil {
+						continue
+					}
+					result = append(result, addr)
 					if ifaceIP.Association != nil {
-						result = append(result, net.ParseIP(aws.ToString(ifaceIP.Association.PublicIp)))
+						addr, err = netip.ParseAddr(aws.ToString(ifaceIP.Association.PublicIp))
+						if err != nil {
+							continue
+						}
+						result = append(result, addr)
 					}
 				}
 			}

--- a/pkg/policy/groups/helpers_test.go
+++ b/pkg/policy/groups/helpers_test.go
@@ -8,7 +8,7 @@ package groups
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 
 	. "gopkg.in/check.v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -95,8 +95,8 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreDeletedIfNoToGroups(c *C) {
 }
 
 func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
-	cb := func(ctx context.Context, group *api.ToGroups) ([]net.IP, error) {
-		return []net.IP{net.ParseIP("192.168.1.1")}, nil
+	cb := func(ctx context.Context, group *api.ToGroups) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("192.168.1.1")}, nil
 	}
 
 	egressRule := []api.EgressRule{


### PR DESCRIPTION
First commit adds a helper function, second commit converts CIDR rules to use netip.Addr internally. This should somewhat improve memory usage when using CIDR rules in policies.

Before/after benchmark:
    
    name          old time/op    new time/op    delta
    GetCIDRSet-8    2.58µs ± 6%    1.96µs ± 6%  -23.84%  (p=0.000 n=20+20)
    
    name          old alloc/op   new alloc/op   delta
    GetCIDRSet-8      608B ± 0%      416B ± 0%  -31.58%  (p=0.000 n=20+20)
    
    name          old allocs/op  new allocs/op  delta
    GetCIDRSet-8      13.0 ± 0%      11.0 ± 0%  -15.38%  (p=0.000 n=20+20)

See commits for details.
