### PR TITLE
Docker image build enhecements for kind

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -41,6 +41,11 @@ ifeq ($(DOCKER_DEV_ACCOUNT),)
     DOCKER_DEV_ACCOUNT=cilium
 endif
 
+ifneq ($(CI_BUILD),)
+    DOCKER_IMAGE_SUFFIX=-ci
+    DOCKER_IMAGE_TAG=$(shell git rev-parse HEAD)
+endif
+
 # Set DOCKER_IMAGE_TAG with "latest" by default
 ifeq ($(DOCKER_IMAGE_TAG),)
     DOCKER_IMAGE_TAG=latest

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -96,12 +96,17 @@ endif
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		--build-arg OPERATOR_VARIANT=$(IMAGE_NAME) \
 		--target $(5) \
-		-t $(IMAGE_REPOSITORY)/$(IMAGE_NAME)$${UNSTRIPPED}:$(4) .
-ifeq ($(findstring --push,$(DOCKER_FLAGS)),)
-	@echo 'Define "DOCKER_FLAGS=--push" to push the build results.'
+		-t $(IMAGE_REPOSITORY)/$(IMAGE_NAME)$${UNSTRIPPED}$(DOCKER_IMAGE_SUFFIX):$(4) .
+ifneq ($(KIND_LOAD),)
+	sleep 1
+	kind load docker-image $(IMAGE_REPOSITORY)/$(IMAGE_NAME)$${UNSTRIPPED}$(DOCKER_IMAGE_SUFFIX):$(4)
 else
+    ifeq ($(findstring --push,$(DOCKER_FLAGS)),)
+	@echo 'Define "DOCKER_FLAGS=--push" to push the build results.'
+    else
 	$(CONTAINER_ENGINE) buildx imagetools inspect $(IMAGE_REPOSITORY)/$(IMAGE_NAME):$(4)
 	@echo '^^^ Images pushed, multi-arch manifest should be above. ^^^'
+    endif
 endif
 
 $(1)-unstripped: NOSTRIP=1

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -27,9 +27,11 @@ ifdef ARCH
   endif
   DOCKER_FLAGS += --push --platform $(DOCKER_PLATFORMS)
 else
-  ifeq ($(findstring --push,$(DOCKER_FLAGS)),)
-    # ARCH and --push are not specified, build for the host platform without pushing, mimicking regular docker build
-    DOCKER_FLAGS += --load
+  ifeq ($(findstring --output,$(DOCKER_FLAGS)),)
+    ifeq ($(findstring --push,$(DOCKER_FLAGS)),)
+      # ARCH, --output, and --push are not specified, build for the host platform without pushing, mimicking regular docker build
+      DOCKER_FLAGS += --load
+    endif
   endif
 endif
 DOCKER_BUILDER := $(shell docker buildx ls | grep -E -e "[a-zA-Z0-9-]+ \*" | cut -d ' ' -f1)


### PR DESCRIPTION
DOCKER_IMAGE_SUFFIX, if defined, will be added to the end of the docker image name, before the tag. For example:

    $ DOCKER_IMAGE_SUFFIX=-ci make docker-cilium-image

will build `quay.io/cilium/cilium-ci:latest`

CI_BUILD, if defined, will define DOCKER_IMAGE_SUFFIX as "-ci", and DOCKER_IMAGE_TAG as the git HEAD SHA, which will then replace the default "latest" tag in the example above. This helps build local images with the same image reference that real CI builds would use.

KIND_LOAD, if defined, will load the build image with "kind load" one second after the build completes. The one second delay was required as without it "kind load" sometimes reported that it can't find the image that was just built.
    
Allow explicit --output docker option to used, e.g.:

$ DOCKER_FLAGS=--output=type=oci,dest=/tmp/cilium.docker make docker-cilium-image

This file can be then loaded to Kind, for example:

    $ kind load image-archive /tmp/cilium.docker
