### PR TITLE
EgressGW cleanups

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1009,10 +1009,6 @@ ct_recreate4:
 
 #ifdef ENABLE_EGRESS_GATEWAY
 	{
-		struct egress_gw_policy_entry *egress_gw_policy;
-		struct endpoint_info *gateway_node_ep;
-		struct endpoint_key key = {};
-
 		/* If the packet is destined to an entity inside the cluster,
 		 * either EP or node, it should not be forwarded to an egress
 		 * gateway since only traffic leaving the cluster is supposed to
@@ -1029,27 +1025,17 @@ ct_recreate4:
 		if (ct_status == CT_REPLY || ct_status == CT_RELATED)
 			goto skip_egress_gateway;
 
-		egress_gw_policy = lookup_ip4_egress_gw_policy(ip4->saddr, ip4->daddr);
-		if (!egress_gw_policy)
-			goto skip_egress_gateway;
+		if (egress_gw_request_needs_redirect(ip4, &tunnel_endpoint)) {
+			struct endpoint_key key = {};
 
-		/* If the gateway node is the local node, then just let the
-		 * packet go through, as it will be SNATed later on by
-		 * handle_nat_fwd().
-		 */
-		gateway_node_ep = __lookup_ip4_endpoint(egress_gw_policy->gateway_ip);
-		if (gateway_node_ep && (gateway_node_ep->flags & ENDPOINT_F_HOST))
-			goto skip_egress_gateway;
+			/* Send the packet to egress gateway node through a tunnel. */
+			ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
+						     &key, SECLABEL, *dst_id, &trace);
+			if (ret == CTX_ACT_OK)
+				goto encrypt_to_stack;
 
-		/* Otherwise encap and redirect the packet to egress gateway
-		 * node through a tunnel.
-		 */
-		ret = encap_and_redirect_lxc(ctx, egress_gw_policy->gateway_ip, encrypt_key,
-					     &key, SECLABEL, *dst_id, &trace);
-		if (ret == CTX_ACT_OK)
-			goto encrypt_to_stack;
-		else
 			return ret;
+		}
 	}
 skip_egress_gateway:
 #endif

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1026,11 +1026,9 @@ ct_recreate4:
 			goto skip_egress_gateway;
 
 		if (egress_gw_request_needs_redirect(ip4, &tunnel_endpoint)) {
-			struct endpoint_key key = {};
-
 			/* Send the packet to egress gateway node through a tunnel. */
-			ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
-						     &key, SECLABEL, *dst_id, &trace);
+			ret = __encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
+						       SECLABEL, *dst_id, &trace);
 			if (ret == CTX_ACT_OK)
 				goto encrypt_to_stack;
 

--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -28,6 +28,62 @@ struct egress_gw_policy_entry *lookup_ip4_egress_gw_policy(__be32 saddr, __be32 
 	return map_lookup_elem(&EGRESS_POLICY_MAP, &key);
 }
 
+static __always_inline
+bool egress_gw_request_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint)
+{
+	struct egress_gw_policy_entry *egress_gw_policy;
+	struct endpoint_info *gateway_node_ep;
+
+	egress_gw_policy = lookup_ip4_egress_gw_policy(ip4->saddr, ip4->daddr);
+	if (!egress_gw_policy)
+		return false;
+
+	/* If the gateway node is the local node, then just let the
+	 * packet go through, as it will be SNATed later on by
+	 * handle_nat_fwd().
+	 */
+	gateway_node_ep = __lookup_ip4_endpoint(egress_gw_policy->gateway_ip);
+	if (gateway_node_ep && (gateway_node_ep->flags & ENDPOINT_F_HOST))
+		return false;
+
+	*tunnel_endpoint = egress_gw_policy->gateway_ip;
+	return true;
+}
+
+static __always_inline
+bool egress_gw_snat_needed(struct iphdr *ip4, __be32 *snat_addr)
+{
+	struct egress_gw_policy_entry *egress_gw_policy;
+
+	egress_gw_policy = lookup_ip4_egress_gw_policy(ip4->saddr, ip4->daddr);
+	if (!egress_gw_policy)
+		return false;
+
+	*snat_addr = egress_gw_policy->egress_ip;
+	return true;
+}
+
+static __always_inline
+bool egress_gw_reply_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint,
+				    __u32 *dst_id)
+{
+	struct egress_gw_policy_entry *egress_policy;
+	struct remote_endpoint_info *info;
+
+	/* Find a matching policy by looking up the reverse address tuple: */
+	egress_policy = lookup_ip4_egress_gw_policy(ip4->daddr, ip4->saddr);
+	if (!egress_policy)
+		return false;
+
+	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
+	if (!info || info->tunnel_endpoint == 0)
+		return false;
+
+	*tunnel_endpoint = info->tunnel_endpoint;
+	*dst_id = info->sec_label;
+	return true;
+}
+
 #endif /* ENABLE_EGRESS_GATEWAY */
 
 #ifdef ENABLE_SRV6

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -158,7 +158,7 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 /* encap_and_redirect_with_nodeid returns CTX_ACT_OK after ctx meta-data is
  * set (eg. when IPSec is enabled). Caller should pass the ctx to the stack at this
  * point. Otherwise returns CTX_ACT_REDIRECT on successful redirect to tunnel device.
- * On error returns CTX_ACT_DROP, DROP_NO_TUNNEL_ENDPOINT or DROP_WRITE_ERROR.
+ * On error returns CTX_ACT_DROP or DROP_WRITE_ERROR.
  */
 static __always_inline int
 encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -665,15 +665,11 @@ static __always_inline bool snat_v4_prepare_state(struct __ctx_buff *ctx,
 	if (is_reply)
 		goto skip_egress_gateway;
 
-	egress_gw_policy = lookup_ip4_egress_gw_policy(ip4->saddr, ip4->daddr);
-	if (!egress_gw_policy)
-		goto skip_egress_gateway;
+	if (egress_gw_snat_needed(ip4, &target->addr)) {
+		target->egress_gateway = true;
 
-	target->addr = egress_gw_policy->egress_ip;
-	target->egress_gateway = true;
-
-	return true;
-
+		return true;
+	}
 skip_egress_gateway:
 #endif
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1792,30 +1792,12 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 		return DROP_INVALID;
 
 #if defined(ENABLE_EGRESS_GATEWAY) && !defined(TUNNEL_MODE)
-	/* Traffic from clients to egress gateway nodes reaches said gateways
-	 * by a vxlan tunnel. If we are not using TUNNEL_MODE, we need to
-	 * identify reverse traffic from the gateway to clients and also steer
-	 * it via the vxlan tunnel to avoid issues with iptables dropping these
-	 * packets. We do this in the code below, by performing a lookup in the
-	 * egress gateway map using a reverse address tuple. A match means that
-	 * the corresponding forward traffic was forwarded to the egress gateway
-	 * via the tunnel.
+	/* If we are not using TUNNEL_MODE, the gateway node needs to manually steer
+	 * any reply traffic for a remote pod into the tunnel (to avoid iptables
+	 * potentially dropping the packets).
 	 */
-	{
-		struct egress_gw_policy_entry *egress_policy;
-
-		egress_policy = lookup_ip4_egress_gw_policy(ip4->daddr, ip4->saddr);
-		if (egress_policy) {
-			struct remote_endpoint_info *info;
-
-			info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
-			if (info && info->tunnel_endpoint != 0) {
-				tunnel_endpoint = info->tunnel_endpoint;
-				dst_id = info->sec_label;
-				goto encap_redirect;
-			}
-		}
-	}
+	if (egress_gw_reply_needs_redirect(ip4, &tunnel_endpoint, &dst_id))
+		goto encap_redirect;
 #endif /* ENABLE_EGRESS_GATEWAY */
 
 	tuple.nexthdr = ip4->protocol;

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -336,8 +336,7 @@ func (d *Daemon) initMaps() error {
 		return err
 	}
 
-	if option.Config.TunnelingEnabled() || option.Config.EnableIPv4EgressGateway {
-		// The IPv4 egress gateway feature also uses tunnel map
+	if option.Config.TunnelingEnabled() {
 		if _, err := tunnel.TunnelMap.OpenOrCreate(); err != nil {
 			return err
 		}


### PR DESCRIPTION
This pulls various pieces of EgressGW code into `egress_policies.h`. We also clean up the unused dependency on `TUNNEL_MAP`.

Fixes: https://github.com/cilium/cilium/issues/19785

```release-note
Egress Gateway: move code into its own header file, and remove the dependency on TUNNEL_MAP.
```
