### PR TITLE
docs: Update docs.cilium.io navigation bar

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==5.1.1
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@d607dabeb0a4af85c0364082789786534571aee1
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@1ef7632859fc0476767eaf794b457bf94540e14b
 # We use semver to parse Cilium's version in the config file
 semver==2.13.0
 # Sphinx extensions


### PR DESCRIPTION
This PR updates the commit hash of https://github.com/cilium/sphinx_rtd_theme/pull/18/commits/0ba6e8882f775ba01b1e332f8a9edcc170c32999 in Documentation/requirements.txt for the changes to take effect on the builds.