### PR TITLE
Fix empty message when host legacy routing is true

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -936,6 +936,8 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup,
 		case option.Config.EgressMasqueradeInterfaces != "":
 			msg = fmt.Sprintf("BPF masquerade does not allow to specify devices via --%s (use --%s instead).",
 				option.EgressMasqueradeInterfaces, option.Devices)
+		case option.Config.TunnelingEnabled() && !hasFullHostReachableServices():
+			msg = "BPF masquerade requires full host reachable services enabled in tunnel mode."
 		}
 		// ipt.InstallRules() (called by Reinitialize()) happens later than
 		// this  statement, so it's OK to fallback to iptables-based MASQ.


### PR DESCRIPTION
when missing tunnel and socketLB service check and  when legacy host routing
set to true, the msg is empty with log

"level=warning msg=" Falling back to iptables-based masquerading." subsys=daemon"

this is confusing to users and not sure why falling back to iptables-based masquerading

before the fix:

run cilium agent in kernel 4.19 with

1 BPF masq enabled
2 Host legacy routing enabled
3 Tunnel enabled
4 FullHostReachableServices false

Cilium agent logs:
 "level=warning msg=" Falling back to iptables-based masquerading." subsys=daemon"

the msg is empty because none of the switch cases matches, this could mis-lead users to
think BPF masquerade is not supported on kernel 4.19.

then when:

1 BPF masq enabled
2 Host legacy routing enabled
3 Tunnel disabled
4 Nodeport enabled

cilium agent keeps BPF masquerade enabled on kernel 4.19 without falling back to iptables-based masquerading

after the fix:

cilum agent log should log correct message + "Falling back to iptables-based masquerading."

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #21237

```release-note
fix empty message when tunnel and socketLB service missing in switch case
```
