### PR TITLE
bpf: remove __non_bpf_context macro

### DIFF
--- a/bpf/cilium-probe-kernel-hz.c
+++ b/bpf/cilium-probe-kernel-hz.c
@@ -15,9 +15,6 @@
 
 #include <sys/resource.h>
 
-#define __non_bpf_context	1
-#include "bpf/compiler.h"
-
 struct cpu_jiffies {
 	uint64_t *jiffies;
 	uint32_t cpus;
@@ -26,6 +23,8 @@ struct cpu_jiffies {
 static const uint64_t kernel_hz[] = { 100, 250, 300, 1000 };
 
 #define abs(x)	({ x < 0 ? -x : x; })
+
+#define array_len(A) (sizeof(A) / sizeof((A)[0]))
 
 static int pin_to_cpu(int cpu)
 {
@@ -122,7 +121,7 @@ static int dump_kern_jiffies(const struct cpu_jiffies *fixed,
 
 	for (i = 0; i < result->cpus; i++) {
 		result->jiffies[i] -= fixed->jiffies[i];
-		for (j = 0, delta = ~0; j < ARRAY_SIZE(kernel_hz); j++) {
+		for (j = 0, delta = ~0; j < array_len(kernel_hz); j++) {
 			x = abs((int64_t)(kernel_hz[j] - result->jiffies[i]));
 			if (x < delta) {
 				delta = x;

--- a/bpf/include/bpf/access.h
+++ b/bpf/include/bpf/access.h
@@ -6,7 +6,7 @@
 
 #include "compiler.h"
 
-#if !defined(__non_bpf_context) && defined(__bpf__)
+#if defined(__bpf__)
 static __always_inline __maybe_unused __u32
 map_array_get_32(const __u32 *array, __u32 index, const __u32 limit)
 {
@@ -33,5 +33,5 @@ map_array_get_32(const __u32 *array, __u32 index, const __u32 limit)
 }
 #else
 # define map_array_get_32(array, index, limit)	__throw_build_bug()
-#endif /* !__non_bpf_context && __bpf__ */
+#endif /* __bpf__ */
 #endif /* __BPF_ACCESS_H_ */

--- a/bpf/include/bpf/builtins.h
+++ b/bpf/include/bpf/builtins.h
@@ -6,8 +6,6 @@
 
 #include "compiler.h"
 
-#ifndef __non_bpf_context
-
 #ifndef lock_xadd
 # define lock_xadd(P, V)	((void) __sync_fetch_and_add((P), (V)))
 #endif
@@ -491,5 +489,4 @@ static __always_inline __nobuiltin("memmove") void memmove(void *d,
 	return __bpf_memmove(d, s, len);
 }
 
-#endif /* __non_bpf_context */
 #endif /* __BPF_BUILTINS__ */

--- a/bpf/include/bpf/compiler.h
+++ b/bpf/include/bpf/compiler.h
@@ -4,9 +4,7 @@
 #ifndef __BPF_COMPILER_H_
 #define __BPF_COMPILER_H_
 
-#ifndef __non_bpf_context
 # include "stddef.h"
-#endif
 
 #ifndef __section
 # define __section(X)		__attribute__((section(X), used))

--- a/bpf/include/bpf/ctx/unspec.h
+++ b/bpf/include/bpf/ctx/unspec.h
@@ -8,11 +8,6 @@
  * something compilable, thus we reuse skb ctx here.
  */
 
-#ifdef __non_bpf_context
-/* Do not include BPF feature header. */
-# define __BPF_FEATURES_SKB__	1
-#endif
-
 #include "skb.h"
 
 #endif /* __BPF_CTX_UNSPEC_H_ */

--- a/bpf/include/bpf/tailcall.h
+++ b/bpf/include/bpf/tailcall.h
@@ -6,7 +6,7 @@
 
 #include "compiler.h"
 
-#if !defined(__non_bpf_context) && defined(__bpf__)
+#if defined(__bpf__)
 static __always_inline __maybe_unused void
 tail_call_static(const struct __ctx_buff *ctx, const void *map,
 		 const __u32 slot)
@@ -50,5 +50,5 @@ tail_call_dynamic(struct __ctx_buff *ctx, const void *map, __u32 slot)
  */
 # define tail_call_static(ctx, map, slot)	__throw_build_bug()
 # define tail_call_dynamic(ctx, map, slot)	__throw_build_bug()
-#endif /* !__non_bpf_context && __bpf__ */
+#endif /* __bpf__ */
 #endif /* __BPF_TAILCALL_H_ */


### PR DESCRIPTION
To allow the usage of `__BPF_FEATURES_SKB__` to be removed in #21451 in favor of `#pragma once`, `__non_bpf_context` also has to be removed, since it is its only user.

A little copying is better than a little dependency, so define the 'array_len' macro in cilium-probe-kernel-hz.c instead of making the BPF universe importable from non-bpf C for just this one macro.

Also, `cilium-probe-kernel-hz` is set to be rewritten in Go as part of the agent, so will no longer be needed in the future.

```release-note
Remove `__non_bpf_context` macro from bpf C code
```
