### PR TITLE
daemon: Top-level composition into a hierarchy of cells

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/gops"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+var (
+	Agent = cell.Module(
+		"agent",
+		"Cilium Agent",
+
+		Infrastructure,
+		ControlPlane,
+		Datapath,
+	)
+
+	// Infrastructure provides access and services to the outside.
+	// A cell should live here instead of ControlPlane if it is not needed by
+	// integrations tests, or needs to be mocked.
+	Infrastructure = cell.Module(
+		"infra",
+		"Infrastructure",
+
+		// Runs the gops agent, a tool to diagnose Go processes.
+		gops.Cell(defaults.GopsPortAgent),
+
+		// Provides Clientset, API for accessing Kubernetes objects.
+		k8sClient.Cell,
+	)
+
+	// ControlPlane implement the per-node control functions. These are pure
+	// business logic and depend on datapath or infrastructure to perform
+	// actions. This separation enables non-privileged integration testing of
+	// the control-plane.
+	ControlPlane = cell.Module(
+		"controlplane",
+		"Control Plane",
+
+		// LocalNodeStore holds onto the information about the local node and allows
+		// observing changes to it.
+		node.LocalNodeStoreCell,
+
+		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
+		daemonCell,
+	)
+
+	// Datapath provides the privileged operations to apply control-plane
+	// decision to the kernel.
+	Datapath = cell.Module(
+		"datapath",
+		"Datapath",
+
+		cell.Provide(
+			newWireguardAgent,
+			newDatapath,
+		),
+	)
+)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -373,9 +373,10 @@ func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 	return nil
 }
 
-// NewDaemon creates and returns a new Daemon with the parameters set in c.
-func NewDaemon(ctx context.Context, cleaner *daemonCleanup,
+// newDaemon creates and returns a new Daemon with the parameters set in c.
+func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	epMgr *endpointmanager.EndpointManager, dp datapath.Datapath,
+	wgAgent *wg.Agent,
 	clientset k8sClient.Clientset,
 ) (*Daemon, *endpointRestoreState, error) {
 
@@ -911,8 +912,8 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup,
 		bootstrapStats.k8sInit.End(true)
 	}
 
-	if wgAgent := dp.WireguardAgent(); option.Config.EnableWireguard {
-		if err := wgAgent.(*wg.Agent).Init(d.ipcache, mtuConfig); err != nil {
+	if wgAgent != nil && option.Config.EnableWireguard {
+		if err := wgAgent.Init(d.ipcache, d.mtuConfig); err != nil {
 			log.WithError(err).Error("failed to initialize wireguard agent")
 			return nil, nil, fmt.Errorf("failed to initialize wireguard agent: %w", err)
 		}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -392,6 +392,12 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup,
 		return nil, nil, fmt.Errorf("invalid daemon configuration: %s", err)
 	}
 
+	// Validate configuration options that depend on other cells.
+	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD && !clientset.IsEnabled() &&
+		option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
+		return nil, nil, fmt.Errorf("CRD Identity allocation mode requires k8s to be configured")
+	}
+
 	if option.Config.ReadCNIConfiguration != "" {
 		netConf, err = cnitypes.ReadNetConf(option.Config.ReadCNIConfiguration)
 		if err != nil {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1224,10 +1224,8 @@ func initEnv() {
 	}
 
 	// set rlimit Memlock to INFINITY before creating any bpf resources.
-	if !option.Config.DryMode {
-		if err := rlimit.RemoveMemlock(); err != nil {
-			log.WithError(err).Fatal("unable to set memory resource limits")
-		}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		log.WithError(err).Fatal("unable to set memory resource limits")
 	}
 	linuxdatapath.CheckMinRequirements()
 
@@ -1740,44 +1738,42 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 		ipmasqAgent.Start()
 	}
 
-	if !option.Config.DryMode {
-		go func() {
-			if restoreComplete != nil {
-				<-restoreComplete
+	go func() {
+		if restoreComplete != nil {
+			<-restoreComplete
+		}
+		d.dnsNameManager.CompleteBootstrap()
+
+		ms := maps.NewMapSweeper(&EndpointMapManager{
+			EndpointManager: d.endpointManager,
+		})
+		ms.CollectStaleMapGarbage()
+		ms.RemoveDisabledMaps()
+
+		if len(d.restoredCIDRs) > 0 {
+			// Release restored CIDR identities after a grace period (default 10
+			// minutes).  Any identities actually in use will still exist after
+			// this.
+			//
+			// This grace period is needed when running on an external workload
+			// where policy synchronization is not done via k8s. Also in k8s
+			// case it is prudent to allow concurrent endpoint regenerations to
+			// (re-)allocate the restored identities before we release them.
+			time.Sleep(option.Config.IdentityRestoreGracePeriod)
+			log.Debugf("Releasing reference counts for %d restored CIDR identities", len(d.restoredCIDRs))
+
+			prefixes := make([]netip.Prefix, 0, len(d.restoredCIDRs))
+			for _, c := range d.restoredCIDRs {
+				prefixes = append(prefixes, ip.IPNetToPrefix(c))
 			}
-			d.dnsNameManager.CompleteBootstrap()
-
-			ms := maps.NewMapSweeper(&EndpointMapManager{
-				EndpointManager: d.endpointManager,
-			})
-			ms.CollectStaleMapGarbage()
-			ms.RemoveDisabledMaps()
-
-			if len(d.restoredCIDRs) > 0 {
-				// Release restored CIDR identities after a grace period (default 10
-				// minutes).  Any identities actually in use will still exist after
-				// this.
-				//
-				// This grace period is needed when running on an external workload
-				// where policy synchronization is not done via k8s. Also in k8s
-				// case it is prudent to allow concurrent endpoint regenerations to
-				// (re-)allocate the restored identities before we release them.
-				time.Sleep(option.Config.IdentityRestoreGracePeriod)
-				log.Debugf("Releasing reference counts for %d restored CIDR identities", len(d.restoredCIDRs))
-
-				prefixes := make([]netip.Prefix, 0, len(d.restoredCIDRs))
-				for _, c := range d.restoredCIDRs {
-					prefixes = append(prefixes, ip.IPNetToPrefix(c))
-				}
-				d.ipcache.ReleaseCIDRIdentitiesByCIDR(prefixes)
-				// release the memory held by restored CIDRs
-				d.restoredCIDRs = nil
-			}
-		}()
-		d.endpointManager.Subscribe(d)
-		// Add the endpoint manager unsubscribe as the last step in cleanup
-		defer cleaner.cleanupFuncs.Add(func() { d.endpointManager.Unsubscribe(d) })
-	}
+			d.ipcache.ReleaseCIDRIdentitiesByCIDR(prefixes)
+			// release the memory held by restored CIDRs
+			d.restoredCIDRs = nil
+		}
+	}()
+	d.endpointManager.Subscribe(d)
+	// Add the endpoint manager unsubscribe as the last step in cleanup
+	defer cleaner.cleanupFuncs.Add(func() { d.endpointManager.Unsubscribe(d) })
 
 	// Migrating the ENI datapath must happen before the API is served to
 	// prevent endpoints from being created. It also must be before the health
@@ -2044,21 +2040,19 @@ func initSockmapOption() {
 func initClockSourceOption() {
 	option.Config.ClockSource = option.ClockSourceKtime
 	option.Config.KernelHz = 1 // Known invalid non-zero to avoid div by zero.
-	if !option.Config.DryMode {
-		hz, err := probes.KernelHZ()
-		if err != nil {
-			log.WithError(err).Infof("Auto-disabling %q feature since KERNEL_HZ cannot be determined", option.EnableBPFClockProbe)
-			option.Config.EnableBPFClockProbe = false
-		} else {
-			option.Config.KernelHz = int(hz)
-		}
+	hz, err := probes.KernelHZ()
+	if err != nil {
+		log.WithError(err).Infof("Auto-disabling %q feature since KERNEL_HZ cannot be determined", option.EnableBPFClockProbe)
+		option.Config.EnableBPFClockProbe = false
+	} else {
+		option.Config.KernelHz = int(hz)
+	}
 
-		if option.Config.EnableBPFClockProbe {
-			if probes.HaveProgramHelper(ebpf.XDP, asm.FnJiffies64) == nil {
-				t, err := bpf.GetJtime()
-				if err == nil && t > 0 {
-					option.Config.ClockSource = option.ClockSourceJiffies
-				}
+	if option.Config.EnableBPFClockProbe {
+		if probes.HaveProgramHelper(ebpf.XDP, asm.FnJiffies64) == nil {
+			t, err := bpf.GetJtime()
+			if err == nil && t > 0 {
+				option.Config.ClockSource = option.ClockSourceJiffies
 			}
 		}
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cilium/ebpf"
@@ -78,8 +79,10 @@ import (
 	"github.com/cilium/cilium/pkg/pidfile"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/pprof"
+	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/version"
+	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wireguard "github.com/cilium/cilium/pkg/wireguard/agent"
 	wireguardTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
@@ -1551,20 +1554,7 @@ func (d *Daemon) initKVStore() {
 	}
 }
 
-func newDatapath(cleaner *daemonCleanup) datapath.Datapath {
-	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice: defaults.HostDevice,
-		ProcFs:     option.Config.ProcFs,
-	}
-
-	iptablesManager := &iptables.IptablesManager{}
-
-	if err := enableIPForwarding(); err != nil {
-		log.Fatalf("enabling IP forwarding via sysctl failed: %s", err)
-	}
-
-	iptablesManager.Init()
-
+func newWireguardAgent(lc hive.Lifecycle) *wg.Agent {
 	var wgAgent *wireguard.Agent
 	if option.Config.EnableWireguard {
 		switch {
@@ -1583,40 +1573,64 @@ func newDatapath(cleaner *daemonCleanup) datapath.Datapath {
 			log.Fatalf("failed to initialize wireguard: %s", err)
 		}
 
-		cleaner.cleanupFuncs.Add(func() {
-			_ = wgAgent.Close()
+		lc.Append(hive.Hook{
+			OnStop: func(hive.HookContext) error {
+				wgAgent.Close()
+				return nil
+			},
 		})
 	} else {
 		// Delete wireguard device from previous run (if such exists)
 		link.DeleteByName(wireguardTypes.IfaceName)
 	}
+	return wgAgent
+}
+
+func newDatapath(lc hive.Lifecycle, wgAgent *wireguard.Agent) datapath.Datapath {
+	datapathConfig := linuxdatapath.DatapathConfiguration{
+		HostDevice: defaults.HostDevice,
+		ProcFs:     option.Config.ProcFs,
+	}
+
+	iptablesManager := &iptables.IptablesManager{}
+
+	lc.Append(hive.Hook{
+		OnStart: func(hive.HookContext) error {
+			if err := enableIPForwarding(); err != nil {
+				log.Fatalf("enabling IP forwarding via sysctl failed: %s", err)
+			}
+
+			iptablesManager.Init()
+			return nil
+		}})
+
 	return linuxdatapath.NewDatapath(datapathConfig, iptablesManager, wgAgent)
 }
+
+// daemonCell wraps the existing implementation of the cilium-agent that has
+// not yet been converted into a cell. Provides *Daemon as a Promise that is
+// resolved once daemon has been started to facilitate conversion into modules.
+var daemonCell = cell.Module(
+	"daemon",
+	"Legacy Daemon",
+
+	cell.Provide(newDaemonPromise),
+	cell.Invoke(func(promise.Promise[*Daemon]) {}), // Force instantiation.
+)
 
 type daemonParams struct {
 	cell.In
 
 	Lifecycle      hive.Lifecycle
-	Shutdowner     hive.Shutdowner
-	Config         DaemonCellConfig
-	LocalNodeStore node.LocalNodeStore
 	Clientset      k8sClient.Clientset
+	Datapath       datapath.Datapath
+	WGAgent        *wg.Agent `optional:"true"`
+	LocalNodeStore node.LocalNodeStore
+	Shutdowner     hive.Shutdowner
 }
 
-// registerDaemonHooks registers the lifecycle hooks for the part of the cilium-agent that has
-// not yet been modularized.
-//
-// The Daemon struct and objects referred to from there are not supplied to the graph as
-// object creation in Daemon is intertwined with side-effectful initialization. This stops
-// us from constructing and inspecting the dependency graph, so instead the daemon is constructed
-// and started via an OnStart hook.
-//
-// If an object still owned by Daemon is required in a module, it should be provided indirectly, e.g. via
-// a callback.
-func registerDaemonHooks(params daemonParams) error {
-	if params.Config.SkipDaemon {
-		return nil
-	}
+func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
+	daemonResolver, daemonPromise := promise.New[*Daemon]()
 
 	// daemonCtx is the daemon-wide context cancelled when stopping.
 	daemonCtx, cancelDaemonCtx := context.WithCancel(context.Background())
@@ -1634,34 +1648,48 @@ func registerDaemonHooks(params daemonParams) error {
 	// LocalNodeStore directly.
 	node.SetLocalNodeStore(params.LocalNodeStore)
 
+	var daemon *Daemon
+	var wg sync.WaitGroup
+
 	params.Lifecycle.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {
+			d, restoredEndpoints, err := newDaemon(
+				daemonCtx, cleaner,
+				WithDefaultEndpointManager(daemonCtx, params.Clientset, endpoint.CheckHealth),
+				params.Datapath,
+				params.WGAgent,
+				params.Clientset)
+			if err != nil {
+				return fmt.Errorf("daemon creation failed: %w", err)
+			}
+			daemon = d
+
+			daemonResolver.Resolve(daemon)
+
 			// Start running the daemon in the background (blocks on API server's Serve()) to allow rest
 			// of the start hooks to run.
-			go runDaemon(daemonCtx, cleaner, params.Shutdowner, params.Clientset)
+			if !option.Config.DryMode {
+				wg.Add(1)
+				go func() {
+					runDaemon(daemon, restoredEndpoints, cleaner, params)
+					wg.Done()
+				}()
+			}
 			return nil
 		},
 		OnStop: func(hive.HookContext) error {
 			cancelDaemonCtx()
 			cleaner.Clean()
+			wg.Wait()
 			return nil
 		},
 	})
-	return nil
+	return daemonPromise
 }
 
 // runDaemon runs the old unmodular part of the cilium-agent.
-func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner hive.Shutdowner, clientset k8sClient.Clientset) {
+func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daemonCleanup, params daemonParams) {
 	log.Info("Initializing daemon")
-
-	dp := newDatapath(cleaner)
-
-	d, restoredEndpoints, err := NewDaemon(ctx, cleaner,
-		WithDefaultEndpointManager(ctx, clientset, endpoint.CheckHealth),
-		dp, clientset)
-	if err != nil {
-		log.Fatalf("daemon creation failed: %s", err)
-	}
 
 	// This validation needs to be done outside of the agent until
 	// datapath.NodeAddressing is used consistently across the code base.
@@ -1678,15 +1706,16 @@ func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner hive.Shut
 	bootstrapStats.enableConntrack.End(true)
 
 	bootstrapStats.k8sInit.Start()
-	if clientset.IsEnabled() {
+	if params.Clientset.IsEnabled() {
 		// Wait only for certain caches, but not all!
 		// (Check Daemon.InitK8sSubsystem() for more info)
 		<-d.k8sCachesSynced
 	}
 	bootstrapStats.k8sInit.End(true)
 	restoreComplete := d.initRestore(restoredEndpoints)
-	if wgAgent, ok := d.datapath.WireguardAgent().(*wireguard.Agent); ok && wgAgent != nil {
-		if err := wgAgent.RestoreFinished(); err != nil {
+
+	if params.WGAgent != nil {
+		if err := params.WGAgent.RestoreFinished(); err != nil {
 			log.WithError(err).Error("Failed to set up wireguard peers")
 		}
 	}
@@ -1757,7 +1786,7 @@ func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner hive.Shut
 	// logic runs before any endpoint creates.
 	if option.Config.IPAM == ipamOption.IPAMENI {
 		migrated, failed := linuxrouting.NewMigrator(
-			&eni.InterfaceDB{Clientset: clientset},
+			&eni.InterfaceDB{Clientset: params.Clientset},
 		).MigrateENIDatapath(option.Config.EgressMultiHomeIPRuleCompat)
 		switch {
 		case failed == -1:
@@ -1787,7 +1816,7 @@ func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner hive.Shut
 		err := <-errs
 		if err != nil {
 			log.WithError(err).Error("Cannot start metrics server")
-			shutdowner.Shutdown(hive.ShutdownWithError(err))
+			params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
 		}
 	}(initMetrics())
 
@@ -1809,7 +1838,7 @@ func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner hive.Shut
 	srv.ConfigureAPI()
 	bootstrapStats.initAPI.End(true)
 
-	err = d.SendNotification(monitorAPI.StartMessage(time.Now()))
+	err := d.SendNotification(monitorAPI.StartMessage(time.Now()))
 	if err != nil {
 		log.WithError(err).Warn("Failed to send agent start monitor message")
 	}
@@ -1863,7 +1892,7 @@ func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner hive.Shut
 	err = srv.Serve()
 	if err != nil {
 		log.WithError(err).Error("Error returned from non-returning Serve() call")
-		shutdowner.Shutdown(hive.ShutdownWithError(err))
+		params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
 	}
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1089,9 +1089,17 @@ func restoreExecPermissions(searchDir string, patterns ...string) error {
 	return err
 }
 
-func initEnv() {
-	var debugDatapath bool
+func initLogging() {
+	// add hooks after setting up metrics in the option.Config
+	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumAgentName))
 
+	// Logging should always be bootstrapped first. Do not add any code above this!
+	if err := logging.SetupLogging(option.Config.LogDriver, logging.LogOptions(option.Config.LogOpt), "cilium-agent", option.Config.Debug); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func initDaemonConfig() {
 	option.Config.SetMapElementSizes(
 		// for the conntrack and NAT element size we assume the largest possible
 		// key size, i.e. IPv6 keys
@@ -1100,16 +1108,17 @@ func initEnv() {
 		neighborsmap.SizeofNeighKey6+neighborsmap.SizeOfNeighValue,
 		lbmap.SizeofSockRevNat6Key+lbmap.SizeofSockRevNat6Value)
 
-	// Prepopulate option.Config with options from CLI.
 	option.Config.Populate(Vp)
+}
 
-	// add hooks after setting up metrics in the option.Config
-	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumAgentName))
+func initEnv() {
+	bootstrapStats.earlyInit.Start()
+	defer bootstrapStats.earlyInit.End(true)
 
-	// Logging should always be bootstrapped first. Do not add any code above this!
-	if err := logging.SetupLogging(option.Config.LogDriver, logging.LogOptions(option.Config.LogOpt), "cilium-agent", option.Config.Debug); err != nil {
-		log.Fatal(err)
-	}
+	var debugDatapath bool
+
+	// Not running tests -> enable the monitor agent.
+	option.Config.RunMonitorAgent = true
 
 	option.LogRegisteredOptions(Vp, log)
 
@@ -1627,10 +1636,6 @@ func registerDaemonHooks(params daemonParams) error {
 
 	params.Lifecycle.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {
-			bootstrapStats.earlyInit.Start()
-			initEnv()
-			bootstrapStats.earlyInit.End(true)
-
 			// Start running the daemon in the background (blocks on API server's Serve()) to allow rest
 			// of the start hooks to run.
 			go runDaemon(daemonCtx, cleaner, params.Shutdowner, params.Clientset)
@@ -1648,8 +1653,6 @@ func registerDaemonHooks(params daemonParams) error {
 // runDaemon runs the old unmodular part of the cilium-agent.
 func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner hive.Shutdowner, clientset k8sClient.Clientset) {
 	log.Info("Initializing daemon")
-
-	option.Config.RunMonitorAgent = true
 
 	dp := newDatapath(cleaner)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1641,11 +1641,6 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 		params.Clientset.Disable()
 	}
 
-	// Set the global LocalNodeStore. This is to retain the API of getters and setters
-	// defined in pkg/node/address.go until uses of them have been converted to use
-	// LocalNodeStore directly.
-	node.SetLocalNodeStore(params.LocalNodeStore)
-
 	var daemon *Daemon
 	var wg sync.WaitGroup
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
@@ -1376,6 +1377,7 @@ func initEnv(clientset k8sClient.Clientset) {
 	// allocation prefixes
 	node.InitDefaultPrefix(option.Config.DirectRoutingDevice)
 
+	// Initialize node IP addresses from configuration.
 	if option.Config.IPv6NodeAddr != "auto" {
 		if ip := net.ParseIP(option.Config.IPv6NodeAddr); ip == nil {
 			log.WithField(logfields.IPAddr, option.Config.IPv6NodeAddr).Fatal("Invalid IPv6 node address")
@@ -1383,11 +1385,9 @@ func initEnv(clientset k8sClient.Clientset) {
 			if !ip.IsGlobalUnicast() {
 				log.WithField(logfields.IPAddr, ip).Fatal("Invalid IPv6 node address: not a global unicast address")
 			}
-
 			node.SetIPv6(ip)
 		}
 	}
-
 	if option.Config.IPv4NodeAddr != "auto" {
 		if ip := net.ParseIP(option.Config.IPv4NodeAddr); ip == nil {
 			log.WithField(logfields.IPAddr, option.Config.IPv4NodeAddr).Fatal("Invalid IPv4 node address")
@@ -1549,6 +1549,48 @@ func (d *Daemon) initKVStore() {
 	}
 }
 
+func newDatapath(cleaner *daemonCleanup) datapath.Datapath {
+	datapathConfig := linuxdatapath.DatapathConfiguration{
+		HostDevice: defaults.HostDevice,
+		ProcFs:     option.Config.ProcFs,
+	}
+
+	iptablesManager := &iptables.IptablesManager{}
+
+	if err := enableIPForwarding(); err != nil {
+		log.Fatalf("enabling IP forwarding via sysctl failed: %s", err)
+	}
+
+	iptablesManager.Init()
+
+	var wgAgent *wireguard.Agent
+	if option.Config.EnableWireguard {
+		switch {
+		case option.Config.EnableIPSec:
+			log.Fatalf("Wireguard (--%s) cannot be used with IPSec (--%s)",
+				option.EnableWireguard, option.EnableIPSecName)
+		case option.Config.EnableL7Proxy:
+			log.Fatalf("Wireguard (--%s) is not compatible with L7 proxy (--%s)",
+				option.EnableWireguard, option.EnableL7Proxy)
+		}
+
+		var err error
+		privateKeyPath := filepath.Join(option.Config.StateDir, wireguardTypes.PrivKeyFilename)
+		wgAgent, err = wireguard.NewAgent(privateKeyPath)
+		if err != nil {
+			log.Fatalf("failed to initialize wireguard: %s", err)
+		}
+
+		cleaner.cleanupFuncs.Add(func() {
+			_ = wgAgent.Close()
+		})
+	} else {
+		// Delete wireguard device from previous run (if such exists)
+		link.DeleteByName(wireguardTypes.IfaceName)
+	}
+	return linuxdatapath.NewDatapath(datapathConfig, iptablesManager, wgAgent)
+}
+
 type daemonParams struct {
 	cell.In
 
@@ -1612,52 +1654,15 @@ func registerDaemonHooks(params daemonParams) error {
 
 // runDaemon runs the old unmodular part of the cilium-agent.
 func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner hive.Shutdowner, clientset k8sClient.Clientset) {
-	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice: defaults.HostDevice,
-		ProcFs:     option.Config.ProcFs,
-	}
-
 	log.Info("Initializing daemon")
 
 	option.Config.RunMonitorAgent = true
 
-	if err := enableIPForwarding(); err != nil {
-		log.Fatalf("enabling IP forwarding via sysctl failed: %s", err)
-	}
-
-	iptablesManager := &iptables.IptablesManager{}
-	iptablesManager.Init()
-
-	var wgAgent *wireguard.Agent
-	if option.Config.EnableWireguard {
-		switch {
-		case option.Config.EnableIPSec:
-			log.Fatalf("Wireguard (--%s) cannot be used with IPSec (--%s)",
-				option.EnableWireguard, option.EnableIPSecName)
-		case option.Config.EnableL7Proxy:
-			log.Fatalf("Wireguard (--%s) is not compatible with L7 proxy (--%s)",
-				option.EnableWireguard, option.EnableL7Proxy)
-		}
-
-		var err error
-		privateKeyPath := filepath.Join(option.Config.StateDir, wireguardTypes.PrivKeyFilename)
-		wgAgent, err = wireguard.NewAgent(privateKeyPath)
-		if err != nil {
-			log.Fatalf("failed to initialize wireguard: %s", err)
-		}
-
-		cleaner.cleanupFuncs.Add(func() {
-			_ = wgAgent.Close()
-		})
-	} else {
-		// Delete wireguard device from previous run (if such exists)
-		link.DeleteByName(wireguardTypes.IfaceName)
-	}
+	dp := newDatapath(cleaner)
 
 	d, restoredEndpoints, err := NewDaemon(ctx, cleaner,
 		WithDefaultEndpointManager(ctx, clientset, endpoint.CheckHealth),
-		linuxdatapath.NewDatapath(datapathConfig, iptablesManager, wgAgent),
-		clientset)
+		dp, clientset)
 	if err != nil {
 		log.Fatalf("daemon creation failed: %s", err)
 	}
@@ -1684,7 +1689,7 @@ func runDaemon(ctx context.Context, cleaner *daemonCleanup, shutdowner hive.Shut
 	}
 	bootstrapStats.k8sInit.End(true)
 	restoreComplete := d.initRestore(restoredEndpoints)
-	if wgAgent != nil {
+	if wgAgent, ok := d.datapath.WireguardAgent().(*wireguard.Agent); ok && wgAgent != nil {
 		if err := wgAgent.RestoreFinished(); err != nil {
 			log.WithError(err).Error("Failed to set up wireguard peers")
 		}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1089,7 +1089,7 @@ func restoreExecPermissions(searchDir string, patterns ...string) error {
 	return err
 }
 
-func initEnv(clientset k8sClient.Clientset) {
+func initEnv() {
 	var debugDatapath bool
 
 	option.Config.SetMapElementSizes(
@@ -1166,13 +1166,6 @@ func initEnv(clientset k8sClient.Clientset) {
 			log.Fatalf("Envoy version %s does not match with required version %s ,aborting.",
 				envoyVersionArray[2], envoy.RequiredEnvoyVersionSHA)
 		}
-	}
-
-	// This check is here instead of in DaemonConfig.Populate (invoked at the
-	// start of this function as option.Config.Populate) to avoid an import loop.
-	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD && !clientset.IsEnabled() &&
-		option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
-		log.Fatal("CRD Identity allocation mode requires k8s to be configured.")
 	}
 
 	if option.Config.PProf {
@@ -1635,7 +1628,7 @@ func registerDaemonHooks(params daemonParams) error {
 	params.Lifecycle.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {
 			bootstrapStats.earlyInit.Start()
-			initEnv(params.Clientset)
+			initEnv()
 			bootstrapStats.earlyInit.End(true)
 
 			// Start running the daemon in the background (blocks on API server's Serve()) to allow rest

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -19,10 +19,12 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath"
-	fakedatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/endpoint"
 	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -33,13 +35,14 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
 )
 
 type DaemonSuite struct {
-	d *Daemon
+	hive *hive.Hive
 
-	cancel context.CancelFunc
+	d *Daemon
 
 	// oldPolicyEnabled is the policy enforcement mode that was set before the test,
 	// as returned by policy.GetPolicyEnabled().
@@ -127,30 +130,44 @@ func (ds *DaemonSuite) TearDownSuite(c *C) {
 }
 
 func (ds *DaemonSuite) SetUpTest(c *C) {
+	ctx := context.Background()
+
 	setupTestDirectories()
 
 	ds.oldPolicyEnabled = policy.GetPolicyEnabled()
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
 
-	_, clientset := k8sClient.NewFakeClientset()
-	clientset.Disable()
+	var daemonPromise promise.Promise[*Daemon]
+	ds.hive = hive.New(
+		cell.Provide(
+			func() k8sClient.Clientset {
+				cs, _ := k8sClient.NewFakeClientset()
+				cs.Disable()
+				return cs
+			},
+			func() datapath.Datapath { return fakeDatapath.NewDatapath() },
+		),
 
-	ctx, cancel := context.WithCancel(context.Background())
-	ds.cancel = cancel
-	d, _, err := NewDaemon(ctx, NewDaemonCleanup(),
-		WithCustomEndpointManager(&dummyEpSyncher{}),
-		fakedatapath.NewDatapath(),
-		clientset)
+		ControlPlane,
+
+		cell.Invoke(func(p promise.Promise[*Daemon]) {
+			daemonPromise = p
+		}),
+	)
+
+	err := ds.hive.Start(ctx)
 	c.Assert(err, IsNil)
-	ds.d = d
 
-	kvstore.Client().DeletePrefix(context.TODO(), kvstore.OperationalPath)
-	kvstore.Client().DeletePrefix(context.TODO(), kvstore.BaseKeyPrefix)
+	ds.d, err = daemonPromise.Await(ctx)
+	c.Assert(err, IsNil)
 
-	ds.OnGetPolicyRepository = d.GetPolicyRepository
+	kvstore.Client().DeletePrefix(ctx, kvstore.OperationalPath)
+	kvstore.Client().DeletePrefix(ctx, kvstore.BaseKeyPrefix)
+
+	ds.OnGetPolicyRepository = ds.d.GetPolicyRepository
 	ds.OnQueueEndpointBuild = nil
-	ds.OnGetCompilationLock = d.GetCompilationLock
-	ds.OnSendNotification = d.SendNotification
+	ds.OnGetCompilationLock = ds.d.GetCompilationLock
+	ds.OnSendNotification = ds.d.SendNotification
 	ds.OnGetCIDRPrefixLengths = nil
 
 	// Reset the most common endpoint states before each test.
@@ -163,7 +180,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 }
 
 func (ds *DaemonSuite) TearDownTest(c *C) {
-	ds.cancel()
+	ctx := context.Background()
 
 	controller.NewManager().RemoveAllAndWait()
 	ds.d.endpointManager.RemoveAll()
@@ -175,8 +192,8 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 	}
 
 	if ds.kvstoreInit {
-		kvstore.Client().DeletePrefix(context.TODO(), kvstore.OperationalPath)
-		kvstore.Client().DeletePrefix(context.TODO(), kvstore.BaseKeyPrefix)
+		kvstore.Client().DeletePrefix(ctx, kvstore.OperationalPath)
+		kvstore.Client().DeletePrefix(ctx, kvstore.BaseKeyPrefix)
 	}
 
 	// Restore the policy enforcement mode.
@@ -187,6 +204,9 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 	ds.d.identityAllocator.Close()
 
 	identitymanager.RemoveAll()
+
+	err := ds.hive.Stop(ctx)
+	c.Assert(err, IsNil)
 
 	ds.d.Close()
 }

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -10,15 +10,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
-	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/hive/cell"
-	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/version"
 )
@@ -52,30 +46,12 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			// Silence log messages from calling invokes and constructors.
 			logging.SetLogLevel(logrus.WarnLevel)
-
 			agentHive.PrintObjects()
 		},
 	}
 
-	agentHive = hive.New(
-		gops.Cell(defaults.GopsPortAgent),
-		k8sClient.Cell,
-
-		cell.Config(DaemonCellConfig{}),
-		cell.Invoke(registerDaemonHooks),
-
-		node.LocalNodeStoreCell,
-	)
+	agentHive = hive.New(Agent)
 )
-
-type DaemonCellConfig struct {
-	SkipDaemon bool
-}
-
-func (DaemonCellConfig) Flags(flags *pflag.FlagSet) {
-	flags.Bool("skip-daemon", false, "Skip running of the daemon, only start normal cells")
-	flags.MarkHidden("skip-daemon")
-}
 
 func init() {
 	setupSleepBeforeFatal()

--- a/pkg/hive/cell/decorator.go
+++ b/pkg/hive/cell/decorator.go
@@ -39,7 +39,7 @@ type decorator struct {
 }
 
 func (d *decorator) Apply(c container) error {
-	scope := c.Scope(fmt.Sprintf("(decorate %T)", d.decorator))
+	scope := c.Scope(fmt.Sprintf("(decorate %s)", internal.PrettyType(d.decorator)))
 	if err := scope.Decorate(d.decorator); err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func (d *decorator) Apply(c container) error {
 }
 
 func (d *decorator) Info() Info {
-	n := NewInfoNode(fmt.Sprintf("🔀 %s: %T", internal.FuncNameAndLocation(d.decorator), d.decorator))
+	n := NewInfoNode(fmt.Sprintf("🔀 %s: %s", internal.FuncNameAndLocation(d.decorator), internal.PrettyType(d.decorator)))
 	for _, cell := range d.cells {
 		n.Add(cell.Info())
 		n.AddBreak()

--- a/pkg/hive/cell/info.go
+++ b/pkg/hive/cell/info.go
@@ -10,7 +10,7 @@ import (
 )
 
 // indentBy is the number of spaces nested elements should be indented by
-const indentBy = 2
+const indentBy = 4
 
 // Info provides a simple way of printing cells hierarchically in
 // textual form.

--- a/pkg/hive/cell/invoke.go
+++ b/pkg/hive/cell/invoke.go
@@ -55,7 +55,7 @@ func (i *invoker) Apply(c container) error {
 func (i *invoker) Info() Info {
 	n := NewInfoNode("")
 	for _, namedFunc := range i.funcs {
-		n.AddLeaf("🛠️ %s: %T", namedFunc.name, namedFunc.fn)
+		n.AddLeaf("🛠️ %s: %s", namedFunc.name, internal.PrettyType(namedFunc.fn))
 	}
 	return n
 }

--- a/pkg/hive/cell/module.go
+++ b/pkg/hive/cell/module.go
@@ -74,7 +74,7 @@ func (m *module) Info() Info {
 	n := NewInfoNode("Ⓜ️ " + m.id + " (" + m.title + ")")
 	for _, cell := range m.cells {
 		n.Add(cell.Info())
-		n.AddBreak()
 	}
+	n.AddBreak()
 	return n
 }

--- a/pkg/hive/cell/provide.go
+++ b/pkg/hive/cell/provide.go
@@ -31,7 +31,7 @@ func (p *provider) Info() Info {
 		if !p.export {
 			privateSymbol = "🔒️"
 		}
-		n.AddLeaf("🚧%s %s: %T", privateSymbol, internal.FuncNameAndLocation(ctor), ctor)
+		n.AddLeaf("🚧%s %s: %s", privateSymbol, internal.FuncNameAndLocation(ctor), internal.PrettyType(ctor))
 	}
 	return n
 }

--- a/pkg/hive/internal/reflect.go
+++ b/pkg/hive/internal/reflect.go
@@ -7,17 +7,25 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"regexp"
 	"runtime"
-	"strings"
 )
 
-func TrimFuncName(name string) string {
-	return strings.TrimPrefix(name, "github.com/cilium/cilium/")
+var (
+	baseNameRegex = regexp.MustCompile(`github.com/cilium/cilium/[\w\/]+/`)
+)
+
+func TrimName(name string) string {
+	return string(baseNameRegex.ReplaceAll([]byte(name), []byte{}))
+}
+
+func PrettyType(x any) string {
+	return TrimName(fmt.Sprintf("%T", x))
 }
 
 func FuncNameAndLocation(fn any) string {
 	f := runtime.FuncForPC(reflect.ValueOf(fn).Pointer())
 	file, line := f.FileLine(f.Entry())
-	name := TrimFuncName(f.Name())
+	name := TrimName(f.Name())
 	return fmt.Sprintf("%s (%s:%d)", name, path.Base(file), line)
 }

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -420,6 +420,8 @@ type FakeClientset struct {
 	clientsetGetters
 
 	SlimFakeClientset *SlimFakeClientset
+
+	enabled bool
 }
 
 var _ Clientset = &FakeClientset{}
@@ -450,6 +452,7 @@ func NewFakeClientset() (*FakeClientset, Clientset) {
 		CiliumFakeClientset:     cilium_fake.NewSimpleClientset(),
 		APIExtFakeClientset:     apiext_fake.NewSimpleClientset(),
 		KubernetesFakeClientset: fake.NewSimpleClientset(),
+		enabled:                 true,
 	}
 	client.clientsetGetters = clientsetGetters{&client}
 	return &client, &client

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -56,10 +56,6 @@ type RouterInfo interface {
 	GetInterfaceNumber() int
 }
 
-func SetLocalNodeStore(s LocalNodeStore) {
-	localNode = s
-}
-
 func makeIPv6HostIP() net.IP {
 	ipstr := "fc00::10CA:1"
 	ip := net.ParseIP(ipstr)
@@ -354,6 +350,7 @@ func SetIPv4AllocRange(net *cidr.CIDR) {
 func Uninitialize() {
 	addrsMu.Lock()
 	addrs = addresses{}
+	localNode = defaultLocalNodeStore()
 	addrsMu.Unlock()
 }
 

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -62,7 +62,7 @@ func TestLocalNodeStore(t *testing.T) {
 	}
 
 	hive := hive.New(
-		LocalNodeStoreCell,
+		cell.Provide(NewLocalNodeStore),
 
 		cell.Provide(func() LocalNodeInitializer { return testInitializer{} }),
 		cell.Invoke(observe),

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/node"
 	agentOption "github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
 )
@@ -33,6 +34,7 @@ func (h *agentHandle) tearDown() {
 	}
 	h.d.Close()
 	os.RemoveAll(h.tempDir)
+	node.Uninitialize()
 }
 
 func startCiliumAgent(t *testing.T, nodeName string, clientset k8sClient.Clientset) (*fakeDatapath.FakeDatapath, agentHandle, error) {

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -139,7 +139,7 @@ func (cpt *ControlPlaneTest) StartAgent() *ControlPlaneTest {
 	if cpt.agentHandle != nil {
 		cpt.t.Fatal("StartAgent() already called")
 	}
-	datapath, agentHandle, err := startCiliumAgent(cpt.nodeName, cpt.clients)
+	datapath, agentHandle, err := startCiliumAgent(cpt.t, cpt.nodeName, cpt.clients)
 	if err != nil {
 		cpt.t.Fatalf("Failed to start cilium agent: %s", err)
 	}


### PR DESCRIPTION
First commit cleans up the `cilium-agent objects` output.
Second commit adds `daemon/cmd/cells.go` that expresses the agent as a composition of 3 top-level modules and refactors daemon_test.go and test/controlplane to use the `cmd.ControlPlane`. This removes the last blocker from being able to start implementing more of the agent as cells.

Here is how the output of `cilium-agent objects` looks now. The agent is divided into 3 top-level modules,
infrastructure, control plane and datapath. The infrastructure and datapath modules are meant to contain implementations that talk to real systems, either external or the local kernel. Control plane is meant to contain pure business logic that can be integration tested in non-privileged platform independent tests (e.g. on both macOS and Linux) by mocking the infrastructure and datapath modules. Preferably over time we would have the source code organization reflect this division (if we can stomach the backport pain).

```
Cells:

  Ⓜ️ Cilium Agent:
      Ⓜ️ Infrastructure:
          Ⓜ️ gops:
              ⚙️ gops.GopsConfig:
                  • gops-port[uint16] = 9890
              🛠️ gops.registerGopsHooks (cell.go:38): func(hive.Lifecycle, logrus.FieldLogger, gops.GopsConfig)

          Ⓜ️ k8s-client:
              ⚙️ client.Config:
                  • enable-k8s-api-discovery[bool]  = false
                  • k8s-api-server[string]          = 
                  • k8s-client-burst[int]           = 0
                  • k8s-client-qps[float32]         = 0
                  • k8s-heartbeat-timeout[duration] = 30s
                  • k8s-kubeconfig-path[string]     = 
              🚧 client.newClientset (cell.go:106): func(hive.Lifecycle, logrus.FieldLogger, client.Config) (client.Clientset, error)


      Ⓜ️ Control Plane:
          🚧 node.newLocalNodeStore (local_node_store.go:71): func(node.LocalNodeStoreParams) (node.LocalNodeStore, error)
          Ⓜ️ Daemon:
              🚧 cmd.newDaemonPromise (daemon_main.go:1614): func(cmd.daemonParams) promise.Promise[*cmd.Daemon]
              🛠️ cmd.glob..func1 (daemon_main.go:1601): func(promise.Promise[*cmd.Daemon])


      Ⓜ️ Datapath:
          🚧 cmd.newDatapath (daemon_main.go:1545): func(hive.Lifecycle) datapath.Datapath

```
