### PR TITLE
ipam: Change default rate limiting access to external APIs

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -57,8 +57,8 @@ cilium-operator-alibabacloud [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -63,8 +63,8 @@ cilium-operator-aws [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -60,8 +60,8 @@ cilium-operator-azure [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -56,8 +56,8 @@ cilium-operator-generic [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -68,8 +68,8 @@ cilium-operator [flags]
       --leader-election-lease-duration duration   Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration   Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration     Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 4)
-      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 20)
+      --limit-ipam-api-burst int                  Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                  Queries per second limit when accessing external IPAM APIs (default 4)
       --log-driver strings                        Logging endpoints to use for example syslog
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1189,6 +1189,14 @@
      - IPv6 CIDR list range to delegate to individual nodes for IPAM.
      - list
      - ``[]``
+   * - ipam.operator.externalAPILimitBurstSize
+     - The maximum burst size when rate limiting access to external APIs. Also known as the token bucket capacity.
+     - string
+     - ``20``
+   * - ipam.operator.externalAPILimitQPS
+     - The maximum queries per second when rate limiting access to external APIs. Also known as the bucket refill rate, which is used to refill the bucket up to the burst size capacity.
+     - string
+     - ``4.0``
    * - ipv4.enabled
      - Enable IPv4 support.
      - bool

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -371,6 +371,13 @@ Removed Metrics/Labels
   the feature was automatically enabled for the ``partial`` when
   ``upgradeCompatibility`` was not set or it was set to ``>= 1.8``.
 
+* The ``limit-ipam-api-burst`` and ``limit-ipam-api-qps`` default values have
+  been made more conservative to better reflect the rate limits used by cloud
+  providers. The new default values are ``limit-ipam-api-burst=20`` and
+  ``limit-ipam-api-qps=4``.
+  Use the Helm values ``ipam.operator.externalAPILimit{BurstSize,QPS}`` to
+  reconfigure if needed.
+
 New Options
 ~~~~~~~~~~~
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -400,6 +400,8 @@ eventQueueSize
 extendable
 extensibility
 extern
+externalAPILimitBurstSize
+externalAPILimitQPS
 externalIPs
 externalWorkloads
 extraArgs

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -348,6 +348,8 @@ contributors across the globe, there is almost always someone available to help.
 | ipam.operator.clusterPoolIPv6MaskSize | int | `120` | IPv6 CIDR mask size to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv6PodCIDR | string | `"fd00::/104"` | Deprecated in favor of ipam.operator.clusterPoolIPv6PodCIDRList. IPv6 CIDR range to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv6PodCIDRList | list | `[]` | IPv6 CIDR list range to delegate to individual nodes for IPAM. |
+| ipam.operator.externalAPILimitBurstSize | string | `20` | The maximum burst size when rate limiting access to external APIs. Also known as the token bucket capacity. |
+| ipam.operator.externalAPILimitQPS | string | `4.0` | The maximum queries per second when rate limiting access to external APIs. Also known as the bucket refill rate, which is used to refill the bucket up to the burst size capacity. |
 | ipv4.enabled | bool | `true` | Enable IPv4 support. |
 | ipv4NativeRoutingCIDR | string | `""` | Allows to explicitly specify the IPv4 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag. |
 | ipv6.enabled | bool | `false` | Enable IPv6 support. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -783,6 +783,13 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if .Values.ipam.operator.externalAPILimitBurstSize }}
+  limit-ipam-api-burst: {{ .Values.ipam.operator.externalAPILimitBurstSize | quote }}
+{{- end }}
+{{- if .Values.ipam.operator.externalAPILimitQPS }}
+  limit-ipam-api-qps: {{ .Values.ipam.operator.externalAPILimitQPS | quote }}
+{{- end }}
+
 {{- if .Values.enableCnpStatusUpdates }}
   disable-cnp-status-updates: {{ (not .Values.enableCnpStatusUpdates) | quote }}
 {{- else if (eq $defaultEnableCnpStatusUpdates "false") }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1156,6 +1156,15 @@ ipam:
     clusterPoolIPv6PodCIDRList: []
     # -- IPv6 CIDR mask size to delegate to individual nodes for IPAM.
     clusterPoolIPv6MaskSize: 120
+    # -- The maximum burst size when rate limiting access to external APIs.
+    # Also known as the token bucket capacity.
+    # @default -- `20`
+    externalAPILimitBurstSize: ~
+    # -- The maximum queries per second when rate limiting access to
+    # external APIs. Also known as the bucket refill rate, which is used to
+    # refill the bucket up to the burst size capacity.
+    # @default -- `4.0`
+    externalAPILimitQPS: ~
 
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1153,6 +1153,15 @@ ipam:
     clusterPoolIPv6PodCIDRList: []
     # -- IPv6 CIDR mask size to delegate to individual nodes for IPAM.
     clusterPoolIPv6MaskSize: 120
+    # -- The maximum burst size when rate limiting access to external APIs.
+    # Also known as the token bucket capacity.
+    # @default -- `20`
+    externalAPILimitBurstSize: ~
+    # -- The maximum queries per second when rate limiting access to
+    # external APIs. Also known as the bucket refill rate, which is used to
+    # refill the bucket up to the burst size capacity.
+    # @default -- `4.0`
+    externalAPILimitQPS: ~
 
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:

--- a/pkg/api/helpers/rate_limit_test.go
+++ b/pkg/api/helpers/rate_limit_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/api/metrics/mock"
+	"github.com/cilium/cilium/pkg/checker"
 )
 
 func Test(t *testing.T) {
@@ -23,14 +24,48 @@ type HelpersSuite struct{}
 
 var _ = check.Suite(&HelpersSuite{})
 
-func (e *HelpersSuite) TestRateLimit(c *check.C) {
+func (e *HelpersSuite) TestRateLimitBurst(c *check.C) {
 	metricsAPI := mock.NewMockMetrics()
-	limiter := NewApiLimiter(metricsAPI, 10.0, 4)
+	limiter := NewApiLimiter(metricsAPI, 1, 10)
 	c.Assert(limiter, check.Not(check.IsNil))
 
+	// Exhaust bucket (rate limit should not kick in)
 	for i := 0; i < 10; i++ {
 		limiter.Limit(context.TODO(), "test")
 	}
+	c.Assert(metricsAPI.RateLimit("test"), check.Equals, time.Duration(0))
 
-	c.Assert(metricsAPI.RateLimit("test"), check.Not(check.DeepEquals), time.Duration(0))
+	// Rate limit should now kick in (use an expired context to avoid waiting 1sec)
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Microsecond)
+	defer cancel()
+	limiter.Limit(ctx, "test")
+	c.Assert(metricsAPI.RateLimit("test"), check.Not(checker.Equals), time.Duration(0))
+}
+
+func (e *HelpersSuite) TestRateLimitWait(c *check.C) {
+	metricsAPI := mock.NewMockMetrics()
+	limiter := NewApiLimiter(metricsAPI, 100, 1)
+	c.Assert(limiter, check.Not(check.IsNil))
+
+	// Exhaust bucket
+	limiter.Limit(context.TODO(), "test")
+	c.Assert(metricsAPI.RateLimit("test"), checker.Equals, time.Duration(0))
+
+	// Hit rate limit 15 times. The bucket refill rate is 100 per second,
+	// meaning we expect this to take around 15 * 10 = 150 milliseconds
+	start := time.Now()
+	for i := 0; i < 15; i++ {
+		limiter.Limit(context.TODO(), "test")
+	}
+	measured := time.Since(start)
+
+	// Measured duration should be approximately the accounted duration
+	accounted := metricsAPI.RateLimit("test")
+	if measured > 2*accounted {
+		// We allow the wait to be up to 2x larger than the expected wait time
+		// to avoid flaky tests. If you are reading this because this test has
+		// been flaky despite the 100% margin of error, my recommendation
+		// is to disable this check by replacing the c.Errorf below with c.Logf
+		c.Errorf("waited longer than expected (expected %s (+/-100%%), measured %s)", accounted, measured)
+	}
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -370,10 +370,10 @@ const (
 	ParallelAllocWorkers = 50
 
 	// IPAMAPIBurst is the default burst value when rate limiting access to external APIs
-	IPAMAPIBurst = 4
+	IPAMAPIBurst = 20
 
 	// IPAMAPIQPSLimit is the default QPS limit when rate limiting access to external APIs
-	IPAMAPIQPSLimit = 20.0
+	IPAMAPIQPSLimit = 4.0
 
 	// IPAMPodCIDRAllocationThreshold is the default value for
 	// CiliumNode.Spec.IPAM.PodCIDRAllocationThreshold if no value is set


### PR DESCRIPTION
This PR addresses three issues around cloud API rate limiting in the operator (one commit per problem):

1. A bug is fixed where the actual rate limit under load was half of the requested rate limit
2. A bug is fixed where the Azure IPAM did not rate limit all API calls
3. The rate limit defaults are adjusted to better reflect the rate limits of the cloud provider. See below for details.

Note: A subsequent PR will be opened to make the operator more robust in case of failiures, such as the operator leaking resources when rate limits are being hint. But since those changes are largely unrelated to the rate limit logic itself (e.g. the operator can also leak resources when crashing etc), I decided to keep the two PRs separate.

---

### New IPAM cloud provider API rate limits

When provisioning network interfaces and IP addresses for Cilium ENI, Azure or
AlibabaCloud IPAM, the operator has to issue requests to the cloud provider API.
Those requests might be subject to throttling if the operator issues too many
requests in a short time window (which an for example happen if many nodes are
added to the cluster at once). Users have reported that the current limits are
not enough to avoid throttling on the cloud provider. If throttling occurs,
some operations (like interface deletion) might fail, causing potential resource
leaks.

Therefore, this commit adjusts the rate limit used by Cilium operator.
**The new limit consist of a bucket size of 20 (also called the burst size) and
a bucket refill rate (called QPS in the config flag) of 4.** The old refill rate
of 20 (effectively 10 under load, due to a bug fixed in the previous commit)
was reportedly high enough to be throttled on the Amazon EC2 API under load.

Therefore, the new refill rate of 4 queries per second (under load) is chosen
rather conservatively, to ensure we are not throttled by the backend API. To
compensate for that, the burst size is raised to 20, meaning the operator can
issue up to 20 operations before throttling to 4 queries per second kicks in.

It should be noted Cilium's rate limiter is shared for all operations
(read and write), where as cloud providers have more sophisticated per
operation quotas. But since the interaction in a real systems is likely even
more complicated than that (e.g. the quota is shared likely with other API
users too), we stick to a rather simple and conservative limit by default.

If the new default limit is too low for sophisticated or large-scale users,
it remains possible to overwrite the new default values if needed.

For reference, these are the documented API rate limits on supported cloud
providers:

Cilium Request Rate
-------------------

| Type   | Burst | RPS |
|--------|-------|-----|
| Old    |     4 |  20 |
| New    |    20 |   4 |

Amazon EC2 API [^1]
------------------

| Type   | Burst | RPS  |
|--------|-------|------|
| Reads  |   100 |   20 |
| Writes |   200 |   10 |

Azure API
---------

**Network API [^2]**

| Type   | Burst*| RPS* |
|--------|-------|------|
| Reads  |  1000 | 3.33 |
| Writes | 10000 | 33.3 |

*Estimated burst refill rate per second based on their 5 minute window.

**Compute API [^3]**

The compute API does not document what the default limits are, and it seems
like the actual setup is more sophisticated. But the rates that apply overall
seems to be in the same ballpark as the Compute API given the sample response
on the page.

Alibaba ECS API [^4]
--------------------

According to the public documentation, the limits are only visible to logged
in users. They may vary based on region and subscription. We assume they are
also in the same ballpark as the other two providers.

[^1]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html#throttling-limits
[^2]: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling#network-throttling
[^3]: https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshooting-throttling-errors
[^4]: https://www.alibabacloud.com/help/en/elastic-compute-service/latest/api-throttling