### PR TITLE
Enable operator operation without kubernetes.

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -31,6 +31,7 @@ cilium-operator-alibabacloud [flags]
       --enable-cilium-endpoint-slice              If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-ipv4                               Enable IPv4 support (default true)
       --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s                                Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -35,6 +35,7 @@ cilium-operator-aws [flags]
       --enable-cilium-endpoint-slice              If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-ipv4                               Enable IPv4 support (default true)
       --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s                                Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -34,6 +34,7 @@ cilium-operator-azure [flags]
       --enable-cilium-endpoint-slice              If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-ipv4                               Enable IPv4 support (default true)
       --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s                                Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -30,6 +30,7 @@ cilium-operator-generic [flags]
       --enable-cilium-endpoint-slice              If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-ipv4                               Enable IPv4 support (default true)
       --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s                                Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -40,6 +40,7 @@ cilium-operator [flags]
       --enable-cilium-endpoint-slice              If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-ipv4                               Enable IPv4 support (default true)
       --enable-ipv6                               Enable IPv6 support (default true)
+      --enable-k8s                                Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes (default true)
       --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -321,6 +321,9 @@ func init() {
 	flags.StringSlice(operatorOption.IngressLBAnnotationPrefixes, operatorOption.IngressLBAnnotationsDefault, "Annotation prefixes for propagating from Ingress to the Load Balancer service")
 	option.BindEnv(Vp, operatorOption.IngressLBAnnotationPrefixes)
 
+	flags.Bool(operatorOption.EnableK8s, true, `Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes`)
+	option.BindEnv(Vp, operatorOption.EnableK8s)
+
 	flags.Duration(option.KVstoreLeaseTTL, defaults.KVstoreLeaseTTL, "Time-to-live for the KVstore lease.")
 	flags.MarkHidden(option.KVstoreLeaseTTL)
 	option.BindEnv(Vp, option.KVstoreLeaseTTL)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -272,6 +272,11 @@ const (
 	// IngressDefaultLoadbalancerMode is the default loadbalancer mode for Ingress.
 	// Applicable values: dedicated, shared
 	IngressDefaultLoadbalancerMode = "ingress-default-lb-mode"
+
+	// EnableK8s operation of Kubernet-related services/controllers.
+	// Intended for operating cilium with CNI-compatible orchestrators
+	// other than Kubernetes. (default is true)
+	EnableK8s = "enable-k8s"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -508,6 +513,11 @@ type OperatorConfig struct {
 	// IngressDefaultLoadbalancerMode is the default loadbalancer mode for Ingress.
 	// Applicable values: dedicated, shared
 	IngressDefaultLoadbalancerMode string
+
+	// Enables/Disables operation of kubernet-related services/controllers.
+	// Intended for operating cilium with CNI-compatible orquestrators
+	// othern than Kubernetes. (default is true)
+	EnableK8s bool
 }
 
 // Populate sets all options with the values from viper.
@@ -548,6 +558,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.IngressLBAnnotationPrefixes = vp.GetStringSlice(IngressLBAnnotationPrefixes)
 	c.IngressSharedLBServiceName = vp.GetString(IngressSharedLBServiceName)
 	c.IngressDefaultLoadbalancerMode = vp.GetString(IngressDefaultLoadbalancerMode)
+	c.EnableK8s = vp.GetBool(EnableK8s)
 
 	c.CiliumK8sNamespace = vp.GetString(CiliumK8sNamespace)
 


### PR DESCRIPTION
Hi, latelly I've been working on setting up cilium with nomad, instead of kubernetes. By following some advices from @joestringer at https://github.com/cilium/cilium/issues/18334, and inspecting some documentation and guidance on howto setup cilium with docker, I've been able to integrate cilium agent, CNI & docker plugins to nomad. 

However, the only component not working out of the box is the operator (actually the generic operator). This is due to some code paths assuming kubernetes availability, and failing (obviously) when no k8s apiserver that can be contacted.

This PR addresses this issues by adding a new command argument (--disable-k8s-services, w/ false as default), which enables basic usage of the operator (lease cleanup, ipam address gc, etc.), but disables any k8s-specific code/features.

There are some more missing pieces/features which I would like to add to operator in future PRs, like being able to provide/distribute policy statements to agents from kvstore, instead of using kubernetes CRDs, etc. But this is the bare initial support for operator w/o kubernetes.

PD: For nomad users interested on this, this github issue is the actual place where using cilium w/ nomad is being handled (https://github.com/hashicorp/nomad/issues/12120)
