### PR TITLE
ipam: Add exponential backoff when pool maintanance fails 

### DIFF
--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -77,6 +77,41 @@ func CalculateDuration(min, max time.Duration, factor float64, jitter bool, fail
 	return time.Duration(t)
 }
 
+// ClusterSizeDependantInterval returns a time.Duration that is dependent on
+// the cluster size, i.e. the number of nodes that have been discovered. This
+// can be used to control sync intervals of shared or centralized resources to
+// avoid overloading these resources as the cluster grows.
+//
+// Example sync interval with baseInterval = 1 * time.Minute
+//
+// nodes | sync interval
+// ------+-----------------
+// 1     |   41.588830833s
+// 2     | 1m05.916737320s
+// 4     | 1m36.566274746s
+// 8     | 2m11.833474640s
+// 16    | 2m49.992800643s
+// 32    | 3m29.790453687s
+// 64    | 4m10.463236193s
+// 128   | 4m51.588744261s
+// 256   | 5m32.944565093s
+// 512   | 6m14.416550710s
+// 1024  | 6m55.946873494s
+// 2048  | 7m37.506428894s
+// 4096  | 8m19.080616652s
+// 8192  | 9m00.662124608s
+// 16384 | 9m42.247293667s
+func ClusterSizeDependantInterval(baseInterval time.Duration, numNodes int) time.Duration {
+	// no nodes are being managed, no work will be performed, return
+	// baseInterval to check again in a reasonable timeframe
+	if numNodes == 0 {
+		return baseInterval
+	}
+
+	waitNanoseconds := float64(baseInterval.Nanoseconds()) * math.Log1p(float64(numNodes))
+	return time.Duration(int64(waitNanoseconds))
+}
+
 // Wait waits for the required time using an exponential backoff
 func (b *Exponential) Wait(ctx context.Context) error {
 	b.attempt++

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 
+	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/controller"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -157,6 +158,14 @@ type NodeManager struct {
 	prefixDelegation   bool
 }
 
+func (n *NodeManager) ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration {
+	n.mutex.RLock()
+	numNodes := len(n.nodes)
+	n.mutex.RUnlock()
+
+	return backoff.ClusterSizeDependantInterval(baseInterval, numNodes)
+}
+
 // NewNodeManager returns a new NodeManager
 func NewNodeManager(instancesAPI AllocationImplementation, k8sAPI CiliumNodeGetterUpdater, metrics MetricsAPI,
 	parallelWorkers int64, releaseExcessIPs bool, prefixDelegation bool) (*NodeManager, error) {
@@ -293,15 +302,24 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 
 		node.ops = n.instancesAPI.CreateNode(resource, node)
 
+		ctx, cancel := context.WithCancel(context.Background())
+		backoff := &backoff.Exponential{
+			Max:         5 * time.Minute,
+			Jitter:      true,
+			NodeManager: n,
+			Name:        fmt.Sprintf("ipam-pool-maintainer-%s", resource.Name),
+		}
 		poolMaintainer, err := trigger.NewTrigger(trigger.Parameters{
 			Name:            fmt.Sprintf("ipam-pool-maintainer-%s", resource.Name),
 			MinInterval:     10 * time.Millisecond,
 			MetricsObserver: n.metricsAPI.PoolMaintainerTrigger(),
 			TriggerFunc: func(reasons []string) {
-				if err := node.MaintainIPPool(context.TODO()); err != nil {
+				if err := node.MaintainIPPool(ctx); err != nil {
 					node.logger().WithError(err).Warning("Unable to maintain ip pool of node")
+					backoff.Wait(ctx)
 				}
 			},
+			ShutdownFunc: cancel,
 		})
 		if err != nil {
 			node.logger().WithError(err).Error("Unable to create pool-maintainer trigger")

--- a/pkg/trigger/trigger.go
+++ b/pkg/trigger/trigger.go
@@ -34,6 +34,9 @@ type Parameters struct {
 	// while respecting MinInterval and serialization
 	TriggerFunc func(reasons []string)
 
+	// ShutdownFunc is called when the trigger is shut down
+	ShutdownFunc func()
+
 	MetricsObserver MetricsObserver
 
 	// Name is the unique name of the trigger. It must be provided in a
@@ -208,6 +211,10 @@ func (t *Trigger) waiter() {
 		case <-sleepTimer.After(t.params.sleepInterval):
 
 		case <-t.closeChan:
+			shutdownFunc := t.params.ShutdownFunc
+			if shutdownFunc != nil {
+				shutdownFunc()
+			}
 			return
 		}
 	}


### PR DESCRIPTION
When pool maintenance fails, the pool maintenance trigger is triggered
such that the logic is executed again. However, if maintenance fails for
example because of external reasons, the default retry interval of 10
milliseconds is way to short. Especially if the cloud provider API is
overloaded, multiple nodes can be stuck in a 10 millisecond retry loop,
which will make the situation even worse.

Therefore, this commit introduces an exponential backoff if the pool
maintenance function fails with an error. The minimum trigger interval
remains 10 milliseconds to allow for other trigger reasons (e.g.
because of a resync) to not be delayed as long as the node is healthy.