### PR TITLE
ipcache: Plumb daemon context through IPCache

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1362,6 +1362,9 @@ func (d *Daemon) ReloadOnDeviceChange(devices []string) {
 
 // Close shuts down a daemon
 func (d *Daemon) Close() {
+	if err := d.ipcache.Shutdown(); err != nil {
+		log.WithError(err).Debug("Failure during ipcache shutdown")
+	}
 	if d.policyUpdater != nil {
 		d.policyUpdater.Shutdown()
 	}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -574,6 +574,7 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup,
 		return nil, nil, fmt.Errorf("error while initializing policy subsystem: %w", err)
 	}
 	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{
+		Context:           ctx,
 		IdentityAllocator: d.identityAllocator,
 		PolicyHandler:     d.policy.GetSelectorCache(),
 		DatapathHandler:   epMgr,

--- a/pkg/ipcache/gc.go
+++ b/pkg/ipcache/gc.go
@@ -29,7 +29,7 @@ type prefixReleaser interface {
 	releaseCIDRIdentities(ctx context.Context, identities []netip.Prefix)
 }
 
-func newAsyncPrefixReleaser(parent prefixReleaser, interval time.Duration) *asyncPrefixReleaser {
+func newAsyncPrefixReleaser(parentCtx context.Context, parent prefixReleaser, interval time.Duration) *asyncPrefixReleaser {
 	result := &asyncPrefixReleaser{
 		queue:          make([]netip.Prefix, 0),
 		prefixReleaser: parent,
@@ -41,10 +41,8 @@ func newAsyncPrefixReleaser(parent prefixReleaser, interval time.Duration) *asyn
 		Name:        "ipcache-identity-gc",
 		MinInterval: interval,
 		TriggerFunc: func(reasons []string) {
-			// TODO: Structure the code to pass context down
-			//       from the Daemon.
 			ctx, cancel := context.WithTimeout(
-				context.TODO(),
+				parentCtx,
 				option.Config.KVstoreConnectivityTimeout)
 			defer cancel()
 			result.run(ctx, reasons...)

--- a/pkg/ipcache/gc.go
+++ b/pkg/ipcache/gc.go
@@ -20,6 +20,9 @@ type asyncPrefixReleaser struct {
 	*trigger.Trigger
 	prefixReleaser
 
+	closeChan chan struct{} // Daemon closes this when shutting down.
+	doneChan  chan struct{} // Trigger closes this to confirm shutdown.
+
 	// Mutex protects read and write to 'queue'.
 	lock.Mutex
 	queue []netip.Prefix
@@ -33,6 +36,8 @@ func newAsyncPrefixReleaser(parentCtx context.Context, parent prefixReleaser, in
 	result := &asyncPrefixReleaser{
 		queue:          make([]netip.Prefix, 0),
 		prefixReleaser: parent,
+		closeChan:      make(chan struct{}),
+		doneChan:       make(chan struct{}),
 	}
 
 	// trigger needs to be updated to reference the object above
@@ -47,15 +52,34 @@ func newAsyncPrefixReleaser(parentCtx context.Context, parent prefixReleaser, in
 			defer cancel()
 			result.run(ctx, reasons...)
 		},
+		ShutdownFunc: func() {
+			close(result.doneChan)
+		},
 	})
 
 	return result
+}
+
+func (pr *asyncPrefixReleaser) Shutdown() {
+	close(pr.closeChan)
+	pr.Trigger.Shutdown()
+	<-pr.doneChan
 }
 
 // enqueue a set of prefixes to be released asynchronously.
 func (pr *asyncPrefixReleaser) enqueue(prefixes []netip.Prefix, reason string) {
 	pr.Lock()
 	defer pr.Unlock()
+	select {
+	case <-pr.closeChan:
+		log.WithFields(logrus.Fields{
+			logfields.CIDRS:  prefixes,
+			logfields.Reason: reason,
+		}).Debug("Received request to release prefixes but the daemon is shutting down")
+		return
+	default:
+		// fallthrough
+	}
 	pr.queue = append(pr.queue, prefixes...)
 	pr.TriggerWithReason(reason)
 }

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -132,6 +132,12 @@ func NewIPCache(c *Configuration) *IPCache {
 	return ipc
 }
 
+// Shutdown cleans up asynchronous routines associated with the IPCache.
+func (ipc *IPCache) Shutdown() error {
+	ipc.deferredPrefixRelease.Shutdown()
+	return ipc.ShutdownLabelInjection()
+}
+
 // Lock locks the IPCache's mutex.
 func (ipc *IPCache) Lock() {
 	ipc.mutex.Lock()

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -4,6 +4,7 @@
 package ipcache
 
 import (
+	"context"
 	"net"
 	"net/netip"
 	"time"
@@ -56,6 +57,7 @@ type K8sMetadata struct {
 
 // Configuration is init-time configuration for the IPCache.
 type Configuration struct {
+	context.Context
 	// Accessors to other subsystems, provided by the daemon
 	cache.IdentityAllocator
 	ipcacheTypes.PolicyHandler
@@ -122,7 +124,11 @@ func NewIPCache(c *Configuration) *IPCache {
 		metadata:          newMetadata(),
 		Configuration:     c,
 	}
-	ipc.deferredPrefixRelease = newAsyncPrefixReleaser(ipc, 1*time.Millisecond)
+	ctx := context.Background()
+	if c != nil && c.Context != nil {
+		ctx = c.Context
+	}
+	ipc.deferredPrefixRelease = newAsyncPrefixReleaser(ctx, ipc, 1*time.Millisecond)
 	return ipc
 }
 

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -27,6 +27,8 @@ var (
 	// ErrLocalIdentityAllocatorUninitialized is an error that's returned when
 	// the local identity allocator is uninitialized.
 	ErrLocalIdentityAllocatorUninitialized = errors.New("local identity allocator uninitialized")
+
+	LabelInjectorName = "ipcache-inject-labels"
 )
 
 // metadata contains the ipcache metadata. Mainily it holds a map which maps IP
@@ -510,8 +512,9 @@ func (ipc *IPCache) TriggerLabelInjection() {
 	// This controller is for retrying this operation in case it fails. It
 	// should eventually succeed.
 	ipc.UpdateController(
-		"ipcache-inject-labels",
+		LabelInjectorName,
 		controller.ControllerParams{
+			Context: ipc.Configuration.Context,
 			DoFunc: func(ctx context.Context) error {
 				var err error
 
@@ -523,4 +526,9 @@ func (ipc *IPCache) TriggerLabelInjection() {
 			},
 		},
 	)
+}
+
+// ShutdownLabelInjection shuts down the controller in TriggerLabelInjection().
+func (ipc *IPCache) ShutdownLabelInjection() error {
+	return ipc.controllers.RemoveControllerAndWait(LabelInjectorName)
 }


### PR DESCRIPTION
Plumb the primary daemon context into the label injector logic and the
async prefix releaser in order to reduce the likelihood of issues where
this logic continues to execute beyond the lifetime of the agent.

Implement a Shutdown() function for the IPCache which shuts down the
goroutines associated with the IPcache and ensures they are completed
before returning. This way, other components should not continue to
cause the IPCache to asynchronously continue to execute work. This
should hopefully fix issues in unit tests where the IPCache defers some
work that interacts with the identityAllocator after it has been cleaned
up.

Found during unit testing, where the identity allocator would be closed
while the ipcache's garbage collection of identities was still running.

Suggested-by: Jussi Maki <jussi@isovalent.com>
Suggested-by: Aditi Ghag <aditi@cilium.io>