### PR TITLE
daemon, options: remove deprecated, ineffective options

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -312,6 +312,12 @@ Annotations:
 1.13 Upgrade Notes
 ------------------
 
+Removed Options
+~~~~~~~~~~~~~~~
+
+* The ineffective ``disable-conntrack``, ``endpoint-interface-name-prefix`` options deprecated in
+  version 1.12 have been removed.
+
 Added Metrics
 ~~~~~~~~~~~~~
 
@@ -323,7 +329,6 @@ Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~
 
 * ``http`` is deprecated. Please use ``httpV2`` instead.
-
 
 Removed Metrics/Labels
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -215,10 +215,6 @@ func initializeFlags() {
 	flags.String(option.DatapathMode, defaults.DatapathMode, "Datapath mode name")
 	option.BindEnv(Vp, option.DatapathMode)
 
-	flags.Bool(option.DisableConntrack, false, "Disable connection tracking")
-	option.BindEnv(Vp, option.DisableConntrack)
-	flags.MarkDeprecated(option.DisableConntrack, "This option is no-op and it will be removed in v1.13")
-
 	flags.Bool(option.EnableEndpointRoutes, defaults.EnableEndpointRoutes, "Use per endpoint routes instead of routing via cilium_host")
 	option.BindEnv(Vp, option.EnableEndpointRoutes)
 
@@ -276,10 +272,6 @@ func initializeFlags() {
 
 	flags.StringSlice(option.IPv6PodSubnets, []string{}, "List of IPv6 pod subnets to preconfigure for encryption")
 	option.BindEnv(Vp, option.IPv6PodSubnets)
-
-	flags.String(option.EndpointInterfaceNamePrefix, "", "Prefix of interface name shared by all endpoints")
-	option.BindEnv(Vp, option.EndpointInterfaceNamePrefix)
-	flags.MarkDeprecated(option.EndpointInterfaceNamePrefix, "This option no longer has any effect and will be removed in v1.13.")
 
 	flags.StringSlice(option.ExcludeLocalAddress, []string{}, "Exclude CIDR from being recognized as local address")
 	option.BindEnv(Vp, option.ExcludeLocalAddress)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -129,9 +129,6 @@ const (
 	// running BPF loadbalancer program
 	LBDevInheritIPAddr = "bpf-lb-dev-ip-addr-inherit"
 
-	// DisableConntrack disables connection tracking
-	DisableConntrack = "disable-conntrack"
-
 	// DisableEnvoyVersionCheck do not perform Envoy binary version check on startup
 	DisableEnvoyVersionCheck = "disable-envoy-version-check"
 
@@ -795,10 +792,6 @@ const (
 
 	// LocalRouterIPv6 is the link-local IPv6 address to use for Cilium router device
 	LocalRouterIPv6 = "local-router-ipv6"
-
-	// EndpointInterfaceNamePrefix is the prefix name of the interface
-	// names shared by all endpoints
-	EndpointInterfaceNamePrefix = "endpoint-interface-name-prefix"
 
 	// ForceLocalPolicyEvalAtSource forces a policy decision at the source
 	// endpoint for all local communication


### PR DESCRIPTION
Remove the `disable-conntrack` and `endpoint-interface-name` options which have been deprecated and ineffective since version 1.12.