### PR TITLE
Helm: configurable capabilities for cilium-agent

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1709,10 +1709,22 @@
      - Enable SCTP support. NOTE: Currently, SCTP support does not support rewriting ports or multihoming.
      - bool
      - ``false``
-   * - securityContext.extraCapabilities
-     - Extra capabilities to add to the ``cilium-agent`` container in the DaemonSet
+   * - securityContext.capabilities.applySysctlOverwrites
+     - capabilities for the ``apply-sysctl-overwrites`` init container
      - list
-     - ``["DAC_OVERRIDE","FOWNER","SETGID","SETUID"]``
+     - ``["SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]``
+   * - securityContext.capabilities.ciliumAgent
+     - Capabilities for the ``cilium-agent`` container
+     - list
+     - ``["CHOWN","KILL","NET_ADMIN","NET_RAW","IPC_LOCK","SYS_MODULE","SYS_ADMIN","SYS_RESOURCE","DAC_OVERRIDE","FOWNER","SETGID","SETUID"]``
+   * - securityContext.capabilities.cleanCiliumState
+     - Capabilities for the ``clean-cilium-state`` init container
+     - list
+     - ``["NET_ADMIN","SYS_MODULE","SYS_ADMIN","SYS_RESOURCE"]``
+   * - securityContext.capabilities.mountCgroup
+     - Capabilities for the ``mount-cgroup`` init container
+     - list
+     - ``["SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]``
    * - securityContext.privileged
      - Run the pod with elevated privileges
      - bool

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1709,10 +1709,14 @@
      - Enable SCTP support. NOTE: Currently, SCTP support does not support rewriting ports or multihoming.
      - bool
      - ``false``
-   * - securityContext
-     - Security context to be added to agent pods
-     - object
-     - ``{"extraCapabilities":["DAC_OVERRIDE","FOWNER","SETGID","SETUID"],"privileged":false}``
+   * - securityContext.extraCapabilities
+     - Extra capabilities to add to the ``cilium-agent`` container in the DaemonSet
+     - list
+     - ``["DAC_OVERRIDE","FOWNER","SETGID","SETUID"]``
+   * - securityContext.privileged
+     - Run the pod with elevated privileges
+     - bool
+     - ``false``
    * - serviceAccounts
      - Define serviceAccount names for components.
      - object

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -338,6 +338,16 @@ Removed Metrics/Labels
 * ``cilium_operator_ipam_release_ops`` is removed. Please use ``cilium_operator_ipam_ip_release_ops`` instead.
 * The label of ``status`` in ``cilium_operator_ipam_interface_creation_ops`` is removed.
 
+Helm Options
+~~~~~~~~~~~~
+
+* The way Linux capabilities are configured has been revamped in this release. 
+  All capabilities of every container in the ``cilium-agent`` DaemonSet is
+  configured from Helm's values, defaulting to the old behavior. If you have not
+  been using ``securityContext.extraCapabilities`` you do not need to do anything.
+  If you were leveraging ``securityContext.extraCapabilities``, you need to review
+  ``securityContext.capabilities.cilium_agent``.
+
 .. _1.12_upgrade_notes:
 
 1.12 Upgrade Notes

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -172,6 +172,7 @@ apiKeys
 apiVersion
 apiserver
 app
+applySysctlOverwrites
 apps
 archs
 arithmetics
@@ -253,9 +254,11 @@ cheatsheet
 ci
 cidr
 cidrs
+ciliumAgent
 classful
 classid
 cleanBpfState
+cleanCiliumState
 cleanState
 cli
 clockProbe
@@ -672,6 +675,7 @@ mlx
 monitorAggregation
 monitorFlags
 monitorInterval
+mountCgroup
 mountHostBoot
 mountPath
 mov

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -478,7 +478,8 @@ contributors across the globe, there is almost always someone available to help.
 | rollOutCiliumPods | bool | `false` | Roll out cilium agent pods automatically when configmap is updated. |
 | sctp | object | `{"enabled":false}` | SCTP Configuration Values |
 | sctp.enabled | bool | `false` | Enable SCTP support. NOTE: Currently, SCTP support does not support rewriting ports or multihoming. |
-| securityContext | object | `{"extraCapabilities":["DAC_OVERRIDE","FOWNER","SETGID","SETUID"],"privileged":false}` | Security context to be added to agent pods |
+| securityContext.extraCapabilities | list | `["DAC_OVERRIDE","FOWNER","SETGID","SETUID"]` | extra capabilities to add to the `cilium-agent` container in the DaemonSet |
+| securityContext.privileged | bool | `false` | run the pod with elevated privileges |
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
 | serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -478,8 +478,11 @@ contributors across the globe, there is almost always someone available to help.
 | rollOutCiliumPods | bool | `false` | Roll out cilium agent pods automatically when configmap is updated. |
 | sctp | object | `{"enabled":false}` | SCTP Configuration Values |
 | sctp.enabled | bool | `false` | Enable SCTP support. NOTE: Currently, SCTP support does not support rewriting ports or multihoming. |
-| securityContext.extraCapabilities | list | `["DAC_OVERRIDE","FOWNER","SETGID","SETUID"]` | extra capabilities to add to the `cilium-agent` container in the DaemonSet |
-| securityContext.privileged | bool | `false` | run the pod with elevated privileges |
+| securityContext.capabilities.applySysctlOverwrites | list | `["SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]` | capabilities for the `apply-sysctl-overwrites` init container |
+| securityContext.capabilities.ciliumAgent | list | `["CHOWN","KILL","NET_ADMIN","NET_RAW","IPC_LOCK","SYS_MODULE","SYS_ADMIN","SYS_RESOURCE","DAC_OVERRIDE","FOWNER","SETGID","SETUID"]` | Capabilities for the `cilium-agent` container |
+| securityContext.capabilities.cleanCiliumState | list | `["NET_ADMIN","SYS_MODULE","SYS_ADMIN","SYS_RESOURCE"]` | Capabilities for the `clean-cilium-state` init container |
+| securityContext.capabilities.mountCgroup | list | `["SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]` | Capabilities for the `mount-cgroup` init container |
+| securityContext.privileged | bool | `false` | Run the pod with elevated privileges |
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
 | serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -268,32 +268,9 @@ spec:
             type: 'spc_t'
           capabilities:
             add:
-              # Use to set socket permission
-              - CHOWN
-              # Used to terminate envoy child process
-              - KILL
-              # Used since cilium modifies routing tables, etc...
-              - NET_ADMIN
-              # Used since cilium creates raw sockets, etc...
-              - NET_RAW
-              # Used since cilium monitor uses mmap
-              - IPC_LOCK
-              # Used in iptables. Consider removing once we are iptables-free
-              - SYS_MODULE
-              # We need it for now but might not need it for >= 5.11 specially
-              # for the 'SYS_RESOURCE'.
-              # In >= 5.8 there's already BPF and PERMON capabilities
-              - SYS_ADMIN
-              # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
-              - SYS_RESOURCE
-              # Both PERFMON and BPF requires kernel 5.8, container runtime
-              # cri-o >= v1.22.0 or containerd >= v1.5.0.
-              # If available, SYS_ADMIN can be removed.
-              #- PERFMON
-              #- BPF
-              {{- with .Values.securityContext.extraCapabilities }}
-              {{- toYaml . | nindent 14 }}
-              {{- end }}
+            {{- with .Values.securityContext.capabilities.ciliumAgent }}
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
             drop:
               - ALL
           {{- end }}
@@ -473,14 +450,12 @@ spec:
             # type available on the system.
             type: 'spc_t'
           capabilities:
+            add:
+            {{- with .Values.securityContext.capabilities.mountCgroup }}
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
             drop:
               - ALL
-            add:
-              # Only used for 'mount' cgroup
-              - SYS_ADMIN
-              # Used for nsenter
-              - SYS_CHROOT
-              - SYS_PTRACE
           {{- end}}
       - name: apply-sysctl-overwrites
         image: {{ include "cilium.image" .Values.image | quote }}
@@ -517,14 +492,12 @@ spec:
             # type available on the system.
             type: 'spc_t'
           capabilities:
+            add:
+            {{- with .Values.securityContext.capabilities.applySysctlOverwrites }}
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
             drop:
               - ALL
-            add:
-              # Required in order to access host's /etc/sysctl.d dir
-              - SYS_ADMIN
-              # Used for nsenter
-              - SYS_CHROOT
-              - SYS_PTRACE
           {{- end}}
       {{- end }}
       {{- if not .Values.securityContext.privileged }}
@@ -609,26 +582,10 @@ spec:
             # type available on the system.
             type: 'spc_t'
           capabilities:
-            # Most of the capabilities here are the same ones used in the
-            # cilium-agent's container because this container can be used to
-            # uninstall all Cilium resources, and therefore it is likely that
-            # will need the same capabilities.
             add:
-              # Used since cilium modifies routing tables, etc...
-              - NET_ADMIN
-              # Used in iptables. Consider removing once we are iptables-free
-              - SYS_MODULE
-              # We need it for now but might not need it for >= 5.11 specially
-              # for the 'SYS_RESOURCE'.
-              # In >= 5.8 there's already BPF and PERMON capabilities
-              - SYS_ADMIN
-              # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
-              - SYS_RESOURCE
-              # Both PERFMON and BPF requires kernel 5.8, container runtime
-              # cri-o >= v1.22.0 or containerd >= v1.5.0.
-              # If available, SYS_ADMIN can be removed.
-              #- PERFMON
-              #- BPF
+            {{- with .Values.securityContext.capabilities.cleanCiliumState }}
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
             drop:
               - ALL
           {{- end}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -179,16 +179,75 @@ securityContext:
   # runAsUser: 0
   # -- Run the pod with elevated privileges
   privileged: false
-  # -- Extra capabilities to add to the `cilium-agent` container in the DaemonSet
-  extraCapabilities:
-    # Allow discretionary access control (e.g. required for package installation)
-    - DAC_OVERRIDE
-    # Allow to set Access Control Lists (ACLs) on arbitrary files (e.g. required for package installation)
-    - FOWNER
-    # Allow to execute program that changes GID (e.g. required for package installation)
-    - SETGID
-    # Allow to execute program that changes UID (e.g. required for package installation)
-    - SETUID
+  capabilities:
+    # -- Capabilities for the `cilium-agent` container
+    ciliumAgent:
+      # Use to set socket permission
+      - CHOWN
+      # Used to terminate envoy child process
+      - KILL
+      # Used since cilium modifies routing tables, etc...
+      - NET_ADMIN
+      # Used since cilium creates raw sockets, etc...
+      - NET_RAW
+      # Used since cilium monitor uses mmap
+      - IPC_LOCK
+      # Used in iptables. Consider removing once we are iptables-free
+      - SYS_MODULE
+      # We need it for now but might not need it for >= 5.11 specially
+      # for the 'SYS_RESOURCE'.
+      # In >= 5.8 there's already BPF and PERMON capabilities
+      - SYS_ADMIN
+      # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
+      - SYS_RESOURCE
+      # Both PERFMON and BPF requires kernel 5.8, container runtime
+      # cri-o >= v1.22.0 or containerd >= v1.5.0.
+      # If available, SYS_ADMIN can be removed.
+      #- PERFMON
+      #- BPF
+      # Allow discretionary access control (e.g. required for package installation)
+      - DAC_OVERRIDE
+      # Allow to set Access Control Lists (ACLs) on arbitrary files (e.g. required for package installation)
+      - FOWNER
+      # Allow to execute program that changes GID (e.g. required for package installation)
+      - SETGID
+      # Allow to execute program that changes UID (e.g. required for package installation)
+      - SETUID
+    # -- Capabilities for the `mount-cgroup` init container
+    mountCgroup:
+      # Only used for 'mount' cgroup
+      - SYS_ADMIN
+      # Used for nsenter
+      - SYS_CHROOT
+      - SYS_PTRACE
+    # -- capabilities for the `apply-sysctl-overwrites` init container
+    applySysctlOverwrites:
+      # Required in order to access host's /etc/sysctl.d dir
+      - SYS_ADMIN
+      # Used for nsenter
+      - SYS_CHROOT
+      - SYS_PTRACE
+    # -- Capabilities for the `clean-cilium-state` init container
+    cleanCiliumState:
+      # Most of the capabilities here are the same ones used in the
+      # cilium-agent's container because this container can be used to
+      # uninstall all Cilium resources, and therefore it is likely that
+      # will need the same capabilities.
+      # Used since cilium modifies routing tables, etc...
+      - NET_ADMIN
+      # Used in iptables. Consider removing once we are iptables-free
+      - SYS_MODULE
+      # We need it for now but might not need it for >= 5.11 specially
+      # for the 'SYS_RESOURCE'.
+      # In >= 5.8 there's already BPF and PERMON capabilities
+      - SYS_ADMIN
+      # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
+      - SYS_RESOURCE
+      # Both PERFMON and BPF requires kernel 5.8, container runtime
+      # cri-o >= v1.22.0 or containerd >= v1.5.0.
+      # If available, SYS_ADMIN can be removed.
+      #- PERFMON
+      #- BPF
 
 # -- Cilium agent update strategy
 updateStrategy:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -174,10 +174,12 @@ resources: {}
   #   cpu: 100m
   #   memory: 512Mi
 
-# -- Security context to be added to agent pods
 securityContext:
+  # -- User to run the pod with
   # runAsUser: 0
+  # -- Run the pod with elevated privileges
   privileged: false
+  # -- Extra capabilities to add to the `cilium-agent` container in the DaemonSet
   extraCapabilities:
     # Allow discretionary access control (e.g. required for package installation)
     - DAC_OVERRIDE

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -171,10 +171,12 @@ resources: {}
   #   cpu: 100m
   #   memory: 512Mi
 
-# -- Security context to be added to agent pods
 securityContext:
+  # -- User to run the pod with
   # runAsUser: 0
+  # -- Run the pod with elevated privileges
   privileged: false
+  # -- Extra capabilities to add to the `cilium-agent` container in the DaemonSet
   extraCapabilities:
     # Allow discretionary access control (e.g. required for package installation)
     - DAC_OVERRIDE

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -176,16 +176,75 @@ securityContext:
   # runAsUser: 0
   # -- Run the pod with elevated privileges
   privileged: false
-  # -- Extra capabilities to add to the `cilium-agent` container in the DaemonSet
-  extraCapabilities:
-    # Allow discretionary access control (e.g. required for package installation)
-    - DAC_OVERRIDE
-    # Allow to set Access Control Lists (ACLs) on arbitrary files (e.g. required for package installation)
-    - FOWNER
-    # Allow to execute program that changes GID (e.g. required for package installation)
-    - SETGID
-    # Allow to execute program that changes UID (e.g. required for package installation)
-    - SETUID
+  capabilities:
+    # -- Capabilities for the `cilium-agent` container
+    ciliumAgent:
+      # Use to set socket permission
+      - CHOWN
+      # Used to terminate envoy child process
+      - KILL
+      # Used since cilium modifies routing tables, etc...
+      - NET_ADMIN
+      # Used since cilium creates raw sockets, etc...
+      - NET_RAW
+      # Used since cilium monitor uses mmap
+      - IPC_LOCK
+      # Used in iptables. Consider removing once we are iptables-free
+      - SYS_MODULE
+      # We need it for now but might not need it for >= 5.11 specially
+      # for the 'SYS_RESOURCE'.
+      # In >= 5.8 there's already BPF and PERMON capabilities
+      - SYS_ADMIN
+      # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
+      - SYS_RESOURCE
+      # Both PERFMON and BPF requires kernel 5.8, container runtime
+      # cri-o >= v1.22.0 or containerd >= v1.5.0.
+      # If available, SYS_ADMIN can be removed.
+      #- PERFMON
+      #- BPF
+      # Allow discretionary access control (e.g. required for package installation)
+      - DAC_OVERRIDE
+      # Allow to set Access Control Lists (ACLs) on arbitrary files (e.g. required for package installation)
+      - FOWNER
+      # Allow to execute program that changes GID (e.g. required for package installation)
+      - SETGID
+      # Allow to execute program that changes UID (e.g. required for package installation)
+      - SETUID
+    # -- Capabilities for the `mount-cgroup` init container
+    mountCgroup:
+      # Only used for 'mount' cgroup
+      - SYS_ADMIN
+      # Used for nsenter
+      - SYS_CHROOT
+      - SYS_PTRACE
+    # -- capabilities for the `apply-sysctl-overwrites` init container
+    applySysctlOverwrites:
+      # Required in order to access host's /etc/sysctl.d dir
+      - SYS_ADMIN
+      # Used for nsenter
+      - SYS_CHROOT
+      - SYS_PTRACE
+    # -- Capabilities for the `clean-cilium-state` init container
+    cleanCiliumState:
+      # Most of the capabilities here are the same ones used in the
+      # cilium-agent's container because this container can be used to
+      # uninstall all Cilium resources, and therefore it is likely that
+      # will need the same capabilities.
+      # Used since cilium modifies routing tables, etc...
+      - NET_ADMIN
+      # Used in iptables. Consider removing once we are iptables-free
+      - SYS_MODULE
+      # We need it for now but might not need it for >= 5.11 specially
+      # for the 'SYS_RESOURCE'.
+      # In >= 5.8 there's already BPF and PERMON capabilities
+      - SYS_ADMIN
+      # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
+      - SYS_RESOURCE
+      # Both PERFMON and BPF requires kernel 5.8, container runtime
+      # cri-o >= v1.22.0 or containerd >= v1.5.0.
+      # If available, SYS_ADMIN can be removed.
+      #- PERFMON
+      #- BPF
 
 # -- Cilium agent update strategy
 updateStrategy:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #20636 

```release-note
Helm: optionally use less permissive linux capabilities.
```

This change is needed to actually run (non-privileged) Cilium on Talos Linux, but is very useful in the (near) future when more fine grained capabilities exist in Linux.