### PR TITLE
add Giant Swarm as Cilium User

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -185,6 +185,11 @@ Users (Alphabetically)
       L: https://github.com/f5devcentral/f5-ci-docs/blob/master/docs/cilium/cilium-bigip-info.rst
       Q: @vincentmli
 
+    * N: Giant Swarm
+      D: Giant Swarm is using Cilium in their Cluster API based managed Kubernetes service (AWS, Azure, GCP, OpenStack, VMware Cloud Director and VMware vSphere) as CNI
+      U: Networking
+      L: https://www.giantswarm.io/
+
     * N: GitLab
       D: GitLab is using Cilium to implement network policies inside Auto DevOps deployed clusters for customers using k8s
       U: Network policies


### PR DESCRIPTION
At [Giant Swarm](https://www.giantswarm.io/) we are using `cilium` as `CNI` for all new CAPI-based environments.

Signed-off-by: Mario Constanti <mario@constanti.de>

Please ensure your pull request adheres to the following guidelines:

- [ ] ~For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)~
- [ ] ~All code is covered by unit and/or runtime tests where feasible.~
- [ ] ~All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.~
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
