### PR TITLE
test: Extend checkReady condition

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1390,6 +1390,10 @@ func checkReady(pod v1.Pod) bool {
 		return false
 	}
 
+	if len(pod.Status.PodIPs) == 0 {
+		return false
+	}
+
 	for _, container := range pod.Status.ContainerStatuses {
 		if !container.Ready {
 			return false
@@ -1466,6 +1470,7 @@ func (kub *Kubectl) waitForNPods(checkStatus checkPodStatusFunc, namespace strin
 		//  - It is not scheduled for deletion when DeletionTimestamp is set
 		//  - All containers in the pod have passed the liveness check via
 		//  containerStatuses.Ready
+		//  - It has a pod IP set
 		currScheduled := 0
 		for _, pod := range podList.Items {
 			if checkStatus(pod) {


### PR DESCRIPTION
Previously, the checkReady() (e.g., used by WaitforNPods()) didn't check whether a pod has IP addr set when deciding on its readiness.

This became a problem when we switched to k8s 1.25, and the "Check BPF masquerading with ip-masq-agent" started to fail to install the route due to missing pod IP addr:

    ip route add  via 192.168.56.12  (spot missing dst)

The further inspection showed that the pod IP addr was missing in a previous cmd which did the following:

    cmd: "kubectl -n
    202209141614k8sdatapathconfigcheckbpfmasqueradingwithip-masq-ag get pods
    -l zgroup=testDSClient -o jsonpath='{range
    .items[*]}{@.metadata.name}{\"=\"}{@.status.podIP}{\"\\n\"}{end}'"
    exitCode: 0 duration: 36.623592ms stdout:
    testclient-9ntf8=
    testclient-xhbkb=10.0.0.187

Fix this by making sure that the wait function waits until a pod has an IP addr set. The change should not affect other test cases, as every pod is expected to have an IP addr set.

Fix #21312 #21120