### PR TITLE
datapath: make tc filter priority configurable - 1.10 backport

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1058,6 +1058,10 @@ func initializeFlags() {
 	flags.MarkHidden(option.BypassIPAvailabilityUponRestore)
 	option.BindEnv(option.BypassIPAvailabilityUponRestore)
 
+	flags.Int(option.TCFilterPriority, 1, "Priority of TC BPF filter")
+	flags.MarkHidden(option.TCFilterPriority)
+	option.BindEnv(option.TCFilterPriority)
+
 	viper.BindPFlags(flags)
 }
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1622,12 +1622,12 @@ clustermesh:
     domain: mesh.cilium.io
     # -- List of clusters to be peered in the mesh.
     clusters: []
-    # clusters: 
+    # clusters:
     # # -- Name of the cluster
     # - name: cluster1
     # # -- Address of the cluster, use this if you created DNS records for
     # # the cluster Clustermesh API server.
-    #   address: cluster1.mesh.cilium.io 
+    #   address: cluster1.mesh.cilium.io
     # # -- Port of the cluster Clustermesh API server.
     #   port: 2379
     # # -- IPs of the cluster Clustermesh API server, use multiple ones when

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -68,6 +69,7 @@ const (
 	initArgNrCPUs
 	initArgEndpointRoutes
 	initArgProxyRule
+	initTCFilterPriority
 	initArgMax
 )
 
@@ -417,6 +419,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	} else {
 		args[initArgProxyRule] = "false"
 	}
+
+	args[initTCFilterPriority] = strconv.Itoa(option.Config.TCFilterPriority)
 
 	// "Legacy" datapath inizialization with the init.sh script
 	// TODO(mrostecki): Rewrite the whole init.sh in Go, step by step.

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command/exec"
@@ -104,8 +105,11 @@ func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirectio
 			"obj", objPath, "sec", progSec}
 	} else {
 		loaderProg = "tc"
+
+		tcPrio := strconv.Itoa(option.Config.TCFilterPriority)
+		log.Debugf("tc filter using priority %s for interface %s", tcPrio, ifName)
 		args = []string{"filter", "replace", "dev", ifName, progDirection,
-			"prio", "1", "handle", "1", "bpf", "da", "obj", objPath,
+			"prio", tcPrio, "handle", "1", "bpf", "da", "obj", objPath,
 			"sec", progSec,
 		}
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1007,6 +1007,10 @@ const (
 	// within IPAM upon endpoint restore and allows the use of the restored IP
 	// regardless of whether it's available in the pool.
 	BypassIPAvailabilityUponRestore = "bypass-ip-availability-upon-restore"
+
+	// TCFilterPriority sets the priority of the cilium tc filter, enabling other
+	// filters to be inserted prior to the cilium filter.
+	TCFilterPriority = "bpf-filter-priority"
 )
 
 // Default string arguments
@@ -2074,6 +2078,10 @@ type DaemonConfig struct {
 	// within IPAM upon endpoint restore and allows the use of the restored IP
 	// regardless of whether it's available in the pool.
 	BypassIPAvailabilityUponRestore bool
+
+	// TCFilterPriority sets the priority of the cilium tc filter, enabling other
+	// filters to be inserted prior to the cilium filter.
+	TCFilterPriority int
 }
 
 var (
@@ -2646,6 +2654,7 @@ func (c *DaemonConfig) Populate() {
 	c.BGPAnnounceLBIP = viper.GetBool(BGPAnnounceLBIP)
 	c.BGPConfigPath = viper.GetString(BGPConfigPath)
 	c.ExternalClusterIP = viper.GetBool(ExternalClusterIPName)
+	c.TCFilterPriority = viper.GetInt(TCFilterPriority)
 
 	err = c.populateMasqueradingSettings()
 	if err != nil {


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/18896 

Needed to re-arrange args to `bpf/init.sh` since `1.10` doesn't have https://github.com/cilium/cilium/pull/16874

Previously, during initialization, cilium installed bpf filters via the tc command using a hardcoded priority of 1. This patch adds the hidden bpf-filter-priority option for specifying a priority of the cilium bpf filters enabling other filters to be inserted prior to cilium's filters. The default is 1, for backward compatibility. Use Helm's extraArgs to pass this option via a Helm install.

Fixes: #17193

