### PR TITLE
helm: Document missing bpf ctTcpMax ctAnyMax natMax neighMax

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -85,6 +85,14 @@
      - Enable BPF clock source probing for more efficient tick retrieval.
      - bool
      - ``false``
+   * - bpf.ctAnyMax
+     - Configure the maximum number of entries for the non-TCP connection tracking table.
+     - int
+     - ``262144``
+   * - bpf.ctTcpMax
+     - Configure the maximum number of entries in the TCP connection tracking table.
+     - int
+     - ``524288``
    * - bpf.hostBoot
      - Configure the path to the host boot directory
      - string
@@ -113,6 +121,14 @@
      - Enable host boot directory mount for BPF clock source probing
      - bool
      - ``true``
+   * - bpf.natMax
+     - Configure the maximum number of entries for the NAT table.
+     - int
+     - ``524288``
+   * - bpf.neighMax
+     - Configure the maximum number of entries for the neighbor table.
+     - int
+     - ``524288``
    * - bpf.policyMapMax
      - Configure the maximum number of entries in endpoint policy map (per endpoint).
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -72,6 +72,8 @@ contributors across the globe, there is almost always someone available to help.
 | bgpControlPlane | object | `{"enabled":false}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
 | bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |
 | bpf.clockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
+| bpf.ctAnyMax | int | `262144` | Configure the maximum number of entries for the non-TCP connection tracking table. |
+| bpf.ctTcpMax | int | `524288` | Configure the maximum number of entries in the TCP connection tracking table. |
 | bpf.hostBoot | string | `"/boot"` | Configure the path to the host boot directory |
 | bpf.lbExternalClusterIP | bool | `false` | Allow cluster external access to ClusterIP services. |
 | bpf.lbMapMax | int | `65536` | Configure the maximum number of service entries in the load balancer maps. |
@@ -79,6 +81,8 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.monitorFlags | string | `"all"` | Configure which TCP flags trigger notifications when seen for the first time in a connection. |
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
 | bpf.mountHostBoot | bool | `true` | Enable host boot directory mount for BPF clock source probing |
+| bpf.natMax | int | `524288` | Configure the maximum number of entries for the NAT table. |
+| bpf.neighMax | int | `524288` | Configure the maximum number of entries for the neighbor table. |
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -311,12 +311,12 @@ data:
   bpf-ct-global-any-max: {{ $bpfCtAnyMax | quote }}
 {{- end }}
 {{- end }}
-{{- if hasKey .Values.bpf "natMax" }}
+{{- if .Values.bpf.natMax }}
   # bpf-nat-global-max specified the maximum number of entries in the
   # BPF NAT table.
   bpf-nat-global-max: "{{ .Values.bpf.natMax }}"
 {{- end }}
-{{- if hasKey .Values.bpf "neighMax" }}
+{{- if .Values.bpf.neighMax }}
   # bpf-neigh-global-max specified the maximum number of entries in the
   # BPF neighbor table.
   bpf-neigh-global-max: "{{ .Values.bpf.neighMax }}"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -275,23 +275,27 @@ bpf:
   # memory usage but can reduce latency.
   preallocateMaps: false
 
-  # -- Configure the maximum number of entries in the TCP connection tracking
+  # -- (int) Configure the maximum number of entries in the TCP connection tracking
   # table.
-  # ctTcpMax: '524288'
+  # @default -- `524288`
+  ctTcpMax: ~
 
-  # -- Configure the maximum number of entries for the non-TCP connection
+  # -- (int) Configure the maximum number of entries for the non-TCP connection
   # tracking table.
-  # ctAnyMax: '262144'
+  # @default -- `262144`
+  ctAnyMax: ~
 
   # -- Configure the maximum number of service entries in the
   # load balancer maps.
   lbMapMax: 65536
 
-  # -- Configure the maximum number of entries for the NAT table.
-  # natMax: 524288
+  # -- (int) Configure the maximum number of entries for the NAT table.
+  # @default -- `524288`
+  natMax: ~
 
-  # -- Configure the maximum number of entries for the neighbor table.
-  # neighMax: 524288
+  # -- (int) Configure the maximum number of entries for the neighbor table.
+  # @default -- `524288`
+  neighMax: ~
 
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
   policyMapMax: 16384

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -272,23 +272,27 @@ bpf:
   # memory usage but can reduce latency.
   preallocateMaps: false
 
-  # -- Configure the maximum number of entries in the TCP connection tracking
+  # -- (int) Configure the maximum number of entries in the TCP connection tracking
   # table.
-  # ctTcpMax: '524288'
+  # @default -- `524288`
+  ctTcpMax: ~
 
-  # -- Configure the maximum number of entries for the non-TCP connection
+  # -- (int) Configure the maximum number of entries for the non-TCP connection
   # tracking table.
-  # ctAnyMax: '262144'
+  # @default -- `262144`
+  ctAnyMax: ~
 
   # -- Configure the maximum number of service entries in the
   # load balancer maps.
   lbMapMax: 65536
 
-  # -- Configure the maximum number of entries for the NAT table.
-  # natMax: 524288
+  # -- (int) Configure the maximum number of entries for the NAT table.
+  # @default -- `524288`
+  natMax: ~
 
-  # -- Configure the maximum number of entries for the neighbor table.
-  # neighMax: 524288
+  # -- (int) Configure the maximum number of entries for the neighbor table.
+  # @default -- `524288`
+  neighMax: ~
 
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
   policyMapMax: 16384


### PR DESCRIPTION
This is follow-up of https://github.com/cilium/cilium/pull/21195 to 
continue to document missing helm options.

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Document missing bpf ctTcpMax ctAnyMax natMax neighMax helm option
```
