### PR TITLE
Optimize generateLabelString()

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -627,7 +627,7 @@ func parseSelectLabel(str string, delim byte) Label {
 // generateLabelString generates the string representation of a label with
 // the provided source, key, and value in the format "source:key=value".
 func generateLabelString(source, key, value string) string {
-	return fmt.Sprintf("%s:%s=%s", source, key, value)
+	return source + ":" + key + "=" + value
 }
 
 // GenerateK8sLabelString generates the string representation of a label with

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -422,6 +422,14 @@ func BenchmarkLabel_String(b *testing.B) {
 	}
 }
 
+func BenchmarkGenerateLabelString(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		generateLabelString("foo", "key", "value")
+	}
+}
+
 func TestLabel_String(t *testing.T) {
 	// with value
 	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", "k8s")


### PR DESCRIPTION
Ref: #19571

Results:

```
new:   BenchmarkGenerateLabelString-8   	36379892	        39.96 ns/op	       0 B/op	       0 allocs/op
old:   BenchmarkGenerateLabelString-8   	 5249149	       211.8 ns/op	      64 B/op	       4 allocs/op
```

Signed-off-by:  youhonglian honglian.you@daocloud.io

