### PR TITLE
hubble/metrics: Add workload-name and app options to sourceContext and destinationContext

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -522,6 +522,8 @@ Option Value          Description
 ``dns``               All known DNS names of the source or destination (comma-separated)
 ``ip``                The IPv4 or IPv6 address
 ``reserved-identity`` Reserved identity label.
+``workload-name``     Kubernetes pod's workload name (workloads are: Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift), etc).
+``app``               Kubernetes pod's app name, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
 ===================== ===================================================================================
 
 When specifying the source and/or destination context, multiple contexts can be

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -235,6 +235,32 @@ func Test_reservedIdentityContext(t *testing.T) {
 	}), []string{"reserved:host", "reserved:remote-node"})
 }
 
+func Test_workloadNameContext(t *testing.T) {
+	opts, err := ParseContextOptions(Options{"sourceContext": "workload-name", "destinationContext": "workload-name"})
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{
+		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod"},
+		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod"}}), []string{"", ""})
+	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{
+		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod", Workloads: []*pb.Workload{{Name: "foo-deploy", Kind: "Deployment"}}},
+		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod", Workloads: []*pb.Workload{{Name: "bar-deploy", Kind: "Deployment"}}},
+	}), []string{"foo-deploy", "bar-deploy"})
+}
+
+func Test_appContext(t *testing.T) {
+	opts, err := ParseContextOptions(Options{"sourceContext": "app", "destinationContext": "app"})
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{
+		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod"},
+		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod"}}), []string{"", ""})
+	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{
+		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod", Labels: []string{"k8s:app=fooapp"}},
+		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod", Labels: []string{"k8s:app=barapp"}},
+	}), []string{"fooapp", "barapp"})
+}
+
 func Test_labelsSetString(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -23,7 +23,7 @@ Options:
  sourceContext          ::= identifier , { "|", identifier }
  destinationContext     ::= identifier , { "|", identifier }
  labels                 ::= label , { ",", label }
- identifier             ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity
+ identifier             ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
  label                  ::= source_pod | source_namespace | source_workload | source_app | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 	assert.Equal(t, expected, plugin.HelpText())


### PR DESCRIPTION
```release-note
hubble/metrics: Add workload-name and app options to sourceContext and destinationContext
```
