### PR TITLE
Remove beta.kubernetes.io/arch as it's already deprecated

### DIFF
--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -49,10 +49,10 @@ var nodeSampleJSON = `{
         },
         "creationTimestamp": "2019-03-07T13:35:02Z",
         "labels": {
-            "beta.kubernetes.io/arch": "amd64",
+            "kubernetes.io/arch": "amd64",
             "beta.kubernetes.io/fluentd-ds-ready": "true",
             "beta.kubernetes.io/instance-type": "foo",
-            "beta.kubernetes.io/os": "linux",
+            "kubernetes.io/os": "linux",
             "cloud.google.com/gke-nodepool": "default-pool",
             "cloud.google.com/gke-os-distribution": "cos",
             "disktype": "ssd",

--- a/test/controlplane/node/ciliumnodes/ciliumnodes.go
+++ b/test/controlplane/node/ciliumnodes/ciliumnodes.go
@@ -30,53 +30,43 @@ var steps = []step{
 	{
 		"state1.yaml",
 		map[string]string{
-			"beta.kubernetes.io/arch": "amd64",
-			"beta.kubernetes.io/os":   "linux",
-			"cilium.io/ci-node":       "k8s1",
-			"kubernetes.io/arch":      "amd64",
-			"kubernetes.io/hostname":  "cilium-nodes-worker",
-			"kubernetes.io/os":        "linux",
-			"test-label":              "test-value",
+			"cilium.io/ci-node":      "k8s1",
+			"kubernetes.io/arch":     "amd64",
+			"kubernetes.io/hostname": "cilium-nodes-worker",
+			"kubernetes.io/os":       "linux",
+			"test-label":             "test-value",
 		},
 	},
 
 	{
 		"state2.yaml",
 		map[string]string{
-			"beta.kubernetes.io/arch": "amd64",
-			"beta.kubernetes.io/os":   "linux",
-			"cilium.io/ci-node":       "k8s1",
-			"kubernetes.io/arch":      "amd64",
-			"kubernetes.io/hostname":  "cilium-nodes-worker",
-			"kubernetes.io/os":        "linux",
+			"cilium.io/ci-node":      "k8s1",
+			"kubernetes.io/arch":     "amd64",
+			"kubernetes.io/hostname": "cilium-nodes-worker",
+			"kubernetes.io/os":       "linux",
 		},
 	},
 
 	{
 		"state3.yaml",
 		map[string]string{
-			"beta.kubernetes.io/arch": "amd64",
-			"beta.kubernetes.io/os":   "linux",
-			"cilium.io/ci-node":       "k8s1",
-			"kubernetes.io/arch":      "amd64",
-			"kubernetes.io/hostname":  "cilium-nodes-worker",
-			"kubernetes.io/os":        "linux",
-
-			"another-test-label": "another-test-value",
+			"cilium.io/ci-node":      "k8s1",
+			"kubernetes.io/arch":     "amd64",
+			"kubernetes.io/hostname": "cilium-nodes-worker",
+			"kubernetes.io/os":       "linux",
+			"another-test-label":     "another-test-value",
 		},
 	},
 
 	{
 		"state4.yaml",
 		map[string]string{
-			"beta.kubernetes.io/arch": "amd64",
-			"beta.kubernetes.io/os":   "linux",
-			"cilium.io/ci-node":       "k8s1",
-			"kubernetes.io/arch":      "amd64",
-			"kubernetes.io/hostname":  "cilium-nodes-worker",
-			"kubernetes.io/os":        "linux",
-
-			"another-test-label": "changed-test-value",
+			"cilium.io/ci-node":      "k8s1",
+			"kubernetes.io/arch":     "amd64",
+			"kubernetes.io/hostname": "cilium-nodes-worker",
+			"kubernetes.io/os":       "linux",
+			"another-test-label":     "changed-test-value",
 		},
 	},
 }

--- a/test/controlplane/node/ciliumnodes/v1.23/init.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.23/init.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:50:06Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -149,8 +147,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:50:36Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker
@@ -277,8 +273,6 @@ items:
     creationTimestamp: "2022-09-12T20:51:11Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -315,8 +309,6 @@ items:
     creationTimestamp: "2022-09-12T20:51:11Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.23/state1.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.23/state1.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:50:06Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -146,8 +144,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:50:36Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.23/state2.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.23/state2.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:50:06Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -146,8 +144,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:50:36Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.23/state3.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.23/state3.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:50:06Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -147,8 +145,6 @@ items:
     creationTimestamp: "2022-09-12T20:50:36Z"
     labels:
       another-test-label: another-test-value
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.23/state4.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.23/state4.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:50:06Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -147,8 +145,6 @@ items:
     creationTimestamp: "2022-09-12T20:50:36Z"
     labels:
       another-test-label: changed-test-value
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.24/init.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/init.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:51:32Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -147,8 +145,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:51:57Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker
@@ -277,8 +273,6 @@ items:
     creationTimestamp: "2022-09-12T20:52:21Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -314,8 +308,6 @@ items:
     creationTimestamp: "2022-09-12T20:52:21Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.24/state1.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state1.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:51:32Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -147,8 +145,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:51:57Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.24/state2.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state2.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:51:32Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -147,8 +145,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:51:57Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.24/state3.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state3.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:51:32Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -148,8 +146,6 @@ items:
     creationTimestamp: "2022-09-12T20:51:57Z"
     labels:
       another-test-label: another-test-value
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.24/state4.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state4.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:51:32Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -148,8 +146,6 @@ items:
     creationTimestamp: "2022-09-12T20:51:57Z"
     labels:
       another-test-label: changed-test-value
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.25/init.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.25/init.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:52:51Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -150,8 +148,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:53:09Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker
@@ -279,8 +275,6 @@ items:
     creationTimestamp: "2022-09-12T20:54:19Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -316,8 +310,6 @@ items:
     creationTimestamp: "2022-09-12T20:54:13Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.25/state1.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.25/state1.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:52:51Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -148,8 +146,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:53:09Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.25/state2.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.25/state2.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:52:51Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -145,8 +143,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:53:09Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.25/state3.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.25/state3.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:52:51Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -146,8 +144,6 @@ items:
     creationTimestamp: "2022-09-12T20:53:09Z"
     labels:
       another-test-label: another-test-value
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/node/ciliumnodes/v1.25/state4.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.25/state4.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T20:52:51Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-control-plane
       kubernetes.io/os: linux
@@ -146,8 +144,6 @@ items:
     creationTimestamp: "2022-09-12T20:53:09Z"
     labels:
       another-test-label: changed-test-value
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: cilium-nodes-worker

--- a/test/controlplane/services/dualstack/v1.23/init.yaml
+++ b/test/controlplane/services/dualstack/v1.23/init.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T22:07:31Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-control-plane
       kubernetes.io/os: linux
@@ -140,8 +138,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T22:08:02Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker
@@ -275,8 +271,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T22:08:01Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker2
@@ -407,8 +401,6 @@ items:
     creationTimestamp: "2022-09-12T22:08:25Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-control-plane
       kubernetes.io/os: linux
@@ -451,8 +443,6 @@ items:
     creationTimestamp: "2022-09-12T22:08:24Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker
@@ -493,8 +483,6 @@ items:
     creationTimestamp: "2022-09-12T22:08:24Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker2

--- a/test/controlplane/services/dualstack/v1.24/init.yaml
+++ b/test/controlplane/services/dualstack/v1.24/init.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T22:09:09Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-control-plane
       kubernetes.io/os: linux
@@ -141,8 +139,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T22:09:34Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker
@@ -277,8 +273,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T22:09:34Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker2
@@ -409,8 +403,6 @@ items:
     creationTimestamp: "2022-09-12T22:10:00Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-control-plane
       kubernetes.io/os: linux
@@ -452,8 +444,6 @@ items:
     creationTimestamp: "2022-09-12T22:10:00Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker
@@ -494,8 +484,6 @@ items:
     creationTimestamp: "2022-09-12T22:10:00Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker2

--- a/test/controlplane/services/dualstack/v1.25/init.yaml
+++ b/test/controlplane/services/dualstack/v1.25/init.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T22:10:37Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-control-plane
       kubernetes.io/os: linux
@@ -148,8 +146,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T22:11:02Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker
@@ -284,8 +280,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T22:11:02Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker2
@@ -416,8 +410,6 @@ items:
     creationTimestamp: "2022-09-12T22:11:30Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-control-plane
       kubernetes.io/os: linux
@@ -459,8 +451,6 @@ items:
     creationTimestamp: "2022-09-12T22:11:30Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker
@@ -501,8 +491,6 @@ items:
     creationTimestamp: "2022-09-12T22:11:30Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: dual-stack-worker2

--- a/test/controlplane/services/graceful-termination/init.yaml
+++ b/test/controlplane/services/graceful-termination/init.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-12T22:12:39Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: graceful-term-control-plane
       kubernetes.io/os: linux
@@ -139,8 +137,6 @@ items:
     creationTimestamp: "2022-09-12T22:13:18Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: graceful-term-control-plane
       kubernetes.io/os: linux

--- a/test/controlplane/services/nodeport/v1.23/init.yaml
+++ b/test/controlplane/services/nodeport/v1.23/init.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-13T10:57:09Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-control-plane
       kubernetes.io/os: linux
@@ -148,8 +146,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-13T10:57:46Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker
@@ -278,8 +274,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-13T10:57:46Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker2
@@ -405,8 +399,6 @@ items:
     creationTimestamp: "2022-09-13T10:58:19Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-control-plane
       kubernetes.io/os: linux
@@ -445,8 +437,6 @@ items:
     creationTimestamp: "2022-09-13T10:58:19Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker
@@ -483,8 +473,6 @@ items:
     creationTimestamp: "2022-09-13T10:58:19Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker2

--- a/test/controlplane/services/nodeport/v1.24/init.yaml
+++ b/test/controlplane/services/nodeport/v1.24/init.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-13T11:08:20Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-control-plane
       kubernetes.io/os: linux
@@ -150,8 +148,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-13T11:08:46Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker
@@ -285,8 +281,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-13T11:08:46Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker2
@@ -418,8 +412,6 @@ items:
     creationTimestamp: "2022-09-13T11:09:16Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-control-plane
       kubernetes.io/os: linux
@@ -457,8 +449,6 @@ items:
     creationTimestamp: "2022-09-13T11:09:16Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker
@@ -495,8 +485,6 @@ items:
     creationTimestamp: "2022-09-13T11:09:16Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker2

--- a/test/controlplane/services/nodeport/v1.25/init.yaml
+++ b/test/controlplane/services/nodeport/v1.25/init.yaml
@@ -9,8 +9,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-13T11:10:20Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-control-plane
       kubernetes.io/os: linux
@@ -148,8 +146,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-13T11:10:45Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker
@@ -287,8 +283,6 @@ items:
       volumes.kubernetes.io/controller-managed-attach-detach: "true"
     creationTimestamp: "2022-09-13T11:10:45Z"
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker2
@@ -424,8 +418,6 @@ items:
     creationTimestamp: "2022-09-13T11:11:16Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-control-plane
       kubernetes.io/os: linux
@@ -463,8 +455,6 @@ items:
     creationTimestamp: "2022-09-13T11:11:16Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s1
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker
@@ -501,8 +491,6 @@ items:
     creationTimestamp: "2022-09-13T11:11:17Z"
     generation: 1
     labels:
-      beta.kubernetes.io/arch: amd64
-      beta.kubernetes.io/os: linux
       cilium.io/ci-node: k8s2
       kubernetes.io/arch: amd64
       kubernetes.io/hostname: nodeport-worker2

--- a/test/provision/manifest/kubedns_deployment.yaml
+++ b/test/provision/manifest/kubedns_deployment.yaml
@@ -72,7 +72,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64


### PR DESCRIPTION
beta.kubernetes.io/arch is already removal

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
