### PR TITLE
hubble: Add "hubble-prefer-ipv6" option

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -164,6 +164,7 @@ cilium-agent [flags]
       --hubble-listen-address string                            An additional address for Hubble server to listen to, e.g. ":4244"
       --hubble-metrics strings                                  List of Hubble metrics to enable.
       --hubble-metrics-server string                            Address to serve Hubble metrics on.
+      --hubble-prefer-ipv6                                      Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-recorder-sink-queue-size int                     Queue size of each Hubble recorder sink (default 1024)
       --hubble-recorder-storage-path string                     Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")
       --hubble-socket-path string                               Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -817,6 +817,10 @@
      - Target Port for the Peer service.
      - int
      - ``4244``
+   * - hubble.preferIpv6
+     - Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available.
+     - bool
+     - ``false``
    * - hubble.relay.affinity
      - Affinity for hubble-replay
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -779,6 +779,7 @@ preCache
 preallocateMaps
 prebuild
 preconfigured
+preferIpv
 prefilter
 preflight
 preload

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -894,6 +894,9 @@ func initializeFlags() {
 	flags.String(option.HubbleListenAddress, "", `An additional address for Hubble server to listen to, e.g. ":4244"`)
 	option.BindEnv(Vp, option.HubbleListenAddress)
 
+	flags.Bool(option.HubblePreferIpv6, false, "Prefer IPv6 addresses for announcing nodes when both address types are available.")
+	option.BindEnv(Vp, option.HubblePreferIpv6)
+
 	flags.Bool(option.HubbleTLSDisabled, false, "Allow Hubble server to run on the given listen address without TLS.")
 	option.BindEnv(Vp, option.HubbleTLSDisabled)
 

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -179,6 +179,9 @@ func (d *Daemon) launchHubble() {
 	if option.Config.HubbleTLSDisabled {
 		peerServiceOptions = append(peerServiceOptions, serviceoption.WithoutTLSInfo())
 	}
+	if option.Config.HubblePreferIpv6 {
+		peerServiceOptions = append(peerServiceOptions, serviceoption.WithAddressFamilyPreference(serviceoption.AddressPreferIPv6))
+	}
 	peerSvc := peer.NewService(d.nodeDiscovery.Manager, peerServiceOptions...)
 	localSrvOpts = append(localSrvOpts,
 		serveroption.WithUnixSocketListener(sockPath),

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -255,6 +255,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.enabled | bool | `true` | Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service. |
+| hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -766,6 +766,9 @@ data:
   hubble-disable-tls: "true"
 {{- end }}
 {{- end }}
+{{- if .Values.hubble.preferIpv6 }}
+  hubble-prefer-ipv6: "true"
+{{- end }}
 {{- end }}
 {{- if hasKey .Values "disableIptablesFeederRules" }}
   # A space separated list of iptables chains to disable when installing feeder rules.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -814,6 +814,9 @@ hubble:
   # Set this field ":4244" if you are enabling Hubble Relay, as it assumes that
   # Hubble is listening on port 4244.
   listenAddress: ":4244"
+  # -- Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available.
+  preferIpv6: false
+
   peerService:
     # -- Enable a K8s Service for the Peer service, so that it can be accessed
     # by a non-local client

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -811,6 +811,9 @@ hubble:
   # Set this field ":4244" if you are enabling Hubble Relay, as it assumes that
   # Hubble is listening on port 4244.
   listenAddress: ":4244"
+  # -- Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available.
+  preferIpv6: false
+
   peerService:
     # -- Enable a K8s Service for the Peer service, so that it can be accessed
     # by a non-local client

--- a/pkg/hubble/peer/service.go
+++ b/pkg/hubble/peer/service.go
@@ -53,7 +53,7 @@ func (s *Service) Notify(_ *peerpb.NotifyRequest, stream peerpb.Peer_NotifyServe
 	g, ctx := errgroup.WithContext(ctx)
 
 	// monitor for global stop signal to tear down all routines
-	h := newHandler(s.opts.WithoutTLSInfo)
+	h := newHandler(s.opts.WithoutTLSInfo, s.opts.AddressFamilyPreference)
 	g.Go(func() error {
 		defer h.Close()
 		select {

--- a/pkg/hubble/peer/serviceoption/defaults.go
+++ b/pkg/hubble/peer/serviceoption/defaults.go
@@ -5,5 +5,6 @@ package serviceoption
 
 // Default serves only as reference point for default values.
 var Default = Options{
-	MaxSendBufferSize: 65_536,
+	MaxSendBufferSize:       65_536,
+	AddressFamilyPreference: AddressPreferIPv4,
 }

--- a/pkg/hubble/peer/serviceoption/option.go
+++ b/pkg/hubble/peer/serviceoption/option.go
@@ -5,12 +5,27 @@ package serviceoption
 
 // Options stores all the configuration values for the peer service.
 type Options struct {
-	MaxSendBufferSize int
-	WithoutTLSInfo    bool
+	MaxSendBufferSize       int
+	WithoutTLSInfo          bool
+	AddressFamilyPreference AddressFamilyPreference
 }
 
 // Option customizes the peer service's configuration.
 type Option func(o *Options)
+
+type AddressFamily uint
+
+const (
+	AddressFamilyIPv4 AddressFamily = 4
+	AddressFamilyIPv6 AddressFamily = 6
+)
+
+type AddressFamilyPreference []AddressFamily
+
+var (
+	AddressPreferIPv4 = AddressFamilyPreference{AddressFamilyIPv4, AddressFamilyIPv6}
+	AddressPreferIPv6 = AddressFamilyPreference{AddressFamilyIPv6, AddressFamilyIPv4}
+)
 
 // WithMaxSendBufferSize sets the maximum size of the send buffer. When the
 // send buffer is full, for example due to errors in the transport, the server
@@ -30,5 +45,14 @@ func WithMaxSendBufferSize(size int) Option {
 func WithoutTLSInfo() Option {
 	return func(o *Options) {
 		o.WithoutTLSInfo = true
+	}
+}
+
+// WithAddressFamilyPreference configures the order in which IP addresses
+// will be considered when sending notifications for nodes that have both IPv4
+// and IPv6 available.
+func WithAddressFamilyPreference(pref AddressFamilyPreference) Option {
+	return func(o *Options) {
+		o.AddressFamilyPreference = pref
 	}
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -906,6 +906,10 @@ const (
 	// HubbleListenAddress specifies address for Hubble server to listen to.
 	HubbleListenAddress = "hubble-listen-address"
 
+	// HubblePreferIpv6 controls whether IPv6 or IPv4 addresses should be preferred for
+	// communication to agents, if both are available.
+	HubblePreferIpv6 = "hubble-prefer-ipv6"
+
 	// HubbleTLSDisabled allows the Hubble server to run on the given listen
 	// address without TLS.
 	HubbleTLSDisabled = "hubble-disable-tls"
@@ -2037,6 +2041,10 @@ type DaemonConfig struct {
 
 	// HubbleListenAddress specifies address for Hubble to listen to.
 	HubbleListenAddress string
+
+	// HubblePreferIpv6 controls whether IPv6 or IPv4 addresses should be preferred for
+	// communication to agents, if both are available.
+	HubblePreferIpv6 bool
 
 	// HubbleTLSDisabled allows the Hubble server to run on the given listen
 	// address without TLS.
@@ -3193,6 +3201,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableHubbleOpenMetrics = vp.GetBool(EnableHubbleOpenMetrics)
 	c.HubbleSocketPath = vp.GetString(HubbleSocketPath)
 	c.HubbleListenAddress = vp.GetString(HubbleListenAddress)
+	c.HubblePreferIpv6 = vp.GetBool(HubblePreferIpv6)
 	c.HubbleTLSDisabled = vp.GetBool(HubbleTLSDisabled)
 	c.HubbleTLSCertFile = vp.GetString(HubbleTLSCertFile)
 	c.HubbleTLSKeyFile = vp.GetString(HubbleTLSKeyFile)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

This change adds an option to the Hubble Relay communication that allows to configure the previously hardcoded IPv4/IPv6 preference. When a node has mixed IPv4 and IPv6 addresses, but internal cluster communication is only IPv6-based, Hubble would announce wrong node addresses which would break communication to the agents. The previous IPv4 preference is kept as default.

Our specific use case for this is EKS with IPv6. When an instance is put into a public subnet and receives a public IP, this IP will be mapped as ExternalIP onto the node. Hubble will then announce that IP, even though no communication can happen on it. Instead, it should announce the IPv6 address the EC2 instance (like it does for nodes without public IP).

We've tested this changeset successfully in real IPv6 EKS clusters using a custom build of v1.12.2.

```release-note
hubble: Add "hubble-prefer-ipv6" option
```
