### PR TITLE
bugtool: Dump envoy config for troubleshooting

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -33,6 +33,7 @@ cilium-bugtool [OPTIONS] [flags]
       --config string             Configuration to decide what should be run (default "./.cilium-bugtool.config")
       --dry-run                   Create configuration file of all commands that would have been executed
       --enable-markdown           Dump output of commands in markdown format
+      --envoy-dump                When set, dump envoy configuration from unix socket (default true)
       --exec-timeout duration     The default timeout for any cmd execution in seconds (default 30s)
       --get-pprof                 When set, only gets the pprof traces from the cilium-agent binary
   -h, --help                      help for cilium-bugtool

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -69,6 +70,7 @@ var (
 	enableMarkdown  bool
 	archivePrefix   string
 	getPProf        bool
+	envoyDump       bool
 	pprofPort       int
 	traceSeconds    int
 	parallelWorkers int
@@ -77,6 +79,7 @@ var (
 func init() {
 	BugtoolRootCmd.Flags().BoolVar(&archive, "archive", true, "Create archive when false skips deletion of the output directory")
 	BugtoolRootCmd.Flags().BoolVar(&getPProf, "get-pprof", false, "When set, only gets the pprof traces from the cilium-agent binary")
+	BugtoolRootCmd.Flags().BoolVar(&envoyDump, "envoy-dump", true, "When set, dump envoy configuration from unix socket")
 	BugtoolRootCmd.Flags().IntVar(&pprofPort,
 		"pprof-port", defaults.GopsPortAgent,
 		fmt.Sprintf(
@@ -202,6 +205,12 @@ func runTool() {
 			os.Exit(1)
 		}
 	} else {
+		if envoyDump {
+			if err := dumpEnvoy(cmdDir); err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to dump envoy config: %s\n", err)
+			}
+		}
+
 		// Check if there is a user supplied configuration
 		if config, _ := loadConfigFile(configPath); config != nil {
 			// All of of the commands run are from the configuration file
@@ -448,28 +457,41 @@ func getCiliumPods(namespace, label string) ([]string, error) {
 	return ciliumPods, nil
 }
 
+func dumpEnvoy(rootDir string) error {
+	// curl --unix-socket /var/run/cilium/envoy-admin.sock http:/admin/config_dump\?include_eds > dump.json
+	c := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", "/var/run/cilium/envoy-admin.sock")
+			},
+		},
+	}
+	return downloadToFile(c, "http://admin/config_dump?include_eds", filepath.Join(rootDir, "envoy-config.json"))
+}
+
 func pprofTraces(rootDir string) error {
 	var wg sync.WaitGroup
 	var profileErr error
 	pprofHost := fmt.Sprintf("localhost:%d", pprofPort)
 	wg.Add(1)
+	httpClient := http.DefaultClient
 	go func() {
 		url := fmt.Sprintf("http://%s/debug/pprof/profile?seconds=%d", pprofHost, traceSeconds)
 		dir := filepath.Join(rootDir, "pprof-cpu")
-		profileErr = downloadToFile(url, dir)
+		profileErr = downloadToFile(httpClient, url, dir)
 		wg.Done()
 	}()
 
 	url := fmt.Sprintf("http://%s/debug/pprof/trace?seconds=%d", pprofHost, traceSeconds)
 	dir := filepath.Join(rootDir, "pprof-trace")
-	err := downloadToFile(url, dir)
+	err := downloadToFile(httpClient, url, dir)
 	if err != nil {
 		return err
 	}
 
 	url = fmt.Sprintf("http://%s/debug/pprof/heap?debug=1", pprofHost)
 	dir = filepath.Join(rootDir, "pprof-heap")
-	err = downloadToFile(url, dir)
+	err = downloadToFile(httpClient, url, dir)
 	if err != nil {
 		return err
 	}
@@ -490,14 +512,14 @@ func pprofTraces(rootDir string) error {
 	return nil
 }
 
-func downloadToFile(url, file string) error {
+func downloadToFile(client *http.Client, url, file string) error {
 	out, err := os.Create(file)
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 
-	resp, err := http.Get(url)
+	resp, err := client.Get(url)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There is more and more usage of envoy proxy in cilium, so it's better to have utility to dump its config for troubleshooting later.

```
root@minikube:/home/cilium# tar -xf /tmp/cilium-bugtool-20220918-132428.955+0000-UTC-2901326153.tar
root@minikube:/home/cilium# ls -lrt cilium-bugtool-20220918-132428.955+0000-UTC-2901326153/cmd/envoy-config.json
-rw-r--r-- 1 root root 28645 Sep 18 13:24 cilium-bugtool-20220918-132428.955+0000-UTC-2901326153/cmd/envoy-config.json
```

Signed-off-by: Tam Mach <tam.mach@cilium.io>
