### PR TITLE
config: support parsing config drop-in directories.

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -103,7 +103,7 @@ spec:
         command:
         - cilium-agent
         args:
-        - --config-dir=/tmp/cilium/config-map
+        - --config-dir=/tmp/cilium/config.d
         {{- with .Values.extraArgs }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}
@@ -355,7 +355,7 @@ spec:
           mountPath: /var/lib/cilium/clustermesh
           readOnly: true
         - name: cilium-config-path
-          mountPath: /tmp/cilium/config-map
+          mountPath: /tmp/cilium/config.d/00-config-map
           readOnly: true
         {{- if .Values.ipMasqAgent.enabled }}
         - name: ip-masq-agent

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -58,7 +58,7 @@ func init() {
 	flags.String(option.ConfigFile, "", `Configuration file (default "$HOME/ciliumd.yaml")`)
 	option.BindEnv(Vp, option.ConfigFile)
 
-	flags.String(option.ConfigDir, "", `Configuration directory that contains a file for each option`)
+	flags.String(option.ConfigDir, "", `Configuration directory of directories that contain a file for each option`)
 	option.BindEnv(Vp, option.ConfigDir)
 
 	flags.Bool(option.DisableCNPStatusUpdates, false, `Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)`)


### PR DESCRIPTION
This adds support for config drop-in directories. Right now, we read configuration from a directory of keyfiles. Support, instead, reading from multiple configuration directories; ordered lexicographically, with later directories overwriting on conflict.

The purpose of this is to enable staged rollouts. I'm thinking of various mechanisms that would write small config overlays in as "dropins".

Signed-off-by: Casey Callendrello <cdc@isovalent.com>