### PR TITLE
makefile: add a new target to run 'golangci-lint run --fix'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,13 +430,18 @@ govet: ## Run govet on Go source files in the repository.
 
 golangci-lint: ## Run golangci-lint
 ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION),$(GOLANGCILINT_VERSION)))
-	@$(ECHO_CHECK) golangci-lint
-	$(QUIET) golangci-lint run
+	@$(ECHO_CHECK) golangci-lint $(GOLANGCI_LINT_ARGS)
+	$(QUIET) golangci-lint run $(GOLANGCI_LINT_ARGS)
 else
-	$(QUIET) $(CONTAINER_ENGINE) run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:v$(GOLANGCILINT_WANT_VERSION)@$(GOLANGCILINT_IMAGE_SHA) golangci-lint run
+	$(QUIET) $(CONTAINER_ENGINE) run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:v$(GOLANGCILINT_WANT_VERSION)@$(GOLANGCILINT_IMAGE_SHA) golangci-lint run $(GOLANGCI_LINT_ARGS)
 endif
 
+golangci-lint-fix: ## Run golangci-lint to automatically fix warnings
+	$(QUIET)$(MAKE) golangci-lint GOLANGCI_LINT_ARGS="--fix"
+
 lint: golangci-lint ## Run golangci-lint and bpf-mock linters.
+
+lint-fix: golangci-lint-fix ## Run golangci-lint and bpf-mock linters.
 
 logging-subsys-field: ## Validate logrus subsystem field for logs in Go source code.
 	@$(ECHO_CHECK) contrib/scripts/check-logging-subsys-field.sh

--- a/Makefile
+++ b/Makefile
@@ -439,9 +439,9 @@ endif
 golangci-lint-fix: ## Run golangci-lint to automatically fix warnings
 	$(QUIET)$(MAKE) golangci-lint GOLANGCI_LINT_ARGS="--fix"
 
-lint: golangci-lint ## Run golangci-lint and bpf-mock linters.
+lint: golangci-lint
 
-lint-fix: golangci-lint-fix ## Run golangci-lint and bpf-mock linters.
+lint-fix: golangci-lint-fix
 
 logging-subsys-field: ## Validate logrus subsystem field for logs in Go source code.
 	@$(ECHO_CHECK) contrib/scripts/check-logging-subsys-field.sh


### PR DESCRIPTION
There is a make target to execute the 'golangci-lint run' command, but there is no simple way to execute it with a '--fix' argument. Add a new target to do this.

If more arguments need to be added to the golangci-lint command, then one can do this by setting the newly added GOLANGCI_LINT_ARGS variable.
