### PR TITLE
eni: Add garbage collector for leaked ENIs

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -39,6 +39,8 @@ cilium-operator-aws [flags]
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
+      --eni-gc-interval duration                  Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
+      --eni-gc-tags map                           Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
       --excess-ip-release-delay int               Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
       --gops-port uint16                          Port for gops server to listen on (default 9891)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -44,6 +44,8 @@ cilium-operator [flags]
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
+      --eni-gc-interval duration                  Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
+      --eni-gc-tags map                           Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
       --excess-ip-release-delay int               Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
       --gops-port uint16                          Port for gops server to listen on (default 9891)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -557,6 +557,14 @@
      - Tags to apply to the newly created ENIs
      - object
      - ``{}``
+   * - eni.gcInterval
+     - Interval for garbage collection of unattached ENIs. Set to "0s" to disable.
+     - string
+     - ``"5m"``
+   * - eni.gcTags
+     - Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
+     - object
+     - ``{"io.cilium/cilium-managed":"true,"io.cilium/cluster-name":"<auto-detected>"}``
    * - eni.iamRole
      - If using IAM role for Service Accounts will not try to inject identity values from cilium-aws kubernetes secret. Adds annotation to service account if managed by Helm. See https://github.com/aws/amazon-eks-pod-identity-webhook
      - string

--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -74,6 +74,15 @@ Configuration
   additional information how to install and run Prometheus including the
   Grafana dashboard.
 
+* By default, ENIs will be tagged with the cluster name, to allow Cilium
+  Operator to garbage collect these ENIs if left dangling. The cluster name is
+  either extracted from Cilium's own ``cluster-name`` flag or from the
+  ``aws:eks:cluster-name`` tag on the operator's EC2 instance. If neither
+  cluster names are available, a static default cluster name is assumed and
+  ENI garbage collection will be performed across all such unnamed clusters.
+  You may override this behavior by setting a cluster-specific ``--eni-gc-tags``
+  tag set.
+
 Custom ENI Configuration
 ========================
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -439,6 +439,8 @@ functionalities
 fwmark
 gRPC
 gVNIC
+gcInterval
+gcTags
 gcc
 gcloud
 gcp

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -190,6 +190,8 @@ contributors across the globe, there is almost always someone available to help.
 | eni.ec2APIEndpoint | string | `""` | EC2 API endpoint to use |
 | eni.enabled | bool | `false` | Enable Elastic Network Interface (ENI) integration. |
 | eni.eniTags | object | `{}` | Tags to apply to the newly created ENIs |
+| eni.gcInterval | string | `"5m"` | Interval for garbage collection of unattached ENIs. Set to "0s" to disable. |
+| eni.gcTags | object | `{"io.cilium/cilium-managed":"true,"io.cilium/cluster-name":"<auto-detected>"}` | Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected |
 | eni.iamRole | string | `""` | If using IAM role for Service Accounts will not try to inject identity values from cilium-aws kubernetes secret. Adds annotation to service account if managed by Helm. See https://github.com/aws/amazon-eks-pod-identity-webhook |
 | eni.instanceTagsFilter | list | `[]` | Filter via AWS EC2 Instance tags (k=v) which will dictate which AWS EC2 Instances are going to be used to create new ENIs |
 | eni.subnetIDsFilter | list | `[]` | Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -417,6 +417,12 @@ data:
   instance-tags-filter: {{ .Values.eni.instanceTagsFilter | join " " | quote }}
 {{- end }}
 {{- end }}
+{{ if .Values.eni.gcInterval }}
+  eni-gc-interval: {{ .Values.eni.gcInterval | quote }}
+{{- end }}
+{{ if .Values.eni.gcTags }}
+  eni-gc-tags: {{ .Values.eni.gcTags | toRawJson | quote }}
+{{- end }}
 
 {{- if .Values.azure.enabled }}
   enable-endpoint-routes: "true"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -604,6 +604,13 @@ eni:
   ec2APIEndpoint: ""
   # -- Tags to apply to the newly created ENIs
   eniTags: {}
+  # -- Interval for garbage collection of unattached ENIs. Set to "0s" to disable.
+  # @default -- `"5m"`
+  gcInterval: ""
+  # -- Additional tags attached to ENIs created by Cilium.
+  # Dangling ENIs with this tag will be garbage collected
+  # @default -- `{"io.cilium/cilium-managed":"true,"io.cilium/cluster-name":"<auto-detected>"}`
+  gcTags: {}
   # -- If using IAM role for Service Accounts will not try to
   # inject identity values from cilium-aws kubernetes secret.
   # Adds annotation to service account if managed by Helm.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -601,6 +601,13 @@ eni:
   ec2APIEndpoint: ""
   # -- Tags to apply to the newly created ENIs
   eniTags: {}
+  # -- Interval for garbage collection of unattached ENIs. Set to "0s" to disable.
+  # @default -- `"5m"`
+  gcInterval: ""
+  # -- Additional tags attached to ENIs created by Cilium.
+  # Dangling ENIs with this tag will be garbage collected
+  # @default -- `{"io.cilium/cilium-managed":"true,"io.cilium/cluster-name":"<auto-detected>"}`
+  gcTags: {}
   # -- If using IAM role for Service Accounts will not try to
   # inject identity values from cilium-aws kubernetes secret.
   # Adds annotation to service account if managed by Helm.

--- a/operator/cmd/provider_aws_flags.go
+++ b/operator/cmd/provider_aws_flags.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -35,6 +36,14 @@ func init() {
 	flags.Var(option.NewNamedMapOptions(operatorOption.ENITags, &operatorOption.Config.ENITags, nil),
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(Vp, operatorOption.ENITags)
+
+	flags.Var(option.NewNamedMapOptions(operatorOption.ENIGarbageCollectionTags, &operatorOption.Config.ENIGarbageCollectionTags, nil),
+		operatorOption.ENIGarbageCollectionTags, "Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected")
+	option.BindEnv(Vp, operatorOption.ENIGarbageCollectionTags)
+
+	flags.Duration(operatorOption.ENIGarbageCollectionInterval, defaults.ENIGarbageCollectionInterval,
+		"Interval for garbage collection of unattached ENIs. Set to 0 to disable")
+	option.BindEnv(Vp, operatorOption.ENIGarbageCollectionInterval)
 
 	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
 	option.BindEnv(Vp, operatorOption.UpdateEC2AdapterLimitViaAPI)

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -103,9 +103,9 @@ func NewSubnetsFilters(tags map[string]string, ids []string) []ec2_types.Filter 
 	return filters
 }
 
-// NewInstancsFilters transforms a map of tags and values
-// into a slice of ec2.Filter adequate to filter AWS Instances.
-func NewInstancesFilters(tags map[string]string) []ec2_types.Filter {
+// NewTagsFilter transforms a map of tags and values
+// into a slice of ec2.Filter adequate to filter resources based on tags.
+func NewTagsFilter(tags map[string]string) []ec2_types.Filter {
 	filters := make([]ec2_types.Filter, 0, len(tags))
 
 	for k, v := range tags {

--- a/pkg/aws/ec2/ec2_test.go
+++ b/pkg/aws/ec2/ec2_test.go
@@ -103,7 +103,7 @@ func TestNewSubnetsFilters(t *testing.T) {
 	}
 }
 
-func TestNewInstancesFilters(t *testing.T) {
+func TestNewTagsFilters(t *testing.T) {
 	type args struct {
 		tags map[string]string
 	}
@@ -140,11 +140,11 @@ func TestNewInstancesFilters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewInstancesFilters(tt.args.tags)
+			got := NewTagsFilter(tt.args.tags)
 			sort.Sort(Filters(got))
 			sort.Sort(Filters(tt.want))
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewInstancesFilters() = %v, want %v", got, tt.want)
+				t.Errorf("NewTagsFilter() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -321,6 +321,20 @@ func (e *API) ModifyNetworkInterface(ctx context.Context, eniID, attachmentID st
 	return nil
 }
 
+func (e *API) GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.Tags, maxResults int32) ([]string, error) {
+	result := make([]string, 0, int(maxResults))
+	for _, eni := range e.unattached {
+		if ipamTypes.Tags(eni.Tags).Match(tags) {
+			result = append(result, eni.ID)
+		}
+
+		if len(result) >= int(maxResults) {
+			break
+		}
+	}
+	return result, nil
+}
+
 func (e *API) AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) error {
 	e.rateLimit()
 	e.delaySim.Delay(AssignPrivateIpAddresses)

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -249,13 +249,17 @@ func (e *API) DeleteNetworkInterface(ctx context.Context, eniID string) error {
 		return err
 	}
 
-	delete(e.unattached, eniID)
+	if _, ok := e.unattached[eniID]; ok {
+		delete(e.unattached, eniID)
+		return nil
+	}
+
 	for _, enis := range e.enis {
 		if _, ok := enis[eniID]; ok {
-			delete(enis, eniID)
-			return nil
+			return fmt.Errorf("ENI ID %s is attached and cannot be deleted", eniID)
 		}
 	}
+
 	return fmt.Errorf("ENI ID %s not found", eniID)
 }
 
@@ -286,6 +290,21 @@ func (e *API) AttachNetworkInterface(ctx context.Context, index int32, instanceI
 	e.enis[instanceID][eniID] = eni
 
 	return "", nil
+}
+
+func (e *API) DetachNetworkInterface(ctx context.Context, instanceID, eniID string) error {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	if enis, ok := e.enis[instanceID]; ok {
+		if eni, ok := enis[eniID]; ok {
+			delete(e.enis[instanceID], eniID)
+			e.unattached[eniID] = eni
+			return nil
+		}
+	}
+
+	return fmt.Errorf("ENI ID %s is not attached to instance %s", eniID, instanceID)
 }
 
 func (e *API) ModifyNetworkInterface(ctx context.Context, eniID, attachmentID string, deleteOnTermination bool) error {

--- a/pkg/aws/ec2/mock/mock_test.go
+++ b/pkg/aws/ec2/mock/mock_test.go
@@ -52,12 +52,23 @@ func (e *MockSuite) TestMock(c *check.C) {
 	_, ok = api.enis["i-1"][eniID2]
 	c.Assert(ok, check.Equals, true)
 
-	err = api.DeleteNetworkInterface(context.TODO(), eniID1)
-	c.Assert(err, check.IsNil)
-
+	// Attached ENIs cannot be deleted
 	err = api.DeleteNetworkInterface(context.TODO(), eniID1)
 	c.Assert(err, check.Not(check.IsNil))
 
+	// Detach and delete ENI
+	err = api.DetachNetworkInterface(context.TODO(), "i-1", eniID1)
+	c.Assert(err, check.IsNil)
+	err = api.DeleteNetworkInterface(context.TODO(), eniID1)
+	c.Assert(err, check.IsNil)
+
+	// ENIs cannot be deleted twice
+	err = api.DeleteNetworkInterface(context.TODO(), eniID1)
+	c.Assert(err, check.Not(check.IsNil))
+
+	// Detach and delete ENI
+	err = api.DetachNetworkInterface(context.TODO(), "i-1", eniID2)
+	c.Assert(err, check.IsNil)
 	err = api.DeleteNetworkInterface(context.TODO(), eniID2)
 	c.Assert(err, check.IsNil)
 

--- a/pkg/aws/eni/eni_gc.go
+++ b/pkg/aws/eni/eni_gc.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package eni
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/ipam/types"
+)
+
+const gcENIControllerName = "ipam-eni-gc"
+
+var controllerManager = controller.NewManager()
+
+type GarbageCollectionParams struct {
+	// RunInterval is both the GC interval and also the minimum amount of time
+	// an ENI has to be available before it is garbage collected
+	RunInterval time.Duration
+	// MaxPerInterval is the maximum number of ENIs which are deleted in a
+	// single interval
+	MaxPerInterval int32
+	// ENITags is used to only garbage collect ENIs with this set of tags
+	ENITags types.Tags
+}
+
+func StartENIGarbageCollector(ctx context.Context, api EC2API, params GarbageCollectionParams) {
+	log.Info("Starting to garbage collect detached ENIs")
+
+	var enisMarkedForDeletion []string
+	controllerManager.UpdateController(gcENIControllerName, controller.ControllerParams{
+		DoFunc: func(ctx context.Context) error {
+			// Unfortunately, the EC2 API does not allow us to determine the age of
+			// a network interface. To mitigate a race where Cilium just created a new
+			// ENI to be attached to a node, we wait for one run interval before we delete
+			// any ENIs. If the interface has been attached by the next run interval,
+			// the deletion will fail and the interface will not be garbage collected.
+			for _, eniID := range enisMarkedForDeletion {
+				log.WithField("eniID", eniID).Debug("Garbage collecting ENI")
+				err := api.DeleteNetworkInterface(ctx, eniID)
+				if err != nil {
+					log.WithError(err).Debug("Failed to garbage collect ENI")
+				}
+			}
+
+			var err error
+			enisMarkedForDeletion, err = api.GetDetachedNetworkInterfaces(ctx, params.ENITags, params.MaxPerInterval)
+			if err != nil {
+				return fmt.Errorf("failed to fetch available interfaces: %w", err)
+			}
+
+			if numENIs := len(enisMarkedForDeletion); numENIs > 0 {
+				log.WithField("numInterfaces", numENIs).
+					Debug("Marked unattached interfaces for garbage collection")
+			}
+
+			return nil
+		},
+		RunInterval: params.RunInterval,
+		Context:     ctx,
+	})
+}

--- a/pkg/aws/eni/eni_gc_test.go
+++ b/pkg/aws/eni/eni_gc_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package eni
+
+import (
+	"context"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	ec2mock "github.com/cilium/cilium/pkg/aws/ec2/mock"
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/logging"
+)
+
+func waitForControllerRun(c *check.C, controller *controller.Manager, name string, expectedCount int64) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for {
+		status := controller.GetStatusModel()
+		for _, st := range status {
+			if st.Name == name && st.Status.SuccessCount == expectedCount {
+				return
+			}
+		}
+
+		select {
+		case <-inctimer.After(10 * time.Millisecond):
+			continue
+		case <-ctx.Done():
+			c.Errorf("timed out waiting for controller %q to reach %d successful runs", name, expectedCount)
+			break
+		}
+	}
+}
+
+func (e *ENISuite) TestStartENIGarbageCollector(c *check.C) {
+	level := logging.GetLevel(logging.DefaultLogger)
+	logging.SetLogLevelToDebug()
+	defer logging.SetLogLevel(level)
+
+	tags := map[string]string{
+		"cilium-managed": "true",
+	}
+
+	ec2api := ec2mock.NewAPI(subnets, vpcs, securityGroups)
+	c.Assert(ec2api, check.Not(check.IsNil))
+
+	untaggedENIs := map[string]bool{}
+	for i := 0; i < 8; i++ {
+		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "subnet-1", "desc", []string{"sg-1", "sg-2"}, false)
+		c.Assert(err, check.IsNil)
+		untaggedENIs[eniID] = true
+	}
+
+	createTaggedENI := func() string {
+		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "subnet-2", "desc", []string{"sg-1", "sg-2"}, false)
+		c.Assert(err, check.IsNil)
+		err = ec2api.TagENI(context.TODO(), eniID, tags)
+		c.Assert(err, check.IsNil)
+		return eniID
+	}
+	for i := 0; i < 8; i++ {
+		createTaggedENI()
+	}
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	StartENIGarbageCollector(ctx, ec2api, GarbageCollectionParams{
+		RunInterval:    0, // for testing, we're triggering the controller manually
+		MaxPerInterval: 4,
+		ENITags:        tags,
+	})
+
+	waitForControllerRun(c, controllerManager, gcENIControllerName, 1)
+
+	// after the first run, no ENIs should have been deleted
+	enis, err := ec2api.GetDetachedNetworkInterfaces(context.TODO(), nil, 25)
+	c.Assert(err, check.IsNil)
+	c.Assert(enis, check.HasLen, 16)
+
+	// Delete first batch of ENIs (4 ENIs should be deleted)
+	controllerManager.TriggerController(gcENIControllerName)
+	waitForControllerRun(c, controllerManager, gcENIControllerName, 2)
+
+	enis, err = ec2api.GetDetachedNetworkInterfaces(context.TODO(), nil, 25)
+	c.Assert(err, check.IsNil)
+	c.Assert(enis, check.HasLen, 12)
+
+	// Create a new unattached ENI (it should _not_ be deleted in the next round)
+	newENI := createTaggedENI()
+
+	// Trigger deletion of second batch of ENIs (4 ENIs should be deleted)
+	controllerManager.TriggerController(gcENIControllerName)
+	waitForControllerRun(c, controllerManager, gcENIControllerName, 3)
+
+	// Now 8 untagged and 1 newENI should be the only ENIs left
+	enis, err = ec2api.GetDetachedNetworkInterfaces(context.TODO(), nil, 25)
+	c.Assert(err, check.IsNil)
+	c.Assert(enis, check.HasLen, 9)
+	for _, eni := range enis {
+		if eni != newENI && !untaggedENIs[eni] {
+			c.Errorf("ENI not garbage collected: %s", eni)
+		}
+	}
+
+	// Attach newENI, this means it can no longer be garbage collected
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 1, "i-1", newENI)
+	c.Assert(err, check.IsNil)
+
+	controllerManager.TriggerController(gcENIControllerName)
+	waitForControllerRun(c, controllerManager, gcENIControllerName, 4)
+
+	// All remaining ENIs should be unattached ones
+	enis, err = ec2api.GetDetachedNetworkInterfaces(context.TODO(), nil, 25)
+	c.Assert(err, check.IsNil)
+	c.Assert(enis, check.HasLen, 8)
+	for _, eni := range enis {
+		if !untaggedENIs[eni] {
+			c.Errorf("ENI not garbage collected: %s", eni)
+		}
+	}
+
+	// Check the attached ENI still exists
+	ec2api.TagENI(context.TODO(), newENI, tags)
+	c.Assert(err, check.IsNil)
+}

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -24,6 +24,7 @@ type EC2API interface {
 	GetSubnets(ctx context.Context) (ipamTypes.SubnetMap, error)
 	GetVpcs(ctx context.Context) (ipamTypes.VirtualNetworkMap, error)
 	GetSecurityGroups(ctx context.Context) (types.SecurityGroupMap, error)
+	GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.Tags, maxResults int32) ([]string, error)
 	CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes bool) (string, *eniTypes.ENI, error)
 	AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string) (string, error)
 	DeleteNetworkInterface(ctx context.Context, eniID string) error

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -842,7 +842,11 @@ func (e *ENISuite) TestInstanceBeenDeleted(c *check.C) {
 
 	// Delete all enis attached to instance, this mocks the operation of
 	// deleting the instance. The deletion should be detected.
+	err = ec2api.DetachNetworkInterface(context.TODO(), "i-testInstanceBeenDeleted-0", eniID1)
+	c.Assert(err, check.IsNil)
 	err = ec2api.DeleteNetworkInterface(context.TODO(), eniID1)
+	c.Assert(err, check.IsNil)
+	err = ec2api.DetachNetworkInterface(context.TODO(), "i-testInstanceBeenDeleted-0", eniID2)
 	c.Assert(err, check.IsNil)
 	err = ec2api.DeleteNetworkInterface(context.TODO(), eniID2)
 	c.Assert(err, check.IsNil)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -362,6 +362,25 @@ const (
 	// CiliumNode.Spec.ENI.DisablePrefixDelegation if no value is set.
 	ENIDisableNodeLevelPD = false
 
+	// ENIGarbageCollectionTagManagedName is part of the ENIGarbageCollectionTags default tag set
+	ENIGarbageCollectionTagManagedName = "io.cilium/cilium-managed"
+
+	// ENIGarbageCollectionTagManagedValue is part of the ENIGarbageCollectionTags default tag set
+	ENIGarbageCollectionTagManagedValue = "true"
+
+	// ENIGarbageCollectionTagClusterName is part of the ENIGarbageCollectionTags default tag set
+	ENIGarbageCollectionTagClusterName = "io.cilium/cluster-name"
+
+	// ENIGarbageCollectionTagClusterValue is part of the ENIGarbageCollectionTags default tag set
+	ENIGarbageCollectionTagClusterValue = ClusterName
+
+	// ENIGarbageCollectionInterval is the default interval for the ENIGarbageCollectionInterval operator flag
+	ENIGarbageCollectionInterval = 5 * time.Minute
+
+	// ENIGarbageCollectionMaxPerInterval is the maximum number of ENIs which might be garbage collected
+	// per GC interval
+	ENIGarbageCollectionMaxPerInterval = 25
+
 	// ParallelAllocWorkers is the default max number of parallel workers doing allocation in the operator
 	ParallelAllocWorkers = 50
 

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -38,7 +38,7 @@ func (a *AllocatorAWS) Init(ctx context.Context) error {
 		return err
 	}
 	subnetsFilters := ec2shim.NewSubnetsFilters(operatorOption.Config.IPAMSubnetsTags, operatorOption.Config.IPAMSubnetsIDs)
-	instancesFilters := ec2shim.NewInstancesFilters(operatorOption.Config.IPAMInstanceTags)
+	instancesFilters := ec2shim.NewTagsFilter(operatorOption.Config.IPAMInstanceTags)
 
 	if operatorOption.Config.EnableMetrics {
 		aMetrics = apiMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, "ec2", operatorMetrics.Registry)


### PR DESCRIPTION
This PR adds a new garbage collector for leaked ENIs. ENIs might be
leaked if the operator is unable to perform an ENI delete operation, for
example because the EC2 API is (temporarily) unavailable or the operator
crashed before it was able to issue the delete operation.

The GC runs in a regular interval and removes any ENIs with a predefined
set of tags. The tags are added to newly created ENIs, meaning this GC
does not remove any ENIs created by older versions of Cilium. This is
done to avoid removing any ENIs which were never managed by Cilium.

The tags used for ENI creation and deletion, as well as the GC interval,
can both be configured using operator flags. If the GC interval is set
to zero, the ENI GC is disabled.

**Review per commit**