### PR TITLE
nodeinit: Move kubelet version check to expected branch

### DIFF
--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -29,15 +29,6 @@ KUBELET_DEFAULTS_FILE="/etc/default/kubelet"
 if [[ -f "${GKE_KUBERNETES_BIN_DIR}/gke" ]] && [[ $(grep -cF -- '--container-runtime-endpoint' "${KUBELET_DEFAULTS_FILE}") == "1" ]]; then
   echo "GKE *_containerd flavor detected..."
 
-  # kubelet version string format is "Kubernetes v1.24-gke.900"
-  K8S_VERSION=$(kubelet --version)
-
-  # Helper to check if a version string, passed as first parameter, is greater than or
-  # equal the one passed as second parameter.
-  function version_gte() {
-    [[ "$(printf '%s\n' "${2}" "${1}" | sort -V | head -n1)" = "${2}" ]] && return
-  }
-
   # (GKE *_containerd) Upon node restarts, GKE's containerd images seem to reset
   # the /etc directory and our changes to the kubelet and Cilium's CNI
   # configuration are removed. This leaves room for containerd and its CNI to
@@ -128,6 +119,15 @@ EOF
     echo "Kubelet wrapper already exists, skipping..."
   fi
 else
+  # kubelet version string format is "Kubernetes v1.24-gke.900"
+  K8S_VERSION=$(kubelet --version)
+
+  # Helper to check if a version string, passed as first parameter, is greater than or
+  # equal the one passed as second parameter.
+  function version_gte() {
+    [[ "$(printf '%s\n' "${2}" "${1}" | sort -V | head -n1)" = "${2}" ]] && return
+  }
+
   # Dockershim flags have been removed since k8s 1.24.
   if ! version_gte "${K8S_VERSION#"Kubernetes "}" "v1.24"; then
     # (Generic) Alter the kubelet configuration to run in CNI mode


### PR DESCRIPTION
Signed-off-by: John Watson <johnw@planetscale.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

This fixes:
- kubelet isn't in PATH in the container (at least for Canonical's GKE image)
- `K8S_VERSION` is unset for the non-GKE containerd flavor

Fixes: 1d6770ba77b253440f52f31b9c9213bd249157e1
