### PR TITLE
contrib: avoid reviews from non-collaborators

### DIFF
--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -40,6 +40,22 @@ get_user_remote() {
   echo $USER_REMOTE
 }
 
+is_collaborator() {
+  local username=${1:-}
+  local org=${2:-cilium}
+  local repo=${3:-cilium}
+  if [ -z "$username" ]; then
+      echo "Error: no username specified in is_collaborator"
+      exit 1
+  fi
+  local path="repos/$org/$repo/collaborators/$username"
+  if hub api "$path" &> /dev/null; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
 require_linux() {
   if [ "$(uname)" != "Linux" ]; then
       echo "$0: Linux required"

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -35,7 +35,17 @@ if ! git branch -a | grep -q "${UPSTREAM_REMOTE}/v${BRANCH}$" || [ ! -e "$SUMMAR
     echo "(branch version: ${BRANCH}, pr-summary: ${SUMMARY}, upstream remote: ${UPSTREAM_REMOTE})" 1>&2
     exit 1
 fi
-AUTHORS="$(grep -ho "@[^)]*" "$SUMMARY" | grep -v "$(get_user)" | sort -u | tr '\n' ',' | sed -e 's/@//g' -e 's/,$//')"
+
+AUTHORS="$(grep -ho "@[^)]*" "$SUMMARY" | grep -v "$(get_user)" | sort -u | tr '\n' ' ' | sed -e 's/@//g' -e 's/ $//')"
+
+# Github complains if we request a review by someone who is not a collaborator, thus filter the authors.
+REVIEWERS=""
+for author in $AUTHORS; do
+    if [ $(is_collaborator "$author") == "yes" ]; then
+        REVIEWERS="$REVIEWERS,$author"
+    fi
+done
+REVIEWERS=${REVIEWERS:1} # Lop off the initial comma.
 
 echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
@@ -43,10 +53,10 @@ echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git config --local "branch.${PR_BRANCH}.remote" "$USER_REMOTE"
 git push -q "$USER_REMOTE" "$PR_BRANCH"
-if [ -z "$AUTHORS" ]; then
+if [ -z "$REVIEWERS" ]; then
   hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 else
-  hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $AUTHORS
+  hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $REVIEWERS
 fi
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')


### PR DESCRIPTION
submit-backport tried to create a backport PR with reviews from all contributors whose fixes are being backported, including people who do not have collaborator status in the repository. GitHub only allows reviews to be assigned to collaborators, and thus rejected the review assignments.

This commit changes submit-backport to filter the review assignments to only include collaborators.

Fixes:  #21548
