### PR TITLE
clustermesh-apiserver: Add support for pprof

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -42,7 +42,7 @@ cilium-bugtool [OPTIONS] [flags]
       --k8s-mode                  Require Kubernetes pods to be found or fail
       --k8s-namespace string      Kubernetes namespace for Cilium pod (default "kube-system")
       --parallel-workers int      Maximum number of parallel worker tasks, use 0 for number of CPUs
-      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061 (default 6060)
+      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061, apiserver:6063 (default 6060)
       --pprof-trace-seconds int   Amount of seconds used for pprof CPU traces (default 180)
   -t, --tmp string                Path to store extracted files. Use '-' to send to stdout. (default "/tmp")
 ```

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -83,8 +83,8 @@ func init() {
 	BugtoolRootCmd.Flags().IntVar(&pprofPort,
 		"pprof-port", defaults.PprofPortAgent,
 		fmt.Sprintf(
-			"Pprof port to connect to. Known Cilium component ports are agent:%d, operator:%d",
-			defaults.PprofPortAgent, defaults.PprofPortOperator,
+			"Pprof port to connect to. Known Cilium component ports are agent:%d, operator:%d, apiserver:%d",
+			defaults.PprofPortAgent, defaults.PprofPortOperator, defaults.PprofPortAPIServer,
 		),
 	)
 	BugtoolRootCmd.Flags().IntVar(&traceSeconds, "pprof-trace-seconds", 180, "Amount of seconds used for pprof CPU traces")

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -52,6 +52,7 @@ import (
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/pprof"
 )
 
 type configuration struct {
@@ -235,6 +236,12 @@ func runApiserver() error {
 
 	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enable support of Kubernetes EndpointSlice")
 	option.BindEnv(vp, option.K8sEnableEndpointSlice)
+
+	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
+	option.BindEnv(vp, option.PProf)
+
+	flags.Int(option.PProfPort, defaults.PprofPortAPIServer, "Port that the pprof listens on")
+	option.BindEnv(vp, option.PProfPort)
 
 	vp.BindPFlags(flags)
 
@@ -600,6 +607,10 @@ func startServer(clientset k8sClient.Clientset) {
 			<-timer.After(kvstore.HeartbeatWriteInterval)
 		}
 	}()
+
+	if option.Config.PProf {
+		pprof.Enable(option.Config.PProfPort)
+	}
 
 	log.Info("Initialization complete")
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -23,6 +23,9 @@ const (
 	// PprofPortAgent is the default value for pprof in the operator
 	PprofPortOperator = 6061
 
+	// PprofPortAPIServer is the default value for pprof in the clustermesh-apiserver
+	PprofPortAPIServer = 6063
+
 	// GopsPortAgent is the default value for option.GopsPort in the agent
 	GopsPortAgent = 9890
 


### PR DESCRIPTION
Currently, clustermesh-apiserver only supports `gops` tool.
This PR adds support for `pprof` debug endpoints, setting the default port to `6063` (other default ports are 6060 for the agent, 6061 for the operator and 6062 for hubble relay).
With `pprof` support, `cilium-bugtool` can collect cpu profile, heap profile and execution traces from the clustermesh-apiserver.
`pprof` support is left disabled by default.