### PR TITLE
Generate SBOM from source and container image during release

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -92,6 +92,26 @@ jobs:
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
 
+      - name: Install Bom and generate SBOM
+        shell: bash
+        run: |
+          curl -L https://github.com/kubernetes-sigs/bom/releases/download/v0.3.0/bom-linux-amd64.tar.gz -o bom          
+          tar -xvf bom
+          ./bom generate -o sbom_source_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx \
+          --dirs=.
+          ./bom generate -o sbom_image_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx \
+          --image=quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }} 
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6
+
+      - name: Attach SBOM to container image
+        run: |
+          cosign attach sbom --sbom sbom_source_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx docker.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+          cosign attach sbom --sbom sbom_image_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx docker.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+          cosign attach sbom --sbom sbom_source_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}  
+          cosign attach sbom --sbom sbom_image_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}  
+
       - name: Image Release Digest
         shell: bash
         run: |


### PR DESCRIPTION
Add steps to generate Software Bill of Materials (SBOM) from source and container image during release and attach the SBOM reports as artifacts to container registries. SBOM helps utilize third-party components, particularly open source components, as needed, while maintaining security and complying with licensing requirements.
