### PR TITLE
plugins/cni: wait for AWS to drop its CNI configuration file

### DIFF
--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -110,7 +110,18 @@ find "${CNI_CONF_DIR}" -maxdepth 1 -type f \
 # the host.
 case "$CILIUM_CNI_CHAINING_MODE" in
 "aws-cni")
-  if [ $(find "${CNI_CONF_DIR}" -maxdepth 1 -type f -name '*.conf' -or -name '*.conflist' -or -name '*.cilium_bak' | wc -l) -eq 0 ]; then
+  tries=30
+  while [[ $tries -gt 0 ]]; do
+  if test -n "$(find "${CNI_CONF_DIR}" -maxdepth 1 -type f -name '*.conf' -or -name '*.conflist' -or -name '*.cilium_bak' )"; then
+      echo "Found existing CNI config for chaining"
+      break
+    else
+      echo "Could not find existing AWS VPC CNI config for chaining, will retry..."
+      tries=$((tries-1))
+      sleep 5
+    fi
+  done
+  if [[ $tries -eq 0 ]]; then
     echo "Existing CNI config is required for chaining but does not exist yet, exiting..."
     exit 1
   fi


### PR DESCRIPTION
The script originally just exited and assumed the kubelet would restart it, but this is quite disruptive, since that restarts the agent as well.

Additionally, it was discovered that some AWS installations need the service network to be functioning before the AWS CNI file is written, leaving clusters in a broken state.

So, change the script to retry looking for the AWS CNI file itself.

Fixes: #21243

```release-note
Fixes cilium startup on certain AWS-VPC clusters.
```
