### PR TITLE
eni: Don't restore the connmark when Cilium is carrying the identity

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1607,6 +1607,7 @@ func (m *IptablesManager) addCiliumENIRules() error {
 
 	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
 	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
+	identityMarkMask := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIdentity, linux_defaults.MagicMarkHostMask)
 
 	// Note: these rules need the xt_connmark module (iptables usually
 	// loads it when required, unless loading modules after boot has been
@@ -1626,5 +1627,12 @@ func (m *IptablesManager) addCiliumENIRules() error {
 		"-A", ciliumPreMangleChain,
 		"-i", "lxc+",
 		"-m", "comment", "--comment", "cilium: primary ENI",
+		// Don't restore the mark when we are carrying the identity with mark,
+		// because we are using 7th bit to carry the uppermost bit of the identity
+		// and it is overlapping with ENI's mark. Below --restore-mark "restores"
+		// the connmark and it zeros the 7th bit when connmark is zero. As a result,
+		// identity will be changed. This will become a problem only when we are
+		// setting the ClusterID 128-255.
+		"-m", "mark", "!", "--mark", identityMarkMask,
 		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask})
 }


### PR DESCRIPTION
This PR partially resolves the issue reported in #21330 for the environment which uses Cilium with ENI mode but doesn't have AWS VPC CNI installed. Please see the commit message and #21330 for context.




### Connectivity test result without fix and cluster-id = 128

```

```

### Connectivity test result with fix and cluster-id = 128
```

```

```release-note
Fixed the issue that AWS VPC CNI overwrites the security identity in ENI mode for self-managed k8s scenario
```
