### PR TITLE
alibabacloud: fix incorrect instance-type reported by cilium-agent

### DIFF
--- a/pkg/alibabacloud/metadata/metadata.go
+++ b/pkg/alibabacloud/metadata/metadata.go
@@ -56,10 +56,16 @@ func getMetadata(ctx context.Context, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("metadata service returned status code %d", resp.StatusCode)
+	}
+
 	defer resp.Body.Close()
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
The mal-formed instance-type looks like below in CiliumNode spec:

```yaml
spec:
  ...
  alibaba-cloud:
    instance-type: |
      <?xml version="1.0" encoding="iso-8859-1"?>
      <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
               "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
      <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
       <head>
        <title>404 - Not Found</title>
       </head>
       <body>
        <h1>404 - Not Found</h1>
       </body>
      </html>
```

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>
Reported-by:   Jaff Cheng <jaff.cheng.sh@gmail.com>