### PR TITLE
Remove references to node encryption

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -138,7 +138,6 @@ cilium-agent [flags]
       --enable-xdp-prefilter                                    Enable XDP prefiltering
       --enable-xt-socket-fallback                               Enable fallback for missing xt_socket module (default true)
       --encrypt-interface string                                Transparent encryption interface
-      --encrypt-node                                            Enables encrypting traffic from non-Cilium pods and host networking
       --endpoint-queue-size int                                 size of EventQueue per-endpoint (default 25)
       --endpoint-status strings                                 Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
       --envoy-config-timeout duration                           Timeout duration for Envoy Config acknowledgements (default 2m0s)

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -80,13 +80,11 @@ Enable Encryption in Cilium
            helm install cilium |CHART_RELEASE| \\
              --namespace kube-system \\
              --set encryption.enabled=true \\
-             --set encryption.nodeEncryption=false \\
              --set encryption.type=ipsec
 
-       ``encryption.enabled`` enables encryption of the traffic between Cilium-managed pods and
-       ``encryption.nodeEncryption`` controls whether host traffic is encrypted.
-       ``encryption.type`` specifies the encryption method and can be omitted
-       as it defaults to ``ipsec``.
+       ``encryption.enabled`` enables encryption of the traffic between
+       Cilium-managed pods. ``encryption.type`` specifies the encryption method
+       and can be omitted as it defaults to ``ipsec``.
 
 .. attention::
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -266,6 +266,7 @@ func initializeFlags() {
 	option.BindEnv(Vp, option.EncryptInterface)
 
 	flags.Bool(option.EncryptNode, defaults.EncryptNode, "Enables encrypting traffic from non-Cilium pods and host networking")
+	flags.MarkHidden(option.EncryptNode)
 	option.BindEnv(Vp, option.EncryptNode)
 
 	flags.StringSlice(option.IPv4PodSubnets, []string{}, "List of IPv4 pod subnets to preconfigure for encryption")


### PR DESCRIPTION
This pull request hides the node encryption flag and removes a missed reference to the feature in the docs.