### PR TITLE
docs: Document the workaround for the kernel bug on new Intel CPUs

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -316,6 +316,15 @@ to enable NFS.
       # vers3=y
       ...
 
+.. note::
+
+   Linux 5.18 on newer Intel CPUs which support Intel CET (11th and
+   12th gen) has a bug that prevents the VMs from starting. If you see
+   a stacktrace with ``kernel BUG at arch/x86/kernel/traps.c`` and
+   ``traps: Missing ENDBR`` messages in dmesg, that means you are
+   affected. A workaround for now is to pass ``ibt=off`` to the kernel
+   command line.
+
 If for some reason, running of the provisioning script fails, you should bring the VM down before trying again:
 
 .. code-block:: shell-session

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -344,6 +344,7 @@ disassembly
 discoverable
 distro
 distros
+dmesg
 dns
 dnsPolicy
 dnsProxy


### PR DESCRIPTION
Development VMs fail to start on new kernels and new Intel CPUs due to a bug in the Intel CET implementation. Document a workaround for this bug.

Signed-off-by: Maxim Mikityanskiy <maxim@isovalent.com>