### PR TITLE
envoy: Allow use of architecture-specific Envoy images for testing

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -108,7 +108,7 @@ endif
 
 ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/images/cilium/Dockerfile),)
     CILIUM_ENVOY_REF=$(shell sed -E -e 's/^FROM (--[^ ]* )*([^ ]*) as cilium-envoy/\2/p;d' < $(ROOT_DIR)/images/cilium/Dockerfile)
-    CILIUM_ENVOY_SHA=$(shell echo $(CILIUM_ENVOY_REF) | sed -E -e 's/[^/]*\/[^:]*:([^:@]*).*/\1/p;d')
+    CILIUM_ENVOY_SHA=$(shell echo $(CILIUM_ENVOY_REF) | sed -E -e 's/[^/]*\/[^:]*:([^:@-]*).*/\1/p;d')
     GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=$(CILIUM_ENVOY_SHA)"
 endif
 


### PR DESCRIPTION
Detect hyphen `-` as the end of the commit/version SHA in Envoy image tags. This allows the use of architecture-specific tags, such as "1234567890abcdef-arm64". This is only useful for testing on a specific architecture, as this drops support for the excluded architecture.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
