### PR TITLE
monitor: Add parser for socket-lb tracing events

### DIFF
--- a/pkg/monitor/datapath_sock_trace.go
+++ b/pkg/monitor/datapath_sock_trace.go
@@ -1,8 +1,15 @@
 package monitor
 
-import "github.com/cilium/cilium/pkg/types"
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
 
-// Socket trace event point with respect to service translation
+	"github.com/cilium/cilium/pkg/types"
+)
+
+// Service translation event point in socket trace event messages
 const (
 	XlatePointUnknown = iota
 	XlatePointPreDirectionFwd
@@ -11,12 +18,14 @@ const (
 	XlatePointPostDirectionRev
 )
 
-// L4 protocol for socket trace event
+// L4 protocol for socket trace event messages
 const (
 	L4ProtocolUnknown = iota
 	L4ProtocolTCP
 	L4ProtocolUDP
 )
+
+const TraceSockNotifyFlagIPv6 uint8 = 0x1
 
 // TraceSockNotify is message format for socket trace notifications sent from datapath.
 // Keep this in sync to the datapath structure (trace_sock_notify) defined in
@@ -30,4 +39,46 @@ type TraceSockNotify struct {
 	CgroupId   uint64
 	L4Proto    uint8
 	Flags      uint8
+}
+
+func (t *TraceSockNotify) DumpDebug(prefix string) {
+	buf := bufio.NewWriter(os.Stdout)
+
+	fmt.Fprintf(buf, "%s [%s] cgroup_id: %d sock_cookie: %d, dst [%s]:%d %s \n",
+		prefix, t.XlatePointStr(), t.CgroupId, t.SockCookie, t.IP(), t.DstPort, t.L4ProtoStr())
+	buf.Flush()
+}
+
+func (t *TraceSockNotify) XlatePointStr() string {
+	switch t.XlatePoint {
+	case XlatePointPreDirectionFwd:
+		return "pre-xlate-fwd"
+	case XlatePointPostDirectionFwd:
+		return "post-xlate-fwd"
+	case XlatePointPreDirectionRev:
+		return "pre-xlate-rev"
+	case XlatePointPostDirectionRev:
+		return "post-xlate-rev"
+	default:
+		return "unknown"
+	}
+}
+
+// IP returns the IPv4 or IPv6 address field.
+func (t *TraceSockNotify) IP() net.IP {
+	if (t.Flags & TraceSockNotifyFlagIPv6) != 0 {
+		return t.DstIP[:]
+	}
+	return t.DstIP[:4]
+}
+
+func (t *TraceSockNotify) L4ProtoStr() string {
+	switch t.L4Proto {
+	case L4ProtocolTCP:
+		return "tcp"
+	case L4ProtocolUDP:
+		return "udp"
+	default:
+		return "unknown"
+	}
 }

--- a/pkg/monitor/format/format.go
+++ b/pkg/monitor/format/format.go
@@ -122,6 +122,19 @@ func (m *MonitorFormatter) traceEvents(prefix string, data []byte) {
 	}
 }
 
+func (m *MonitorFormatter) traceSockEvents(prefix string, data []byte) {
+	tn := monitor.TraceSockNotify{}
+
+	if err := binary.Read(bytes.NewReader(data), byteorder.Native, &tn); err != nil {
+		fmt.Printf("Error while parsing socket trace notification message: %s\n", err)
+	}
+	// Currently only printed with the debug option. Extend it to info and json.
+	// GH issue: https://github.com/cilium/cilium/issues/21510
+	if m.Verbosity == DEBUG {
+		tn.DumpDebug(prefix)
+	}
+}
+
 func (m *MonitorFormatter) policyVerdictEvents(prefix string, data []byte) {
 	pn := monitor.PolicyVerdictNotify{}
 
@@ -250,7 +263,7 @@ func (m *MonitorFormatter) FormatSample(data []byte, cpu int) {
 	case monitorAPI.MessageTypeRecCapture:
 		m.recorderCaptureEvents(prefix, data)
 	case monitorAPI.MessageTypeTraceSock:
-		// TODO: events to be formatted
+		m.traceSockEvents(prefix, data)
 	default:
 		fmt.Printf("%s Unknown event: %+v\n", prefix, data)
 	}


### PR DESCRIPTION
This is a no-frills parser that only prints parsed socket-lb tracing events in the debug mode. The socket-lb tracing hook points were added in - https://github.com/cilium/cilium/pull/20492.
See commit description for more details.

```
$cilium monitor -v -t trace-sock

CPU 03: [pre-xlate-fwd] cgroup_id: 13125 sock_cookie: 114605, dst [172.20.0.178:80] tcp
CPU 03: [post-xlate-fwd] cgroup_id: 13125 sock_cookie: 114605, dst [10.12.0.43:80] tcp
CPU 03: [pre-xlate-rev] cgroup_id: 13125 sock_cookie: 114605, dst [10.12.0.43:80] tcp
CPU 03: [post-xlate-rev] cgroup_id: 13125 sock_cookie: 114605, dst [172.20.0.178:80] tcp

$ find /run/cilium/cgroupv2/ -inum 13125

/run/cilium/cgroupv2/kubepods/besteffort/poda48639f8-0ab5-40cc-aaa2-ae63adb71fe5/ae31f464145ffd38ec0bb80943ba5a23a47acb5b69e8ac52c912cf58430a1404
```

Signed-off-by: Aditi Ghag <aditi@cilium.io>