### PR TITLE
Prepend Envoy resources with CEC namespace and name

### DIFF
--- a/operator/pkg/model/translation/ingress/shared_ingress.go
+++ b/operator/pkg/model/translation/ingress/shared_ingress.go
@@ -93,7 +93,6 @@ func (i *SharedIngressTranslator) getBackendServices(m *model.Model) []*ciliumv2
 func (i *SharedIngressTranslator) getServices(_ *model.Model) []*ciliumv2.ServiceListener {
 	return []*ciliumv2.ServiceListener{
 		{
-			Listener:  fmt.Sprintf("%s-%s-listener", i.namespace, i.name),
 			Name:      i.name,
 			Namespace: i.namespace,
 		},

--- a/operator/pkg/model/translation/ingress/shared_ingress.go
+++ b/operator/pkg/model/translation/ingress/shared_ingress.go
@@ -119,7 +119,7 @@ func (i *SharedIngressTranslator) getListener(m *model.Model) []ciliumv2.XDSReso
 		}
 	}
 
-	l, _ := translation.NewListenerWithDefaults(fmt.Sprintf("%s-%s-listener", i.namespace, i.name), i.secretsNamespace, tls)
+	l, _ := translation.NewListenerWithDefaults("listener", i.secretsNamespace, tls)
 	return []ciliumv2.XDSResource{l}
 }
 
@@ -158,7 +158,7 @@ func (i *SharedIngressTranslator) getRouteConfiguration(m *model.Model) []cilium
 
 		// the route name should match the value in http connection manager
 		// otherwise the request will be dropped by envoy
-		routeName := fmt.Sprintf("%s-%s-listener-%s", i.namespace, i.name, port)
+		routeName := fmt.Sprintf("listener-%s", port)
 		rc, _ := translation.NewRouteConfiguration(routeName, virtualhosts)
 		res = append(res, rc)
 	}

--- a/operator/pkg/model/translation/ingress/shared_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/shared_ingress_test.go
@@ -172,7 +172,6 @@ func TestSharedIngressTranslator_getServices(t *testing.T) {
 				{
 					Name:      "cilium-ingress",
 					Namespace: "kube-system",
-					Listener:  "kube-system-cilium-ingress-listener",
 				},
 			},
 		},

--- a/operator/pkg/model/translation/ingress/shared_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/shared_ingress_test.go
@@ -222,15 +222,15 @@ func TestSharedIngressTranslator_getListener(t *testing.T) {
 	err = proto.Unmarshal(listener.FilterChains[0].Filters[0].ConfigType.(*envoy_config_listener.Filter_TypedConfig).TypedConfig.Value, insecureConnectionManager)
 	require.NoError(t, err)
 
-	require.Equal(t, "kube-system-cilium-ingress-listener-insecure", insecureConnectionManager.StatPrefix)
-	require.Equal(t, "kube-system-cilium-ingress-listener-insecure", insecureConnectionManager.GetRds().RouteConfigName)
+	require.Equal(t, "listener-insecure", insecureConnectionManager.StatPrefix)
+	require.Equal(t, "listener-insecure", insecureConnectionManager.GetRds().RouteConfigName)
 
 	secureConnectionManager := &envoy_http_connection_manager_v3.HttpConnectionManager{}
 	err = proto.Unmarshal(listener.FilterChains[1].Filters[0].ConfigType.(*envoy_config_listener.Filter_TypedConfig).TypedConfig.Value, secureConnectionManager)
 	require.NoError(t, err)
 
-	require.Equal(t, "kube-system-cilium-ingress-listener-secure", secureConnectionManager.StatPrefix)
-	require.Equal(t, "kube-system-cilium-ingress-listener-secure", secureConnectionManager.GetRds().RouteConfigName)
+	require.Equal(t, "listener-secure", secureConnectionManager.StatPrefix)
+	require.Equal(t, "listener-secure", secureConnectionManager.GetRds().RouteConfigName)
 
 	// check TLS configuration
 	require.Equal(t, "envoy.transport_sockets.tls", listener.FilterChains[1].TransportSocket.Name)
@@ -334,7 +334,7 @@ func TestSharedIngressTranslator_getRouteConfiguration(t *testing.T) {
 				m: defaultBackendModel,
 			},
 			expectedRouteVHMap: map[string][]string{
-				"kube-system-cilium-ingress-listener-insecure": {
+				"listener-insecure": {
 					"*",
 				},
 			},
@@ -345,11 +345,11 @@ func TestSharedIngressTranslator_getRouteConfiguration(t *testing.T) {
 				m: hostRulesModel,
 			},
 			expectedRouteVHMap: map[string][]string{
-				"kube-system-cilium-ingress-listener-insecure": {
+				"listener-insecure": {
 					"*.foo.com",
 					"foo.bar.com",
 				},
-				"kube-system-cilium-ingress-listener-secure": {
+				"listener-secure": {
 					"foo.bar.com",
 				},
 			},
@@ -360,7 +360,7 @@ func TestSharedIngressTranslator_getRouteConfiguration(t *testing.T) {
 				m: pathRulesModel,
 			},
 			expectedRouteVHMap: map[string][]string{
-				"kube-system-cilium-ingress-listener-insecure": {
+				"listener-insecure": {
 					"exact-path-rules",
 					"mixed-path-rules",
 					"prefix-path-rules",
@@ -374,10 +374,10 @@ func TestSharedIngressTranslator_getRouteConfiguration(t *testing.T) {
 				m: complexIngressModel,
 			},
 			expectedRouteVHMap: map[string][]string{
-				"kube-system-cilium-ingress-listener-insecure": {
+				"listener-insecure": {
 					"*",
 				},
-				"kube-system-cilium-ingress-listener-secure": {
+				"listener-secure": {
 					"very-secure.server.com",
 					"another-very-secure.server.com",
 				},

--- a/pkg/envoy/ciliumenvoyconfig_test.go
+++ b/pkg/envoy/ciliumenvoyconfig_test.go
@@ -162,9 +162,10 @@ func (s *JSONSuite) TestCiliumEnvoyConfig(c *C) {
 	c.Assert(cec.Spec.Resources, HasLen, 1)
 	c.Assert(cec.Spec.Resources[0].TypeUrl, Equals, "type.googleapis.com/envoy.config.listener.v3.Listener")
 
-	resources, err := ParseResources("prefix", cec.Spec.Resources, true, portAllocator)
+	resources, err := ParseResources("namespace", "name", cec.Spec.Resources, true, portAllocator)
 	c.Assert(err, IsNil)
 	c.Assert(resources.Listeners, HasLen, 1)
+	c.Assert(resources.Listeners[0].Name, Equals, "namespace/name/envoy-prometheus-metrics-listener")
 	c.Assert(resources.Listeners[0].Address.GetSocketAddress().GetPortValue(), Equals, uint32(10000))
 	c.Assert(resources.Listeners[0].FilterChains, HasLen, 1)
 	chain := resources.Listeners[0].FilterChains[0]
@@ -203,6 +204,7 @@ func (s *JSONSuite) TestCiliumEnvoyConfig(c *C) {
 	//
 	rds := hcm.GetRds()
 	c.Assert(rds, Not(IsNil))
+	c.Assert(rds.RouteConfigName, Equals, "namespace/name/local_route")
 	checkCiliumXDS(c, rds.GetConfigSource())
 
 	//
@@ -251,9 +253,10 @@ func (s *JSONSuite) TestCiliumEnvoyConfigValidation(c *C) {
 	c.Assert(cec.Spec.Resources, HasLen, 1)
 	c.Assert(cec.Spec.Resources[0].TypeUrl, Equals, "type.googleapis.com/envoy.config.listener.v3.Listener")
 
-	resources, err := ParseResources("prefix", cec.Spec.Resources, false, portAllocator)
+	resources, err := ParseResources("namespace", "name", cec.Spec.Resources, false, portAllocator)
 	c.Assert(err, IsNil)
 	c.Assert(resources.Listeners, HasLen, 1)
+	c.Assert(resources.Listeners[0].Name, Equals, "namespace/name/envoy-prometheus-metrics-listener")
 	c.Assert(resources.Listeners[0].Address.GetSocketAddress().GetPortValue(), Equals, uint32(0)) // invalid listener port number
 	c.Assert(resources.Listeners[0].FilterChains, HasLen, 1)
 	chain := resources.Listeners[0].FilterChains[0]
@@ -271,6 +274,7 @@ func (s *JSONSuite) TestCiliumEnvoyConfigValidation(c *C) {
 	//
 	rds := hcm.GetRds()
 	c.Assert(rds, Not(IsNil))
+	c.Assert(rds.RouteConfigName, Equals, "namespace/name/local_route")
 	checkCiliumXDS(c, rds.GetConfigSource())
 
 	//
@@ -282,7 +286,7 @@ func (s *JSONSuite) TestCiliumEnvoyConfigValidation(c *C) {
 	//
 	// Same with validation fails
 	//
-	resources, err = ParseResources("prefix", cec.Spec.Resources, true, portAllocator)
+	resources, err = ParseResources("namespace", "name", cec.Spec.Resources, true, portAllocator)
 	c.Assert(err, Not(IsNil))
 }
 
@@ -322,9 +326,10 @@ func (s *JSONSuite) TestCiliumEnvoyConfigNoAddress(c *C) {
 	c.Assert(cec.Spec.Resources, HasLen, 1)
 	c.Assert(cec.Spec.Resources[0].TypeUrl, Equals, "type.googleapis.com/envoy.config.listener.v3.Listener")
 
-	resources, err := ParseResources("prefix", cec.Spec.Resources, true, portAllocator)
+	resources, err := ParseResources("namespace", "name", cec.Spec.Resources, true, portAllocator)
 	c.Assert(err, IsNil)
 	c.Assert(resources.Listeners, HasLen, 1)
+	c.Assert(resources.Listeners[0].Name, Equals, "namespace/name/envoy-prometheus-metrics-listener")
 	c.Assert(resources.Listeners[0].Address, Not(IsNil))
 	c.Assert(resources.Listeners[0].Address.GetSocketAddress(), Not(IsNil))
 	c.Assert(resources.Listeners[0].Address.GetSocketAddress().GetPortValue(), Not(Equals), 0)
@@ -345,6 +350,7 @@ func (s *JSONSuite) TestCiliumEnvoyConfigNoAddress(c *C) {
 	//
 	rds := hcm.GetRds()
 	c.Assert(rds, Not(IsNil))
+	c.Assert(rds.RouteConfigName, Equals, "namespace/name/local_route")
 	checkCiliumXDS(c, rds.GetConfigSource())
 
 	//
@@ -434,9 +440,10 @@ func (s *JSONSuite) TestCiliumEnvoyConfigMulti(c *C) {
 	c.Assert(cec.Spec.Resources, HasLen, 5)
 	c.Assert(cec.Spec.Resources[0].TypeUrl, Equals, "type.googleapis.com/envoy.config.listener.v3.Listener")
 
-	resources, err := ParseResources("prefix", cec.Spec.Resources, true, portAllocator)
+	resources, err := ParseResources("namespace", "name", cec.Spec.Resources, true, portAllocator)
 	c.Assert(err, IsNil)
 	c.Assert(resources.Listeners, HasLen, 1)
+	c.Assert(resources.Listeners[0].Name, Equals, "namespace/name/multi-resource-listener")
 	c.Assert(resources.Listeners[0].Address.GetSocketAddress().GetPortValue(), Equals, uint32(10000))
 	c.Assert(resources.Listeners[0].FilterChains, HasLen, 1)
 	chain := resources.Listeners[0].FilterChains[0]
@@ -453,6 +460,7 @@ func (s *JSONSuite) TestCiliumEnvoyConfigMulti(c *C) {
 	//
 	rds := hcm.GetRds()
 	c.Assert(rds, Not(IsNil))
+	c.Assert(rds.RouteConfigName, Equals, "namespace/name/local_route")
 	checkCiliumXDS(c, rds.GetConfigSource())
 	//
 	// Check that HTTP filters are parsed
@@ -465,7 +473,7 @@ func (s *JSONSuite) TestCiliumEnvoyConfigMulti(c *C) {
 	//
 	c.Assert(cec.Spec.Resources[1].TypeUrl, Equals, "type.googleapis.com/envoy.config.route.v3.RouteConfiguration")
 	c.Assert(resources.Routes, HasLen, 1)
-	c.Assert(resources.Routes[0].Name, Equals, "local_route")
+	c.Assert(resources.Routes[0].Name, Equals, "namespace/name/local_route")
 	c.Assert(resources.Routes[0].VirtualHosts, HasLen, 1)
 	vh := resources.Routes[0].VirtualHosts[0]
 	c.Assert(vh.Name, Equals, "local_service")
@@ -555,4 +563,29 @@ func checkCiliumXDS(c *C, cs *envoy_config_core.ConfigSource) {
 	eg := acs.GrpcServices[0].GetEnvoyGrpc()
 	c.Assert(eg, Not(IsNil))
 	c.Assert(eg.ClusterName, Equals, "xds-grpc-cilium")
+}
+
+func (s *JSONSuite) TestResourceQualifiedName(c *C) {
+	var fullName, namespace, name, resource string
+
+	resource = "test-resource"
+	fullName = resourceQualifiedName(namespace, name, resource)
+	c.Assert(fullName, Equals, "test-resource")
+
+	name = "test-name"
+	resource = "test-resource"
+	fullName = resourceQualifiedName(namespace, name, resource)
+	c.Assert(fullName, Equals, "test-name/test-resource")
+
+	namespace = "test-namespace"
+	name = ""
+	resource = "test-resource"
+	fullName = resourceQualifiedName(namespace, name, resource)
+	c.Assert(fullName, Equals, "test-namespace/test-resource")
+
+	namespace = "test-namespace"
+	name = "test-name"
+	resource = "test-resource"
+	fullName = resourceQualifiedName(namespace, name, resource)
+	c.Assert(fullName, Equals, "test-namespace/test-name/test-resource")
 }

--- a/pkg/k8s/watchers/cilium_clusterwide_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_envoy_config.go
@@ -88,7 +88,13 @@ func (k *K8sWatcher) addCiliumClusterwideEnvoyConfig(ccec *cilium_v2.CiliumClust
 		logfields.K8sAPIVersion: ccec.TypeMeta.APIVersion,
 	})
 
-	resources, err := envoy.ParseResources("", ccec.Spec.Resources, true, k.envoyConfigManager)
+	resources, err := envoy.ParseResources(
+		ccec.GetNamespace(),
+		ccec.GetName(),
+		ccec.Spec.Resources,
+		true,
+		k.envoyConfigManager,
+	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to add CiliumClusterwideEnvoyConfig: malformed Envoy config")
 		return err
@@ -118,12 +124,24 @@ func (k *K8sWatcher) updateCiliumClusterwideEnvoyConfig(oldCCEC *cilium_v2.Ciliu
 		logfields.K8sAPIVersion: newCCEC.TypeMeta.APIVersion,
 	})
 
-	oldResources, err := envoy.ParseResources("", oldCCEC.Spec.Resources, false, k.envoyConfigManager)
+	oldResources, err := envoy.ParseResources(
+		oldCCEC.GetNamespace(),
+		oldCCEC.GetName(),
+		oldCCEC.Spec.Resources,
+		false,
+		k.envoyConfigManager,
+	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to update CiliumClusterwideEnvoyConfig: malformed old Envoy config")
 		return err
 	}
-	newResources, err := envoy.ParseResources("", newCCEC.Spec.Resources, true, k.envoyConfigManager)
+	newResources, err := envoy.ParseResources(
+		newCCEC.GetNamespace(),
+		newCCEC.GetName(),
+		newCCEC.Spec.Resources,
+		true,
+		k.envoyConfigManager,
+	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to update CiliumClusterwideEnvoyConfig: malformed new Envoy config")
 		return err
@@ -157,7 +175,13 @@ func (k *K8sWatcher) deleteCiliumClusterwideEnvoyConfig(ccec *cilium_v2.CiliumCl
 		logfields.K8sAPIVersion: ccec.TypeMeta.APIVersion,
 	})
 
-	resources, err := envoy.ParseResources("", ccec.Spec.Resources, false, k.envoyConfigManager)
+	resources, err := envoy.ParseResources(
+		ccec.GetNamespace(),
+		ccec.GetName(),
+		ccec.Spec.Resources,
+		false,
+		k.envoyConfigManager,
+	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to delete CiliumClusterwideEnvoyConfig: parsing rersource names failed")
 		return err

--- a/pkg/k8s/watchers/cilium_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_envoy_config.go
@@ -92,7 +92,13 @@ func (k *K8sWatcher) addCiliumEnvoyConfig(cec *cilium_v2.CiliumEnvoyConfig) erro
 		logfields.K8sAPIVersion:         cec.TypeMeta.APIVersion,
 	})
 
-	resources, err := envoy.ParseResources(cec.ObjectMeta.Namespace, cec.Spec.Resources, true, k.envoyConfigManager)
+	resources, err := envoy.ParseResources(
+		cec.GetNamespace(),
+		cec.GetName(),
+		cec.Spec.Resources,
+		true,
+		k.envoyConfigManager,
+	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to add CiliumEnvoyConfig: malformed Envoy config")
 		return err
@@ -180,12 +186,24 @@ func (k *K8sWatcher) updateCiliumEnvoyConfig(oldCEC *cilium_v2.CiliumEnvoyConfig
 		logfields.K8sAPIVersion:         newCEC.TypeMeta.APIVersion,
 	})
 
-	oldResources, err := envoy.ParseResources(oldCEC.ObjectMeta.Namespace, oldCEC.Spec.Resources, false, k.envoyConfigManager)
+	oldResources, err := envoy.ParseResources(
+		oldCEC.GetNamespace(),
+		oldCEC.GetName(),
+		oldCEC.Spec.Resources,
+		false,
+		k.envoyConfigManager,
+	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to update CiliumEnvoyConfig: malformed old Envoy config")
 		return err
 	}
-	newResources, err := envoy.ParseResources(newCEC.ObjectMeta.Namespace, newCEC.Spec.Resources, true, k.envoyConfigManager)
+	newResources, err := envoy.ParseResources(
+		newCEC.GetNamespace(),
+		newCEC.GetName(),
+		newCEC.Spec.Resources,
+		true,
+		k.envoyConfigManager,
+	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to update CiliumEnvoyConfig: malformed new Envoy config")
 		return err
@@ -279,7 +297,13 @@ func (k *K8sWatcher) deleteCiliumEnvoyConfig(cec *cilium_v2.CiliumEnvoyConfig) e
 		logfields.K8sAPIVersion:         cec.TypeMeta.APIVersion,
 	})
 
-	resources, err := envoy.ParseResources(cec.ObjectMeta.Namespace, cec.Spec.Resources, false, k.envoyConfigManager)
+	resources, err := envoy.ParseResources(
+		cec.GetNamespace(),
+		cec.GetName(),
+		cec.Spec.Resources,
+		false,
+		k.envoyConfigManager,
+	)
 	if err != nil {
 		scopedLog.WithError(err).Warn("Failed to delete CiliumEnvoyConfig: parsing rersource names failed")
 		return err

--- a/pkg/k8s/watchers/cilium_envoy_config_test.go
+++ b/pkg/k8s/watchers/cilium_envoy_config_test.go
@@ -65,7 +65,7 @@ func (s *K8sWatcherSuite) TestParseEnvoySpec(c *C) {
 	c.Assert(cec.Spec.Resources, HasLen, 1)
 	c.Assert(cec.Spec.Resources[0].TypeUrl, Equals, "type.googleapis.com/envoy.config.listener.v3.Listener")
 
-	resources, err := envoy.ParseResources("prefix", cec.Spec.Resources, true, nil)
+	resources, err := envoy.ParseResources("namespace", "name", cec.Spec.Resources, true, nil)
 	c.Assert(err, IsNil)
 	c.Assert(resources.Listeners, HasLen, 1)
 	c.Assert(resources.Listeners[0].Address.GetSocketAddress().GetPortValue(), Equals, uint32(10000))


### PR DESCRIPTION
This PR changes the naming of Envoy Listeners and Routes resources.
To avoid possible name clashing between resources in different namespaces, each Envoy Listener and Route name is prepended with its CEC namespace and name.
This is done while translating the CEC specifications to generate the Envoy config, and not during CEC creation. Thanks to this, a user generated CEC does not need to use the format <cecNamespace-cecName-resourceName> to be similar to an operator-generated CEC.

Relates #19698 #20655