### PR TITLE
Fix behavior where packets leave node if there are no backends

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -680,7 +680,7 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx)
 		 * the CT entry for destination endpoints where we can't encode the
 		 * state in the address.
 		 */
-		svc = lb6_lookup_service(&key, is_defined(ENABLE_NODEPORT));
+		svc = lb6_lookup_service(&key, is_defined(ENABLE_NODEPORT), false);
 		if (svc) {
 #if defined(ENABLE_L7_LB)
 			if (lb6_svc_is_l7loadbalancer(svc)) {
@@ -1252,7 +1252,7 @@ static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx)
 				return ret;
 		}
 
-		svc = lb4_lookup_service(&key, is_defined(ENABLE_NODEPORT));
+		svc = lb4_lookup_service(&key, is_defined(ENABLE_NODEPORT), false);
 		if (svc) {
 #if defined(ENABLE_L7_LB)
 			if (lb4_svc_is_l7loadbalancer(svc)) {

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -218,7 +218,7 @@ sock4_wildcard_lookup(struct lb4_key *key __maybe_unused,
 	return NULL;
 wildcard_lookup:
 	key->address = 0;
-	return lb4_lookup_service(key, true);
+	return lb4_lookup_service(key, true, true);
 }
 #endif /* ENABLE_NODEPORT */
 
@@ -322,7 +322,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	 * service entries via wildcarded lookup for NodePort and
 	 * HostPort services.
 	 */
-	svc = lb4_lookup_service(&key, true);
+	svc = lb4_lookup_service(&key, true, true);
 	if (!svc)
 		svc = sock4_wildcard_lookup_full(&key, in_hostns);
 	if (!svc)
@@ -479,7 +479,7 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 	    !ctx_in_hostns(ctx_full, NULL))
 		return 0;
 
-	svc = lb4_lookup_service(&key, true);
+	svc = lb4_lookup_service(&key, true, true);
 	if (!svc)
 		/* Perform a wildcard lookup for the case where the caller
 		 * tries to bind to loopback or an address with host identity
@@ -576,7 +576,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 			.dport		= val->port,
 		};
 
-		svc = lb4_lookup_service(&svc_key, true);
+		svc = lb4_lookup_service(&svc_key, true, true);
 		if (!svc)
 			svc = sock4_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx_full, NULL));
@@ -754,7 +754,7 @@ sock6_wildcard_lookup(struct lb6_key *key __maybe_unused,
 	return NULL;
 wildcard_lookup:
 	memset(&key->address, 0, sizeof(key->address));
-	return lb6_lookup_service(key, true);
+	return lb6_lookup_service(key, true, true);
 }
 #endif /* ENABLE_NODEPORT */
 
@@ -844,7 +844,7 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 
 	ctx_get_v6_src_address(ctx, &key.address);
 
-	svc = lb6_lookup_service(&key, true);
+	svc = lb6_lookup_service(&key, true, true);
 	if (!svc) {
 		svc = sock6_wildcard_lookup(&key, false, false, true);
 		if (!svc)
@@ -972,7 +972,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	ctx_get_v6_address(ctx, &key.address);
 	memcpy(&orig_key, &key, sizeof(key));
 
-	svc = lb6_lookup_service(&key, true);
+	svc = lb6_lookup_service(&key, true, true);
 	if (!svc)
 		svc = sock6_wildcard_lookup_full(&key, in_hostns);
 	if (!svc)
@@ -1145,7 +1145,7 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 			.dport		= val->port,
 		};
 
-		svc = lb6_lookup_service(&svc_key, true);
+		svc = lb6_lookup_service(&svc_key, true, true);
 		if (!svc)
 			svc = sock6_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx, NULL));

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -565,7 +565,7 @@ lb6_to_lb4_service(const struct lb6_service *svc __maybe_unused)
 
 static __always_inline
 struct lb6_service *lb6_lookup_service(struct lb6_key *key,
-				       const bool scope_switch)
+	   const bool scope_switch, const bool check_svc_backends)
 {
 	struct lb6_service *svc;
 
@@ -575,10 +575,11 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 	if (svc) {
 		if (!scope_switch || !lb6_svc_is_local_scope(svc))
 			/* Packets for L7 LB are redirected even when there are no backends. */
-			return (svc->count || lb6_svc_is_l7loadbalancer(svc)) ? svc : NULL;
+			return (svc->count || !check_svc_backends ||
+				lb6_svc_is_l7loadbalancer(svc)) ? svc : NULL;
 		key->scope = LB_LOOKUP_SCOPE_INT;
 		svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
-		if (svc && (svc->count || lb6_svc_is_l7loadbalancer(svc)))
+		if (svc && (svc->count || !check_svc_backends || lb6_svc_is_l7loadbalancer(svc)))
 			return svc;
 	}
 
@@ -851,6 +852,8 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 
 	ipv6_addr_copy(&client_id.client_ip, &tuple->saddr);
 #endif
+	if (unlikely(svc->count == 0))
+		return DROP_NO_SERVICE;
 
 	/* See lb4_local comments re svc endpoint lookup process */
 	ret = ct_lookup6(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
@@ -927,7 +930,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		if (backend && !state->syn)
 			goto update_state;
 		key->backend_slot = 0;
-		svc = lb6_lookup_service(key, false);
+		svc = lb6_lookup_service(key, false, true);
 		if (!svc)
 			goto drop_no_service;
 		backend_id = lb6_select_backend_id(ctx, key, tuple, svc);
@@ -1004,7 +1007,7 @@ static __always_inline void lb6_ctx_restore_state(struct __ctx_buff *ctx,
  */
 static __always_inline
 struct lb6_service *lb6_lookup_service(struct lb6_key *key __maybe_unused,
-				       const bool scope_switch __maybe_unused)
+	   const bool scope_switch __maybe_unused, const bool check_svc_backends __maybe_unused)
 {
 	return NULL;
 }
@@ -1211,7 +1214,7 @@ lb4_to_lb6_service(const struct lb4_service *svc __maybe_unused)
 
 static __always_inline
 struct lb4_service *lb4_lookup_service(struct lb4_key *key,
-				       const bool scope_switch)
+				  const bool scope_switch, const bool check_svc_backends)
 {
 	struct lb4_service *svc;
 
@@ -1221,11 +1224,11 @@ struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 	if (svc) {
 		if (!scope_switch || !lb4_svc_is_local_scope(svc))
 			/* Packets for L7 LB are redirected even when there are no backends. */
-			return (svc->count || lb4_to_lb6_service(svc) ||
+			return (svc->count || !check_svc_backends || lb4_to_lb6_service(svc) ||
 				lb4_svc_is_l7loadbalancer(svc)) ? svc : NULL;
 		key->scope = LB_LOOKUP_SCOPE_INT;
 		svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
-		if (svc && (svc->count || lb4_svc_is_l7loadbalancer(svc)))
+		if (svc && (svc->count || !check_svc_backends || lb4_svc_is_l7loadbalancer(svc)))
 			return svc;
 	}
 
@@ -1523,6 +1526,9 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		.client_ip = saddr,
 	};
 #endif
+	if (unlikely(svc->count == 0))
+		return DROP_NO_SERVICE;
+
 	ret = ct_lookup4(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
@@ -1609,7 +1615,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		if (backend && !state->syn)
 			goto update_state;
 		key->backend_slot = 0;
-		svc = lb4_lookup_service(key, false);
+		svc = lb4_lookup_service(key, false, true);
 		if (!svc)
 			goto drop_no_service;
 		backend_id = lb4_select_backend_id(ctx, key, tuple, svc);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -892,7 +892,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	svc = lb6_lookup_service(&key, false);
+	svc = lb6_lookup_service(&key, false, false);
 	if (svc) {
 		const bool skip_l3_xlate = DSR_ENCAP_MODE == DSR_ENCAP_IPIP;
 
@@ -1825,7 +1825,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	svc = lb4_lookup_service(&key, false);
+	svc = lb4_lookup_service(&key, false, false);
 	if (svc) {
 		const bool skip_l3_xlate = DSR_ENCAP_MODE == DSR_ENCAP_IPIP;
 

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -67,7 +67,7 @@ static inline void bpf_sock_ops_ipv4(struct bpf_sock_ops *skops)
 	 * pulled in as needed.
 	 */
 	sk_lb4_key(&lb4_key, &key);
-	svc = lb4_lookup_service(&lb4_key, true);
+	svc = lb4_lookup_service(&lb4_key, true, true);
 	if (svc)
 		return;
 

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -36,13 +36,14 @@ struct {
 	},
 };
 
+#define FRONTEND_IP 0x0F00010A /* 10.0.1.15 */
+#define FRONTEND_PORT 80
 #define BACKEND_IP 0x0F00020A /* 10.2.0.15 */
 #define BACKEND_PORT 8080
 
 static long (*bpf_xdp_adjust_tail)(struct xdp_md *xdp_md, int delta) = (void *)65;
 
-SETUP("xdp", "forward_to_other_node")
-int test1_setup(struct __ctx_buff *ctx)
+static int build_packet(struct __ctx_buff *ctx)
 {
 	/* Create room for our packet to be crafted */
 	unsigned int data_len = ctx->data_end - ctx->data;
@@ -77,7 +78,7 @@ int test1_setup(struct __ctx_buff *ctx)
 		.ttl = 64,
 		.protocol = IPPROTO_TCP,
 		.saddr = 0x0F00000A, /* 10.0.0.15 */
-		.daddr = 0x0F00010A /* 10.0.1.15 */
+		.daddr = FRONTEND_IP,
 	};
 	memcpy(data, &l3, sizeof(struct iphdr));
 	data += sizeof(struct iphdr);
@@ -90,7 +91,7 @@ int test1_setup(struct __ctx_buff *ctx)
 
 	struct tcphdr l4 = {
 		.source = 23445,
-		.dest = 80,
+		.dest = FRONTEND_PORT,
 		.seq = 2922048129,
 		.doff = 0, /* no options */
 		.syn = 1,
@@ -108,10 +109,22 @@ int test1_setup(struct __ctx_buff *ctx)
 	offset = (long)data - (long)ctx->data_end;
 	bpf_xdp_adjust_tail(ctx, offset);
 
+	return 0;
+}
+
+SETUP("xdp", "xdp_lb4_forward_to_other_node")
+int test1_setup(struct __ctx_buff *ctx)
+{
+	int ret;
+
+	ret = build_packet(ctx);
+	if (ret)
+		return ret;
+
 	/* Register a fake LB backend with endpoint ID 124 matching our packet. */
 	struct lb4_key lb_svc_key = {
-		.address = 0x0F00010A,
-		.dport = 80,
+		.address = FRONTEND_IP,
+		.dport = FRONTEND_PORT,
 		.scope = LB_LOOKUP_SCOPE_EXT
 	};
 	/* Create a service with only one backend */
@@ -148,7 +161,7 @@ int test1_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("xdp", "forward_to_other_node")
+CHECK("xdp", "xdp_lb4_forward_to_other_node")
 int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -208,6 +221,57 @@ int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	if (memcmp(body, msg, sizeof(msg)) != 0)
 		test_fatal("body changed");
+
+	test_finish();
+}
+
+SETUP("xdp", "xdp_lb4_drop_no_backend")
+int test2_setup(struct __ctx_buff *ctx)
+{
+	/* Fake Service matching our packet. */
+	struct lb4_key lb_svc_key = {
+		.address = FRONTEND_IP,
+		.dport = FRONTEND_PORT,
+		.scope = LB_LOOKUP_SCOPE_EXT
+	};
+	/* Service with no backends */
+	struct lb4_service lb_svc_value = {
+		.count = 0,
+		.flags = SVC_FLAG_ROUTABLE,
+	};
+	int ret;
+
+	ret = build_packet(ctx);
+	if (ret)
+		return ret;
+
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_INT;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, 0);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("xdp", "xdp_lb4_drop_no_backend")
+int test2_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data_end = (void *)(long)ctx->data_end;
+	void *data = (void *)(long)ctx->data;
+	__u32 expected_status = XDP_DROP;
+	__u32 *status_code;
+
+	test_init();
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	if (*status_code != expected_status)
+		test_fatal("status code is %lu, expected %lu", *status_code, expected_status);
 
 	test_finish();
 }


### PR DESCRIPTION
This PR resolves an issue where an outgoing packet destined for a service will not be dropped if it does not have any backends. Currently we will not return the service if there are no backends for it, causing https://github.com/cilium/cilium/blob/58e4081c3c2a6e052d7c5e3443be33dd6ae5024b/bpf/bpf_lxc.c#L1254-L1266

To never be run, meaning we will never drop a packet in this case and instead simply route it through the kernels default routes.

Let me know if there is anything I am missing here, I think this is the behavior of kube-proxy and other CNI's. 

Fixes: #21453

Signed-off-by: Michael Aspinwall <maspinwall@google.com>