### PR TITLE
kind.sh: Retry pulling docker registry image

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -49,6 +49,17 @@ reg_name="kind-registry"
 reg_port="5000"
 running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
 if [[ "${running}" != "true" ]]; then
+  retry_count=0
+  while ! docker pull registry:2
+  do
+    retry_count=$((retry_count+1))
+    if [[ "$retry_count" -ge 10 ]]; then
+      echo "ERROR: 'docker pull registry:2' failed $retry_count times. Please make sure docker is running"
+      exit 1
+    fi
+    echo "docker pull registry:2 failed. Sleeping for 1 second and trying again..."
+    sleep 1
+  done
   docker run \
     -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
     registry:2


### PR DESCRIPTION
ci-datapath fails fairly regularly with this error trying to pull registry:2 image:

    docker: Error response from daemon: Get "https://registry-1.docker.io/v2/":
    net/http: request canceled while waiting for connection (Client.Timeout
    exceeded while awaiting headers).

This commit modifies kind.sh to retry pulling the registry image.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

```release-note
kind.sh: Retry pulling docker registry image
```
