### PR TITLE
EndpointManager and NodeManager Cells

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/node"
+	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -60,6 +61,9 @@ var (
 
 		// EndpointManager maintains a collection of the locally running endpoints.
 		endpointmanager.Cell,
+
+		// NodeManager maintains a collection of other nodes in the cluster.
+		nodeManager.Cell,
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -56,6 +57,9 @@ var (
 		// Shared resources provide access to k8s resources as event streams or as
 		// read-only stores.
 		k8s.SharedResourcesCell,
+
+		// EndpointManager maintains a collection of the locally running endpoints.
+		endpointmanager.Cell,
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -73,6 +73,7 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
+	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	nodemanager "github.com/cilium/cilium/pkg/node/manager"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -400,7 +401,9 @@ func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 
 // newDaemon creates and returns a new Daemon with the parameters set in c.
 func newDaemon(ctx context.Context, cleaner *daemonCleanup,
-	epMgr endpointmanager.EndpointManager, dp datapath.Datapath,
+	epMgr endpointmanager.EndpointManager,
+	nodeMngr nodeManager.NodeManager,
+	dp datapath.Datapath,
 	wgAgent *wg.Agent,
 	clientset k8sClient.Clientset,
 	sharedResources k8s.SharedResources,
@@ -515,10 +518,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		externalIP,
 	)
 
-	nodeMngr, err := nodemanager.NewManager("all", dp.Node(), option.Config, nil, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	nodeMngr.Subscribe(dp.Node())
 
 	identity.IterateReservedIdentities(func(_ identity.NumericIdentity, _ *identity.Identity) {
 		metrics.Identity.WithLabelValues(identity.ReservedIdentityType).Inc()
@@ -639,9 +639,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 			}
 		}
 	}
-	nodeMngr = nodeMngr.WithIPCache(d.ipcache)
-	nodeMngr = nodeMngr.WithSelectorCacheUpdater(d.policy.GetSelectorCache()) // must be after initPolicy
-	nodeMngr = nodeMngr.WithPolicyTriggerer(epMgr)                            // must be after initPolicy
+	nodeMngr.SetIPCache(d.ipcache)
 
 	proxy.Allocator = d.identityAllocator
 
@@ -1310,7 +1308,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	return &d, restoredEndpoints, nil
 }
 
-func (d *Daemon) bootstrapClusterMesh(nodeMngr *nodemanager.Manager) {
+func (d *Daemon) bootstrapClusterMesh(nodeMngr nodemanager.NodeManager) {
 	bootstrapStats.clusterMeshInit.Start()
 	if path := option.Config.ClusterMeshConfig; path != "" {
 		if option.Config.ClusterID == 0 {
@@ -1389,7 +1387,6 @@ func (d *Daemon) Close() {
 	}
 	d.identityAllocator.Close()
 	identitymanager.RemoveAll()
-	d.nodeDiscovery.Close()
 	d.cgroupManager.Close()
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -42,7 +42,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/maps"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/hive"
@@ -1646,6 +1646,7 @@ type daemonParams struct {
 	BGPController   *bgpv1.Controller
 	Shutdowner      hive.Shutdowner
 	SharedResources k8s.SharedResources
+	EndpointManager endpointmanager.EndpointManager
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
@@ -1669,7 +1670,7 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 		OnStart: func(hive.HookContext) error {
 			d, restoredEndpoints, err := newDaemon(
 				daemonCtx, cleaner,
-				WithDefaultEndpointManager(daemonCtx, params.Clientset, endpoint.CheckHealth),
+				params.EndpointManager,
 				params.Datapath,
 				params.WGAgent,
 				params.Clientset,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -71,6 +71,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
+	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
@@ -1646,6 +1647,7 @@ type daemonParams struct {
 	BGPController   *bgpv1.Controller
 	Shutdowner      hive.Shutdowner
 	SharedResources k8s.SharedResources
+	NodeManager     nodeManager.NodeManager
 	EndpointManager endpointmanager.EndpointManager
 }
 
@@ -1671,6 +1673,7 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 			d, restoredEndpoints, err := newDaemon(
 				daemonCtx, cleaner,
 				params.EndpointManager,
+				params.NodeManager,
 				params.Datapath,
 				params.WGAgent,
 				params.Clientset,

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -141,7 +141,7 @@ func (d *Daemon) SetPrefilter(preFilter datapath.PreFilter) {
 // EndpointMapManager is a wrapper around an endpointmanager as well as the
 // filesystem for removing maps related to endpoints from the filesystem.
 type EndpointMapManager struct {
-	*endpointmanager.EndpointManager
+	endpointmanager.EndpointManager
 }
 
 // RemoveDatapathMapping unlinks the endpointID from the global policy map, preventing

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
@@ -126,7 +127,7 @@ func (ds *DaemonFQDNSuite) SetUpTest(c *C) {
 		Cache:           fqdn.NewDNSCache(0),
 		UpdateSelectors: d.updateSelectors,
 	})
-	d.endpointManager = WithCustomEndpointManager(&dummyEpSyncher{})
+	d.endpointManager = endpointmanager.New(&dummyEpSyncher{})
 	d.policy.GetSelectorCache().SetLocalIdentityNotifier(d.dnsNameManager)
 	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{
 		Context:           context.TODO(),

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -41,7 +41,7 @@ import (
 )
 
 // initPolicy initializes the core policy components of the daemon.
-func (d *Daemon) initPolicy(epMgr *endpointmanager.EndpointManager) error {
+func (d *Daemon) initPolicy(epMgr endpointmanager.EndpointManager) error {
 	// Reuse policy.TriggerMetrics and PolicyTriggerInterval here since
 	// this is only triggered by agent configuration changes for now and
 	// should be counted in pol.TriggerMetrics.

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -27,7 +26,7 @@ type GetNodesSuite struct {
 
 var _ = Suite(&GetNodesSuite{})
 
-var nm *manager.Manager
+var nm manager.NodeManager
 
 func (g *GetNodesSuite) SetUpTest(c *C) {
 	option.Config.IPv4ServiceRange = AutoCIDR
@@ -36,7 +35,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.NewManager("", fake.NewNodeHandler(), &fakeConfig.Config{}, nil, nil)
+	nm, err = manager.New("", &fakeConfig.Config{})
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -15,10 +15,10 @@ import (
 )
 
 type AuthManager struct {
-	endpointManager *endpointmanager.EndpointManager
+	endpointManager endpointmanager.EndpointsLookup
 }
 
-func NewAuthManager(epMgr *endpointmanager.EndpointManager) *AuthManager {
+func NewAuthManager(epMgr endpointmanager.EndpointsLookup) *AuthManager {
 	return &AuthManager{
 		endpointManager: epMgr,
 	}

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -57,7 +57,7 @@ type Configuration struct {
 
 	// NodeManager is the node manager to manage all discovered remote
 	// nodes
-	NodeManager *nodemanager.Manager
+	NodeManager nodemanager.NodeManager
 
 	nodeObserver store.Observer
 

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointmanager
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+// Cell provides the EndpointManager which maintains the collection of locally
+// running Cilium endpoints. Also exposed are EndpointsLookup and
+// EndpointsModify APIs that EndpointManager implements. If possible, choose
+// the minimal API as your dependency.
+var Cell = cell.Module(
+	"endpoint-manager",
+	"Manages the collection of local endpoints",
+
+	cell.Config(defaultEndpointManagerConfig),
+	cell.Provide(newDefaultEndpointManager),
+)
+
+type EndpointsLookup interface {
+	// Lookup looks up endpoint by prefix ID
+	Lookup(id string) (*endpoint.Endpoint, error)
+
+	// LookupCiliumID looks up endpoint by endpoint ID
+	LookupCiliumID(id uint16) *endpoint.Endpoint
+
+	// LookupContainerID looks up endpoint by container ID
+	LookupContainerID(id string) *endpoint.Endpoint
+
+	// LookupIPv4 looks up endpoint by IPv4 address
+	LookupIPv4(ipv4 string) *endpoint.Endpoint
+
+	// LookupIPv6 looks up endpoint by IPv6 address
+	LookupIPv6(ipv6 string) *endpoint.Endpoint
+
+	// LookupIP looks up endpoint by IP address
+	LookupIP(ip net.IP) (ep *endpoint.Endpoint)
+
+	// LookupPodName looks up endpoint by namespace + pod name, e.g. "prod/pod-0"
+	LookupPodName(name string) *endpoint.Endpoint
+
+	// GetEndpoints returns a slice of all endpoints present in endpoint manager.
+	GetEndpoints() []*endpoint.Endpoint
+
+	// EndpointExists returns whether the endpoint with id exists.
+	EndpointExists(id uint16) bool
+
+	// GetHostEndpoint returns the host endpoint.
+	GetHostEndpoint() *endpoint.Endpoint
+
+	// HostEndpointExists returns true if the host endpoint exists.
+	HostEndpointExists() bool
+}
+
+type EndpointsModify interface {
+	// AddEndpoint takes the prepared endpoint object and starts managing it.
+	AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) (err error)
+
+	AddHostEndpoint(
+		ctx context.Context,
+		owner regeneration.Owner,
+		policyGetter policyRepoGetter,
+		ipcache *ipcache.IPCache,
+		proxy endpoint.EndpointProxy,
+		allocator cache.IdentityAllocator,
+		reason, nodeName string,
+	) error
+
+	// RestoreEndpoint exposes the specified endpoint to other subsystems via the
+	// manager.
+	RestoreEndpoint(ep *endpoint.Endpoint) error
+
+	// UpdateReferences updates maps the contents of mappings to the specified endpoint.
+	UpdateReferences(ep *endpoint.Endpoint) error
+
+	// RemoveEndpoint stops the active handling of events by the specified endpoint,
+	// and prevents the endpoint from being globally acccessible via other packages.
+	RemoveEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error
+
+	// RemoveAll removes all endpoints from the global maps.
+	RemoveAll()
+}
+
+type EndpointManager interface {
+	EndpointsLookup
+	EndpointsModify
+	subscriber.Node
+	EndpointResourceSynchronizer
+
+	// InitMetrics hooks the EndpointManager into the metrics subsystem. This can
+	// only be done once, globally, otherwise the metrics library will panic.
+	InitMetrics()
+
+	// Subscribe to endpoint events.
+	Subscribe(s Subscriber)
+
+	// Unsubscribe from endpoint events.
+	Unsubscribe(s Subscriber)
+
+	// UpdatePolicyMaps returns a WaitGroup which is signaled upon once all endpoints
+	// have had their PolicyMaps updated against the Endpoint's desired policy state.
+	//
+	// Endpoints will wait on the 'notifyWg' parameter before updating policy maps.
+	UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup
+
+	// RegenerateAllEndpoints calls a setState for each endpoint and
+	// regenerates if state transaction is valid. During this process, the endpoint
+	// list is locked and cannot be modified.
+	// Returns a waiting group that can be used to know when all the endpoints are
+	// regenerated.
+	RegenerateAllEndpoints(regenMetadata *regeneration.ExternalRegenerationMetadata) *sync.WaitGroup
+
+	// WaitForEndpointsAtPolicyRev waits for all endpoints which existed at the time
+	// this function is called to be at a given policy revision.
+	// New endpoints appearing while waiting are ignored.
+	WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error
+
+	// OverrideEndpointOpts applies the given options to all endpoints.
+	OverrideEndpointOpts(om option.OptionMap)
+
+	// InitHostEndpointLabels initializes the host endpoint's labels with the
+	// node's known labels.
+	InitHostEndpointLabels(ctx context.Context)
+
+	// GetPolicyEndpoints returns a map of all endpoints present in endpoint
+	// manager as policy.Endpoint interface set for the map key.
+	GetPolicyEndpoints() map[policy.Endpoint]struct{}
+
+	// HasGlobalCT returns true if the endpoints have a global CT, false otherwise.
+	HasGlobalCT() bool
+
+	// CallbackForEndpointsAtPolicyRev registers a callback on all endpoints that
+	// exist when invoked. It is similar to WaitForEndpointsAtPolicyRevision but
+	// each endpoint that reaches the desired revision calls 'done' independently.
+	// The provided callback should not block and generally be lightweight.
+	CallbackForEndpointsAtPolicyRev(ctx context.Context, rev uint64, done func(time.Time)) error
+}
+
+var (
+	_ EndpointsLookup = &endpointManager{}
+	_ EndpointsModify = &endpointManager{}
+	_ EndpointManager = &endpointManager{}
+)
+
+type endpointManagerParams struct {
+	cell.In
+
+	Lifecycle hive.Lifecycle
+	Config    EndpointManagerConfig
+	Clientset client.Clientset
+}
+
+type endpointManagerOut struct {
+	cell.Out
+
+	Lookup  EndpointsLookup
+	Modify  EndpointsModify
+	Manager EndpointManager
+}
+
+func newDefaultEndpointManager(p endpointManagerParams) endpointManagerOut {
+	checker := endpoint.CheckHealth
+
+	mgr := New(&watchers.EndpointSynchronizer{Clientset: p.Clientset})
+	if p.Config.EndpointGCInterval > 0 {
+		ctx, cancel := context.WithCancel(context.Background())
+		mgr = mgr.WithPeriodicEndpointGC(ctx, checker, p.Config.EndpointGCInterval)
+		p.Lifecycle.Append(hive.Hook{
+			OnStop: func(hive.HookContext) error {
+				cancel()
+				return nil
+			},
+		})
+	}
+
+	mgr.InitMetrics()
+
+	return endpointManagerOut{
+		Lookup:  mgr,
+		Modify:  mgr,
+		Manager: mgr,
+	}
+}

--- a/pkg/endpointmanager/config.go
+++ b/pkg/endpointmanager/config.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointmanager
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type EndpointManagerConfig struct {
+	// EndpointGCInterval is interval to attempt garbage collection of
+	// endpoints that are no longer alive and healthy.
+	EndpointGCInterval time.Duration
+}
+
+func (def EndpointManagerConfig) Flags(flags *pflag.FlagSet) {
+	flags.Duration(option.EndpointGCInterval, def.EndpointGCInterval,
+		"Periodically monitor local endpoint health via link status on this interval and garbage collect them if they become unhealthy, set to 0 to disable")
+	flags.MarkHidden(option.EndpointGCInterval)
+}
+
+var defaultEndpointManagerConfig = EndpointManagerConfig{
+	EndpointGCInterval: 5 * time.Minute,
+}

--- a/pkg/endpointmanager/gc.go
+++ b/pkg/endpointmanager/gc.go
@@ -24,7 +24,7 @@ type EndpointCheckerFunc func(*endpoint.Endpoint) error
 // This way, if there is a temporary condition that will be resolved by other
 // components in the system, then we will not flag warnings about the system
 // getting out-of-sync.
-func (mgr *EndpointManager) markAndSweep(ctx context.Context) error {
+func (mgr *endpointManager) markAndSweep(ctx context.Context) error {
 	marked := mgr.markEndpoints()
 
 	mgr.mutex.Lock()
@@ -41,7 +41,7 @@ func (mgr *EndpointManager) markAndSweep(ctx context.Context) error {
 // markEndpoints runs all endpoints in the manager against the configured
 // EndpointChecker and returns a slice of endpoint ids that require garbage
 // collection.
-func (mgr *EndpointManager) markEndpoints() []uint16 {
+func (mgr *endpointManager) markEndpoints() []uint16 {
 	mgr.mutex.RLock()
 	defer mgr.mutex.RUnlock()
 
@@ -56,7 +56,7 @@ func (mgr *EndpointManager) markEndpoints() []uint16 {
 
 // sweepEndpoints iterates through the specified list of endpoints marked for
 // deletion and attempts to garbage-collect them if they still exist.
-func (mgr *EndpointManager) sweepEndpoints(markedEndpoints []uint16) {
+func (mgr *endpointManager) sweepEndpoints(markedEndpoints []uint16) {
 	toSweep := make([]*endpoint.Endpoint, 0, len(markedEndpoints))
 
 	// 'markedEndpoints' were marked during the previous mark round, so

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -25,7 +25,7 @@ func fakeCheck(ep *endpoint.Endpoint) error {
 
 func (s *EndpointManagerSuite) TestmarkAndSweep(c *C) {
 	// Open-code WithPeriodicGC() to avoid running the controller
-	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{})
 	mgr.checkHealth = fakeCheck
 	mgr.deleteEndpoint = endpointDeleteFunc(mgr.waitEndpointRemoved)
 

--- a/pkg/endpointmanager/host.go
+++ b/pkg/endpointmanager/host.go
@@ -13,7 +13,7 @@ import (
 )
 
 // GetHostEndpoint returns the host endpoint.
-func (mgr *EndpointManager) GetHostEndpoint() *endpoint.Endpoint {
+func (mgr *endpointManager) GetHostEndpoint() *endpoint.Endpoint {
 	mgr.mutex.RLock()
 	defer mgr.mutex.RUnlock()
 	for _, ep := range mgr.endpoints {
@@ -25,23 +25,23 @@ func (mgr *EndpointManager) GetHostEndpoint() *endpoint.Endpoint {
 }
 
 // HostEndpointExists returns true if the host endpoint exists.
-func (mgr *EndpointManager) HostEndpointExists() bool {
+func (mgr *endpointManager) HostEndpointExists() bool {
 	return mgr.GetHostEndpoint() != nil
 }
 
-// OnAddNode implements the EndpointManager's logic for reacting to new nodes
-// from K8s. It is currently not implemented as the EndpointManager has not
+// OnAddNode implements the endpointManager's logic for reacting to new nodes
+// from K8s. It is currently not implemented as the endpointManager has not
 // need for it. This adheres to the subscriber.NodeHandler interface.
-func (mgr *EndpointManager) OnAddNode(node *v1.Node,
+func (mgr *endpointManager) OnAddNode(node *v1.Node,
 	swg *lock.StoppableWaitGroup) error {
 
 	return nil
 }
 
-// OnUpdateNode implements the EndpointManager's logic for reacting to updated
-// nodes in K8s. It is currently not implemented as the EndpointManager has not
+// OnUpdateNode implements the endpointManager's logic for reacting to updated
+// nodes in K8s. It is currently not implemented as the endpointManager has not
 // need for it. This adheres to the subscriber.NodeHandler interface.
-func (mgr *EndpointManager) OnUpdateNode(oldNode, newNode *v1.Node,
+func (mgr *endpointManager) OnUpdateNode(oldNode, newNode *v1.Node,
 	swg *lock.StoppableWaitGroup) error {
 
 	oldNodeLabels := oldNode.GetLabels()
@@ -63,10 +63,10 @@ func (mgr *EndpointManager) OnUpdateNode(oldNode, newNode *v1.Node,
 	return nil
 }
 
-// OnDeleteNode implements the EndpointManager's logic for reacting to node
-// deletions from K8s. It is currently not implemented as the EndpointManager
+// OnDeleteNode implements the endpointManager's logic for reacting to node
+// deletions from K8s. It is currently not implemented as the endpointManager
 // has not need for it. This adheres to the subscriber.NodeHandler interface.
-func (mgr *EndpointManager) OnDeleteNode(node *v1.Node,
+func (mgr *endpointManager) OnDeleteNode(node *v1.Node,
 	swg *lock.StoppableWaitGroup) error {
 
 	return nil

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -40,13 +40,13 @@ var (
 	launchTime  = 30 * time.Second
 )
 
-// compile time check - EndpointManager must implement
+// compile time check - endpointManager must implement
 // subscriber.Node
-var _ subscriber.Node = (*EndpointManager)(nil)
+var _ subscriber.Node = (*endpointManager)(nil)
 
-// EndpointManager is a structure designed for containing state about the
+// endpointManager is a structure designed for containing state about the
 // collection of locally running endpoints.
-type EndpointManager struct {
+type endpointManager struct {
 	// mutex protects endpoints and endpointsAux
 	mutex lock.RWMutex
 
@@ -64,7 +64,7 @@ type EndpointManager struct {
 	// up-to-date information about endpoints managed by the endpoint manager.
 	EndpointResourceSynchronizer
 
-	// subscribers are notified when events occur in the EndpointManager.
+	// subscribers are notified when events occur in the endpointManager.
 	subscribers map[Subscriber]struct{}
 
 	// checkHealth supports endpoint garbage collection by verifying the health
@@ -72,7 +72,7 @@ type EndpointManager struct {
 	checkHealth EndpointCheckerFunc
 
 	// deleteEndpoint is the function used to remove the endpoint from the
-	// EndpointManager and clean it up. Always set to RemoveEndpoint.
+	// endpointManager and clean it up. Always set to RemoveEndpoint.
 	deleteEndpoint endpointDeleteFunc
 
 	// A mark-and-sweep garbage collector may operate on the endpoint list.
@@ -93,9 +93,9 @@ type EndpointResourceSynchronizer interface {
 // functionality from endpoint management for testing purposes.
 type endpointDeleteFunc func(*endpoint.Endpoint, endpoint.DeleteConfig) []error
 
-// NewEndpointManager creates a new EndpointManager.
-func NewEndpointManager(epSynchronizer EndpointResourceSynchronizer) *EndpointManager {
-	mgr := EndpointManager{
+// New creates a new endpointManager.
+func New(epSynchronizer EndpointResourceSynchronizer) *endpointManager {
+	mgr := endpointManager{
 		endpoints:                    make(map[uint16]*endpoint.Endpoint),
 		endpointsAux:                 make(map[string]*endpoint.Endpoint),
 		mcastManager:                 mcastmanager.New(option.Config.IPv6MCastDevice),
@@ -109,7 +109,7 @@ func NewEndpointManager(epSynchronizer EndpointResourceSynchronizer) *EndpointMa
 
 // WithPeriodicEndpointGC runs a controller to periodically garbage collect
 // endpoints that match the specified EndpointCheckerFunc.
-func (mgr *EndpointManager) WithPeriodicEndpointGC(ctx context.Context, checkHealth EndpointCheckerFunc, interval time.Duration) *EndpointManager {
+func (mgr *endpointManager) WithPeriodicEndpointGC(ctx context.Context, checkHealth EndpointCheckerFunc, interval time.Duration) *endpointManager {
 	mgr.checkHealth = checkHealth
 	controller.NewManager().UpdateController("endpoint-gc",
 		controller.ControllerParams{
@@ -142,7 +142,7 @@ func waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup) error {
 // have had their PolicyMaps updated against the Endpoint's desired policy state.
 //
 // Endpoints will wait on the 'notifyWg' parameter before updating policy maps.
-func (mgr *EndpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup {
+func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup {
 	var epWG sync.WaitGroup
 	var wg sync.WaitGroup
 
@@ -178,9 +178,9 @@ func (mgr *EndpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync
 	return &wg
 }
 
-// InitMetrics hooks the EndpointManager into the metrics subsystem. This can
+// InitMetrics hooks the endpointManager into the metrics subsystem. This can
 // only be done once, globally, otherwise the metrics library will panic.
-func (mgr *EndpointManager) InitMetrics() {
+func (mgr *endpointManager) InitMetrics() {
 	if option.Config.DryMode {
 		return
 	}
@@ -203,7 +203,7 @@ func (mgr *EndpointManager) InitMetrics() {
 // AllocateID checks if the ID can be reused. If it cannot, returns an error.
 // If an ID of 0 is provided, a new ID is allocated. If a new ID cannot be
 // allocated, returns an error.
-func (mgr *EndpointManager) AllocateID(currID uint16) (uint16, error) {
+func (mgr *endpointManager) AllocateID(currID uint16) (uint16, error) {
 	var newID uint16
 	if currID != 0 {
 		if err := idallocator.Reuse(currID); err != nil {
@@ -221,19 +221,19 @@ func (mgr *EndpointManager) AllocateID(currID uint16) (uint16, error) {
 	return newID, nil
 }
 
-func (mgr *EndpointManager) removeIDLocked(currID uint16) {
+func (mgr *endpointManager) removeIDLocked(currID uint16) {
 	delete(mgr.endpoints, currID)
 }
 
-// RemoveID removes the id from the endpoints map in the EndpointManager.
-func (mgr *EndpointManager) RemoveID(currID uint16) {
+// RemoveID removes the id from the endpoints map in the endpointManager.
+func (mgr *endpointManager) RemoveID(currID uint16) {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
 	mgr.removeIDLocked(currID)
 }
 
 // Lookup looks up the endpoint by prefix id
-func (mgr *EndpointManager) Lookup(id string) (*endpoint.Endpoint, error) {
+func (mgr *endpointManager) Lookup(id string) (*endpoint.Endpoint, error) {
 	mgr.mutex.RLock()
 	defer mgr.mutex.RUnlock()
 
@@ -280,15 +280,15 @@ func (mgr *EndpointManager) Lookup(id string) (*endpoint.Endpoint, error) {
 }
 
 // LookupCiliumID looks up endpoint by endpoint ID
-func (mgr *EndpointManager) LookupCiliumID(id uint16) *endpoint.Endpoint {
+func (mgr *endpointManager) LookupCiliumID(id uint16) *endpoint.Endpoint {
 	mgr.mutex.RLock()
 	ep := mgr.lookupCiliumID(id)
 	mgr.mutex.RUnlock()
 	return ep
 }
 
-// LookupContainerID looks up endpoint by Docker ID
-func (mgr *EndpointManager) LookupContainerID(id string) *endpoint.Endpoint {
+// LookupContainerID looks up endpoint by container ID
+func (mgr *endpointManager) LookupContainerID(id string) *endpoint.Endpoint {
 	mgr.mutex.RLock()
 	ep := mgr.lookupContainerID(id)
 	mgr.mutex.RUnlock()
@@ -296,7 +296,7 @@ func (mgr *EndpointManager) LookupContainerID(id string) *endpoint.Endpoint {
 }
 
 // LookupIPv4 looks up endpoint by IPv4 address
-func (mgr *EndpointManager) LookupIPv4(ipv4 string) *endpoint.Endpoint {
+func (mgr *endpointManager) LookupIPv4(ipv4 string) *endpoint.Endpoint {
 	mgr.mutex.RLock()
 	ep := mgr.lookupIPv4(ipv4)
 	mgr.mutex.RUnlock()
@@ -304,7 +304,7 @@ func (mgr *EndpointManager) LookupIPv4(ipv4 string) *endpoint.Endpoint {
 }
 
 // LookupIPv6 looks up endpoint by IPv6 address
-func (mgr *EndpointManager) LookupIPv6(ipv6 string) *endpoint.Endpoint {
+func (mgr *endpointManager) LookupIPv6(ipv6 string) *endpoint.Endpoint {
 	mgr.mutex.RLock()
 	ep := mgr.lookupIPv6(ipv6)
 	mgr.mutex.RUnlock()
@@ -312,7 +312,7 @@ func (mgr *EndpointManager) LookupIPv6(ipv6 string) *endpoint.Endpoint {
 }
 
 // LookupIP looks up endpoint by IP address
-func (mgr *EndpointManager) LookupIP(ip net.IP) (ep *endpoint.Endpoint) {
+func (mgr *endpointManager) LookupIP(ip net.IP) (ep *endpoint.Endpoint) {
 	addr := ip.String()
 	mgr.mutex.RLock()
 	if ip.To4() != nil {
@@ -325,22 +325,22 @@ func (mgr *EndpointManager) LookupIP(ip net.IP) (ep *endpoint.Endpoint) {
 }
 
 // LookupPodName looks up endpoint by namespace + pod name
-func (mgr *EndpointManager) LookupPodName(name string) *endpoint.Endpoint {
+func (mgr *endpointManager) LookupPodName(name string) *endpoint.Endpoint {
 	mgr.mutex.RLock()
 	ep := mgr.lookupPodNameLocked(name)
 	mgr.mutex.RUnlock()
 	return ep
 }
 
-// ReleaseID releases the ID of the specified endpoint from the EndpointManager.
+// ReleaseID releases the ID of the specified endpoint from the endpointManager.
 // Returns an error if the ID cannot be released.
-func (mgr *EndpointManager) ReleaseID(ep *endpoint.Endpoint) error {
+func (mgr *endpointManager) ReleaseID(ep *endpoint.Endpoint) error {
 	return idallocator.Release(ep.ID)
 }
 
 // unexpose removes the endpoint from the endpointmanager, so subsequent
 // lookups will no longer find the endpoint.
-func (mgr *EndpointManager) unexpose(ep *endpoint.Endpoint) {
+func (mgr *endpointManager) unexpose(ep *endpoint.Endpoint) {
 	// Fetch the identifiers; this will only fail if the endpoint is
 	// already disconnected, in which case we don't need to proceed with
 	// the rest of cleaning up the endpoint.
@@ -375,7 +375,7 @@ func (mgr *EndpointManager) unexpose(ep *endpoint.Endpoint) {
 
 // removeEndpoint stops the active handling of events by the specified endpoint,
 // and prevents the endpoint from being globally acccessible via other packages.
-func (mgr *EndpointManager) removeEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
+func (mgr *endpointManager) removeEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
 	mgr.unexpose(ep)
 	result := ep.Delete(conf)
 
@@ -390,12 +390,12 @@ func (mgr *EndpointManager) removeEndpoint(ep *endpoint.Endpoint, conf endpoint.
 
 // RemoveEndpoint stops the active handling of events by the specified endpoint,
 // and prevents the endpoint from being globally acccessible via other packages.
-func (mgr *EndpointManager) RemoveEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
+func (mgr *endpointManager) RemoveEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
 	return mgr.deleteEndpoint(ep, conf)
 }
 
 // RemoveAll removes all endpoints from the global maps.
-func (mgr *EndpointManager) RemoveAll() {
+func (mgr *endpointManager) RemoveAll() {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
 	idallocator.ReallocatePool()
@@ -404,65 +404,65 @@ func (mgr *EndpointManager) RemoveAll() {
 }
 
 // lookupCiliumID looks up endpoint by endpoint ID
-func (mgr *EndpointManager) lookupCiliumID(id uint16) *endpoint.Endpoint {
+func (mgr *endpointManager) lookupCiliumID(id uint16) *endpoint.Endpoint {
 	if ep, ok := mgr.endpoints[id]; ok {
 		return ep
 	}
 	return nil
 }
 
-func (mgr *EndpointManager) lookupDockerEndpoint(id string) *endpoint.Endpoint {
+func (mgr *endpointManager) lookupDockerEndpoint(id string) *endpoint.Endpoint {
 	if ep, ok := mgr.endpointsAux[endpointid.NewID(endpointid.DockerEndpointPrefix, id)]; ok {
 		return ep
 	}
 	return nil
 }
 
-func (mgr *EndpointManager) lookupPodNameLocked(name string) *endpoint.Endpoint {
+func (mgr *endpointManager) lookupPodNameLocked(name string) *endpoint.Endpoint {
 	if ep, ok := mgr.endpointsAux[endpointid.NewID(endpointid.PodNamePrefix, name)]; ok {
 		return ep
 	}
 	return nil
 }
 
-func (mgr *EndpointManager) lookupDockerContainerName(name string) *endpoint.Endpoint {
+func (mgr *endpointManager) lookupDockerContainerName(name string) *endpoint.Endpoint {
 	if ep, ok := mgr.endpointsAux[endpointid.NewID(endpointid.ContainerNamePrefix, name)]; ok {
 		return ep
 	}
 	return nil
 }
 
-func (mgr *EndpointManager) lookupIPv4(ipv4 string) *endpoint.Endpoint {
+func (mgr *endpointManager) lookupIPv4(ipv4 string) *endpoint.Endpoint {
 	if ep, ok := mgr.endpointsAux[endpointid.NewID(endpointid.IPv4Prefix, ipv4)]; ok {
 		return ep
 	}
 	return nil
 }
 
-func (mgr *EndpointManager) lookupIPv6(ipv6 string) *endpoint.Endpoint {
+func (mgr *endpointManager) lookupIPv6(ipv6 string) *endpoint.Endpoint {
 	if ep, ok := mgr.endpointsAux[endpointid.NewID(endpointid.IPv6Prefix, ipv6)]; ok {
 		return ep
 	}
 	return nil
 }
 
-func (mgr *EndpointManager) lookupContainerID(id string) *endpoint.Endpoint {
+func (mgr *endpointManager) lookupContainerID(id string) *endpoint.Endpoint {
 	if ep, ok := mgr.endpointsAux[endpointid.NewID(endpointid.ContainerIdPrefix, id)]; ok {
 		return ep
 	}
 	return nil
 }
 
-// updateIDReferenceLocked updates the endpoints map in the EndpointManager for
+// updateIDReferenceLocked updates the endpoints map in the endpointManager for
 // the given Endpoint.
-func (mgr *EndpointManager) updateIDReferenceLocked(ep *endpoint.Endpoint) {
+func (mgr *endpointManager) updateIDReferenceLocked(ep *endpoint.Endpoint) {
 	if ep == nil {
 		return
 	}
 	mgr.endpoints[ep.ID] = ep
 }
 
-func (mgr *EndpointManager) updateReferencesLocked(ep *endpoint.Endpoint, identifiers endpointid.Identifiers) {
+func (mgr *endpointManager) updateReferencesLocked(ep *endpoint.Endpoint, identifiers endpointid.Identifiers) {
 	for k := range identifiers {
 		id := endpointid.NewID(k, identifiers[k])
 		mgr.endpointsAux[id] = ep
@@ -470,7 +470,7 @@ func (mgr *EndpointManager) updateReferencesLocked(ep *endpoint.Endpoint, identi
 }
 
 // UpdateReferences updates maps the contents of mappings to the specified endpoint.
-func (mgr *EndpointManager) UpdateReferences(ep *endpoint.Endpoint) error {
+func (mgr *endpointManager) UpdateReferences(ep *endpoint.Endpoint) error {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
 
@@ -484,7 +484,7 @@ func (mgr *EndpointManager) UpdateReferences(ep *endpoint.Endpoint) error {
 }
 
 // removeReferencesLocked removes the mappings from the endpointmanager.
-func (mgr *EndpointManager) removeReferencesLocked(identifiers endpointid.Identifiers) {
+func (mgr *endpointManager) removeReferencesLocked(identifiers endpointid.Identifiers) {
 	for prefix := range identifiers {
 		id := endpointid.NewID(prefix, identifiers[prefix])
 		delete(mgr.endpointsAux, id)
@@ -492,12 +492,12 @@ func (mgr *EndpointManager) removeReferencesLocked(identifiers endpointid.Identi
 }
 
 // AddIPv6Address notifies an addition of an IPv6 address
-func (mgr *EndpointManager) AddIPv6Address(ipv6 netip.Addr) {
+func (mgr *endpointManager) AddIPv6Address(ipv6 netip.Addr) {
 	mgr.mcastManager.AddAddress(ipv6)
 }
 
 // RemoveAIPv6ddress notifies a removal of an IPv6 address
-func (mgr *EndpointManager) RemoveIPv6Address(ipv6 netip.Addr) {
+func (mgr *endpointManager) RemoveIPv6Address(ipv6 netip.Addr) {
 	mgr.mcastManager.RemoveAddress(ipv6)
 }
 
@@ -506,7 +506,7 @@ func (mgr *EndpointManager) RemoveIPv6Address(ipv6 netip.Addr) {
 // list is locked and cannot be modified.
 // Returns a waiting group that can be used to know when all the endpoints are
 // regenerated.
-func (mgr *EndpointManager) RegenerateAllEndpoints(regenMetadata *regeneration.ExternalRegenerationMetadata) *sync.WaitGroup {
+func (mgr *endpointManager) RegenerateAllEndpoints(regenMetadata *regeneration.ExternalRegenerationMetadata) *sync.WaitGroup {
 	var wg sync.WaitGroup
 
 	eps := mgr.GetEndpoints()
@@ -527,7 +527,7 @@ func (mgr *EndpointManager) RegenerateAllEndpoints(regenMetadata *regeneration.E
 }
 
 // OverrideEndpointOpts applies the given options to all endpoints.
-func (mgr *EndpointManager) OverrideEndpointOpts(om option.OptionMap) {
+func (mgr *endpointManager) OverrideEndpointOpts(om option.OptionMap) {
 	for _, ep := range mgr.GetEndpoints() {
 		if _, err := ep.ApplyOpts(om); err != nil && !errors.Is(err, endpoint.ErrEndpointDeleted) {
 			log.WithError(err).WithFields(logrus.Fields{
@@ -538,7 +538,7 @@ func (mgr *EndpointManager) OverrideEndpointOpts(om option.OptionMap) {
 }
 
 // HasGlobalCT returns true if the endpoints have a global CT, false otherwise.
-func (mgr *EndpointManager) HasGlobalCT() bool {
+func (mgr *endpointManager) HasGlobalCT() bool {
 	eps := mgr.GetEndpoints()
 	for _, e := range eps {
 		if !e.Options.IsEnabled(option.ConntrackLocal) {
@@ -549,7 +549,7 @@ func (mgr *EndpointManager) HasGlobalCT() bool {
 }
 
 // GetEndpoints returns a slice of all endpoints present in endpoint manager.
-func (mgr *EndpointManager) GetEndpoints() []*endpoint.Endpoint {
+func (mgr *endpointManager) GetEndpoints() []*endpoint.Endpoint {
 	mgr.mutex.RLock()
 	eps := make([]*endpoint.Endpoint, 0, len(mgr.endpoints))
 	for _, ep := range mgr.endpoints {
@@ -561,7 +561,7 @@ func (mgr *EndpointManager) GetEndpoints() []*endpoint.Endpoint {
 
 // GetPolicyEndpoints returns a map of all endpoints present in endpoint
 // manager as policy.Endpoint interface set for the map key.
-func (mgr *EndpointManager) GetPolicyEndpoints() map[policy.Endpoint]struct{} {
+func (mgr *endpointManager) GetPolicyEndpoints() map[policy.Endpoint]struct{} {
 	mgr.mutex.RLock()
 	eps := make(map[policy.Endpoint]struct{}, len(mgr.endpoints))
 	for _, ep := range mgr.endpoints {
@@ -571,7 +571,7 @@ func (mgr *EndpointManager) GetPolicyEndpoints() map[policy.Endpoint]struct{} {
 	return eps
 }
 
-func (mgr *EndpointManager) expose(ep *endpoint.Endpoint) error {
+func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 	newID, err := mgr.AllocateID(ep.ID)
 	if err != nil {
 		return err
@@ -593,13 +593,13 @@ func (mgr *EndpointManager) expose(ep *endpoint.Endpoint) error {
 
 // RestoreEndpoint exposes the specified endpoint to other subsystems via the
 // manager.
-func (mgr *EndpointManager) RestoreEndpoint(ep *endpoint.Endpoint) error {
+func (mgr *endpointManager) RestoreEndpoint(ep *endpoint.Endpoint) error {
 	ep.SetDefaultConfiguration(true)
 	return mgr.expose(ep)
 }
 
 // AddEndpoint takes the prepared endpoint object and starts managing it.
-func (mgr *EndpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) (err error) {
+func (mgr *endpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) (err error) {
 	ep.SetDefaultConfiguration(false)
 
 	if ep.ID != 0 {
@@ -619,7 +619,7 @@ func (mgr *EndpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.E
 	return nil
 }
 
-func (mgr *EndpointManager) AddHostEndpoint(
+func (mgr *endpointManager) AddHostEndpoint(
 	ctx context.Context,
 	owner regeneration.Owner,
 	policyGetter policyRepoGetter,
@@ -650,7 +650,7 @@ type policyRepoGetter interface {
 
 // InitHostEndpointLabels initializes the host endpoint's labels with the
 // node's known labels.
-func (mgr *EndpointManager) InitHostEndpointLabels(ctx context.Context) {
+func (mgr *endpointManager) InitHostEndpointLabels(ctx context.Context) {
 	ep := mgr.GetHostEndpoint()
 	if ep == nil {
 		log.Error("Attempted to init host endpoint labels but host endpoint not set.")
@@ -662,7 +662,7 @@ func (mgr *EndpointManager) InitHostEndpointLabels(ctx context.Context) {
 // WaitForEndpointsAtPolicyRev waits for all endpoints which existed at the time
 // this function is called to be at a given policy revision.
 // New endpoints appearing while waiting are ignored.
-func (mgr *EndpointManager) WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error {
+func (mgr *endpointManager) WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error {
 	eps := mgr.GetEndpoints()
 	for i := range eps {
 		select {
@@ -681,7 +681,7 @@ func (mgr *EndpointManager) WaitForEndpointsAtPolicyRev(ctx context.Context, rev
 // exist when invoked. It is similar to WaitForEndpointsAtPolicyRevision but
 // each endpoint that reaches the desired revision calls 'done' independently.
 // The provided callback should not block and generally be lightweight.
-func (mgr *EndpointManager) CallbackForEndpointsAtPolicyRev(ctx context.Context, rev uint64, done func(time.Time)) error {
+func (mgr *endpointManager) CallbackForEndpointsAtPolicyRev(ctx context.Context, rev uint64, done func(time.Time)) error {
 	eps := mgr.GetEndpoints()
 	for i := range eps {
 		eps[i].WaitForPolicyRevision(ctx, rev, done)
@@ -690,6 +690,6 @@ func (mgr *EndpointManager) CallbackForEndpointsAtPolicyRev(ctx context.Context,
 }
 
 // EndpointExists returns whether the endpoint with id exists.
-func (mgr *EndpointManager) EndpointExists(id uint16) bool {
+func (mgr *endpointManager) EndpointExists(id uint16) bool {
 	return mgr.LookupCiliumID(id) != nil
 }

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -31,7 +31,7 @@ import (
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) { TestingT(t) }
 
-func (mgr *EndpointManager) waitEndpointRemoved(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
+func (mgr *endpointManager) waitEndpointRemoved(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
 	mgr.unexpose(ep)
 	ep.Stop()
 	return nil
@@ -40,7 +40,7 @@ func (mgr *EndpointManager) waitEndpointRemoved(ep *endpoint.Endpoint, conf endp
 // WaitEndpointRemoved waits until all operations associated with Remove of
 // the endpoint have been completed.
 // Note: only used for unit tests, to avoid ep.Delete()
-func (mgr *EndpointManager) WaitEndpointRemoved(ep *endpoint.Endpoint) {
+func (mgr *endpointManager) WaitEndpointRemoved(ep *endpoint.Endpoint) {
 	mgr.waitEndpointRemoved(ep, endpoint.DeleteConfig{})
 }
 
@@ -117,7 +117,7 @@ func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) 
 
 func (s *EndpointManagerSuite) TestLookup(c *C) {
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
-	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{})
 	type args struct {
 		id string
 	}
@@ -367,7 +367,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
-	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 2, endpoint.StateReady)
 	type args struct {
 		id uint16
@@ -434,7 +434,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
-	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 3, endpoint.StateReady)
 	type args struct {
 		id string
@@ -499,7 +499,7 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
-	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 4, endpoint.StateReady)
 	type args struct {
 		ip string
@@ -564,7 +564,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
-	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 5, endpoint.StateReady)
 	type args struct {
 		podName string
@@ -630,7 +630,7 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
-	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 6, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
@@ -704,7 +704,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestRemove(c *C) {
-	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 7, endpoint.StateReady)
 	type args struct {
 	}
@@ -744,7 +744,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
-	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	type want struct {
 		result bool
@@ -805,7 +805,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
-	mgr := NewEndpointManager(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	type args struct {
 		ctx    context.Context

--- a/pkg/endpointmanager/subscribe.go
+++ b/pkg/endpointmanager/subscribe.go
@@ -18,14 +18,14 @@ type Subscriber interface {
 	EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConfig)
 }
 
-func (mgr *EndpointManager) Subscribe(s Subscriber) {
+func (mgr *endpointManager) Subscribe(s Subscriber) {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
 
 	mgr.subscribers[s] = struct{}{}
 }
 
-func (mgr *EndpointManager) Unsubscribe(s Subscriber) {
+func (mgr *endpointManager) Unsubscribe(s Subscriber) {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
 	delete(mgr.subscribers, s)

--- a/pkg/hive/lifecycle.go
+++ b/pkg/hive/lifecycle.go
@@ -155,7 +155,6 @@ func (lc *DefaultLifecycle) PrintHooks() {
 	for _, hook := range lc.hooks {
 		fnName, exists := getHookFuncName(hook, true)
 		if !exists {
-			fmt.Printf("%v not defined\n", hook)
 			continue
 		}
 		fmt.Printf("  • %s\n", fnName)

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package manager
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell provides the NodeManager, which manages information about Cilium nodes
+// in the cluster and informs other modules of changes to node configuration.
+var Cell = cell.Module(
+	"node-manager",
+	"Manages the collection of Cilium nodes",
+	cell.Provide(newAllNodeManager),
+)
+
+// Notifier is the interface the wraps Subscribe and Unsubscribe. An
+// implementation of this interface notifies subscribers of nodes being added,
+// updated or deleted.
+type Notifier interface {
+	// Subscribe adds the given NodeHandler to the list of subscribers that are
+	// notified of node changes. Upon call to this method, the NodeHandler is
+	// being notified of all nodes that are already in the cluster by calling
+	// the NodeHandler's NodeAdd callback.
+	Subscribe(datapath.NodeHandler)
+
+	// Unsubscribe removes the given NodeHandler from the list of subscribers.
+	Unsubscribe(datapath.NodeHandler)
+}
+
+type NodeManager interface {
+	Notifier
+
+	// GetNodes returns a copy of all of the nodes as a map from Identity to Node.
+	GetNodes() map[types.Identity]types.Node
+
+	// GetNodeIdentities returns a list of all node identities store in node
+	// manager.
+	GetNodeIdentities() []types.Identity
+
+	// NodeUpdated is called when the store detects a change in node
+	// information
+	NodeUpdated(n types.Node)
+
+	// NodeDeleted is called when the store detects a deletion of a node
+	NodeDeleted(n types.Node)
+
+	// ClusterSizeDependantInterval returns a time.Duration that is dependant on
+	// the cluster size, i.e. the number of nodes that have been discovered. This
+	// can be used to control sync intervals of shared or centralized resources to
+	// avoid overloading these resources as the cluster grows.
+	ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration
+
+	// SetIPCache sets the ipcache field in the Manager.
+	SetIPCache(ipc IPCache)
+
+	// StartNeighborRefresh spawns a controller which refreshes neighbor table
+	// by sending arping periodically.
+	StartNeighborRefresh(nh datapath.NodeHandler)
+}
+
+func newAllNodeManager(lc hive.Lifecycle) (NodeManager, error) {
+	mngr, err := New("all", option.Config)
+	if err != nil {
+		return nil, err
+	}
+	lc.Append(mngr)
+	return mngr, nil
+}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"net"
 	"net/netip"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -17,8 +16,8 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -67,23 +66,10 @@ type Configuration interface {
 	EncryptionEnabled() bool
 }
 
-// Notifier is the interface the wraps Subscribe and Unsubscribe. An
-// implementation of this interface notifies subscribers of nodes being added,
-// updated or deleted.
-type Notifier interface {
-	// Subscribe adds the given NodeHandler to the list of subscribers that are
-	// notified of node changes. Upon call to this method, the NodeHandler is
-	// being notified of all nodes that are already in the cluster by calling
-	// the NodeHandler's NodeAdd callback.
-	Subscribe(datapath.NodeHandler)
-	// Unsubscribe removes the given NodeHandler from the list of subscribers.
-	Unsubscribe(datapath.NodeHandler)
-}
+var _ Notifier = (*manager)(nil)
 
-var _ Notifier = (*Manager)(nil)
-
-// Manager is the entity that manages a collection of nodes
-type Manager struct {
+// manager is the entity that manages a collection of nodes
+type manager struct {
 	// mutex is the lock protecting access to the nodes map. The mutex must
 	// be held for any access of the nodes map.
 	//
@@ -141,24 +127,10 @@ type Manager struct {
 	// controllerManager manages the controllers that are launched within the
 	// Manager.
 	controllerManager *controller.Manager
-
-	// selectorCacheUpdater updates the identities inside the selector cache.
-	selectorCacheUpdater selectorCacheUpdater
-
-	// policyTriggerer triggers policy updates (recalculations).
-	policyTriggerer policyTriggerer
-}
-
-type selectorCacheUpdater interface {
-	UpdateIdentities(added, deleted cache.IdentityCache, wg *sync.WaitGroup)
-}
-
-type policyTriggerer interface {
-	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
 }
 
 // Subscribe subscribes the given node handler to node events.
-func (m *Manager) Subscribe(nh datapath.NodeHandler) {
+func (m *manager) Subscribe(nh datapath.NodeHandler) {
 	m.nodeHandlersMu.Lock()
 	m.nodeHandlers[nh] = struct{}{}
 	m.nodeHandlersMu.Unlock()
@@ -173,14 +145,14 @@ func (m *Manager) Subscribe(nh datapath.NodeHandler) {
 }
 
 // Unsubscribe unsubscribes the given node handler with node events.
-func (m *Manager) Unsubscribe(nh datapath.NodeHandler) {
+func (m *manager) Unsubscribe(nh datapath.NodeHandler) {
 	m.nodeHandlersMu.Lock()
 	delete(m.nodeHandlers, nh)
 	m.nodeHandlersMu.Unlock()
 }
 
 // Iter executes the given function in all subscribed node handlers.
-func (m *Manager) Iter(f func(nh datapath.NodeHandler)) {
+func (m *manager) Iter(f func(nh datapath.NodeHandler)) {
 	m.nodeHandlersMu.RLock()
 	defer m.nodeHandlersMu.RUnlock()
 
@@ -189,19 +161,16 @@ func (m *Manager) Iter(f func(nh datapath.NodeHandler)) {
 	}
 }
 
-// NewManager returns a new node manager
-func NewManager(name string, dp datapath.NodeHandler, c Configuration, sc selectorCacheUpdater, pt policyTriggerer) (*Manager, error) {
-	m := &Manager{
-		name:                 name,
-		nodes:                map[nodeTypes.Identity]*nodeEntry{},
-		conf:                 c,
-		controllerManager:    controller.NewManager(),
-		selectorCacheUpdater: sc,
-		policyTriggerer:      pt,
-		nodeHandlers:         map[datapath.NodeHandler]struct{}{},
-		closeChan:            make(chan struct{}),
+// New returns a new node manager
+func New(name string, c Configuration) (*manager, error) {
+	m := &manager{
+		name:              name,
+		nodes:             map[nodeTypes.Identity]*nodeEntry{},
+		conf:              c,
+		controllerManager: controller.NewManager(),
+		nodeHandlers:      map[datapath.NodeHandler]struct{}{},
+		closeChan:         make(chan struct{}),
 	}
-	m.Subscribe(dp)
 
 	m.metricEventsReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
@@ -229,31 +198,21 @@ func NewManager(name string, dp datapath.NodeHandler, c Configuration, sc select
 		return nil, err
 	}
 
-	go m.backgroundSync()
-
 	return m, nil
 }
 
-// WithSelectorCacheUpdater sets the selector cache updater in the Manager.
-func (m *Manager) WithSelectorCacheUpdater(sc selectorCacheUpdater) *Manager {
-	m.selectorCacheUpdater = sc
-	return m
-}
-
-// WithPolicyTriggerer sets the policy update trigger in the Manager.
-func (m *Manager) WithPolicyTriggerer(pt policyTriggerer) *Manager {
-	m.policyTriggerer = pt
-	return m
-}
-
-// WithIPCache sets the ipcache field in the Manager.
-func (m *Manager) WithIPCache(ipc IPCache) *Manager {
+// SetIPCache sets the ipcache field in the Manager.
+func (m *manager) SetIPCache(ipc IPCache) {
 	m.ipcache = ipc
-	return m
 }
 
-// Close shuts down a node manager
-func (m *Manager) Close() {
+func (m *manager) Start(hive.HookContext) error {
+	go m.backgroundSync()
+	return nil
+}
+
+// Stop shuts down a node manager
+func (m *manager) Stop(hive.HookContext) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -271,6 +230,8 @@ func (m *Manager) Close() {
 		})
 		n.mutex.Unlock()
 	}
+
+	return nil
 }
 
 // ClusterSizeDependantInterval returns a time.Duration that is dependant on
@@ -297,7 +258,7 @@ func (m *Manager) Close() {
 // 4096  | 8m19.080616652s
 // 8192  | 9m00.662124608s
 // 16384 | 9m42.247293667s
-func (m *Manager) ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration {
+func (m *manager) ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration {
 	m.mutex.RLock()
 	numNodes := len(m.nodes)
 	m.mutex.RUnlock()
@@ -305,13 +266,13 @@ func (m *Manager) ClusterSizeDependantInterval(baseInterval time.Duration) time.
 	return backoff.ClusterSizeDependantInterval(baseInterval, numNodes)
 }
 
-func (m *Manager) backgroundSyncInterval() time.Duration {
+func (m *manager) backgroundSyncInterval() time.Duration {
 	return m.ClusterSizeDependantInterval(baseBackgroundSyncInterval)
 }
 
 // backgroundSync ensures that local node has a valid datapath in-place for
 // each node in the cluster. See NodeValidateImplementation().
-func (m *Manager) backgroundSync() {
+func (m *manager) backgroundSync() {
 	syncTimer, syncTimerDone := inctimer.New()
 	defer syncTimerDone()
 	for {
@@ -351,7 +312,7 @@ func (m *Manager) backgroundSync() {
 
 // legacyNodeIpBehavior returns true if the agent is still running in legacy
 // mode regarding node IPs
-func (m *Manager) legacyNodeIpBehavior() bool {
+func (m *manager) legacyNodeIpBehavior() bool {
 	// Cilium < 1.7 only exposed the Cilium internalIP to the ipcache
 	// unless encryption was enabled. This meant that for the majority of
 	// node IPs, CIDR policy rules would apply. With the introduction of
@@ -378,7 +339,7 @@ func (m *Manager) legacyNodeIpBehavior() bool {
 // node in the manager is added or updated if the source is allowed to update
 // the node. If an update or addition has occurred, NodeUpdate() of the datapath
 // interface is invoked.
-func (m *Manager) NodeUpdated(n nodeTypes.Node) {
+func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	log.Debugf("Received node update event from %s: %#v", n.Source, n)
 
 	nodeIdentity := n.Identity()
@@ -577,7 +538,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 // upsertIntoIDMD upserts the given CIDR into the ipcache.identityMetadata
 // (IDMD) map. The given node identity determines which labels are associated
 // with the CIDR.
-func (m *Manager) upsertIntoIDMD(prefix netip.Prefix, id identity.NumericIdentity, rid ipcacheTypes.ResourceID) {
+func (m *manager) upsertIntoIDMD(prefix netip.Prefix, id identity.NumericIdentity, rid ipcacheTypes.ResourceID) {
 	if id == identity.ReservedIdentityHost {
 		m.ipcache.UpsertLabels(prefix, labels.LabelHost, source.Local, rid)
 	} else {
@@ -587,7 +548,7 @@ func (m *Manager) upsertIntoIDMD(prefix netip.Prefix, id identity.NumericIdentit
 
 // deleteIPCache deletes the IP addresses from the IPCache with the 'oldSource'
 // if they are not found in the newIPs slice.
-func (m *Manager) deleteIPCache(oldSource source.Source, oldIPs []string, newIPs []string) {
+func (m *manager) deleteIPCache(oldSource source.Source, oldIPs []string, newIPs []string) {
 	for _, address := range oldIPs {
 		var found bool
 		for _, ipAdded := range newIPs {
@@ -608,7 +569,7 @@ func (m *Manager) deleteIPCache(oldSource source.Source, oldIPs []string, newIPs
 // from the manager if the node is still owned by the source of which the event
 // origins from. If the node was removed, NodeDelete() is invoked of the
 // datapath interface.
-func (m *Manager) NodeDeleted(n nodeTypes.Node) {
+func (m *manager) NodeDeleted(n nodeTypes.Node) {
 	m.metricEventsReceived.WithLabelValues("delete", string(n.Source)).Inc()
 
 	log.Debugf("Received node delete event from %s", n.Source)
@@ -629,7 +590,7 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 		m.mutex.Unlock()
 		if n.IsLocal() && n.Source == source.Kubernetes {
 			log.Debugf("Kubernetes is deleting local node, close manager")
-			m.Close()
+			m.Stop(context.Background())
 		} else {
 			log.Debugf("Ignoring delete event of node %s from source %s. The node is owned by %s",
 				n.Name, n.Source, entry.node.Source)
@@ -677,7 +638,7 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 
 // GetNodeIdentities returns a list of all node identities store in node
 // manager.
-func (m *Manager) GetNodeIdentities() []nodeTypes.Identity {
+func (m *manager) GetNodeIdentities() []nodeTypes.Identity {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
@@ -690,7 +651,7 @@ func (m *Manager) GetNodeIdentities() []nodeTypes.Identity {
 }
 
 // GetNodes returns a copy of all of the nodes as a map from Identity to Node.
-func (m *Manager) GetNodes() map[nodeTypes.Identity]nodeTypes.Node {
+func (m *manager) GetNodes() map[nodeTypes.Identity]nodeTypes.Node {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
@@ -706,7 +667,7 @@ func (m *Manager) GetNodes() map[nodeTypes.Identity]nodeTypes.Node {
 
 // StartNeighborRefresh spawns a controller which refreshes neighbor table
 // by sending arping periodically.
-func (m *Manager) StartNeighborRefresh(nh datapath.NodeHandler) {
+func (m *manager) StartNeighborRefresh(nh datapath.NodeHandler) {
 	ctx, cancel := context.WithCancel(context.Background())
 	controller.NewManager().UpdateController("neighbor-table-refresh",
 		controller.ControllerParams{

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -234,17 +234,8 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	_, ok = nodes[n1.Identity()]
 	c.Assert(ok, check.Equals, false)
 
-	mngr.Stop(context.TODO())
-	select {
-	case nodeEvent := <-dp.NodeDeleteEvent:
-		c.Assert(nodeEvent, checker.DeepEquals, n2)
-	case nodeEvent := <-dp.NodeAddEvent:
-		c.Errorf("Unexpected NodeAdd() event %#v", nodeEvent)
-	case nodeEvent := <-dp.NodeUpdateEvent:
-		c.Errorf("Unexpected NodeUpdate() event %#v", nodeEvent)
-	case <-time.After(3 * time.Second):
-		c.Errorf("timeout while waiting for NodeDelete() event for node2")
-	}
+	err = mngr.Stop(context.TODO())
+	c.Assert(err, check.IsNil)
 }
 
 func (s *managerTestSuite) TestMultipleSources(c *check.C) {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -64,7 +64,7 @@ type k8sGetters interface {
 
 // NodeDiscovery represents a node discovery action
 type NodeDiscovery struct {
-	Manager               *nodemanager.Manager
+	Manager               nodemanager.NodeManager
 	LocalConfig           datapath.LocalNodeConfiguration
 	Registrar             nodestore.NodeRegistrar
 	Registered            chan struct{}
@@ -84,7 +84,7 @@ func enableLocalNodeRoute() bool {
 }
 
 // NewNodeDiscovery returns a pointer to new node discovery object
-func NewNodeDiscovery(manager *nodemanager.Manager, clientset client.Clientset, mtuConfig mtu.Configuration, netConf *cnitypes.NetConf) *NodeDiscovery {
+func NewNodeDiscovery(manager nodemanager.NodeManager, clientset client.Clientset, mtuConfig mtu.Configuration, netConf *cnitypes.NetConf) *NodeDiscovery {
 	auxPrefixes := []*cidr.CIDR{}
 
 	if option.Config.IPv4ServiceRange != AutoCIDR {
@@ -334,11 +334,6 @@ func (n *NodeDiscovery) LocalNode() *types.Node {
 
 	n.fillLocalNode()
 	return n.localNode.DeepCopy()
-}
-
-// Close shuts down the node discovery engine
-func (n *NodeDiscovery) Close() {
-	n.Manager.Close()
 }
 
 // UpdateCiliumNodeResource updates the CiliumNode resource representing the


### PR DESCRIPTION
This PR adds cells for EndpointManager and NodeManager (cilium-agent objects snippet): 
```
          Ⓜ️ endpoint-manager (Manages the collection of local endpoints):
              ⚙️ (endpointmanager.EndpointManagerConfig) {
                  EndpointGCInterval: (time.Duration) 5m0s
              }

              🚧 endpointmanager.newDefaultEndpointManager (cell.go:177):
                  ⇨ client.Clientset, endpointmanager.EndpointManagerConfig, hive.Lifecycle
                  ⇦ endpointmanager.EndpointManager, endpointmanager.EndpointsLookup, 
                      endpointmanager.EndpointsModify

          Ⓜ️ node-manager (Manages the collection of Cilium nodes):
              🚧 manager.newAllNodeManager (cell.go:69):
                  ⇨ hive.Lifecycle
                  ⇦ manager.NodeManager
```

The endpoint manager is now exposed as 3 different APIs: EndpointsLookup (for read-only lookups of endpoints), EndpointsModify (for adding and removing endpoints), and EndpointManager (for initialization and operations on all endpoints). This division by functionality adds clarity ("ah this module only needs to look up endpoints") and makes integration testing of cells depending on e.g. endpoint lookup simpler.

Node manager's API is kept as in one chunk as it's relatively small. It is still exposed as an interface rather than as struct pointer, again for improved integration testing and for clarity. Providing interfaces at the cell-level does not go against the "return structs, accept interfaces" rule. That rule is all about loose coupling in public APIs, e.g. library functions should be flexible in what they accept (don't take `*os.File`, but `io.Reader`). Here we're following the same spirit, but at the macro level. With interfaces in the object graph we can choose the implementation to provide to a cell or augment an existing one (cell.Decorate) if needed. This gives maximum flexibility and loose coupling that comes especially handy in integration testing.