### PR TITLE
fqdn: convert map keys and internal types to `netip.Addr`

### DIFF
--- a/cilium/cmd/preflight.go
+++ b/cilium/cmd/preflight.go
@@ -6,7 +6,7 @@ package cmd
 import (
 	"encoding/json"
 	"io"
-	"net"
+	"net/netip"
 	"os"
 	"time"
 
@@ -112,7 +112,7 @@ func preflightPoller() {
 // matchName. In cases where different sets of matchNames are used, each with a
 // different combination of names, the IPs set per name will reflects IPs that
 // actuall belong to other names also seen in the toFQDNs section of that rule.
-func getDNSMappings() (DNSData map[string][]net.IP, err error) {
+func getDNSMappings() (DNSData map[string][]netip.Addr, err error) {
 	policy, err := client.PolicyGet(nil)
 	if err != nil {
 		return nil, err
@@ -127,7 +127,7 @@ func getDNSMappings() (DNSData map[string][]net.IP, err error) {
 	// inserted into that rule as IPs for that DNS name (this may be shared by many
 	// DNS names). We ensure that we only read /32 CIDRs, since we only ever insert
 	// those.
-	DNSData = make(map[string][]net.IP)
+	DNSData = make(map[string][]netip.Addr)
 	for _, rule := range rules {
 		for _, egressRule := range rule.Egress {
 			for _, ToFQDN := range egressRule.ToFQDNs {
@@ -137,12 +137,12 @@ func getDNSMappings() (DNSData map[string][]net.IP, err error) {
 					continue
 				}
 				for _, cidr := range egressRule.ToCIDRSet {
-					ip, _, err := net.ParseCIDR(string(cidr.Cidr))
+					prefix, err := netip.ParsePrefix(string(cidr.Cidr))
 					if err != nil {
 						return nil, err
 					}
 					name := matchpattern.Sanitize(ToFQDN.MatchName)
-					DNSData[name] = append(DNSData[name], ip)
+					DNSData[name] = append(DNSData[name], prefix.Addr())
 				}
 			}
 		}

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -817,7 +817,7 @@ func deleteDNSLookups(globalCache *fqdn.DNSCache, endpoints []*endpoint.Endpoint
 		namesToRegen = append(namesToRegen, ep.DNSHistory.ForceExpire(expireLookupsBefore, nameMatcher)...)
 		globalCache.UpdateFromCache(ep.DNSHistory, nil)
 
-		namesToRegen = append(namesToRegen, ep.DNSZombies.ForceExpire(expireLookupsBefore, nameMatcher, nil)...)
+		namesToRegen = append(namesToRegen, ep.DNSZombies.ForceExpire(expireLookupsBefore, nameMatcher)...)
 		activeConnections := fqdn.NewDNSCache(0)
 		zombies, _ := ep.DNSZombies.GC()
 		lookupTime := time.Now()

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -234,7 +234,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 				for _, zombie := range alive {
 					namesToClean = fqdn.KeepUniqueNames(append(namesToClean, zombie.Names...))
 					for _, name := range zombie.Names {
-						activeConnections.Update(lookupTime, name, []net.IP{zombie.IP}, activeConnectionsTTL)
+						activeConnections.Update(lookupTime, name, []net.IP{zombie.IP.AsSlice()}, activeConnectionsTTL)
 					}
 				}
 
@@ -317,7 +317,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 			alive, _ := possibleEP.DNSZombies.GC()
 			for _, zombie := range alive {
 				for _, name := range zombie.Names {
-					globalCache.Update(lookupTime, name, []net.IP{zombie.IP}, int(2*dnsGCJobInterval.Seconds()))
+					globalCache.Update(lookupTime, name, []net.IP{zombie.IP.AsSlice()}, int(2*dnsGCJobInterval.Seconds()))
 				}
 			}
 		}
@@ -824,7 +824,7 @@ func deleteDNSLookups(globalCache *fqdn.DNSCache, endpoints []*endpoint.Endpoint
 		for _, zombie := range zombies {
 			namesToRegen = append(namesToRegen, zombie.Names...)
 			for _, name := range zombie.Names {
-				activeConnections.Update(lookupTime, name, []net.IP{zombie.IP}, 0)
+				activeConnections.Update(lookupTime, name, []net.IP{zombie.IP.AsSlice()}, 0)
 			}
 		}
 		globalCache.UpdateFromCache(activeConnections, nil)

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -125,10 +125,10 @@ func (ds *DaemonFQDNSuite) SetUpTest(c *C) {
 }
 
 // makeIPs generates count sequential IPv4 IPs
-func makeIPs(count uint32) []net.IP {
-	ips := make([]net.IP, 0, count)
+func makeIPs(count uint32) []netip.Addr {
+	ips := make([]netip.Addr, 0, count)
 	for i := uint32(0); i < count; i++ {
-		ips = append(ips, net.IPv4(byte(i>>24), byte(i>>16), byte(i>>8), byte(i>>0)))
+		ips = append(ips, netip.AddrFrom4([4]byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i >> 0)}))
 	}
 	return ips
 }

--- a/pkg/endpoint/fqdn.go
+++ b/pkg/endpoint/fqdn.go
@@ -4,7 +4,7 @@
 package endpoint
 
 import (
-	"net"
+	"net/netip"
 	"time"
 )
 
@@ -18,9 +18,9 @@ const logSubsys = "fqdn"
 // function.
 // Internally, the lookupTime is used to checkpoint this update so that
 // dns-garbage-collector-job can correctly clear older connection data.
-func (e *Endpoint) MarkDNSCTEntry(dstIP net.IP, now time.Time) {
-	if dstIP == nil {
-		e.Logger(logSubsys).Error("MarkDNSCTEntry called with nil IP")
+func (e *Endpoint) MarkDNSCTEntry(dstIP netip.Addr, now time.Time) {
+	if !dstIP.IsValid() {
+		e.Logger(logSubsys).Error("MarkDNSCTEntry called with invalid IP")
 		return
 	}
 

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -1003,11 +1003,10 @@ func (zombies *DNSZombieMappings) SetCTGCTime(ctGCStart time.Time) {
 //
 // nameMatch will remove that specific DNS name from zombies that include it,
 // deleting it when no DNS names remain.
-func (zombies *DNSZombieMappings) ForceExpire(expireLookupsBefore time.Time, nameMatch *regexp.Regexp, cidr *net.IPNet) (namesAffected []string) {
+func (zombies *DNSZombieMappings) ForceExpire(expireLookupsBefore time.Time, nameMatch *regexp.Regexp) (namesAffected []string) {
 	zombies.Lock()
 	defer zombies.Unlock()
-	return zombies.forceExpireLocked(expireLookupsBefore, nameMatch, cidr)
-
+	return zombies.forceExpireLocked(expireLookupsBefore, nameMatch, nil)
 }
 
 func (zombies *DNSZombieMappings) forceExpireLocked(expireLookupsBefore time.Time, nameMatch *regexp.Regexp, cidr *net.IPNet) (namesAffected []string) {

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -856,7 +856,7 @@ func (ds *DNSCacheTestSuite) TestZombiesForceExpire(c *C) {
 	// Expire only 1 name on 1 zombie
 	nameMatch, err := regexp.Compile("^test.com$")
 	c.Assert(err, IsNil)
-	zombies.ForceExpire(time.Time{}, nameMatch, nil)
+	zombies.ForceExpire(time.Time{}, nameMatch)
 
 	alive, dead = zombies.GC()
 	c.Assert(dead, HasLen, 0)
@@ -869,7 +869,7 @@ func (ds *DNSCacheTestSuite) TestZombiesForceExpire(c *C) {
 	// GC
 	nameMatch, err = regexp.Compile("^anothertest.com$")
 	c.Assert(err, IsNil)
-	zombies.ForceExpire(time.Time{}, nameMatch, nil)
+	zombies.ForceExpire(time.Time{}, nameMatch)
 	alive, dead = zombies.GC()
 	c.Assert(dead, HasLen, 0)
 	assertZombiesContain(c, alive, map[string][]string{

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -667,7 +667,7 @@ func (ds *DNSCacheTestSuite) TestZombiesSiblingsGC(c *C) {
 	// Mark 1.1.1.2 alive which should also keep 1.1.1.1 alive since they
 	// have the same name
 	now = now.Add(time.Second)
-	zombies.MarkAlive(now, net.ParseIP("1.1.1.2"))
+	zombies.MarkAlive(now, netip.MustParseAddr("1.1.1.2"))
 	zombies.SetCTGCTime(now)
 
 	alive, dead := zombies.GC()
@@ -706,10 +706,10 @@ func (ds *DNSCacheTestSuite) TestZombiesGC(c *C) {
 	})
 
 	// Cause 1.1.1.1 to die by not marking it alive before the second GC
-	//zombies.MarkAlive(now, net.ParseIP("1.1.1.1"))
+	//zombies.MarkAlive(now, netip.MustParseAddr("1.1.1.1"))
 	now = now.Add(time.Second)
 	// Mark 2.2.2.2 alive with 1 second grace period
-	zombies.MarkAlive(now.Add(time.Second), net.ParseIP("2.2.2.2"))
+	zombies.MarkAlive(now.Add(time.Second), netip.MustParseAddr("2.2.2.2"))
 	zombies.SetCTGCTime(now)
 
 	// alive should contain 2.2.2.2 -> somethingelse.com
@@ -829,8 +829,8 @@ func (ds *DNSCacheTestSuite) TestZombiesGCDeferredDeletes(c *C) {
 	// latest insert time.
 	zombies.Upsert(now.Add(0*time.Second), "1.1.1.1", "test.com")
 	gcTime := now.Add(4 * time.Second)
-	zombies.MarkAlive(gcTime, net.ParseIP("1.1.1.1"))
-	zombies.MarkAlive(gcTime, net.ParseIP("2.2.2.2"))
+	zombies.MarkAlive(gcTime, netip.MustParseAddr("1.1.1.1"))
+	zombies.MarkAlive(gcTime, netip.MustParseAddr("2.2.2.2"))
 	zombies.SetCTGCTime(gcTime)
 
 	alive, dead = zombies.GC()
@@ -981,8 +981,8 @@ func (ds *DNSCacheTestSuite) TestZombiesDumpAlive(c *C) {
 	})
 
 	now = now.Add(time.Second)
-	zombies.MarkAlive(now, net.ParseIP("1.1.1.1"))
-	zombies.MarkAlive(now, net.ParseIP("2.2.2.2"))
+	zombies.MarkAlive(now, netip.MustParseAddr("1.1.1.1"))
+	zombies.MarkAlive(now, netip.MustParseAddr("2.2.2.2"))
 	zombies.SetCTGCTime(now)
 
 	alive = zombies.DumpAlive(nil)

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"net/netip"
 	"regexp"
 	"sort"
 	"time"
@@ -589,7 +590,7 @@ func (ds *DNSCacheTestSuite) TestOverlimitEntriesWithValidLimit(c *C) {
 
 	c.Assert(cache.Lookup("test.com"), HasLen, limit)
 	c.Assert(cache.LookupIP(net.ParseIP("1.1.1.1")), checker.DeepEquals, []string{"foo.bar"})
-	c.Assert(cache.forward["test.com"]["1.1.1.1"], IsNil)
+	c.Assert(cache.forward["test.com"][netip.MustParseAddr("1.1.1.1")], IsNil)
 	c.Assert(cache.Lookup("foo.bar"), HasLen, 1)
 	c.Assert(cache.Lookup("bar.foo"), HasLen, 1)
 	c.Assert(cache.overLimit, HasLen, 0)

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -45,12 +45,12 @@ func (ds *DNSCacheTestSuite) TestUpdateLookup(c *C) {
 		ttl := i
 		cache.Update(now,
 			name,
-			[]net.IP{net.ParseIP(fmt.Sprintf("1.1.1.%d", i)), net.ParseIP(fmt.Sprintf("2.2.2.%d", i))},
+			[]netip.Addr{netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i)), netip.MustParseAddr(fmt.Sprintf("2.2.2.%d", i))},
 			ttl)
 
 		cache.Update(now,
 			name,
-			[]net.IP{net.ParseIP(fmt.Sprintf("1.1.1.%d", i))},
+			[]netip.Addr{netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))},
 			ttl/2)
 	}
 
@@ -80,18 +80,18 @@ func (ds *DNSCacheTestSuite) TestUpdateLookup(c *C) {
 
 // TestDelete tests that we can forcibly clear parts of the cache.
 func (ds *DNSCacheTestSuite) TestDelete(c *C) {
-	names := map[string]net.IP{
-		"test1.com": net.ParseIP("2.2.2.1"),
-		"test2.com": net.ParseIP("2.2.2.2"),
-		"test3.com": net.ParseIP("2.2.2.3")}
-	sharedIP := net.ParseIP("1.1.1.1")
+	names := map[string]netip.Addr{
+		"test1.com": netip.MustParseAddr("2.2.2.1"),
+		"test2.com": netip.MustParseAddr("2.2.2.2"),
+		"test3.com": netip.MustParseAddr("2.2.2.3")}
+	sharedIP := netip.MustParseAddr("1.1.1.1")
 	now := time.Now()
 	cache := NewDNSCache(0)
 
 	// Insert 3 records with 1 shared IP and 3 with different IPs
-	cache.Update(now, "test1.com", []net.IP{sharedIP, names["test1.com"]}, 5)
-	cache.Update(now, "test2.com", []net.IP{sharedIP, names["test2.com"]}, 5)
-	cache.Update(now, "test3.com", []net.IP{sharedIP, names["test3.com"]}, 5)
+	cache.Update(now, "test1.com", []netip.Addr{sharedIP, names["test1.com"]}, 5)
+	cache.Update(now, "test2.com", []netip.Addr{sharedIP, names["test2.com"]}, 5)
+	cache.Update(now, "test3.com", []netip.Addr{sharedIP, names["test3.com"]}, 5)
 
 	now = now.Add(time.Second)
 
@@ -157,7 +157,7 @@ func (ds *DNSCacheTestSuite) Test_forceExpiredByNames(c *C) {
 		cache.Update(
 			now,
 			fmt.Sprintf("test%d.com", i),
-			[]net.IP{net.ParseIP(fmt.Sprintf("1.1.1.%d", i))},
+			[]netip.Addr{netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))},
 			5)
 	}
 
@@ -181,8 +181,8 @@ func (ds *DNSCacheTestSuite) TestReverseUpdateLookup(c *C) {
 	cache := NewDNSCache(0)
 
 	// insert 2 records, with 1 shared IP
-	cache.Update(now, "test1.com", []net.IP{sharedIP.AsSlice(), names["test1.com"].AsSlice()}, 2)
-	cache.Update(now, "test2.com", []net.IP{sharedIP.AsSlice(), names["test2.com"].AsSlice()}, 4)
+	cache.Update(now, "test1.com", []netip.Addr{sharedIP, names["test1.com"]}, 2)
+	cache.Update(now, "test2.com", []netip.Addr{sharedIP, names["test2.com"]}, 4)
 
 	// lookup within the TTL for both names should return 2 names for sharedIPs,
 	// and one name for the 2.2.2.* IPs
@@ -239,21 +239,21 @@ func (ds *DNSCacheTestSuite) TestReverseUpdateLookup(c *C) {
 }
 
 func (ds *DNSCacheTestSuite) TestJSONMarshal(c *C) {
-	names := map[string]net.IP{
-		"test1.com": net.ParseIP("2.2.2.1"),
-		"test2.com": net.ParseIP("2.2.2.2"),
-		"test3.com": net.ParseIP("2.2.2.3")}
-	sharedIP := net.ParseIP("1.1.1.1")
+	names := map[string]netip.Addr{
+		"test1.com": netip.MustParseAddr("2.2.2.1"),
+		"test2.com": netip.MustParseAddr("2.2.2.2"),
+		"test3.com": netip.MustParseAddr("2.2.2.3")}
+	sharedIP := netip.MustParseAddr("1.1.1.1")
 	now := time.Now()
 	cache := NewDNSCache(0)
 
 	// insert 3 records with 1 shared IP and 3 with different IPs
-	cache.Update(now, "test1.com", []net.IP{sharedIP}, 5)
-	cache.Update(now, "test2.com", []net.IP{sharedIP}, 5)
-	cache.Update(now, "test3.com", []net.IP{sharedIP}, 5)
-	cache.Update(now, "test1.com", []net.IP{names["test1.com"]}, 5)
-	cache.Update(now, "test2.com", []net.IP{names["test2.com"]}, 5)
-	cache.Update(now, "test3.com", []net.IP{names["test3.com"]}, 5)
+	cache.Update(now, "test1.com", []netip.Addr{sharedIP}, 5)
+	cache.Update(now, "test2.com", []netip.Addr{sharedIP}, 5)
+	cache.Update(now, "test3.com", []netip.Addr{sharedIP}, 5)
+	cache.Update(now, "test1.com", []netip.Addr{names["test1.com"]}, 5)
+	cache.Update(now, "test2.com", []netip.Addr{names["test2.com"]}, 5)
+	cache.Update(now, "test3.com", []netip.Addr{names["test3.com"]}, 5)
 
 	// Marshal and unmarshal
 	data, err := cache.MarshalJSON()
@@ -290,17 +290,17 @@ func (ds *DNSCacheTestSuite) TestJSONMarshal(c *C) {
 }
 
 func (ds *DNSCacheTestSuite) TestCountIPs(c *C) {
-	names := map[string]net.IP{
-		"test1.com": net.ParseIP("1.1.1.1"),
-		"test2.com": net.ParseIP("2.2.2.2"),
-		"test3.com": net.ParseIP("3.3.3.3")}
-	sharedIP := net.ParseIP("8.8.8.8")
+	names := map[string]netip.Addr{
+		"test1.com": netip.MustParseAddr("1.1.1.1"),
+		"test2.com": netip.MustParseAddr("2.2.2.2"),
+		"test3.com": netip.MustParseAddr("3.3.3.3")}
+	sharedIP := netip.MustParseAddr("8.8.8.8")
 	cache := NewDNSCache(0)
 
 	// Insert 3 records all sharing one IP and 1 unique IP.
-	cache.Update(now, "test1.com", []net.IP{sharedIP, names["test1.com"]}, 5)
-	cache.Update(now, "test2.com", []net.IP{sharedIP, names["test2.com"]}, 5)
-	cache.Update(now, "test3.com", []net.IP{sharedIP, names["test3.com"]}, 5)
+	cache.Update(now, "test1.com", []netip.Addr{sharedIP, names["test1.com"]}, 5)
+	cache.Update(now, "test2.com", []netip.Addr{sharedIP, names["test2.com"]}, 5)
+	cache.Update(now, "test3.com", []netip.Addr{sharedIP, names["test3.com"]}, 5)
 
 	fqdns, ips := cache.Count()
 
@@ -325,10 +325,10 @@ var (
 )
 
 // makeIPs generates count sequential IPv4 IPs
-func makeIPs(count uint32) []net.IP {
-	ips := make([]net.IP, 0, count)
+func makeIPs(count uint32) []netip.Addr {
+	ips := make([]netip.Addr, 0, count)
 	for i := uint32(0); i < count; i++ {
-		ips = append(ips, net.IPv4(byte(i>>24), byte(i>>16), byte(i>>8), byte(i>>0)))
+		ips = append(ips, netip.AddrFrom4([4]byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i >> 0)}))
 	}
 	return ips
 }
@@ -338,14 +338,14 @@ func makeEntries(now time.Time, live, redundant, expired uint32) (entries []*cac
 	redundantTTL := 60
 
 	for ; live > 0; live-- {
-		ip := net.IPv4(byte(live>>24), byte(live>>16), byte(live>>8), byte(live>>0))
+		ip := netip.AddrFrom4([4]byte{byte(live >> 24), byte(live >> 16), byte(live >> 8), byte(live >> 0)})
 
 		entries = append(entries, &cacheEntry{
 			Name:           fmt.Sprintf("live-%s", ip.String()),
 			LookupTime:     now,
 			ExpirationTime: now.Add(time.Duration(liveTTL) * time.Second),
 			TTL:            liveTTL,
-			IPs:            []net.IP{ip}})
+			IPs:            []netip.Addr{ip}})
 
 		if redundant > 0 {
 			redundant--
@@ -354,7 +354,7 @@ func makeEntries(now time.Time, live, redundant, expired uint32) (entries []*cac
 				LookupTime:     now,
 				ExpirationTime: now.Add(time.Duration(redundantTTL) * time.Second),
 				TTL:            redundantTTL,
-				IPs:            []net.IP{ip}})
+				IPs:            []netip.Addr{ip}})
 		}
 
 		if expired > 0 {
@@ -364,7 +364,7 @@ func makeEntries(now time.Time, live, redundant, expired uint32) (entries []*cac
 				LookupTime:     now.Add(-time.Duration(liveTTL) * time.Second),
 				ExpirationTime: now.Add(-time.Second),
 				TTL:            liveTTL,
-				IPs:            []net.IP{ip}})
+				IPs:            []netip.Addr{ip}})
 		}
 	}
 
@@ -380,7 +380,7 @@ func (ds *DNSCacheTestSuite) BenchmarkGetIPs(c *C) {
 	c.StopTimer()
 	now := time.Now()
 	cache := NewDNSCache(0)
-	cache.Update(now, "test.com", []net.IP{net.ParseIP("1.2.3.4")}, 60)
+	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.2.3.4")}, 60)
 	entries := cache.forward["test.com"]
 	for _, entry := range entriesOrig {
 		cache.updateWithEntryIPs(entries, entry)
@@ -398,7 +398,7 @@ func (ds *DNSCacheTestSuite) BenchmarkUpdateIPs(c *C) {
 		c.StopTimer()
 		now := time.Now()
 		cache := NewDNSCache(0)
-		cache.Update(now, "test.com", []net.IP{net.ParseIP("1.2.3.4")}, 60)
+		cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.2.3.4")}, 60)
 		entries := cache.forward["test.com"]
 		c.StartTimer()
 
@@ -487,7 +487,7 @@ func benchmarkUnmarshalJSON(c *C, numDNSEntries int) {
 func (ds *DNSCacheTestSuite) TestTTLInsertWithMinValue(c *C) {
 	now := time.Now()
 	cache := NewDNSCache(60)
-	cache.Update(now, "test.com", []net.IP{net.ParseIP("1.2.3.4")}, 3)
+	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.2.3.4")}, 3)
 
 	// Checking just now to validate that is inserted correctly
 	res := cache.lookupByTime(now, "test.com")
@@ -508,7 +508,7 @@ func (ds *DNSCacheTestSuite) TestTTLInsertWithMinValue(c *C) {
 func (ds *DNSCacheTestSuite) TestTTLInsertWithZeroValue(c *C) {
 	now := time.Now()
 	cache := NewDNSCache(0)
-	cache.Update(now, "test.com", []net.IP{net.ParseIP("1.2.3.4")}, 10)
+	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.2.3.4")}, 10)
 
 	// Checking just now to validate that is inserted correctly
 	res := cache.lookupByTime(now, "test.com")
@@ -528,7 +528,7 @@ func (ds *DNSCacheTestSuite) TestTTLInsertWithZeroValue(c *C) {
 
 func (ds *DNSCacheTestSuite) TestTTLCleanupEntries(c *C) {
 	cache := NewDNSCache(0)
-	cache.Update(now, "test.com", []net.IP{net.ParseIP("1.2.3.4")}, 3)
+	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.2.3.4")}, 3)
 	c.Assert(len(cache.cleanup), Equals, 1)
 	entries, _ := cache.cleanupExpiredEntries(time.Now().Add(5 * time.Second))
 	c.Assert(entries, HasLen, 1)
@@ -551,10 +551,10 @@ func (ds *DNSCacheTestSuite) TestOverlimitEntriesWithValidLimit(c *C) {
 	limit := 5
 	cache := NewDNSCacheWithLimit(0, limit)
 
-	cache.Update(now, "foo.bar", []net.IP{net.ParseIP("1.1.1.1")}, 1)
-	cache.Update(now, "bar.foo", []net.IP{net.ParseIP("2.1.1.1")}, 1)
+	cache.Update(now, "foo.bar", []netip.Addr{netip.MustParseAddr("1.1.1.1")}, 1)
+	cache.Update(now, "bar.foo", []netip.Addr{netip.MustParseAddr("2.1.1.1")}, 1)
 	for i := 1; i < limit+2; i++ {
-		cache.Update(now, "test.com", []net.IP{net.ParseIP(fmt.Sprintf("1.1.1.%d", i))}, i)
+		cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))}, i)
 	}
 	affectedNames, _ := cache.cleanupOverLimitEntries()
 	c.Assert(affectedNames, checker.DeepEquals, []string{"test.com"})
@@ -571,7 +571,7 @@ func (ds *DNSCacheTestSuite) TestOverlimitEntriesWithoutLimit(c *C) {
 	limit := 0
 	cache := NewDNSCacheWithLimit(0, limit)
 	for i := 0; i < 5; i++ {
-		cache.Update(now, "test.com", []net.IP{net.ParseIP(fmt.Sprintf("1.1.1.%d", i))}, i)
+		cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))}, i)
 	}
 	affectedNames, _ := cache.cleanupOverLimitEntries()
 	c.Assert(affectedNames, HasLen, 0)
@@ -585,7 +585,7 @@ func (ds *DNSCacheTestSuite) TestGCOverlimitAfterTTLCleanup(c *C) {
 	// Make sure that the cleanup takes all the changes from 1 minute ago.
 	cache.lastCleanup = time.Now().Add(-1 * time.Minute)
 	for i := 1; i < limit+2; i++ {
-		cache.Update(now, "test.com", []net.IP{net.ParseIP(fmt.Sprintf("1.1.1.%d", i))}, 1)
+		cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))}, 1)
 	}
 
 	c.Assert(cache.Lookup("test.com"), HasLen, limit+1)
@@ -893,8 +893,8 @@ func (ds *DNSCacheTestSuite) TestCacheToZombiesGCCascade(c *C) {
 	zombies := NewDNSZombieMappings(defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
 
 	// Add entries that should expire at different times
-	cache.Update(now, "test.com", []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}, 3)
-	cache.Update(now, "test.com", []net.IP{net.ParseIP("3.3.3.3")}, 5)
+	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("2.2.2.2")}, 3)
+	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("3.3.3.3")}, 5)
 
 	// Cascade expirations from cache to zombies. The 3.3.3.3 lookup has not expired
 	now = now.Add(4 * time.Second)
@@ -1004,27 +1004,27 @@ func (ds *DNSCacheTestSuite) TestOverlimitPreferNewerEntries(c *C) {
 	zombies := NewDNSZombieMappings(toFQDNsMaxDeferredConnectionDeletes, toFQDNsMaxIPsPerHost)
 
 	name := "test.com"
-	IPs := []net.IP{
-		net.ParseIP("1.1.1.1"),
-		net.ParseIP("1.1.1.2"),
-		net.ParseIP("1.1.1.3"),
-		net.ParseIP("1.1.1.4"),
-		net.ParseIP("1.1.1.5"),
-		net.ParseIP("1.1.1.6"),
-		net.ParseIP("1.1.1.7"),
-		net.ParseIP("1.1.1.8"),
-		net.ParseIP("1.1.1.9"),
-		net.ParseIP("1.1.1.10"),
-		net.ParseIP("1.1.1.11"),
-		net.ParseIP("1.1.1.12"),
-		net.ParseIP("1.1.1.13"),
-		net.ParseIP("1.1.1.14"),
-		net.ParseIP("1.1.1.15"),
-		net.ParseIP("1.1.1.16"),
-		net.ParseIP("1.1.1.17"),
-		net.ParseIP("1.1.1.18"),
-		net.ParseIP("1.1.1.19"),
-		net.ParseIP("1.1.1.20"),
+	IPs := []netip.Addr{
+		netip.MustParseAddr("1.1.1.1"),
+		netip.MustParseAddr("1.1.1.2"),
+		netip.MustParseAddr("1.1.1.3"),
+		netip.MustParseAddr("1.1.1.4"),
+		netip.MustParseAddr("1.1.1.5"),
+		netip.MustParseAddr("1.1.1.6"),
+		netip.MustParseAddr("1.1.1.7"),
+		netip.MustParseAddr("1.1.1.8"),
+		netip.MustParseAddr("1.1.1.9"),
+		netip.MustParseAddr("1.1.1.10"),
+		netip.MustParseAddr("1.1.1.11"),
+		netip.MustParseAddr("1.1.1.12"),
+		netip.MustParseAddr("1.1.1.13"),
+		netip.MustParseAddr("1.1.1.14"),
+		netip.MustParseAddr("1.1.1.15"),
+		netip.MustParseAddr("1.1.1.16"),
+		netip.MustParseAddr("1.1.1.17"),
+		netip.MustParseAddr("1.1.1.18"),
+		netip.MustParseAddr("1.1.1.19"),
+		netip.MustParseAddr("1.1.1.20"),
 	}
 	ttl := 0 // will be overwritten with toFQDNsMinTTL
 
@@ -1032,7 +1032,7 @@ func (ds *DNSCacheTestSuite) TestOverlimitPreferNewerEntries(c *C) {
 	for i, ip := range IPs {
 		// Entries with lower values in last IP octet will expire earlier
 		lookupTime := now.Add(-time.Duration(len(IPs)-i) * time.Second)
-		cache.Update(lookupTime, name, []net.IP{ip}, ttl)
+		cache.Update(lookupTime, name, []netip.Addr{ip}, ttl)
 	}
 
 	affected := cache.GC(time.Now(), zombies)

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -322,7 +322,6 @@ var (
 	now         = time.Now()
 	size        = uint32(1000) // size of array to operate on
 	entriesOrig = makeEntries(now, 1+size/3, 1+size/3, 1+size/3)
-	ipsOrig     = makeIPs(size)
 )
 
 // makeIPs generates count sequential IPv4 IPs
@@ -406,35 +405,6 @@ func (ds *DNSCacheTestSuite) BenchmarkUpdateIPs(c *C) {
 		for _, entry := range entriesOrig {
 			cache.updateWithEntryIPs(entries, entry)
 			cache.removeExpired(entries, now, time.Time{})
-		}
-	}
-}
-
-func (ds *DNSCacheTestSuite) BenchmarkIPString(c *C) {
-	for i := 0; i < c.N; i++ {
-		_ = net.IPv4(byte(i>>24), byte(i>>16), byte(i>>8), byte(i>>0)).String()
-	}
-}
-
-func (ds *DNSCacheTestSuite) BenchmarkParseIPSimple(c *C) {
-	ip := ipsOrig[0].String()
-	for i := 0; i < c.N; i++ {
-		_ = net.ParseIP(ip)
-	}
-}
-
-// Note: each "op" works on size things
-func (ds *DNSCacheTestSuite) BenchmarkParseIP(c *C) {
-	c.StopTimer()
-	ips := make([]string, 0, len(ipsOrig))
-	for _, ip := range ipsOrig {
-		ips = append(ips, ip.String())
-	}
-	c.StartTimer()
-
-	for i := 0; i < c.N; i++ {
-		for _, ipStr := range ips {
-			_ = net.ParseIP(ipStr)
 		}
 	}
 }

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -88,6 +88,7 @@ func (n *NameManager) MapSelectorsToIPsLocked(fqdnSelectors map[api.FQDNSelector
 		}
 	}
 
+	selectorsMissingIPs = make([]api.FQDNSelector, 0, len(missing))
 	for dnsName := range missing {
 		selectorsMissingIPs = append(selectorsMissingIPs, dnsName)
 	}

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -6,13 +6,14 @@ package fqdn
 import (
 	"fmt"
 	"math/rand"
-	"net"
+	"net/netip"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
@@ -82,10 +83,9 @@ func (ds *DNSCacheTestSuite) BenchmarkKeepUniqueNames(c *C) {
 }
 
 func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
-
 	var (
-		ciliumIP1   = net.ParseIP("1.2.3.4")
-		ciliumIP2   = net.ParseIP("1.2.3.5")
+		ciliumIP1   = netip.MustParseAddr("1.2.3.4")
+		ciliumIP2   = netip.MustParseAddr("1.2.3.5")
 		nameManager = NewNameManager(Config{
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
@@ -109,7 +109,7 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	c.Assert(len(selIPMapping), Equals, 0)
 
 	// Just one IP.
-	changed := cache.Update(now, prepareMatchName(ciliumIOSel.MatchName), []net.IP{ciliumIP1}, 100)
+	changed := cache.Update(now, prepareMatchName(ciliumIOSel.MatchName), []netip.Addr{ciliumIP1}, 100)
 	c.Assert(changed, Equals, true)
 	selsMissingIPs, selIPMapping = nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 0)
@@ -117,10 +117,10 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	ciliumIPs, ok := selIPMapping[ciliumIOSel]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 1)
-	c.Assert(ciliumIPs[0].Equal(ciliumIP1), Equals, true)
+	c.Assert(ip.MustAddrFromIP(ciliumIPs[0]), Equals, ciliumIP1)
 
 	// Two IPs now.
-	changed = cache.Update(now, prepareMatchName(ciliumIOSel.MatchName), []net.IP{ciliumIP1, ciliumIP2}, 100)
+	changed = cache.Update(now, prepareMatchName(ciliumIOSel.MatchName), []netip.Addr{ciliumIP1, ciliumIP2}, 100)
 	c.Assert(changed, Equals, true)
 	selsMissingIPs, selIPMapping = nameManager.MapSelectorsToIPsLocked(selectors)
 	c.Assert(len(selsMissingIPs), Equals, 0)
@@ -128,8 +128,8 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	ciliumIPs, ok = selIPMapping[ciliumIOSel]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
-	c.Assert(ciliumIPs[0].Equal(ciliumIP1), Equals, true)
-	c.Assert(ciliumIPs[1].Equal(ciliumIP2), Equals, true)
+	c.Assert(ip.MustAddrFromIP(ciliumIPs[0]), Equals, ciliumIP1)
+	c.Assert(ip.MustAddrFromIP(ciliumIPs[1]), Equals, ciliumIP2)
 
 	// Test with a MatchPattern.
 	selectors = map[api.FQDNSelector]struct{}{
@@ -141,8 +141,8 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
-	c.Assert(ciliumIPs[0].Equal(ciliumIP1), Equals, true)
-	c.Assert(ciliumIPs[1].Equal(ciliumIP2), Equals, true)
+	c.Assert(ip.MustAddrFromIP(ciliumIPs[0]), Equals, ciliumIP1)
+	c.Assert(ip.MustAddrFromIP(ciliumIPs[1]), Equals, ciliumIP2)
 
 	selectors = map[api.FQDNSelector]struct{}{
 		ciliumIOSelMatchPattern: {},
@@ -154,11 +154,11 @@ func (ds *DNSCacheTestSuite) TestMapIPsToSelectors(c *C) {
 	ciliumIPs, ok = selIPMapping[ciliumIOSelMatchPattern]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
-	c.Assert(ciliumIPs[0].Equal(ciliumIP1), Equals, true)
-	c.Assert(ciliumIPs[1].Equal(ciliumIP2), Equals, true)
+	c.Assert(ip.MustAddrFromIP(ciliumIPs[0]), Equals, ciliumIP1)
+	c.Assert(ip.MustAddrFromIP(ciliumIPs[1]), Equals, ciliumIP2)
 	ciliumIPs, ok = selIPMapping[ciliumIOSel]
 	c.Assert(ok, Equals, true)
 	c.Assert(len(ciliumIPs), Equals, 2)
-	c.Assert(ciliumIPs[0].Equal(ciliumIP1), Equals, true)
-	c.Assert(ciliumIPs[1].Equal(ciliumIP2), Equals, true)
+	c.Assert(ip.MustAddrFromIP(ciliumIPs[0]), Equals, ciliumIP1)
+	c.Assert(ip.MustAddrFromIP(ciliumIPs[1]), Equals, ciliumIP2)
 }

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -206,7 +206,8 @@ func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[strin
 	affectedSelectors = make(map[api.FQDNSelector]struct{}, len(updatedDNSIPs))
 
 	for dnsName, lookupIPs := range updatedDNSIPs {
-		updated := n.updateIPsForName(lookupTime, dnsName, lookupIPs.IPs, lookupIPs.TTL)
+		addrs := ip.MustAddrsFromIPs(lookupIPs.IPs)
+		updated := n.updateIPsForName(lookupTime, dnsName, addrs, lookupIPs.TTL)
 
 		// The IPs didn't change. No more to be done for this dnsName
 		if !updated && n.bootstrapCompleted {
@@ -241,7 +242,7 @@ func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[strin
 // updateIPsName will update the IPs for dnsName. It always retains a copy of
 // newIPs.
 // updated is true when the new IPs differ from the old IPs
-func (n *NameManager) updateIPsForName(lookupTime time.Time, dnsName string, newIPs []net.IP, ttl int) (updated bool) {
+func (n *NameManager) updateIPsForName(lookupTime time.Time, dnsName string, newIPs []netip.Addr, ttl int) (updated bool) {
 	cacheIPs := n.cache.Lookup(dnsName)
 
 	if n.config.MinTTL > ttl {

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -972,3 +972,14 @@ func MustAddrFromIP(ip net.IP) netip.Addr {
 	}
 	return addr
 }
+
+// MustAddrsFromIPs converts a slice of net.IP to a slice of netip.Addr. It assumes
+// the input slice contains only valid IP addresses and always returns a slice
+// containing valid netip.Addr.
+func MustAddrsFromIPs(ips []net.IP) []netip.Addr {
+	addrs := make([]netip.Addr, 0, len(ips))
+	for _, ip := range ips {
+		addrs = append(addrs, MustAddrFromIP(ip))
+	}
+	return addrs
+}

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -1062,3 +1062,35 @@ func (s *IPTestSuite) TestAddrFromIP(c *C) {
 		}
 	}
 }
+
+func (s *IPTestSuite) TestMustAddrsFromIPs(c *C) {
+	type args struct {
+		ips   []net.IP
+		addrs []netip.Addr
+	}
+	for _, tt := range []args{
+		{
+			ips:   []net.IP{},
+			addrs: []netip.Addr{},
+		},
+		{
+			ips:   []net.IP{net.ParseIP("1.1.1.1")},
+			addrs: []netip.Addr{netip.MustParseAddr("1.1.1.1")},
+		},
+		{
+			ips:   []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2"), net.ParseIP("0.0.0.0")},
+			addrs: []netip.Addr{netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("2.2.2.2"), netip.MustParseAddr("0.0.0.0")},
+		},
+	} {
+		addrs := MustAddrsFromIPs(tt.ips)
+		c.Assert(addrs, checker.DeepEquals, tt.addrs)
+	}
+
+	nilIPs := []net.IP{nil}
+	defer func() {
+		if r := recover(); r == nil {
+			c.Errorf("MustAddrsFromIPs(%v) should panic", nilIPs)
+		}
+	}()
+	_ = MustAddrsFromIPs(nilIPs)
+}

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -81,7 +81,7 @@ func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr Endpoin
 						return
 					}
 					if ep, exists := epsMap[srcIP]; exists {
-						ep.MarkDNSCTEntry(dstIP.AsSlice(), aliveTime)
+						ep.MarkDNSCTEntry(dstIP, aliveTime)
 					}
 				}
 			)


### PR DESCRIPTION
Best reviewed by commit.

This change converts some FQDN cache internal maps and data structures to use `netip.Addr` for map operations directly instead of having to convert `net.IP` for the map key.

I have more local branches depending on these changes, changing other aspects of `pkg/fqdn`. I'm sending these changes in smaller batches to ease reviews.