### PR TITLE
Update the cert-manager's Certificate to fully qualify the duration

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
@@ -12,5 +12,5 @@ spec:
   commonName: root
   dnsNames:
   - localhost
-  duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
+  duration: {{ printf "%dh0m0s" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
@@ -10,5 +10,5 @@ spec:
     {{- include "clustermesh-apiserver-generate-certs.certmanager.issuer" . | nindent 4 }}
   secretName: clustermesh-apiserver-client-cert
   commonName: externalworkload
-  duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
+  duration: {{ printf "%dh0m0s" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
@@ -10,5 +10,5 @@ spec:
     {{- include "clustermesh-apiserver-generate-certs.certmanager.issuer" . | nindent 4 }}
   secretName: clustermesh-apiserver-remote-cert
   commonName: remote
-  duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
+  duration: {{ printf "%dh0m0s" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
@@ -22,5 +22,5 @@ spec:
   {{- range $ip := .Values.clustermesh.apiserver.tls.server.extraIpAddresses }}
   - {{ $ip | quote }}
   {{- end }}
-  duration: {{ printf "%dh" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
+  duration: {{ printf "%dh0m0s" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -12,5 +12,5 @@ spec:
   commonName: "*.hubble-relay.cilium.io"
   dnsNames:
   - "*.hubble-relay.cilium.io"
-  duration: {{ printf "%dh" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
+  duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -21,5 +21,5 @@ spec:
   - {{ $ip | quote }}
   {{- end }}
   {{- end }}
-  duration: {{ printf "%dh" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
+  duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -22,5 +22,5 @@ spec:
   - {{ $ip | quote }}
   {{- end }}
   {{- end }}
-  duration: {{ printf "%dh" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
+  duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -12,5 +12,5 @@ spec:
   commonName: "*.hubble-ui.cilium.io"
   dnsNames:
   - "*.hubble-ui.cilium.io"
-  duration: {{ printf "%dh" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
+  duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
 {{- end }}


### PR DESCRIPTION
.spec.duration is specified as `XXhXXmXXs` and cm's webhook will rewrite the shorter values into the full ones.

Signed-off-by: Vladimir Pouzanov <farcaller@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

This fully qualifies the duration field, thus removing the diff from argocd if cilium is managed via argocd/helm and cert-manager's webhook rewrites the Certificate resource.

```release-note
Update the cert-manager's Certificate to fully qualify the duration
```
