### PR TITLE
k8s: Resource[T], an implementation of informers with per-sub queues

### DIFF
--- a/pkg/k8s/resource/event.go
+++ b/pkg/k8s/resource/event.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+// Event emitted from resource. One of SyncEvent, UpdateEvent or DeleteEvent.
+type Event[T k8sRuntime.Object] interface {
+	// Handle the event by invoking the right handler.
+	// On error the event is requeued by key for later processing.
+	//
+	// If you use Handle(), then Done() should not be called.
+	// If you need to process the events in parallel/asynchronously,
+	// then do a type-switch on Event[T] and call Done() after the
+	// event has been processed.
+	Handle(
+		onSync func(Store[T]) error,
+		onUpdate func(Key, T) error,
+		onDelete func(Key, T) error,
+	)
+
+	// Done marks the event as processed.  If err is non-nil, the
+	// key of the object is requeued and the processing retried at
+	// a later time with a potentially new version of the object.
+	//
+	// If you choose not to use Handle(), then this must always be called after the
+	// event has been processed.
+	Done(err error)
+}
+
+type baseEvent struct {
+	done func(error)
+}
+
+func (b *baseEvent) Done(err error) {
+	b.done(err)
+}
+
+// SyncEvent is emitted after a set of initial objects has been emitted as UpdateEvents. At this
+// point the subscriber will have a consistent snapshot of the state of this resource and can
+// perform e.g. garbage collection operations.
+type SyncEvent[T k8sRuntime.Object] struct {
+	baseEvent
+	Store Store[T]
+}
+
+var _ Event[*corev1.Node] = &SyncEvent[*corev1.Node]{}
+
+func (ev *SyncEvent[T]) Handle(onSync func(store Store[T]) error, onUpdate func(Key, T) error, onDelete func(Key, T) error) {
+	ev.Done(onSync(ev.Store))
+}
+
+// UpdateEvent is emitted when an object has been added or updated
+type UpdateEvent[T k8sRuntime.Object] struct {
+	baseEvent
+	Key    Key
+	Object T
+}
+
+var _ Event[*corev1.Node] = &UpdateEvent[*corev1.Node]{}
+
+func (ev *UpdateEvent[T]) Handle(onSync func(Store[T]) error, onUpdate func(Key, T) error, onDelete func(Key, T) error) {
+	ev.Done(onUpdate(ev.Key, ev.Object))
+}
+
+// DeleteEvent is emitted when an object has been deleted
+type DeleteEvent[T k8sRuntime.Object] struct {
+	baseEvent
+	Key    Key
+	Object T
+}
+
+var _ Event[*corev1.Node] = &DeleteEvent[*corev1.Node]{}
+
+func (ev *DeleteEvent[T]) Handle(onSync func(Store[T]) error, onUpdate func(Key, T) error, onDelete func(Key, T) error) {
+	ev.Done(onDelete(ev.Key, ev.Object))
+}

--- a/pkg/k8s/resource/example/main.go
+++ b/pkg/k8s/resource/example/main.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.uber.org/fx"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/stream"
+)
+
+// PrintServices for the pkg/k8s/resource which observers pods and services and once a second prints the list of
+// services with the pods associated with each service.
+//
+// Run with:
+//
+//  go run . --k8s-kubeconfig-path ~/.kube/config
+//
+// To test, try running:
+//
+//  kubectl run -it --rm --image=nginx  --port=80 --expose nginx
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "example")
+)
+
+func main() {
+	hive := hive.New(
+		viper.GetViper(), pflag.CommandLine,
+
+		client.Cell,
+		resourcesCell,
+		printServicesCell,
+
+		hive.Require[*PrintServices](),
+	)
+	pflag.Parse()
+	hive.Run()
+}
+
+var resourcesCell = hive.NewCell(
+	"resources",
+	fx.Provide(
+		resource.NewResourceConstructor[*corev1.Pod](
+			func(c client.Clientset) cache.ListerWatcher {
+				return utils.ListerWatcherFromTyped[*corev1.PodList](c.CoreV1().Pods(""))
+			},
+		),
+		resource.NewResourceConstructor[*corev1.Service](
+			func(c client.Clientset) cache.ListerWatcher {
+				return utils.ListerWatcherFromTyped[*corev1.ServiceList](c.CoreV1().Services(""))
+			},
+		),
+	),
+)
+
+var printServicesCell = hive.NewCell(
+	"print-services",
+	fx.Provide(newPrintServices),
+)
+
+type PrintServices struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	pods     resource.Resource[*corev1.Pod]
+	services resource.Resource[*corev1.Service]
+}
+
+type printServicesParams struct {
+	fx.In
+
+	Lifecycle fx.Lifecycle
+	Pods      resource.Resource[*corev1.Pod]
+	Services  resource.Resource[*corev1.Service]
+}
+
+func newPrintServices(p printServicesParams) (*PrintServices, error) {
+	if p.Pods == nil || p.Services == nil {
+		return nil, fmt.Errorf("Resources not available. Missing --k8s-kubeconfig-path?")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ps := &PrintServices{
+		ctx:      ctx,
+		cancel:   cancel,
+		pods:     p.Pods,
+		services: p.Services,
+	}
+	p.Lifecycle.Append(fx.Hook{OnStart: ps.start, OnStop: ps.stop})
+	return ps, nil
+}
+
+func (ps *PrintServices) start(context.Context) error {
+	ps.wg.Add(1)
+
+	ps.printServices()
+	go ps.run()
+
+	return nil
+}
+
+func (ps *PrintServices) stop(context.Context) error {
+	ps.cancel()
+	ps.wg.Wait()
+	return nil
+}
+
+// printServices prints services at start to show how Store() can be used.
+func (ps *PrintServices) printServices() {
+
+	// Retrieve a handle to the store. Blocks until the store has synced.
+	// Can fail if the context is cancelled (e.g. PrintServices is being stopped).
+	store, err := ps.services.Store(ps.ctx)
+	if err != nil {
+		log.Errorf("Failed to retrieve store: %s, aborting", err)
+		return
+	}
+
+	log.Info("Services:")
+	for _, svc := range store.List() {
+		labels := labels.Map2Labels(svc.Spec.Selector, "k8s")
+		log.Infof("  - %s/%s\ttype=%s\tselector=%s", svc.Namespace, svc.Name, svc.Spec.Type, labels)
+	}
+
+}
+
+func (ps *PrintServices) run() {
+	defer ps.wg.Done()
+
+	// Always restart unless we're being stopped.
+	for ps.ctx.Err() == nil {
+		log.Info("Starting to print periodic updates to service to pod mappings")
+		ps.processLoop()
+	}
+}
+
+// processLoop observes changes to pods and services and periodically prints the
+// services and the pods that each service selects.
+func (ps *PrintServices) processLoop() {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	// Subscribe to pods and services. Use a shared channel for errors
+	// and make it buffered so unsubscribing from the resource does not get
+	// blocked.
+	errs := make(chan error, 2)
+	pods := stream.ToChannel[resource.Event[*corev1.Pod]](ps.ctx, errs, ps.pods)
+	services := stream.ToChannel[resource.Event[*corev1.Service]](ps.ctx, errs, ps.services)
+
+	// State:
+	podLabels := make(map[resource.Key]labels.Labels)
+	serviceSelectors := make(map[resource.Key]labels.Labels)
+
+	// Process the pod and service events and periodically print the services.
+	// Loop until the pods and services have completed. We need to process
+	// both streams to the end to make sure we're not blocking the resource even
+	// if we're stopping (e.g. context cancelled).
+	for pods != nil || services != nil {
+		select {
+		case <-ticker.C:
+			for key, selectors := range serviceSelectors {
+				log.Infof("%s (%s)", key, selectors)
+				for podName, lbls := range podLabels {
+					match := true
+					for _, sel := range selectors {
+						match = match && lbls.Has(sel)
+					}
+					if match {
+						log.Infof("  - %s", podName)
+					}
+				}
+			}
+			log.Println("----------------------------------------------------------")
+
+		case ev, ok := <-pods:
+			if !ok {
+				pods = nil
+				continue
+			}
+
+			// Event can be handled synchronously with 'Handle()':
+			ev.Handle(
+				func(store resource.Store[*corev1.Pod]) error {
+					log.Infof("Pods synced (%d pods)", len(store.List()))
+					return nil
+				},
+				func(k resource.Key, pod *corev1.Pod) error {
+					log.Infof("Pod %s updated", k)
+					podLabels[k] = labels.Map2Labels(pod.Labels, "k8s")
+					return nil
+				},
+				func(k resource.Key, deletedPod *corev1.Pod) error {
+					log.Infof("Pod %s deleted", k)
+					delete(podLabels, k)
+					return nil
+				},
+			)
+
+		case ev, ok := <-services:
+			if !ok {
+				services = nil
+				continue
+			}
+
+			// Simulate a fault 10% of the time. This will cause this event to be retried
+			// later.
+			if rand.Intn(10) == 1 {
+				log.Info("Injecting a fault!")
+				ev.Done(errors.New("injected fault"))
+				continue
+			}
+
+			// Event can also be handled with a type switch and call to 'Done()'
+			// (which allows parallel processing of events):
+			switch ev := ev.(type) {
+			case *resource.SyncEvent[*corev1.Service]:
+				log.Infof("Services synced (%d services)", len(ev.Store.List()))
+			case *resource.UpdateEvent[*corev1.Service]:
+				log.Infof("Service %s updated", ev.Key)
+				if len(ev.Object.Spec.Selector) > 0 {
+					serviceSelectors[ev.Key] = labels.Map2Labels(ev.Object.Spec.Selector, "k8s")
+				}
+			case *resource.DeleteEvent[*corev1.Service]:
+				log.Infof("Service %s deleted", ev.Key)
+				delete(serviceSelectors, ev.Key)
+			}
+			// We must now call 'Done()' directly. If we would call it with a non-nil
+			// error the processing for this object would be retried later, with possible
+			// a newer version of the object. If retries fail, the stream would complete
+			// with the error.
+			ev.Done(nil)
+		}
+	}
+
+	// Log errors if any
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			log.WithError(err).Error("Error occurred processing updates")
+		}
+	}
+}

--- a/pkg/k8s/resource/key.go
+++ b/pkg/k8s/resource/key.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Key of an K8s object, e.g. name and optional namespace.
+type Key struct {
+	// Name is the name of the object
+	Name string
+
+	// Namespace is the namespace, or empty if object is not namespaced.
+	Namespace string
+}
+
+func (k Key) String() string {
+	if len(k.Namespace) > 0 {
+		return k.Namespace + "/" + k.Name
+	}
+	return k.Name
+}
+
+func NewKey(obj any) Key {
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		namespace, name, _ := cache.SplitMetaNamespaceKey(d.Key)
+		return Key{name, namespace}
+	}
+
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return Key{}
+	}
+	if len(meta.GetNamespace()) > 0 {
+		return Key{meta.GetName(), meta.GetNamespace()}
+	}
+	return Key{meta.GetName(), ""}
+}

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/fx"
+	corev1 "k8s.io/api/core/v1"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/stream"
+)
+
+// Resource provides access to a Kubernetes resource through either
+// a stream of events or a read-only store.
+//
+// Observing of the events can be done from a constructor as subscriber
+// registration is non-blocking.
+//
+// Store() however should only be called from a start hook, or from a
+// goroutine forked from the start hook as it blocks until the store
+// has been synchronized.
+//
+// The subscriber can process the event synchronously with the
+// Event[T].Handle function, or asynchronously by calling Event[T].Done
+// once the event has been processed. On errors the object's key is requeued
+// for later processing. Once maximum number of retries is reached the subscriber's
+// event stream will be completed with the error from the last retry attempt.
+//
+// Resource is provided to the hive via NewResourceConstructor.
+type Resource[T k8sRuntime.Object] interface {
+	stream.Observable[Event[T]]
+
+	// Store retrieves the read-only store for the resource. Blocks until
+	// the store has been synchronized or the context cancelled.
+	// Returns a non-nil error if context is cancelled or the resource
+	// has been stopped before store has synchronized.
+	Store(context.Context) (Store[T], error)
+}
+
+// NewResourceConstructor provides a constructor for Resource when given a function
+// that maps from a Clientset into a ListerWatcher:
+//
+//	var exampleCell = hive.NewCell(
+//		"example",
+//	 	fx.Provide(
+//		 	// Provide `Resource[*slim_corev1.Pod]` to the hive:
+//	 		resource.NewResourceConstructor(
+//	 			func(c k8sClient.Clientset) cache.ListerWatcher {
+//					return utils.ListerWatcherFromTyped[*slim_corev1.PodList](
+//						c.Slim().CoreV1().Pods(""),
+//					)
+//				}),
+//			// Use the resource:
+//			newExample,
+//		}),
+//		...
+//	)
+//	func newExample(pods resource.Resource[*slim_corev1.Pod]) *Example {
+//		e := &Example{...}
+//		pods.Observe(e.ctx, e.onPodUpdated, e.onPodsComplete)
+//		return e
+//	}
+//	func (e *Example) onPodUpdated(key resource.Key, pod *slim_core.Pod) error {
+//		// Process event ...
+//	}
+//	func (e *Example) onPodsComplete(err error) {
+//		// Handle error ...
+//	}
+//
+// See also pkg/k8s/resource/example/main.go.
+func NewResourceConstructor[T k8sRuntime.Object](lw func(c k8sClient.Clientset) cache.ListerWatcher) func(lc fx.Lifecycle, c k8sClient.Clientset) Resource[T] {
+	return NewResourceConstructorWithRateLimiter[T](workqueue.DefaultControllerRateLimiter(), lw)
+}
+
+// NewResourceConstructorWithRateLimiter is the same as NewResourceConstructor, but with a custom rate limiter.
+func NewResourceConstructorWithRateLimiter[T k8sRuntime.Object](rateLimiter workqueue.RateLimiter, lw func(c k8sClient.Clientset) cache.ListerWatcher) func(lc fx.Lifecycle, c k8sClient.Clientset) Resource[T] {
+	return func(lc fx.Lifecycle, c k8sClient.Clientset) Resource[T] {
+		if !c.IsEnabled() {
+			return nil
+		}
+		newLW := func() cache.ListerWatcher { return lw(c) }
+		res := newResource[T](newLW, rateLimiter)
+		lc.Append(fx.Hook{OnStart: res.start, OnStop: res.stop})
+		return res
+	}
+}
+
+// defaultMaxRetries is the default number of retries for processing an event that was marked
+// failed by a non-nil error to Done().
+const defaultMaxRetries = 5
+
+type resource[T k8sRuntime.Object] struct {
+	mu     lock.RWMutex
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	queues map[uint64]*keyQueue
+	subId  uint64
+
+	rateLimiter     workqueue.RateLimiter
+	maxEventRetries int
+
+	storePromise  promise.Promise[Store[T]]
+	storeResolver promise.Resolver[Store[T]]
+
+	// newLW is the constructor for the ListerWatcher. It's invoked only when starting as the
+	// Clientset is not usable before it has been started.
+	newLW func() cache.ListerWatcher
+}
+
+var _ Resource[*corev1.Node] = &resource[*corev1.Node]{}
+
+func newResource[T k8sRuntime.Object](newLW func() cache.ListerWatcher, rateLimiter workqueue.RateLimiter) *resource[T] {
+	r := &resource[T]{
+		newLW:           newLW,
+		queues:          make(map[uint64]*keyQueue),
+		maxEventRetries: defaultMaxRetries,
+		rateLimiter:     rateLimiter,
+	}
+	r.ctx, r.cancel = context.WithCancel(context.Background())
+	r.storeResolver, r.storePromise = promise.New[Store[T]]()
+	return r
+}
+
+func (r *resource[T]) Store(ctx context.Context) (Store[T], error) {
+	return r.storePromise.Await(ctx)
+}
+
+func (r *resource[T]) pushUpdate(key Key) {
+	r.mu.RLock()
+	for _, queue := range r.queues {
+		queue.Add(&updateEntry{key})
+	}
+	r.mu.RUnlock()
+}
+
+func (r *resource[T]) pushDelete(lastState any) {
+	key := NewKey(lastState)
+	obj := lastState
+	if d, ok := lastState.(cache.DeletedFinalStateUnknown); ok {
+		obj = d.Obj
+	}
+	r.mu.RLock()
+	for _, queue := range r.queues {
+		queue.Add(&deleteEntry{key, obj})
+	}
+	r.mu.RUnlock()
+}
+
+func (r *resource[T]) start(startCtx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var objType T
+	handlerFuncs :=
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj any) { r.pushUpdate(NewKey(obj)) },
+			UpdateFunc: func(old any, new any) { r.pushUpdate(NewKey(new)) },
+			DeleteFunc: func(obj any) { r.pushDelete(obj) },
+		}
+
+	store, informer := cache.NewInformer(r.newLW(), objType, 0, handlerFuncs)
+
+	r.wg.Add(2)
+	go func() {
+		defer r.wg.Done()
+		informer.Run(r.ctx.Done())
+	}()
+	go func() {
+		defer r.wg.Done()
+
+		// Wait for cache to be synced before resolving the store
+		if !cache.WaitForCacheSync(r.ctx.Done(), informer.HasSynced) {
+			// The context is cancelled when stopping and all dependees of Resource[T] are
+			// stopped before it, but to be safe, resolve the store with nil to catch
+			// misbehaving dependees.
+			r.storeResolver.Reject(r.ctx.Err())
+			return
+		}
+		r.storeResolver.Resolve(&typedStore[T]{store})
+	}()
+
+	return nil
+}
+
+func (r *resource[T]) stop(stopCtx context.Context) error {
+	r.cancel()
+	r.wg.Wait()
+	return nil
+}
+
+func (r *resource[T]) Observe(subCtx context.Context, next func(Event[T]), complete func(error)) {
+	subCtx, subCancel := context.WithCancel(subCtx)
+
+	queue := &keyQueue{
+		RateLimitingInterface: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		maxRetries:            r.maxEventRetries,
+	}
+
+	// Fork a goroutine to pop elements from the queue and pass them to the subscriber.
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		defer subCancel()
+
+		// Wait for the store so we can emit the initial items and the sync event.
+		store, err := r.storePromise.Await(subCtx)
+		if err != nil {
+			complete(err)
+			return
+		}
+
+		r.mu.Lock()
+		r.subId++
+		r.queues[r.subId] = queue
+
+		// Append the initial set of keys to the queue + sentinel for the sync event.
+		// We go through the queue instead of directly emitting to avoid a race between
+		// the queue add and listing keys, plus to have one error handling path for Event.Done().
+		keyIter := store.IterKeys()
+		for keyIter.Next() {
+			queue.Add(&updateEntry{keyIter.Key()})
+		}
+		queue.Add(&syncEntry{})
+		r.mu.Unlock()
+
+		for {
+			// Retrieve an item from the subscribers queue and then fetch the object
+			// from the store.
+			raw, shutdown := queue.Get()
+			if shutdown {
+				break
+			}
+			entry := raw.(queueEntry)
+			baseEvent := baseEvent{
+				func(err error) { queue.eventDone(entry, err) },
+			}
+			switch entry := entry.(type) {
+			case *syncEntry:
+				next(&SyncEvent[T]{baseEvent, store})
+			case *deleteEntry:
+				next(&DeleteEvent[T]{baseEvent, entry.key, entry.obj.(T)})
+			case *updateEntry:
+				obj, exists, err := store.GetByKey(entry.key)
+				if err != nil {
+					queue.setError(err)
+					break
+				}
+				// Emit the update event if the item exists, if it doesn't, then
+				// it has been deleted and a delete will follow soon.
+				if exists {
+					next(&UpdateEvent[T]{baseEvent, entry.key, obj})
+				}
+			}
+		}
+		r.mu.Lock()
+		delete(r.queues, r.subId)
+		r.mu.Unlock()
+		complete(queue.getError())
+	}()
+
+	// Fork a goroutine to wait for either the subscriber cancelling or the resource
+	// shutting down.
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		select {
+		case <-r.ctx.Done():
+			subCancel()
+		case <-subCtx.Done():
+		}
+		queue.ShutDownWithDrain()
+	}()
+}
+
+// keyQueue wraps the workqueue to implement the error retry logic for a single subscriber,
+// e.g. it implements the eventDone() method called by Event[T].Done().
+type keyQueue struct {
+	lock.Mutex
+	workqueue.RateLimitingInterface
+
+	maxRetries int
+	err        error
+}
+
+func (kq *keyQueue) getError() error {
+	kq.Lock()
+	defer kq.Unlock()
+	return kq.err
+}
+
+func (kq *keyQueue) setError(err error) {
+	kq.Lock()
+	defer kq.Unlock()
+	if kq.err == nil {
+		kq.err = err
+	}
+}
+
+func (kq *keyQueue) eventDone(entry queueEntry, err error) {
+	// This is based on the example found in k8s.io/client-go/examples/workqueue/main.go.
+
+	// Mark the object as done being processed. If it was marked dirty
+	// during processing, it'll be processed again.
+	defer kq.Done(entry)
+
+	if err != nil {
+		// Processing of this item failed. Check if retry limit has been reached.
+		if kq.NumRequeues(entry) >= kq.maxRetries-1 {
+			kq.setError(err)
+			kq.ShutDown()
+			return
+		}
+
+		// Can still retry processing it. Add it back to the queue
+		// after a delay.
+		go kq.AddRateLimited(entry)
+	} else {
+		// As the object was processed successfully we can "forget" it.
+		// This clears any rate limiter state associated with this object, so
+		// it won't be throttled based on previous failure history.
+		kq.Forget(entry)
+	}
+}
+
+type queueEntry interface {
+	isQueueEntry()
+}
+
+type syncEntry struct{}
+
+func (syncEntry) isQueueEntry() {}
+
+type updateEntry struct {
+	key Key
+}
+
+func (updateEntry) isQueueEntry() {}
+
+type deleteEntry struct {
+	key Key
+	obj any
+}
+
+func (deleteEntry) isQueueEntry() {}

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package resource
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/cilium/cilium/pkg/hive"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/stream"
+)
+
+func testStore(t *testing.T, node *corev1.Node, store Store[*corev1.Node]) {
+	var (
+		item   *corev1.Node
+		exists bool
+		err    error
+	)
+
+	check := func() {
+		if err != nil {
+			t.Fatalf("unexpected error from GetByKey: %s", err)
+		}
+		if !exists {
+			t.Fatalf("GetByKey returned exists=false")
+		}
+		if item.Name != node.ObjectMeta.Name {
+			t.Fatalf("expected item returned by GetByKey to have name %s, got %s",
+				node.ObjectMeta.Name, item.ObjectMeta.Name)
+		}
+	}
+	item, exists, err = store.GetByKey(Key{Name: node.ObjectMeta.Name})
+	check()
+	item, exists, err = store.Get(node)
+	check()
+
+	keys := []Key{}
+	iter := store.IterKeys()
+	for iter.Next() {
+		keys = append(keys, iter.Key())
+	}
+
+	if len(keys) != 1 && keys[0].Name != "some-node" {
+		t.Fatalf("unexpected keys: %#v", keys)
+	}
+
+	items := store.List()
+	if len(items) != 1 && items[0].ObjectMeta.Name != "some-node" {
+		t.Fatalf("unexpected items: %#v", items)
+	}
+}
+
+func TestResourceWithFakeClient(t *testing.T) {
+	var node = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "some-node",
+			ResourceVersion: "0",
+		},
+		Status: corev1.NodeStatus{
+			Phase: "init",
+		},
+	}
+
+	runTestWithNodesResource(t, func(app *fxtest.App, res Resource[*corev1.Node], cs *k8sClient.FakeClientset) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		// Create the initial version of the node.
+		cs.KubernetesFakeClientset.Tracker().Create(
+			corev1.SchemeGroupVersion.WithResource("nodes"),
+			node, "")
+
+		errs := make(chan error, 1)
+		xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, res)
+
+		app.RequireStart()
+
+		// First event should be the node (initial set)
+		(<-xs).Handle(
+			func(_ Store[*corev1.Node]) error {
+				t.Fatal("unexpected sync")
+				return nil
+			},
+			func(key Key, node *corev1.Node) error {
+				if key.String() != "some-node" {
+					t.Fatalf("unexpected update of %s", key)
+				}
+				if node.GetName() != "some-node" {
+					t.Fatalf("unexpected node name: %#v", node)
+				}
+				if node.Status.Phase != "init" {
+					t.Fatalf("unexpected status in node, expected \"init\", got: %s", node.Status.Phase)
+				}
+				return nil
+			},
+			func(key Key, node *corev1.Node) error {
+				t.Fatalf("unexpected delete of %s", key)
+				return nil
+			},
+		)
+
+		// Second should be a sync.
+		(<-xs).Handle(
+			func(s Store[*corev1.Node]) error {
+				testStore(t, node, s)
+				return nil
+			},
+			func(key Key, node *corev1.Node) error {
+				t.Fatalf("unexpected update of %s", key)
+				return nil
+			},
+			func(key Key, node *corev1.Node) error {
+				t.Fatalf("unexpected delete of %s", key)
+				return nil
+			},
+		)
+
+		// After sync event we can also use Store() with it blocking.
+		store, err := res.Store(ctx)
+		if err != nil {
+			t.Fatalf("expected non-nil error from Store(), got: %q", err)
+		}
+		testStore(t, node, store)
+
+		// Update the node and check the update event
+		node.Status.Phase = "update1"
+		node.ObjectMeta.ResourceVersion = "1"
+		cs.KubernetesFakeClientset.Tracker().Update(
+			corev1.SchemeGroupVersion.WithResource("nodes"),
+			node, "")
+		(<-xs).Handle(
+			func(_ Store[*corev1.Node]) error {
+				t.Fatalf("unexpected sync")
+				return nil
+			},
+			func(key Key, node *corev1.Node) error {
+				if key.String() != "some-node" {
+					t.Fatalf("unexpected update of %s", key)
+				}
+				if node.Status.Phase != "update1" {
+					t.Fatalf("unexpected status in node, expected \"update1\", got: %s", node.Status.Phase)
+				}
+				return nil
+			},
+			func(key Key, node *corev1.Node) error {
+				t.Fatalf("unexpected delete")
+				return nil
+			},
+		)
+
+		// Finally delete the node
+		cs.KubernetesFakeClientset.Tracker().Delete(
+			corev1.SchemeGroupVersion.WithResource("nodes"),
+			"", "some-node")
+		(<-xs).Handle(
+			func(_ Store[*corev1.Node]) error {
+				t.Fatalf("unexpected sync")
+				return nil
+			},
+			func(key Key, node *corev1.Node) error {
+				t.Fatalf("unexpected update of %s: %s", key, node)
+				return nil
+			},
+			func(key Key, node *corev1.Node) error {
+				if key.String() != "some-node" {
+					t.Fatalf("unexpected key in delete of node: %s", key)
+				}
+				if node.ResourceVersion != "1" {
+					t.Fatalf("unexpected version at delete, expected 1, got %q", node.ResourceVersion)
+				}
+				return nil
+			},
+		)
+
+		// Cancel the subscriber context and verify that the stream gets completed.
+		cancel()
+
+		// No more events should be observed.
+		ev, ok := <-xs
+		if ok {
+			t.Fatalf("unexpected event still in stream: %v", ev)
+		}
+
+		// Stream should complete without errors
+		err = <-errs
+		if err != nil {
+			t.Fatalf("expected nil error, got %s", err)
+		}
+
+		// Finally check that the app stops correctly. Note that we're not doing this in a
+		// defer to avoid potentially deadlocking on the Fatal calls.
+		app.RequireStop()
+	})
+}
+
+func TestResourceCompletionOnStop(t *testing.T) {
+	runTestWithNodesResource(t, func(app *fxtest.App, res Resource[*corev1.Node], cs *k8sClient.FakeClientset) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		errs := make(chan error, 1)
+		xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, res)
+
+		app.RequireStart()
+
+		// We should only see a sync event
+		(<-xs).Handle(
+			func(s Store[*corev1.Node]) error {
+				return nil
+			},
+			func(key Key, node *corev1.Node) error {
+				t.Fatalf("unexpected update of %s", key)
+				return nil
+			},
+			func(key Key, node *corev1.Node) error {
+				t.Fatalf("unexpected delete of %s", key)
+				return nil
+			},
+		)
+
+		// After sync Store() should not block and should be empty.
+		store, err := res.Store(ctx)
+		if err != nil {
+			t.Fatalf("expected non-nil error from Store(), got %q", err)
+		}
+		if len(store.List()) != 0 {
+			t.Fatalf("expected empty store, got %d items", len(store.List()))
+		}
+
+		// Stop the application to stop the resource.
+		app.RequireStop()
+
+		// No event should be observed.
+		ev, ok := <-xs
+		if ok {
+			t.Fatalf("unexpected event still in stream: %v", ev)
+		}
+
+		// Stream should complete without errors
+		err = <-errs
+		if err != nil {
+			t.Fatalf("expected nil error, got %s", err)
+		}
+
+	})
+}
+
+func TestResourceSyncEventRetry(t *testing.T) {
+	runTestWithNodesResource(t, func(app *fxtest.App, res Resource[*corev1.Node], cs *k8sClient.FakeClientset) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		errs := make(chan error, 1)
+		xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, res)
+
+		app.RequireStart()
+
+		expectedErr := errors.New("sync")
+		numRetries := counter{}
+
+		for ev := range xs {
+			ev.Handle(
+				func(s Store[*corev1.Node]) error {
+					numRetries.Inc()
+					return expectedErr
+				},
+				func(key Key, node *corev1.Node) error {
+					return nil
+				},
+				func(key Key, node *corev1.Node) error {
+					t.Fatalf("unexpected delete of %s", key)
+					return nil
+				},
+			)
+		}
+
+		app.RequireStop()
+
+		if numRetries.Get() != defaultMaxRetries {
+			t.Fatalf("expected to see %d retry attempts, saw %d", defaultMaxRetries, numRetries)
+		}
+
+		err := <-errs
+		if err != expectedErr {
+			t.Fatalf("expected %q error, got %q", expectedErr, err)
+		}
+	})
+}
+
+func TestResourceSyncEventRetryOnce(t *testing.T) {
+	runTestWithNodesResource(t, func(app *fxtest.App, res Resource[*corev1.Node], cs *k8sClient.FakeClientset) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		errs := make(chan error, 1)
+		xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, res)
+
+		app.RequireStart()
+
+		expectedErr := errors.New("update")
+		numRetries := counter{}
+
+		for ev := range xs {
+			ev.Handle(
+				func(s Store[*corev1.Node]) error {
+					if numRetries.Get() == 1 {
+						cancel()
+						return nil
+					}
+					numRetries.Inc()
+					return expectedErr
+				},
+				func(key Key, node *corev1.Node) error {
+					t.Fatalf("unexpected update of %s", key)
+					return nil
+				},
+				func(key Key, node *corev1.Node) error {
+					t.Fatalf("unexpected delete of %s", key)
+					return nil
+				},
+			)
+		}
+
+		app.RequireStop()
+
+		if numRetries.Get() != 1 {
+			t.Fatalf("expected to see 1 retry attempt, saw %d", numRetries)
+		}
+
+		err := <-errs
+		if err != nil {
+			t.Fatalf("expected nil error, got %q", err)
+		}
+	})
+}
+
+func TestResourceUpdateEventRetry(t *testing.T) {
+	var node = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "some-node",
+			ResourceVersion: "0",
+		},
+		Status: corev1.NodeStatus{
+			Phase: "init",
+		},
+	}
+
+	runTestWithNodesResource(t, func(app *fxtest.App, res Resource[*corev1.Node], cs *k8sClient.FakeClientset) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		// Create the initial version of the node.
+		cs.KubernetesFakeClientset.Tracker().Create(
+			corev1.SchemeGroupVersion.WithResource("nodes"),
+			node, "")
+
+		errs := make(chan error, 1)
+		xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, res)
+
+		app.RequireStart()
+
+		expectedErr := errors.New("sync")
+		numRetries := counter{}
+
+		// Since no objects were created, we'll only see a sync event.
+		// Always return an error to force reprocessing until we hit the
+		// retry limit.
+		for ev := range xs {
+			ev.Handle(
+				func(s Store[*corev1.Node]) error {
+					return nil
+				},
+				func(key Key, node *corev1.Node) error {
+					numRetries.Inc()
+					return expectedErr
+				},
+				func(key Key, node *corev1.Node) error {
+					t.Fatalf("unexpected delete of %s", key)
+					return nil
+				},
+			)
+		}
+
+		app.RequireStop()
+
+		if numRetries.Get() != defaultMaxRetries {
+			t.Fatalf("expected to see %d retry attempts, saw %d", defaultMaxRetries, numRetries)
+		}
+
+		err := <-errs
+		if err != expectedErr {
+			t.Fatalf("expected %q error, got %q", expectedErr, err)
+		}
+	})
+}
+
+//
+// Helpers
+//
+
+func runTestWithNodesResource(t *testing.T, test func(app *fxtest.App, res Resource[*corev1.Node], cs *k8sClient.FakeClientset)) {
+	nodesLW := func(c k8sClient.Clientset) cache.ListerWatcher {
+		return utils.ListerWatcherFromTyped[*corev1.NodeList](c.CoreV1().Nodes())
+	}
+
+	var (
+		res Resource[*corev1.Node]
+		cs  *k8sClient.FakeClientset
+	)
+
+	// Create a test application with a fake clientset and the nodes resource,
+	// and pull the objects into 'res' and 'cs'.
+	testApp, err := hive.New(
+		viper.New(),
+		pflag.NewFlagSet("", pflag.ContinueOnError),
+
+		k8sClient.FakeClientCell,
+		hive.NewCell("test",
+			fx.Provide(
+				NewResourceConstructorWithRateLimiter[*corev1.Node](testRateLimiter(), nodesLW),
+			),
+			fx.Populate(&res, &cs),
+		)).TestApp(t)
+
+	if err != nil {
+		t.Fatalf("TestApp() error: %s", err)
+	}
+
+	test(testApp, res, cs)
+}
+
+type counter struct{ int64 }
+
+func (c *counter) Inc() {
+	atomic.AddInt64(&c.int64, 1)
+}
+
+func (c *counter) Get() int64 {
+	return atomic.LoadInt64(&c.int64)
+}
+
+type nopLimiter struct {
+	lock.Mutex
+	requeues map[any]int
+}
+
+func (n *nopLimiter) When(item any) time.Duration {
+	n.Lock()
+	n.requeues[item] = 0
+	n.Unlock()
+	return time.Duration(1)
+}
+func (n *nopLimiter) Forget(item any) {
+	n.Lock()
+	delete(n.requeues, item)
+	n.Unlock()
+}
+func (n *nopLimiter) NumRequeues(item any) int {
+	n.Lock()
+	defer n.Unlock()
+	return n.requeues[item]
+}
+
+// testRateLimiter is a custom rate limiter for the tests to allow testing retrying
+// without making the tests slow.
+func testRateLimiter() workqueue.RateLimiter {
+	return &nopLimiter{requeues: make(map[any]int)}
+}

--- a/pkg/k8s/resource/store.go
+++ b/pkg/k8s/resource/store.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Store is a read-only typed wrapper for cache.Store.
+type Store[T k8sRuntime.Object] interface {
+	// List returns all items currently in the store.
+	List() []T
+
+	// IterKeys returns a key iterator.
+	IterKeys() KeyIter
+
+	// Get returns the latest version by deriving the key from the given object.
+	Get(obj T) (item T, exists bool, err error)
+
+	// GetByKey returns the latest version of the object with given key.
+	GetByKey(key Key) (item T, exists bool, err error)
+}
+
+// typedStore implements Store on top of an untyped cache.Store.
+type typedStore[T k8sRuntime.Object] struct {
+	store cache.Store
+}
+
+var _ Store[*corev1.Node] = &typedStore[*corev1.Node]{}
+
+func (s *typedStore[T]) List() []T {
+	items := s.store.List()
+	result := make([]T, len(items))
+	for i := range items {
+		result[i] = items[i].(T)
+	}
+	return result
+}
+
+func (s *typedStore[T]) IterKeys() KeyIter {
+	return &keyIterImpl{keys: s.store.ListKeys(), pos: -1}
+}
+
+func (s *typedStore[T]) Get(obj T) (item T, exists bool, err error) {
+	return s.GetByKey(NewKey(obj))
+}
+
+func (s *typedStore[T]) GetByKey(key Key) (item T, exists bool, err error) {
+	var itemAny any
+	itemAny, exists, err = s.store.GetByKey(key.String())
+	if exists {
+		item = itemAny.(T)
+	}
+	return
+}
+
+type KeyIter interface {
+	// Next returns true if there is a key, false if iteration has finished.
+	Next() bool
+	Key() Key
+}
+
+type keyIterImpl struct {
+	keys []string
+	pos  int
+}
+
+func (it *keyIterImpl) Next() bool {
+	it.pos++
+	return it.pos < len(it.keys)
+}
+
+func (it *keyIterImpl) Key() Key {
+	ns, name, _ := cache.SplitMetaNamespaceKey(it.keys[it.pos])
+	// ignoring error from SplitMetaNamespaceKey as the string is from
+	// the cache.
+	return Key{Namespace: ns, Name: name}
+}

--- a/pkg/logging/fx_logger.go
+++ b/pkg/logging/fx_logger.go
@@ -46,18 +46,36 @@ func (log *FxLogger) PrintObjects() {
 	slices.SortFunc(log.ctors, func(a, b *fxevent.Provided) bool {
 		return a.ModuleName < b.ModuleName || (a.ModuleName == b.ModuleName && a.ConstructorName < b.ConstructorName)
 	})
-	fmt.Print("Constructors:\n\n")
+	// Collapse constructors by ModuleName
+	ctorsByModule := make(map[string][]*fxevent.Provided)
 	for _, ctor := range log.ctors {
-		if ctor.ModuleName != "" {
-			fmt.Printf("  🛠️  %s (%s):\n", ctor.ModuleName, ctor.ConstructorName)
-		} else {
-			fmt.Printf("  🛠️  %s:\n", ctor.ConstructorName)
-		}
+		ctorsByModule[ctor.ModuleName] = append(ctorsByModule[ctor.ModuleName], ctor)
+	}
+
+	fmt.Print("Constructors:\n\n")
+	for _, ctor := range ctorsByModule[""] {
+		fmt.Printf("  🛠️  %s:\n", ctor.ConstructorName)
 		for _, rtype := range ctor.OutputTypeNames {
 			fmt.Printf("    • %s\n", rtype)
 		}
 		if ctor.Err != nil {
 			fmt.Printf("  ❌%s error: %s\n", ctor.ConstructorName, strings.Replace(ctor.Err.Error(), ":", ":\n\t", -1))
+		}
+		fmt.Println()
+	}
+	for modName, ctors := range ctorsByModule {
+		if modName == "" {
+			continue
+		}
+
+		fmt.Printf("  🛠️  %s:\n", modName)
+		for _, ctor := range ctors {
+			for _, rtype := range ctor.OutputTypeNames {
+				fmt.Printf("    • %s\n", rtype)
+			}
+			if ctor.Err != nil {
+				fmt.Printf("  ❌%s error: %s\n", ctor.ConstructorName, strings.Replace(ctor.Err.Error(), ":", ":\n\t", -1))
+			}
 		}
 		fmt.Println()
 	}

--- a/pkg/stream/sinks.go
+++ b/pkg/stream/sinks.go
@@ -99,7 +99,6 @@ func ToChannel[T any](ctx context.Context, errs chan<- error, src Observable[T])
 		func(err error) {
 			close(items)
 			errs <- err
-			close(errs)
 		})
 	return items
 }


### PR DESCRIPTION
The Resource[T] provides access to a Kubernetes resource as an
observable stream of events or as via a read-only Store[T]:

```
type Resource[T k8sRuntime.Object] interface {
    stream.Observable[Event[T]]
    Store(context.Context) (Store[T], error)
}
```

An event is either *SyncEvent, *UpdateEvent or *DeleteEvent. The
event can be processed synchronously with event.Handle(onSync,
onUpdate, onDelete), or asynchronously with a type switch and call
to event.Done(err). On non-nil errors from event handling the key
corresponding to the object being handled is requeued for later
processing and after retries are exhausted the stream completes with
the error from final retry.

The Store() method blocks until the resource has been synchronized with
the api-server (e.g. CachesSynced == true).  Store[T] is a wrapper around
cache.Store that only provides the methods that are safe to use (Get,
GetByKey, List, ListKeys) and that are specialized to type T.

This abstracts the management of an informer and cache behind the
`NewResourceConstructor` function that takes a cache.ListerWatcher
and provides a constructor that can be used from a cell to provide the
Resource to the application:

```
var exampleCell = hive.NewCell(
       "example",
       fx.Provide(
               // Provide `Resource[*slim_corev1.Pod]` to the application:
               resource.NewResourceConstructor(func(c k8sClient.Clientset) cache.ListerWatcher {
                       return utils.ListerWatcherFromTyped[*slim_corev1.PodList](c.Slim().CoreV1().Pods(""))
               }),
               // Use the resource:
               newExample,
       }),
)

func newExample(pods resource.Resource[*slim_corev1.Pod]) *Example {
           e := &Example{...}
           pods.Observe(e.ctx, e.onPodEvent, e.onPodsComplete)
           return e
}
func (e *Example) onPodEvent(key resource.Key, ev resource.Event[*slim_core.Pod]) error {
           // Process event ...
}
func (e *Example) onPodsComplete(err error) {
           // Handle error. We may end up here when:
           // 1. Observing context cancelled (e.g. we're stopping)
           // 2. Resource is being stopped
           // 3. Processing an event has failed after maximum number of retries.
}
```

If multiple resources are being used, it may make sense to go via channels to ensure
sequential processing and to avoid locks:

```
type Foo struct {
    ctx context.Context
    pods resource.Resource[*slim_corev1.Pod]
    services resource.Resource[*slim_corev1.Service]
}

func (f *Foo) processLoop() {
  errs := make(chan error)
  pods := stream.ToChannel(f.ctx, errs, f.pods)
  services := stream.ToChannel(f.ctx, errs, f.services)
  for {
    select {
    case ev := <-pods:
      ev.Handle(f.podsSynced, f.podUpdated, f.podsComplete)
    case ev := <-services:
      ev.Handle(f.servicesSynced, f.serviceUpdated, f.servicesComplete)
    case err := <-errs:
      // handle error by e.g. full state reset and replay etc.
    }
  }
}
```
