### PR TITLE
fqdn/dnsproxy, daemon: Define new error type for DNS notification

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -460,7 +460,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		// cache if we don't know that an endpoint asked for it (this is
 		// asserted via ep != nil here and msg.Response && msg.Rcode ==
 		// dns.RcodeSuccess below).
-		err := errors.New("DNS request cannot be associated with an existing endpoint")
+		err := dnsproxy.ErrDNSRequestNoEndpoint{}
 		log.WithFields(logrus.Fields{
 			logfields.L3n4Addr: epIPPort,
 		}).WithError(err).Error("cannot find matching endpoint")

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -384,6 +384,15 @@ func (e ErrTimedOutAcquireSemaphore) Error() string {
 	)
 }
 
+// ErrDNSRequestNoEndpoint represents an error when the local daemon cannot
+// find the corresponding endpoint that triggered a DNS request processed by
+// the local DNS proxy (FQDN proxy).
+type ErrDNSRequestNoEndpoint struct{}
+
+func (ErrDNSRequestNoEndpoint) Error() string {
+	return "DNS request cannot be associated with an existing endpoint"
+}
+
 // ProxyRequestContext proxy dns request context struct to send in the callback
 type ProxyRequestContext struct {
 	ProcessingTime spanstat.SpanStat // This is going to happen at the end of the second callback.


### PR DESCRIPTION
This error is returned when the DNS proxy receives a DNS request for an
endpoint that no longer exists to the local daemon.

External components which integrate with the DNS proxy code may find it
useful to check for this error, hence defining and exporting a type in
this package.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
