### PR TITLE
bugtool: Fix pprof default ports

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -42,7 +42,7 @@ cilium-bugtool [OPTIONS] [flags]
       --k8s-mode                  Require Kubernetes pods to be found or fail
       --k8s-namespace string      Kubernetes namespace for Cilium pod (default "kube-system")
       --parallel-workers int      Maximum number of parallel worker tasks, use 0 for number of CPUs
-      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:9890, operator:9891, apiserver:9892 (default 9890)
+      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061 (default 6060)
       --pprof-trace-seconds int   Amount of seconds used for pprof CPU traces (default 180)
   -t, --tmp string                Path to store extracted files. Use '-' to send to stdout. (default "/tmp")
 ```

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -81,10 +81,10 @@ func init() {
 	BugtoolRootCmd.Flags().BoolVar(&getPProf, "get-pprof", false, "When set, only gets the pprof traces from the cilium-agent binary")
 	BugtoolRootCmd.Flags().BoolVar(&envoyDump, "envoy-dump", true, "When set, dump envoy configuration from unix socket")
 	BugtoolRootCmd.Flags().IntVar(&pprofPort,
-		"pprof-port", defaults.GopsPortAgent,
+		"pprof-port", defaults.PprofPortAgent,
 		fmt.Sprintf(
-			"Pprof port to connect to. Known Cilium component ports are agent:%d, operator:%d, apiserver:%d",
-			defaults.GopsPortAgent, defaults.GopsPortOperator, defaults.GopsPortApiserver,
+			"Pprof port to connect to. Known Cilium component ports are agent:%d, operator:%d",
+			defaults.PprofPortAgent, defaults.PprofPortOperator,
 		),
 	)
 	BugtoolRootCmd.Flags().IntVar(&traceSeconds, "pprof-trace-seconds", 180, "Amount of seconds used for pprof CPU traces")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -748,7 +748,7 @@ func initializeFlags() {
 	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
 	option.BindEnv(Vp, option.PProf)
 
-	flags.Int(option.PProfPort, 6060, "Port that the pprof listens on")
+	flags.Int(option.PProfPort, defaults.PprofPortAgent, "Port that the pprof listens on")
 	option.BindEnv(Vp, option.PProfPort)
 
 	flags.Bool(option.EnableXDPPrefilter, false, "Enable XDP prefiltering")

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -257,7 +257,7 @@ func init() {
 	flags.Bool(operatorOption.PProf, false, "Enable pprof debugging endpoint")
 	option.BindEnv(Vp, operatorOption.PProf)
 
-	flags.Int(operatorOption.PProfPort, 6061, "Port that the pprof listens on")
+	flags.Int(operatorOption.PProfPort, defaults.PprofPortOperator, "Port that the pprof listens on")
 	option.BindEnv(Vp, operatorOption.PProfPort)
 
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -17,6 +17,12 @@ const (
 	// ClusterMeshHealthPort is the default value for option.ClusterMeshHealthPort
 	ClusterMeshHealthPort = 80
 
+	// PprofPortAgent is the default value for pprof in the agent
+	PprofPortAgent = 6060
+
+	// PprofPortAgent is the default value for pprof in the operator
+	PprofPortOperator = 6061
+
 	// GopsPortAgent is the default value for option.GopsPort in the agent
 	GopsPortAgent = 9890
 


### PR DESCRIPTION
`gops` and `pprof` do not use neither the same protocol nor the same port to collect profile data.

When `cilium-bugtool` queries the gops server embedded in the agent, it collects the data calling the gops cli from the shell, without passing any extra port argument: https://github.com/cilium/cilium/blob/master/bugtool/cmd/root.go#L499-L506

Instead, when querying the `pprof` debug endpoints, `cilium-bugtool` should use the proper agent default pprof port: https://github.com/cilium/cilium/blob/master/bugtool/cmd/root.go#L478-L497

This PR changes the default port for pprof endpoints in `cilium-bugtool` to be the same default port set in the agent, even if pprof support is disabled by default in the agent.
 
Besides, clustermesh-apiserver does not support pprof yet, but only gops. Thus, the help message for the pprof port option in cilium-bugtool is fixed accordingly.

Fixes: #17004
