### PR TITLE
docs: Add cilium overview to internals section

### DIFF
--- a/Documentation/internals/index.rst
+++ b/Documentation/internals/index.rst
@@ -12,6 +12,7 @@ Internals
 .. toctree::
    :maxdepth: 1
 
+   ../contributing/development/codeoverview
    hubble
    cilium_operator
    security-identities


### PR DESCRIPTION
This was previously only linked from the development guide, but it also
lists general internals details for cilium & hubble. Make it easier to
find by also including it in the toctree from the internals page.
