### PR TITLE
v1.12 backports 2022-10-06

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -42,7 +42,7 @@ cilium-bugtool [OPTIONS] [flags]
       --k8s-mode                  Require Kubernetes pods to be found or fail
       --k8s-namespace string      Kubernetes namespace for Cilium pod (default "kube-system")
       --parallel-workers int      Maximum number of parallel worker tasks, use 0 for number of CPUs
-      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:9890, operator:9891, apiserver:9892 (default 9890)
+      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061 (default 6060)
       --pprof-trace-seconds int   Amount of seconds used for pprof CPU traces (default 180)
   -t, --tmp string                Path to store extracted files. Use '-' to send to stdout. (default "/tmp")
 ```

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1172,7 +1172,8 @@ Graceful Termination
 Cilium's eBPF kube-proxy replacement supports graceful termination of service
 endpoint pods. The feature requires at least Kubernetes version 1.20, and
 the feature gate ``EndpointSliceTerminatingCondition`` needs to be enabled.
-By default, the Cilium agent then detects such terminating Pod state. If needed,
+By default, the Cilium agent then detects such terminating Pod events, and
+increments the metric ``k8s_terminating_endpoints_events_total``. If needed,
 the feature can be disabled with the configuration option ``enable-k8s-terminating-endpoint``.
 
 The cilium agent feature flag can be probed by running ``cilium status`` command:

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -404,7 +404,10 @@ default. The default starting interval is 5 minutes. Alternatively, the value
 for ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` can be increased.
 Setting both of these options will be a trade-off of CPU for ``conntrack-gc-interval``, and for
 ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
-consumed.
+consumed. You can track conntrack garbage collection related metrics such as
+``datapath_conntrack_gc_runs_total`` and ``datapath_conntrack_gc_entries`` to
+get visibility into garbage collection runs. Refer to :ref:`metrics` for more
+details.
 
 Enabling datapath debug messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -81,10 +81,10 @@ func init() {
 	BugtoolRootCmd.Flags().BoolVar(&getPProf, "get-pprof", false, "When set, only gets the pprof traces from the cilium-agent binary")
 	BugtoolRootCmd.Flags().BoolVar(&envoyDump, "envoy-dump", true, "When set, dump envoy configuration from unix socket")
 	BugtoolRootCmd.Flags().IntVar(&pprofPort,
-		"pprof-port", defaults.GopsPortAgent,
+		"pprof-port", defaults.PprofPortAgent,
 		fmt.Sprintf(
-			"Pprof port to connect to. Known Cilium component ports are agent:%d, operator:%d, apiserver:%d",
-			defaults.GopsPortAgent, defaults.GopsPortOperator, defaults.GopsPortApiserver,
+			"Pprof port to connect to. Known Cilium component ports are agent:%d, operator:%d",
+			defaults.PprofPortAgent, defaults.PprofPortOperator,
 		),
 	)
 	BugtoolRootCmd.Flags().IntVar(&traceSeconds, "pprof-trace-seconds", 180, "Amount of seconds used for pprof CPU traces")

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -40,6 +40,22 @@ get_user_remote() {
   echo $USER_REMOTE
 }
 
+is_collaborator() {
+  local username=${1:-}
+  local org=${2:-cilium}
+  local repo=${3:-cilium}
+  if [ -z "$username" ]; then
+      echo "Error: no username specified in is_collaborator"
+      exit 1
+  fi
+  local path="repos/$org/$repo/collaborators/$username"
+  if hub api "$path" &> /dev/null; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
 require_linux() {
   if [ "$(uname)" != "Linux" ]; then
       echo "$0: Linux required"

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -35,7 +35,17 @@ if ! git branch -a | grep -q "${UPSTREAM_REMOTE}/v${BRANCH}$" || [ ! -e "$SUMMAR
     echo "(branch version: ${BRANCH}, pr-summary: ${SUMMARY}, upstream remote: ${UPSTREAM_REMOTE})" 1>&2
     exit 1
 fi
-AUTHORS="$(grep -ho "@[^)]*" "$SUMMARY" | grep -v "$(get_user)" | sort -u | tr '\n' ',' | sed -e 's/@//g' -e 's/,$//')"
+
+AUTHORS="$(grep -ho "@[^)]*" "$SUMMARY" | grep -v "$(get_user)" | sort -u | tr '\n' ' ' | sed -e 's/@//g' -e 's/ $//')"
+
+# Github complains if we request a review by someone who is not a collaborator, thus filter the authors.
+REVIEWERS=""
+for author in $AUTHORS; do
+    if [ $(is_collaborator "$author") == "yes" ]; then
+        REVIEWERS="$REVIEWERS,$author"
+    fi
+done
+REVIEWERS=${REVIEWERS:1} # Lop off the initial comma.
 
 echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
@@ -43,10 +53,10 @@ echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git config --local "branch.${PR_BRANCH}.remote" "$USER_REMOTE"
 git push -q "$USER_REMOTE" "$PR_BRANCH"
-if [ -z "$AUTHORS" ]; then
+if [ -z "$REVIEWERS" ]; then
   hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 else
-  hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $AUTHORS
+  hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $REVIEWERS
 fi
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -821,7 +821,7 @@ func initializeFlags() {
 	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
 	option.BindEnv(option.PProf)
 
-	flags.Int(option.PProfPort, 6060, "Port that the pprof listens on")
+	flags.Int(option.PProfPort, defaults.PprofPortAgent, "Port that the pprof listens on")
 	option.BindEnv(option.PProfPort)
 
 	flags.Bool(option.EnableXDPPrefilter, false, "Enable XDP prefiltering")

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       containers:
       - name: cilium-operator
-        image: {{ include "cilium.operator.image" . }}
+        image: {{ include "cilium.operator.image" . | quote }}
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         command:
         - cilium-operator-{{ include "cilium.operator.cloud" . }}

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -70,7 +70,7 @@ spec:
           value: "revision"
         - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
           value: "25000"
-        image: {{ .Values.etcd.image.repository }}:{{ .Values.etcd.image.tag }}
+        image: {{ include "cilium.image" .Values.etcd.image | quote }}
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
         terminationMessagePolicy: FallbackToLogsOnError

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -261,7 +261,7 @@ func init() {
 	flags.Bool(operatorOption.PProf, false, "Enable pprof debugging endpoint")
 	option.BindEnv(operatorOption.PProf)
 
-	flags.Int(operatorOption.PProfPort, 6061, "Port that the pprof listens on")
+	flags.Int(operatorOption.PProfPort, defaults.PprofPortOperator, "Port that the pprof listens on")
 	option.BindEnv(operatorOption.PProfPort)
 
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")

--- a/pkg/alibabacloud/metadata/metadata.go
+++ b/pkg/alibabacloud/metadata/metadata.go
@@ -56,10 +56,16 @@ func getMetadata(ctx context.Context, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("metadata service returned status code %d", resp.StatusCode)
+	}
+
 	defer resp.Body.Close()
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -411,9 +411,9 @@ func UpsertIPsecEndpointPolicy(local, remote, localTmpl, remoteTmpl *net.IPNet, 
 }
 
 // DeleteIPsecEndpoint deletes a endpoint associated with the remote IP address
-func DeleteIPsecEndpoint(remote *net.IPNet) {
-	ipsecDeleteXfrmState(remote.IP)
-	ipsecDeleteXfrmPolicy(remote.IP)
+func DeleteIPsecEndpoint(remote net.IP) {
+	ipsecDeleteXfrmState(remote)
+	ipsecDeleteXfrmPolicy(remote)
 }
 
 func isXfrmPolicyCilium(policy netlink.XfrmPolicy) bool {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -195,8 +195,8 @@ func _ipSecReplacePolicyInFwd(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, dir 
 
 	policy := ipSecNewPolicy()
 	policy.Dir = dir
-	policy.Src = &net.IPNet{IP: src.IP.Mask(src.Mask), Mask: src.Mask}
-	policy.Dst = &net.IPNet{IP: dst.IP.Mask(dst.Mask), Mask: dst.Mask}
+	policy.Src = src
+	policy.Dst = dst
 	if dir == netlink.XFRM_DIR_IN {
 		// We require a policy to match on packets going to the proxy which are
 		// therefore carrying the proxy mark. We however don't need a policy
@@ -262,9 +262,9 @@ func ipSecReplacePolicyOut(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, dir IPS
 		wildcardMask := net.IPv4Mask(0, 0, 0, 0)
 		policy.Src = &net.IPNet{IP: wildcardIP, Mask: wildcardMask}
 	} else {
-		policy.Src = &net.IPNet{IP: src.IP.Mask(src.Mask), Mask: src.Mask}
+		policy.Src = src
 	}
-	policy.Dst = &net.IPNet{IP: dst.IP.Mask(dst.Mask), Mask: dst.Mask}
+	policy.Dst = dst
 	policy.Dir = netlink.XFRM_DIR_OUT
 	policy.Mark = &netlink.XfrmMark{
 		Value: ipSecXfrmMarkSetSPI(linux_defaults.RouteMarkEncrypt, key.Spi),

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -57,7 +57,7 @@ func (p *IPSecSuitePrivileged) TestInvalidLoadKeys(c *C) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, NotNil)
 }
 
@@ -90,7 +90,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, IsNil)
 
 	cleanIPSecStatesAndPolicies(c)
@@ -108,7 +108,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, IsNil)
 
 	cleanIPSecStatesAndPolicies(c)
@@ -137,7 +137,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, IsNil)
 
 	cleanIPSecStatesAndPolicies(c)
@@ -156,11 +156,11 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, IsNil)
 
 	// Assert additional rule when tunneling is enabled is inserted
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, IsNil)
 	toProxyPolicy, err := netlink.XfrmPolicyGet(&netlink.XfrmPolicy{
 		Src: remote,
@@ -186,7 +186,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecKeyMissing(c *C) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, ErrorMatches, "unable to replace local state: IPSec key missing")
 
 	cleanIPSecStatesAndPolicies(c)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1454,10 +1454,9 @@ func (n *linuxNodeHandler) replaceNodeIPSecInRoute(ip *net.IPNet) {
 func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 	if n.nodeConfig.EnableIPv4 && oldNode.IPv4AllocCIDR != nil {
 		ciliumInternalIPv4 := oldNode.GetCiliumInternalIP(false)
-		old4Net := &net.IPNet{IP: ciliumInternalIPv4, Mask: oldNode.IPv4AllocCIDR.Mask}
 		old4RouteNet := &net.IPNet{IP: oldNode.IPv4AllocCIDR.IP, Mask: oldNode.IPv4AllocCIDR.Mask}
 		n.deleteNodeIPSecOutRoute(old4RouteNet)
-		ipsec.DeleteIPsecEndpoint(old4Net)
+		ipsec.DeleteIPsecEndpoint(ciliumInternalIPv4)
 		if n.nodeConfig.EncryptNode {
 			if remoteIPv4 := oldNode.GetNodeIP(false); remoteIPv4 != nil {
 				exactMask := net.IPv4Mask(255, 255, 255, 255)
@@ -1469,10 +1468,9 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 
 	if n.nodeConfig.EnableIPv6 && oldNode.IPv6AllocCIDR != nil {
 		ciliumInternalIPv6 := oldNode.GetCiliumInternalIP(true)
-		old6Net := &net.IPNet{IP: ciliumInternalIPv6, Mask: oldNode.IPv6AllocCIDR.Mask}
 		old6RouteNet := &net.IPNet{IP: oldNode.IPv6AllocCIDR.IP, Mask: oldNode.IPv6AllocCIDR.Mask}
 		n.deleteNodeIPSecOutRoute(old6RouteNet)
-		ipsec.DeleteIPsecEndpoint(old6Net)
+		ipsec.DeleteIPsecEndpoint(ciliumInternalIPv6)
 		if n.nodeConfig.EncryptNode {
 			if remoteIPv6 := oldNode.GetNodeIP(true); remoteIPv6 != nil {
 				exactMask := net.CIDRMask(128, 128)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1000,27 +1000,27 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 	}
 
 	if n.nodeConfig.EnableIPv4 && newNode.IPv4AllocCIDR != nil {
-		new4Net := &net.IPNet{IP: newNode.IPv4AllocCIDR.IP, Mask: newNode.IPv4AllocCIDR.Mask}
+		new4Net := newNode.IPv4AllocCIDR.IPNet
+		wildcardCIDR := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
+
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new4Net)
-			ciliumInternalIPv4 := newNode.GetCiliumInternalIP(false)
-			if ciliumInternalIPv4 != nil {
-				ipsecLocal := &net.IPNet{IP: ciliumInternalIPv4, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
-				ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv4Wildcard, ipsecLocal, ipsec.IPSecDirIn, false)
-				upsertIPsecLog(err, "local IPv4", ipsecLocal, ipsecIPv4Wildcard, spi)
+			if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
+				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, ipsec.IPSecDirIn, false)
+				upsertIPsecLog(err, "local IPv4", localCIDR, wildcardCIDR, spi)
 			}
 		} else {
-			if ciliumInternalIPv4 := newNode.GetCiliumInternalIP(false); ciliumInternalIPv4 != nil {
-				ipsecLocal := &net.IPNet{IP: n.nodeAddressing.IPv4().Router(), Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
-				ipsecRemote := &net.IPNet{IP: ciliumInternalIPv4, Mask: newNode.IPv4AllocCIDR.Mask}
+			if remoteIP := newNode.GetCiliumInternalIP(false); remoteIP != nil {
+				localIP := n.nodeAddressing.IPv4().Router()
+				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
+				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv4AllocCIDR.Mask}
 				n.replaceNodeIPSecOutRoute(new4Net)
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, ipsec.IPSecDirOut, false)
-				upsertIPsecLog(err, "IPv4", ipsecLocal, ipsecRemote, spi)
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, ipsec.IPSecDirOut, false)
+				upsertIPsecLog(err, "IPv4", localCIDR, remoteCIDR, spi)
 
 				/* Insert wildcard policy rules for traffic skipping back through host */
-				ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
-				if err = ipsec.IpSecReplacePolicyFwd(ipsecIPv4Wildcard, ipsecRemote, ipsecIPv4Wildcard, ipsecRemote); err != nil {
+				if err = ipsec.IpSecReplacePolicyFwd(wildcardCIDR, remoteCIDR, wildcardCIDR, remoteCIDR); err != nil {
 					log.WithError(err).Warning("egress unable to replace policy fwd:")
 				}
 			}
@@ -1028,23 +1028,25 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 	}
 
 	if n.nodeConfig.EnableIPv6 && newNode.IPv6AllocCIDR != nil {
-		new6Net := &net.IPNet{IP: newNode.IPv6AllocCIDR.IP, Mask: newNode.IPv6AllocCIDR.Mask}
+		new6Net := newNode.IPv6AllocCIDR.IPNet
+		wildcardIP := net.ParseIP(wildcardIPv6)
+		wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 0)}
+
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new6Net)
-			ciliumInternalIPv6 := newNode.GetCiliumInternalIP(true)
-			if ciliumInternalIPv6 != nil {
-				ipsecLocal := &net.IPNet{IP: ciliumInternalIPv6, Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
-				ipsecIPv6Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv6), Mask: net.CIDRMask(0, 0)}
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv6Wildcard, ipsecLocal, ipsec.IPSecDirIn, false)
-				upsertIPsecLog(err, "local IPv6", ipsecLocal, ipsecIPv6Wildcard, spi)
+			if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
+				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, ipsec.IPSecDirIn, false)
+				upsertIPsecLog(err, "local IPv6", localCIDR, wildcardCIDR, spi)
 			}
 		} else {
-			if ciliumInternalIPv6 := newNode.GetCiliumInternalIP(true); ciliumInternalIPv6 != nil {
-				ipsecLocal := &net.IPNet{IP: n.nodeAddressing.IPv6().Router(), Mask: net.CIDRMask(0, 0)}
-				ipsecRemote := &net.IPNet{IP: ciliumInternalIPv6, Mask: newNode.IPv6AllocCIDR.Mask}
+			if remoteIP := newNode.GetCiliumInternalIP(true); remoteIP != nil {
+				localIP := n.nodeAddressing.IPv6().Router()
+				localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
+				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv6AllocCIDR.Mask}
 				n.replaceNodeIPSecOutRoute(new6Net)
-				spi, err := ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, ipsec.IPSecDirOut, false)
-				upsertIPsecLog(err, "IPv6", ipsecLocal, ipsecRemote, spi)
+				spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, ipsec.IPSecDirOut, false)
+				upsertIPsecLog(err, "IPv6", localCIDR, remoteCIDR, spi)
 			}
 		}
 	}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -534,14 +534,15 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 	}
 
 	for _, cidr := range v4CIDR {
-		ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
+		wildcardIP := net.ParseIP(wildcardIPv4)
+		ipsecIPv4Wildcard := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
 
 		if !option.Config.EnableEndpointRoutes {
 			n.replaceNodeIPSecInRoute(cidr)
 		}
 
 		n.replaceNodeIPSecOutRoute(cidr)
-		spi, err = ipsec.UpsertIPsecEndpoint(ipsecIPv4Wildcard, cidr, ipsecIPv4Wildcard, ipsec.IPSecDirOut, zeroMark)
+		spi, err = ipsec.UpsertIPsecEndpoint(ipsecIPv4Wildcard, cidr, ipsecIPv4Wildcard, wildcardIP, cidr.IP, ipsec.IPSecDirOut, zeroMark)
 		upsertIPsecLog(err, "CNI Out IPv4", ipsecIPv4Wildcard, cidr, spi)
 
 		if n.nodeConfig.EncryptNode {
@@ -551,18 +552,19 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 			if err != nil {
 				upsertIPsecLog(err, "getV4LinkLocalIP failed", ipsecIPv4Wildcard, cidr, spi)
 			}
-			spi, err := ipsec.UpsertIPsecEndpoint(linkAddr, ipsecIPv4Wildcard, cidr, ipsec.IPSecDirIn, zeroMark)
+			spi, err := ipsec.UpsertIPsecEndpoint(linkAddr, ipsecIPv4Wildcard, cidr, linkAddr.IP, wildcardIP, ipsec.IPSecDirIn, zeroMark)
 			upsertIPsecLog(err, "CNI In IPv4", linkAddr, ipsecIPv4Wildcard, spi)
 		}
 	}
 
 	for _, cidr := range v6CIDR {
-		ipsecIPv6Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv6), Mask: net.CIDRMask(0, 0)}
+		wildcardIP := net.ParseIP(wildcardIPv6)
+		ipsecIPv6Wildcard := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 0)}
 
 		n.replaceNodeIPSecInRoute(cidr)
 
 		n.replaceNodeIPSecOutRoute(cidr)
-		spi, err := ipsec.UpsertIPsecEndpoint(ipsecIPv6Wildcard, cidr, ipsecIPv6Wildcard, ipsec.IPSecDirOut, zeroMark)
+		spi, err := ipsec.UpsertIPsecEndpoint(ipsecIPv6Wildcard, cidr, ipsecIPv6Wildcard, wildcardIP, cidr.IP, ipsec.IPSecDirOut, zeroMark)
 		upsertIPsecLog(err, "CNI Out IPv6", cidr, ipsecIPv6Wildcard, spi)
 
 		if n.nodeConfig.EncryptNode {
@@ -572,7 +574,7 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 			if err != nil {
 				upsertIPsecLog(err, "getV6LinkLocalIP failed", ipsecIPv6Wildcard, cidr, spi)
 			}
-			spi, err := ipsec.UpsertIPsecEndpoint(linkAddr, ipsecIPv6Wildcard, cidr, ipsec.IPSecDirIn, zeroMark)
+			spi, err := ipsec.UpsertIPsecEndpoint(linkAddr, ipsecIPv6Wildcard, cidr, linkAddr.IP, wildcardIP, ipsec.IPSecDirIn, zeroMark)
 			upsertIPsecLog(err, "CNI In IPv6", linkAddr, ipsecIPv6Wildcard, spi)
 		}
 	}
@@ -589,15 +591,16 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 		exactMask := net.IPv4Mask(255, 255, 255, 255)
 		ipsecLocal := &net.IPNet{IP: internalIPv4, Mask: exactMask}
 		if newNode.IsLocal() {
-			ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
+			wildcardIP := net.ParseIP(wildcardIPv4)
+			ipsecIPv4Wildcard := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
 			n.replaceNodeIPSecInRoute(ipsecLocal)
-			spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv4Wildcard, ipsecLocal, ipsec.IPSecDirIn, false)
+			spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv4Wildcard, ipsecLocal, internalIPv4, wildcardIP, ipsec.IPSecDirIn, false)
 			upsertIPsecLog(err, "EncryptNode local IPv4", ipsecLocal, ipsecIPv4Wildcard, spi)
 		} else {
 			if remoteIPv4 := newNode.GetNodeIP(false); remoteIPv4 != nil {
 				ipsecRemote := &net.IPNet{IP: remoteIPv4, Mask: exactMask}
 				n.replaceNodeExternalIPSecOutRoute(ipsecRemote)
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, ipsec.IPSecDirOutNode, false)
+				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, internalIPv4, remoteIPv4, ipsec.IPSecDirOutNode, false)
 				upsertIPsecLog(err, "EncryptNode IPv4", ipsecLocal, ipsecRemote, spi)
 			}
 			remoteIPv4 := newNode.GetCiliumInternalIP(false)
@@ -609,8 +612,7 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 
 				n.replaceNodeExternalIPSecOutRoute(ipsecRemoteRoute)
 				if remoteIPv4T := newNode.GetNodeIP(false); remoteIPv4T != nil {
-					ipsecRemoteT := &net.IPNet{IP: remoteIPv4T, Mask: exactMask}
-					err = ipsec.UpsertIPsecEndpointPolicy(ipsecWildcard, ipsecRemote, ipsecLocal, ipsecRemoteT, ipsec.IPSecDirOutNode)
+					err = ipsec.UpsertIPsecEndpointPolicy(ipsecWildcard, ipsecRemote, internalIPv4, remoteIPv4T, ipsec.IPSecDirOutNode)
 				}
 				upsertIPsecLog(err, "EncryptNode Cilium IPv4", ipsecWildcard, ipsecRemote, spi)
 			}
@@ -622,15 +624,16 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 		exactMask := net.CIDRMask(128, 128)
 		ipsecLocal := &net.IPNet{IP: internalIPv6, Mask: exactMask}
 		if newNode.IsLocal() {
-			ipsecIPv6Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv6), Mask: net.CIDRMask(0, 0)}
+			wildcardIP := net.ParseIP(wildcardIPv6)
+			ipsecIPv6Wildcard := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 0)}
 			n.replaceNodeIPSecInRoute(ipsecLocal)
-			spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv6Wildcard, ipsecLocal, ipsec.IPSecDirIn, false)
+			spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv6Wildcard, ipsecLocal, internalIPv6, wildcardIP, ipsec.IPSecDirIn, false)
 			upsertIPsecLog(err, "EncryptNode local IPv6", ipsecLocal, ipsecIPv6Wildcard, spi)
 		} else {
 			if remoteIPv6 := newNode.GetNodeIP(true); remoteIPv6 != nil {
 				ipsecRemote := &net.IPNet{IP: remoteIPv6, Mask: exactMask}
 				n.replaceNodeExternalIPSecOutRoute(ipsecRemote)
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, ipsec.IPSecDirOut, false)
+				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, internalIPv6, remoteIPv6, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "EncryptNode IPv6", ipsecLocal, ipsecRemote, spi)
 			}
 			remoteIPv6 := newNode.GetCiliumInternalIP(true)
@@ -642,8 +645,7 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 
 				n.replaceNodeExternalIPSecOutRoute(ipsecRemoteRoute)
 				if remoteIPv6T := newNode.GetNodeIP(true); remoteIPv6T != nil {
-					ipsecRemoteT := &net.IPNet{IP: remoteIPv6T, Mask: exactMask}
-					err = ipsec.UpsertIPsecEndpointPolicy(ipsecWildcard, ipsecRemote, ipsecLocal, ipsecRemoteT, ipsec.IPSecDirOutNode)
+					err = ipsec.UpsertIPsecEndpointPolicy(ipsecWildcard, ipsecRemote, internalIPv6, remoteIPv6T, ipsec.IPSecDirOutNode)
 				}
 				upsertIPsecLog(err, "EncryptNode Cilium IPv6", ipsecWildcard, ipsecRemote, spi)
 			}
@@ -1001,13 +1003,14 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 
 	if n.nodeConfig.EnableIPv4 && newNode.IPv4AllocCIDR != nil {
 		new4Net := newNode.IPv4AllocCIDR.IPNet
-		wildcardCIDR := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
+		wildcardIP := net.ParseIP(wildcardIPv4)
+		wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
 
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new4Net)
 			if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
 				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
-				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, ipsec.IPSecDirIn, false)
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, localIP, wildcardIP, ipsec.IPSecDirIn, false)
 				upsertIPsecLog(err, "local IPv4", localCIDR, wildcardCIDR, spi)
 			}
 		} else {
@@ -1016,11 +1019,11 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
 				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv4AllocCIDR.Mask}
 				n.replaceNodeIPSecOutRoute(new4Net)
-				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, ipsec.IPSecDirOut, false)
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, localIP, remoteIP, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "IPv4", localCIDR, remoteCIDR, spi)
 
 				/* Insert wildcard policy rules for traffic skipping back through host */
-				if err = ipsec.IpSecReplacePolicyFwd(wildcardCIDR, remoteCIDR, wildcardCIDR, remoteCIDR); err != nil {
+				if err = ipsec.IpSecReplacePolicyFwd(wildcardCIDR, remoteCIDR, wildcardIP, remoteIP); err != nil {
 					log.WithError(err).Warning("egress unable to replace policy fwd:")
 				}
 			}
@@ -1036,7 +1039,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 			n.replaceNodeIPSecInRoute(new6Net)
 			if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
 				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
-				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, ipsec.IPSecDirIn, false)
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, localIP, wildcardIP, ipsec.IPSecDirIn, false)
 				upsertIPsecLog(err, "local IPv6", localCIDR, wildcardCIDR, spi)
 			}
 		} else {
@@ -1045,7 +1048,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 				localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
 				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv6AllocCIDR.Mask}
 				n.replaceNodeIPSecOutRoute(new6Net)
-				spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, ipsec.IPSecDirOut, false)
+				spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, localIP, remoteIP, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "IPv6", localCIDR, remoteCIDR, spi)
 			}
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1009,15 +1009,15 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new4Net)
 			if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
-				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
+				localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
 				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, localIP, wildcardIP, ipsec.IPSecDirIn, false)
 				upsertIPsecLog(err, "local IPv4", localCIDR, wildcardCIDR, spi)
 			}
 		} else {
 			if remoteIP := newNode.GetCiliumInternalIP(false); remoteIP != nil {
 				localIP := n.nodeAddressing.IPv4().Router()
-				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
-				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv4AllocCIDR.Mask}
+				localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
+				remoteCIDR := newNode.IPv4AllocCIDR.IPNet
 				n.replaceNodeIPSecOutRoute(new4Net)
 				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, localIP, remoteIP, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "IPv4", localCIDR, remoteCIDR, spi)
@@ -1038,7 +1038,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new6Net)
 			if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
-				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
+				localCIDR := n.nodeAddressing.IPv6().AllocationCIDR().IPNet
 				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, localIP, wildcardIP, ipsec.IPSecDirIn, false)
 				upsertIPsecLog(err, "local IPv6", localCIDR, wildcardCIDR, spi)
 			}
@@ -1046,7 +1046,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 			if remoteIP := newNode.GetCiliumInternalIP(true); remoteIP != nil {
 				localIP := n.nodeAddressing.IPv6().Router()
 				localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
-				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv6AllocCIDR.Mask}
+				remoteCIDR := newNode.IPv6AllocCIDR.IPNet
 				n.replaceNodeIPSecOutRoute(new6Net)
 				spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, localIP, remoteIP, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "IPv6", localCIDR, remoteCIDR, spi)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -17,6 +17,12 @@ const (
 	// ClusterMeshHealthPort is the default value for option.ClusterMeshHealthPort
 	ClusterMeshHealthPort = 80
 
+	// PprofPortAgent is the default value for pprof in the agent
+	PprofPortAgent = 6060
+
+	// PprofPortAgent is the default value for pprof in the operator
+	PprofPortOperator = 6061
+
 	// GopsPortAgent is the default value for option.GopsPort in the agent
 	GopsPortAgent = 9890
 

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -110,7 +110,18 @@ find "${CNI_CONF_DIR}" -maxdepth 1 -type f \
 # the host.
 case "$CILIUM_CNI_CHAINING_MODE" in
 "aws-cni")
-  if [ $(find "${CNI_CONF_DIR}" -maxdepth 1 -type f -name '*.conf' -or -name '*.conflist' -or -name '*.cilium_bak' | wc -l) -eq 0 ]; then
+  tries=30
+  while [[ $tries -gt 0 ]]; do
+  if test -n "$(find "${CNI_CONF_DIR}" -maxdepth 1 -type f -name '*.conf' -or -name '*.conflist' -or -name '*.cilium_bak' )"; then
+      echo "Found existing CNI config for chaining"
+      break
+    else
+      echo "Could not find existing AWS VPC CNI config for chaining, will retry..."
+      tries=$((tries-1))
+      sleep 5
+    fi
+  done
+  if [[ $tries -eq 0 ]]; then
     echo "Existing CNI config is required for chaining but does not exist yet, exiting..."
     exit 1
   fi

--- a/test/k8s/manifests.go
+++ b/test/k8s/manifests.go
@@ -13,7 +13,7 @@ var (
 	DemoDaemonSet = helpers.Manifest{
 		Filename:        "demo_ds.yaml",
 		Alternate:       "demo_ds_local.yaml",
-		DaemonSetNames:  []string{"testds", "testclient"},
+		DaemonSetNames:  []string{"testds", "testclient", "testclient-2"},
 		DeploymentNames: []string{"test-k8s2"},
 		NumPods:         1,
 		Singleton:       true,


### PR DESCRIPTION
- [x] PR: 20520 -- Reference datapath metrics in feature and troubleshooting guides (@aditighag) -- https://github.com/cilium/cilium/pull/20520 (Note: Verified by myself).
- [x] PR: 21495 -- alibabacloud: fix incorrect instance-type reported by cilium-agent (@ArthurChiao) -- https://github.com/cilium/cilium/pull/21495. (Note: Verified by myself).
- [x] PR: 21463 -- helm: Quote operator and etcd-operator image fields (@michi-covalent) -- https://github.com/cilium/cilium/pull/21463
- [x] PR: 21461 -- ipsec: Refactoring around `UpsertIPsecEndpoint` (@pchaigno) -- https://github.com/cilium/cilium/pull/21461
- [x] PR: 21497 -- bugtool: Fix pprof default ports (@pippolo84) -- https://github.com/cilium/cilium/pull/21497
- [x] PR: 21577 -- contrib: avoid reviews from non-collaborators (@bimmlerd) -- https://github.com/cilium/cilium/pull/21577
- [x] PR: 21588 -- test: fix up the number of pods in DemoDaemonSet (@julianwiedmann) -- https://github.com/cilium/cilium/pull/21588
- [x] PR: 21444 -- plugins/cni: wait for AWS to drop its CNI configuration file (@squeed) -- https://github.com/cilium/cilium/pull/21444

```upstream-prs
$ for pr in 21444 21588 21577 21497 21461 21463 21495 20520; do contrib/backporting/set-labels.py $pr done 1.12; done
```