### PR TITLE
v1.11 backports 2022-10-03

### DIFF
--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -329,6 +329,8 @@ Identity
 Name                                     Labels                                             Description
 ======================================== ================================================== ========================================================
 ``identity``                             ``type``                                           Number of identities currently allocated
+``ipcache_errors_total``                 ``type``, ``error``                                Number of errors interacting with the ipcache
+``ipcache_events_total``                 ``type``                                           Number of events interacting with the ipcache
 ======================================== ================================================== ========================================================
 
 Events external to Cilium

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -624,7 +624,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 	// Upsert restored CIDRs after the new ipcache has been opened above
 	if len(restoredCIDRidentities) > 0 {
-		ipcache.UpsertGeneratedIdentities(restoredCIDRidentities)
+		ipcache.UpsertGeneratedIdentities(restoredCIDRidentities, nil)
 	}
 
 	// Read the service IDs of existing services from the BPF map and

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -58,7 +58,7 @@ const (
 	dnsSourceConnection = "connection"
 )
 
-func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, identityAllocator secIDCache.IdentityAllocator) (map[policyApi.FQDNSelector][]*identity.Identity, map[string]*identity.Identity, error) {
+func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, identityAllocator secIDCache.IdentityAllocator) (map[policyApi.FQDNSelector][]*identity.Identity, []*identity.Identity, map[string]*identity.Identity, error) {
 	var err error
 
 	// Used to track identities which are allocated in calls to
@@ -107,13 +107,13 @@ func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSel
 			identityAllocator.ReleaseSlice(context.TODO(), nil, usedIdentities)
 			log.WithError(err).WithField("prefixes", selectorIPs).Warn(
 				"failed to allocate identities for IPs")
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		usedIdentities = append(usedIdentities, currentlyAllocatedIdentities...)
 		selectorIdentitySliceMapping[selector] = currentlyAllocatedIdentities
 	}
 
-	return selectorIdentitySliceMapping, newlyAllocatedIdentities, nil
+	return selectorIdentitySliceMapping, usedIdentities, newlyAllocatedIdentities, nil
 }
 
 func (d *Daemon) updateSelectorCacheFQDNs(ctx context.Context, selectors map[policyApi.FQDNSelector][]*identity.Identity, selectorsWithoutIPs []policyApi.FQDNSelector) *sync.WaitGroup {
@@ -374,16 +374,16 @@ func (d *Daemon) updateDNSDatapathRules(ctx context.Context) error {
 // updateSelectors propagates the mapping of FQDNSelector to identity, as well
 // as the set of FQDNSelectors which have no IPs which correspond to them
 // (usually due to TTL expiry), down to policy layer managed by this daemon.
-func (d *Daemon) updateSelectors(ctx context.Context, selectorWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup, newlyAllocatedIdentities map[string]*identity.Identity, err error) {
+func (d *Daemon) updateSelectors(ctx context.Context, selectorWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup, usedIdentities []*identity.Identity, newlyAllocatedIdentities map[string]*identity.Identity, err error) {
 	// Convert set of selectors with IPs to update to set of selectors
 	// with identities corresponding to said IPs.
-	selectorsIdentities, newlyAllocatedIdentities, err := identitiesForFQDNSelectorIPs(selectorWithIPsToUpdate, d.identityAllocator)
+	selectorsIdentities, usedIdentities, newlyAllocatedIdentities, err := identitiesForFQDNSelectorIPs(selectorWithIPsToUpdate, d.identityAllocator)
 	if err != nil {
-		return &sync.WaitGroup{}, nil, err
+		return &sync.WaitGroup{}, nil, nil, err
 	}
 
 	// Update mapping in selector cache with new identities.
-	return d.updateSelectorCacheFQDNs(ctx, selectorsIdentities, selectorsWithoutIPs), newlyAllocatedIdentities, nil
+	return d.updateSelectorCacheFQDNs(ctx, selectorsIdentities, selectorsWithoutIPs), usedIdentities, newlyAllocatedIdentities, nil
 }
 
 // lookupEPByIP returns the endpoint that this IP belongs to
@@ -548,7 +548,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		defer updateCancel()
 		updateStart := time.Now()
 
-		wg, newlyAllocatedIdentities, err := d.dnsNameManager.UpdateGenerateDNS(updateCtx, lookupTime, map[string]*fqdn.DNSIPRecords{
+		wg, usedIdentities, newlyAllocatedIdentities, err := d.dnsNameManager.UpdateGenerateDNS(updateCtx, lookupTime, map[string]*fqdn.DNSIPRecords{
 			qname: {
 				IPs: responseIPs,
 				TTL: int(TTL),
@@ -577,7 +577,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		}).Debug("Waited for endpoints to regenerate due to a DNS response")
 
 		// Add new identities to the ipcache after the wait for the policy updates above
-		ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities)
+		ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities, usedIdentities)
 
 		endMetric()
 	}

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -180,19 +180,19 @@ func (ds *DaemonFQDNSuite) TestFQDNIdentityReferenceCounting(c *C) {
 	nameManager.Unlock()
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
-	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ciliumDNSRecord)
+	_, _, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ciliumDNSRecord)
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(idAllocator.IdentityReferenceCounter()), Equals, 1,
 		Commentf("Unexpected number of identities allocated during DNS name event handler"))
 
 	// Same thing, new reference for same identity but otherwise the same.
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ciliumDNSRecord)
+	_, _, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ciliumDNSRecord)
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(idAllocator.IdentityReferenceCounter()), Equals, 1,
 		Commentf("Unexpected number of identities allocated during DNS name event handler"))
 
 	// poll DNS for ebpf.io, check that we now have two different identities referenced
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ebpfDNSRecord)
+	_, _, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), ebpfDNSRecord)
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(idAllocator.IdentityReferenceCounter()), Equals, 2,
 		Commentf("Unexpected number of identities allocated during DNS name event handler"))

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -433,7 +433,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		// TODO: Remove 'enable-selective-regeneration' agent option.  Without selective
 		// regeneration we retain the old behavior of upserting new identities to ipcache
 		// before endpoint policy maps have been updated.
-		ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities)
+		ipcache.UpsertGeneratedIdentities(newlyAllocatedIdentities, nil)
 	}
 
 	return
@@ -507,7 +507,7 @@ func reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev u
 	// policy maps are ready to classify packets using the newly allocated identities before
 	// they are upserted to the ipcache here.
 	if upsertIdentities != nil {
-		ipcache.UpsertGeneratedIdentities(upsertIdentities)
+		ipcache.UpsertGeneratedIdentities(upsertIdentities, nil)
 	}
 }
 

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -24,5 +24,5 @@ type Config struct {
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.
-	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error)
+	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error)
 }

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -116,8 +116,8 @@ func NewNameManager(config Config) *NameManager {
 	}
 
 	if config.UpdateSelectors == nil {
-		config.UpdateSelectors = func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error) {
-			return &sync.WaitGroup{}, nil, nil
+		config.UpdateSelectors = func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error) {
+			return &sync.WaitGroup{}, nil, nil, nil
 		}
 	}
 
@@ -136,7 +136,7 @@ func (n *NameManager) GetDNSCache() *DNSCache {
 
 // UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 // have changed for a name they will be reflected in updatedDNSIPs.
-func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, newlyAllocatedIdentities map[string]*identity.Identity, err error) {
+func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, usedIdentities []*identity.Identity, newlyAllocatedIdentities map[string]*identity.Identity, err error) {
 	n.Mutex.Lock()
 	defer n.Mutex.Unlock()
 
@@ -184,8 +184,8 @@ func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []strin
 	}
 
 	// Emit the new rules.
-	// Ignore newly allocated IDs (2nd result) as this is only used for deletes.
-	wg, _, err = n.config.UpdateSelectors(ctx, selectorIPMapping, namesMissingIPs)
+	// Ignore newly allocated IDs (3rd result) as this is only used for deletes.
+	wg, _, _, err = n.config.UpdateSelectors(ctx, selectorIPMapping, namesMissingIPs)
 	return wg, err
 }
 

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -32,11 +32,11 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return &sync.WaitGroup{}, nil, nil
+				return &sync.WaitGroup{}, nil, nil, nil
 			},
 		})
 	)
@@ -49,7 +49,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
 	// still have 1 ToFQDN rule, and that the IP is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, _, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect length for testCase with single ToFQDNs entry"))
 
@@ -61,7 +61,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
 	// different, is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
+	_, _, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
 	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Only one entry per FQDNSelector should be present"))
 	expectedIPs = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}
@@ -78,11 +78,11 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, map[string]*identity.Identity, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return &sync.WaitGroup{}, nil, nil
+				return &sync.WaitGroup{}, nil, nil, nil
 			},
 		})
 	)
@@ -97,14 +97,14 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, _, _, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect number of plumbed FQDN selectors"))
 	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true)
 
 	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
+	_, _, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.FQDN("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.FQDN("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
@@ -117,7 +117,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached github.com IP, 1 new github.com IP
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
+	_, _, _, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.FQDN("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.FQDN("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))

--- a/pkg/ipcache/gc.go
+++ b/pkg/ipcache/gc.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/trigger"
+)
+
+type asyncPrefixReleaser struct {
+	*trigger.Trigger
+	prefixReleaser
+
+	// Mutex protects read and write to 'queue'.
+	lock.Mutex
+	queue []string
+}
+
+type prefixReleaser interface {
+	releaseCIDRIdentities(ctx context.Context, identities []string)
+}
+
+func newAsyncPrefixReleaser(parent prefixReleaser, interval time.Duration) *asyncPrefixReleaser {
+	result := &asyncPrefixReleaser{
+		queue:          make([]string, 0),
+		prefixReleaser: parent,
+	}
+
+	// trigger needs to be updated to reference the object above
+	// Ignore error case since the TriggerFunc is provided.
+	result.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
+		Name:        "ipcache-identity-gc",
+		MinInterval: interval,
+		TriggerFunc: func(reasons []string) {
+			// TODO: Structure the code to pass context down
+			//       from the Daemon.
+			ctx, cancel := context.WithTimeout(
+				context.TODO(),
+				option.Config.KVstoreConnectivityTimeout)
+			defer cancel()
+			result.run(ctx, reasons...)
+		},
+	})
+
+	return result
+}
+
+// enqueue a set of prefixes to be released asynchronously.
+func (pr *asyncPrefixReleaser) enqueue(prefixes []string, reason string) {
+	pr.Lock()
+	defer pr.Unlock()
+	pr.queue = append(pr.queue, prefixes...)
+	pr.TriggerWithReason(reason)
+}
+
+// dequeue  the outstanding set of prefixes that are queued fro release.
+func (pr *asyncPrefixReleaser) dequeue() (result []string) {
+	pr.Lock()
+	defer pr.Unlock()
+	result = pr.queue
+	pr.queue = make([]string, 0)
+	return result
+}
+
+// run the core logic to dequeue & release identities / ipcache entries
+func (pr *asyncPrefixReleaser) run(ctx context.Context, reasons ...string) {
+	prefixes := pr.dequeue()
+	log.WithFields(logrus.Fields{
+		logfields.Count:  len(prefixes),
+		logfields.Reason: reasons,
+	}).Debug("Garbage collecting identities and entries from ipcache")
+	pr.prefixReleaser.releaseCIDRIdentities(ctx, prefixes)
+}

--- a/pkg/ipcache/metrics.go
+++ b/pkg/ipcache/metrics.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+var (
+	metricTypeUpsert  = "upsert"
+	metricTypeDelete  = "delete"
+	metricTypeRecover = "recover"
+
+	metricErrorIdempotent = "idempotent_operation"
+	metricErrorInvalid    = "invalid_prefix"
+	metricErrorNoExist    = "no_such_prefix"
+	metricErrorOverwrite  = "cannot_overwrite_by_source"
+	metricErrorUnexpected = "upsert_unexpectedly_deleted_entry"
+)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -43,6 +43,9 @@ const (
 	// SubsystemAgent is the subsystem to scope metrics related to the cilium agent itself.
 	SubsystemAgent = "agent"
 
+	// SubsystemFQDN is the subsystem to scope metrics related to the FQDN proxy.
+	SubsystemIPCache = "ipcache"
+
 	// SubsystemK8s is the subsystem to scope metrics related to Kubernetes
 	SubsystemK8s = "k8s"
 
@@ -460,6 +463,14 @@ var (
 	// the admission semaphore.
 	FQDNSemaphoreRejectedTotal = NoOpCounter
 
+	// IPCacheErrorsTotal is the total number of IPCache events handled in
+	// the IPCache subsystem that resulted in errors.
+	IPCacheErrorsTotal = NoOpCounterVec
+
+	// IPCacheEventsTotal is the total number of IPCache events handled in
+	// the IPCache subsystem.
+	IPCacheEventsTotal = NoOpCounterVec
+
 	// BPFSyscallDuration is the metric for bpf syscalls duration.
 	BPFSyscallDuration = NoOpObserverVec
 
@@ -565,6 +576,8 @@ type Configuration struct {
 	KubernetesCNPStatusCompletionEnabled    bool
 	KubernetesTerminatingEndpointsEnabled   bool
 	IpamEventEnabled                        bool
+	IPCacheErrorsTotalEnabled               bool
+	IPCacheEventsTotalEnabled               bool
 	KVStoreOperationsDurationEnabled        bool
 	KVStoreEventsQueueDurationEnabled       bool
 	KVStoreQuorumErrorsEnabled              bool
@@ -640,6 +653,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemKVStore + "_operations_duration_seconds":          {},
 		Namespace + "_" + SubsystemKVStore + "_events_queue_seconds":                 {},
 		Namespace + "_" + SubsystemKVStore + "_quorum_errors_total":                  {},
+		Namespace + "_" + SubsystemIPCache + "_errors_total":                         {},
 		Namespace + "_" + SubsystemFQDN + "_gc_deletions_total":                      {},
 		Namespace + "_" + SubsystemBPF + "_map_ops_total":                            {},
 		Namespace + "_" + SubsystemTriggers + "_policy_update_total":                 {},
@@ -1192,6 +1206,28 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, KVStoreQuorumErrors)
 			c.KVStoreQuorumErrorsEnabled = true
+
+		case Namespace + "_" + SubsystemIPCache + "_errors_total":
+			IPCacheErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemIPCache,
+				Name:      "errors_total",
+				Help:      "Number of errors interacting with the IP to Identity cache",
+			}, []string{LabelType, LabelError})
+
+			collectors = append(collectors, IPCacheErrorsTotal)
+			c.IPCacheErrorsTotalEnabled = true
+
+		case Namespace + "_" + SubsystemIPCache + "_events_total":
+			IPCacheEventsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemIPCache,
+				Name:      "events_total",
+				Help:      "Number of events interacting with the IP to Identity cache",
+			}, []string{LabelType})
+
+			collectors = append(collectors, IPCacheEventsTotal)
+			c.IPCacheEventsTotalEnabled = true
 
 		case Namespace + "_" + SubsystemFQDN + "_gc_deletions_total":
 			FQDNGarbageCollectorCleanedTotal = prometheus.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
* #20721 -- Improve dnsproxy ipcache handling, metrics (@joestringer)
* #20833 -- ipcache: Fix lock leak (@joestringer)
* #21565 -- ipcache: Fix metadata access from CIDR allocation (@joestringer)
  * Minor conflicts. I also found one additional corner case locking issue which is fixed here. I'll send a separate fix to master.
  * https://github.com/cilium/cilium/pull/21653 -- ipcache: Release metadata mutex in loop error condition (@joestringer)
* #21629 -- Fix agent deadlock caused by frequent kube-apiserver IP recycling (@joestringer)
  * Conflicts: Use of *net.IPNet and string instead of netip.Prefix on v1.12 branch. Had to adapt some code to a global IPIdentityCache and using functions instead of methods for release.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20721 20833 21565 21629 21653; do contrib/backporting/set-labels.py $pr done 1.11; done
```