### PR TITLE
helm: avoid generating ConfigMapList

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble/dashboards-configmap.yaml
@@ -1,29 +1,25 @@
 {{- if .Values.hubble.metrics.dashboards.enabled }}
 {{- $files := .Files.Glob "files/hubble/dashboards/*.json" }}
-{{- if $files }}
-apiVersion: v1
-kind: ConfigMapList
-items:
 {{- range $path, $fileContents := $files }}
 {{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: {{ $dashboardName | trunc 63 | trimSuffix "-" }}
-    namespace: {{ $.Values.hubble.metrics.dashboards.namespace | default $.Release.Namespace }}
-    labels:
-      k8s-app: hubble
-      app.kubernetes.io/name: hubble
-      app.kubernetes.io/part-of: cilium
-      {{- if $.Values.hubble.metrics.dashboards.label }}
-      {{ $.Values.hubble.metrics.dashboards.label }}: {{ ternary $.Values.hubble.metrics.dashboards.labelValue "1" (not (empty $.Values.hubble.metrics.dashboards.labelValue)) | quote }}
-      {{- end }}
-    {{- with $.Values.hubble.metrics.dashboards.annotations }}
-    annotations:
-      {{- toYaml . | nindent 6 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $dashboardName | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $.Values.hubble.metrics.dashboards.namespace | default $.Release.Namespace }}
+  labels:
+    k8s-app: hubble
+    app.kubernetes.io/name: hubble
+    app.kubernetes.io/part-of: cilium
+    {{- if $.Values.hubble.metrics.dashboards.label }}
+    {{ $.Values.hubble.metrics.dashboards.label }}: {{ ternary $.Values.hubble.metrics.dashboards.labelValue "1" (not (empty $.Values.hubble.metrics.dashboards.labelValue)) | quote }}
     {{- end }}
-  data:
-    {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
-{{- end }}
+  {{- with $.Values.hubble.metrics.dashboards.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
According to [the Kubernetes documentation](https://kubernetes.io/docs/reference/using-api/api-concepts/#collections), List objects should not appear in requests.

See also https://github.com/prometheus-operator/kube-prometheus/issues/1735