### PR TITLE
cilium/cmd: check datapath mode on running daemon

### DIFF
--- a/cilium/cmd/service_update.go
+++ b/cilium/cmd/service_update.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -157,7 +156,15 @@ func updateService(cmd *cobra.Command, args []string) {
 	}
 
 	if len(backendWeights) > 0 {
-		if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
+		resp, err := client.ConfigGet()
+		if err != nil {
+			Fatalf("Unable to retrieve cilium configuration: %s", err)
+		}
+		if resp.Status == nil {
+			Fatalf("Unable to retrieve cilium configuration: empty response")
+		}
+
+		if resp.Status.DatapathMode != datapathOption.DatapathModeLBOnly {
 			Fatalf("Backend weights are supported currently only in lb-only mode")
 		}
 		if len(backendWeights) != len(backends) {

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -3,6 +3,8 @@
 PS4='+[\t] '
 set -eux
 
+export LC_NUMERIC=C
+
 IMG_OWNER=${1:-cilium}
 IMG_TAG=${2:-latest}
 HELM_CHART_DIR=${3:-/vagrant/install/kubernetes/cilium}
@@ -125,7 +127,7 @@ kubectl -n kube-system exec "${CILIUM_POD_NAME}" -- \
 set +e
 # Issue 10 requests to LB (with 500ms timeout) which are expected to timeout
 for i in $(seq 1 10); do
-    curl -o /dev/null -m 0,5 "${LB_VIP}:80"
+    curl -o /dev/null -m 0.5 "${LB_VIP}:80"
     # code 28 - Operation timeout
     if [ ! "$?" -eq 28 ]; then
         exit -1;


### PR DESCRIPTION
The current check fails because on the CLI we don't set the datapath mode. We need to retrieve the config of the running daemon and check the datapath mode there instead.

Fixes: #21303
Fixes: a5558f6e4784 ("fix: logic to allow backend weights moved to service_update.go file")
