### PR TITLE
gh/workflows: Set LVH image version to 5.10

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -192,6 +192,7 @@ jobs:
             --config monitor-aggregation=none \
             --nodes-without-cilium=kind-worker3 --kube-proxy-replacement=strict --helm-set-string="k8sServiceHost=kind-control-plane,k8sServicePort=6443"
 
+            ./cilium-cli status
             ./cilium-cli connectivity test --datapath
             ./cilium-cli connectivity test -t -d
 

--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -165,10 +165,11 @@ jobs:
           done
 
       - name: Run tests
-        uses: cilium/little-vm-helper-action@b1ff6cddb67545973471cadc7a1620b71728c77e
+        uses: cilium/little-vm-helper-action@9eb481cbe6a32bf74273106b315d43aeaa46a2ee
         with:
           test-name: datapath-conformance
           image: kind
+          image-version: '5.10'
           host-mount: ./
           cmd: |
             set -eux
@@ -196,7 +197,7 @@ jobs:
 
       - name: Fetch artifacts
         if: ${{ !success() }}
-        uses: cilium/little-vm-helper-action@b1ff6cddb67545973471cadc7a1620b71728c77e
+        uses: cilium/little-vm-helper-action@9eb481cbe6a32bf74273106b315d43aeaa46a2ee
         with:
           provision: 'false'
           cmd: |


### PR DESCRIPTION
The recent change in lvh-action \[1\] allows us to set a custom Kind LVH image version. For now, set it to 5.10. Once others (bpf-next, 4.9, 5.4) are fixed, we can run the DP conformance suite on all of them.

\[1\]: https://github.com/cilium/little-vm-helper-action/commit/9eb481cbe6a32bf74273106b315d43aeaa46a2ee
