### PR TITLE
v1.11 backports 2022-10-08

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -42,7 +42,7 @@ cilium-bugtool [OPTIONS] [flags]
       --k8s-mode                  Require Kubernetes pods to be found or fail
       --k8s-namespace string      Kubernetes namespace for Cilium pod (default "kube-system")
       --parallel-workers int      Maximum number of parallel worker tasks, use 0 for number of CPUs
-      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:9890, operator:9891, apiserver:9892 (default 9890)
+      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061 (default 6060)
       --pprof-trace-seconds int   Amount of seconds used for pprof CPU traces (default 180)
   -t, --tmp string                Path to store extracted files. Use '-' to send to stdout. (default "/tmp")
 ```

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -81,10 +81,10 @@ func init() {
 	BugtoolRootCmd.Flags().BoolVar(&getPProf, "get-pprof", false, "When set, only gets the pprof traces from the cilium-agent binary")
 	BugtoolRootCmd.Flags().BoolVar(&envoyDump, "envoy-dump", true, "When set, dump envoy configuration from unix socket")
 	BugtoolRootCmd.Flags().IntVar(&pprofPort,
-		"pprof-port", defaults.GopsPortAgent,
+		"pprof-port", defaults.PprofPortAgent,
 		fmt.Sprintf(
-			"Pprof port to connect to. Known Cilium component ports are agent:%d, operator:%d, apiserver:%d",
-			defaults.GopsPortAgent, defaults.GopsPortOperator, defaults.GopsPortApiserver,
+			"Pprof port to connect to. Known Cilium component ports are agent:%d, operator:%d",
+			defaults.PprofPortAgent, defaults.PprofPortOperator,
 		),
 	)
 	BugtoolRootCmd.Flags().IntVar(&traceSeconds, "pprof-trace-seconds", 180, "Amount of seconds used for pprof CPU traces")

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -52,6 +52,22 @@ get_user_remote() {
   echo $USER_REMOTE
 }
 
+is_collaborator() {
+  local username=${1:-}
+  local org=${2:-cilium}
+  local repo=${3:-cilium}
+  if [ -z "$username" ]; then
+      echo "Error: no username specified in is_collaborator"
+      exit 1
+  fi
+  local path="repos/$org/$repo/collaborators/$username"
+  if hub api "$path" &> /dev/null; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
 require_linux() {
   if [ "$(uname)" != "Linux" ]; then
       echo "$0: Linux required"

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -47,7 +47,17 @@ if ! git branch -a | grep -q "${UPSTREAM_REMOTE}/v${BRANCH}$" || [ ! -e "$SUMMAR
     echo "(branch version: ${BRANCH}, pr-summary: ${SUMMARY}, upstream remote: ${UPSTREAM_REMOTE})" 1>&2
     exit 1
 fi
-AUTHORS="$(grep -ho "@[^)]*" "$SUMMARY" | grep -v "$(get_user)" | sort -u | tr '\n' ',' | sed -e 's/@//g' -e 's/,$//')"
+
+AUTHORS="$(grep -ho "@[^)]*" "$SUMMARY" | grep -v "$(get_user)" | sort -u | tr '\n' ' ' | sed -e 's/@//g' -e 's/ $//')"
+
+# Github complains if we request a review by someone who is not a collaborator, thus filter the authors.
+REVIEWERS=""
+for author in $AUTHORS; do
+    if [ $(is_collaborator "$author") == "yes" ]; then
+        REVIEWERS="$REVIEWERS,$author"
+    fi
+done
+REVIEWERS=${REVIEWERS:1} # Lop off the initial comma.
 
 echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
 cat $SUMMARY 1>&2
@@ -55,10 +65,10 @@ echo -e "\nSending pull request..." 2>&1
 PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git config --local "branch.${PR_BRANCH}.remote" "$USER_REMOTE"
 git push -q "$USER_REMOTE" "$PR_BRANCH"
-if [ -z "$AUTHORS" ]; then
+if [ -z "$REVIEWERS" ]; then
   hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY
 else
-  hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $AUTHORS
+  hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $REVIEWERS
 fi
 
 prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -791,7 +791,7 @@ func initializeFlags() {
 	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
 	option.BindEnv(option.PProf)
 
-	flags.Int(option.PProfPort, 6060, "Port that the pprof listens on")
+	flags.Int(option.PProfPort, defaults.PprofPortAgent, "Port that the pprof listens on")
 	option.BindEnv(option.PProfPort)
 
 	flags.Bool(option.EnableXDPPrefilter, false, "Enable XDP prefiltering")

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -257,7 +257,7 @@ func init() {
 	flags.Bool(operatorOption.PProf, false, "Enable pprof debugging endpoint")
 	option.BindEnv(operatorOption.PProf)
 
-	flags.Int(operatorOption.PProfPort, 6061, "Port that the pprof listens on")
+	flags.Int(operatorOption.PProfPort, defaults.PprofPortOperator, "Port that the pprof listens on")
 	option.BindEnv(operatorOption.PProfPort)
 
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -173,7 +173,7 @@ func ipSecReplaceStateOut(remoteIP, localIP net.IP) (uint8, error) {
 	return key.Spi, netlink.XfrmStateAdd(state)
 }
 
-func _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst *net.IPNet, dir netlink.Dir) error {
+func _ipSecReplacePolicyInFwd(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, dir netlink.Dir) error {
 	optional := int(0)
 	key := getIPSecKeys(dst.IP)
 	if key == nil {
@@ -204,15 +204,15 @@ func _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst *net.IPNet, dir netlink
 		optional = 1
 		policy.Priority = linux_defaults.IPsecFwdPriority
 	}
-	ipSecAttachPolicyTempl(policy, key, tmplSrc.IP, tmplDst.IP, false, optional)
+	ipSecAttachPolicyTempl(policy, key, tmplSrc, tmplDst, false, optional)
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
-func ipSecReplacePolicyIn(src, dst, tmplSrc, tmplDst *net.IPNet) error {
+func ipSecReplacePolicyIn(src, dst *net.IPNet, tmplSrc, tmplDst net.IP) error {
 	return _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst, netlink.XFRM_DIR_IN)
 }
 
-func IpSecReplacePolicyFwd(src, dst, tmplSrc, tmplDst *net.IPNet) error {
+func IpSecReplacePolicyFwd(src, dst *net.IPNet, tmplSrc, tmplDst net.IP) error {
 	return _ipSecReplacePolicyInFwd(src, dst, tmplSrc, tmplDst, netlink.XFRM_DIR_FWD)
 }
 
@@ -235,7 +235,7 @@ func getSPIFromXfrmPolicy(policy *netlink.XfrmPolicy) uint8 {
 	return ipSecXfrmMarkGetSPI(policy.Mark.Value)
 }
 
-func ipSecReplacePolicyOut(src, dst, tmplSrc, tmplDst *net.IPNet, dir IPSecDir) error {
+func ipSecReplacePolicyOut(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, dir IPSecDir) error {
 	// TODO: Remove old policy pointing to target net
 
 	key := getIPSecKeys(dst.IP)
@@ -257,7 +257,7 @@ func ipSecReplacePolicyOut(src, dst, tmplSrc, tmplDst *net.IPNet, dir IPSecDir) 
 		Value: ipSecXfrmMarkSetSPI(linux_defaults.RouteMarkEncrypt, key.Spi),
 		Mask:  linux_defaults.IPsecMarkMask,
 	}
-	ipSecAttachPolicyTempl(policy, key, tmplSrc.IP, tmplDst.IP, true, 0)
+	ipSecAttachPolicyTempl(policy, key, tmplSrc, tmplDst, true, 0)
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
@@ -338,7 +338,7 @@ func ipsecDeleteXfrmPolicy(ip net.IP) {
  * state space. Basic idea would be to reference a state using any key generated
  * from BPF program allowing for a single state per security ctx.
  */
-func UpsertIPsecEndpoint(local, remote, fwd *net.IPNet, dir IPSecDir, outputMark bool) (uint8, error) {
+func UpsertIPsecEndpoint(local, remote, fwd *net.IPNet, outerLocal, outerRemote net.IP, dir IPSecDir, outputMark bool) (uint8, error) {
 	var spi uint8
 	var err error
 
@@ -350,19 +350,19 @@ func UpsertIPsecEndpoint(local, remote, fwd *net.IPNet, dir IPSecDir, outputMark
 	 * netlink API at all when we "know" an entry is a duplicate. To do this the xfer
 	 * state would need to be cached in the ipcache.
 	 */
-	if !local.IP.Equal(remote.IP) {
+	if !outerLocal.Equal(outerRemote) {
 		if dir == IPSecDirIn || dir == IPSecDirBoth {
-			if spi, err = ipSecReplaceStateIn(local.IP, remote.IP, outputMark); err != nil {
+			if spi, err = ipSecReplaceStateIn(outerLocal, outerRemote, outputMark); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace local state: %s", err)
 				}
 			}
-			if err = ipSecReplacePolicyIn(remote, local, remote, local); err != nil {
+			if err = ipSecReplacePolicyIn(remote, local, outerRemote, outerLocal); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace policy in: %s", err)
 				}
 			}
-			if err = IpSecReplacePolicyFwd(remote, fwd, remote, local); err != nil {
+			if err = IpSecReplacePolicyFwd(remote, fwd, outerRemote, outerLocal); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace policy fwd: %s", err)
 				}
@@ -370,13 +370,13 @@ func UpsertIPsecEndpoint(local, remote, fwd *net.IPNet, dir IPSecDir, outputMark
 		}
 
 		if dir == IPSecDirOut || dir == IPSecDirOutNode || dir == IPSecDirBoth {
-			if spi, err = ipSecReplaceStateOut(remote.IP, local.IP); err != nil {
+			if spi, err = ipSecReplaceStateOut(outerRemote, outerLocal); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace remote state: %s", err)
 				}
 			}
 
-			if err = ipSecReplacePolicyOut(local, remote, local, remote, dir); err != nil {
+			if err = ipSecReplacePolicyOut(local, remote, outerLocal, outerRemote, dir); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace policy out: %s", err)
 				}
@@ -388,7 +388,7 @@ func UpsertIPsecEndpoint(local, remote, fwd *net.IPNet, dir IPSecDir, outputMark
 
 // UpsertIPsecEndpointPolicy adds a policy to the xfrm rules. Used to add a policy when the state
 // rule is already available.
-func UpsertIPsecEndpointPolicy(local, remote, localTmpl, remoteTmpl *net.IPNet, dir IPSecDir) error {
+func UpsertIPsecEndpointPolicy(local, remote *net.IPNet, localTmpl, remoteTmpl net.IP, dir IPSecDir) error {
 	if err := ipSecReplacePolicyOut(local, remote, localTmpl, remoteTmpl, dir); err != nil {
 		if !os.IsExist(err) {
 			return fmt.Errorf("unable to replace templated policy out: %s", err)

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -398,9 +398,9 @@ func UpsertIPsecEndpointPolicy(local, remote, localTmpl, remoteTmpl *net.IPNet, 
 }
 
 // DeleteIPsecEndpoint deletes a endpoint associated with the remote IP address
-func DeleteIPsecEndpoint(remote *net.IPNet) {
-	ipsecDeleteXfrmState(remote.IP)
-	ipsecDeleteXfrmPolicy(remote.IP)
+func DeleteIPsecEndpoint(remote net.IP) {
+	ipsecDeleteXfrmState(remote)
+	ipsecDeleteXfrmPolicy(remote)
 }
 
 func isXfrmPolicyCilium(policy netlink.XfrmPolicy) bool {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -182,8 +182,8 @@ func _ipSecReplacePolicyInFwd(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, dir 
 
 	policy := ipSecNewPolicy()
 	policy.Dir = dir
-	policy.Src = &net.IPNet{IP: src.IP.Mask(src.Mask), Mask: src.Mask}
-	policy.Dst = &net.IPNet{IP: dst.IP.Mask(dst.Mask), Mask: dst.Mask}
+	policy.Src = src
+	policy.Dst = dst
 	if dir == netlink.XFRM_DIR_IN {
 		// We require a policy to match on packets going to the proxy which are
 		// therefore carrying the proxy mark. We however don't need a policy
@@ -249,9 +249,9 @@ func ipSecReplacePolicyOut(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, dir IPS
 		wildcardMask := net.IPv4Mask(0, 0, 0, 0)
 		policy.Src = &net.IPNet{IP: wildcardIP, Mask: wildcardMask}
 	} else {
-		policy.Src = &net.IPNet{IP: src.IP.Mask(src.Mask), Mask: src.Mask}
+		policy.Src = src
 	}
-	policy.Dst = &net.IPNet{IP: dst.IP.Mask(dst.Mask), Mask: dst.Mask}
+	policy.Dst = dst
 	policy.Dir = netlink.XFRM_DIR_OUT
 	policy.Mark = &netlink.XfrmMark{
 		Value: ipSecXfrmMarkSetSPI(linux_defaults.RouteMarkEncrypt, key.Spi),

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -57,7 +57,7 @@ func (p *IPSecSuitePrivileged) TestInvalidLoadKeys(c *C) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, NotNil)
 }
 
@@ -90,7 +90,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, IsNil)
 
 	cleanIPSecStatesAndPolicies(c)
@@ -108,7 +108,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, IsNil)
 
 	cleanIPSecStatesAndPolicies(c)
@@ -137,7 +137,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, IsNil)
 
 	cleanIPSecStatesAndPolicies(c)
@@ -156,11 +156,11 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, IsNil)
 
 	// Assert additional rule when tunneling is enabled is inserted
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, IsNil)
 	toProxyPolicy, err := netlink.XfrmPolicyGet(&netlink.XfrmPolicy{
 		Src: remote,
@@ -186,7 +186,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecKeyMissing(c *C) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)
 
-	_, err = UpsertIPsecEndpoint(local, remote, local, IPSecDirBoth, false)
+	_, err = UpsertIPsecEndpoint(local, remote, local, local.IP, remote.IP, IPSecDirBoth, false)
 	c.Assert(err, ErrorMatches, "unable to replace local state: IPSec key missing")
 
 	cleanIPSecStatesAndPolicies(c)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -973,27 +973,27 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 	}
 
 	if n.nodeConfig.EnableIPv4 && newNode.IPv4AllocCIDR != nil {
-		new4Net := &net.IPNet{IP: newNode.IPv4AllocCIDR.IP, Mask: newNode.IPv4AllocCIDR.Mask}
+		new4Net := newNode.IPv4AllocCIDR.IPNet
+		wildcardCIDR := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
+
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new4Net)
-			ciliumInternalIPv4 := newNode.GetCiliumInternalIP(false)
-			if ciliumInternalIPv4 != nil {
-				ipsecLocal := &net.IPNet{IP: ciliumInternalIPv4, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
-				ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv4Wildcard, ipsecLocal, ipsec.IPSecDirIn, false)
-				upsertIPsecLog(err, "local IPv4", ipsecLocal, ipsecIPv4Wildcard, spi)
+			if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
+				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, ipsec.IPSecDirIn, false)
+				upsertIPsecLog(err, "local IPv4", localCIDR, wildcardCIDR, spi)
 			}
 		} else {
-			if ciliumInternalIPv4 := newNode.GetCiliumInternalIP(false); ciliumInternalIPv4 != nil {
-				ipsecLocal := &net.IPNet{IP: n.nodeAddressing.IPv4().Router(), Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
-				ipsecRemote := &net.IPNet{IP: ciliumInternalIPv4, Mask: newNode.IPv4AllocCIDR.Mask}
+			if remoteIP := newNode.GetCiliumInternalIP(false); remoteIP != nil {
+				localIP := n.nodeAddressing.IPv4().Router()
+				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
+				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv4AllocCIDR.Mask}
 				n.replaceNodeIPSecOutRoute(new4Net)
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, ipsec.IPSecDirOut, false)
-				upsertIPsecLog(err, "IPv4", ipsecLocal, ipsecRemote, spi)
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, ipsec.IPSecDirOut, false)
+				upsertIPsecLog(err, "IPv4", localCIDR, remoteCIDR, spi)
 
 				/* Insert wildcard policy rules for traffic skipping back through host */
-				ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
-				if err = ipsec.IpSecReplacePolicyFwd(ipsecIPv4Wildcard, ipsecRemote, ipsecIPv4Wildcard, ipsecRemote); err != nil {
+				if err = ipsec.IpSecReplacePolicyFwd(wildcardCIDR, remoteCIDR, wildcardCIDR, remoteCIDR); err != nil {
 					log.WithError(err).Warning("egress unable to replace policy fwd:")
 				}
 			}
@@ -1001,23 +1001,25 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 	}
 
 	if n.nodeConfig.EnableIPv6 && newNode.IPv6AllocCIDR != nil {
-		new6Net := &net.IPNet{IP: newNode.IPv6AllocCIDR.IP, Mask: newNode.IPv6AllocCIDR.Mask}
+		new6Net := newNode.IPv6AllocCIDR.IPNet
+		wildcardIP := net.ParseIP(wildcardIPv6)
+		wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 0)}
+
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new6Net)
-			ciliumInternalIPv6 := newNode.GetCiliumInternalIP(true)
-			if ciliumInternalIPv6 != nil {
-				ipsecLocal := &net.IPNet{IP: ciliumInternalIPv6, Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
-				ipsecIPv6Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv6), Mask: net.CIDRMask(0, 0)}
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv6Wildcard, ipsecLocal, ipsec.IPSecDirIn, false)
-				upsertIPsecLog(err, "local IPv6", ipsecLocal, ipsecIPv6Wildcard, spi)
+			if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
+				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, ipsec.IPSecDirIn, false)
+				upsertIPsecLog(err, "local IPv6", localCIDR, wildcardCIDR, spi)
 			}
 		} else {
-			if ciliumInternalIPv6 := newNode.GetCiliumInternalIP(true); ciliumInternalIPv6 != nil {
-				ipsecLocal := &net.IPNet{IP: n.nodeAddressing.IPv6().Router(), Mask: net.CIDRMask(0, 0)}
-				ipsecRemote := &net.IPNet{IP: ciliumInternalIPv6, Mask: newNode.IPv6AllocCIDR.Mask}
+			if remoteIP := newNode.GetCiliumInternalIP(true); remoteIP != nil {
+				localIP := n.nodeAddressing.IPv6().Router()
+				localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
+				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv6AllocCIDR.Mask}
 				n.replaceNodeIPSecOutRoute(new6Net)
-				spi, err := ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, ipsec.IPSecDirOut, false)
-				upsertIPsecLog(err, "IPv6", ipsecLocal, ipsecRemote, spi)
+				spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, ipsec.IPSecDirOut, false)
+				upsertIPsecLog(err, "IPv6", localCIDR, remoteCIDR, spi)
 			}
 		}
 	}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -529,14 +529,15 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 	}
 
 	for _, cidr := range v4CIDR {
-		ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
+		wildcardIP := net.ParseIP(wildcardIPv4)
+		ipsecIPv4Wildcard := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
 
 		if !option.Config.EnableEndpointRoutes {
 			n.replaceNodeIPSecInRoute(cidr)
 		}
 
 		n.replaceNodeIPSecOutRoute(cidr)
-		spi, err = ipsec.UpsertIPsecEndpoint(ipsecIPv4Wildcard, cidr, ipsecIPv4Wildcard, ipsec.IPSecDirOut, zeroMark)
+		spi, err = ipsec.UpsertIPsecEndpoint(ipsecIPv4Wildcard, cidr, ipsecIPv4Wildcard, wildcardIP, cidr.IP, ipsec.IPSecDirOut, zeroMark)
 		upsertIPsecLog(err, "CNI Out IPv4", ipsecIPv4Wildcard, cidr, spi)
 
 		if n.nodeConfig.EncryptNode {
@@ -546,18 +547,19 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 			if err != nil {
 				upsertIPsecLog(err, "getV4LinkLocalIP failed", ipsecIPv4Wildcard, cidr, spi)
 			}
-			spi, err := ipsec.UpsertIPsecEndpoint(linkAddr, ipsecIPv4Wildcard, cidr, ipsec.IPSecDirIn, zeroMark)
+			spi, err := ipsec.UpsertIPsecEndpoint(linkAddr, ipsecIPv4Wildcard, cidr, linkAddr.IP, wildcardIP, ipsec.IPSecDirIn, zeroMark)
 			upsertIPsecLog(err, "CNI In IPv4", linkAddr, ipsecIPv4Wildcard, spi)
 		}
 	}
 
 	for _, cidr := range v6CIDR {
-		ipsecIPv6Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv6), Mask: net.CIDRMask(0, 0)}
+		wildcardIP := net.ParseIP(wildcardIPv6)
+		ipsecIPv6Wildcard := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 0)}
 
 		n.replaceNodeIPSecInRoute(cidr)
 
 		n.replaceNodeIPSecOutRoute(cidr)
-		spi, err := ipsec.UpsertIPsecEndpoint(ipsecIPv6Wildcard, cidr, ipsecIPv6Wildcard, ipsec.IPSecDirOut, zeroMark)
+		spi, err := ipsec.UpsertIPsecEndpoint(ipsecIPv6Wildcard, cidr, ipsecIPv6Wildcard, wildcardIP, cidr.IP, ipsec.IPSecDirOut, zeroMark)
 		upsertIPsecLog(err, "CNI Out IPv6", cidr, ipsecIPv6Wildcard, spi)
 
 		if n.nodeConfig.EncryptNode {
@@ -567,7 +569,7 @@ func (n *linuxNodeHandler) enableSubnetIPsec(v4CIDR, v6CIDR []*net.IPNet) {
 			if err != nil {
 				upsertIPsecLog(err, "getV6LinkLocalIP failed", ipsecIPv6Wildcard, cidr, spi)
 			}
-			spi, err := ipsec.UpsertIPsecEndpoint(linkAddr, ipsecIPv6Wildcard, cidr, ipsec.IPSecDirIn, zeroMark)
+			spi, err := ipsec.UpsertIPsecEndpoint(linkAddr, ipsecIPv6Wildcard, cidr, linkAddr.IP, wildcardIP, ipsec.IPSecDirIn, zeroMark)
 			upsertIPsecLog(err, "CNI In IPv6", linkAddr, ipsecIPv6Wildcard, spi)
 		}
 	}
@@ -582,15 +584,16 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 		exactMask := net.IPv4Mask(255, 255, 255, 255)
 		ipsecLocal := &net.IPNet{IP: internalIPv4, Mask: exactMask}
 		if newNode.IsLocal() {
-			ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
+			wildcardIP := net.ParseIP(wildcardIPv4)
+			ipsecIPv4Wildcard := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
 			n.replaceNodeIPSecInRoute(ipsecLocal)
-			spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv4Wildcard, ipsecLocal, ipsec.IPSecDirIn, false)
+			spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv4Wildcard, ipsecLocal, internalIPv4, wildcardIP, ipsec.IPSecDirIn, false)
 			upsertIPsecLog(err, "EncryptNode local IPv4", ipsecLocal, ipsecIPv4Wildcard, spi)
 		} else {
 			if remoteIPv4 := newNode.GetNodeIP(false); remoteIPv4 != nil {
 				ipsecRemote := &net.IPNet{IP: remoteIPv4, Mask: exactMask}
 				n.replaceNodeExternalIPSecOutRoute(ipsecRemote)
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, ipsec.IPSecDirOutNode, false)
+				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, internalIPv4, remoteIPv4, ipsec.IPSecDirOutNode, false)
 				upsertIPsecLog(err, "EncryptNode IPv4", ipsecLocal, ipsecRemote, spi)
 			}
 			remoteIPv4 := newNode.GetCiliumInternalIP(false)
@@ -602,8 +605,7 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 
 				n.replaceNodeExternalIPSecOutRoute(ipsecRemoteRoute)
 				if remoteIPv4T := newNode.GetNodeIP(false); remoteIPv4T != nil {
-					ipsecRemoteT := &net.IPNet{IP: remoteIPv4T, Mask: exactMask}
-					err = ipsec.UpsertIPsecEndpointPolicy(ipsecWildcard, ipsecRemote, ipsecLocal, ipsecRemoteT, ipsec.IPSecDirOutNode)
+					err = ipsec.UpsertIPsecEndpointPolicy(ipsecWildcard, ipsecRemote, internalIPv4, remoteIPv4T, ipsec.IPSecDirOutNode)
 				}
 				upsertIPsecLog(err, "EncryptNode Cilium IPv4", ipsecWildcard, ipsecRemote, spi)
 			}
@@ -615,15 +617,16 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 		exactMask := net.CIDRMask(128, 128)
 		ipsecLocal := &net.IPNet{IP: internalIPv6, Mask: exactMask}
 		if newNode.IsLocal() {
-			ipsecIPv6Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv6), Mask: net.CIDRMask(0, 0)}
+			wildcardIP := net.ParseIP(wildcardIPv6)
+			ipsecIPv6Wildcard := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 0)}
 			n.replaceNodeIPSecInRoute(ipsecLocal)
-			spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv6Wildcard, ipsecLocal, ipsec.IPSecDirIn, false)
+			spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv6Wildcard, ipsecLocal, internalIPv6, wildcardIP, ipsec.IPSecDirIn, false)
 			upsertIPsecLog(err, "EncryptNode local IPv6", ipsecLocal, ipsecIPv6Wildcard, spi)
 		} else {
 			if remoteIPv6 := newNode.GetNodeIP(true); remoteIPv6 != nil {
 				ipsecRemote := &net.IPNet{IP: remoteIPv6, Mask: exactMask}
 				n.replaceNodeExternalIPSecOutRoute(ipsecRemote)
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, ipsec.IPSecDirOut, false)
+				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsecLocal, internalIPv6, remoteIPv6, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "EncryptNode IPv6", ipsecLocal, ipsecRemote, spi)
 			}
 			remoteIPv6 := newNode.GetCiliumInternalIP(true)
@@ -635,8 +638,7 @@ func (n *linuxNodeHandler) encryptNode(newNode *nodeTypes.Node) {
 
 				n.replaceNodeExternalIPSecOutRoute(ipsecRemoteRoute)
 				if remoteIPv6T := newNode.GetNodeIP(true); remoteIPv6T != nil {
-					ipsecRemoteT := &net.IPNet{IP: remoteIPv6T, Mask: exactMask}
-					err = ipsec.UpsertIPsecEndpointPolicy(ipsecWildcard, ipsecRemote, ipsecLocal, ipsecRemoteT, ipsec.IPSecDirOutNode)
+					err = ipsec.UpsertIPsecEndpointPolicy(ipsecWildcard, ipsecRemote, internalIPv6, remoteIPv6T, ipsec.IPSecDirOutNode)
 				}
 				upsertIPsecLog(err, "EncryptNode Cilium IPv6", ipsecWildcard, ipsecRemote, spi)
 			}
@@ -974,13 +976,14 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 
 	if n.nodeConfig.EnableIPv4 && newNode.IPv4AllocCIDR != nil {
 		new4Net := newNode.IPv4AllocCIDR.IPNet
-		wildcardCIDR := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
+		wildcardIP := net.ParseIP(wildcardIPv4)
+		wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
 
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new4Net)
 			if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
 				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
-				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, ipsec.IPSecDirIn, false)
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, localIP, wildcardIP, ipsec.IPSecDirIn, false)
 				upsertIPsecLog(err, "local IPv4", localCIDR, wildcardCIDR, spi)
 			}
 		} else {
@@ -989,11 +992,11 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
 				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv4AllocCIDR.Mask}
 				n.replaceNodeIPSecOutRoute(new4Net)
-				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, ipsec.IPSecDirOut, false)
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, localIP, remoteIP, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "IPv4", localCIDR, remoteCIDR, spi)
 
 				/* Insert wildcard policy rules for traffic skipping back through host */
-				if err = ipsec.IpSecReplacePolicyFwd(wildcardCIDR, remoteCIDR, wildcardCIDR, remoteCIDR); err != nil {
+				if err = ipsec.IpSecReplacePolicyFwd(wildcardCIDR, remoteCIDR, wildcardIP, remoteIP); err != nil {
 					log.WithError(err).Warning("egress unable to replace policy fwd:")
 				}
 			}
@@ -1009,7 +1012,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 			n.replaceNodeIPSecInRoute(new6Net)
 			if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
 				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
-				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, ipsec.IPSecDirIn, false)
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, localIP, wildcardIP, ipsec.IPSecDirIn, false)
 				upsertIPsecLog(err, "local IPv6", localCIDR, wildcardCIDR, spi)
 			}
 		} else {
@@ -1018,7 +1021,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 				localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
 				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv6AllocCIDR.Mask}
 				n.replaceNodeIPSecOutRoute(new6Net)
-				spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, ipsec.IPSecDirOut, false)
+				spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, localIP, remoteIP, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "IPv6", localCIDR, remoteCIDR, spi)
 			}
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1425,10 +1425,9 @@ func (n *linuxNodeHandler) replaceNodeIPSecInRoute(ip *net.IPNet) {
 func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 	if n.nodeConfig.EnableIPv4 && oldNode.IPv4AllocCIDR != nil {
 		ciliumInternalIPv4 := oldNode.GetCiliumInternalIP(false)
-		old4Net := &net.IPNet{IP: ciliumInternalIPv4, Mask: oldNode.IPv4AllocCIDR.Mask}
 		old4RouteNet := &net.IPNet{IP: oldNode.IPv4AllocCIDR.IP, Mask: oldNode.IPv4AllocCIDR.Mask}
 		n.deleteNodeIPSecOutRoute(old4RouteNet)
-		ipsec.DeleteIPsecEndpoint(old4Net)
+		ipsec.DeleteIPsecEndpoint(ciliumInternalIPv4)
 		if n.nodeConfig.EncryptNode {
 			if remoteIPv4 := oldNode.GetNodeIP(false); remoteIPv4 != nil {
 				exactMask := net.IPv4Mask(255, 255, 255, 255)
@@ -1440,10 +1439,9 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 
 	if n.nodeConfig.EnableIPv6 && oldNode.IPv6AllocCIDR != nil {
 		ciliumInternalIPv6 := oldNode.GetCiliumInternalIP(true)
-		old6Net := &net.IPNet{IP: ciliumInternalIPv6, Mask: oldNode.IPv6AllocCIDR.Mask}
 		old6RouteNet := &net.IPNet{IP: oldNode.IPv6AllocCIDR.IP, Mask: oldNode.IPv6AllocCIDR.Mask}
 		n.deleteNodeIPSecOutRoute(old6RouteNet)
-		ipsec.DeleteIPsecEndpoint(old6Net)
+		ipsec.DeleteIPsecEndpoint(ciliumInternalIPv6)
 		if n.nodeConfig.EncryptNode {
 			if remoteIPv6 := oldNode.GetNodeIP(true); remoteIPv6 != nil {
 				exactMask := net.CIDRMask(128, 128)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -982,15 +982,15 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new4Net)
 			if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
-				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
+				localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
 				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, localIP, wildcardIP, ipsec.IPSecDirIn, false)
 				upsertIPsecLog(err, "local IPv4", localCIDR, wildcardCIDR, spi)
 			}
 		} else {
 			if remoteIP := newNode.GetCiliumInternalIP(false); remoteIP != nil {
 				localIP := n.nodeAddressing.IPv4().Router()
-				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
-				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv4AllocCIDR.Mask}
+				localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
+				remoteCIDR := newNode.IPv4AllocCIDR.IPNet
 				n.replaceNodeIPSecOutRoute(new4Net)
 				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, localIP, remoteIP, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "IPv4", localCIDR, remoteCIDR, spi)
@@ -1011,7 +1011,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new6Net)
 			if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
-				localCIDR := &net.IPNet{IP: localIP, Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
+				localCIDR := n.nodeAddressing.IPv6().AllocationCIDR().IPNet
 				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localCIDR, localIP, wildcardIP, ipsec.IPSecDirIn, false)
 				upsertIPsecLog(err, "local IPv6", localCIDR, wildcardCIDR, spi)
 			}
@@ -1019,7 +1019,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 			if remoteIP := newNode.GetCiliumInternalIP(true); remoteIP != nil {
 				localIP := n.nodeAddressing.IPv6().Router()
 				localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
-				remoteCIDR := &net.IPNet{IP: remoteIP, Mask: newNode.IPv6AllocCIDR.Mask}
+				remoteCIDR := newNode.IPv6AllocCIDR.IPNet
 				n.replaceNodeIPSecOutRoute(new6Net)
 				spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localCIDR, localIP, remoteIP, ipsec.IPSecDirOut, false)
 				upsertIPsecLog(err, "IPv6", localCIDR, remoteCIDR, spi)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -14,6 +14,15 @@ const (
 	// ClusterHealthPort is the default value for option.ClusterHealthPort
 	ClusterHealthPort = 4240
 
+	// ClusterMeshHealthPort is the default value for option.ClusterMeshHealthPort
+	ClusterMeshHealthPort = 80
+
+	// PprofPortAgent is the default value for pprof in the agent
+	PprofPortAgent = 6060
+
+	// PprofPortAgent is the default value for pprof in the operator
+	PprofPortOperator = 6061
+
 	// GopsPortAgent is the default value for option.GopsPort in the agent
 	GopsPortAgent = 9890
 


### PR DESCRIPTION
- [x] #21461 -- ipsec: Refactoring around `UpsertIPsecEndpoint` (@pchaigno)
- [x] #21497 -- bugtool: Fix pprof default ports (@pippolo84) - (Conflicted)
- [x] #21577 -- contrib: avoid reviews from non-collaborators (@bimmlerd)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 21461 21497 21577; do contrib/backporting/set-labels.py $pr done 1.11; done
```