### PR TITLE
daemon: Fix a nil dereference on cleanup when DNS proxy is not enabled

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -840,10 +840,12 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup,
 		bootstrapStats.fqdn.EndError(err)
 		return nil, restoredEndpoints, err
 	}
-	// This is done in preCleanup so that proxy stops serving DNS traffic before shutdown
-	cleaner.preCleanupFuncs.Add(func() {
-		proxy.DefaultDNSProxy.Cleanup()
-	})
+	if proxy.DefaultDNSProxy != nil {
+		// This is done in preCleanup so that proxy stops serving DNS traffic before shutdown
+		cleaner.preCleanupFuncs.Add(func() {
+			proxy.DefaultDNSProxy.Cleanup()
+		})
+	}
 
 	bootstrapStats.fqdn.End(true)
 

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -104,8 +104,6 @@ func (cpt *ControlPlaneTest) SetupEnvironment(modConfig func(*agentOption.Daemon
 	version.Update(cpt.clients, true)
 	k8s.SetClients(cpt.clients, cpt.clients.Slim(), cpt.clients, cpt.clients)
 
-	proxy.DefaultDNSProxy = fqdnproxy.MockFQDNProxy{}
-
 	agentOption.Config.Populate(agentCmd.Vp)
 	agentOption.Config.IdentityAllocationMode = agentOption.IdentityAllocationModeCRD
 	agentOption.Config.DryMode = true
@@ -130,6 +128,9 @@ func (cpt *ControlPlaneTest) SetupEnvironment(modConfig func(*agentOption.Daemon
 	// Apply the test specific configuration
 	modConfig(agentOption.Config, operatorOption.Config)
 
+	if agentOption.Config.EnableL7Proxy {
+		proxy.DefaultDNSProxy = fqdnproxy.MockFQDNProxy{}
+	}
 	return cpt
 }
 


### PR DESCRIPTION
The DNS proxy is only allocated if L7 proxy is enabled. The cleanup code did not check if it allocated causing a nil deref on shutdown.

controlplane test was modified to only set the mock DNS proxy when L7 proxy is enabled to reflect behavior of bootstrapFDQN and catch similar issue in the future.

Fixes: #21264
Fixes: 266f705888 ("dnsproxy: add cleanup")