### PR TITLE
fqdn/dnsproxy: Add concurrency grace period parameter

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -344,7 +344,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	}
 	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
 		option.Config.DNSMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
-		d.notifyOnDNSMsg, option.Config.DNSProxyConcurrencyLimit)
+		d.notifyOnDNSMsg, option.Config.DNSProxyConcurrencyLimit, option.Config.DNSProxyConcurrencyProcessingGracePeriod)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
 		err = d.l7Proxy.SetProxyPort(proxy.DNSProxyName, proxy.ProxyTypeDNS, proxy.DefaultDNSProxy.GetBindPort(), false)

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -425,7 +425,14 @@ func (proxyStat *ProxyRequestContext) IsTimeout() bool {
 // notifyFunc will be called with DNS response data that is returned to a
 // requesting endpoint. Note that denied requests will not trigger this
 // callback.
-func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRestoreDNSIPs int, lookupEPFunc LookupEndpointIDByIPFunc, lookupSecIDFunc LookupSecIDByIPFunc, lookupIPsFunc LookupIPsBySecIDFunc, notifyFunc NotifyOnDNSMsgFunc, concurrencyLimit int) (*DNSProxy, error) {
+func StartDNSProxy(
+	address string, port uint16, enableDNSCompression bool, maxRestoreDNSIPs int,
+	lookupEPFunc LookupEndpointIDByIPFunc,
+	lookupSecIDFunc LookupSecIDByIPFunc,
+	lookupIPsFunc LookupIPsBySecIDFunc,
+	notifyFunc NotifyOnDNSMsgFunc,
+	concurrencyLimit int, concurrencyGracePeriod time.Duration,
+) (*DNSProxy, error) {
 	if err := re.InitRegexCompileLRU(option.Config.FQDNRegexCompileLRUSize); err != nil {
 		return nil, fmt.Errorf("failed to start DNS proxy: %w", err)
 	}
@@ -454,7 +461,7 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 	}
 	if concurrencyLimit > 0 {
 		p.ConcurrencyLimit = semaphore.NewWeighted(int64(concurrencyLimit))
-		p.ConcurrencyGracePeriod = option.Config.DNSProxyConcurrencyProcessingGracePeriod
+		p.ConcurrencyGracePeriod = concurrencyGracePeriod
 	}
 	atomic.StoreInt32(&p.rejectReply, dns.RcodeRefused)
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -231,7 +231,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error {
 			return nil
 		},
-		0,
+		0, 0,
 	)
 	c.Assert(err, IsNil, Commentf("error starting DNS Proxy"))
 	s.proxy = proxy


### PR DESCRIPTION
Add a parameter to explicitly set the concurrency grace period of the dnsproxy.
Doing this instead of relying directly on the value from the option package enables better reuse of the dnsproxy from other consumers.