### PR TITLE
gh/workflows: Make cilium status to wait in DP suite

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -192,7 +192,7 @@ jobs:
             --config monitor-aggregation=none \
             --nodes-without-cilium=kind-worker3 --kube-proxy-replacement=strict --helm-set-string="k8sServiceHost=kind-control-plane,k8sServicePort=6443"
 
-            ./cilium-cli status
+            ./cilium-cli status --wait
             ./cilium-cli connectivity test --datapath
             ./cilium-cli connectivity test -t -d
 


### PR DESCRIPTION
This should fix flakes when "cilium-cli install --wait" returns before cilium-agents are ready. E.g.:

    [...]
    Cilium was successfully installed! Run 'cilium status' to view installation health
    + ./cilium-cli status
	/¯¯\
     /¯¯\__/¯¯\    Cilium:         1 errors, 3 warnings
     \__/¯¯\__/    Operator:       1 errors, 1 warnings
     /¯¯\__/¯¯\    Hubble:         disabled
     \__/¯¯\__/    ClusterMesh:    disabled
	\__/