### PR TITLE
gops: Fix the gops default port

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -35,7 +35,7 @@ cilium-operator-alibabacloud [flags]
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
-      --gops-port uint16                          Port for gops server to listen on (default 9890)
+      --gops-port uint16                          Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator-alibabacloud
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration             GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -41,7 +41,7 @@ cilium-operator-aws [flags]
       --enable-metrics                            Enable Prometheus metrics
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
       --excess-ip-release-delay int               Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
-      --gops-port uint16                          Port for gops server to listen on (default 9890)
+      --gops-port uint16                          Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator-aws
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration             GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -38,7 +38,7 @@ cilium-operator-azure [flags]
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
-      --gops-port uint16                          Port for gops server to listen on (default 9890)
+      --gops-port uint16                          Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator-azure
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration             GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -34,7 +34,7 @@ cilium-operator-generic [flags]
       --enable-k8s-endpoint-slice                 Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                 Enable k8s event handover to kvstore for improved scalability
       --enable-metrics                            Enable Prometheus metrics
-      --gops-port uint16                          Port for gops server to listen on (default 9890)
+      --gops-port uint16                          Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator-generic
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration             GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -46,7 +46,7 @@ cilium-operator [flags]
       --enable-metrics                            Enable Prometheus metrics
       --eni-tags map                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
       --excess-ip-release-delay int               Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
-      --gops-port uint16                          Port for gops server to listen on (default 9890)
+      --gops-port uint16                          Port for gops server to listen on (default 9891)
   -h, --help                                      help for cilium-operator
       --identity-allocation-mode string           Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration             GC interval for security identities (default 15m0s)

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -99,6 +99,8 @@ var (
 )
 
 func init() {
+	gops.DefaultGopsPort = defaults.GopsPortApiserver
+
 	rootHive = hive.New(
 		vp, rootCmd.Flags(),
 

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/fx"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -67,6 +68,8 @@ func init() {
 	setupSleepBeforeFatal()
 	registerBootstrapMetrics()
 	initializeFlags()
+
+	gops.DefaultGopsPort = defaults.GopsPortAgent
 
 	agentHive = hive.New(
 		Vp,

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -30,6 +30,7 @@ import (
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
 
 	"github.com/cilium/cilium/pkg/components"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
@@ -133,6 +134,8 @@ func registerOperatorHooks(lc fx.Lifecycle, clientset k8sClient.Clientset, shutd
 
 func init() {
 	rootCmd.AddCommand(MetricsCmd)
+
+	gops.DefaultGopsPort = defaults.GopsPortOperator
 
 	operatorHive = hive.New(
 		Vp,

--- a/pkg/gops/cell.go
+++ b/pkg/gops/cell.go
@@ -12,17 +12,21 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/fx"
 
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
 
-// Gops runs the gops agent, a tool to list and diagnose Go processes.
-// See https://github.com/google/gops.
-var Cell = hive.NewCellWithConfig[GopsConfig](
-	"gops",
-	fx.Invoke(registerGopsHooks),
+var (
+	// DefaultGopsPort is the default for --gops-port option.
+	DefaultGopsPort = uint16(0)
+
+	// Cell runs the gops agent, a tool to list and diagnose Go processes.
+	// See https://github.com/google/gops.
+	Cell = hive.NewCellWithConfig[GopsConfig](
+		"gops",
+		fx.Invoke(registerGopsHooks),
+	)
 )
 
 type GopsConfig struct {
@@ -30,7 +34,7 @@ type GopsConfig struct {
 }
 
 func (GopsConfig) CellFlags(flags *pflag.FlagSet) {
-	flags.Uint16(option.GopsPort, defaults.GopsPortAgent, "Port for gops server to listen on")
+	flags.Uint16(option.GopsPort, DefaultGopsPort, "Port for gops server to listen on")
 }
 
 func registerGopsHooks(lc fx.Lifecycle, log logrus.FieldLogger, cfg GopsConfig) {


### PR DESCRIPTION
The gops cell cannot default to GopsPortAgent, but rather requires that each application supplies the right default so they do not overlap.

Fixes: a64ff19711 ("gops: Create the gops cell for the gops agent")