### PR TITLE
cilium-cni: use netip.Addr instead of CiliumIPv{4,6} types

### DIFF
--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -46,6 +46,18 @@ func PrefixToIPNet(prefix netip.Prefix) *net.IPNet {
 	}
 }
 
+// AddrToIPNet is a convenience helper to convert a netip.Addr to a *net.IPNet
+// with a mask corresponding to the addresses's bit length.
+func AddrToIPNet(addr netip.Addr) *net.IPNet {
+	if !addr.IsValid() {
+		return nil
+	}
+	return &net.IPNet{
+		IP:   addr.AsSlice(),
+		Mask: net.CIDRMask(addr.BitLen(), addr.BitLen()),
+	}
+}
+
 // IPNetToPrefix is a convenience helper for migrating from the older 'net'
 // standard library types to the newer 'netip' types. Use this to plug the
 // new types in newer code into older types in older code during the migration.

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -25,6 +25,24 @@ func TestPrefixToIPNet(t *testing.T) {
 	assert.Equal(t, nilNet, PrefixToIPNet(netip.Prefix{}))
 }
 
+func TestAddrToIPNet(t *testing.T) {
+	_, v4IPNet, err := net.ParseCIDR("1.1.1.1/32")
+	assert.NoError(t, err)
+	_, v6IPNet, err := net.ParseCIDR("::ff/128")
+	assert.NoError(t, err)
+
+	ip4 := netip.MustParseAddr("1.1.1.1")
+	assert.NoError(t, err)
+	assert.Equal(t, v4IPNet, AddrToIPNet(ip4))
+
+	ip6 := netip.MustParseAddr("::ff")
+	assert.NoError(t, err)
+	assert.Equal(t, v6IPNet, AddrToIPNet(ip6))
+
+	var nilNet *net.IPNet
+	assert.Equal(t, nilNet, AddrToIPNet(netip.Addr{}))
+}
+
 func TestIPNetToPrefix(t *testing.T) {
 	_, v4IPNet, err := net.ParseCIDR("1.1.1.1/32")
 	assert.NoError(t, err)


### PR DESCRIPTION
This simplifies dealing with IPv4 vs. IPv6 addresses a bit and is one step towards making the CiliumIPv{4,6} types obsolete.