### PR TITLE
gh/workflows: Pin lvh to v0.0.1

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -170,6 +170,7 @@ jobs:
           test-name: datapath-conformance
           image: kind
           image-version: '5.10'
+          lvh-version: 'v0.0.1'
           host-mount: ./
           cmd: |
             set -eux

--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -175,6 +175,8 @@ jobs:
           cmd: |
             set -eux
 
+            echo 'nameserver 1.1.1.1' > /etc/resolv.conf
+
             cd /host/
 
             ./contrib/scripts/kind.sh "" 3 "" "" "none"


### PR DESCRIPTION
    gh/workflows: Pin lvh to v0.0.1

    As the latest moved the "lvh" binary path and the "lvh" is close to
    being stable.

    The switch is needed to fix the following failure:

        Status: Downloaded newer image for quay.io/lvh-images/lvh:latest
        Error: No such container:path:
        16b9166a07097cd9f301d48d6767644139edb54aea07e8ecf4429a9efd8bf2ac:/usr/bin/lvh

    Reported-by: Tam Mach <tam.mach@cilium.io>
    Signed-off-by: Martynas Pumputis <m@lambda.lt>
