### PR TITLE
test: add ownership SIG for each ginkgo context

### DIFF
--- a/test/k8s/bandwidth.go
+++ b/test/k8s/bandwidth.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cilium/cilium/test/helpers"
 )
 
-var _ = SkipDescribeIf(helpers.DoesNotRunOnNetNextKernel, "K8sBandwidthTest", func() {
+var _ = SkipDescribeIf(helpers.DoesNotRunOnNetNextKernel, "K8sDatapathBandwidthTest", func() {
 	var (
 		kubectl        *helpers.Kubectl
 		ciliumFilename string

--- a/test/k8s/bgp.go
+++ b/test/k8s/bgp.go
@@ -26,7 +26,7 @@ var _ = SkipDescribeIf(
 			// Test requests to the LB are going to be sent from the node which
 			// doesn't run Cilium.
 			helpers.DoesNotExistNodeWithoutCilium()
-	}, "K8sBGPTests", func() {
+	}, "K8sDatapathBGPTests", func() {
 		var (
 			kubectl        *helpers.Kubectl
 			ciliumFilename string

--- a/test/k8s/chaos.go
+++ b/test/k8s/chaos.go
@@ -15,7 +15,7 @@ import (
 
 // The 5.4 CI job is intended to catch BPF complexity regressions and as such
 // doesn't need to execute this test suite.
-var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sChaosTest", func() {
+var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentChaosTest", func() {
 
 	var (
 		kubectl        *helpers.Kubectl

--- a/test/k8s/cli.go
+++ b/test/k8s/cli.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cilium/cilium/test/helpers"
 )
 
-var _ = Describe("K8sCLI", func() {
+var _ = Describe("K8sDatapathCLI", func() {
 	SkipContextIf(func() bool {
 		return helpers.DoesNotRunOnGKE() && helpers.DoesNotRunOnEKS()
 	}, "CLI", func() {

--- a/test/k8s/custom_calls.go
+++ b/test/k8s/custom_calls.go
@@ -32,7 +32,7 @@ var _ = SkipDescribeIf(func() bool {
 	// skips GKE).
 	return helpers.DoesNotRunOnNetNextKernel() ||
 		helpers.RunsOnGKE()
-}, "K8sCustomCalls", func() {
+}, "K8sDatapathCustomCalls", func() {
 
 	var (
 		kubectl *helpers.Kubectl

--- a/test/k8s/egress.go
+++ b/test/k8s/egress.go
@@ -18,7 +18,7 @@ import (
 
 var _ = SkipDescribeIf(func() bool {
 	return helpers.RunsOnEKS() || helpers.RunsOnGKE() || helpers.DoesNotRunWithKubeProxyReplacement() || helpers.DoesNotExistNodeWithoutCilium() || helpers.DoesNotRunOn54OrLaterKernel()
-}, "K8sEgressGatewayTest", func() {
+}, "K8sDatapathEgressGatewayTest", func() {
 	const (
 		namespaceSelector = "ns=cilium-test"
 		testDS            = "zgroup=testDS"

--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -15,7 +15,7 @@ import (
 
 // The 5.4 CI job is intended to catch BPF complexity regressions and as such
 // doesn't need to execute this test suite.
-var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sFQDNTest", func() {
+var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 	var (
 		kubectl *helpers.Kubectl
 

--- a/test/k8s/health.go
+++ b/test/k8s/health.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/cilium/test/helpers"
 )
 
-var _ = Describe("K8sHealthTest", func() {
+var _ = Describe("K8sAgentHealthTest", func() {
 	SkipContextIf(func() bool {
 		return helpers.DoesNotRunOnGKE() && helpers.DoesNotRunOnEKS()
 	}, "cilium-health", func() {

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/cilium/test/helpers"
 )
 
-var _ = Describe("K8sHubbleTest", func() {
+var _ = Describe("K8sAgentHubbleTest", func() {
 	// We want to run Hubble tests both with and without our kube-proxy
 	// replacement, as the trace events depend on it. We thus run the tests
 	// on GKE and our 4.9 pipeline.

--- a/test/k8s/istio.go
+++ b/test/k8s/istio.go
@@ -19,7 +19,7 @@ import (
 // Documentation/gettingstarted/istio.rst.
 // The 5.4 CI job is intended to catch BPF complexity regressions and as such
 // doesn't need to execute this test suite.
-var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sIstioTest", func() {
+var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentIstioTest", func() {
 
 	var (
 		// istioSystemNamespace is the default namespace into which Istio is

--- a/test/k8s/lrp.go
+++ b/test/k8s/lrp.go
@@ -18,7 +18,7 @@ import (
 
 // The 5.4 CI job is intended to catch BPF complexity regressions and as such
 // doesn't need to execute this test suite.
-var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sLRPTests", func() {
+var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathLRPTests", func() {
 	var (
 		kubectl        *helpers.Kubectl
 		ciliumFilename string

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -30,7 +30,7 @@ var _ = SkipDescribeIf(func() bool {
 	//
 	// For GKE coverage, see the K8sPolicyTestExtended Describe block below.
 	return helpers.RunsOnGKE() || helpers.RunsOn419Kernel() || helpers.RunsOn54Kernel()
-}, "K8sPolicyTest", func() {
+}, "K8sAgentPolicyTest", func() {
 
 	var (
 		kubectl *helpers.Kubectl

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -32,7 +32,7 @@ const (
 
 // The 5.4 CI job is intended to catch BPF complexity regressions and as such
 // doesn't need to execute this test suite.
-var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sServicesTest", func() {
+var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func() {
 	var (
 		kubectl        *helpers.Kubectl
 		ciliumFilename string

--- a/test/k8s/verifier.go
+++ b/test/k8s/verifier.go
@@ -71,7 +71,7 @@ var (
 // privileged Pod (test-verifier) which mounts the bpffs and the Cilium source
 // directory. All test commands are executed in this privileged Pod after
 // uninstalling Cilium from the cluster.
-var _ = Describe("K8sVerifier", func() {
+var _ = Describe("K8sDatapathVerifier", func() {
 	var kubectl *helpers.Kubectl
 
 	collectObjectFiles := func() {

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/cilium/test/helpers/constants"
 )
 
-var _ = Describe("RuntimeChaos", func() {
+var _ = Describe("RuntimeAgentChaos", func() {
 	var (
 		vm            *helpers.SSHMeta
 		testStartTime time.Time

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium/test/helpers/constants"
 )
 
-var _ = Describe("RuntimeConntrackInVethModeTest", runtimeConntrackTest("veth"))
+var _ = Describe("RuntimeDatapathConntrackInVethModeTest", runtimeConntrackTest("veth"))
 
 var runtimeConntrackTest = func(datapathMode string) func() {
 	return func() {

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -114,7 +114,7 @@ zone "dnssec.test" {
 };
 `
 
-var _ = Describe("RuntimeFQDNPolicies", func() {
+var _ = Describe("RuntimeAgentFQDNPolicies", func() {
 	const (
 		bindContainerName = "bind"
 		WorldHttpd1       = "WorldHttpd1"

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cilium/cilium/test/helpers/constants"
 )
 
-var _ = Describe("RuntimeKVStoreTest", func() {
+var _ = Describe("RuntimeAgentKVStoreTest", func() {
 	var vm *helpers.SSHMeta
 	var testStartTime time.Time
 

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/cilium/test/helpers/constants"
 )
 
-var _ = Describe("RuntimeLB", func() {
+var _ = Describe("RuntimeDatapathLB", func() {
 	var (
 		vm            *helpers.SSHMeta
 		testStartTime time.Time

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -25,7 +25,7 @@ const (
 	MonitorTraceNotification = "TraceNotification"
 )
 
-var _ = Describe("RuntimeMonitorTest", func() {
+var _ = Describe("RuntimeDatapathMonitorTest", func() {
 
 	var (
 		vm            *helpers.SSHMeta

--- a/test/runtime/net_policies.go
+++ b/test/runtime/net_policies.go
@@ -47,7 +47,7 @@ const (
 	initContainer = "initContainer"
 )
 
-var _ = Describe("RuntimePolicies", func() {
+var _ = Describe("RuntimeAgentPolicies", func() {
 
 	var (
 		vm            *helpers.SSHMeta

--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -21,7 +21,7 @@ const (
 	privilegedUnitTestTimeout = 30 * time.Minute
 )
 
-var _ = Describe("RuntimePrivilegedUnitTests", func() {
+var _ = Describe("RuntimeDatapathPrivilegedUnitTests", func() {
 
 	var vm *helpers.SSHMeta
 


### PR DESCRIPTION
Setting an ownership of the tests will allow us to understand if certain PRs can be merged by checking if the code changes are agent or datapath-specific. This will obviously not be bulletproof since some agent-specific PR change might affect datapath behavior and vice-versa but at least it will help to tell immediately to which team a particular test belongs to.

Signed-off-by: André Martins <andre@cilium.io>