### PR TITLE
cli: Update regex for key-value validation to allow spaces in values

### DIFF
--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -20,7 +20,7 @@ const (
 	equal = '='
 )
 
-var keyValueRegex = regexp.MustCompile(`([\w-:./@]+=[\w-:,./@]*,)*([\w-:./@]+=[\w-,:./@]*[\w-:./@]+)$`)
+var keyValueRegex = regexp.MustCompile(`([\w-:./@]+=([\w-:,./@][\w-:,./@ ]*[\w-:,./@])?[\w-:,./@]*,)*([\w-:./@]+=([\w-:,./@][\w-:,./@ ]*)?[\w-:./@]+)$`)
 
 // GetStringMapString contains one enhancement to support k1=v2,k2=v2 compared to original
 // implementation of GetStringMapString function

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -143,6 +143,17 @@ func TestGetStringMapString(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "valid kv format with space",
+			args: args{
+				key:   "FOO_BAR",
+				value: "cluster=my cluster",
+			},
+			want: map[string]string{
+				"cluster": "my cluster",
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "valid kv format from issue #20666",
 			args: args{
 				key:   "FOO_BAR",
@@ -276,6 +287,13 @@ func Test_isValidKeyValuePair(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "valid format with multiple pairs with commas",
+			args: args{
+				str: "k1=v,1,k2=v2,,k3=,v3,k4=v,4,k4=v4,k4=v,4",
+			},
+			want: true,
+		},
+		{
 			name: "empty value",
 			args: args{
 				str: "",
@@ -299,12 +317,12 @@ func Test_isValidKeyValuePair(t *testing.T) {
 		{
 			name: "no pair at all",
 			args: args{
-				str: "here is the test",
+				str: "here-is-the-test",
 			},
 			want: false,
 		},
 		{
-			name: "ending with command",
+			name: "ending with comma",
 			args: args{
 				str: "k1=v1,k2=v2,",
 			},
@@ -332,9 +350,30 @@ func Test_isValidKeyValuePair(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "space in value",
+			name: "value starts with space",
+			args: args{
+				str: "k1= v1,k2=v2",
+			},
+			want: false,
+		},
+		{
+			name: "last value starts with space",
 			args: args{
 				str: "k1=v1,k2= v2",
+			},
+			want: false,
+		},
+		{
+			name: "value ends with space",
+			args: args{
+				str: "k1=v1 ,k2=v2",
+			},
+			want: false,
+		},
+		{
+			name: "last value ends with space",
+			args: args{
+				str: "k1=v1,k2=v2 ",
 			},
 			want: false,
 		},


### PR DESCRIPTION
Fixes: #19793
Signed-off-by: John Gardiner Myers <jgmyers@proofpoint.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

The key value validation incorrectly rejects values with spaces in them.

Fixes: #19793

```release-note
cli: Update regex for key-value validation to allow spaces in values
```
