### PR TITLE
v1.12 backports 2022-10-09

### DIFF
--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -189,7 +189,7 @@ func (ipc *IPCache) allocate(prefix *net.IPNet, lbls labels.Labels, oldNID ident
 	return id, isNew, err
 }
 
-func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, identities map[string]*identity.Identity) {
+func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, prefixes []string) {
 	// Create a critical section for identity release + removal from ipcache.
 	// Otherwise, it's possible to trigger the following race condition:
 	//
@@ -205,7 +205,24 @@ func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, identities map[st
 	// is that the identity is allocated but the ipcache entry is missing.
 	ipc.Lock()
 	defer ipc.Unlock()
-	for prefix, id := range identities {
+
+	toDelete := make([]string, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		_, c, err := net.ParseCIDR(prefix)
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				logfields.CIDR: c,
+			}).WithError(err).Error("Unable to parse CIDR during ipcache release")
+			continue
+		}
+		lbls := cidr.GetCIDRLabels(c)
+		id := ipc.IdentityAllocator.LookupIdentity(ctx, lbls)
+		if id == nil {
+			log.WithFields(logrus.Fields{
+				logfields.CIDR: prefix,
+			}).Errorf("Unable to find identity of previously used CIDR")
+			continue
+		}
 		released, err := ipc.IdentityAllocator.Release(ctx, id, false)
 		if err != nil {
 			log.WithFields(logrus.Fields{
@@ -213,43 +230,33 @@ func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, identities map[st
 				logfields.CIDR:     prefix,
 			}).WithError(err).Warning("Unable to release CIDR identity. Ignoring error. Identity may be leaked")
 		}
-
 		if released {
-			ipc.deleteLocked(prefix, source.Generated)
+			toDelete = append(toDelete, prefix)
 		}
+	}
+
+	for _, prefix := range toDelete {
+		ipc.deleteLocked(prefix, source.Generated)
 	}
 }
 
 // ReleaseCIDRIdentitiesByCIDR releases the identities of a list of CIDRs.
 // When the last use of the identity is released, the ipcache entry is deleted.
-func (ipc *IPCache) ReleaseCIDRIdentitiesByCIDR(prefixes []*net.IPNet) {
-	// TODO: Structure the code to pass context down from the Daemon.
-	releaseCtx, cancel := context.WithTimeout(context.TODO(), option.Config.KVstoreConnectivityTimeout)
-	defer cancel()
-
-	identities := make(map[string]*identity.Identity, len(prefixes))
-	for _, prefix := range prefixes {
-		if prefix == nil {
-			continue
-		}
-
-		if id := ipc.IdentityAllocator.LookupIdentity(releaseCtx, cidr.GetCIDRLabels(prefix)); id != nil {
-			identities[prefix.String()] = id
-		} else {
-			log.Errorf("Unable to find identity of previously used CIDR %s", prefix.String())
-		}
+func (ipc *IPCache) ReleaseCIDRIdentitiesByCIDR(nets []*net.IPNet) {
+	prefixes := make([]string, 0, len(nets))
+	for _, n := range nets {
+		prefixes = append(prefixes, n.String())
 	}
-
-	ipc.releaseCIDRIdentities(releaseCtx, identities)
+	ipc.deferredPrefixRelease.enqueue(prefixes, "cidr-prefix-release")
 }
 
 // ReleaseCIDRIdentitiesByID releases the specified identities.
 // When the last use of the identity is released, the ipcache entry is deleted.
 func (ipc *IPCache) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
-	fullIdentities := make(map[string]*identity.Identity, len(identities))
+	prefixes := make([]string, 0, len(identities))
 	for _, nid := range identities {
 		if id := ipc.IdentityAllocator.LookupIdentityByID(ctx, nid); id != nil {
-			cidr, ok := cidrLabelToPrefix(id.CIDRLabel.String())
+			prefix, ok := cidrLabelToPrefix(id.CIDRLabel.String())
 			if !ok {
 				log.WithFields(logrus.Fields{
 					logfields.Identity: nid,
@@ -257,7 +264,7 @@ func (ipc *IPCache) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []
 				}).Warn("Unexpected release of non-CIDR identity, will leak this identity. Please report this issue to the developers.")
 				continue
 			}
-			fullIdentities[cidr] = id
+			prefixes = append(prefixes, prefix)
 		} else {
 			log.WithFields(logrus.Fields{
 				logfields.Identity: nid,
@@ -265,5 +272,5 @@ func (ipc *IPCache) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []
 		}
 	}
 
-	ipc.releaseCIDRIdentities(ctx, fullIdentities)
+	ipc.deferredPrefixRelease.enqueue(prefixes, "selector-prefix-release")
 }

--- a/pkg/ipcache/gc.go
+++ b/pkg/ipcache/gc.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/trigger"
+)
+
+type asyncPrefixReleaser struct {
+	*trigger.Trigger
+	prefixReleaser
+
+	// Mutex protects read and write to 'queue'.
+	lock.Mutex
+	queue []string
+}
+
+type prefixReleaser interface {
+	releaseCIDRIdentities(ctx context.Context, identities []string)
+}
+
+func newAsyncPrefixReleaser(parent prefixReleaser, interval time.Duration) *asyncPrefixReleaser {
+	result := &asyncPrefixReleaser{
+		queue:          make([]string, 0),
+		prefixReleaser: parent,
+	}
+
+	// trigger needs to be updated to reference the object above
+	// Ignore error case since the TriggerFunc is provided.
+	result.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
+		Name:        "ipcache-identity-gc",
+		MinInterval: interval,
+		TriggerFunc: func(reasons []string) {
+			// TODO: Structure the code to pass context down
+			//       from the Daemon.
+			ctx, cancel := context.WithTimeout(
+				context.TODO(),
+				option.Config.KVstoreConnectivityTimeout)
+			defer cancel()
+			result.run(ctx, reasons...)
+		},
+	})
+
+	return result
+}
+
+// enqueue a set of prefixes to be released asynchronously.
+func (pr *asyncPrefixReleaser) enqueue(prefixes []string, reason string) {
+	pr.Lock()
+	defer pr.Unlock()
+	pr.queue = append(pr.queue, prefixes...)
+	pr.TriggerWithReason(reason)
+}
+
+// dequeue  the outstanding set of prefixes that are queued fro release.
+func (pr *asyncPrefixReleaser) dequeue() (result []string) {
+	pr.Lock()
+	defer pr.Unlock()
+	result = pr.queue
+	pr.queue = make([]string, 0)
+	return result
+}
+
+// run the core logic to dequeue & release identities / ipcache entries
+func (pr *asyncPrefixReleaser) run(ctx context.Context, reasons ...string) {
+	prefixes := pr.dequeue()
+	log.WithFields(logrus.Fields{
+		logfields.Count:  len(prefixes),
+		logfields.Reason: reasons,
+	}).Debug("Garbage collecting identities and entries from ipcache")
+	pr.prefixReleaser.releaseCIDRIdentities(ctx, prefixes)
+}

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -86,10 +86,14 @@ func (ipc *IPCache) GetIDMetadataByIP(prefix string) labels.Labels {
 	return ipc.metadata.get(prefix)
 }
 
+func (m *metadata) getLocked(prefix string) labels.Labels {
+	return m.m[prefix]
+}
+
 func (m *metadata) get(prefix string) labels.Labels {
 	m.RLock()
 	defer m.RUnlock()
-	return m.m[prefix]
+	return m.getLocked(prefix)
 }
 
 // InjectLabels injects labels from the ipcache metadata (IDMD) map into the


### PR DESCRIPTION
* #21565 -- ipcache: Fix metadata access from CIDR allocation (@joestringer)
  * Minor conflicts. I also found one additional corner case locking issue which is fixed here. I'll send a separate fix to master.
    * https://github.com/cilium/cilium/pull/21653 -- ipcache: Release metadata mutex in loop error condition (@joestringer)
* #21629 -- Fix agent deadlock caused by frequent kube-apiserver IP recycling (@joestringer)
  * Conflicts: Use of *net.IPNet and string instead of netip.Prefix on v1.12 branch

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 21565 21629 21653; do contrib/backporting/set-labels.py $pr done 1.12; done
```