### PR TITLE
treewide: Switch ipcache interface to netip.Prefix

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -587,7 +587,7 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup,
 	// (datapath) ipcache after it has been initialized below. This is accomplished by passing
 	// 'restoredCIDRidentities' to AllocateCIDRs() and then calling
 	// UpsertGeneratedIdentities(restoredCIDRidentities) after initMaps() below.
-	restoredCIDRidentities := make(map[string]*identity.Identity)
+	restoredCIDRidentities := make(map[netip.Prefix]*identity.Identity)
 	if len(d.restoredCIDRs) > 0 {
 		log.Infof("Restoring %d old CIDR identities", len(d.restoredCIDRs))
 		prefixes := make([]netip.Prefix, 0, len(d.restoredCIDRs))
@@ -602,7 +602,7 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup,
 		// same numeric identity as before the restart. This can only happen if we have
 		// re-introduced bugs into this agent bootstrap order, so we want to surface this.
 		for i, prefix := range d.restoredCIDRs {
-			id, exists := restoredCIDRidentities[prefix.String()]
+			id, exists := restoredCIDRidentities[ip.IPNetToPrefix(prefix)]
 			if !exists || id.ID != oldNIDs[i] {
 				log.WithField(logfields.Identity, oldNIDs[i]).Warn("Could not restore all CIDR identities")
 				break

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -67,7 +68,7 @@ func NewFakeIdentityAllocator(c cache.IdentityCache) *FakeRefcountingIdentityAll
 // 'newlyAllocatedIdentities' is not properly mocked out.
 //
 // The resulting identities are not guaranteed to have all fields populated.
-func (f *FakeRefcountingIdentityAllocator) AllocateCIDRsForIPs(IPs []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error) {
+func (f *FakeRefcountingIdentityAllocator) AllocateCIDRsForIPs(IPs []net.IP, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error) {
 	result := make([]*identity.Identity, 0, len(IPs))
 	for _, ip := range IPs {
 		id, ok := f.ipToIdentity[ip.String()]

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"net"
+	"net/netip"
 
 	"github.com/go-openapi/runtime/middleware"
 	k8sCache "k8s.io/client-go/tools/cache"
@@ -110,7 +111,7 @@ func NewCachingIdentityAllocator(d *Daemon) cachingIdentityAllocator {
 	}
 }
 
-func (c cachingIdentityAllocator) AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error) {
+func (c cachingIdentityAllocator) AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error) {
 	return c.d.ipcache.AllocateCIDRsForIPs(ips, newlyAllocatedIdentities)
 }
 

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -290,7 +290,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	//
 	// Release of these identities will be tied to the corresponding policy
 	// in the policy.Repository and released upon policyDelete().
-	newlyAllocatedIdentities := make(map[string]*identity.Identity)
+	newlyAllocatedIdentities := make(map[netip.Prefix]*identity.Identity)
 	if _, err := d.ipcache.AllocateCIDRs(prefixes, nil, newlyAllocatedIdentities); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
@@ -440,8 +440,8 @@ type PolicyReactionEvent struct {
 	epsToBumpRevision *policy.EndpointSet
 	endpointsToRegen  *policy.EndpointSet
 	newRev            uint64
-	upsertIdentities  map[string]*identity.Identity // deferred CIDR identity upserts, if any
-	releasePrefixes   []netip.Prefix                // deferred CIDR identity deletes, if any
+	upsertIdentities  map[netip.Prefix]*identity.Identity // deferred CIDR identity upserts, if any
+	releasePrefixes   []netip.Prefix                      // deferred CIDR identity deletes, if any
 }
 
 // Handle implements pkg/eventqueue/EventHandler interface.
@@ -458,7 +458,7 @@ func (r *PolicyReactionEvent) Handle(res chan interface{}) {
 //     in allEps, to revision rev.
 //   - wait for the regenerations to be finished
 //   - upsert or delete CIDR identities to the ipcache, as needed.
-func (d *Daemon) reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev uint64, upsertIdentities map[string]*identity.Identity, releasePrefixes []netip.Prefix) {
+func (d *Daemon) reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev uint64, upsertIdentities map[netip.Prefix]*identity.Identity, releasePrefixes []netip.Prefix) {
 	var enqueueWaitGroup sync.WaitGroup
 
 	// Release CIDR identities before regenerations have been started, if any. This makes sure

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -8,6 +8,7 @@ package endpoint
 import (
 	"context"
 	"net"
+	"net/netip"
 	"reflect"
 	"strings"
 	"testing"
@@ -128,7 +129,7 @@ type fakeIdentityAllocator struct {
 	*cache.CachingIdentityAllocator
 }
 
-func (f fakeIdentityAllocator) AllocateCIDRsForIPs([]net.IP, map[string]*identity.Identity) ([]*identity.Identity, error) {
+func (f fakeIdentityAllocator) AllocateCIDRsForIPs([]net.IP, map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error) {
 	return nil, nil
 }
 

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -6,6 +6,7 @@ package fqdn
 import (
 	"context"
 	"net"
+	"net/netip"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/identity"
@@ -24,5 +25,5 @@ type Config struct {
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.
-	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error)
+	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[netip.Prefix]*identity.Identity, error)
 }

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -6,6 +6,7 @@ package fqdn
 import (
 	"context"
 	"net"
+	"net/netip"
 	"regexp"
 	"sync"
 	"time"
@@ -116,7 +117,7 @@ func NewNameManager(config Config) *NameManager {
 	}
 
 	if config.UpdateSelectors == nil {
-		config.UpdateSelectors = func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error) {
+		config.UpdateSelectors = func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[netip.Prefix]*identity.Identity, error) {
 			return &sync.WaitGroup{}, nil, nil, nil
 		}
 	}
@@ -136,7 +137,7 @@ func (n *NameManager) GetDNSCache() *DNSCache {
 
 // UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 // have changed for a name they will be reflected in updatedDNSIPs.
-func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, usedIdentities []*identity.Identity, newlyAllocatedIdentities map[string]*identity.Identity, err error) {
+func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, usedIdentities []*identity.Identity, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity, err error) {
 	n.RWMutex.Lock()
 	defer n.RWMutex.Unlock()
 

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -6,6 +6,7 @@ package fqdn
 import (
 	"context"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -29,7 +30,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[netip.Prefix]*identity.Identity, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
@@ -75,7 +76,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[string]*identity.Identity, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[netip.Prefix]*identity.Identity, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"path"
 	"strings"
 
@@ -153,7 +154,7 @@ type IdentityAllocator interface {
 	// be released via a subsequent call to ReleaseCIDRIdentitiesByID().
 	//
 	// The implementation for this function currently lives in pkg/ipcache.
-	AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[string]*identity.Identity) ([]*identity.Identity, error)
+	AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error)
 
 	// ReleaseCIDRIdentitiesByID() is a wrapper for ReleaseSlice() that
 	// also handles ipcache entries.

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -36,7 +36,7 @@ import (
 // Upon success, the caller must also arrange for the resulting identities to
 // be released via a subsequent call to ReleaseCIDRIdentitiesByCIDR().
 func (ipc *IPCache) AllocateCIDRs(
-	prefixes []netip.Prefix, oldNIDs []identity.NumericIdentity, newlyAllocatedIdentities map[string]*identity.Identity,
+	prefixes []netip.Prefix, oldNIDs []identity.NumericIdentity, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity,
 ) ([]*identity.Identity, error) {
 	// maintain list of used identities to undo on error
 	usedIdentities := make([]*identity.Identity, 0, len(prefixes))
@@ -46,7 +46,7 @@ func (ipc *IPCache) AllocateCIDRs(
 	upsert := false
 	if newlyAllocatedIdentities == nil {
 		upsert = true
-		newlyAllocatedIdentities = map[string]*identity.Identity{}
+		newlyAllocatedIdentities = map[netip.Prefix]*identity.Identity{}
 	}
 
 	allocateCtx, cancel := context.WithTimeout(context.Background(), option.Config.IPAllocationTimeout)
@@ -71,7 +71,7 @@ func (ipc *IPCache) AllocateCIDRs(
 		usedIdentities = append(usedIdentities, id)
 		allocatedIdentities[prefix] = id
 		if isNew {
-			newlyAllocatedIdentities[prefix.String()] = id
+			newlyAllocatedIdentities[prefix] = id
 		}
 	}
 	ipc.Unlock()
@@ -95,16 +95,30 @@ func (ipc *IPCache) AllocateCIDRs(
 // Upon success, the caller must also arrange for the resulting identities to
 // be released via a subsequent call to ReleaseCIDRIdentitiesByID().
 func (ipc *IPCache) AllocateCIDRsForIPs(
-	prefixes []net.IP, newlyAllocatedIdentities map[string]*identity.Identity,
+	prefixes []net.IP, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity,
 ) ([]*identity.Identity, error) {
 	return ipc.AllocateCIDRs(ip.IPsToNetPrefixes(prefixes), nil, newlyAllocatedIdentities)
 }
 
-func cidrLabelToPrefix(label string) (string, bool) {
+func cidrLabelToPrefix(id *identity.Identity) (prefix netip.Prefix, ok bool) {
+	var err error
+
+	label := id.CIDRLabel.String()
 	if !strings.HasPrefix(label, labels.LabelSourceCIDR) {
-		return "", false
+		log.WithFields(logrus.Fields{
+			logfields.Identity: id.ID,
+		}).Warning("BUG: Attempting to upsert non-CIDR identity")
+		return
 	}
-	return strings.TrimPrefix(label, labels.LabelSourceCIDR+":"), true
+
+	if prefix, err = netip.ParsePrefix(strings.TrimPrefix(label, labels.LabelSourceCIDR+":")); err != nil {
+		log.WithFields(logrus.Fields{
+			logfields.Identity: id.ID,
+			logfields.Labels:   label,
+		}).Warning("BUG: Attempting to upsert identity with bad CIDR label")
+		return
+	}
+	return prefix, true
 }
 
 // UpsertGeneratedIdentities unconditionally upserts 'newlyAllocatedIdentities'
@@ -112,9 +126,9 @@ func cidrLabelToPrefix(label string) (string, bool) {
 // that were not already upserted. If any 'usedIdentities' are upserted, these
 // are counted separately as they may provide an indication of another logic
 // error elsewhere in the codebase that is causing premature ipcache deletions.
-func (ipc *IPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[string]*identity.Identity, usedIdentities []*identity.Identity) {
-	for prefixString, id := range newlyAllocatedIdentities {
-		ipc.Upsert(prefixString, nil, 0, nil, Identity{
+func (ipc *IPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[netip.Prefix]*identity.Identity, usedIdentities []*identity.Identity) {
+	for prefix, id := range newlyAllocatedIdentities {
+		ipc.Upsert(prefix.String(), nil, 0, nil, Identity{
 			ID:     id.ID,
 			Source: source.Generated,
 		})
@@ -123,17 +137,14 @@ func (ipc *IPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[strin
 		return
 	}
 
-	toUpsert := make(map[string]*identity.Identity)
+	toUpsert := make(map[netip.Prefix]*identity.Identity)
 	ipc.mutex.RLock()
 	for _, id := range usedIdentities {
-		prefix, ok := cidrLabelToPrefix(id.CIDRLabel.String())
+		prefix, ok := cidrLabelToPrefix(id)
 		if !ok {
-			log.WithFields(logrus.Fields{
-				logfields.Identity: id.ID,
-			}).Warning("BUG: Attempting to upsert non-CIDR identity")
 			continue
 		}
-		if _, ok := ipc.LookupByIPRLocked(prefix); ok {
+		if _, ok := ipc.LookupByIPRLocked(prefix.String()); ok {
 			// Already there; continue
 			continue
 		}
@@ -144,7 +155,7 @@ func (ipc *IPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[strin
 		metrics.IPCacheErrorsTotal.WithLabelValues(
 			metricTypeRecover, metricErrorUnexpected,
 		).Inc()
-		ipc.Upsert(prefix, nil, 0, nil, Identity{
+		ipc.Upsert(prefix.String(), nil, 0, nil, Identity{
 			ID:     id.ID,
 			Source: source.Generated,
 		})
@@ -234,20 +245,12 @@ func (ipc *IPCache) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []
 	fullIdentities := make(map[netip.Prefix]*identity.Identity, len(identities))
 	for _, nid := range identities {
 		if id := ipc.IdentityAllocator.LookupIdentityByID(ctx, nid); id != nil {
-			cidr, ok := cidrLabelToPrefix(id.CIDRLabel.String())
+			prefix, ok := cidrLabelToPrefix(id)
 			if !ok {
 				log.WithFields(logrus.Fields{
 					logfields.Identity: nid,
 					logfields.Labels:   id.Labels,
 				}).Warn("Unexpected release of non-CIDR identity, will leak this identity. Please report this issue to the developers.")
-				continue
-			}
-			prefix, err := netip.ParsePrefix(strings.TrimPrefix(cidr, labels.LabelSourceCIDR+":"))
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					logfields.Identity: nid,
-					logfields.Labels:   id.Labels,
-				}).Warn("BUG: Cannot parse prefix from CIDR label during CIDR identity release. Please report this issue to the developers.")
 				continue
 			}
 			fullIdentities[prefix] = id

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -6,6 +6,7 @@ package testidentity
 import (
 	"context"
 	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -143,7 +144,7 @@ func (f *MockIdentityAllocator) LookupIdentityByID(ctx context.Context, id ident
 
 // AllocateCIDRsForIPs allocates CIDR identities for the given IPs. It is meant
 // to generally mock the CIDR identity allocator logic.
-func (f *MockIdentityAllocator) AllocateCIDRsForIPs(IPs []net.IP, _ map[string]*identity.Identity) ([]*identity.Identity, error) {
+func (f *MockIdentityAllocator) AllocateCIDRsForIPs(IPs []net.IP, _ map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error) {
 	result := make([]*identity.Identity, 0, len(IPs))
 	for _, ip := range IPs {
 		id, ok := f.ipToIdentity[ip.String()]


### PR DESCRIPTION
The netip.Prefix provides a much richer IP prefix type that's easier to
work with. Switch all of the remaining users of the ipcache CIDR
allocation to this new type.
