### PR TITLE
ipcache: Add support to store identities internally

### DIFF
--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -5,7 +5,6 @@ package ipcache
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/netip"
 	"strings"
@@ -56,13 +55,13 @@ func (ipc *IPCache) AllocateCIDRs(
 	ipc.Lock()
 	allocatedIdentities := make(map[netip.Prefix]*identity.Identity, len(prefixes))
 	for i, prefix := range prefixes {
-		lbls := cidr.GetCIDRLabels(prefix)
-		lbls.MergeLabels(ipc.metadata.getLocked(prefix).ToLabels())
+		info := ipc.metadata.getLocked(prefix)
+
 		oldNID := identity.InvalidIdentity
 		if oldNIDs != nil && len(oldNIDs) > i {
 			oldNID = oldNIDs[i]
 		}
-		id, isNew, err := ipc.allocate(allocateCtx, prefix, lbls, oldNID)
+		id, isNew, err := ipc.resolveIdentity(allocateCtx, prefix, info, oldNID)
 		if err != nil {
 			ipc.IdentityAllocator.ReleaseSlice(context.Background(), nil, usedIdentities)
 			ipc.Unlock()
@@ -162,33 +161,6 @@ func (ipc *IPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[netip
 			Source: source.Generated,
 		})
 	}
-}
-
-// allocate will allocate a new identity for the given prefix based on the
-// given set of labels. This function performs both global and local (CIDR)
-// identity allocation and the set of labels determine which identity
-// allocation type is to occur.
-//
-// If the identity is a CIDR identity, then its corresponding Identity will
-// have its CIDR labels set correctly.
-//
-// A possible previously used numeric identity for these labels can be passed
-// in as the 'oldNID' parameter; identity.InvalidIdentity must be passed if no
-// previous numeric identity exists.
-//
-// It is up to the caller to provide the full set of labels for identity
-// allocation.
-func (ipc *IPCache) allocate(ctx context.Context, prefix netip.Prefix, lbls labels.Labels, oldNID identity.NumericIdentity) (*identity.Identity, bool, error) {
-	id, isNew, err := ipc.IdentityAllocator.AllocateIdentity(ctx, lbls, false, oldNID)
-	if err != nil {
-		return nil, isNew, fmt.Errorf("failed to allocate identity for cidr %s: %s", prefix, err)
-	}
-
-	if lbls.Has(labels.LabelWorld[labels.IDNameWorld]) {
-		id.CIDRLabel = labels.NewLabelsFromModel([]string{labels.LabelSourceCIDR + ":" + prefix.String()})
-	}
-
-	return id, isNew, err
 }
 
 func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, prefixes []netip.Prefix) {

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -379,6 +379,14 @@ func (ipc *IPCache) injectLabels(ctx context.Context, prefix netip.Prefix, lbls 
 
 	// If no other labels are associated with this IP, we assume that it's
 	// outside of the cluster and hence needs a CIDR identity.
+	//
+	// This is trying to ensure that remote nodes are assigned the reserved
+	// identity "remote-node" (6) or "kube-apiserver" (7). The datapath
+	// later makes assumptions about remote cluster nodes in the function
+	// identity_is_remote_node(). For now, there is no way to associate any
+	// other labels with such IPs, but this assumption will break if/when
+	// we allow more arbitrary labels to be associated with these IPs that
+	// correspond to remote nodes.
 	if !(lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode])) {
 		// GH-17962: Handle the following case:
 		//   1) Apply ToCIDR policy (matching IPs of kube-apiserver)

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -188,10 +188,8 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 		} else {
 			var newID *identity.Identity
 
-			lbls := prefixInfo.ToLabels()
-
 			// Insert to propagate the updated set of labels after removal.
-			newID, _, err = ipc.injectLabels(ctx, prefix, lbls)
+			newID, _, err = ipc.resolveIdentity(ctx, prefix, prefixInfo, identity.InvalidIdentity)
 			if err != nil {
 				// NOTE: This may fail during a 2nd or later
 				// iteration of the loop. To handle this, break
@@ -206,7 +204,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 				log.WithError(err).WithFields(logrus.Fields{
 					logfields.IPAddr:   prefix,
 					logfields.Identity: id,
-					logfields.Labels:   lbls, // new labels
+					logfields.Labels:   newID.Labels,
 				}).Warning(
 					"Failed to allocate new identity while handling change in labels associated with a prefix.",
 				)
@@ -225,7 +223,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 				goto releaseIdentity
 			}
 
-			idsToAdd[newID.ID] = lbls.LabelArray()
+			idsToAdd[newID.ID] = newID.Labels.LabelArray()
 			entriesToReplace[prefix] = Identity{
 				ID:     newID.ID,
 				Source: prefixInfo.Source(),
@@ -345,18 +343,22 @@ func (ipc *IPCache) UpdatePolicyMaps(ctx context.Context, addedIdentities, delet
 	policyImplementedWG.Wait()
 }
 
-// injectLabels will allocate an identity for the given prefix and the given
-// labels. The caller of this function can expect that an identity is newly
-// allocated with reference count of 1 or an identity is looked up and its
-// reference count is incremented.
+// resolveIdentity will either return a previously-allocated identity for the
+// given prefix or allocate a new one corresponding to the labels associated
+// with the specified prefixInfo.
 //
-// The release of the identity must be managed by the caller, except for the
-// case where a CIDR policy exists first and then the kube-apiserver policy is
-// applied. This is because the CIDR identities before the kube-apiserver
-// policy is applied will need to be converted (released and re-allocated) to
-// account for the new kube-apiserver label that will be attached to them. This
-// is a known issue, see GH-17962 below.
-func (ipc *IPCache) injectLabels(ctx context.Context, prefix netip.Prefix, lbls labels.Labels) (*identity.Identity, bool, error) {
+// This function will take an additional reference on the returned identity.
+// The caller *must* ensure that this reference is eventually released via
+// a call to ipc.IdentityAllocator.Release(). Typically this is tied to whether
+// the caller subsequently injects an entry into the BPF IPCache map:
+//   - If the entry is inserted, we assume that the entry will eventually be
+//     removed, and when it is removed, we will remove that reference from the
+//     identity & release the identity.
+//   - If the entry is not inserted (for instance, because the bpf IPCache map
+//     already has the same IP -> identity entry in the map), immediately release
+//     the reference.
+func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, info prefixInfo, restoredIdentity identity.NumericIdentity) (*identity.Identity, bool, error) {
+	lbls := info.ToLabels()
 	if lbls.Has(labels.LabelHost[labels.IDNameHost]) {
 		// Associate any new labels with the host identity.
 		//
@@ -387,38 +389,19 @@ func (ipc *IPCache) injectLabels(ctx context.Context, prefix netip.Prefix, lbls 
 	// other labels with such IPs, but this assumption will break if/when
 	// we allow more arbitrary labels to be associated with these IPs that
 	// correspond to remote nodes.
-	if !(lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode])) {
-		// GH-17962: Handle the following case:
-		//   1) Apply ToCIDR policy (matching IPs of kube-apiserver)
-		//   2) Apply kube-apiserver policy
-		//
-		// Possible implementation:
-		//   Lookup CIDR ID => get all CIDR labels minus kube-apiserver label.
-		//   If found, means that ToCIDR policy already applied. Convert CIDR
-		//   IDs to include a new identity with kube-apiserver label. We don't
-		//   need to remove old entries from ipcache because the caller will
-		//   overwrite the ipcache entry anyway.
-
-		return ipc.injectLabelsForCIDR(ctx, prefix, lbls)
+	if !lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) {
+		cidrLabels := cidrlabels.GetCIDRLabels(prefix)
+		lbls.MergeLabels(cidrLabels)
 	}
 
-	return ipc.IdentityAllocator.AllocateIdentity(ctx, lbls, false, identity.InvalidIdentity)
-}
-
-// injectLabelsForCIDR will allocate a CIDR identity for the given prefix. The
-// release of the identity must be managed by the caller.
-func (ipc *IPCache) injectLabelsForCIDR(ctx context.Context, prefix netip.Prefix, lbls labels.Labels) (*identity.Identity, bool, error) {
-	allLbls := cidrlabels.GetCIDRLabels(prefix)
-	allLbls.MergeLabels(lbls)
-
-	log.WithFields(logrus.Fields{
-		logfields.CIDR:   prefix,
-		logfields.Labels: lbls, // omitting allLbls as CIDR labels would make this massive
-	}).Debug(
-		"Injecting CIDR labels for prefix",
-	)
-
-	return ipc.allocate(ctx, prefix, allLbls, identity.InvalidIdentity)
+	// This should only ever allocate an identity locally on the node,
+	// which could theoretically fail if we ever allocate a very large
+	// number of identities.
+	id, isNew, err := ipc.IdentityAllocator.AllocateIdentity(ctx, lbls, false, restoredIdentity)
+	if lbls.Has(labels.LabelWorld[labels.IDNameWorld]) {
+		id.CIDRLabel = labels.NewLabelsFromModel([]string{labels.LabelSourceCIDR + ":" + prefix.String()})
+	}
+	return id, isNew, err
 }
 
 // RemoveLabelsExcluded removes the given labels from all IPs inside the IDMD


### PR DESCRIPTION
This PR is provided as a draft for exploring these ideas only. It is expected to be superseded by #21667 

Review commit by commit.

Background                                                                                                                                                                                                                                                                                                                                                                                                                                
==========                                                                                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                          
The original IPCache userspace API supported two overlapping identities                                                                                                                                                                                                                                                                                                                                                                   
in the userspace IPCache, if the caller was aware that by specifying the                                                                                                                                                                                                                                                                                                                                                                  
key as '192.0.2.3' is different from '192.0.2.3/32'. In this case, when                                                                                                                                                                                                                                                                                                                                                                   
the userspace IPCache representation attempts to populate the datapath                                                                                                                                                                                                                                                                                                                                                                    
IPCache map, it would resolve the overlapping identities by prioritizing                                                                                                                                                                                                                                                                                                                                                                  
the entry without the suffix.                                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                          
Conflicting identities fall into one of the two following categories:                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                          
Endpoint Security Identities                                                                                                                                                                                                                                                                                                                                                                                                              
----------------------------                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                          
- Corresponds roughly to a Kubernetes Deployment                                                                                                                                                                                                                                                                                                                                                                                          
- May be shared by a set of specific IP addresses, not CIDRs                                                                                                                                                                                                                                                                                                                                                                              
- Synchronized between all Cilium agents in the cluster                                                                                                                                                                                                                                                                                                                                                                                   
- Allocated when a Pod is deployed in the cluster                                                                                                                                                                                                                                                                                                                                                                                         
- All Pods in the Deployment have the same Security Identity                                                                                                                                                                                                                                                                                                                                                                              
- Referenced in (Cilium) Network Policy by labels or Entities                                                                                                                                                                                                                                                                                                                                                                             
- Represents a peer within the Cilium-managed cluster.                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                                          
CIDR Security Identities                                                                                                                                                                                                                                                                                                                                                                                                                  
------------------------                                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                          
- Corresponds to a peer or range of peers, typically non-k8s workloads                                                                                                                                                                                                                                                                                                                                                                    
- Not shared, different for each CIDR (including specific IP addresses)                                                                                                                                                                                                                                                                                                                                                                   
- Not synchronized across the cluster, allocated locally on the node                                                                                                                                                                                                                                                                                                                                                                      
- Allocated when a network policy is created or DNS name is learned                                                                                                                                                                                                                                                                                                                                                                       
- Referenced in (Cilium) Network Policy by CIDR, IP or Entities                                                                                                                                                                                                                                                                                                                                                                           
- Typically represents a peer that a local endpoint attempts to                                                                                                                                                                                                                                                                                                                                                                           
  communicate with outside the cluster ("world")                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                          
The Cilium Network Policy model defines that an endpoint / IP peer                                                                                                                                                                                                                                                                                                                                                                        
belongs to exactly one of these two categories. The IP can only belong                                                                                                                                                                                                                                                                                                                                                                    
to the first category if a Kubernetes resource (CiliumEndpoint) defines                                                                                                                                                                                                                                                                                                                                                                   
that the IP corresponds to a specific set of labels (CiliumIdentity). If                                                                                                                                                                                                                                                                                                                                                                  
there is no such resource and a policy references a CIDR or IP, that                                                                                                                                                                                                                                                                                                                                                                      
range will correspond to a CIDR Identity. If this is the case, then                                                                                                                                                                                                                                                                                                                                                                       
subsequently an Endpoint is created for this IP, then this resource will                                                                                                                                                                                                                                                                                                                                                                  
override the Identity for the IP and it will switch from the "CIDR                                                                                                                                                                                                                                                                                                                                                                        
Identity" category to the Endpoint Security Identity category. For                                                                                                                                                                                                                                                                                                                                                                        
semantic consistency, the reverse is also true: If an IP corresponds to                                                                                                                                                                                                                                                                                                                                                                   
an Endpoint and there is an overlapping CIDR range in a policy, then the                                                                                                                                                                                                                                                                                                                                                                  
IP is released from the Endpoint, then the IP switches back to a CIDR                                                                                                                                                                                                                                                                                                                                                                     
identity and may be matched by the policy since the IP no longer                                                                                                                                                                                                                                                                                                                                                                          
corresponds to a peer inside the cluster.                                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                          
In order to implement these semantics, the IPCache internally holds each                                                                                                                                                                                                                                                                                                                                                                  
Identity that each CIDR / IP may map to, and if it is informed that both                                                                                                                                                                                                                                                                                                                                                                  
exist, it will resolve the conflict in userspace as described at the                                                                                                                                                                                                                                                                                                                                                                      
beginning of this background discussion. When the BPF ipcache map is                                                                                                                                                                                                                                                                                                                                                                      
updated, exactly one of those identities is populated (the one                                                                                                                                                                                                                                                                                                                                                                            
corresponding to the Endpoint in the cluster).                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                          
Description                                                                                                                                                                                                                                                                                                                                                                                                                               
===========                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                          
The older synchronous IPCache API has a few deficiencies that make it                                                                                                                                                                                                                                                                                                                                                                     
difficult to integrate with the rest of the codebase. It imposes more                                                                                                                                                                                                                                                                                                                                                                     
complexity on callers, such as:                                                                                                                                                                                                                                                                                                                                                                                                           
- Forcing callers to resolve label conflicts/merging                                                                                                                                                                                                                                                                                                                                                                                      
- Despite the key ultimately being a CIDR, the API requires strings                                                                                                                                                                                                                                                                                                                                                                       
- Understand the lock ordering across different subsystems such as                                                                                                                                                                                                                                                                                                                                                                        
  policy, endpoint, etc.                                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                          
Commit e63781492e1d ("ipcache: Introduce new asynchronous API") began                                                                                                                                                                                                                                                                                                                                                                     
introducing a newer, cleaner internal userspace IPCache API in order to                                                                                                                                                                                                                                                                                                                                                                   
address the aformentioned issues, but it did not yet provide a way to                                                                                                                                                                                                                                                                                                                                                                     
resolve the conflicts between the clusterwide Endpoint Security                                                                                                                                                                                                                                                                                                                                                                           
Identities and the CIDR Security Identities described in the background.                                                                                                                                                                                                                                                                                                                                                                  
Its API was tailored around the CIDR Security Identity callers.                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                          
This PR introduces new API functions for callers to specify the                                                                                                                                                                                                                                                                                                                                                                       
Endpoint Security Identities. The IPCache conflict resolution logic here                                                                                                                                                                                                                                                                                                                                                                  
prioritizes these Identities over the labels provided by callers into                                                                                                                                                                                                                                                                                                                                                                     
the UpsertMetadata() calls. By adding a dedicated API for these and                                                                                                                                                                                                                                                                                                                                                                       
integrating the internals into the new IPCache metadata data structure,                                                                                                                                                                                                                                                                                                                                                                   
it should allow more easy sharing of auxiliary information for specific                                                                                                                                                                                                                                                                                                                                                                   
CIDRs and support more consistent resolution of overlapping and                                                                                                                                                                                                                                                                                                                                                                           
conflicting information that needs to be provided to the datapath.                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                          
This PR introduces the infrastructure to convert callers over to                                                                                                                                                                                                                                                                                                                                                                      
this newer API, but it does not yet convert the callers over. That will                                                                                                                                                                                                                                                                                                                                                                   
be handled in subsequent PRs.