### PR TITLE
k8s/{client,resource}: API improvements and support for custom retries

### DIFF
--- a/cilium/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium/cmd/preflight_k8s_valid_cnp.go
@@ -38,7 +38,7 @@ has an exit code 1 is returned.`,
 
 		cell.Invoke(func(lc hive.Lifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner) {
 			lc.Append(hive.Hook{
-				OnStart: func(context.Context) error { return validateCNPs(clientset, shutdowner) },
+				OnStart: func(hive.HookContext) error { return validateCNPs(clientset, shutdowner) },
 			})
 		}),
 	)

--- a/clustermesh-apiserver/health.go
+++ b/clustermesh-apiserver/health.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -54,7 +53,7 @@ func registerHealthAPIServer(lc hive.Lifecycle, clientset k8sClient.Clientset, c
 	}
 
 	lc.Append(hive.Hook{
-		OnStart: func(context.Context) error {
+		OnStart: func(hive.HookContext) error {
 			go func() {
 				log.Info("Started health API")
 				if err := srv.ListenAndServe(); err != nil {
@@ -63,6 +62,6 @@ func registerHealthAPIServer(lc hive.Lifecycle, clientset k8sClient.Clientset, c
 			}()
 			return nil
 		},
-		OnStop: srv.Shutdown,
+		OnStop: func(ctx hive.HookContext) error { return srv.Shutdown(ctx) },
 	})
 }

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -118,8 +118,8 @@ func registerHooks(lc hive.Lifecycle, clientset k8sClient.Clientset) error {
 
 	k8s.SetClients(clientset, clientset.Slim(), clientset, clientset)
 	lc.Append(hive.Hook{
-		OnStart: func(context.Context) error {
-			startServer(clientset)
+		OnStart: func(ctx hive.HookContext) error {
+			startServer(ctx, clientset)
 			return nil
 		},
 	})
@@ -541,14 +541,14 @@ func synchronizeCiliumEndpoints(clientset k8sClient.Clientset) {
 	go ciliumEndpointsInformer.Run(wait.NeverStop)
 }
 
-func startServer(clientset k8sClient.Clientset) {
+func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset) {
 	log.WithFields(logrus.Fields{
 		"cluster-name": cfg.clusterName,
 		"cluster-id":   clusterID,
 	}).Info("Starting clustermesh-apiserver...")
 
 	if mockFile == "" {
-		synced.SyncCRDs(context.TODO(), synced.AllCRDResourceNames(), &synced.Resources{}, &synced.APIGroups{})
+		synced.SyncCRDs(startCtx, synced.AllCRDResourceNames(), &synced.Resources{}, &synced.APIGroups{})
 	}
 
 	mgr := NewVMManager(clientset)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1564,7 +1564,8 @@ func registerDaemonHooks(params daemonParams) error {
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	// daemonCtx is the daemon-wide context cancelled when stopping.
+	daemonCtx, cancelDaemonCtx := context.WithCancel(context.Background())
 	cleaner := NewDaemonCleanup()
 
 	if Vp.GetString(option.DatapathMode) == datapathOption.DatapathModeLBOnly {
@@ -1580,7 +1581,7 @@ func registerDaemonHooks(params daemonParams) error {
 	node.SetLocalNodeStore(params.LocalNodeStore)
 
 	params.Lifecycle.Append(hive.Hook{
-		OnStart: func(context.Context) error {
+		OnStart: func(hive.HookContext) error {
 			// Set the k8s clients provided by the K8s client cell. The global clients will be refactored out
 			// by later commits.
 			if params.Clientset.IsEnabled() {
@@ -1593,11 +1594,11 @@ func registerDaemonHooks(params daemonParams) error {
 
 			// Start running the daemon in the background (blocks on API server's Serve()) to allow rest
 			// of the start hooks to run.
-			go runDaemon(ctx, cleaner, params.Shutdowner, params.Clientset)
+			go runDaemon(daemonCtx, cleaner, params.Shutdowner, params.Clientset)
 			return nil
 		},
-		OnStop: func(context.Context) error {
-			cancel()
+		OnStop: func(hive.HookContext) error {
+			cancelDaemonCtx()
 			cleaner.Clean()
 			return nil
 		},

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -117,11 +117,11 @@ func registerOperatorHooks(lc hive.Lifecycle, llc *LeaderLifecycle, clientset k8
 	k8s.SetClients(clientset, clientset.Slim(), clientset, clientset)
 
 	lc.Append(hive.Hook{
-		OnStart: func(context.Context) error {
+		OnStart: func(hive.HookContext) error {
 			go runOperator(llc, clientset, shutdowner)
 			return nil
 		},
-		OnStop: func(ctx context.Context) error {
+		OnStop: func(ctx hive.HookContext) error {
 			if err := llc.Stop(ctx); err != nil {
 				return err
 			}
@@ -378,14 +378,14 @@ type legacyOnLeader struct {
 	clientset k8sClient.Clientset
 }
 
-func (legacy *legacyOnLeader) onStop(_ context.Context) error {
+func (legacy *legacyOnLeader) onStop(_ hive.HookContext) error {
 	legacy.cancel()
 	return nil
 }
 
 // OnOperatorStartLeading is the function called once the operator starts leading
 // in HA mode.
-func (legacy *legacyOnLeader) onStart(_ context.Context) error {
+func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 	IsLeader.Store(true)
 
 	// If CiliumEndpointSlice feature is enabled, create CESController, start CEP watcher and run controller.

--- a/pkg/gops/cell.go
+++ b/pkg/gops/cell.go
@@ -4,7 +4,6 @@
 package gops
 
 import (
-	"context"
 	"fmt"
 
 	gopsAgent "github.com/google/gops/agent"
@@ -40,14 +39,14 @@ func registerGopsHooks(lc hive.Lifecycle, log logrus.FieldLogger, cfg GopsConfig
 	addrField := logrus.Fields{"address": addr, logfields.LogSubsys: "gops"}
 	log = log.WithFields(addrField)
 	lc.Append(hive.Hook{
-		OnStart: func(context.Context) error {
+		OnStart: func(hive.HookContext) error {
 			log.Info("Started gops server")
 			return gopsAgent.Listen(gopsAgent.Options{
 				Addr:                   addr,
 				ReuseSocketAddrAndPort: true,
 			})
 		},
-		OnStop: func(context.Context) error {
+		OnStop: func(hive.HookContext) error {
 			gopsAgent.Close()
 			log.Info("Stopped gops server")
 			return nil

--- a/pkg/hive/example/main.go
+++ b/pkg/hive/example/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -126,7 +125,11 @@ type ExampleObject struct {
 // onStart is a lifecycle hook that is executed when the hive is started.
 // If onStart fails, then hive will rewind by calling stop hooks for
 // already started components and then return the error.
-func (o *ExampleObject) onStart(context.Context) error {
+//
+// The HookContext is provided to allow aborting the start in case of
+// a timeout. It should always be used to abort any long running operation
+// performed directly from the start hook.
+func (o *ExampleObject) onStart(hive.HookContext) error {
 	o.log.Infof("onStart: Config: %#v", o.cfg)
 	return nil
 }
@@ -134,7 +137,7 @@ func (o *ExampleObject) onStart(context.Context) error {
 // onStop is a lifecycle hook that is executed when the hive is stopped,
 // either by a signal (SIGINT (ctrl-c), SIGTERM) or a call to Shutdowner.Shutdown().
 // All stop hooks are executed regardless if one fails.
-func (o *ExampleObject) onStop(context.Context) error {
+func (o *ExampleObject) onStop(hive.HookContext) error {
 	o.log.Info("onStop")
 	return nil
 }

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/hive/cell"
-	"github.com/cilium/cilium/pkg/hive/internal"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -285,23 +284,7 @@ func (h *Hive) PrintObjects() {
 	if err := h.populate(); err != nil {
 		log.WithError(err).Fatal("Failed to populate object graph")
 	}
-
-	fmt.Printf("Start hooks:\n\n")
-	for _, hook := range h.lifecycle.hooks {
-		if hook.OnStart == nil {
-			continue
-		}
-		fmt.Printf("  • %s\n", internal.FuncNameAndLocation(hook.OnStart))
-	}
-
-	fmt.Printf("\nStop hooks:\n\n")
-	for i := len(h.lifecycle.hooks) - 1; i >= 0; i-- {
-		hook := h.lifecycle.hooks[i]
-		if hook.OnStop == nil {
-			continue
-		}
-		fmt.Printf("  • %s\n", internal.FuncNameAndLocation(hook.OnStop))
-	}
+	h.lifecycle.PrintHooks()
 }
 
 func (h *Hive) PrintDotGraph() {

--- a/pkg/hive/lifecycle.go
+++ b/pkg/hive/lifecycle.go
@@ -5,6 +5,7 @@ package hive
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"go.uber.org/multierr"
@@ -20,21 +21,50 @@ type Hook struct {
 	OnStop  func(context.Context) error
 }
 
+func (h Hook) Start(ctx context.Context) error {
+	if h.OnStart == nil {
+		return nil
+	}
+	return h.OnStart(ctx)
+}
+
+func (h Hook) Stop(ctx context.Context) error {
+	if h.OnStop == nil {
+		return nil
+	}
+	return h.OnStop(ctx)
+}
+
+type HookInterface interface {
+	// Start hook is called when the hive is started.
+	// Returning a non-nil error causes the start to abort and
+	// the stop hooks for already started cells to be called.
+	//
+	// The context is valid only for the duration of the start
+	// and is used to allow aborting of start hook on timeout.
+	Start(context.Context) error
+
+	// Stop hook is called when the hive is stopped or start aborted.
+	// Returning a non-nil error does not abort stopping. The error
+	// is recorded and rest of the stop hooks are executed.
+	Stop(context.Context) error
+}
+
 // Lifecycle enables cells to register start and stop hooks, either
 // from a constructor or an invoke function.
 type Lifecycle interface {
-	Append(Hook)
+	Append(HookInterface)
 }
 
 // DefaultLifecycle lifecycle implements a simple lifecycle management that conforms
 // to Lifecycle. It is exported for use in applications that have nested lifecycles
 // (e.g. operator).
 type DefaultLifecycle struct {
-	hooks      []Hook
+	hooks      []HookInterface
 	numStarted int
 }
 
-func (lc *DefaultLifecycle) Append(hook Hook) {
+func (lc *DefaultLifecycle) Append(hook HookInterface) {
 	lc.hooks = append(lc.hooks, hook)
 }
 
@@ -46,19 +76,30 @@ func (lc *DefaultLifecycle) Start(ctx context.Context) error {
 	defer cancel()
 
 	for _, hook := range lc.hooks {
-		if hook.OnStart != nil {
-			fn := internal.FuncNameAndLocation(hook.OnStart)
-			l := log.WithField("function", fn)
-			l.Debug("Executing start hook")
-			t0 := time.Now()
-			if err := hook.OnStart(ctx); err != nil {
-				l.WithError(err).Error("Start hook failed")
-				return multierr.Combine(err, lc.Stop(ctx))
-			}
-			d := time.Since(t0)
-			l.WithField("duration", d).Info("Start hook executed")
-		}
+		// Count the number of hooks processed, not the number
+		// of start calls as we also support hooks with only stop
+		// function.
 		lc.numStarted++
+
+		var fn string
+		if hook, ok := hook.(Hook); ok {
+			if hook.OnStart == nil {
+				continue
+			}
+			fn = internal.FuncNameAndLocation(hook.OnStart)
+		} else {
+			fn = internal.FuncNameAndLocation(hook.Start)
+		}
+
+		l := log.WithField("function", fn)
+		l.Debug("Executing start hook")
+		t0 := time.Now()
+		if err := hook.Start(ctx); err != nil {
+			l.WithError(err).Error("Start hook failed")
+			return multierr.Combine(err, lc.Stop(ctx))
+		}
+		d := time.Since(t0)
+		l.WithField("duration", d).Info("Start hook executed")
 	}
 	return nil
 }
@@ -76,21 +117,60 @@ func (lc *DefaultLifecycle) Stop(ctx context.Context) error {
 			return ctx.Err()
 		}
 		hook := lc.hooks[lc.numStarted-1]
-		if hook.OnStop != nil {
-			fn := internal.FuncNameAndLocation(hook.OnStop)
-			l := log.WithField("function", fn)
-			l.Debug("Executing stop hook")
-			t0 := time.Now()
-			if err := hook.OnStop(ctx); err != nil {
-				l.WithError(err).Error("Stop hook failed")
-				errs = append(errs, err)
-			} else {
-				d := time.Since(t0)
-				l.WithField("duration", d).Info("Stop hook executed")
+
+		var fn string
+		if hook, ok := hook.(Hook); ok {
+			if hook.OnStop == nil {
+				continue
 			}
+			fn = internal.FuncNameAndLocation(hook.OnStop)
+		} else {
+			fn = internal.FuncNameAndLocation(hook.Stop)
+		}
+		l := log.WithField("function", fn)
+		l.Debug("Executing stop hook")
+		t0 := time.Now()
+		if err := hook.Stop(ctx); err != nil {
+			l.WithError(err).Error("Stop hook failed")
+			errs = append(errs, err)
+		} else {
+			d := time.Since(t0)
+			l.WithField("duration", d).Info("Stop hook executed")
 		}
 	}
 	return multierr.Combine(errs...)
+}
+
+func (lc *DefaultLifecycle) PrintHooks() {
+	fmt.Printf("Start hooks:\n\n")
+	for _, hook := range lc.hooks {
+		var fn string
+		if hook, ok := hook.(Hook); ok {
+			if hook.OnStart == nil {
+				continue
+			}
+			fn = internal.FuncNameAndLocation(hook.OnStart)
+		} else {
+			fn = internal.FuncNameAndLocation(hook.Start)
+		}
+		fmt.Printf("  • %s\n", fn)
+	}
+
+	fmt.Printf("\nStop hooks:\n\n")
+	for i := len(lc.hooks) - 1; i >= 0; i-- {
+		hook := lc.hooks[i]
+		var fn string
+		if hook, ok := hook.(Hook); ok {
+			if hook.OnStop == nil {
+				continue
+			}
+			fn = internal.FuncNameAndLocation(hook.OnStop)
+		} else {
+			fn = internal.FuncNameAndLocation(hook.Stop)
+		}
+		fmt.Printf("  • %s\n", fn)
+	}
+
 }
 
 var _ Lifecycle = &DefaultLifecycle{}

--- a/pkg/hive/lifecycle_test.go
+++ b/pkg/hive/lifecycle_test.go
@@ -19,28 +19,28 @@ var (
 	lifecycleErr = errors.New("nope")
 
 	goodHook = hive.Hook{
-		OnStart: func(context.Context) error {
+		OnStart: func(hive.HookContext) error {
 			started++
 			return nil
 		},
-		OnStop: func(context.Context) error {
+		OnStop: func(hive.HookContext) error {
 			stopped++
 			return nil
 		},
 	}
 
 	badStartHook = hive.Hook{
-		OnStart: func(context.Context) error {
+		OnStart: func(hive.HookContext) error {
 			return lifecycleErr
 		},
 	}
 
 	badStopHook = hive.Hook{
-		OnStart: func(context.Context) error {
+		OnStart: func(hive.HookContext) error {
 			started++
 			return nil
 		},
-		OnStop: func(context.Context) error {
+		OnStop: func(hive.HookContext) error {
 			return lifecycleErr
 		},
 	}
@@ -86,7 +86,6 @@ func TestLifecycle(t *testing.T) {
 	assert.ErrorIs(t, err, lifecycleErr, "expected Start to fail")
 
 	assert.Equal(t, 2, started)
-	assert.Equal(t, 2, stopped)
 	started = 0
 	stopped = 0
 
@@ -110,7 +109,7 @@ func TestLifecycle(t *testing.T) {
 	// Test that one can have hook with a stop and no start.
 	lc = hive.DefaultLifecycle{}
 	lc.Append(hive.Hook{
-		OnStop: func(context.Context) error { stopped++; return nil },
+		OnStop: func(hive.HookContext) error { stopped++; return nil },
 	})
 	err = lc.Start(context.TODO())
 	assert.NoError(t, err, "expected Start to succeed")
@@ -129,7 +128,7 @@ func TestLifecycleCancel(t *testing.T) {
 	// Test cancellation in start hook
 	lc := hive.DefaultLifecycle{}
 	lc.Append(hive.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(ctx hive.HookContext) error {
 			<-ctx.Done()
 			return ctx.Err()
 		},
@@ -143,7 +142,7 @@ func TestLifecycleCancel(t *testing.T) {
 	inStop := make(chan struct{})
 	lc = hive.DefaultLifecycle{}
 	lc.Append(hive.Hook{
-		OnStop: func(ctx context.Context) error {
+		OnStop: func(ctx hive.HookContext) error {
 			close(inStop)
 			<-ctx.Done()
 			assert.ErrorIs(t, ctx.Err(), context.Canceled)

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -447,10 +447,10 @@ func NewFakeClientset() (*FakeClientset, Clientset) {
 }
 
 type standaloneLifecycle struct {
-	hooks []hive.Hook
+	hooks []hive.HookInterface
 }
 
-func (s *standaloneLifecycle) Append(hook hive.Hook) {
+func (s *standaloneLifecycle) Append(hook hive.HookInterface) {
 	s.hooks = append(s.hooks, hook)
 }
 
@@ -466,7 +466,7 @@ func NewStandaloneClientset(cfg Config) (Clientset, error) {
 	}
 
 	for _, hook := range lc.hooks {
-		if err := hook.OnStart(context.Background()); err != nil {
+		if err := hook.Start(context.Background()); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -197,7 +197,7 @@ func (c *compositeClientset) Config() Config {
 	return c.config
 }
 
-func (c *compositeClientset) onStart(startCtx context.Context) error {
+func (c *compositeClientset) onStart(startCtx hive.HookContext) error {
 	if !c.IsEnabled() {
 		return nil
 	}
@@ -222,7 +222,7 @@ func (c *compositeClientset) onStart(startCtx context.Context) error {
 	return nil
 }
 
-func (c *compositeClientset) onStop(ctx context.Context) error {
+func (c *compositeClientset) onStop(stopCtx hive.HookContext) error {
 	if c.IsEnabled() {
 		c.controller.RemoveAllAndWait()
 		c.closeAllConns()

--- a/pkg/k8s/resource/event.go
+++ b/pkg/k8s/resource/event.go
@@ -18,7 +18,7 @@ type Event[T k8sRuntime.Object] interface {
 	// then do a type-switch on Event[T] and call Done() after the
 	// event has been processed.
 	Handle(
-		onSync func(Store[T]) error,
+		onSync func() error,
 		onUpdate func(Key, T) error,
 		onDelete func(Key, T) error,
 	)
@@ -45,13 +45,12 @@ func (b *baseEvent) Done(err error) {
 // perform e.g. garbage collection operations.
 type SyncEvent[T k8sRuntime.Object] struct {
 	baseEvent
-	Store Store[T]
 }
 
 var _ Event[*corev1.Node] = &SyncEvent[*corev1.Node]{}
 
-func (ev *SyncEvent[T]) Handle(onSync func(store Store[T]) error, onUpdate func(Key, T) error, onDelete func(Key, T) error) {
-	ev.Done(onSync(ev.Store))
+func (ev *SyncEvent[T]) Handle(onSync func() error, onUpdate func(Key, T) error, onDelete func(Key, T) error) {
+	ev.Done(onSync())
 }
 
 // UpdateEvent is emitted when an object has been added or updated
@@ -63,7 +62,7 @@ type UpdateEvent[T k8sRuntime.Object] struct {
 
 var _ Event[*corev1.Node] = &UpdateEvent[*corev1.Node]{}
 
-func (ev *UpdateEvent[T]) Handle(onSync func(Store[T]) error, onUpdate func(Key, T) error, onDelete func(Key, T) error) {
+func (ev *UpdateEvent[T]) Handle(onSync func() error, onUpdate func(Key, T) error, onDelete func(Key, T) error) {
 	ev.Done(onUpdate(ev.Key, ev.Object))
 }
 
@@ -76,6 +75,6 @@ type DeleteEvent[T k8sRuntime.Object] struct {
 
 var _ Event[*corev1.Node] = &DeleteEvent[*corev1.Node]{}
 
-func (ev *DeleteEvent[T]) Handle(onSync func(Store[T]) error, onUpdate func(Key, T) error, onDelete func(Key, T) error) {
+func (ev *DeleteEvent[T]) Handle(onSync func() error, onUpdate func(Key, T) error, onDelete func(Key, T) error) {
 	ev.Done(onDelete(ev.Key, ev.Object))
 }

--- a/pkg/k8s/resource/example/main.go
+++ b/pkg/k8s/resource/example/main.go
@@ -103,31 +103,35 @@ func newPrintServices(p printServicesParams) (*PrintServices, error) {
 		pods:     p.Pods,
 		services: p.Services,
 	}
-	p.Lifecycle.Append(hive.Hook{OnStart: ps.start, OnStop: ps.stop})
+	p.Lifecycle.Append(ps)
 	return ps, nil
 }
 
-func (ps *PrintServices) start(context.Context) error {
+func (ps *PrintServices) Start(startCtx hive.HookContext) error {
 	ps.wg.Add(1)
 
-	ps.printServices()
+	// Using the start context, do a blocking dump of all
+	// services. Using the start context here makes sure that
+	// this operation is aborted if it blocks too long.
+	ps.printServices(startCtx)
+
 	go ps.run()
 
 	return nil
 }
 
-func (ps *PrintServices) stop(context.Context) error {
+func (ps *PrintServices) Stop(hive.HookContext) error {
 	ps.cancel()
 	ps.wg.Wait()
 	return nil
 }
 
 // printServices prints services at start to show how Store() can be used.
-func (ps *PrintServices) printServices() {
+func (ps *PrintServices) printServices(ctx context.Context) {
 
 	// Retrieve a handle to the store. Blocks until the store has synced.
 	// Can fail if the context is cancelled (e.g. PrintServices is being stopped).
-	store, err := ps.services.Store(ps.ctx)
+	store, err := ps.services.Store(ctx)
 	if err != nil {
 		log.Errorf("Failed to retrieve store: %s, aborting", err)
 		return

--- a/pkg/k8s/resource/example/main.go
+++ b/pkg/k8s/resource/example/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -54,16 +53,20 @@ func main() {
 var resourcesCell = cell.Module(
 	"resources",
 	cell.Provide(
-		resource.NewResourceConstructor[*corev1.Pod](
-			func(c client.Clientset) cache.ListerWatcher {
-				return utils.ListerWatcherFromTyped[*corev1.PodList](c.CoreV1().Pods(""))
-			},
-		),
-		resource.NewResourceConstructor[*corev1.Service](
-			func(c client.Clientset) cache.ListerWatcher {
-				return utils.ListerWatcherFromTyped[*corev1.ServiceList](c.CoreV1().Services(""))
-			},
-		),
+		func(lc hive.Lifecycle, c client.Clientset) resource.Resource[*corev1.Pod] {
+			if !c.IsEnabled() {
+				return nil
+			}
+			lw := utils.ListerWatcherFromTyped[*corev1.PodList](c.CoreV1().Pods(""))
+			return resource.New[*corev1.Pod](lc, lw)
+		},
+		func(lc hive.Lifecycle, c client.Clientset) resource.Resource[*corev1.Service] {
+			if !c.IsEnabled() {
+				return nil
+			}
+			lw := utils.ListerWatcherFromTyped[*corev1.ServiceList](c.CoreV1().Services(""))
+			return resource.New[*corev1.Service](lc, lw)
+		},
 	),
 )
 
@@ -194,8 +197,8 @@ func (ps *PrintServices) processLoop() {
 
 			// Event can be handled synchronously with 'Handle()':
 			ev.Handle(
-				func(store resource.Store[*corev1.Pod]) error {
-					log.Infof("Pods synced (%d pods)", len(store.List()))
+				func() error {
+					log.Info("Pods synced")
 					return nil
 				},
 				func(k resource.Key, pod *corev1.Pod) error {
@@ -228,7 +231,7 @@ func (ps *PrintServices) processLoop() {
 			// (which allows parallel processing of events):
 			switch ev := ev.(type) {
 			case *resource.SyncEvent[*corev1.Service]:
-				log.Infof("Services synced (%d services)", len(ev.Store.List()))
+				log.Info("Services synced")
 			case *resource.UpdateEvent[*corev1.Service]:
 				log.Infof("Service %s updated", ev.Key)
 				if len(ev.Object.Spec.Selector) > 0 {

--- a/pkg/k8s/resource/options.go
+++ b/pkg/k8s/resource/options.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"k8s.io/client-go/util/workqueue"
+)
+
+type Option func(*options)
+
+// WithRateLimiter sets the rate limiter to use with the resource.
+func WithRateLimiter(newLimiter func() workqueue.RateLimiter) Option {
+	return func(o *options) { o.rateLimiter = newLimiter }
+}
+
+// WithErrorHandler sets the function that decides how to handle
+// an error from event processing.
+func WithErrorHandler(h ErrorHandler) Option {
+	return func(o *options) { o.errorHandler = h }
+}
+
+type options struct {
+	rateLimiter  func() workqueue.RateLimiter
+	errorHandler ErrorHandler
+}
+
+func defaultOptions() options {
+	return options{
+		rateLimiter: func() workqueue.RateLimiter {
+			return workqueue.DefaultControllerRateLimiter()
+		},
+		errorHandler: AlwaysRetry,
+	}
+}

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -87,7 +87,7 @@ func New[T k8sRuntime.Object](lc hive.Lifecycle, lw cache.ListerWatcher, opts ..
 	}
 	r.ctx, r.cancel = context.WithCancel(context.Background())
 	r.storeResolver, r.storePromise = promise.New[Store[T]]()
-	lc.Append(hive.Hook{OnStart: r.start, OnStop: r.stop})
+	lc.Append(r)
 	return r
 }
 
@@ -134,7 +134,7 @@ func (r *resource[T]) pushDelete(lastState any) {
 	r.mu.RUnlock()
 }
 
-func (r *resource[T]) start(startCtx context.Context) error {
+func (r *resource[T]) Start(startCtx hive.HookContext) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -170,7 +170,7 @@ func (r *resource[T]) start(startCtx context.Context) error {
 	return nil
 }
 
-func (r *resource[T]) stop(stopCtx context.Context) error {
+func (r *resource[T]) Stop(stopCtx hive.HookContext) error {
 	r.cancel()
 	r.wg.Wait()
 	return nil

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -231,7 +231,7 @@ func (r *resource[T]) Observe(subCtx context.Context, next func(Event[T]), compl
 			}
 			switch entry := entry.(type) {
 			case *syncEntry:
-				next(&SyncEvent[T]{baseEvent, store})
+				next(&SyncEvent[T]{baseEvent})
 			case *deleteEntry:
 				next(&DeleteEvent[T]{baseEvent, entry.key, entry.obj.(T)})
 			case *updateEntry:

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -10,20 +10,24 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/stream"
 )
 
 const testTimeout = time.Minute
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func testStore(t *testing.T, node *corev1.Node, store Store[*corev1.Node]) {
 	var (
@@ -285,203 +289,166 @@ func TestResourceCompletionOnStop(t *testing.T) {
 	}
 }
 
-func TestResourceSyncEventRetry(t *testing.T) {
-	var nodes Resource[*corev1.Node]
-
-	hive := hive.New(
-		k8sClient.FakeClientCell,
-		nodesResource,
-		cell.Invoke(func(r Resource[*corev1.Node]) {
-			nodes = r
-		}))
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	if err := hive.Start(ctx); err != nil {
-		t.Fatalf("hive.Start failed: %s", err)
+var RetryFiveTimes ErrorHandler = func(key Key, numRetries int, err error) ErrorAction {
+	if numRetries >= 4 {
+		return ErrorActionStop
 	}
-
-	errs := make(chan error, 1)
-	xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, nodes)
-
-	expectedErr := errors.New("sync")
-	numRetries := counter{}
-
-	for ev := range xs {
-		ev.Handle(
-			func(s Store[*corev1.Node]) error {
-				numRetries.Inc()
-				return expectedErr
-			},
-			func(key Key, node *corev1.Node) error {
-				return nil
-			},
-			func(key Key, node *corev1.Node) error {
-				t.Fatalf("unexpected delete of %s", key)
-				return nil
-			},
-		)
-	}
-
-	if err := hive.Stop(ctx); err != nil {
-		t.Fatalf("hive.Stop failed: %s", err)
-	}
-
-	if numRetries.Get() != defaultMaxRetries {
-		t.Fatalf("expected to see %d retry attempts, saw %d", defaultMaxRetries, numRetries)
-	}
-
-	err := <-errs
-	if !errors.Is(err, expectedErr) {
-		t.Fatalf("expected %q error, got %q", expectedErr, err)
-	}
+	return ErrorActionRetry
 }
 
-func TestResourceSyncEventRetryOnce(t *testing.T) {
-	var nodes Resource[*corev1.Node]
-
-	hive := hive.New(
-		k8sClient.FakeClientCell,
-		nodesResource,
-		cell.Invoke(func(r Resource[*corev1.Node]) {
-			nodes = r
-		}))
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	if err := hive.Start(ctx); err != nil {
-		t.Fatalf("hive.Start failed: %s", err)
-	}
-
-	errs := make(chan error, 1)
-	xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, nodes)
-
-	expectedErr := errors.New("update")
-	numRetries := counter{}
-
-	for ev := range xs {
-		ev.Handle(
-			func(s Store[*corev1.Node]) error {
-				if numRetries.Get() == 1 {
-					cancel()
-					return nil
-				}
-				numRetries.Inc()
-				return expectedErr
-			},
-			func(key Key, node *corev1.Node) error {
-				t.Fatalf("unexpected update of %s", key)
-				return nil
-			},
-			func(key Key, node *corev1.Node) error {
-				t.Fatalf("unexpected delete of %s", key)
-				return nil
-			},
-		)
-	}
-
-	if err := hive.Stop(context.TODO()); err != nil {
-		t.Fatalf("hive.Stop failed: %s", err)
-	}
-
-	if numRetries.Get() != 1 {
-		t.Fatalf("expected to see 1 retry attempt, saw %d", numRetries)
-	}
-
-	err := <-errs
-	if err != nil {
-		t.Fatalf("expected nil error, got %q", err)
-	}
-}
-
-func TestResourceUpdateEventRetry(t *testing.T) {
+func TestResourceRetries(t *testing.T) {
 	var (
-		node = &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            "some-node",
-				ResourceVersion: "0",
-			},
-			Status: corev1.NodeStatus{
-				Phase: "init",
-			},
-		}
-
-		nodes Resource[*corev1.Node]
-
+		nodes          Resource[*corev1.Node]
 		fakeClient, cs = k8sClient.NewFakeClientset()
 	)
 
-	// Create the initial version of the node. Do this before anything
-	// starts watching the resources to avoid a race.
+	rateLimiterUsed := counter{}
+	rateLimiter := func() workqueue.RateLimiter {
+		rateLimiterUsed.Inc()
+		return workqueue.DefaultControllerRateLimiter()
+	}
+
+	hive := hive.New(
+		cell.Provide(func() k8sClient.Clientset { return cs }),
+		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) Resource[*corev1.Node] {
+			nodesLW := utils.ListerWatcherFromTyped[*corev1.NodeList](c.CoreV1().Nodes())
+			return New[*corev1.Node](lc, nodesLW,
+				WithRateLimiter(rateLimiter),
+				WithErrorHandler(RetryFiveTimes))
+		}),
+		cell.Invoke(func(r Resource[*corev1.Node]) {
+			nodes = r
+		}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := hive.Start(ctx)
+	assert.NoError(t, err)
+
+	// Check that the WithRateLimiter option works.
+	ev, err := stream.First[Event[*corev1.Node]](ctx, nodes)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), rateLimiterUsed.Get())
+	ev.Done(nil)
+
+	// Test that stream completes on a single sync error.
+	{
+		errs := make(chan error, 1)
+		xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, nodes)
+
+		expectedErr := errors.New("sync")
+		numRetries := counter{}
+
+		for ev := range xs {
+			ev.Handle(
+				func(s Store[*corev1.Node]) error {
+					numRetries.Inc()
+					return expectedErr
+				},
+				func(key Key, node *corev1.Node) error {
+					return nil
+				},
+				func(key Key, node *corev1.Node) error {
+					t.Fatalf("unexpected delete of %s", key)
+					return nil
+				},
+			)
+		}
+
+		assert.Equal(t, int64(1), numRetries.Get(), "expected to see 1 attempt for sync")
+		err = <-errs
+		assert.ErrorIs(t, err, expectedErr)
+	}
+
+	var node = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "some-node",
+			ResourceVersion: "0",
+		},
+		Status: corev1.NodeStatus{
+			Phase: "init",
+		},
+	}
+
+	// Create the initial version of the node.
 	fakeClient.KubernetesFakeClientset.Tracker().Create(
 		corev1.SchemeGroupVersion.WithResource("nodes"),
 		node, "")
 
-	hive := hive.New(
-		cell.Provide(func() k8sClient.Clientset { return cs }),
-		nodesResource,
-		cell.Invoke(func(r Resource[*corev1.Node]) {
-			nodes = r
-		}))
+	// Test that update events are retried
+	{
+		errs := make(chan error, 1)
+		xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, nodes)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+		expectedErr := errors.New("update")
+		numRetries := counter{}
 
-	if err := hive.Start(ctx); err != nil {
-		t.Fatalf("hive.Start failed: %s", err)
+		for ev := range xs {
+			ev.Handle(
+				func(s Store[*corev1.Node]) error {
+					return nil
+				},
+				func(key Key, node *corev1.Node) error {
+					numRetries.Inc()
+					return expectedErr
+				},
+				func(key Key, node *corev1.Node) error {
+					t.Fatalf("unexpected delete of %s", key)
+					return nil
+				},
+			)
+		}
+
+		assert.Equal(t, int64(5), numRetries.Get(), "expected to see 5 retries for update")
+		err = <-errs
+		assert.ErrorIs(t, err, expectedErr)
 	}
 
-	errs := make(chan error, 1)
-	xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, nodes)
+	// Test that delete events are retried
+	{
+		errs := make(chan error, 1)
+		xs := stream.ToChannel[Event[*corev1.Node]](ctx, errs, nodes)
 
-	expectedErr := errors.New("sync")
-	numRetries := counter{}
+		expectedErr := errors.New("delete")
+		numRetries := counter{}
 
-	// Since no objects were created, we'll only see a sync event.
-	// Always return an error to force reprocessing until we hit the
-	// retry limit.
-	for ev := range xs {
-		ev.Handle(
-			func(s Store[*corev1.Node]) error {
-				return nil
-			},
-			func(key Key, node *corev1.Node) error {
-				numRetries.Inc()
-				return expectedErr
-			},
-			func(key Key, node *corev1.Node) error {
-				t.Fatalf("unexpected delete of %s", key)
-				return nil
-			},
-		)
+		for ev := range xs {
+			ev.Handle(
+				func(s Store[*corev1.Node]) error {
+					return nil
+				},
+				func(key Key, node *corev1.Node) error {
+					fakeClient.KubernetesFakeClientset.Tracker().Delete(
+						corev1.SchemeGroupVersion.WithResource("nodes"),
+						"", node.Name)
+					return nil
+				},
+				func(key Key, node *corev1.Node) error {
+					numRetries.Inc()
+					return expectedErr
+				},
+			)
+		}
+
+		assert.Equal(t, int64(5), numRetries.Get(), "expected to see 5 retries for delete")
+		err = <-errs
+		assert.ErrorIs(t, err, expectedErr)
 	}
 
-	if err := hive.Stop(ctx); err != nil {
-		t.Fatalf("hive.Stop failed: %s", err)
-	}
-
-	if numRetries.Get() != defaultMaxRetries {
-		t.Fatalf("expected to see %d retry attempts, saw %d", defaultMaxRetries, numRetries)
-	}
-
-	err := <-errs
-	if !errors.Is(err, expectedErr) {
-		t.Fatalf("expected %q error, got %q", expectedErr, err)
-	}
+	err = hive.Stop(ctx)
+	assert.NoError(t, err)
 }
 
 //
 // Helpers
 //
 
-func nodesLW(c k8sClient.Clientset) cache.ListerWatcher {
-	return utils.ListerWatcherFromTyped[*corev1.NodeList](c.CoreV1().Nodes())
-}
-
 var nodesResource = cell.Provide(
-	NewResourceConstructorWithRateLimiter[*corev1.Node](testRateLimiter(), nodesLW),
+	func(lc hive.Lifecycle, c k8sClient.Clientset) Resource[*corev1.Node] {
+		lw := utils.ListerWatcherFromTyped[*corev1.NodeList](c.CoreV1().Nodes())
+		return New[*corev1.Node](lc, lw)
+	},
 )
 
 type counter struct{ int64 }
@@ -492,32 +459,4 @@ func (c *counter) Inc() {
 
 func (c *counter) Get() int64 {
 	return atomic.LoadInt64(&c.int64)
-}
-
-type nopLimiter struct {
-	lock.Mutex
-	requeues map[any]int
-}
-
-func (n *nopLimiter) When(item any) time.Duration {
-	n.Lock()
-	n.requeues[item] = 0
-	n.Unlock()
-	return time.Duration(1)
-}
-func (n *nopLimiter) Forget(item any) {
-	n.Lock()
-	delete(n.requeues, item)
-	n.Unlock()
-}
-func (n *nopLimiter) NumRequeues(item any) int {
-	n.Lock()
-	defer n.Unlock()
-	return n.requeues[item]
-}
-
-// testRateLimiter is a custom rate limiter for the tests to allow testing retrying
-// without making the tests slow.
-func testRateLimiter() workqueue.RateLimiter {
-	return &nopLimiter{requeues: make(map[any]int)}
 }

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -69,7 +69,7 @@ func testStore(t *testing.T, node *corev1.Node, store Store[*corev1.Node]) {
 	}
 }
 
-func TestResourceWithFakeClient(t *testing.T) {
+func TestResource_WithFakeClient(t *testing.T) {
 	var (
 		node = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -226,7 +226,7 @@ func TestResourceWithFakeClient(t *testing.T) {
 	}
 }
 
-func TestResourceCompletionOnStop(t *testing.T) {
+func TestResource_CompletionOnStop(t *testing.T) {
 	var nodes Resource[*corev1.Node]
 
 	hive := hive.New(
@@ -295,7 +295,7 @@ var RetryFiveTimes ErrorHandler = func(key Key, numRetries int, err error) Error
 	return ErrorActionRetry
 }
 
-func TestResourceRetries(t *testing.T) {
+func TestResource_Retries(t *testing.T) {
 	var (
 		nodes          Resource[*corev1.Node]
 		fakeClient, cs = k8sClient.NewFakeClientset()
@@ -385,9 +385,7 @@ func TestResourceRetries(t *testing.T) {
 
 		for ev := range xs {
 			ev.Handle(
-				func() error {
-					return nil
-				},
+				nil, // nil handlers are allowed.
 				func(key Key, node *corev1.Node) error {
 					numRetries.Inc()
 					return expectedErr
@@ -414,9 +412,7 @@ func TestResourceRetries(t *testing.T) {
 
 		for ev := range xs {
 			ev.Handle(
-				func() error {
-					return nil
-				},
+				nil, // nil handlers are allowed.
 				func(key Key, node *corev1.Node) error {
 					fakeClient.KubernetesFakeClientset.Tracker().Delete(
 						corev1.SchemeGroupVersion.WithResource("nodes"),

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -110,7 +110,7 @@ func TestResourceWithFakeClient(t *testing.T) {
 
 	// First event should be the node (initial set)
 	(<-xs).Handle(
-		func(_ Store[*corev1.Node]) error {
+		func() error {
 			t.Fatal("unexpected sync")
 			return nil
 		},
@@ -134,8 +134,7 @@ func TestResourceWithFakeClient(t *testing.T) {
 
 	// Second should be a sync.
 	(<-xs).Handle(
-		func(s Store[*corev1.Node]) error {
-			testStore(t, node, s)
+		func() error {
 			return nil
 		},
 		func(key Key, node *corev1.Node) error {
@@ -162,7 +161,7 @@ func TestResourceWithFakeClient(t *testing.T) {
 		corev1.SchemeGroupVersion.WithResource("nodes"),
 		node, "")
 	(<-xs).Handle(
-		func(_ Store[*corev1.Node]) error {
+		func() error {
 			t.Fatalf("unexpected sync")
 			return nil
 		},
@@ -186,7 +185,7 @@ func TestResourceWithFakeClient(t *testing.T) {
 		corev1.SchemeGroupVersion.WithResource("nodes"),
 		"", "some-node")
 	(<-xs).Handle(
-		func(_ Store[*corev1.Node]) error {
+		func() error {
 			t.Fatalf("unexpected sync")
 			return nil
 		},
@@ -249,7 +248,7 @@ func TestResourceCompletionOnStop(t *testing.T) {
 
 	// We should only see a sync event
 	(<-xs).Handle(
-		func(s Store[*corev1.Node]) error {
+		func() error {
 			return nil
 		},
 		func(key Key, node *corev1.Node) error {
@@ -342,7 +341,7 @@ func TestResourceRetries(t *testing.T) {
 
 		for ev := range xs {
 			ev.Handle(
-				func(s Store[*corev1.Node]) error {
+				func() error {
 					numRetries.Inc()
 					return expectedErr
 				},
@@ -386,7 +385,7 @@ func TestResourceRetries(t *testing.T) {
 
 		for ev := range xs {
 			ev.Handle(
-				func(s Store[*corev1.Node]) error {
+				func() error {
 					return nil
 				},
 				func(key Key, node *corev1.Node) error {
@@ -415,7 +414,7 @@ func TestResourceRetries(t *testing.T) {
 
 		for ev := range xs {
 			ev.Handle(
-				func(s Store[*corev1.Node]) error {
+				func() error {
 					return nil
 				},
 				func(key Key, node *corev1.Node) error {

--- a/pkg/k8s/resource/retry.go
+++ b/pkg/k8s/resource/retry.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+type ErrorAction string
+
+var (
+	// ErrorActionRetry instructs to retry the processing. The key is requeued after
+	// rate limiting.
+	ErrorActionRetry ErrorAction = "retry"
+
+	// ErrorActionIgnore instructs to ignore the error.
+	ErrorActionIgnore ErrorAction = "ignore"
+
+	// ErrorActionStop instructs to stop the processing for this subscriber.
+	// The stream is completed with the error leading to this action.
+	ErrorActionStop ErrorAction = "stop"
+)
+
+type ErrorHandler func(key Key, numRetries int, err error) ErrorAction
+
+// AlwaysRetry is an error handler that always retries the error.
+func AlwaysRetry(Key, int, error) ErrorAction {
+	return ErrorActionRetry
+}
+
+// RetryUpTo is an error handler that retries a key up to specified number of
+// times before stopping.
+func RetryUpTo(n int) ErrorHandler {
+	return func(key Key, numRetries int, err error) ErrorAction {
+		if numRetries >= n {
+			return ErrorActionStop
+		}
+		return ErrorActionRetry
+	}
+}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -41,7 +41,7 @@ const (
 // default to avoid external dependencies from writing out unexpectedly
 var DefaultLogger = InitializeDefaultLogger()
 
-func init() {
+func initializeKLog() {
 	log := DefaultLogger.WithField(logfields.LogSubsys, "klog")
 
 	//Create a new flag set and set error handler
@@ -151,6 +151,10 @@ func AddHooks(hooks ...logrus.Hook) {
 // SetupLogging sets up each logging service provided in loggers and configures
 // each logger with the provided logOpts.
 func SetupLogging(loggers []string, logOpts LogOptions, tag string, debug bool) error {
+	// Bridge klog to logrus. Note that this will open multiple pipes and fork
+	// background goroutines that are not cleaned up.
+	initializeKLog()
+
 	// Updating the default log format
 	SetLogFormat(logOpts.GetLogFormat())
 

--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -77,7 +77,7 @@ func newLocalNodeStore(params LocalNodeStoreParams) (LocalNodeStore, error) {
 	s.cond = sync.NewCond(&s.mu)
 
 	params.Lifecycle.Append(hive.Hook{
-		OnStart: func(context.Context) error {
+		OnStart: func(hive.HookContext) error {
 			s.mu.Lock()
 			defer s.mu.Unlock()
 			if params.Init != nil {
@@ -92,7 +92,7 @@ func newLocalNodeStore(params LocalNodeStoreParams) (LocalNodeStore, error) {
 			emit(s.value)
 			return nil
 		},
-		OnStop: func(context.Context) error {
+		OnStop: func(hive.HookContext) error {
 			s.mu.Lock()
 			s.complete(nil)
 			s.complete = nil

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -49,7 +49,7 @@ func TestLocalNodeStore(t *testing.T) {
 	// the local node.
 	update := func(lc hive.Lifecycle, store LocalNodeStore) {
 		lc.Append(hive.Hook{
-			OnStart: func(context.Context) error {
+			OnStart: func(hive.HookContext) error {
 				// emit 2, 3, 4, 5
 				for _, i := range expected[1:] {
 					store.Update(func(n *types.Node) {

--- a/pkg/stream/helpers_test.go
+++ b/pkg/stream/helpers_test.go
@@ -8,8 +8,14 @@ import (
 	"errors"
 	"testing"
 
+	"go.uber.org/goleak"
+
 	. "github.com/cilium/cilium/pkg/stream"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func assertSlice[T comparable](t *testing.T, what string, expected []T, actual []T) {
 	t.Helper()

--- a/pkg/stream/operators_test.go
+++ b/pkg/stream/operators_test.go
@@ -192,9 +192,13 @@ func TestDebounce(t *testing.T) {
 	defer cancel()
 
 	in := make(chan int, 16)
+
+	defer close(in)
 	src := FromChannel(in)
 	src = Debounce(src, 5*time.Millisecond)
+
 	errs := make(chan error)
+	defer close(errs)
 	out := ToChannel(ctx, errs, src)
 
 	in <- -1


### PR DESCRIPTION
This PR includes multiple small improvements to pkg/k8s/resource and pkg/k8s/client libraries found during review of https://github.com/cilium/cilium/pull/21617. 

*logging: Initialize klog from SetupLogging*
This delays the klog bridging to logrus so we don't have logging related goroutines running for tests and we can use the goleak library to check for leaked goroutines.

*k8s/client: Set up clientset in constructor*
It's useful to be able to use the clientset object before starting to get a narrower interface from the clientset for constructing e.g. ListerWatcher: `clientset.CoreV1().Pods("")` does not perform actual API calls so should be allowed.

*k8s/resource: Make retries configurable*
Adds configurable retries to resource and simplifies the construction of the resource:
`func New[T k8sRuntime.Object](lc hive.Lifecycle, lw cache.ListerWatcher, opts ...Option) Resource[T]`
This commit also fixes a goroutine leak as the DelayingQueue in client-go's workqueue didn't implement
override for ShutDownWithDrain. Workaround is to call both ShutDownWithDrain() and ShutDown().

*hive: Make Hook into an interface*
Often the lifecycle hook is implemented by an object. This changes `Append` to take an interface instead of the hook struct
to simplify use in the common case. Downside is that we need special handling for the hook struct to show the correct function name and to support optionality (OnStart=nil).

*stream: Add goroutine leak checks*
Add the goleak check to the stream library and fix an issue in the Debounce operator: the errors channel given to ToChannel was not drained on context cancellation, leading to ToChannel's goroutine getting blocked on send to error channel.

*k8s/resource: Drop Store[T] from SyncEvent*
Drop the Store[T] from the sync event. It's already available via Store() and usually not useful.

*k8s/resource: Make handlers optional in Event.Handle()*
Allow `event.Handle(nil, onUpdate, onDelete)` as quite often we don't need to handle the sync event.