### PR TITLE
bpf: remove cilium_host ip addr scope link

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -352,7 +352,7 @@ esac
 		[ -n "$(ip -6 addr show to $IP6_HOST dev $HOST_DEV1)" ] || ip -6 addr add $IP6_HOST dev $HOST_DEV1
 	fi
 	if [ "$IP4_HOST" != "<nil>" ]; then
-		[ -n "$(ip -4 addr show to $IP4_HOST dev $HOST_DEV1)" ] || ip -4 addr add $IP4_HOST dev $HOST_DEV1 scope link
+		[ -n "$(ip -4 addr show to $IP4_HOST dev $HOST_DEV1)" ] || ip -4 addr add $IP4_HOST dev $HOST_DEV1
 	fi
 
 if [ "$PROXY_RULE" = "true" ]; then


### PR DESCRIPTION
make iptables masquerade choose cilium_host ip addr when access service external ip (backend is a pod in another node) in a pod

<!-- Description of change -->

Fixes: #21737
