### PR TITLE
consolidate_go_stacktrace.py: Add support for replacing Cilium source directory inline

### DIFF
--- a/contrib/scripts/consolidate_go_stacktrace.py
+++ b/contrib/scripts/consolidate_go_stacktrace.py
@@ -4,8 +4,11 @@
 # stack. Addresses, goroutine ID and goroutine ages are ignored when determining
 # uniqeness. A sample of each unique trace is printed
 
-import re,sys,collections
+import re
+import sys
+import collections
 from functools import cmp_to_key
+
 
 def get_stacks(f):
     """
@@ -20,10 +23,13 @@ def get_stacks(f):
         else:
             accum.append(line)
 
+
 # Regexes used to find and remove addresses, ids and age
 strip_addresses = re.compile(r"0x[0-9a-fA-F]+")
 strip_goroutine_id = re.compile(r"goroutine [0-9]+")
 strip_goroutine_time = re.compile(r", [0-9]+ minutes")
+
+
 def strip_stack(stack):
     """
     strip_stack replaces addresses, goroutine IDs and ages with a fixed sentinel
@@ -33,6 +39,7 @@ def strip_stack(stack):
     stack = [strip_goroutine_time.sub("", l) for l in stack]
     return stack
 
+
 def get_hashable_stack_value(stack):
     """
     get_hashable_stack_value transforms stack (and array of strings) into
@@ -40,11 +47,13 @@ def get_hashable_stack_value(stack):
     """
     return "".join(strip_stack(stack))
 
+
 def print_usage():
     print("""usage: {} [-h | path/to/file]
         -h:         This help.
         path/to/file:   Read and parse file with go stacktraces
         '-' or no params: Read and parse stdin""".format(sys.argv[0]))
+
 
 if __name__ == "__main__":
     # Handle arguments. We only support a file path, or stdin on "-" or no
@@ -67,7 +76,12 @@ if __name__ == "__main__":
 
     # print count of each unique stack, and a sample, sorted by frequency
     print("{} unique stack traces".format(len(consolidated)))
-    for stack in sorted(consolidated.values(), key=cmp_to_key(lambda a,b: len(a)-len(b)), reverse=True):
+    for stack in sorted(
+            consolidated.values(),
+            key=cmp_to_key(
+                lambda a,
+                b: len(a) - len(b)),
+            reverse=True):
         print("{} occurences. Sample stack trace:".format(len(stack)))
         print("\n".join(stack[0]))
 

--- a/contrib/scripts/consolidate_go_stacktrace.py
+++ b/contrib/scripts/consolidate_go_stacktrace.py
@@ -8,6 +8,7 @@ import re
 import sys
 import collections
 from functools import cmp_to_key
+import argparse
 
 
 def get_stacks(f):
@@ -48,24 +49,22 @@ def get_hashable_stack_value(stack):
     return "".join(strip_stack(stack))
 
 
-def print_usage():
-    print("""usage: {} [-h | path/to/file]
-        -h:         This help.
-        path/to/file:   Read and parse file with go stacktraces
-        '-' or no params: Read and parse stdin""".format(sys.argv[0]))
-
-
 if __name__ == "__main__":
     # Handle arguments. We only support a file path, or stdin on "-" or no
     # parameter
-    infile = sys.argv[1] if len(sys.argv) > 1 else ""
-    if infile in ["-h", "help"]:
-        print_usage()
-        sys.exit(0)
-    elif infile in ["-", "", None]:
+    parser = argparse.ArgumentParser(
+        description='Consolidate stacktraces to remove duplicate stacks.')
+    parser.add_argument(
+        'infile',
+        metavar='PATH',
+        nargs='?',
+        help='Read and parse this file. Specify \'-\' or omit this option for stdin.')
+    args = parser.parse_args()
+
+    if args.infile in ["-", "", None]:
         f = sys.stdin
     else:
-        f = open(infile)
+        f = open(args.infile)
 
     # collect stacktraces into groups, each keyed by a version of the stack
     # where unwanted fields have been made into sentinels

--- a/contrib/scripts/consolidate_go_stacktrace.py
+++ b/contrib/scripts/consolidate_go_stacktrace.py
@@ -11,6 +11,9 @@ from functools import cmp_to_key
 import argparse
 
 
+cilium_source = '/go/src/github.com/cilium/cilium'
+
+
 def get_stacks(f):
     """
     get_stacks parses file f and yields all lines in go stackrace as one array
@@ -59,6 +62,12 @@ if __name__ == "__main__":
         metavar='PATH',
         nargs='?',
         help='Read and parse this file. Specify \'-\' or omit this option for stdin.')
+    parser.add_argument(
+        '-s',
+        '--source-dir',
+        nargs=1,
+        default=cilium_source,
+        help='Rewrite Cilium source paths to refer to this directory')
     args = parser.parse_args()
 
     if args.infile in ["-", "", None]:
@@ -82,7 +91,7 @@ if __name__ == "__main__":
                 b: len(a) - len(b)),
             reverse=True):
         print("{} occurences. Sample stack trace:".format(len(stack)))
-        print("\n".join(stack[0]))
+        print("\n".join(stack[0]).replace(cilium_source, args.source_dir[0]))
 
     if f != sys.stdin:
         f.close()


### PR DESCRIPTION
Add an option to allow the user to specify a cilium source directory,
and substitute all stack traces to Cilium paths with this path.

This way, when using an IDE that allows Ctrl+click navigation in order
to browse to the location, it is easier to just run this script with the
extra dir from the cilium source directory and directly click on the
paths into the codebase for easy stack trace browsing:

```
$ contrib/scripts/consolidate_go_stacktrace.py stacktrace.txt -s . | head -n 20
114 unique stack traces
18 occurences. Sample stack trace:
sync.runtime_SemacquireMutex(0x30?, 0x0?, 0xc0033a3620?)
        /usr/local/go/src/runtime/sema.go:77 +0x25
sync.(*RWMutex).RLock(...)
        /usr/local/go/src/sync/rwmutex.go:71
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).unconditionalRLock(...)
        ./pkg/endpoint/lock.go:53
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).HasLabels(0xc000ee2000?, 0x2807b69?)
        ./pkg/endpoint/endpoint.go:1028 +0x59
github.com/cilium/cilium/daemon/cmd.(*Daemon).getEndpointList.func1(0xc0006f9e60?, 0xc0030ff590?, 0xc0030ff5a0?)
        ./daemon/cmd/endpoint.go:96 +0x71
created by github.com/cilium/cilium/daemon/cmd.(*Daemon).getEndpointList
        ./daemon/cmd/endpoint.go:94 +0x16f
...
```

This is a nice shorthand instead of having to pass the output to sed something like this:

    $ consolidate_go_stacktrace.py /path/to/my/stacktrace | sed 's;/go/src/github.com/cilium/cilium;/my/custom/path;g`

The first couple of commits are just tidying up to allow the above in
the third commit.
