### PR TITLE
daemon: Remove SelectiveRegeneration option

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -871,10 +871,6 @@ func initializeFlags() {
 	flags.MarkHidden(option.EndpointGCInterval)
 	option.BindEnv(Vp, option.EndpointGCInterval)
 
-	flags.Bool(option.SelectiveRegeneration, true, "only regenerate endpoints which need to be regenerated upon policy changes")
-	flags.MarkHidden(option.SelectiveRegeneration)
-	option.BindEnv(Vp, option.SelectiveRegeneration)
-
 	flags.String(option.WriteCNIConfigurationWhenReady, "", fmt.Sprintf("Write the CNI configuration as specified via --%s to path when agent is ready", option.ReadCNIConfiguration))
 	option.BindEnv(Vp, option.WriteCNIConfigurationWhenReady)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -271,10 +271,6 @@ const (
 	// EndpointQueueSize is the default queue size for an endpoint.
 	EndpointQueueSize = 25
 
-	// SelectiveRegeneration specifies whether regeneration of endpoints will be
-	// invoked only for endpoints which are selected by policy changes.
-	SelectiveRegeneration = true
-
 	// K8sSyncTimeout specifies the default time to wait after the last event
 	// of a Kubernetes resource type before timing out while waiting for synchronization.
 	K8sSyncTimeout = 3 * time.Minute

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -777,10 +777,6 @@ const (
 	// endpoints that are no longer alive and healthy.
 	EndpointGCInterval = "endpoint-gc-interval"
 
-	// SelectiveRegeneration specifies whether only the endpoints which policy
-	// changes select should be regenerated upon policy changes.
-	SelectiveRegeneration = "enable-selective-regeneration"
-
 	// K8sEventHandover is the name of the K8sEventHandover option
 	K8sEventHandover = "enable-k8s-event-handover"
 
@@ -1773,13 +1769,6 @@ type DaemonConfig struct {
 	// endpoints that are no longer alive and healthy.
 	EndpointGCInterval time.Duration
 
-	// SelectiveRegeneration, when true, enables the functionality to only
-	// regenerate endpoints which are selected by the policy rules that have
-	// been changed (added, deleted, or updated). If false, then all endpoints
-	// are regenerated upon every policy change regardless of the scope of the
-	// policy change.
-	SelectiveRegeneration bool
-
 	// ConntrackGCInterval is the connection tracking garbage collection
 	// interval
 	ConntrackGCInterval time.Duration
@@ -2263,7 +2252,6 @@ var (
 		FixedIdentityMapping:         make(map[string]string),
 		KVStoreOpt:                   make(map[string]string),
 		LogOpt:                       make(map[string]string),
-		SelectiveRegeneration:        defaults.SelectiveRegeneration,
 		LoopbackIPv4:                 defaults.LoopbackIPv4,
 		ForceLocalPolicyEvalAtSource: defaults.ForceLocalPolicyEvalAtSource,
 		EnableEndpointRoutes:         defaults.EnableEndpointRoutes,
@@ -3206,7 +3194,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.PolicyQueueSize = sanitizeIntParam(vp, PolicyQueueSize, defaults.PolicyQueueSize)
 	c.EndpointQueueSize = sanitizeIntParam(vp, EndpointQueueSize, defaults.EndpointQueueSize)
 	c.EndpointGCInterval = vp.GetDuration(EndpointGCInterval)
-	c.SelectiveRegeneration = vp.GetBool(SelectiveRegeneration)
 	c.DisableCNPStatusUpdates = vp.GetBool(DisableCNPStatusUpdates)
 	c.EnableICMPRules = vp.GetBool(EnableICMPRules)
 	c.BypassIPAvailabilityUponRestore = vp.GetBool(BypassIPAvailabilityUponRestore)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -437,12 +437,6 @@ func (p *Repository) Iterate(f func(rule *api.Rule)) {
 // provided EndpointSet. The provided WaitGroup is signaled for a given endpoint
 // when it is finished being processed.
 func (r ruleSlice) UpdateRulesEndpointsCaches(endpointsToBumpRevision, endpointsToRegenerate *EndpointSet, policySelectionWG *sync.WaitGroup) {
-	// No need to check whether endpoints need to be regenerated here since we
-	// will unconditionally regenerate all endpoints later.
-	if !option.Config.SelectiveRegeneration {
-		return
-	}
-
 	endpointsToBumpRevision.ForEachGo(policySelectionWG, func(epp Endpoint) {
 		endpointSelected, err := r.updateEndpointsCaches(epp)
 		if endpointSelected {


### PR DESCRIPTION
SelectiveRegeneration was a safety tool for migrating from the previous
"regenerate everything" codepaths for handling policy updates to a newer
codepath that chooses which endpoints need the policy regenerated and
only regenerates them. It's been on by default since about Cilium 1.5.0,
so at this point it's unlikely we'll ever turn it off again. It was
always hidden, so we also don't need to deprecate it before removing it.

Remove this codepath so we don't have to maintain the old path any more.
This will simplify other upcoming changes.
