### PR TITLE
Documentation: Fix out-of-sync codeowners

### DIFF
--- a/Documentation/codeowners.rst
+++ b/Documentation/codeowners.rst
@@ -140,6 +140,9 @@ external software and protocols:
   overall agent architecture, ordering constraints with respect to network
   policies and encryption. Handle the relationship between Kubernetes state
   and datapath state as it pertains to remote peers.
+- `@cilium/ipsec <https://github.com/orgs/cilium/teams/ipsec>`__:
+  Maintain the kernel IPsec configuration and related eBPF logic to ensure
+  traffic is correctly encrypted.
 - `@cilium/kvstore <https://github.com/orgs/cilium/teams/kvstore>`__:
   Review Cilium interactions with key-value stores, particularly etcd.
   Understand the client libraries used by Cilium for sharing state between


### PR DESCRIPTION
The default make target is currently failing because 7335755e ("CODEOWNERS: Add ownerships for IPsec team") updated the `CODEOWNERS` file without regenerating the `Documentation/codeowners.rst` file. This commit it by regenerating the Documentation copy.

This is covered in CI but as part of the Travis CI build only. I'm guessing we all missed it because we didn't expect tests to cover `CODEOWNERS` changes, and especially not Travis.

Fixes: https://github.com/cilium/cilium/pull/21567.