### PR TITLE
Remove unused sections for bpf_lxc from nodeport header

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -11,6 +11,8 @@
 
 #include <linux/icmpv6.h>
 
+#define IS_BPF_LXC 1
+
 /* Controls the inclusion of the CILIUM_CALL_SRV6 section in the object file.
  */
 #define SKIP_SRV6_HANDLING

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -533,7 +533,7 @@ drop_err:
 }
 #endif /* ENABLE_DSR */
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT_INGRESS)
+declare_tailcall_if(__not(is_defined(IS_BPF_LXC)), CILIUM_CALL_IPV6_NODEPORT_NAT_INGRESS)
 int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 {
 	const bool nat_46x64 = ctx_load_meta(ctx, CB_NAT_46X64);
@@ -572,7 +572,7 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
 }
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT_EGRESS)
+declare_tailcall_if(__not(is_defined(IS_BPF_LXC)), CILIUM_CALL_IPV6_NODEPORT_NAT_EGRESS)
 int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 {
 	const bool nat_46x64 = ctx_load_meta(ctx, CB_NAT_46X64);
@@ -1425,7 +1425,7 @@ drop_err:
 }
 #endif /* ENABLE_DSR */
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_NAT_INGRESS)
+declare_tailcall_if(__not(is_defined(IS_BPF_LXC)), CILIUM_CALL_IPV4_NODEPORT_NAT_INGRESS)
 int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 {
 	struct ipv4_nat_target target = {
@@ -1472,7 +1472,7 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
 }
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_NAT_EGRESS)
+declare_tailcall_if(__not(is_defined(IS_BPF_LXC)), CILIUM_CALL_IPV4_NODEPORT_NAT_EGRESS)
 int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 {
 	struct bpf_fib_lookup_padded fib_params = {

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -27,6 +27,10 @@
 #define __or3_0(y, z)  __or(y, z)
 #define __or3(x, y, z) __eval(__or3_, x)(y, z)
 
+#define __not_0 1
+#define __not_1 0
+#define __not(x) __eval(__not_, x)
+
 /* declare_tailcall_if() and invoke_tailcall_if() is a pair
  * of helpers which based on COND either selects to emit a
  * tail call for the underlying function when true or emits


### PR DESCRIPTION
**Background**
One of the Kubernetes SLO is the Pod Startup Latency SLO. The current limit is the 99th percentile <= 5s. With the use of cilium Kubernetes is very close to this limit, sometimes even exceeding it. One of the major bottlenecks is eBPF program verification performed by kernel.

**Change description**
I went through the code to find kernel verification times for different sections, the most consuming ones were `tail_nodeport_nat_egress_ipv4` and `tail_nodeport_nat_egress_ipv6`. These sections are actually not used by bpf_lxc at all, but added and verified by kernel. So this change removes unused for bpf_lxc sections from nodeport header. After this change the total verification time for all programs for bpf_lxc reduced almost twice (from ~500ms to ~270ms). And with all the routine to load program, these changes contributed to the whole latency drop even more.

**Test scenario**
All tests were run on the cluster version 1.24.4-gke.300. The cilium master branch was used as a baseline for all the tests.

To test different configurations a GKE sandbox with custom Dataplane v2 images was used. The cluster was created with 100 nodes and DPv2 enabled. For Pod Startup Latency measurements a modified configuration of a GKE Scalability 100 nodes performance test was used.

In the beginning for each run 1 pod was created on each node with the same image as in Pod Startup Latency measurement, so image pull time is not affecting the resulting latency. Then 500 deployments with 5 pods each were created and waited until running to measure the pod startup latency.

**Results**

Result were aggregated from 20 separate test runs.

Percentile | Baseline | Optimized
--- | --- | ---
P50 | 3088 ms | 2584 ms
P90 | 3701 ms | 3169 ms
P99 | 4126 ms | 3573 ms

**Summary**
This optimization reduces the total latency by ~500ms and removes unnecessary sections loading to kernel.

```release-note
Remove unused sections for bpf_lxc from nodeport.h
```

Signed-off-by: Alex Katsman <alexkats@google.com>