### PR TITLE
ctmap: add support for GC of DSR orphaned entries

### DIFF
--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -320,6 +320,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	stats := PurgeOrphanNATEntries(ctMapTCP, ctMapAny)
 	c.Assert(stats.IngressAlive, Equals, uint32(1))
 	c.Assert(stats.IngressDeleted, Equals, uint32(0))
+	c.Assert(stats.EgressAlive, Equals, uint32(1))
 	c.Assert(stats.EgressDeleted, Equals, uint32(0))
 	// Check that both entries haven't removed
 	buf := make(map[string][]string)
@@ -334,6 +335,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	c.Assert(stats.IngressDeleted, Equals, uint32(1))
 	c.Assert(stats.IngressAlive, Equals, uint32(0))
 	c.Assert(stats.EgressDeleted, Equals, uint32(1))
+	c.Assert(stats.EgressAlive, Equals, uint32(0))
 	// Check that both orphan NAT entries have been removed
 	buf = make(map[string][]string)
 	err = natMap.Map.Dump(buf)
@@ -348,6 +350,82 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapAny)
 	c.Assert(stats.IngressDeleted, Equals, uint32(1))
 	c.Assert(stats.EgressDeleted, Equals, uint32(0))
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+
+	// Test DSR
+	//
+	// Create the following entries and check that SNAT entries are NOT GC-ed
+	// (as we have the CT entry which they belong to):
+	//
+	//     CT:	TCP IN  10.0.2.10:50000  -> 10.20.30.40:1234
+	//     NAT:	TCP OUT 10.20.30.40:1234 -> 10.0.2.10:50000 XLATE_SRC 10.0.2.20:40000
+
+	ctKey = &CtKey4Global{
+		TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				DestAddr:   types.IPv4{10, 0, 2, 10},
+				SourceAddr: types.IPv4{10, 20, 30, 40},
+				SourcePort: 0x50c3,
+				DestPort:   0xd204,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_IN,
+			},
+		},
+	}
+	ctVal = &CtEntry{
+		TxPackets: 1,
+		TxBytes:   216,
+		Lifetime:  37459,
+	}
+	err = bpf.UpdateElement(ctMapTCP.Map.GetFd(), ctMapTCP.Map.Name(), unsafe.Pointer(ctKey),
+		unsafe.Pointer(ctVal), 0)
+	c.Assert(err, IsNil)
+
+	natKey = &nat.NatKey4{
+		TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				SourceAddr: types.IPv4{10, 20, 30, 40},
+				DestAddr:   types.IPv4{10, 0, 2, 10},
+				SourcePort: 0xd204,
+				DestPort:   0x50c3,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	natVal = &nat.NatEntry4{
+		Created:   37400,
+		HostLocal: 1,
+		Addr:      types.IPv4{10, 0, 2, 20},
+		Port:      0x409c,
+	}
+	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
+		unsafe.Pointer(natVal), 0)
+	c.Assert(err, IsNil)
+
+	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
+	c.Assert(stats.IngressAlive, Equals, uint32(0))
+	c.Assert(stats.IngressDeleted, Equals, uint32(0))
+	c.Assert(stats.EgressAlive, Equals, uint32(1))
+	c.Assert(stats.EgressDeleted, Equals, uint32(0))
+	// Check that the entry hasn't been removed
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 1)
+
+	// Now remove the CT entry which should remove the NAT entry
+	err = bpf.DeleteElement(ctMapTCP.Map.GetFd(), unsafe.Pointer(ctKey))
+	c.Assert(err, IsNil)
+	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
+	c.Assert(stats.IngressAlive, Equals, uint32(0))
+	c.Assert(stats.IngressDeleted, Equals, uint32(0))
+	c.Assert(stats.EgressAlive, Equals, uint32(0))
+	c.Assert(stats.EgressDeleted, Equals, uint32(1))
+	// Check that the orphan NAT entry has been removed
 	buf = make(map[string][]string)
 	err = natMap.Map.Dump(buf)
 	c.Assert(err, IsNil)

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -224,6 +224,7 @@ func runGC(e *endpoint.Endpoint, ipv4, ipv6, triggeredBySignal bool, filter *ctm
 					"ingressDeleted": stats.IngressDeleted,
 					"egressDeleted":  stats.EgressDeleted,
 					"ingressAlive":   stats.IngressAlive,
+					"egressAlive":    stats.EgressAlive,
 					"ctMapIPVersion": vsn,
 				}).Info("Deleted orphan SNAT entries from map")
 			}

--- a/pkg/maps/ctmap/metrics.go
+++ b/pkg/maps/ctmap/metrics.go
@@ -122,8 +122,7 @@ type NatGCStats struct {
 	IngressAlive   uint32
 	IngressDeleted uint32
 	EgressDeleted  uint32
-	// It's not possible with the current PurgeOrphanNATEntries implementation
-	// to correctly count EgressAlive, so skip it
+	EgressAlive    uint32
 }
 
 func newNatGCStats(m *nat.Map, family gcFamily) NatGCStats {
@@ -137,5 +136,6 @@ func (s *NatGCStats) finish() {
 	family := s.Family.String()
 	metrics.NatGCSize.WithLabelValues(family, metricsIngress, metricsAlive).Set(float64(s.IngressAlive))
 	metrics.NatGCSize.WithLabelValues(family, metricsIngress, metricsDeleted).Set(float64(s.IngressDeleted))
+	metrics.NatGCSize.WithLabelValues(family, metricsEgress, metricsAlive).Set(float64(s.EgressAlive))
 	metrics.NatGCSize.WithLabelValues(family, metricsEgress, metricsDeleted).Set(float64(s.EgressDeleted))
 }

--- a/pkg/maps/ctmap/utils.go
+++ b/pkg/maps/ctmap/utils.go
@@ -4,42 +4,14 @@
 package ctmap
 
 import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/tuple"
 )
-
-// NOTE: the function does NOT copy addr fields, so it's not safe to
-// reuse the returned natKey.
-func oNatKeyFromReverse(k nat.NatKey, v nat.NatEntry) nat.NatKey {
-	natKey, ok := k.(*nat.NatKey4)
-	if ok { // ipv4
-		natVal := v.(*nat.NatEntry4)
-		return &nat.NatKey4{TupleKey4Global: tuple.TupleKey4Global{
-			TupleKey4: tuple.TupleKey4{
-				SourceAddr: natVal.Addr,
-				SourcePort: natVal.Port,
-				DestAddr:   natKey.SourceAddr,
-				DestPort:   natKey.SourcePort,
-				NextHeader: natKey.NextHeader,
-				Flags:      tuple.TUPLE_F_OUT,
-			}}}
-	}
-
-	{ // ipv6
-		natKey := k.(*nat.NatKey6)
-		natVal := v.(*nat.NatEntry6)
-		return &nat.NatKey6{TupleKey6Global: tuple.TupleKey6Global{
-			TupleKey6: tuple.TupleKey6{
-				SourceAddr: natVal.Addr,
-				SourcePort: natVal.Port,
-				DestAddr:   natKey.SourceAddr,
-				DestPort:   natKey.SourcePort,
-				NextHeader: natKey.NextHeader,
-				Flags:      tuple.TUPLE_F_OUT,
-			}}}
-	}
-}
 
 // NOTE: the function does NOT copy addr fields, so it's not safe to
 // reuse the returned ctKey.
@@ -159,4 +131,9 @@ func egressCTKeyFromEgressNatKey(k nat.NatKey) bpf.MapKey {
 
 		return &tuple.TupleKey6Global{TupleKey6: t}
 	}
+}
+
+func ctEntryExist(ctMap *Map, ctKey bpf.MapKey) bool {
+	_, err := ctMap.Lookup(ctKey)
+	return !errors.Is(err, unix.ENOENT)
 }

--- a/pkg/maps/ctmap/utils.go
+++ b/pkg/maps/ctmap/utils.go
@@ -46,28 +46,37 @@ func oNatKeyFromReverse(k nat.NatKey, v nat.NatEntry) nat.NatKey {
 func ingressCTKeyFromEgressNatKey(k nat.NatKey) bpf.MapKey {
 	natKey, ok := k.(*nat.NatKey4)
 	if ok { // ipv4
-		return &tuple.TupleKey4Global{TupleKey4: tuple.TupleKey4{
-			// Workaround #5848
-			SourceAddr: natKey.SourceAddr,
-			DestPort:   natKey.SourcePort,
-			DestAddr:   natKey.DestAddr,
+		t := tuple.TupleKey4{
+			SourceAddr: natKey.DestAddr,
 			SourcePort: natKey.DestPort,
+			DestAddr:   natKey.SourceAddr,
+			DestPort:   natKey.SourcePort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_IN,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey4Global{TupleKey4: t}
 	}
 
 	{ // ipv6
 		natKey := k.(*nat.NatKey6)
-		return &tuple.TupleKey6Global{TupleKey6: tuple.TupleKey6{
-			// Workaround #5848
-			SourceAddr: natKey.SourceAddr,
-			DestPort:   natKey.SourcePort,
-			DestAddr:   natKey.DestAddr,
+
+		t := tuple.TupleKey6{
+			SourceAddr: natKey.DestAddr,
 			SourcePort: natKey.DestPort,
+			DestAddr:   natKey.SourceAddr,
+			DestPort:   natKey.SourcePort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_IN,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey6Global{TupleKey6: t}
 	}
 }
 
@@ -77,29 +86,39 @@ func egressCTKeyFromIngressNatKeyAndVal(k nat.NatKey, v nat.NatEntry) bpf.MapKey
 	natKey, ok := k.(*nat.NatKey4)
 	if ok { // ipv4
 		natVal := v.(*nat.NatEntry4)
-		return &tuple.TupleKey4Global{TupleKey4: tuple.TupleKey4{
-			// Workaround #5848
-			SourceAddr: natKey.SourceAddr,
-			DestPort:   natKey.SourcePort,
-			DestAddr:   natVal.Addr,
+
+		t := tuple.TupleKey4{
+			SourceAddr: natVal.Addr,
 			SourcePort: natVal.Port,
+			DestAddr:   natKey.SourceAddr,
+			DestPort:   natKey.SourcePort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_OUT,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey4Global{TupleKey4: t}
 	}
 
 	{ // ipv6
 		natKey := k.(*nat.NatKey6)
 		natVal := v.(*nat.NatEntry6)
-		return &tuple.TupleKey6Global{TupleKey6: tuple.TupleKey6{
-			// Workaround #5848
-			SourceAddr: natKey.SourceAddr,
-			DestPort:   natKey.SourcePort,
-			DestAddr:   natVal.Addr,
+
+		t := tuple.TupleKey6{
+			SourceAddr: natVal.Addr,
 			SourcePort: natVal.Port,
+			DestAddr:   natKey.SourceAddr,
+			DestPort:   natKey.SourcePort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_OUT,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey6Global{TupleKey6: t}
 	}
 }
 
@@ -108,27 +127,36 @@ func egressCTKeyFromIngressNatKeyAndVal(k nat.NatKey, v nat.NatEntry) bpf.MapKey
 func egressCTKeyFromEgressNatKey(k nat.NatKey) bpf.MapKey {
 	natKey, ok := k.(*nat.NatKey4)
 	if ok { // ipv4
-		return &tuple.TupleKey4Global{TupleKey4: tuple.TupleKey4{
-			// Workaround #5848
-			SourceAddr: natKey.DestAddr,
-			DestPort:   natKey.DestPort,
-			DestAddr:   natKey.SourceAddr,
+		t := tuple.TupleKey4{
+			SourceAddr: natKey.SourceAddr,
 			SourcePort: natKey.SourcePort,
+			DestAddr:   natKey.DestAddr,
+			DestPort:   natKey.DestPort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_OUT,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey4Global{TupleKey4: t}
 	}
 
 	{ // ipv6
 		natKey := k.(*nat.NatKey6)
-		return &tuple.TupleKey6Global{TupleKey6: tuple.TupleKey6{
-			// Workaround #5848
-			SourceAddr: natKey.DestAddr,
-			DestPort:   natKey.DestPort,
-			DestAddr:   natKey.SourceAddr,
+
+		t := tuple.TupleKey6{
+			SourceAddr: natKey.SourceAddr,
 			SourcePort: natKey.SourcePort,
+			DestAddr:   natKey.DestAddr,
+			DestPort:   natKey.DestPort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_OUT,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey6Global{TupleKey6: t}
 	}
 }

--- a/pkg/tuple/ipv4.go
+++ b/pkg/tuple/ipv4.go
@@ -99,6 +99,13 @@ func (k TupleKey4) Dump(sb *strings.Builder, reverse bool) bool {
 	return true
 }
 
+// SwapAddresses swaps the tuple source and destination addresses.
+func (t *TupleKey4) SwapAddresses() {
+	tmp := t.SourceAddr
+	t.SourceAddr = t.DestAddr
+	t.DestAddr = tmp
+}
+
 // TupleKey4Global represents the key for IPv4 entries in the global BPF
 // conntrack map.
 // +k8s:deepcopy-gen=true

--- a/pkg/tuple/ipv6.go
+++ b/pkg/tuple/ipv6.go
@@ -99,6 +99,13 @@ func (k TupleKey6) Dump(sb *strings.Builder, reverse bool) bool {
 	return true
 }
 
+// SwapAddresses swaps the tuple source and destination addresses.
+func (t *TupleKey6) SwapAddresses() {
+	tmp := t.SourceAddr
+	t.SourceAddr = t.DestAddr
+	t.DestAddr = tmp
+}
+
 // TupleKey6Global represents the key for IPv6 entries in the global BPF conntrack map.
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapKey


### PR DESCRIPTION
Let's start from some context: normally, when traffic on a node needs to
get SNAT-ed by the datapath, the following map entries get created:

CT table:

  | Dir | Source      | Destination |
  | --- | ----------- | ----------- |
  | OUT | src IP/port | dst IP/port |

NAT table:

  | Dir | Source      | Destination | Xlate target          |
  | --- | ----------- | ----------- | --------------------- |
  | OUT | src IP/port | dst IP/port | XLATE_SRC nat IP/port |
  | IN  | dst IP/port | nat IP/port | XLATE_DST src IP/port |

Given this, the current algorithm to clear orphan NAT entries (i.e.
entries that are not backed anymore by a related CT one) can be
described as follow:

for each ingress NAT entry:
  - derive the related egress CT key:

        source      = ingress NAT entry xlate target
        destination = ingress NAT entry source

  - if there's no entry for the egress CT key
    - derive the related egress NAT entry (aka original tuple/ingress
      reverse tuple):

          source       = ingress NAT entry xlate targe
          destination  = ingress NAT entry source
          xlate target = ingress NAT entry destination

    - delete both ingress and egress NAT entries

This commit is about adding support for collecting orphaned NAT entries
created by the DSR loadbalancer mode.

In DSR mode, when a client connects to a NodePort service, the traffic
flow will be something like:

- client connects to a second node where the NodePort service is running
- this second node selects a backend and (unless the backend is running
  locally) forwards the traffic to a third node where the backend is
  running, while:
  - keeping the original client source IP
  - encoding the original destination in an IP option
  - rewriting the destination to the backend IP
- in the third node, the original destination is extracted from the IP
  option and the following bpf entries are created:

CT table:

  | Dir | Source      | Destination | Flags |
  | --- | ----------- | ----------- | ----- |
  | IN  | src IP/port | dst IP/port | DSR   |

NAT:

  | Dir | Source      | Destination | Xlate target     |
  | --- | ----------- | ----------- | ---------------- |
  | OUT | dst IP/port | src IP/port | XLATE_SRC nat IP |

  where:

  - src IP is the IP of the client
  - dst IP is the IP of the backend running on the node
  - nat IP is the IP of the nodeport node (second node), which was
    encoded by the node itself in an IP option before forwarding traffic
    to the third node.
    This is used to implement DSR as the reply traffic leaving the
    current node is forwarded back to the original client with this IP
    as source

Considering the entries that get created by the regular (i.e. non DSR)
NAT operations, to implement GC of the DSR SNAT entries we can extend
the algorithm as follows:

for each egress NAT entry:
  - derive the related ingress CT key:

        source      = ingress NAT entry destination
        destination = ingress NAT entry source

  - derive the related egress CT key:

        source      = ingress NAT entry source
        destination = ingress NAT entry destination

  - if both the ingress and egress CT keys don't have a corresponding
    entry:
    - delete the egress NAT entry

If both ingress and egress CT keys for a given NAT entry don't exist we
can assume the entry is orphan, as the lack of the ingress key will
cover the DSR case while the lack of the egress key will cover the
"regular" one.

There's one last catch: to simplify this writing, we discussed the
_logical_ content of the CT keys, but in practice every key has the
source and destination addresses swapped because of the way the datapath
creates these entries.

Fixes: https://github.com/cilium/cilium/issues/21346