### PR TITLE
Fix agent deadlock caused by frequent kube-apiserver IP recycling

### DIFF
--- a/pkg/ipcache/gc.go
+++ b/pkg/ipcache/gc.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"context"
+	"net/netip"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/trigger"
+)
+
+type asyncPrefixReleaser struct {
+	*trigger.Trigger
+	prefixReleaser
+
+	// Mutex protects read and write to 'queue'.
+	lock.Mutex
+	queue []netip.Prefix
+}
+
+type prefixReleaser interface {
+	releaseCIDRIdentities(ctx context.Context, identities []netip.Prefix)
+}
+
+func newAsyncPrefixReleaser(parent prefixReleaser, interval time.Duration) *asyncPrefixReleaser {
+	result := &asyncPrefixReleaser{
+		queue:          make([]netip.Prefix, 0),
+		prefixReleaser: parent,
+	}
+
+	// trigger needs to be updated to reference the object above
+	// Ignore error case since the TriggerFunc is provided.
+	result.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
+		Name:        "ipcache-identity-gc",
+		MinInterval: interval,
+		TriggerFunc: func(reasons []string) {
+			// TODO: Structure the code to pass context down
+			//       from the Daemon.
+			ctx, cancel := context.WithTimeout(
+				context.TODO(),
+				option.Config.KVstoreConnectivityTimeout)
+			defer cancel()
+			result.run(ctx, reasons...)
+		},
+	})
+
+	return result
+}
+
+// enqueue a set of prefixes to be released asynchronously.
+func (pr *asyncPrefixReleaser) enqueue(prefixes []netip.Prefix, reason string) {
+	pr.Lock()
+	defer pr.Unlock()
+	pr.queue = append(pr.queue, prefixes...)
+	pr.TriggerWithReason(reason)
+}
+
+// dequeue  the outstanding set of prefixes that are queued fro release.
+func (pr *asyncPrefixReleaser) dequeue() (result []netip.Prefix) {
+	pr.Lock()
+	defer pr.Unlock()
+	result = pr.queue
+	pr.queue = make([]netip.Prefix, 0)
+	return result
+}
+
+// run the core logic to dequeue & release identities / ipcache entries
+func (pr *asyncPrefixReleaser) run(ctx context.Context, reasons ...string) {
+	prefixes := pr.dequeue()
+	log.WithFields(logrus.Fields{
+		logfields.Count:  len(prefixes),
+		logfields.Reason: reasons,
+	}).Debug("Garbage collecting identities and entries from ipcache")
+	pr.prefixReleaser.releaseCIDRIdentities(ctx, prefixes)
+}

--- a/pkg/ipcache/gc_test.go
+++ b/pkg/ipcache/gc_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type dummyReleaser struct {
+	released map[string]int
+}
+
+func newDummyReleaser() *dummyReleaser {
+	return &dummyReleaser{released: make(map[string]int)}
+}
+
+func (d *dummyReleaser) releaseCIDRIdentities(ctx context.Context, prefixes []netip.Prefix) {
+	for _, prefix := range prefixes {
+		p := prefix.String()
+		count := d.released[p]
+		d.released[p] = count + 1
+	}
+}
+
+func TestDeferRelease(t *testing.T) {
+	prefix := netip.MustParsePrefix("192.0.2.3/32")
+	parent := newDummyReleaser()
+	// set a high interval so we can manually test the internals without
+	// racing against the trigger that's set up in the constructor.
+	releaser := newAsyncPrefixReleaser(parent, 5*time.Minute)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	releaser.enqueue([]netip.Prefix{prefix, prefix}, "test enqueue basics")
+	releaser.run(ctx)
+	remaining := releaser.dequeue()
+	assert.Len(t, remaining, 0)
+	assert.Equal(t, 2, parent.released[prefix.String()])
+	remaining = releaser.dequeue()
+	assert.Len(t, remaining, 0)
+
+	parent = newDummyReleaser()
+	releaser = newAsyncPrefixReleaser(parent, 5*time.Minute)
+	newPrefix := netip.MustParsePrefix("0.0.0.0/0")
+	releaser.enqueue([]netip.Prefix{prefix, newPrefix}, "multiple inputs")
+	releaser.run(ctx)
+	remaining = releaser.dequeue()
+	assert.Len(t, remaining, 0)
+	assert.Equal(t, 1, parent.released[prefix.String()])
+	assert.Equal(t, 1, parent.released[newPrefix.String()])
+}

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -6,6 +6,7 @@ package ipcache
 import (
 	"net"
 	"net/netip"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -100,12 +101,17 @@ type IPCache struct {
 
 	// metadata is the ipcache identity metadata map, which maps IPs to labels.
 	metadata *metadata
+
+	// deferredPrefixRelease is a queue for garbage collecting old
+	// references to identities and removing the corresponding IPCache
+	// entries if unused.
+	deferredPrefixRelease *asyncPrefixReleaser
 }
 
 // NewIPCache returns a new IPCache with the mappings of endpoint IP to security
 // identity (and vice-versa) initialized.
 func NewIPCache(c *Configuration) *IPCache {
-	return &IPCache{
+	ipc := &IPCache{
 		mutex:             lock.NewSemaphoredMutex(),
 		ipToIdentityCache: map[string]Identity{},
 		identityToIPCache: map[identity.NumericIdentity]map[string]struct{}{},
@@ -116,6 +122,8 @@ func NewIPCache(c *Configuration) *IPCache {
 		metadata:          newMetadata(),
 		Configuration:     c,
 	}
+	ipc.deferredPrefixRelease = newAsyncPrefixReleaser(ipc, 1*time.Millisecond)
+	return ipc
 }
 
 // Lock locks the IPCache's mutex.


### PR DESCRIPTION
A user reports the following deadlock in with lock chain[^1] and
lock chain[^2].

Lock chain 2 is at a high level trying to implement the new network
policy for an endpoint. As part of this step, it calculates a new
policy, then attempts to switch the policy pointer over to the new
policy, and then garbage collect references & objects in the old policy.
When garbage collecting the old policy objects, it is going into the
selectorcache and identifying that certain identities are no longer used
by the selector and cleaning up those identities. Hence we end up in the
ReleaseCIDRIdentitiesByID() call and attempting to grab the ipcache
lock.

Commit 40e13ea attempted to mitigate a bug where interleaved ordering of
identity reference counting and ipcache updates could lead to
inconsistent internal state (=> packet drops), but the core idea there
was that these two operations (identity refcount update + ipcache
update) must happen together in the same critical section, but the exact
timing when these two operations occur is not particularly important. I
think they should happen in a canonical order, but when that order is
iterated is not critical. Given that overall agent state is eventually
consistent, cleanup of these ipcache entries can happen at any
subsequent time. The sooner the better for sure, but I don't think that
there are any hard constraints on this.

If lock chain 2 was not holding the endpoint lock while releasing these
resources, then this deadlock would not occur. So, this commit proposes
to add a new queue + GC goroutine in the ipcache that handles the
release of these CIDR identities out-of-band so that they can be cleaned
up while not holding the endpoint lock. Then, from the endpoint policy
generation perspective it can continue with the remaining endpoint
policy calculation / datapath updates, return, and then that will allow
lock chain 1 to proceed since it's waiting for all endpoints to
regenerate their policies, then once that completes & unlocks the lock,
this new dedicated goroutine can do this cleanup.

[1]: Lock chain 1: ipc.Lock() -> e.lockAlive()
     When removeLabelsFromIPs is triggered through an EP change, it performs
     ipc.Lock() first, then collects information about added/deleted
     identities in a loop and then calls ipc.UpdatePolicyMaps(...), which
     then calls UpdatePolicyMaps(...) from the EndpointManager. The call
     stack of this is:

    ```
    goroutine 237 [semacquire, 417 minutes]:
    sync.runtime_Semacquire(0xc00038d880?)
            /usr/local/go/src/runtime/sema.go:56 +0x25
    sync.(*WaitGroup).Wait(0xc000398700?)
            /usr/local/go/src/sync/waitgroup.go:136 +0x52
    github.com/cilium/cilium/pkg/ipcache.(*IPCache).UpdatePolicyMaps(0xc00083c980, {0x3461140, 0xc000128008}, 0xc?, 0xc0024410e0)
            /go/src/github.com/cilium/cilium/pkg/ipcache/metadata.go:235 +0xc7
    github.com/cilium/cilium/pkg/ipcache.(*IPCache).removeLabelsFromIPs(0xc00083c980, 0xc0013d5778?, {0x2f2a9f6, 0xf})
            /go/src/github.com/cilium/cilium/pkg/ipcache/metadata.go:414 +0x7c5
    github.com/cilium/cilium/pkg/ipcache.(*IPCache).RemoveLabelsExcluded(0xc00083c980, 0xc0000d5c50, 0xc000bf41d8?, {0x2f2a9f6, 0xf})
            /go/src/github.com/cilium/cilium/pkg/ipcache/metadata.go:328 +0x1ab
    github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).handleKubeAPIServerServiceEPChanges(0xc000a91d40, 0xc001a739b0?)
            /go/src/github.com/cilium/cilium/pkg/k8s/watchers/endpoint.go:135 +0x5b
    github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).addKubeAPIServerServiceEPSliceV1(0x1861426?, 0xc0020f2c30)
            /go/src/github.com/cilium/cilium/pkg/k8s/watchers/endpoint_slice.go:205 +0x452
    github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).updateK8sEndpointSliceV1(0xc000a91d40, 0xc0020f2c30?, 0xc0020f2c30?)
            /go/src/github.com/cilium/cilium/pkg/k8s/watchers/endpoint_slice.go:178 +0x69
    github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).endpointSlicesInit.func2({0x2ebcec0?, 0xc0020f3a00?}, {0x2ebcec0, 0xc0020f2c30})
            /go/src/github.com/cilium/cilium/pkg/k8s/watchers/endpoint_slice.go:71 +0x125
    k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
            /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:239
    github.com/cilium/cilium/pkg/k8s/informer.NewInformerWithStore.func1({0x2a48d00?, 0xc000a9b5f0?})
            /go/src/github.com/cilium/cilium/pkg/k8s/informer/informer.go:103 +0x2fe
    k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc000c5a960, 0xc00013b240)
            /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:554 +0x566
    k8s.io/client-go/tools/cache.(*controller).processLoop(0xc000eff710)
            /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:184 +0x36
    k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x40d645?)
            /go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x3e
    k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x102fe25?, {0x3436f20, 0xc000b54b10}, 0x1, 0xc0005e06c0)
            /go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xb6
    k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000eff778?, 0x3b9aca00, 0x0, 0x40?, 0x7f72ce949c00?)
            /go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x89
    k8s.io/apimachinery/pkg/util/wait.Until(...)
            /go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
    k8s.io/client-go/tools/cache.(*controller).Run(0xc000eff710, 0xc0005e06c0)
            /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/controller.go:155 +0x2c5
    created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).endpointSlicesInit
            /go/src/github.com/cilium/cilium/pkg/k8s/watchers/endpoint_slice.go:156 +0x759
    UpdatePolicyMaps will then start a goroutine for each EP and just return a WaitGroup, so that the caller can wait on it. The goroutines then end up in calling locking the EP lock via lockAlive().
    ```

[2]: Lock chain 2: e.lockAlive() -> ipc.Lock()
     If at the same time a EndpointRegenerationEvent is handled, it
     might end up locking the Endpoint locks first and then (through
     a quite deep stack) end up calling ipc.Lock() in
     IPCache.releaseCIDRIdentities(), which will then cause a
     deadlock. The stack trace looks like this:

    ```
    goroutine 455 [select, 417 minutes]:
    golang.org/x/sync/semaphore.(*Weighted).Acquire(0xc000842050, {0x3461140, 0xc000128000}, 0x40000000)
            /go/src/github.com/cilium/cilium/vendor/golang.org/x/sync/semaphore/semaphore.go:60 +0x345
    github.com/cilium/cilium/pkg/lock.(*SemaphoredMutex).Lock(...)
            /go/src/github.com/cilium/cilium/pkg/lock/semaphored_mutex.go:30
    github.com/cilium/cilium/pkg/ipcache.(*IPCache).Lock(...)
            /go/src/github.com/cilium/cilium/pkg/ipcache/ipcache.go:121
    github.com/cilium/cilium/pkg/ipcache.(*IPCache).releaseCIDRIdentities(0xc00083c980, {0x3461178, 0xc000445680}, 0x0?)
            /go/src/github.com/cilium/cilium/pkg/ipcache/cidr.go:203 +0x85
    github.com/cilium/cilium/pkg/ipcache.(*IPCache).ReleaseCIDRIdentitiesByID(0xc00083c980, {0x3461178, 0xc000445680}, {0x0, 0x0, 0x1bf08eb000?})
            /go/src/github.com/cilium/cilium/pkg/ipcache/cidr.go:265 +0x497
    github.com/cilium/cilium/daemon/cmd.cachingIdentityAllocator.ReleaseCIDRIdentitiesByID(...)
            /go/src/github.com/cilium/cilium/daemon/cmd/identity.go:118
    github.com/cilium/cilium/pkg/policy.(*SelectorCache).releaseIdentityMappings(0xc000398700, {0x0, 0x0, 0x0})
            /go/src/github.com/cilium/cilium/pkg/policy/selectorcache.go:556 +0x9d
    github.com/cilium/cilium/pkg/policy.(*SelectorCache).RemoveSelectors(0xc000398700, {0xc001a00210, 0x1, 0x0?}, {0x3429f40, 0xc003d42600})
            /go/src/github.com/cilium/cilium/pkg/policy/selectorcache.go:961 +0xc5
    github.com/cilium/cilium/pkg/policy.(*L4Filter).removeSelectors(0xc003d42600, 0xc001c02518?)
            /go/src/github.com/cilium/cilium/pkg/policy/l4.go:627 +0x185
    github.com/cilium/cilium/pkg/policy.(*L4Filter).detach(0xb?, 0x0?)
            /go/src/github.com/cilium/cilium/pkg/policy/l4.go:634 +0x1e
    github.com/cilium/cilium/pkg/policy.L4PolicyMap.Detach(...)
            /go/src/github.com/cilium/cilium/pkg/policy/l4.go:804
    github.com/cilium/cilium/pkg/policy.(*L4Policy).Detach(0xc0048b0180, 0x1?)
            /go/src/github.com/cilium/cilium/pkg/policy/l4.go:1013 +0x7b
    github.com/cilium/cilium/pkg/policy.(*selectorPolicy).Detach(...)
            /go/src/github.com/cilium/cilium/pkg/policy/resolve.go:104
    github.com/cilium/cilium/pkg/policy.(*cachedSelectorPolicy).setPolicy(0xc000398770?, 0xc000c275c0?)
            /go/src/github.com/cilium/cilium/pkg/policy/distillery.go:188 +0x3b
    github.com/cilium/cilium/pkg/policy.(*PolicyCache).updateSelectorPolicy(0xc00098a090, 0xc000c275c0)
            /go/src/github.com/cilium/cilium/pkg/policy/distillery.go:124 +0x195
    github.com/cilium/cilium/pkg/policy.(*PolicyCache).UpdatePolicy(...)
            /go/src/github.com/cilium/cilium/pkg/policy/distillery.go:153
    github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regeneratePolicy(0xc000e47c00)
            /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:230 +0x22b
    github.com/cilium/cilium/pkg/endpoint.(*Endpoint).runPreCompilationSteps(0xc000e47c00, 0xc0015cf400)
            /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:809 +0x2c5
    github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF(0xc000e47c00, 0xc0015cf400)
            /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:579 +0x189
    github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerate(0xc000e47c00, 0xc0015cf400)
            /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:398 +0x7a5
    github.com/cilium/cilium/pkg/endpoint.(*EndpointRegenerationEvent).Handle(0xc005584d10, 0xc0003dae80?)
            /go/src/github.com/cilium/cilium/pkg/endpoint/events.go:53 +0x325
    github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run.func1()
            /go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:245 +0x13b
    sync.(*Once).doSlow(0x1?, 0x442205?)
            /usr/local/go/src/sync/once.go:68 +0xc2
    sync.(*Once).Do(...)
            /usr/local/go/src/sync/once.go:59
    github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run(0x0?)
            /go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:233 +0x45
    created by github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).Run
            /go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:229 +0x76
    ```

Thanks to John Watson (@dctrwatson), Alexander Block (@codablock), and Chris Tarazi (@christarazi) for their
reports and assistance in digging to the bottom of this issue.

Fixes: 40e13ea2a5a9 ("ipcache: Fix race in identity/ipcache release")
Fixes: #20721
Fixes: #21596
