### PR TITLE
test: fix up the number of pods in DemoDaemonSet

### DIFF
--- a/test/k8s/manifests.go
+++ b/test/k8s/manifests.go
@@ -13,7 +13,7 @@ var (
 	DemoDaemonSet = helpers.Manifest{
 		Filename:        "demo_ds.yaml",
 		Alternate:       "demo_ds_local.yaml",
-		DaemonSetNames:  []string{"testds", "testclient"},
+		DaemonSetNames:  []string{"testds", "testclient", "testclient-2"},
 		DeploymentNames: []string{"test-k8s2"},
 		NumPods:         1,
 		Singleton:       true,


### PR DESCRIPTION
https://github.com/cilium/cilium/issues/21120#issuecomment-1255807192 uncovered that WaitUntilReady() is racy when using the DemoDaemonSet. After adding an additional DaemonSet to this manifest, the number of expected pods (as calculated per numExpectedPods()) no longer matches the actually deployed pods. So WaitUntilReady() exits prematurely, and we potentially access the pods' state before they are fully set up. This explains the CI flakes we've observed in eg.
https://github.com/cilium/cilium/issues/21120.

Fix this by updating the internal manifest description of the demo_ds.yaml manifest.

This allows WaitUntilReady() to wait for the correct number of pods to become ready when using demo_ds. Also deleteInAnyNamespace() can clean up _all_ daemon sets of this manifest.

Fixes: 74d9f564f95a ("egressgw: manager: add support for new egressGateway policy's property") Fixes https://github.com/cilium/cilium/issues/21120
Reported-by: Martynas Pumputis <m@lambda.lt>
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>