### PR TITLE
dashboards: Enable exemplars for histogram queries in Hubble L7 workloads dashboard

### DIFF
--- a/install/kubernetes/cilium/files/hubble/dashboards/hubble-l7-http-metrics-by-workload.json
+++ b/install/kubernetes/cilium/files/hubble/dashboards/hubble-l7-http-metrics-by-workload.json
@@ -621,7 +621,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "exemplar": false,
+          "exemplar": true,
           "expr": "histogram_quantile(0.50, sum(rate(hubble_http_request_duration_seconds_bucket{cluster=~\"${cluster}\", destination_namespace=~\"${destination_namespace}\", destination_workload=~\"${destination_workload}\", reporter=\"${reporter}\", source_namespace=~\"${source_namespace}\", source_workload=~\"${source_workload}\"}[$__rate_interval])) by (cluster, source_namespace, source_workload, le))",
           "interval": "",
           "legendFormat": "{{ cluster }} {{ source_namespace }}/{{ source_workload }} P50",
@@ -634,7 +634,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "exemplar": false,
+          "exemplar": true,
           "expr": "histogram_quantile(0.95, sum(rate(hubble_http_request_duration_seconds_bucket{cluster=~\"${cluster}\", destination_namespace=~\"${destination_namespace}\", destination_workload=~\"${destination_workload}\", reporter=\"${reporter}\", source_namespace=~\"${source_namespace}\", source_workload=~\"${source_workload}\"}[$__rate_interval])) by (cluster, source_namespace, source_workload, le))",
           "hide": false,
           "interval": "",
@@ -648,7 +648,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "exemplar": false,
+          "exemplar": true,
           "expr": "histogram_quantile(0.99, sum(rate(hubble_http_request_duration_seconds_bucket{cluster=~\"${cluster}\", destination_namespace=~\"${destination_namespace}\", destination_workload=~\"${destination_workload}\", reporter=\"${reporter}\", source_namespace=~\"${source_namespace}\", source_workload=~\"${source_workload}\"}[$__rate_interval])) by (cluster, source_namespace, source_workload, le))",
           "hide": false,
           "interval": "",
@@ -955,7 +955,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "exemplar": false,
+          "exemplar": true,
           "expr": "histogram_quantile(0.50, sum(rate(hubble_http_request_duration_seconds_bucket{cluster=~\"${cluster}\", destination_namespace=~\"${destination_namespace}\", destination_workload=~\"${destination_workload}\", reporter=\"${reporter}\", source_namespace=~\"${source_namespace}\", source_workload=~\"${source_workload}\"}[$__rate_interval])) by (cluster, destination_namespace, destination_workload, le))",
           "interval": "",
           "legendFormat": "{{ cluster }} {{ destination_namespace }}/{{ destination_workload }} P50",
@@ -968,7 +968,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "exemplar": false,
+          "exemplar": true,
           "expr": "histogram_quantile(0.95, sum(rate(hubble_http_request_duration_seconds_bucket{cluster=~\"${cluster}\", destination_namespace=~\"${destination_namespace}\", destination_workload=~\"${destination_workload}\", reporter=\"${reporter}\", source_namespace=~\"${source_namespace}\", source_workload=~\"${source_workload}\"}[$__rate_interval])) by (cluster, destination_namespace, destination_workload, le))",
           "hide": false,
           "interval": "",
@@ -982,7 +982,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "exemplar": false,
+          "exemplar": true,
           "expr": "histogram_quantile(0.99, sum(rate(hubble_http_request_duration_seconds_bucket{cluster=~\"${cluster}\", destination_namespace=~\"${destination_namespace}\", destination_workload=~\"${destination_workload}\", reporter=\"${reporter}\", source_namespace=~\"${source_namespace}\", source_workload=~\"${source_workload}\"}[$__rate_interval])) by (cluster, destination_namespace, destination_workload, le))",
           "hide": false,
           "interval": "",


### PR DESCRIPTION
With https://github.com/cilium/cilium/pull/21599 it's possible to
extract traceIDs into exemplars from HTTP flows, but to visualize them
in the Hubble L7 HTTP workloads dashboard, we need to explicitly enable
exemplars on the panels we wish to have them displayed on.

This commit enables exemplars on the HTTP request duration by
source/destination panels.

I opted to not enable it on the top-level request duration dashboard because it's smaller and isn't broken up by source/destination and ends up with potentially a lot of exemplars, making the graph hard to see.

```release-note
dashboards: Enable exemplars for histogram queries in Hubble L7 workloads dashboard
```
