### PR TITLE
ipcache: Add ability to override identity via UpsertMetadata

### DIFF
--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -5,7 +5,6 @@ package ipcache
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/netip"
 	"strings"
@@ -56,13 +55,13 @@ func (ipc *IPCache) AllocateCIDRs(
 	ipc.Lock()
 	allocatedIdentities := make(map[netip.Prefix]*identity.Identity, len(prefixes))
 	for i, prefix := range prefixes {
-		lbls := cidr.GetCIDRLabels(prefix)
-		lbls.MergeLabels(ipc.metadata.getLocked(prefix).ToLabels())
+		info := ipc.metadata.getLocked(prefix)
+
 		oldNID := identity.InvalidIdentity
 		if oldNIDs != nil && len(oldNIDs) > i {
 			oldNID = oldNIDs[i]
 		}
-		id, isNew, err := ipc.allocate(allocateCtx, prefix, lbls, oldNID)
+		id, isNew, err := ipc.resolveIdentity(allocateCtx, prefix, info, oldNID)
 		if err != nil {
 			ipc.IdentityAllocator.ReleaseSlice(context.Background(), nil, usedIdentities)
 			ipc.Unlock()
@@ -163,33 +162,6 @@ func (ipc *IPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[netip
 			Source: source.Generated,
 		})
 	}
-}
-
-// allocate will allocate a new identity for the given prefix based on the
-// given set of labels. This function performs both global and local (CIDR)
-// identity allocation and the set of labels determine which identity
-// allocation type is to occur.
-//
-// If the identity is a CIDR identity, then its corresponding Identity will
-// have its CIDR labels set correctly.
-//
-// A possible previously used numeric identity for these labels can be passed
-// in as the 'oldNID' parameter; identity.InvalidIdentity must be passed if no
-// previous numeric identity exists.
-//
-// It is up to the caller to provide the full set of labels for identity
-// allocation.
-func (ipc *IPCache) allocate(ctx context.Context, prefix netip.Prefix, lbls labels.Labels, oldNID identity.NumericIdentity) (*identity.Identity, bool, error) {
-	id, isNew, err := ipc.IdentityAllocator.AllocateIdentity(ctx, lbls, false, oldNID)
-	if err != nil {
-		return nil, isNew, fmt.Errorf("failed to allocate identity for cidr %s: %s", prefix, err)
-	}
-
-	if lbls.Has(labels.LabelWorld[labels.IDNameWorld]) {
-		id.CIDRLabel = labels.NewLabelsFromModel([]string{labels.LabelSourceCIDR + ":" + prefix.String()})
-	}
-
-	return id, isNew, err
 }
 
 func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, prefixes []netip.Prefix) {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -506,6 +506,24 @@ func (ipc *IPCache) RemoveLabels(cidr netip.Prefix, lbls labels.Labels, resource
 	ipc.RemoveMetadata(cidr, resource, lbls)
 }
 
+// OverrideIdentity overrides the identity for a given prefix in the IPCache metadata
+// map. This is used when a resource indicates that this prefix already has a
+// defined identity, and where any additional labels associated with the prefix
+// are to be ignored.
+// If multiple resources override the identity, a warning is emitted and only
+// one of the override identities is used.
+// This will trigger asynchronous calculation of any local identity changes
+// that must occur to associate the specified labels with the prefix, and push
+// any datapath updates necessary to implement the logic associated with the
+// metadata currently associated with the 'prefix'.
+func (ipc *IPCache) OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
+	ipc.UpsertMetadata(prefix, src, resource, overrideIdentity(true), identityLabels)
+}
+
+func (ipc *IPCache) RemoveIdentityOverride(cidr netip.Prefix, identityLabels labels.Labels, resource ipcacheTypes.ResourceID) {
+	ipc.RemoveMetadata(cidr, resource, overrideIdentity(true), identityLabels)
+}
+
 // DumpToListenerLocked dumps the entire contents of the IPCache by triggering
 // the listener's "OnIPIdentityCacheChange" method for each entry in the cache.
 // The caller *MUST* grab the IPCache.Lock for reading before calling this

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -251,9 +251,8 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 			// iteration of the loop, then we must balance the
 			// allocation from the prior InjectLabels() call by
 			// releasing the previous reference.
-			if _, ok := idsToAdd[oldID.ID]; !ok {
-				previouslyAllocatedIdentities[prefix] = oldID
-			}
+			previouslyAllocatedIdentities[prefix] = oldID
+
 			// If all associated metadata for this prefix has been removed,
 			// and the existing IPCache entry was never touched by any other
 			// subsystem using the old Upsert API, then we can safely remove

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -382,6 +382,14 @@ func (ipc *IPCache) injectLabels(ctx context.Context, prefix netip.Prefix, lbls 
 
 	// If no other labels are associated with this IP, we assume that it's
 	// outside of the cluster and hence needs a CIDR identity.
+	//
+	// This is trying to ensure that remote nodes are assigned the reserved
+	// identity "remote-node" (6) or "kube-apiserver" (7). The datapath
+	// later makes assumptions about remote cluster nodes in the function
+	// identity_is_remote_node(). For now, there is no way to associate any
+	// other labels with such IPs, but this assumption will break if/when
+	// we allow more arbitrary labels to be associated with these IPs that
+	// correspond to remote nodes.
 	if !(lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode])) {
 		// GH-17962: Handle the following case:
 		//   1) Apply ToCIDR policy (matching IPs of kube-apiserver)

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -4,8 +4,14 @@
 package ipcache
 
 import (
+	"bytes"
+	"sort"
+
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -15,13 +21,20 @@ import (
 // to generate ipcache output based on a range of inputs.
 type prefixInfo map[types.ResourceID]*resourceInfo
 
+// IdentityOverride can be used to override the identity of a given prefix.
+// Must be provided together with a set of labels. Any other labels associated
+// with this prefix are ignored while an override is present.
+// This type implements ipcache.IPMetadata
+type overrideIdentity bool
+
 // resourceInfo is all of the information that has been collected from a given
 // resource (types.ResourceID) about this IP. Each field must have a 'zero'
 // value that indicates that it should be ignored for purposes of merging
 // multiple resourceInfo across multiple ResourceIDs together.
 type resourceInfo struct {
-	labels labels.Labels
-	source source.Source
+	labels           labels.Labels
+	source           source.Source
+	identityOverride overrideIdentity
 }
 
 // IPMetadata is an empty interface intended to inform developers using the
@@ -41,6 +54,8 @@ func (m *resourceInfo) merge(info IPMetadata, src source.Source) {
 	switch info := info.(type) {
 	case labels.Labels:
 		m.labels = labels.NewFrom(info)
+	case overrideIdentity:
+		m.identityOverride = info
 	default:
 		log.Errorf("BUG: Invalid IPMetadata passed to ipinfo.merge(): %+v", info)
 		return
@@ -53,6 +68,8 @@ func (m *resourceInfo) unmerge(info IPMetadata) {
 	switch info.(type) {
 	case labels.Labels:
 		m.labels = nil
+	case overrideIdentity:
+		m.identityOverride = false
 	default:
 		log.Errorf("BUG: Invalid IPMetadata passed to ipinfo.unmerge(): %+v", info)
 		return
@@ -60,7 +77,13 @@ func (m *resourceInfo) unmerge(info IPMetadata) {
 }
 
 func (m *resourceInfo) isValid() bool {
-	return m.labels != nil
+	if m.labels != nil {
+		return true
+	}
+	if m.identityOverride {
+		return true
+	}
+	return false
 }
 
 func (s prefixInfo) isValid() bool {
@@ -88,4 +111,70 @@ func (s prefixInfo) Source() source.Source {
 		}
 	}
 	return src
+}
+
+// identityOverride extracts the labels of the pre-determined identity from
+// the prefix info. If no override identity is present, this returns nil.
+// This pre-determined identity will overwrite any other identity which may
+// be derived from the prefix labels.
+func (s prefixInfo) identityOverride() (lbls labels.Labels, hasOverride bool) {
+	identities := make([]labels.Labels, 0, 1)
+	for _, info := range s {
+		// We emit a warning in logConflicts if an identity override
+		// was requested without labels
+		if info.identityOverride && len(info.labels) > 0 {
+			identities = append(identities, info.labels)
+		}
+	}
+
+	// No override identity present
+	if len(identities) == 0 {
+		return nil, false
+	}
+
+	// Conflict-resolution: We pick the labels with the alphabetically
+	// lowest value when formatted in the KV store format. The conflict
+	// is logged below in logConflicts.
+	if len(identities) > 1 {
+		sort.Slice(identities, func(i, j int) bool {
+			a := identities[i].SortedList()
+			b := identities[j].SortedList()
+			return bytes.Compare(a, b) == -1
+		})
+	}
+
+	return identities[0], true
+}
+
+func (s prefixInfo) logConflicts(scopedLog *logrus.Entry) {
+	var (
+		override           labels.Labels
+		overrideResourceID types.ResourceID
+	)
+
+	for resourceID, info := range s {
+		if info.identityOverride {
+			if len(override) > 0 {
+				scopedLog.WithFields(logrus.Fields{
+					logfields.Identity:            override.String(),
+					logfields.Resource:            overrideResourceID,
+					logfields.ConflictingIdentity: info.labels.String(),
+					logfields.ConflictingResource: resourceID,
+				}).Warning("Detected conflicting identity override for prefix. " +
+					"This may cause connectivity issues for this address.")
+			}
+
+			if len(info.labels) == 0 {
+				scopedLog.WithFields(logrus.Fields{
+					logfields.Resource:    resourceID,
+					logfields.OldIdentity: s.ToLabels().String(),
+				}).Warning("Detected identity override, but no labels where specified. " +
+					"Falling back on the old non-override labels. " +
+					"This may cause connectivity issues for this address.")
+			} else {
+				override = info.labels
+				overrideResourceID = resourceID
+			}
+		}
+	}
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -50,6 +50,10 @@ const (
 	// Identity is the identifier of a security identity
 	Identity = "identity"
 
+	// ConflictingIdentity is the identifier of a security identity that conflicts
+	// with 'Identity'
+	ConflictingIdentity = "conflictingIdentity"
+
 	// Ingress is the identifier of an ingress object
 	Ingress = "ingress"
 
@@ -383,6 +387,9 @@ const (
 
 	// Resource is a resource
 	Resource = "resource"
+
+	// ConflictingResource is a resource that conflicts with 'Resource'
+	ConflictingResource = "conflictingResource"
 
 	// Route is a L2 or L3 Linux route
 	Route = "route"

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -108,6 +108,11 @@ func (f *MockIdentityAllocator) Release(_ context.Context, id *identity.Identity
 	if realID.ReferenceCount == 1 {
 		delete(f.idToIdentity, int(id.ID))
 		delete(f.IdentityCache, id.ID)
+		for key, lblID := range f.labelsToIdentity {
+			if lblID == int(id.ID) {
+				delete(f.labelsToIdentity, key)
+			}
+		}
 	} else {
 		realID.ReferenceCount--
 		return false, nil

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -70,7 +70,7 @@ func (f *MockIdentityAllocator) AllocateIdentity(_ context.Context, lbls labels.
 
 	requiresGlobal := identity.RequiresGlobalIdentity(lbls)
 
-	if numID, ok := f.labelsToIdentity[lbls.String()]; ok && !requiresGlobal {
+	if numID, ok := f.labelsToIdentity[lbls.String()]; ok {
 		id := f.idToIdentity[numID]
 		id.ReferenceCount++
 		return id, false, nil


### PR DESCRIPTION
The new asynchronous IPCache API tries to determine the identity of a
prefix based on the provided labels. However, in some cases, the sources
providing the IPCache metadata (e.g. CiliumNode, CiliumEndpoint) already
know the numeric identity of the prefix. In that case, we want to give
that predefined global identity preference over any local identity we
might derive from the labels.

All other metadata is still tracked. If the override is ever removed
from the prefix, the metadata will be used to determine the new prefix
identity.

Currently, the override identity is always accepted, regardless whether
the numeric identity is known e.g. to the identity allocator. This
behavior mirrors the current semantics of the legacy IPCache.Upsert
method. In the future, we could consider blocking overrides until they
are actually known to the identity allocator.

Identities added via override do not trigger a policy map update. It is
assumed that the policy map update for those identities is handled
elsewhere. This again mirrors the current behavior of IPCache.Upsert.