### PR TITLE
sctp: Handle SCTP when correlating Endpoints to services.

### DIFF
--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -255,6 +255,8 @@ func parseEndpointPortV1Beta1(port slim_discovery_v1beta1.EndpointPort) (string,
 			proto = loadbalancer.TCP
 		case slim_corev1.ProtocolUDP:
 			proto = loadbalancer.UDP
+		case slim_corev1.ProtocolSCTP:
+			proto = loadbalancer.SCTP
 		default:
 			return "", nil
 		}
@@ -348,6 +350,8 @@ func parseEndpointPortV1(port slim_discovery_v1.EndpointPort) (string, *loadbala
 			proto = loadbalancer.TCP
 		case slim_corev1.ProtocolUDP:
 			proto = loadbalancer.UDP
+		case slim_corev1.ProtocolSCTP:
+			proto = loadbalancer.SCTP
 		default:
 			return "", nil
 		}


### PR DESCRIPTION
Otherwise, Services with SCTP ports and pods with SCTP ports will not have their backends correctly populated.

This was missed in the original SCTP PR.

Signed-off-by: Harsh Modi <harshmodi@google.com>

