### PR TITLE
Fixed CCNP garbage collection

### DIFF
--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -384,6 +384,9 @@ func runCNPNodeStatusGC(name string, clusterwide bool, clientset k8sClient.Clien
 						cnpItemsList = make([]cilium_v2.CiliumNetworkPolicy, 0)
 						for _, ccnp := range ccnpList.Items {
 							cnpItemsList = append(cnpItemsList, cilium_v2.CiliumNetworkPolicy{
+								ObjectMeta: meta_v1.ObjectMeta{
+									Name: ccnp.Name,
+								},
 								Status: ccnp.Status,
 							})
 						}


### PR DESCRIPTION
<!-- Description of change -->

CCNPs are converted internally into CNPs, but `metadata.name` has been forgotten.

Fixes: https://github.com/cilium/cilium/issues/21393

```release-note
Fixed CCNP garbage collection
```
