### PR TITLE
daemon: avoid nil pointer dereference on invalid endpoint state

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -191,7 +191,9 @@ func (d *Daemon) fetchK8sLabelsAndAnnotations(nsName, podName string) (*slim_cor
 
 func invalidDataError(ep *endpoint.Endpoint, err error) (*endpoint.Endpoint, int, error) {
 	ep.Logger(daemonSubsys).WithError(err).Warning("Creation of endpoint failed due to invalid data")
-	ep.SetState(endpoint.StateInvalid, "Invalid endpoint")
+	if ep != nil {
+		ep.SetState(endpoint.StateInvalid, "Invalid endpoint")
+	}
 	return nil, PutEndpointIDInvalidCode, err
 }
 


### PR DESCRIPTION
In case the call to `endpoint.NewEndpointFromChangeModel` in `(*Daemon).createEndpoint` fails (e.g. due to invalid data in the request), the returned `*endpoint.Endpoint` is `nil` while `err` is non-nil. However, `invalidDataError` is called with `ep=nil`, leading to a `nil` pointer dereference in `ep.SetState`.

Fixes: 0d6b7ade8d3f ("endpoint: Add Invalid state")