### PR TITLE
Revert "eni: fix new node not triggering creation of ENI"

### DIFF
--- a/pkg/alibabacloud/eni/instances.go
+++ b/pkg/alibabacloud/eni/instances.go
@@ -56,14 +56,6 @@ func (m *InstancesManager) CreateNode(obj *v2.CiliumNode, node *ipam.Node) ipam.
 	return &Node{k8sObj: obj, manager: m, node: node, instanceID: node.InstanceID()}
 }
 
-// HasInstance returns whether the instance is in instances
-func (m *InstancesManager) HasInstance(instanceID string) bool {
-	m.mutex.RLock()
-	instanceExist := m.instances.Exists(instanceID)
-	m.mutex.RUnlock()
-	return instanceExist
-}
-
 // GetPoolQuota returns the number of available IPs in all IP pools
 func (m *InstancesManager) GetPoolQuota() ipamTypes.PoolQuotaMap {
 	pool := ipamTypes.PoolQuotaMap{}
@@ -199,11 +191,4 @@ func (m *InstancesManager) FindSecurityGroupByTags(vpcID string, required ipamTy
 	}
 
 	return securityGroups
-}
-
-// DeleteInstance delete instance from m.instances
-func (m *InstancesManager) DeleteInstance(instanceID string) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.instances.Delete(instanceID)
 }

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -59,14 +59,6 @@ func (m *InstancesManager) CreateNode(obj *v2.CiliumNode, n *ipam.Node) ipam.Nod
 	return NewNode(n, obj, m)
 }
 
-// HasInstance returns whether the instance is in instances
-func (m *InstancesManager) HasInstance(instanceID string) bool {
-	m.mutex.RLock()
-	instanceExist := m.instances.Exists(instanceID)
-	m.mutex.RUnlock()
-	return instanceExist
-}
-
 // GetPoolQuota returns the number of available IPs in all IP pools
 func (m *InstancesManager) GetPoolQuota() ipamTypes.PoolQuotaMap {
 	pool := ipamTypes.PoolQuotaMap{}
@@ -236,11 +228,4 @@ func (m *InstancesManager) ForeachInstance(instanceID string, fn ipamTypes.Inter
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 	m.instances.ForeachInterface(instanceID, fn)
-}
-
-// DeleteInstance delete instance from m.instances
-func (m *InstancesManager) DeleteInstance(instanceID string) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.instances.Delete(instanceID)
 }

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -80,8 +80,7 @@ func (e *ENISuite) TestGetNodeNames(c *check.C) {
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 
-	node1 := newCiliumNode("node1", "i-testGetNodeNames-1", "m4.large", "us-west-1", "vpc-1", 0, 0, 0, 0)
-	mngr.Update(node1)
+	mngr.Update(newCiliumNode("node1", "i-testGetNodeNames-1", "m4.large", "us-west-1", "vpc-1", 0, 0, 0, 0))
 
 	names := mngr.GetNames()
 	c.Assert(len(names), check.Equals, 1)
@@ -92,7 +91,7 @@ func (e *ENISuite) TestGetNodeNames(c *check.C) {
 	names = mngr.GetNames()
 	c.Assert(len(names), check.Equals, 2)
 
-	mngr.Delete(node1)
+	mngr.Delete("node1")
 
 	names = mngr.GetNames()
 	c.Assert(len(names), check.Equals, 1)
@@ -113,13 +112,12 @@ func (e *ENISuite) TestNodeManagerGet(c *check.C) {
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 
-	node1 := newCiliumNode("node1", "i-testNodeManagerGet-1", "m4.large", "us-west-1", "vpc-1", 0, 0, 0, 0)
-	mngr.Update(node1)
+	mngr.Update(newCiliumNode("node1", "i-testNodeManagerGet-1", "m4.large", "us-west-1", "vpc-1", 0, 0, 0, 0))
 
 	c.Assert(mngr.Get("node1"), check.Not(check.IsNil))
 	c.Assert(mngr.Get("node2"), check.IsNil)
 
-	mngr.Delete(node1)
+	mngr.Delete("node1")
 	c.Assert(mngr.Get("node1"), check.IsNil)
 	c.Assert(mngr.Get("node2"), check.IsNil)
 }

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -46,14 +46,6 @@ func (m *InstancesManager) CreateNode(obj *v2.CiliumNode, n *ipam.Node) ipam.Nod
 	return &Node{manager: m, node: n}
 }
 
-// HasInstance returns whether the instance is in instances
-func (m *InstancesManager) HasInstance(instanceID string) bool {
-	m.mutex.RLock()
-	instanceExist := m.instances.Exists(instanceID)
-	m.mutex.RUnlock()
-	return instanceExist
-}
-
 // GetPoolQuota returns the number of available IPs in all IP pools
 func (m *InstancesManager) GetPoolQuota() (quota ipamTypes.PoolQuotaMap) {
 	m.mutex.RLock()
@@ -98,11 +90,4 @@ func (m *InstancesManager) Resync(ctx context.Context) time.Time {
 	m.mutex.Unlock()
 
 	return resyncStart
-}
-
-// DeleteInstance delete instance from m.instances
-func (m *InstancesManager) DeleteInstance(instanceID string) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.instances.Delete(instanceID)
 }

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -417,19 +417,19 @@ func (n *NodesPodCIDRManager) update(node *v2.CiliumNode) bool {
 
 // Delete deletes the node from the allocator and releases the associated
 // CIDRs of that node.
-func (n *NodesPodCIDRManager) Delete(node *v2.CiliumNode) {
+func (n *NodesPodCIDRManager) Delete(nodeName string) {
 	n.Mutex.Lock()
 	defer n.Mutex.Unlock()
 	if !n.canAllocatePodCIDRs {
-		delete(n.nodesToAllocate, node.Name)
+		delete(n.nodesToAllocate, nodeName)
 	}
 
-	found := n.releaseIPNets(node.Name)
+	found := n.releaseIPNets(nodeName)
 	if !found {
 		return
 	}
 	// Mark the node to be deleted in k8s.
-	n.ciliumNodesToK8s[node.Name] = &ciliumNodeK8sOp{
+	n.ciliumNodesToK8s[nodeName] = &ciliumNodeK8sOp{
 		op: k8sOpDelete,
 	}
 	n.k8sReSync.Trigger()

--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -493,7 +493,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Delete(c *C) {
 		ciliumNodesToK8s    map[string]*ciliumNodeK8sOp
 	}
 	type args struct {
-		node *v2.CiliumNode
+		nodeName string
 	}
 	tests := []struct {
 		testSetup   func() *fields
@@ -544,11 +544,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Delete(c *C) {
 				c.Assert(atomic.LoadInt32(&reSyncCalls), Equals, int32(1))
 			},
 			args: args{
-				node: &v2.CiliumNode{
-					ObjectMeta: v1.ObjectMeta{
-						Name: "node-1",
-					},
-				},
+				nodeName: "node-1",
 			},
 		},
 		{
@@ -565,11 +561,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Delete(c *C) {
 				c.Assert(atomic.LoadInt32(&reSyncCalls), Equals, int32(0))
 			},
 			args: args{
-				node: &v2.CiliumNode{
-					ObjectMeta: v1.ObjectMeta{
-						Name: "node-1",
-					},
-				},
+				nodeName: "node-1",
 			},
 		},
 	}
@@ -587,7 +579,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Delete(c *C) {
 				nodes:               tt.fields.nodes,
 				ciliumNodesToK8s:    tt.fields.ciliumNodesToK8s,
 			}
-			n.Delete(tt.args.node)
+			n.Delete(tt.args.nodeName)
 
 			if tt.testPostRun != nil {
 				tt.testPostRun(tt.fields)

--- a/pkg/ipam/allocator/provider.go
+++ b/pkg/ipam/allocator/provider.go
@@ -22,6 +22,6 @@ type AllocatorProvider interface {
 type NodeEventHandler interface {
 	Create(resource *v2.CiliumNode) bool
 	Update(resource *v2.CiliumNode) bool
-	Delete(resource *v2.CiliumNode)
+	Delete(nodeName string)
 	Resync(context.Context, time.Time)
 }

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -115,12 +115,6 @@ type AllocationImplementation interface {
 	// chance to resync its own state with external APIs or systems. It is
 	// also called when the IPAM layer detects that state got out of sync.
 	Resync(ctx context.Context) time.Time
-
-	// HasInstance returns whether the instance is in instances
-	HasInstance(instanceID string) bool
-
-	// DeleteInstance deletes the instance from instances
-	DeleteInstance(instanceID string)
 }
 
 // MetricsAPI represents the metrics being maintained by a NodeManager
@@ -285,12 +279,6 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 			logLimiter:          logging.NewLimiter(10*time.Second, 3), // 1 log / 10 secs, burst of 3
 		}
 
-		if !n.instancesAPI.HasInstance(resource.InstanceID()) {
-			if _, ok := n.instancesAPIResync(context.TODO()); !ok {
-				node.logger().Warning("Failed to resync the instances from the API after new node was found")
-			}
-		}
-
 		node.ops = n.instancesAPI.CreateNode(resource, node)
 
 		poolMaintainer, err := trigger.NewTrigger(trigger.Parameters{
@@ -344,10 +332,10 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 
 // Delete is called after a CiliumNode resource has been deleted via the
 // Kubernetes apiserver
-func (n *NodeManager) Delete(resource *v2.CiliumNode) {
+func (n *NodeManager) Delete(nodeName string) {
 	n.mutex.Lock()
 
-	if node, ok := n.nodes[resource.Name]; ok {
+	if node, ok := n.nodes[nodeName]; ok {
 		if node.poolMaintainer != nil {
 			node.poolMaintainer.Shutdown()
 		}
@@ -359,15 +347,7 @@ func (n *NodeManager) Delete(resource *v2.CiliumNode) {
 		}
 	}
 
-	// Delete the instance from instanceManager. This will cause Update() to
-	// invoke instancesAPIResync if this instance rejoins the cluster.
-	// This ensures that Node.recalculate() does not use stale data for
-	// instances which rejoin the cluster after their EC2 configuration has changed.
-	if resource.Spec.InstanceID != "" {
-		n.instancesAPI.DeleteInstance(resource.Spec.InstanceID)
-	}
-
-	delete(n.nodes, resource.Name)
+	delete(n.nodes, nodeName)
 	n.mutex.Unlock()
 }
 

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -60,13 +60,6 @@ func (a *allocationImplementationMock) Resync(ctx context.Context) time.Time {
 	return time.Now()
 }
 
-func (a *allocationImplementationMock) HasInstance(instanceID string) bool {
-	return true
-}
-
-func (a *allocationImplementationMock) DeleteInstance(instanceID string) {
-}
-
 type nodeOperationsMock struct {
 	allocator *allocationImplementationMock
 
@@ -176,8 +169,7 @@ func (e *IPAMSuite) TestGetNodeNames(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
-	node1 := newCiliumNode("node1", 0, 0, 0)
-	mngr.Update(node1)
+	mngr.Update(newCiliumNode("node1", 0, 0, 0))
 
 	names := mngr.GetNames()
 	c.Assert(len(names), check.Equals, 1)
@@ -188,7 +180,7 @@ func (e *IPAMSuite) TestGetNodeNames(c *check.C) {
 	names = mngr.GetNames()
 	c.Assert(len(names), check.Equals, 2)
 
-	mngr.Delete(node1)
+	mngr.Delete("node1")
 
 	names = mngr.GetNames()
 	c.Assert(len(names), check.Equals, 1)
@@ -204,13 +196,12 @@ func (e *IPAMSuite) TestNodeManagerGet(c *check.C) {
 
 	// instances.Resync(context.TODO())
 
-	node1 := newCiliumNode("node1", 0, 0, 0)
-	mngr.Update(node1)
+	mngr.Update(newCiliumNode("node1", 0, 0, 0))
 
 	c.Assert(mngr.Get("node1"), check.Not(check.IsNil))
 	c.Assert(mngr.Get("node2"), check.IsNil)
 
-	mngr.Delete(node1)
+	mngr.Delete("node1")
 	c.Assert(mngr.Get("node1"), check.IsNil)
 	c.Assert(mngr.Get("node2"), check.IsNil)
 }

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -482,20 +482,3 @@ func (m *InstanceMap) NumInstances() (size int) {
 	m.mutex.RUnlock()
 	return
 }
-
-// Exists returns whether the instance ID is in the instanceMap
-func (m *InstanceMap) Exists(instanceID string) (exists bool) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	if instance := m.data[instanceID]; instance != nil {
-		return true
-	}
-	return false
-}
-
-// Delete instance from m.data
-func (m *InstanceMap) Delete(instanceID string) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	delete(m.data, instanceID)
-}


### PR DESCRIPTION
This reverts commit 344863ac55e30f88706db06aca5af9d79db4c00a.

The commit introduced a deadlock in the operator,
NodeManager.instancesAPIResync cannot be called from NodeManager.Update, since the latter holds the NodeManager lock, which is also required by the former.

cc @wu0407 