### PR TITLE
EndpointManager: fix deadlock when releasing an endpoint

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -364,8 +364,8 @@ func (mgr *EndpointManager) unexpose(ep *endpoint.Endpoint) {
 		if err = mgr.ReleaseID(ep); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				"state":               previousState,
-				logfields.ContainerID: ep.GetShortContainerID(),
-				logfields.K8sPodName:  ep.GetK8sNamespaceAndPodName(),
+				logfields.ContainerID: identifiers[endpointid.ContainerIdPrefix],
+				logfields.K8sPodName:  identifiers[endpointid.PodNamePrefix],
 			}).Warning("Unable to release endpoint ID")
 		}
 	}


### PR DESCRIPTION
In high-churn clusters, there can be a three-party deadlock between the EndpointManager, the PolicyRepository, and a given Endpoint. One of the "links in the chain" is merely trying to get the container ID and namespace+name of an Endpoint for logging. Which we already have.

So, rather than trying to lock an Endpoint to get it's identifiers again, just use the copy we already have.

Fixes: https://github.com/cilium/cilium/commit/dae07b58f9f49017f54a72b36f0f02461d843732 (endpointmanager: Remove goroutine for ID release)

Signed-off-by: Casey Callendrello <cdc@isovalent.com>

```release-note
Fixes a deadlock that can be exposed in high-churn clusters when Pods are deleted rapidly.
```
