### PR TITLE
Catch ginkgo test regressions on macOS

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -26,9 +26,13 @@ all: build
 
 build:
 	@$(ECHO_GINKGO)$@
-	GOOS=darwin $(GINKGO) build -tags=integration_tests && rm -f test.test
 	$(GINKGO) build -tags=integration_tests
 	$(QUIET)$(MAKE) -C bpf/
+
+build-darwin:
+	@$(ECHO_GINKGO)$@
+	GOOS=darwin $(GINKGO) build -tags=integration_tests
+	rm test.test
 
 test: run k8s-test
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -26,6 +26,7 @@ all: build
 
 build:
 	@$(ECHO_GINKGO)$@
+	GOOS=darwin $(GINKGO) build -tags=integration_tests && rm -f test.test
 	$(GINKGO) build -tags=integration_tests
 	$(QUIET)$(MAKE) -C bpf/
 


### PR DESCRIPTION
<!-- Description of change -->
build tests using GOOS=darwin to ensure the build would work on MacOS as well

Fixes: #19569

Signed-off-by: Cyril Scetbon <cscetbon@gmail.com>
