### PR TITLE
gha: Update the names for ConformanceIngress jobs

### DIFF
--- a/.github/workflows/loki.yaml
+++ b/.github/workflows/loki.yaml
@@ -30,6 +30,8 @@ on:
       - ConformanceGKE (ci-gke-1.11)
       - ConformanceGKE (ci-gke-1.12)
       - ConformanceIngress
+      - ConformanceIngress (Dedicated LB)
+      - ConformanceIngress (Shared LB)
       - ConformanceKind1.19
       - Cyclonus network policy test
       - Documentation Updates


### PR DESCRIPTION
The previous PR #21386 renames existing ConformanceIngress job, and also adds one new one. This commit is to sync up names.

Signed-off-by: Tam Mach <tam.mach@cilium.io>
