### PR TITLE
Support XDP Nodeport & Tunnel config

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -586,8 +586,11 @@ In case of a multi-device environment, where Cilium's device auto-detection sele
 more than a single device to expose NodePort or a user specifies multiple devices
 with ``devices``, the XDP acceleration is enabled on all devices. This means that
 each underlying device's driver must have native XDP support on all Cilium managed
-nodes. In addition, for the performance reasons we recommend kernel >= 5.5 for
+nodes. In addition, for performance reasons we recommend kernel >= 5.5 for
 the multi-device XDP acceleration.
+
+NodePort acceleration can be used with either direct routing (``tunnel=disabled``)
+or tunnel mode. Direct routing is recommended to achieve optimal performance.
 
 A list of drivers supporting native XDP can be found in the table below. The
 corresponding network driver name of an interface can be determined as follows:
@@ -807,7 +810,6 @@ In order to run XDP, large receive offload (LRO) needs to be disabled on the
 
    $ ethtool -K eth0 lro off
 
-NodePort XDP requires Cilium to run in direct routing mode (``tunnel=disabled``).
 It is recommended to use Azure IPAM for the pod IP address allocation, which
 will automatically configure your virtual network to route pod traffic correctly:
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1281,7 +1281,7 @@ out:
 	 (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) || \
 	 defined(ENABLE_MASQUERADE) || \
 	 defined(ENABLE_EGRESS_GATEWAY))
-	if ((ctx->mark & MARK_MAGIC_SNAT_DONE) != MARK_MAGIC_SNAT_DONE) {
+	if (!ctx_snat_done(ctx)) {
 		/*
 		 * handle_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1135,7 +1135,8 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 {
 	__u32 __maybe_unused vlan_id;
 
-#if defined(ENABLE_NODEPORT_ACCELERATION) && defined(ENABLE_EGRESS_GATEWAY)
+#ifdef ENABLE_NODEPORT_ACCELERATION
+#ifdef HAVE_ENCAP
 	__u32 flags = ctx_get_xfer(ctx, XFER_FLAGS);
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
@@ -1151,6 +1152,7 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 							ctx_get_xfer(ctx, XFER_ENCAP_DSTID),
 							NOT_VTEP_DST, &trace);
 	}
+#endif
 #endif
 
 	/* Filter allowed vlan id's and pass them back to kernel.

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -556,7 +556,7 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 #endif
 
 #ifdef ENABLE_NODEPORT
-	if ((ctx->mark & MARK_MAGIC_SNAT_DONE) == MARK_MAGIC_SNAT_DONE) {
+	if (ctx_snat_done(ctx)) {
 		ret = CTX_ACT_OK;
 		goto out;
 	}

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -62,9 +62,12 @@
 # endif
 #endif
 
-/* XDP to SKB transferred meta data. */
-#define XFER_PKT_NO_SVC		1 /* Skip upper service handling. */
-#define XFER_PKT_ENCAP		2 /* needs encap, tunnel info is in metadata. */
+/* XFER_FLAGS that get transferred from XDP to SKB */
+enum {
+	XFER_PKT_NO_SVC		= (1 << 0),  /* Skip upper service handling. */
+	XFER_PKT_ENCAP		= (1 << 1),  /* needs encap, tunnel info is in metadata. */
+	XFER_PKT_SNAT_DONE	= (1 << 2),  /* SNAT is done */
+};
 
 /* For use in ctx_get_xfer(), after XDP called ctx_move_xfer(). */
 enum {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -600,7 +600,7 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT_EGRESS)
-int tail_nodeport_nat_ipv6_egress(struct __ctx_buff *ctx)
+int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 {
 	const bool nat_46x64 = ctx_load_meta(ctx, CB_NAT_46X64);
 	union v6addr tmp = IPV6_DIRECT_ROUTING;

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -165,6 +165,16 @@ ctx_change_head(struct __sk_buff *ctx, __u32 head_room, __u64 flags)
 	return skb_change_head(ctx, head_room, flags);
 }
 
+static __always_inline void ctx_snat_done_set(struct __sk_buff *ctx)
+{
+	ctx->mark |= MARK_MAGIC_SNAT_DONE;
+}
+
+static __always_inline bool ctx_snat_done(struct __sk_buff *ctx)
+{
+	return (ctx->mark & MARK_MAGIC_SNAT_DONE) == MARK_MAGIC_SNAT_DONE;
+}
+
 #ifdef HAVE_ENCAP
 static __always_inline __maybe_unused int
 ctx_set_encap_info(struct __sk_buff *ctx, __u32 node_id, __u32 seclabel,

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -130,6 +130,18 @@ ctx_change_head(struct xdp_md *ctx __maybe_unused,
 	return 0; /* Only intended for SKB context. */
 }
 
+static __always_inline void ctx_snat_done_set(struct xdp_md *ctx __maybe_unused)
+{
+	/* From XDP layer, we do not go through an egress hook from
+	 * here, hence nothing to be done.
+	 */
+}
+
+static __always_inline bool ctx_snat_done(struct xdp_md *ctx __maybe_unused)
+{
+	return false;
+}
+
 #ifdef HAVE_ENCAP
 static __always_inline __maybe_unused int
 ctx_set_encap_info(struct xdp_md *ctx __maybe_unused,

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -152,17 +152,12 @@ ctx_set_encap_info(struct xdp_md *ctx __maybe_unused,
 		   __u32 dstid __maybe_unused,
 		   __u32 vni __maybe_unused, __u32 *ifindex __maybe_unused)
 {
-/* needs more work in the callers: */
-#ifdef TUNNEL_MODE
-	return DROP_INVALID;
-#else
 	ctx_store_meta(ctx, CB_ENCAP_NODEID, bpf_ntohl(node_id));
 	ctx_store_meta(ctx, CB_ENCAP_SECLABEL, seclabel);
 	ctx_store_meta(ctx, CB_ENCAP_DSTID, dstid);
 	ctx_set_xfer(ctx, XFER_PKT_ENCAP);
 
 	return CTX_ACT_OK;
-#endif /* TUNNEL_MODE */
 }
 #endif /* HAVE_ENCAP */
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -224,13 +224,6 @@ func initKubeProxyReplacementOptions() (bool, error) {
 			option.Config.NodePortMode = option.NodePortModeSNAT
 		}
 
-		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled &&
-			option.Config.TunnelingEnabled() {
-
-			return false, fmt.Errorf("Cannot use NodePort acceleration with tunneling. Either run cilium-agent with --%s=%s or --%s=%s",
-				option.NodePortAcceleration, option.NodePortAccelerationDisabled, option.TunnelName, option.TunnelDisabled)
-		}
-
 		if option.Config.NodePortMode == option.NodePortModeDSR &&
 			option.Config.LoadBalancerDSRDispatch == option.DSRDispatchIPIP {
 			if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -424,16 +424,16 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	ctx, cancel := context.WithTimeout(ctx, defaults.ExecTimeout)
 	defer cancel()
 
-	extraArgs := []string{"-Dcapture_enabled=0"}
-	if err := l.reinitializeXDPLocked(ctx, extraArgs); err != nil {
-		log.WithError(err).Fatal("Failed to compile XDP program")
-	}
-
 	prog := filepath.Join(option.Config.BpfDir, "init.sh")
 	cmd := exec.CommandContext(ctx, prog, args...)
 	cmd.Env = bpf.Environment()
 	if _, err := cmd.CombinedOutput(log, true); err != nil {
 		return err
+	}
+
+	extraArgs := []string{"-Dcapture_enabled=0"}
+	if err := l.reinitializeXDPLocked(ctx, extraArgs); err != nil {
+		log.WithError(err).Fatal("Failed to compile XDP program")
 	}
 
 	// Compile alignchecker program

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -492,6 +492,17 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			testNodePortExternal(kubectl, ni, false, false, false)
 		})
 
+		It("Tests with XDP, vxlan tunnel, SNAT and Random", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"loadBalancer.acceleration": "testing-only",
+				"loadBalancer.mode":         "snat",
+				"loadBalancer.algorithm":    "random",
+				"tunnel":                    "vxlan",
+				"devices":                   fmt.Sprintf(`'{%s}'`, ni.PrivateIface),
+			})
+			testNodePortExternal(kubectl, ni, false, false, false)
+		})
+
 		It("Tests with XDP, direct routing, SNAT and Maglev", func() {
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 				"loadBalancer.acceleration": "testing-only",


### PR DESCRIPTION
[follow-on to [the recent EgressGW + XDP work](https://github.com/cilium/cilium/pull/20837)]

In order to support XDP Nodeport acceleration in a tunnel config, the XDP Nodeport code needs to encap packets before forwarding them to a backend on a different node. As we currently can't `bpf_redirect()` to `cilium_vxlan` / `cilium_geneve` from within XDP, the datapath supports punting such packets from XDP to TC-Ingress (and then handling the redirect from there).

This patchset converts the existing TUNNEL_MODE sections in `lib/nodeport.h` to support such punting from XDP to TC-Ingress. Performance won't be as good as pure-XDP.

```release-note
XDP NodePort Acceleration can also be used for clusters in tunnel mode.
```
