### PR TITLE
ipcache: Remove unsafe ipc.metadata.get

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -124,16 +124,12 @@ func (m *metadata) upsertLocked(prefix netip.Prefix, src source.Source, resource
 // map.
 func (ipc *IPCache) GetIDMetadataByIP(addr netip.Addr) labels.Labels {
 	prefix := netip.PrefixFrom(addr, addr.BitLen())
-	if info := ipc.metadata.get(prefix); info != nil {
+	ipc.metadata.RLock()
+	defer ipc.metadata.RUnlock()
+	if info := ipc.metadata.getLocked(prefix); info != nil {
 		return info.ToLabels()
 	}
 	return nil
-}
-
-func (m *metadata) get(prefix netip.Prefix) prefixInfo {
-	m.RLock()
-	defer m.RUnlock()
-	return m.getLocked(prefix)
 }
 
 func (m *metadata) getLocked(prefix netip.Prefix) prefixInfo {


### PR DESCRIPTION
As [previously discussed][1], the `ipc.metadata.get` method is not safe, as it returns a reference to a map which could be mutated, without holding on to the lock protecting that map. This commit therefore removes that method and ensures that the caller holds on to the lock while the data is being read. The `ToLabels` method creates a copy of the data, so it is safe to be read after the metadata lock has been released.

[1]: https://github.com/cilium/cilium/pull/21565#issuecomment-1268229090
