### PR TITLE
Fix hubble metrics label ordering with contextOptions

### DIFF
--- a/pkg/hubble/metrics/drop/handler.go
+++ b/pkg/hubble/metrics/drop/handler.go
@@ -26,8 +26,8 @@ func (d *dropHandler) Init(registry *prometheus.Registry, options api.Options) e
 	}
 	d.context = c
 
-	labels := []string{"reason", "protocol"}
-	labels = append(labels, d.context.GetLabelNames()...)
+	contextLabels := d.context.GetLabelNames()
+	labels := append(contextLabels, "reason", "protocol")
 
 	d.drops = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: api.DefaultPrometheusNamespace,
@@ -48,12 +48,12 @@ func (d *dropHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error 
 		return nil
 	}
 
-	labels, err := d.context.GetLabelValues(flow)
+	contextLabels, err := d.context.GetLabelValues(flow)
 	if err != nil {
 		return err
 	}
 
-	labels = append(labels, monitorAPI.DropReason(uint8(flow.GetDropReason())), v1.FlowProtocol(flow))
+	labels := append(contextLabels, monitorAPI.DropReason(uint8(flow.GetDropReason())), v1.FlowProtocol(flow))
 
 	d.drops.WithLabelValues(labels...).Inc()
 	return nil

--- a/pkg/hubble/metrics/tcp/handler.go
+++ b/pkg/hubble/metrics/tcp/handler.go
@@ -23,9 +23,8 @@ func (h *tcpHandler) Init(registry *prometheus.Registry, options api.Options) er
 		return err
 	}
 	h.context = c
-
-	labels := []string{"flag", "family"}
-	labels = append(labels, h.context.GetLabelNames()...)
+	contextLabels := h.context.GetLabelNames()
+	labels := append(contextLabels, "flag", "family")
 
 	h.tcpFlags = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: api.DefaultPrometheusNamespace,
@@ -53,11 +52,11 @@ func (h *tcpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
 		return nil
 	}
 
-	labels, err := h.context.GetLabelValues(flow)
+	contextLabels, err := h.context.GetLabelValues(flow)
 	if err != nil {
 		return err
 	}
-	labels = append(labels, "", ip.IpVersion.String())
+	labels := append(contextLabels, "", ip.IpVersion.String())
 
 	if tcp.Flags.FIN {
 		labels[0] = "FIN"


### PR DESCRIPTION
This fixes an issue introduced by https://github.com/cilium/cilium/pull/21079/commits/d4d73681026bdf0335699d6ad262397613d143e4 in #21079  where metrics labels for drop, dns, and tcp metrics are incorrect when using any contextOptions. This is because the order labels are registered in, was different from the order the labels are used when incrementing the counters.

I had to refactor DNS a little bit because the logic was so complicated, and I tried to make it less "stateful" with the labels, which is part of the reason that one got done incorrectly in the first place. drop/tcp were simpler.

I'm not sure this actually needs a release note because I don't think the contextLabels PR has made it into a release yet, but I added one anyways.

```release-note
Fix hubble metrics label ordering with contextOptions
```