### PR TITLE
maps/ctmap: convert to use netip.Addr internally

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"sync"
@@ -1022,9 +1023,9 @@ func (e *Endpoint) garbageCollectConntrack(filter *ctmap.GCFilter) {
 
 func (e *Endpoint) scrubIPsInConntrackTableLocked() {
 	e.garbageCollectConntrack(&ctmap.GCFilter{
-		MatchIPs: map[string]struct{}{
-			e.GetIPv4Address(): {},
-			e.GetIPv6Address(): {},
+		MatchIPs: map[netip.Addr]struct{}{
+			e.IPv4: {},
+			e.IPv6: {},
 		},
 	})
 }

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -5,7 +5,7 @@ package gc
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"os"
 	"time"
 
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/inctimer"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -55,7 +56,7 @@ func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr Endpoin
 
 				// epsMap contains an IP -> EP mapping. It is used by EmitCTEntryCB to
 				// avoid doing mgr.LookupIP, which is more expensive.
-				epsMap = make(map[string]*endpoint.Endpoint)
+				epsMap = make(map[netip.Addr]*endpoint.Endpoint)
 
 				// gcStart and emitEntryCB are used to populate DNSZombieMapping fields
 				// on endpoints. These hold IPs that are deletable in the DNS caches,
@@ -74,21 +75,21 @@ func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr Endpoin
 				// alive during idle periods of upto ToFQDNsIdleConnectionGracePeriod.
 				aliveTime = gcStart.Add(option.Config.ToFQDNsIdleConnectionGracePeriod)
 
-				emitEntryCB = func(srcIP, dstIP net.IP, srcPort, dstPort uint16, nextHdr, flags uint8, entry *ctmap.CtEntry) {
+				emitEntryCB = func(srcIP, dstIP netip.Addr, srcPort, dstPort uint16, nextHdr, flags uint8, entry *ctmap.CtEntry) {
 					// FQDN related connections can only be outbound
 					if flags != ctmap.TUPLE_F_OUT {
 						return
 					}
-					if ep, exists := epsMap[srcIP.String()]; exists {
-						ep.MarkDNSCTEntry(dstIP, aliveTime)
+					if ep, exists := epsMap[srcIP]; exists {
+						ep.MarkDNSCTEntry(dstIP.AsSlice(), aliveTime)
 					}
 				}
 			)
 
 			eps := mgr.GetEndpoints()
 			for _, e := range eps {
-				epsMap[e.GetIPv4Address()] = e
-				epsMap[e.GetIPv6Address()] = e
+				epsMap[e.IPv4Address()] = e
+				epsMap[e.IPv6Address()] = e
 			}
 
 			if len(eps) > 0 || initialScan {
@@ -244,16 +245,16 @@ func createGCFilter(initialScan bool, restoredEndpoints []*endpoint.Endpoint,
 	// endpoints can appear yet so we can assume that any other entry not
 	// belonging to a restored endpoint has become stale.
 	if initialScan {
-		filter.ValidIPs = map[string]struct{}{}
+		filter.ValidIPs = map[netip.Addr]struct{}{}
 		for _, ep := range restoredEndpoints {
 			if ep.IsHost() {
 				continue
 			}
 			if ep.IPv6.IsValid() {
-				filter.ValidIPs[ep.IPv6.String()] = struct{}{}
+				filter.ValidIPs[ep.IPv6] = struct{}{}
 			}
 			if ep.IPv4.IsValid() {
-				filter.ValidIPs[ep.IPv4.String()] = struct{}{}
+				filter.ValidIPs[ep.IPv4] = struct{}{}
 			}
 		}
 
@@ -275,7 +276,7 @@ func createGCFilter(initialScan bool, restoredEndpoints []*endpoint.Endpoint,
 				if option.Config.IsExcludedLocalAddress(ip) {
 					continue
 				}
-				filter.ValidIPs[ip.String()] = struct{}{}
+				filter.ValidIPs[iputil.MustAddrFromIP(ip)] = struct{}{}
 			}
 		}
 	}

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -194,9 +194,9 @@ func (k *CtKey4) Dump(sb *strings.Builder, reverse bool) bool {
 
 	// Addresses swapped, see issue #5848
 	if reverse {
-		addrDest = k.SourceAddr.IP().String()
+		addrDest = k.SourceAddr.String()
 	} else {
-		addrDest = k.DestAddr.IP().String()
+		addrDest = k.DestAddr.String()
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
@@ -281,11 +281,11 @@ func (k *CtKey4Global) Dump(sb *strings.Builder, reverse bool) bool {
 
 	// Addresses swapped, see issue #5848
 	if reverse {
-		addrSource = k.DestAddr.IP().String()
-		addrDest = k.SourceAddr.IP().String()
+		addrSource = k.DestAddr.String()
+		addrDest = k.SourceAddr.String()
 	} else {
-		addrSource = k.SourceAddr.IP().String()
-		addrDest = k.DestAddr.IP().String()
+		addrSource = k.SourceAddr.String()
+		addrDest = k.DestAddr.String()
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
@@ -362,9 +362,9 @@ func (k *CtKey6) Dump(sb *strings.Builder, reverse bool) bool {
 
 	// Addresses swapped, see issue #5848
 	if reverse {
-		addrDest = k.SourceAddr.IP().String()
+		addrDest = k.SourceAddr.String()
 	} else {
-		addrDest = k.DestAddr.IP().String()
+		addrDest = k.DestAddr.String()
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
@@ -451,11 +451,11 @@ func (k *CtKey6Global) Dump(sb *strings.Builder, reverse bool) bool {
 
 	// Addresses swapped, see issue #5848
 	if reverse {
-		addrSource = k.DestAddr.IP().String()
-		addrDest = k.SourceAddr.IP().String()
+		addrSource = k.DestAddr.String()
+		addrDest = k.SourceAddr.String()
 	} else {
-		addrSource = k.SourceAddr.IP().String()
-		addrDest = k.DestAddr.IP().String()
+		addrSource = k.SourceAddr.String()
+		addrDest = k.DestAddr.String()
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {

--- a/pkg/tuple/ipv4.go
+++ b/pkg/tuple/ipv4.go
@@ -71,9 +71,9 @@ func (k TupleKey4) Dump(sb *strings.Builder, reverse bool) bool {
 
 	// Addresses swapped, see issue #5848
 	if reverse {
-		addrDest = k.SourceAddr.IP().String()
+		addrDest = k.SourceAddr.String()
 	} else {
-		addrDest = k.DestAddr.IP().String()
+		addrDest = k.DestAddr.String()
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
@@ -150,11 +150,11 @@ func (k TupleKey4Global) Dump(sb *strings.Builder, reverse bool) bool {
 
 	// Addresses swapped, see issue #5848
 	if reverse {
-		addrSource = k.DestAddr.IP().String()
-		addrDest = k.SourceAddr.IP().String()
+		addrSource = k.DestAddr.String()
+		addrDest = k.SourceAddr.String()
 	} else {
-		addrSource = k.SourceAddr.IP().String()
-		addrDest = k.DestAddr.IP().String()
+		addrSource = k.SourceAddr.String()
+		addrDest = k.DestAddr.String()
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {

--- a/pkg/tuple/ipv6.go
+++ b/pkg/tuple/ipv6.go
@@ -71,9 +71,9 @@ func (k TupleKey6) Dump(sb *strings.Builder, reverse bool) bool {
 
 	// Addresses swapped, see issue #5848
 	if reverse {
-		addrDest = k.SourceAddr.IP().String()
+		addrDest = k.SourceAddr.String()
 	} else {
-		addrDest = k.DestAddr.IP().String()
+		addrDest = k.DestAddr.String()
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {
@@ -149,11 +149,11 @@ func (k TupleKey6Global) Dump(sb *strings.Builder, reverse bool) bool {
 
 	// Addresses swapped, see issue #5848
 	if reverse {
-		addrSource = k.DestAddr.IP().String()
-		addrDest = k.SourceAddr.IP().String()
+		addrSource = k.DestAddr.String()
+		addrDest = k.SourceAddr.String()
 	} else {
-		addrSource = k.SourceAddr.IP().String()
-		addrDest = k.DestAddr.IP().String()
+		addrSource = k.SourceAddr.String()
+		addrDest = k.DestAddr.String()
 	}
 
 	if k.Flags&TUPLE_F_IN != 0 {

--- a/pkg/types/ipv4.go
+++ b/pkg/types/ipv4.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"net"
+	"net/netip"
 )
 
 // IPv4 is the binary representation for encoding in binary structs.
@@ -16,6 +17,11 @@ func (v4 IPv4) IsZero() bool {
 
 func (v4 IPv4) IP() net.IP {
 	return v4[:]
+}
+
+func (v4 IPv4) Addr() netip.Addr {
+	addr, _ := netip.AddrFromSlice(v4[:])
+	return addr
 }
 
 func (v4 IPv4) String() string {

--- a/pkg/types/ipv4_test.go
+++ b/pkg/types/ipv4_test.go
@@ -7,6 +7,7 @@ package types
 
 import (
 	"net"
+	"net/netip"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -29,6 +30,13 @@ func (s *IPv4Suite) TestIP(c *check.C) {
 	var expectedAddress net.IP
 	expectedAddress = []byte{10, 0, 0, 2}
 	result := testIPv4Address.IP()
+
+	c.Assert(result, checker.DeepEquals, expectedAddress)
+}
+
+func (s *IPv4Suite) TestAddr(c *check.C) {
+	expectedAddress := netip.MustParseAddr("10.0.0.2")
+	result := testIPv4Address.Addr()
 
 	c.Assert(result, checker.DeepEquals, expectedAddress)
 }

--- a/pkg/types/ipv6.go
+++ b/pkg/types/ipv6.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"net"
+	"net/netip"
 )
 
 // IPv6 is the binary representation for encoding in binary structs.
@@ -12,6 +13,11 @@ type IPv6 [16]byte
 
 func (v6 IPv6) IP() net.IP {
 	return v6[:]
+}
+
+func (v6 IPv6) Addr() netip.Addr {
+	addr, _ := netip.AddrFromSlice(v6[:])
+	return addr
 }
 
 func (v6 IPv6) String() string {

--- a/pkg/types/ipv6_test.go
+++ b/pkg/types/ipv6_test.go
@@ -7,6 +7,7 @@ package types
 
 import (
 	"net"
+	"net/netip"
 
 	"gopkg.in/check.v1"
 
@@ -23,6 +24,13 @@ func (s *IPv6Suite) TestIP(c *check.C) {
 	var expectedAddress net.IP
 	expectedAddress = []byte{240, 13, 0, 0, 0, 0, 0, 0, 172, 16, 0, 20, 0, 0, 0, 1}
 	result := testIPv6Address.IP()
+
+	c.Assert(result, checker.DeepEquals, expectedAddress)
+}
+
+func (s *IPv6Suite) TestAddr(c *check.C) {
+	expectedAddress := netip.AddrFrom16(testIPv6Address)
+	result := testIPv6Address.Addr()
 
 	c.Assert(result, checker.DeepEquals, expectedAddress)
 }


### PR DESCRIPTION
Review by commit. The first two commits are preparatory changes and refactorings. The main change is the 3rd commit. This will simplify the ctmap GC code a bit, e.g. by using `netip.Addr` for map operations directly instead of having to convert `net.IP` to string. This will allow future cleanups using `netip.Addr`. I have some local branches depending on these changes. Sending these changes in smaller batches to ease reviews.