### PR TITLE
CI: Using the same function for Native CIDR for GKE and AKS 

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -150,7 +150,7 @@ var (
 		"cni.binPath":                 "/home/kubernetes/bin",
 		"gke.enabled":                 "true",
 		"loadBalancer.mode":           "snat",
-		"ipv4NativeRoutingCIDR":       GKENativeRoutingCIDR(),
+		"ipv4NativeRoutingCIDR":       NativeRoutingCIDR(),
 		"hostFirewall.enabled":        "false",
 		"ipam.mode":                   "kubernetes",
 		"devices":                     "", // Override "eth0 eth0\neth0"
@@ -163,7 +163,7 @@ var (
 		"extraArgs":                           "{--local-router-ipv4=169.254.23.0}",
 		"k8s.requireIPv4PodCIDR":              "false",
 		"ipv6.enabled":                        "false",
-		"ipv4NativeRoutingCIDR":               AKSNativeRoutingCIDR(),
+		"ipv4NativeRoutingCIDR":               NativeRoutingCIDR(),
 		"enableIPv4Masquerade":                "false",
 		"install-no-conntrack-iptables-rules": "false",
 		"installIptablesRules":                "true",

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -514,11 +514,7 @@ func RunsOn419Kernel() bool {
 	return os.Getenv("KERNEL") == "419"
 }
 
-func GKENativeRoutingCIDR() string {
-	return os.Getenv("NATIVE_CIDR")
-}
-
-func AKSNativeRoutingCIDR() string {
+func NativeRoutingCIDR() string {
 	return os.Getenv("NATIVE_CIDR")
 }
 

--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -48,7 +48,6 @@ var _ = Describe("K8sUpdates", func() {
 	)
 
 	BeforeAll(func() {
-
 		SkipIfIntegration(helpers.CIIntegrationAKS)
 		canRun, err := helpers.CanRunK8sVersion(helpers.CiliumStableVersion, helpers.GetCurrentK8SEnv())
 		ExpectWithOffset(1, err).To(BeNil(), "Unable to get k8s constraints for %s", helpers.CiliumStableVersion)


### PR DESCRIPTION

<!-- Description of change -->
- Using the same function to get the Native CIDR for GKE and AKS in e2e test.
- Addressing the nit comment of extra line in [PR ](https://github.com/cilium/cilium/pull/21277)

