### PR TITLE
ipsec: Fix incorrect CIDR in XFRM IN policy for proxy

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -551,8 +551,8 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 			if err != nil {
 				upsertIPsecLog(err, "getV4LinkLocalIP failed", ipsecIPv4Wildcard, cidr, spi)
 			}
-			spi, err := ipsec.UpsertIPsecEndpoint(linkAddr, ipsecIPv4Wildcard, cidr, linkAddr.IP, wildcardIP, ipsec.IPSecDirIn, zeroMark)
-			upsertIPsecLog(err, "CNI In IPv4", linkAddr, ipsecIPv4Wildcard, spi)
+			spi, err := ipsec.UpsertIPsecEndpoint(cidr, ipsecIPv4Wildcard, cidr, linkAddr.IP, wildcardIP, ipsec.IPSecDirIn, zeroMark)
+			upsertIPsecLog(err, "CNI In IPv4", cidr, ipsecIPv4Wildcard, spi)
 		}
 	}
 
@@ -573,8 +573,8 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 			if err != nil {
 				upsertIPsecLog(err, "getV6LinkLocalIP failed", ipsecIPv6Wildcard, cidr, spi)
 			}
-			spi, err := ipsec.UpsertIPsecEndpoint(linkAddr, ipsecIPv6Wildcard, cidr, linkAddr.IP, wildcardIP, ipsec.IPSecDirIn, zeroMark)
-			upsertIPsecLog(err, "CNI In IPv6", linkAddr, ipsecIPv6Wildcard, spi)
+			spi, err := ipsec.UpsertIPsecEndpoint(cidr, ipsecIPv6Wildcard, cidr, linkAddr.IP, wildcardIP, ipsec.IPSecDirIn, zeroMark)
+			upsertIPsecLog(err, "CNI In IPv6", cidr, ipsecIPv6Wildcard, spi)
 		}
 	}
 }


### PR DESCRIPTION
When IPsec is enabled, we have one XFRM IN policy with mark 0x200 (proxy redirect) configured to allow proxy traffic through. That is needed because that traffic is redirected through the INPUT netfilter chains and the XFRM lookup as part of TPROXY.

In EKS & AKS, the CIDR to match destination IP addresses of those packets is incorrect. Instead of being the CIDR(s) encompassing all pod IP addresses, it's the CIDR for the encryption interface.

The IP address from the encryption interface should only be used as the outer destination IP address of IPsec encapsulation, as shown below (/16 to match packets in dst; 116.92 IP address as tmpl dst).

Before:

    src 0.0.0.0/0 dst 192.168.116.92/19
        dir in priority 0 ptype main
        mark 0x200/0xf00
        tmpl src 0.0.0.0 dst 192.168.116.92
            proto esp reqid 1 mode tunnel
            level use

After:

    src 0.0.0.0/0 dst 192.168.0.0/16
        dir in priority 0 ptype main
        mark 0x200/0xf00
        tmpl src 0.0.0.0 dst 192.168.116.92
            proto esp reqid 1 mode tunnel
            level use

This bug was causing packet drops when using IPsec with L7 policies (including FQDN policies).

It was introduced by a9f18f36e ("datapath/linux/ipsec: Insert additional In rule when tunneling") which introduced this XFRM IN policy for proxy traffic. This new policy was copied from the XFRM IN policy used to decrypt traffic. But in the XFRM IN policy for decryption it's okay to use this /19 CIDR because it's before decryption & decapsulation so that CIDR will match the outer destination IP address (even a /32 would). That's not the case for the inner packet, after decryption.

Fixes: https://github.com/cilium/cilium/pull/16057.
```release-note
Fix bug that can cause some traffic covered by an L7 policy to be dropped when IPsec is enabled on EKS. 
```