### PR TITLE
hubble: Add "syn-only" option to flows-to-world metric

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -645,6 +645,7 @@ Option Key     Option Value  Description
 ============== ============= ======================================================
 ``any-drop``   N/A           Count any dropped flows regardless of the drop reason.
 ``port``       N/A           Include the destination port as label ``port``.
+``syn-only``   N/A           Only count non-reply SYNs for TCP flows.
 ============== ============= ======================================================
 
 

--- a/pkg/hubble/metrics/flows-to-world/handler.go
+++ b/pkg/hubble/metrics/flows-to-world/handler.go
@@ -59,7 +59,17 @@ func (h *flowsToWorldHandler) Init(registry *prometheus.Registry, options api.Op
 }
 
 func (h *flowsToWorldHandler) Status() string {
-	return h.context.Status()
+	var status []string
+	if h.anyDrop {
+		status = append(status, "any-drop")
+	}
+	if h.port {
+		status = append(status, "port")
+	}
+	if h.synOnly {
+		status = append(status, "syn-only")
+	}
+	return strings.Join(append(status, h.context.Status()), ",")
 }
 
 func (h *flowsToWorldHandler) isReservedWorld(endpoint *flowpb.Endpoint) bool {

--- a/pkg/hubble/metrics/flows-to-world/handler_test.go
+++ b/pkg/hubble/metrics/flows-to-world/handler_test.go
@@ -235,3 +235,19 @@ hubble_flows_to_world_total{destination="cilium.io",protocol="TCP",source="src-a
 `)
 	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, expected))
 }
+
+func Test_flowsToWorldHandler_Status(t *testing.T) {
+	h := &flowsToWorldHandler{
+		context: &api.ContextOptions{
+			Destination: api.ContextIdentifierList{api.ContextNamespace},
+			Source:      api.ContextIdentifierList{api.ContextReservedIdentity},
+		},
+		anyDrop: true,
+		port:    true,
+		synOnly: true,
+	}
+	assert.Equal(t, "any-drop,port,syn-only,destination=namespace,source=reserved-identity", h.Status())
+	h.anyDrop = false
+	h.port = false
+	assert.Equal(t, "syn-only,destination=namespace,source=reserved-identity", h.Status())
+}

--- a/pkg/hubble/metrics/flows-to-world/plugin.go
+++ b/pkg/hubble/metrics/flows-to-world/plugin.go
@@ -24,7 +24,8 @@ Options:
  any-drop - By default, this metric counts dropped flows if and only
             if the drop_reason is "Policy denied". Set this option to
             count any dropped flows to reserved:world.
- port     - Include destination port as a label.` +
+ port     - Include destination port as a label.
+ syn-only - Only count non-reply SYNs for TCP flows.` +
 		api.ContextOptionsHelp
 }
 


### PR DESCRIPTION
2 commits:

- add `syn-only` option.
- implement `Status()` method so that it prints option flags. for example:
  `level=info msg="Configured metrics plugin" name=flows-to-world status="syn-only,destination=dns|reserved-identity,source=namespace" subsys=hubble`

```release-note
hubble: Add "syn-only" option to flows-to-world metric
```
