### PR TITLE
Add a check for having a single argument

### DIFF
--- a/cilium/cmd/bpf_endpoint_delete.go
+++ b/cilium/cmd/bpf_endpoint_delete.go
@@ -15,6 +15,7 @@ import (
 var bpfEndpointDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete local endpoint entries",
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf endpoint delete")
 


### PR DESCRIPTION
Signed-off-by: Vladimir Pouzanov <farcaller@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

This fixes a crash in `cilium bpf endpoint delete` when ran without arguments.

```release-note
Fix a crash in `cilium bpf endpoint delete` when ran without arguments.
```
