### PR TITLE
operator: Fix enabling of API discovery

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -137,6 +137,10 @@ func init() {
 
 	gops.DefaultGopsPort = defaults.GopsPortOperator
 
+	// Enable fallback to direct API probing to check for support of Leases in
+	// case Discovery API fails.
+	Vp.Set(option.K8sEnableAPIDiscovery, true)
+
 	operatorHive = hive.New(
 		Vp,
 		rootCmd.Flags(),
@@ -162,10 +166,6 @@ func initEnv() {
 	}
 
 	option.LogRegisteredOptions(Vp, log)
-
-	// Enable fallback to direct API probing to check for support of Leases in
-	// case Discovery API fails.
-	Vp.Set(option.K8sEnableAPIDiscovery, true)
 }
 
 func doCleanup() {


### PR DESCRIPTION
After the switch to using the k8s-client cell, the operator had the enabling of the API discovery happening too late as the populating of the configurations happens in hive.New() and initEnv() was called after it. This is evident in the logs:

```
level=info msg="Support for coordination.k8s.io/v1 not present, fallback to non HA mode" subsys=cilium-operator
```

This moves the setting just prior to call to hive.New(). Verified manually that now the lease support is correctly detected:

```
level=info msg="attempting to acquire leader lease default/cilium-operator-resource-lock..." subsys=klog level=info msg="successfully acquired lease default/cilium-operator-resource-lock" subsys=klog level=info msg="Leading the operator HA deployment" subsys=cilium-operator
```

Fixes: af61d36f5f ("operator: Use hive and the k8s-client")