### PR TITLE
Add missing egressGateway/SRV6 Go struct field align tag

### DIFF
--- a/pkg/maps/egressmap/policy.go
+++ b/pkg/maps/egressmap/policy.go
@@ -21,16 +21,16 @@ const (
 // EgressPolicyKey4 is the key of an egress policy map.
 type EgressPolicyKey4 struct {
 	// PrefixLen is full 32 bits of SourceIP + DestCIDR's mask bits
-	PrefixLen uint32
+	PrefixLen uint32 `align:"lpm_key"`
 
-	SourceIP types.IPv4
-	DestCIDR types.IPv4
+	SourceIP types.IPv4 `align:"saddr"`
+	DestCIDR types.IPv4 `align:"daddr"`
 }
 
 // EgressPolicyVal4 is the value of an egress policy map.
 type EgressPolicyVal4 struct {
-	EgressIP  types.IPv4
-	GatewayIP types.IPv4
+	EgressIP  types.IPv4 `align:"egress_ip"`
+	GatewayIP types.IPv4 `align:"gateway_ip"`
 }
 
 // egressPolicyMap is the internal representation of an egress policy map.

--- a/pkg/maps/srv6map/policy.go
+++ b/pkg/maps/srv6map/policy.go
@@ -118,18 +118,18 @@ type srv6PolicyMap struct {
 
 type PolicyKey4 struct {
 	// PrefixLen is full 32 bits of VRF ID + DestCIDR's mask bits
-	PrefixLen uint32
+	PrefixLen uint32 `align:"lpm"`
 
-	VRFID    uint32
-	DestCIDR types.IPv4
+	VRFID    uint32     `align:"vrf_id"`
+	DestCIDR types.IPv4 `align:"dst_cidr"`
 }
 
 type PolicyKey6 struct {
 	// PrefixLen is full 32 bits of VRF ID + DestCIDR's mask bits
-	PrefixLen uint32
+	PrefixLen uint32 `align:"lpm"`
 
-	VRFID    uint32
-	DestCIDR types.IPv6
+	VRFID    uint32     `align:"vrf_id"`
+	DestCIDR types.IPv6 `align:"dst_cidr"`
 }
 
 func (k *PolicyKey4) getDestCIDR() *net.IPNet {

--- a/pkg/maps/srv6map/vrf.go
+++ b/pkg/maps/srv6map/vrf.go
@@ -116,18 +116,18 @@ type srv6VRFMap struct {
 
 type VRFKey4 struct {
 	// PrefixLen is full 32 bits of VRF ID + DestCIDR's mask bits
-	PrefixLen uint32
+	PrefixLen uint32 `align:"lpm"`
 
-	SourceIP types.IPv4
-	DestCIDR types.IPv4
+	SourceIP types.IPv4 `align:"src_ip"`
+	DestCIDR types.IPv4 `align:"dst_cidr"`
 }
 
 type VRFKey6 struct {
 	// PrefixLen is full 32 bits of VRF ID + DestCIDR's mask bits
-	PrefixLen uint32
+	PrefixLen uint32 `align:"lpm"`
 
-	SourceIP types.IPv6
-	DestCIDR types.IPv6
+	SourceIP types.IPv6 `align:"src_ip"`
+	DestCIDR types.IPv6 `align:"dst_cidr"`
 }
 
 func (k *VRFKey4) getDestCIDR() *net.IPNet {


### PR DESCRIPTION
egressGateway and SRV6 C and Go struct alignment are added in alignchecker.c, 
but the Go structs are missing align tag, which is bypassed by alignchecker, 
add the missing align tag.

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Add missing egressGateway/SRV6 Go struct field align tag
```
