### PR TITLE
test: Wait for pods before retrieving IP addrs

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -1000,6 +1000,11 @@ func testPodHTTPToOutside(kubectl *helpers.Kubectl, outsideURL string, expectNod
 	deploymentManager.WaitUntilReady()
 
 	label := "zgroup=testDSClient"
+	// The deployment manager wait doesn't wait for all pods in the DS, so
+	// thus the explicit wait here.
+	err := kubectl.WaitforPods(namespace, "-l "+label, helpers.HelperTimeout)
+	ExpectWithOffset(1, err).Should(BeNil(), "Failed to wait for pods with labels: %s", label)
+
 	pods, err := kubectl.GetPodNames(namespace, label)
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot retrieve pod names by label %s", label)
 


### PR DESCRIPTION
This commit is the second attempt to fix \[1\].

The flakes kept popping up after \[2\] got merged. Further inspection into the failure revealed that when the testPodHTTPToOutside() was trying to retrieve a pod IP, the pod was still in the "ContainerCreating" state.

The culprit seems to be deploymentManager.WaitUntilReady() which is invoked before the retrieval. From the flake test output \[3\] we can see that there were 7 pods in the test namespace, while the wait was assuming 5.

Fix this by explicitly waiting for the pod instead of relying on the deploymentManager.

\[1\]: https://github.com/cilium/cilium/issues/21120
\[2\]: https://github.com/cilium/cilium/pull/21337
\[3\]: https://github.com/cilium/cilium/issues/21120#issuecomment-1255807192

Fix #21120 