### PR TITLE
gh/worklows: Add connectivity tests to DP conformance

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -192,6 +192,7 @@ jobs:
             --nodes-without-cilium=kind-worker3 --kube-proxy-replacement=strict --helm-set-string="k8sServiceHost=kind-control-plane,k8sServicePort=6443"
 
             ./cilium-cli connectivity test --datapath
+            ./cilium-cli connectivity test -t -d
 
       - name: Fetch artifacts
         if: ${{ !success() }}


### PR DESCRIPTION
To stress tests the new infrastructure even more until we have more tests in the conformance suite.

The CI passed: https://github.com/cilium/cilium/actions/runs/3096983007/jobs/5013158158