### PR TITLE
operator: Add leader lifecycle

### DIFF
--- a/operator/cmd/lifecycle.go
+++ b/operator/cmd/lifecycle.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+// LeaderLifecycle is the inner lifecycle of the operator that is started when this
+// operator instance is elected leader. It implements hive.Lifecycle allowing cells
+// to use it.
+type LeaderLifecycle struct {
+	hive.DefaultLifecycle
+}
+
+func WithLeaderLifecycle(cells ...cell.Cell) cell.Cell {
+	return cell.Module(
+		"leader-lifecycle",
+		cell.Provide(
+			func() *LeaderLifecycle { return &LeaderLifecycle{} },
+		),
+		cell.Decorate(
+			func(lc *LeaderLifecycle) hive.Lifecycle {
+				return lc
+			},
+			cells...,
+		),
+	)
+
+}

--- a/pkg/k8s/version/version.go
+++ b/pkg/k8s/version/version.go
@@ -111,6 +111,12 @@ func Capabilities() ServerCapabilities {
 	return c
 }
 
+func DisableLeasesResourceLock() {
+	cached.mutex.Lock()
+	defer cached.mutex.Unlock()
+	cached.capabilities.LeasesResourceLock = false
+}
+
 func updateVersion(version semver.Version) {
 	cached.mutex.Lock()
 	defer cached.mutex.Unlock()

--- a/test/controlplane/suite/operator.go
+++ b/test/controlplane/suite/operator.go
@@ -5,12 +5,18 @@ package suite
 
 import (
 	"context"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/hive"
 )
 
 type operatorHandle struct {
-	cancel context.CancelFunc
+	t    *testing.T
+	hive *hive.Hive
 }
 
 func (h *operatorHandle) tearDown() {
-	h.cancel()
+	if err := h.hive.Stop(context.Background()); err != nil {
+		h.t.Fatalf("Operator hive failed to stop: %s", err)
+	}
 }


### PR DESCRIPTION
Add a custom lifecycle to the operator hive that gets started when the
operator is elected leader. This allows implementing the operator functionality
as cells that gets started only after the operator becomes a leader and by
having the lifecycle conform to hive.Lifecycle we can have any cell use this lifecycle.

Control-plane tests are adapted to start the operator via hive.