### PR TITLE
policy,labels: Convert more packages to use netip library

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"path"
 	"path/filepath"
@@ -48,6 +49,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/exporter/exporteroption"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -1719,7 +1721,11 @@ func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner fx.Shutdo
 				time.Sleep(option.Config.IdentityRestoreGracePeriod)
 				log.Debugf("Releasing reference counts for %d restored CIDR identities", len(d.restoredCIDRs))
 
-				d.ipcache.ReleaseCIDRIdentitiesByCIDR(d.restoredCIDRs)
+				prefixes := make([]netip.Prefix, 0, len(d.restoredCIDRs))
+				for _, c := range d.restoredCIDRs {
+					prefixes = append(prefixes, ip.IPNetToPrefix(c))
+				}
+				d.ipcache.ReleaseCIDRIdentitiesByCIDR(prefixes)
 				// release the memory held by restored CIDRs
 				d.restoredCIDRs = nil
 			}

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	stdlog "log"
-	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -307,7 +307,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 
 	// removedPrefixes tracks prefixes that we replace in the rules. It is used
 	// after we release the policy repository lock.
-	var removedPrefixes []*net.IPNet
+	var removedPrefixes []netip.Prefix
 
 	// policySelectionWG is used to signal when the updating of all of the
 	// caches of endpoints in the rules which were added / updated have been
@@ -449,7 +449,7 @@ type PolicyReactionEvent struct {
 	endpointsToRegen  *policy.EndpointSet
 	newRev            uint64
 	upsertIdentities  map[string]*identity.Identity // deferred CIDR identity upserts, if any
-	releasePrefixes   []*net.IPNet                  // deferred CIDR identity deletes, if any
+	releasePrefixes   []netip.Prefix                // deferred CIDR identity deletes, if any
 }
 
 // Handle implements pkg/eventqueue/EventHandler interface.
@@ -466,7 +466,7 @@ func (r *PolicyReactionEvent) Handle(res chan interface{}) {
 //     in allEps, to revision rev.
 //   - wait for the regenerations to be finished
 //   - upsert or delete CIDR identities to the ipcache, as needed.
-func (d *Daemon) reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev uint64, upsertIdentities map[string]*identity.Identity, releasePrefixes []*net.IPNet) {
+func (d *Daemon) reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev uint64, upsertIdentities map[string]*identity.Identity, releasePrefixes []netip.Prefix) {
 	var enqueueWaitGroup sync.WaitGroup
 
 	// Release CIDR identities before regenerations have been started, if any. This makes sure

--- a/pkg/counter/prefixes_test.go
+++ b/pkg/counter/prefixes_test.go
@@ -7,6 +7,7 @@ package counter
 
 import (
 	"net"
+	"net/netip"
 
 	. "gopkg.in/check.v1"
 
@@ -14,12 +15,12 @@ import (
 )
 
 func (cs *CounterTestSuite) TestReferenceTracker(c *C) {
-	v4Prefixes := []*net.IPNet{
-		{Mask: net.CIDRMask(0, 32)},
-		{Mask: net.CIDRMask(15, 32)},
-		{Mask: net.CIDRMask(15, 32)},
-		{Mask: net.CIDRMask(31, 32)},
-		{Mask: net.CIDRMask(32, 32)},
+	v4Prefixes := []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/0"),
+		netip.MustParsePrefix("192.0.0.0/15"),
+		netip.MustParsePrefix("192.0.0.0/15"),
+		netip.MustParsePrefix("192.0.2.2/31"),
+		netip.MustParsePrefix("192.0.2.3/32"),
 	}
 	v4PrefixesLengths := map[int]int{
 		0:  1,
@@ -54,8 +55,8 @@ func (cs *CounterTestSuite) TestReferenceTracker(c *C) {
 
 	// Delete the /15 prefix and see that it is removed and doesn't affect
 	// other counts
-	prefixes15 := []*net.IPNet{
-		{Mask: net.CIDRMask(15, 32)},
+	prefixes15 := []netip.Prefix{
+		netip.MustParsePrefix("192.0.0.0/15"),
 	}
 	expectedPrefixLengths[15]--
 	c.Assert(result.Delete(prefixes15), Equals, false)
@@ -87,11 +88,11 @@ func (cs *CounterTestSuite) TestReferenceTracker(c *C) {
 	c.Assert(changed, Equals, true)
 	c.Assert(result.v4, checker.DeepEquals, expectedPrefixLengths)
 
-	v6Prefixes := []*net.IPNet{
-		{Mask: net.CIDRMask(0, 128)},
-		{Mask: net.CIDRMask(76, 128)},
-		{Mask: net.CIDRMask(96, 128)},
-		{Mask: net.CIDRMask(120, 128)},
+	v6Prefixes := []netip.Prefix{
+		netip.MustParsePrefix("::/0"),
+		netip.MustParsePrefix("FD33:DEAD:BEEF:CAFE::/76"),
+		netip.MustParsePrefix("FD33:DEAD:BEEF:CAFE::/96"),
+		netip.MustParsePrefix("fd33:dead:beef:cafe::91b2:b600/120"),
 	}
 	v6PrefixesLengths := map[int]int{
 		0:   1,
@@ -146,17 +147,17 @@ func (cs *CounterTestSuite) TestCheckLimits(c *C) {
 	c.Assert(checkLimits(0, 4, result.maxUniquePrefixes6), IsNil)
 	c.Assert(checkLimits(0, 5, result.maxUniquePrefixes6), NotNil)
 
-	prefixes := []*net.IPNet{
-		{Mask: net.CIDRMask(0, 32)},
-		{Mask: net.CIDRMask(15, 32)},
-		{Mask: net.CIDRMask(31, 32)},
-		{Mask: net.CIDRMask(32, 32)},
+	prefixes := []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/0"),
+		netip.MustParsePrefix("192.0.0.0/15"),
+		netip.MustParsePrefix("192.0.2.2/31"),
+		netip.MustParsePrefix("192.0.2.3/32"),
 	}
 	changed, err := result.Add(prefixes)
 	c.Assert(err, IsNil)
 	c.Assert(changed, Equals, true)
 
-	changed, err = result.Add([]*net.IPNet{{Mask: net.CIDRMask(8, 32)}})
+	changed, err = result.Add([]netip.Prefix{netip.MustParsePrefix("192.0.0.0/8")})
 	c.Assert(err, NotNil)
 	c.Assert(changed, Equals, false)
 }
@@ -169,10 +170,9 @@ func (cs *CounterTestSuite) TestToBPFData(c *C) {
 		"192.0.2.0/32",
 		"192.0.64.0/20",
 	}
-	prefixesToAdd := []*net.IPNet{}
+	prefixesToAdd := []netip.Prefix{}
 	for _, prefix := range prefixes {
-		_, net, err := net.ParseCIDR(prefix)
-		c.Assert(err, IsNil)
+		net := netip.MustParsePrefix(prefix)
 		prefixesToAdd = append(prefixesToAdd, net)
 	}
 
@@ -185,10 +185,6 @@ func (cs *CounterTestSuite) TestToBPFData(c *C) {
 }
 
 func (cs *CounterTestSuite) TestDefaultPrefixLengthCounter(c *C) {
-	defer func() {
-		r := recover()
-		c.Assert(r, IsNil)
-	}()
 	result := DefaultPrefixLengthCounter(net.IPv6len*8, net.IPv4len*8)
 	c.Assert(result.v4[0], Equals, 1)
 	c.Assert(result.v6[0], Equals, 1)

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -6,7 +6,7 @@
 package identity
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,13 +73,11 @@ func (s *IdentityTestSuite) TestIsReservedIdentity(c *C) {
 }
 
 func (s *IdentityTestSuite) TestRequiresGlobalIdentity(c *C) {
-	_, ipnet, err := net.ParseCIDR("0.0.0.0/0")
-	c.Assert(err, IsNil)
-	c.Assert(RequiresGlobalIdentity(cidr.GetCIDRLabels(ipnet)), Equals, false)
+	prefix := netip.MustParsePrefix("0.0.0.0/0")
+	c.Assert(RequiresGlobalIdentity(cidr.GetCIDRLabels(prefix)), Equals, false)
 
-	_, ipnet, err = net.ParseCIDR("192.168.23.0/24")
-	c.Assert(err, IsNil)
-	c.Assert(RequiresGlobalIdentity(cidr.GetCIDRLabels(ipnet)), Equals, false)
+	prefix = netip.MustParsePrefix("192.168.23.0/24")
+	c.Assert(RequiresGlobalIdentity(cidr.GetCIDRLabels(prefix)), Equals, false)
 
 	c.Assert(RequiresGlobalIdentity(labels.NewLabelsFromModel([]string{"k8s:foo=bar"})), Equals, true)
 }

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -10,6 +10,8 @@ import (
 
 // ParseCIDRs fetches all CIDRs referred to by the specified slice and returns
 // them as regular golang CIDR objects.
+//
+// Deprecated. Consider using ParsePrefixes() instead.
 func ParseCIDRs(cidrs []string) (valid []*net.IPNet, invalid []string) {
 	valid = make([]*net.IPNet, 0, len(cidrs))
 	invalid = make([]string, 0, len(cidrs))
@@ -30,6 +32,29 @@ func ParseCIDRs(cidrs []string) (valid []*net.IPNet, invalid []string) {
 		}
 	}
 	return valid, invalid
+}
+
+// ParsePrefixes parses all CIDRs referred to by the specified slice and
+// returns them as regular golang netip.Prefix objects.
+func ParsePrefixes(cidrs []string) (valid []netip.Prefix, invalid []string, errors []error) {
+	valid = make([]netip.Prefix, 0, len(cidrs))
+	invalid = make([]string, 0, len(cidrs))
+	errors = make([]error, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			ip, err2 := netip.ParseAddr(cidr)
+			if err2 != nil {
+				invalid = append(invalid, cidr)
+				errors = append(errors, err2)
+				continue
+			}
+			prefix = netip.PrefixFrom(ip, ip.BitLen())
+		}
+		valid = append(valid, prefix.Masked())
+	}
+
+	return valid, invalid, errors
 }
 
 // PrefixToIPNet is a convenience helper for migrating from the older 'net'
@@ -80,4 +105,18 @@ func IPToNetPrefix(ip net.IP) netip.Prefix {
 		return netip.Prefix{}
 	}
 	return netip.PrefixFrom(a, a.BitLen())
+}
+
+// IPsToNetPrefixes returns all of the ips as a slice of netip.Prefix.
+//
+// See IPToNetPrefix() for how net.IP types are handled by this function.
+func IPsToNetPrefixes(ips []net.IP) []netip.Prefix {
+	if len(ips) == 0 {
+		return nil
+	}
+	res := make([]netip.Prefix, 0, len(ips))
+	for _, ip := range ips {
+		res = append(res, IPToNetPrefix(ip))
+	}
+	return res
 }

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -812,6 +812,8 @@ func IsPublicAddr(ip net.IP) bool {
 }
 
 // GetCIDRPrefixesFromIPs returns all of the ips as a slice of *net.IPNet.
+//
+// Deprecated. Consider using IPsToNetPrefixes() instead.
 func GetCIDRPrefixesFromIPs(ips []net.IP) []*net.IPNet {
 	if len(ips) == 0 {
 		return nil

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -59,8 +59,8 @@ func (ipc *IPCache) AllocateCIDRs(
 			continue
 		}
 
-		lbls := cidr.GetCIDRLabels(p)
 		prefix := ip.IPNetToPrefix(p)
+		lbls := cidr.GetCIDRLabels(prefix)
 		lbls.MergeLabels(ipc.metadata.get(prefix).ToLabels())
 		oldNID := identity.InvalidIdentity
 		if oldNIDs != nil && len(oldNIDs) > i {
@@ -228,7 +228,7 @@ func (ipc *IPCache) ReleaseCIDRIdentitiesByCIDR(prefixes []*net.IPNet) {
 		}
 
 		p := ip.IPNetToPrefix(prefix)
-		if id := ipc.IdentityAllocator.LookupIdentity(releaseCtx, cidr.GetCIDRLabels(prefix)); id != nil {
+		if id := ipc.IdentityAllocator.LookupIdentity(releaseCtx, cidr.GetCIDRLabels(p)); id != nil {
 			identities[p] = id
 		} else {
 			log.Errorf("Unable to find identity of previously used CIDR %s", p.String())

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	cidrlabels "github.com/cilium/cilium/pkg/labels/cidr"
@@ -405,7 +404,7 @@ func (ipc *IPCache) injectLabels(ctx context.Context, prefix netip.Prefix, lbls 
 // injectLabelsForCIDR will allocate a CIDR identity for the given prefix. The
 // release of the identity must be managed by the caller.
 func (ipc *IPCache) injectLabelsForCIDR(ctx context.Context, prefix netip.Prefix, lbls labels.Labels) (*identity.Identity, bool, error) {
-	allLbls := cidrlabels.GetCIDRLabels(ip.PrefixToIPNet(prefix))
+	allLbls := cidrlabels.GetCIDRLabels(prefix)
 	allLbls.MergeLabels(lbls)
 
 	log.WithFields(logrus.Fields{

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -103,7 +103,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.NotNil(t, id)
 	assert.Equal(t, 1, id.ReferenceCount)
 	// Simulate adding CIDR policy.
-	ids, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{net.ParseIP("1.1.1.1")}, nil)
+	ids, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{net.ParseIP("1.1.1.1").To4()}, nil)
 	assert.Nil(t, err)
 	assert.Len(t, ids, 1)
 	assert.Equal(t, 2, id.ReferenceCount)

--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -5,12 +5,10 @@ package cidr
 
 import (
 	"fmt"
-	"net"
 	"net/netip"
 	"strconv"
 	"strings"
 
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
 )
 
@@ -86,8 +84,8 @@ func IPStringToLabel(ip string) (labels.Label, error) {
 //	"cidr:0.0.0.0/2",  "cidr:0.0.0.0/1",  "cidr:0.0.0.0/0"
 //
 // The identity reserved:world is always added as it includes any CIDR.
-func GetCIDRLabels(cidr *net.IPNet) labels.Labels {
-	ones, _ := cidr.Mask.Size()
+func GetCIDRLabels(prefix netip.Prefix) labels.Labels {
+	ones := prefix.Bits()
 	result := make([]string, 0, ones+1)
 
 	// If ones is zero, then it's the default CIDR prefix /0 which should
@@ -95,10 +93,10 @@ func GetCIDRLabels(cidr *net.IPNet) labels.Labels {
 	// to generate the set of prefixes starting from the /0 up to the
 	// specified prefix length.
 	if ones > 0 {
-		ip, _ := ip.AddrFromIP(cidr.IP)
+		ip := prefix.Addr()
 		for i := 0; i <= ones; i++ {
-			prefix := netip.PrefixFrom(ip, i)
-			label := maskedIPToLabelString(prefix.Masked().Addr(), i)
+			p := netip.PrefixFrom(ip, i)
+			label := maskedIPToLabelString(p.Masked().Addr(), i)
 			result = append(result, label)
 		}
 	}

--- a/pkg/policy/cidr.go
+++ b/pkg/policy/cidr.go
@@ -4,7 +4,7 @@
 package policy
 
 import (
-	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -12,8 +12,8 @@ import (
 
 // getPrefixesFromCIDR fetches all CIDRs referred to by the specified slice
 // and returns them as regular golang CIDR objects.
-func getPrefixesFromCIDR(cidrs api.CIDRSlice) []*net.IPNet {
-	result, _ := ip.ParseCIDRs(cidrs.StringSlice())
+func getPrefixesFromCIDR(cidrs api.CIDRSlice) []netip.Prefix {
+	result, _, _ := ip.ParsePrefixes(cidrs.StringSlice())
 	return result
 }
 
@@ -21,7 +21,7 @@ func getPrefixesFromCIDR(cidrs api.CIDRSlice) []*net.IPNet {
 // and returns them as regular golang CIDR objects.
 //
 // Assumes that validation already occurred on 'rules'.
-func GetPrefixesFromCIDRSet(rules api.CIDRRuleSlice) []*net.IPNet {
+func GetPrefixesFromCIDRSet(rules api.CIDRRuleSlice) []netip.Prefix {
 	cidrs := api.ComputeResultantCIDRSet(rules)
 	return getPrefixesFromCIDR(cidrs)
 }
@@ -32,11 +32,11 @@ func GetPrefixesFromCIDRSet(rules api.CIDRRuleSlice) []*net.IPNet {
 // the CIDR in the returned slice.
 //
 // Assumes that validation already occurred on 'rules'.
-func GetCIDRPrefixes(rules api.Rules) []*net.IPNet {
+func GetCIDRPrefixes(rules api.Rules) []netip.Prefix {
 	if len(rules) == 0 {
 		return nil
 	}
-	res := make([]*net.IPNet, 0, 32)
+	res := make([]netip.Prefix, 0, 32)
 	for _, r := range rules {
 		for _, ir := range r.Ingress {
 			if len(ir.FromCIDR) > 0 {

--- a/pkg/policy/cidr_test.go
+++ b/pkg/policy/cidr_test.go
@@ -6,7 +6,7 @@
 package policy
 
 import (
-	"net"
+	"net/netip"
 
 	. "gopkg.in/check.v1"
 
@@ -25,11 +25,10 @@ func (ds *PolicyTestSuite) TestgetPrefixesFromCIDR(c *C) {
 		"::/0":         "::/0",
 		"fdff::ff":     "fdff::ff/128",
 	}
-	expected := []*net.IPNet{}
+	expected := []netip.Prefix{}
 	inputs := []api.CIDR{}
 	for ruleStr, cidr := range inputToCIDRString {
-		_, net, err := net.ParseCIDR(cidr)
-		c.Assert(err, IsNil)
+		net := netip.MustParsePrefix(cidr)
 		expected = append(expected, net)
 		inputs = append(inputs, api.CIDR(ruleStr))
 	}
@@ -69,10 +68,9 @@ func (ds *PolicyTestSuite) TestGetCIDRPrefixes(c *C) {
 		"192.0.2.0/24",
 		"192.0.3.0/24",
 	}
-	expectedCIDRs := []*net.IPNet{}
+	expectedCIDRs := []netip.Prefix{}
 	for _, ipStr := range expectedCIDRStrings {
-		_, cidr, err := net.ParseCIDR(ipStr)
-		c.Assert(err, IsNil)
+		cidr := netip.MustParsePrefix(ipStr)
 		expectedCIDRs = append(expectedCIDRs, cidr)
 	}
 	c.Assert(GetCIDRPrefixes(rules), checker.DeepEquals, expectedCIDRs)
@@ -122,10 +120,9 @@ func (ds *PolicyTestSuite) TestGetCIDRPrefixes(c *C) {
 		"10.1.0.0/16",
 		// Not "10.0.0.0/16",
 	}
-	expectedCIDRs = []*net.IPNet{}
+	expectedCIDRs = []netip.Prefix{}
 	for _, ipStr := range expectedCIDRStrings {
-		_, cidr, err := net.ParseCIDR(ipStr)
-		c.Assert(err, IsNil)
+		cidr := netip.MustParsePrefix(ipStr)
 		expectedCIDRs = append(expectedCIDRs, cidr)
 	}
 	c.Assert(GetCIDRPrefixes(rules), checker.DeepEquals, expectedCIDRs)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 
@@ -616,11 +616,11 @@ type TranslationResult struct {
 
 	// BackendPrefixes contains all egress CIDRs that are to be added
 	// for the translation.
-	PrefixesToAdd []*net.IPNet
+	PrefixesToAdd []netip.Prefix
 
 	// BackendPrefixes contains all egress CIDRs that are to be removed
 	// for the translation.
-	PrefixesToRelease []*net.IPNet
+	PrefixesToRelease []netip.Prefix
 }
 
 // TranslateRules traverses rules and applies provided translator to rules


### PR DESCRIPTION
Switch most of the handling for CIDR types across the tree over to the
netip.Prefix type, which is a nice cleanup and will help with
simplifying code in various places in future.
