### PR TITLE
only setup ip rules when l7 policy enabled

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -405,7 +405,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args[initArgHostDev1] = hostDev1.Attrs().Name
 	args[initArgHostDev2] = hostDev2.Attrs().Name
 
-	if option.Config.InstallIptRules {
+	if option.Config.InstallIptRules && option.Config.EnableL7Proxy {
 		args[initArgProxyRule] = "true"
 	} else {
 		args[initArgProxyRule] = "false"


### PR DESCRIPTION
We use cilium vxlan in our environment, and we don't use l7 policy.
We found cilium will setup ip rules, it makes some problem.
We try set `--install-iptables-rules=false` to make cilium didn't setup ip rules.
But we meet a new problem, cilium vxlan need `CILIUM_FORWARD` iptables rules.
We found ip rules only needed when use l7 policy, so I think we shouldn't setup ip rules unless l7 policy enabled.

Before
```
0:	from all lookup local
32766:	from all lookup main
32767:	from all lookup default
```

After
```
$ ip rule
9:	from all fwmark 0x200/0xf00 lookup 2004
100:	from all lookup local
32766:	from all lookup main
32767:	from all lookup default
```