### PR TITLE
hubble/metrics: Add source_ip/destination_ip labels to contextLabels

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -551,10 +551,12 @@ of different values being put into the same metric label, the ``labelsContext`` 
 ========================= ===============================================================================
 Option Value              Description
 ========================= ===============================================================================
+``source_ip``             The source IP of the flow.
 ``source_namespace``      The namespace of the pod if the flow source is from a Kubernetes pod.
 ``source_pod``            The pod name if the flow source is from a Kubernetes pod.
 ``source_workload``       The name of the source pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).
 ``source_app``            The app name of the source pod, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
+``destination_ip``        The destination IP of the flow.
 ``destination_namespace`` The namespace of the pod if the flow destination is from a Kubernetes pod.
 ``destination_pod``       The pod name if the flow destination is from a Kubernetes pod.
 ``destination_workload``  The name of the destination pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -52,7 +52,7 @@ const ContextOptionsHelp = `
  destinationContext     ::= identifier , { "|", identifier }
  labels                 ::= label , { ",", label }
  identifier             ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
- label                  ::= source_pod | source_namespace | source_workload | source_app | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
+ label                  ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 
 var (
@@ -61,10 +61,12 @@ var (
 	// contextLabelsList defines available labels for the ContextLabels
 	// ContextIdentifier and the order of those labels for GetLabelNames and GetLabelValues.
 	contextLabelsList = []string{
+		"source_ip",
 		"source_pod",
 		"source_namespace",
 		"source_workload",
 		"source_app",
+		"destination_ip",
 		"destination_pod",
 		"destination_namespace",
 		"destination_workload",
@@ -241,8 +243,10 @@ func (ls labelsSet) String() string {
 
 func labelsContext(invertSourceDestination bool, wantedLabels labelsSet, flow *pb.Flow) (outputLabels []string, err error) {
 	source, destination := flow.GetSource(), flow.GetDestination()
+	sourceIp, destinationIp := flow.GetIP().GetSource(), flow.GetIP().GetDestination()
 	if invertSourceDestination {
 		source, destination = flow.GetDestination(), flow.GetSource()
+		sourceIp, destinationIp = flow.GetIP().GetDestination(), flow.GetIP().GetSource()
 	}
 	// Iterate over contextLabelsList so that the label order is stable,
 	// otherwise GetLabelNames and GetLabelValues might be mismatched
@@ -250,6 +254,8 @@ func labelsContext(invertSourceDestination bool, wantedLabels labelsSet, flow *p
 		if wantedLabels.HasLabel(label) {
 			var labelValue string
 			switch label {
+			case "source_ip":
+				labelValue = sourceIp
 			case "source_pod":
 				labelValue = source.GetPodName()
 			case "source_namespace":
@@ -260,6 +266,8 @@ func labelsContext(invertSourceDestination bool, wantedLabels labelsSet, flow *p
 				}
 			case "source_app":
 				labelValue = getK8sAppFromLabels(source.GetLabels())
+			case "destination_ip":
+				labelValue = destinationIp
 			case "destination_pod":
 				labelValue = destination.GetPodName()
 			case "destination_namespace":

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -24,7 +24,7 @@ Options:
  destinationContext     ::= identifier , { "|", identifier }
  labels                 ::= label , { ",", label }
  identifier             ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
- label                  ::= source_pod | source_namespace | source_workload | source_app | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
+ label                  ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 	assert.Equal(t, expected, plugin.HelpText())
 }


### PR DESCRIPTION
Update hubble metrics to support exposing the source/destination IP as source_ip and destination_ip labels.

```release-note
hubble/metrics: Add source_ip/destination_ip labels to contextLabels
```
