### PR TITLE
ipcache: Release metadata mutex in loop error condition

### DIFF
--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -66,6 +66,7 @@ func (ipc *IPCache) AllocateCIDRs(
 		if err != nil {
 			ipc.IdentityAllocator.ReleaseSlice(context.Background(), nil, usedIdentities)
 			ipc.Unlock()
+			ipc.metadata.RUnlock()
 			return nil, err
 		}
 


### PR DESCRIPTION
Found while backporting the following commit to older branches.

Fixes: 021ea42e6f8c ("ipcache: Fix metadata access from CIDR allocation")
