### PR TITLE
daemon: Clarify host IP sync controller's intent

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -104,7 +104,7 @@ const (
 	// configuration updates to the daemon
 	ConfigModifyQueueSize = 10
 
-	syncEndpointsAndHostIPsController = "sync-endpoints-and-host-ips"
+	syncHostIPsController = "sync-host-ips"
 )
 
 // Daemon is the cilium daemon that is in charge of perform all necessary plumbing,
@@ -1253,10 +1253,10 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	// reinserted to the bpf maps if they are ever removed from them.
 	syncErrs := make(chan error, 1)
 	d.controllers.UpdateController(
-		syncEndpointsAndHostIPsController,
+		syncHostIPsController,
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				err := d.syncEndpointsAndHostIPs()
+				err := d.syncHostIPs()
 				select {
 				case syncErrs <- err:
 				default:
@@ -1371,7 +1371,7 @@ func (d *Daemon) ReloadOnDeviceChange(devices []string) {
 		} else {
 			// Synchronize services and endpoints to reflect new addresses onto lbmap.
 			d.svc.SyncServicesOnDeviceChange(d.Datapath().LocalNodeAddressing())
-			d.controllers.TriggerController(syncEndpointsAndHostIPsController)
+			d.controllers.TriggerController(syncHostIPsController)
 		}
 	}
 

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -164,10 +164,10 @@ func endParallelMapMode() {
 	ipcachemap.IPCacheMap().EndParallelMode()
 }
 
-// syncEndpointsAndHostIPs adds local host enties to bpf lxcmap, as well as
-// ipcache, if needed, and also notifies the daemon and network policy
-// hosts cache if changes were made.
-func (d *Daemon) syncEndpointsAndHostIPs() error {
+// syncHostIPs adds local host entries to bpf lxcmap, as well as ipcache, if
+// needed, and also notifies the daemon and network policy hosts cache if
+// changes were made.
+func (d *Daemon) syncHostIPs() error {
 	if option.Config.DryMode {
 		return nil
 	}
@@ -263,6 +263,8 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 		})
 	}
 
+	// existingEndpoints is a map from endpoint IP to endpoint info. Referring
+	// to the key as host IP here because we only care about the host endpoint.
 	for hostIP, info := range existingEndpoints {
 		if ip := net.ParseIP(hostIP); info.IsHost() && ip != nil {
 			if err := lxcmap.DeleteEntry(ip); err != nil {
@@ -270,7 +272,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 					logfields.IPAddr: hostIP,
 				}).Warn("Unable to delete obsolete host IP from BPF map")
 			} else {
-				log.Debugf("Removed outdated host ip %s from endpoint map", hostIP)
+				log.Debugf("Removed outdated host IP %s from endpoint map", hostIP)
 			}
 
 			d.ipcache.Delete(hostIP, d.sourceByIP(ip, source.Local))

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -226,8 +226,8 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState, clean bool) er
 	}).Info("Endpoints restored")
 
 	if existingEndpoints != nil {
-		for hostIP, info := range existingEndpoints {
-			if ip := net.ParseIP(hostIP); !info.IsHost() && ip != nil {
+		for epIP, info := range existingEndpoints {
+			if ip := net.ParseIP(epIP); !info.IsHost() && ip != nil {
 				if err := lxcmap.DeleteEntry(ip); err != nil {
 					log.WithError(err).Warn("Unable to delete obsolete endpoint from BPF map")
 				} else {


### PR DESCRIPTION
The code confusingly references "endpoints", which to the reader,
signals that this function also cleans up stale endpoint information (as
in workloads / pods) as well as host information. However the former is
not the case. It only cleans up host information (confusingly referred
to as the host endpoint). In other words, this function ensures that the
ipcache and the endpoint map (lxcmap) do not contain stale host
information, i.e. cilium_host IP or the internal node IP.

Attempt to clarify the code by removing references to "endpoint" and
rename the controller function accordingly. This commit should have no
functional impact.

An incorrect reference inside restoreOldEndpoints() was also fixed to
refer to endpoints instead of host.

Fixes: 19be15be0f3 ("agent: Fix endpoint restore with unmounted BPF
                     filesystem")
Fixes: 4ecf111c35 ("agent: Fix temporary corruption of BPF endpoint map
                    on restart")
Fixes: fd10ded5da ("agent: Add all local addresses to endpoints map and
                    ipcache")
Signed-off-by: Chris Tarazi <chris@isovalent.com>
