### PR TITLE
v1.12 backports 2022-10-19

### DIFF
--- a/Documentation/concepts/kubernetes/policy.rst
+++ b/Documentation/concepts/kubernetes/policy.rst
@@ -16,9 +16,8 @@ distributing the policies across all nodes and Cilium will automatically apply
 the policies. Three formats are available to configure network policies natively
 with Kubernetes:
 
-- The standard `NetworkPolicy` resource which at the time of this writing,
-  supports to specify L3/L4 ingress policies with limited egress support marked
-  as beta.
+- The standard `NetworkPolicy` resource which supports L3 and L4 policies
+  at ingress or egress of the Pod.
 
 - The extended `CiliumNetworkPolicy` format which is available as a
   :term:`CustomResourceDefinition` which supports specification of policies
@@ -46,13 +45,15 @@ For more information, see the official `NetworkPolicy documentation
 
 Known missing features for Kubernetes Network Policy:
 
-+-------------------------------+------------------+
-| Feature                       | Tracking Issue   |
-+===============================+==================+
-| ``ipBlock`` set with a pod IP | :gh-issue:`9209` |
-+-------------------------------+------------------+
-| SCTP                          | :gh-issue:`5719` |
-+-------------------------------+------------------+
++-------------------------------+-------------------+
+| Feature                       | Tracking Issue    |
++===============================+===================+
+| ``ipBlock`` set with a pod IP | :gh-issue:`9209`  |
++-------------------------------+-------------------+
+| SCTP                          | :gh-issue:`5719`  |
++-------------------------------+-------------------+
+| Port ranges (endPort)         | :gh-issue:`16622` |
++-------------------------------+-------------------+
 
 .. _CiliumNetworkPolicy:
 

--- a/Documentation/gettingstarted/egress-gateway.rst
+++ b/Documentation/gettingstarted/egress-gateway.rst
@@ -243,7 +243,7 @@ There are 3 different ways this can be achieved:
        nodeSelector:
          matchLabels:
            testLabel: testVal
-         interface: ethX
+       interface: ethX
 
    In this case the first IPv4 address assigned to the ``ethX`` interface will be used.
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -376,6 +376,7 @@ enableK
 enableRuntimeDeviceDetection
 enableXTSocketFallback
 enablement
+endPort
 endian
 endianness
 endpointGCInterval

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -663,7 +663,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		option.Config,
 		d.ipcache,
 	)
-	nd.RegisterK8sNodeGetter(d.k8sWatcher)
+	nd.RegisterK8sGetters(d.k8sWatcher)
 	d.ipcache.RegisterK8sSyncedChecker(&d)
 
 	d.k8sWatcher.RegisterNodeSubscriber(d.endpointManager)

--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -367,6 +367,9 @@ func runCNPNodeStatusGC(name string, clusterwide bool, nodeStore cache.Store) {
 						cnpItemsList = make([]cilium_v2.CiliumNetworkPolicy, 0)
 						for _, ccnp := range ccnpList.Items {
 							cnpItemsList = append(cnpItemsList, cilium_v2.CiliumNetworkPolicy{
+								ObjectMeta: meta_v1.ObjectMeta{
+									Name: ccnp.Name,
+								},
 								Status: ccnp.Status,
 							})
 						}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -364,8 +364,8 @@ func (mgr *EndpointManager) unexpose(ep *endpoint.Endpoint) {
 		if err = mgr.ReleaseID(ep); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				"state":               previousState,
-				logfields.ContainerID: ep.GetShortContainerID(),
-				logfields.K8sPodName:  ep.GetK8sNamespaceAndPodName(),
+				logfields.ContainerID: identifiers[endpointid.ContainerIdPrefix],
+				logfields.K8sPodName:  identifiers[endpointid.PodNamePrefix],
 			}).Warning("Unable to release endpoint ID")
 		}
 	}

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/controller"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -144,4 +145,13 @@ func (k8sCli K8sClient) GetK8sNode(ctx context.Context, nodeName string) (*core_
 	}
 
 	return k8sCli.CoreV1().Nodes().Get(ctx, nodeName, v1.GetOptions{})
+}
+
+// GetCiliumNode returns the CiliumNode with the given nodeName.
+func (k8sCiliumCli K8sCiliumClient) GetCiliumNode(ctx context.Context, nodeName string) (*cilium_v2.CiliumNode, error) {
+	if k8sCiliumCli.Interface == nil {
+		return nil, fmt.Errorf("GetK8sNode: No k8s, cannot access k8s nodes")
+	}
+
+	return k8sCiliumCli.CiliumV2().CiliumNodes().Get(ctx, nodeName, v1.GetOptions{})
 }

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/rest"
 
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/controller"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/constants"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -34,11 +34,12 @@ const (
 	nodeRetrievalMaxRetries = 15
 )
 
-type nodeGetter interface {
+type k8sGetter interface {
 	GetK8sNode(ctx context.Context, nodeName string) (*corev1.Node, error)
+	GetCiliumNode(ctx context.Context, nodeName string) (*ciliumv2.CiliumNode, error)
 }
 
-func waitForNodeInformation(ctx context.Context, nodeGetter nodeGetter, nodeName string) *nodeTypes.Node {
+func waitForNodeInformation(ctx context.Context, k8sGetter k8sGetter, nodeName string) *nodeTypes.Node {
 	backoff := backoff.Exponential{
 		Min:    time.Duration(200) * time.Millisecond,
 		Max:    2 * time.Minute,
@@ -47,7 +48,7 @@ func waitForNodeInformation(ctx context.Context, nodeGetter nodeGetter, nodeName
 	}
 
 	for retry := 0; retry < nodeRetrievalMaxRetries; retry++ {
-		n, err := retrieveNodeInformation(ctx, nodeGetter, nodeName)
+		n, err := retrieveNodeInformation(ctx, k8sGetter, nodeName)
 		if err != nil {
 			log.WithError(err).Warning("Waiting for k8s node information")
 			backoff.Wait(ctx)
@@ -60,7 +61,7 @@ func waitForNodeInformation(ctx context.Context, nodeGetter nodeGetter, nodeName
 	return nil
 }
 
-func retrieveNodeInformation(ctx context.Context, nodeGetter nodeGetter, nodeName string) (*nodeTypes.Node, error) {
+func retrieveNodeInformation(ctx context.Context, nodeGetter k8sGetter, nodeName string) (*nodeTypes.Node, error) {
 	requireIPv4CIDR := option.Config.K8sRequireIPv4PodCIDR
 	requireIPv6CIDR := option.Config.K8sRequireIPv6PodCIDR
 	// At this point it's not clear whether the device auto-detection will
@@ -71,7 +72,7 @@ func retrieveNodeInformation(ctx context.Context, nodeGetter nodeGetter, nodeNam
 	var n *nodeTypes.Node
 
 	if option.Config.IPAM == ipamOption.IPAMClusterPool || option.Config.IPAM == ipamOption.IPAMClusterPoolV2 {
-		ciliumNode, err := CiliumClient().CiliumV2().CiliumNodes().Get(ctx, nodeName, v1.GetOptions{})
+		ciliumNode, err := nodeGetter.GetCiliumNode(ctx, nodeName)
 		if err != nil {
 			// If no CIDR is required, retrieving the node information is
 			// optional
@@ -219,9 +220,9 @@ func Init(conf k8sconfig.Configuration) error {
 
 // WaitForNodeInformation retrieves the node information via the CiliumNode or
 // Kubernetes Node resource. This function will block until the information is
-// received. nodeGetter is a function used to retrieved the node from either
+// received. k8sGetter is a function used to retrieve the node from either
 // the kube-apiserver or a local cache, depending on the caller.
-func WaitForNodeInformation(ctx context.Context, nodeGetter nodeGetter) error {
+func WaitForNodeInformation(ctx context.Context, k8sGetter k8sGetter) error {
 	// Use of the environment variable overwrites the node-name
 	// automatically derived
 	nodeName := nodeTypes.GetName()
@@ -235,7 +236,7 @@ func WaitForNodeInformation(ctx context.Context, nodeGetter nodeGetter) error {
 		return nil
 	}
 
-	if n := waitForNodeInformation(ctx, nodeGetter, nodeName); n != nil {
+	if n := waitForNodeInformation(ctx, k8sGetter, nodeName); n != nil {
 		nodeIP4 := n.GetNodeIP(false)
 		nodeIP6 := n.GetNodeIP(true)
 

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -4,10 +4,14 @@
 package watchers
 
 import (
+	"context"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/comparator"
@@ -142,4 +146,42 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncCo
 
 		log.Info("Disconnected from key-value store, restarting CiliumNode watcher")
 	}
+}
+
+// GetCiliumNode returns the CiliumNode "nodeName" from the local store. If the
+// local store is not initialized then it will fallback retrieving the node
+// from kube-apiserver.
+func (k *K8sWatcher) GetCiliumNode(ctx context.Context, nodeName string) (*cilium_v2.CiliumNode, error) {
+	var (
+		err                      error
+		nodeInterface            interface{}
+		exists, getFromAPIServer bool
+	)
+	k.ciliumNodeStoreMU.RLock()
+	// k.ciliumNodeStore might not be set in all invocations of GetCiliumNode,
+	// for example, during Cilium initialization GetCiliumNode is called from
+	// WaitForNodeInformation, which happens before ciliumNodeStore,
+	// so we will fallback to perform an API request to kube-apiserver.
+	if k.ciliumNodeStore == nil {
+		getFromAPIServer = true
+	} else {
+		nodeInterface, exists, err = k.ciliumNodeStore.GetByKey(nodeName)
+	}
+	k.ciliumNodeStoreMU.RUnlock()
+
+	if getFromAPIServer {
+		// fallback to using the kube-apiserver
+		return k8s.CiliumClient().CiliumV2().CiliumNodes().Get(ctx, nodeName, meta.GetOptions{})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, k8sErrors.NewNotFound(schema.GroupResource{
+			Group:    "cilium",
+			Resource: "CiliumNode",
+		}, nodeName)
+	}
+	return nodeInterface.(*cilium_v2.CiliumNode).DeepCopy(), nil
 }

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -4,7 +4,6 @@
 package ctmap
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -16,7 +15,6 @@ import (
 	"unsafe"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bpf"
@@ -610,13 +608,9 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 
 		if natKey.GetFlags()&tuple.TUPLE_F_IN == tuple.TUPLE_F_IN { // natKey is r(everse)tuple
 			ctKey := egressCTKeyFromIngressNatKeyAndVal(natKey, natVal)
-			if _, err := ctMap.Lookup(ctKey); errors.Is(err, unix.ENOENT) {
-				// No CT entry is found, so delete SNAT for both original and
-				// reverse flows
-				oNatKey := oNatKeyFromReverse(natKey, natVal)
-				if deleted, _ := natMap.Delete(oNatKey); deleted {
-					stats.EgressDeleted += 1
-				}
+
+			if !ctEntryExist(ctMap, ctKey) {
+				// No egress CT entry is found, delete the orphan ingress SNAT entry
 				if deleted, _ := natMap.Delete(natKey); deleted {
 					stats.IngressDeleted += 1
 				}
@@ -626,14 +620,11 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 		} else if natKey.GetFlags()&tuple.TUPLE_F_OUT == tuple.TUPLE_F_OUT {
 			ingressCTKey := ingressCTKeyFromEgressNatKey(natKey)
 			egressCTKey := egressCTKeyFromEgressNatKey(natKey)
-			if _, err := ctMap.Lookup(ingressCTKey); errors.Is(err, unix.ENOENT) {
-				if _, err := ctMap.Lookup(egressCTKey); errors.Is(err, unix.ENOENT) {
-					// No ingress and egress CT entries were found, delete the egress NAT entry
-					if deleted, _ := natMap.Delete(natKey); deleted {
-						stats.EgressDeleted += 1
-					}
-				} else {
-					stats.EgressAlive += 1
+
+			if !ctEntryExist(ctMap, ingressCTKey) && !ctEntryExist(ctMap, egressCTKey) {
+				// No ingress and egress CT entries were found, delete the orphan egress NAT entry
+				if deleted, _ := natMap.Delete(natKey); deleted {
+					stats.EgressDeleted += 1
 				}
 			} else {
 				stats.EgressAlive += 1

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -579,14 +579,7 @@ func GC(m *Map, filter *GCFilter) int {
 // In the case of 1-3, we always create a CT_EGRESS CT entry. This allows the
 // CT GC to remove corresponding SNAT entries. In the case of 4, will create
 // CT_INGRESS CT entry. See the unit test TestOrphanNatGC for more examples.
-//
-// The function only handles 1-3 cases, the 4. case is TODO(brb).
 func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
-	if option.Config.NodePortMode == option.NodePortModeDSR ||
-		option.Config.NodePortMode == option.NodePortModeHybrid {
-		return nil
-	}
-
 	// Both CT maps should point to the same natMap, so use the first one
 	// to determine natMap
 	ctMap := mapInfo[ctMapTCP.mapType]
@@ -615,7 +608,7 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 			ctMap = ctMapTCP
 		}
 
-		if natKey.GetFlags()&tuple.TUPLE_F_IN == 1 { // natKey is r(everse)tuple
+		if natKey.GetFlags()&tuple.TUPLE_F_IN == tuple.TUPLE_F_IN { // natKey is r(everse)tuple
 			ctKey := egressCTKeyFromIngressNatKeyAndVal(natKey, natVal)
 			if _, err := ctMap.Lookup(ctKey); errors.Is(err, unix.ENOENT) {
 				// No CT entry is found, so delete SNAT for both original and
@@ -629,6 +622,21 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 				}
 			} else {
 				stats.IngressAlive += 1
+			}
+		} else if natKey.GetFlags()&tuple.TUPLE_F_OUT == tuple.TUPLE_F_OUT {
+			ingressCTKey := ingressCTKeyFromEgressNatKey(natKey)
+			egressCTKey := egressCTKeyFromEgressNatKey(natKey)
+			if _, err := ctMap.Lookup(ingressCTKey); errors.Is(err, unix.ENOENT) {
+				if _, err := ctMap.Lookup(egressCTKey); errors.Is(err, unix.ENOENT) {
+					// No ingress and egress CT entries were found, delete the egress NAT entry
+					if deleted, _ := natMap.Delete(natKey); deleted {
+						stats.EgressDeleted += 1
+					}
+				} else {
+					stats.EgressAlive += 1
+				}
+			} else {
+				stats.EgressAlive += 1
 			}
 		}
 	}

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -324,6 +324,7 @@ func (k *CTMapTestSuite) TestOrphanNatGC(c *C) {
 	stats := PurgeOrphanNATEntries(ctMapTCP, ctMapAny)
 	c.Assert(stats.IngressAlive, Equals, uint32(1))
 	c.Assert(stats.IngressDeleted, Equals, uint32(0))
+	c.Assert(stats.EgressAlive, Equals, uint32(1))
 	c.Assert(stats.EgressDeleted, Equals, uint32(0))
 	// Check that both entries haven't removed
 	buf := make(map[string][]string)
@@ -338,6 +339,7 @@ func (k *CTMapTestSuite) TestOrphanNatGC(c *C) {
 	c.Assert(stats.IngressDeleted, Equals, uint32(1))
 	c.Assert(stats.IngressAlive, Equals, uint32(0))
 	c.Assert(stats.EgressDeleted, Equals, uint32(1))
+	c.Assert(stats.EgressAlive, Equals, uint32(0))
 	// Check that both orphan NAT entries have been removed
 	buf = make(map[string][]string)
 	err = natMap.Map.Dump(buf)
@@ -352,6 +354,82 @@ func (k *CTMapTestSuite) TestOrphanNatGC(c *C) {
 	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapAny)
 	c.Assert(stats.IngressDeleted, Equals, uint32(1))
 	c.Assert(stats.EgressDeleted, Equals, uint32(0))
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+
+	// Test DSR
+	//
+	// Create the following entries and check that SNAT entries are NOT GC-ed
+	// (as we have the CT entry which they belong to):
+	//
+	//     CT:	TCP IN  10.0.2.10:50000  -> 10.20.30.40:1234
+	//     NAT:	TCP OUT 10.20.30.40:1234 -> 10.0.2.10:50000 XLATE_SRC 10.0.2.20:40000
+
+	ctKey = &CtKey4Global{
+		TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				DestAddr:   types.IPv4{10, 0, 2, 10},
+				SourceAddr: types.IPv4{10, 20, 30, 40},
+				SourcePort: 0x50c3,
+				DestPort:   0xd204,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_IN,
+			},
+		},
+	}
+	ctVal = &CtEntry{
+		TxPackets: 1,
+		TxBytes:   216,
+		Lifetime:  37459,
+	}
+	err = bpf.UpdateElement(ctMapTCP.Map.GetFd(), ctMapTCP.Map.Name(), unsafe.Pointer(ctKey),
+		unsafe.Pointer(ctVal), 0)
+	c.Assert(err, IsNil)
+
+	natKey = &nat.NatKey4{
+		TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				SourceAddr: types.IPv4{10, 20, 30, 40},
+				DestAddr:   types.IPv4{10, 0, 2, 10},
+				SourcePort: 0xd204,
+				DestPort:   0x50c3,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	natVal = &nat.NatEntry4{
+		Created:   37400,
+		HostLocal: 1,
+		Addr:      types.IPv4{10, 0, 2, 20},
+		Port:      0x409c,
+	}
+	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
+		unsafe.Pointer(natVal), 0)
+	c.Assert(err, IsNil)
+
+	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
+	c.Assert(stats.IngressAlive, Equals, uint32(0))
+	c.Assert(stats.IngressDeleted, Equals, uint32(0))
+	c.Assert(stats.EgressAlive, Equals, uint32(1))
+	c.Assert(stats.EgressDeleted, Equals, uint32(0))
+	// Check that the entry hasn't been removed
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 1)
+
+	// Now remove the CT entry which should remove the NAT entry
+	err = bpf.DeleteElement(ctMapTCP.Map.GetFd(), unsafe.Pointer(ctKey))
+	c.Assert(err, IsNil)
+	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
+	c.Assert(stats.IngressAlive, Equals, uint32(0))
+	c.Assert(stats.IngressDeleted, Equals, uint32(0))
+	c.Assert(stats.EgressAlive, Equals, uint32(0))
+	c.Assert(stats.EgressDeleted, Equals, uint32(1))
+	// Check that the orphan NAT entry has been removed
 	buf = make(map[string][]string)
 	err = natMap.Map.Dump(buf)
 	c.Assert(err, IsNil)

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -223,6 +223,7 @@ func runGC(e *endpoint.Endpoint, ipv4, ipv6, triggeredBySignal bool, filter *ctm
 					"ingressDeleted": stats.IngressDeleted,
 					"egressDeleted":  stats.EgressDeleted,
 					"ingressAlive":   stats.IngressAlive,
+					"egressAlive":    stats.EgressAlive,
 					"ctMapIPVersion": vsn,
 				}).Info("Deleted orphan SNAT entries from map")
 			}

--- a/pkg/maps/ctmap/metrics.go
+++ b/pkg/maps/ctmap/metrics.go
@@ -122,8 +122,7 @@ type NatGCStats struct {
 	IngressAlive   uint32
 	IngressDeleted uint32
 	EgressDeleted  uint32
-	// It's not possible with the current PurgeOrphanNATEntries implementation
-	// to correctly count EgressAlive, so skip it
+	EgressAlive    uint32
 }
 
 func newNatGCStats(m *nat.Map, family gcFamily) NatGCStats {
@@ -137,5 +136,6 @@ func (s *NatGCStats) finish() {
 	family := s.Family.String()
 	metrics.NatGCSize.WithLabelValues(family, metricsIngress, metricsAlive).Set(float64(s.IngressAlive))
 	metrics.NatGCSize.WithLabelValues(family, metricsIngress, metricsDeleted).Set(float64(s.IngressDeleted))
+	metrics.NatGCSize.WithLabelValues(family, metricsEgress, metricsAlive).Set(float64(s.EgressAlive))
 	metrics.NatGCSize.WithLabelValues(family, metricsEgress, metricsDeleted).Set(float64(s.EgressDeleted))
 }

--- a/pkg/maps/ctmap/utils.go
+++ b/pkg/maps/ctmap/utils.go
@@ -4,42 +4,14 @@
 package ctmap
 
 import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/tuple"
 )
-
-// NOTE: the function does NOT copy addr fields, so it's not safe to
-// reuse the returned natKey.
-func oNatKeyFromReverse(k nat.NatKey, v nat.NatEntry) nat.NatKey {
-	natKey, ok := k.(*nat.NatKey4)
-	if ok { // ipv4
-		natVal := v.(*nat.NatEntry4)
-		return &nat.NatKey4{TupleKey4Global: tuple.TupleKey4Global{
-			TupleKey4: tuple.TupleKey4{
-				SourceAddr: natVal.Addr,
-				SourcePort: natVal.Port,
-				DestAddr:   natKey.SourceAddr,
-				DestPort:   natKey.SourcePort,
-				NextHeader: natKey.NextHeader,
-				Flags:      tuple.TUPLE_F_OUT,
-			}}}
-	}
-
-	{ // ipv6
-		natKey := k.(*nat.NatKey6)
-		natVal := v.(*nat.NatEntry6)
-		return &nat.NatKey6{TupleKey6Global: tuple.TupleKey6Global{
-			TupleKey6: tuple.TupleKey6{
-				SourceAddr: natVal.Addr,
-				SourcePort: natVal.Port,
-				DestAddr:   natKey.SourceAddr,
-				DestPort:   natKey.SourcePort,
-				NextHeader: natKey.NextHeader,
-				Flags:      tuple.TUPLE_F_OUT,
-			}}}
-	}
-}
 
 // NOTE: the function does NOT copy addr fields, so it's not safe to
 // reuse the returned ctKey.
@@ -159,4 +131,9 @@ func egressCTKeyFromEgressNatKey(k nat.NatKey) bpf.MapKey {
 
 		return &tuple.TupleKey6Global{TupleKey6: t}
 	}
+}
+
+func ctEntryExist(ctMap *Map, ctKey bpf.MapKey) bool {
+	_, err := ctMap.Lookup(ctKey)
+	return !errors.Is(err, unix.ENOENT)
 }

--- a/pkg/maps/ctmap/utils.go
+++ b/pkg/maps/ctmap/utils.go
@@ -46,28 +46,37 @@ func oNatKeyFromReverse(k nat.NatKey, v nat.NatEntry) nat.NatKey {
 func ingressCTKeyFromEgressNatKey(k nat.NatKey) bpf.MapKey {
 	natKey, ok := k.(*nat.NatKey4)
 	if ok { // ipv4
-		return &tuple.TupleKey4Global{TupleKey4: tuple.TupleKey4{
-			// Workaround #5848
-			SourceAddr: natKey.SourceAddr,
-			DestPort:   natKey.SourcePort,
-			DestAddr:   natKey.DestAddr,
+		t := tuple.TupleKey4{
+			SourceAddr: natKey.DestAddr,
 			SourcePort: natKey.DestPort,
+			DestAddr:   natKey.SourceAddr,
+			DestPort:   natKey.SourcePort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_IN,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey4Global{TupleKey4: t}
 	}
 
 	{ // ipv6
 		natKey := k.(*nat.NatKey6)
-		return &tuple.TupleKey6Global{TupleKey6: tuple.TupleKey6{
-			// Workaround #5848
-			SourceAddr: natKey.SourceAddr,
-			DestPort:   natKey.SourcePort,
-			DestAddr:   natKey.DestAddr,
+
+		t := tuple.TupleKey6{
+			SourceAddr: natKey.DestAddr,
 			SourcePort: natKey.DestPort,
+			DestAddr:   natKey.SourceAddr,
+			DestPort:   natKey.SourcePort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_IN,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey6Global{TupleKey6: t}
 	}
 }
 
@@ -77,29 +86,39 @@ func egressCTKeyFromIngressNatKeyAndVal(k nat.NatKey, v nat.NatEntry) bpf.MapKey
 	natKey, ok := k.(*nat.NatKey4)
 	if ok { // ipv4
 		natVal := v.(*nat.NatEntry4)
-		return &tuple.TupleKey4Global{TupleKey4: tuple.TupleKey4{
-			// Workaround #5848
-			SourceAddr: natKey.SourceAddr,
-			DestPort:   natKey.SourcePort,
-			DestAddr:   natVal.Addr,
+
+		t := tuple.TupleKey4{
+			SourceAddr: natVal.Addr,
 			SourcePort: natVal.Port,
+			DestAddr:   natKey.SourceAddr,
+			DestPort:   natKey.SourcePort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_OUT,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey4Global{TupleKey4: t}
 	}
 
 	{ // ipv6
 		natKey := k.(*nat.NatKey6)
 		natVal := v.(*nat.NatEntry6)
-		return &tuple.TupleKey6Global{TupleKey6: tuple.TupleKey6{
-			// Workaround #5848
-			SourceAddr: natKey.SourceAddr,
-			DestPort:   natKey.SourcePort,
-			DestAddr:   natVal.Addr,
+
+		t := tuple.TupleKey6{
+			SourceAddr: natVal.Addr,
 			SourcePort: natVal.Port,
+			DestAddr:   natKey.SourceAddr,
+			DestPort:   natKey.SourcePort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_OUT,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey6Global{TupleKey6: t}
 	}
 }
 
@@ -108,27 +127,36 @@ func egressCTKeyFromIngressNatKeyAndVal(k nat.NatKey, v nat.NatEntry) bpf.MapKey
 func egressCTKeyFromEgressNatKey(k nat.NatKey) bpf.MapKey {
 	natKey, ok := k.(*nat.NatKey4)
 	if ok { // ipv4
-		return &tuple.TupleKey4Global{TupleKey4: tuple.TupleKey4{
-			// Workaround #5848
-			SourceAddr: natKey.DestAddr,
-			DestPort:   natKey.DestPort,
-			DestAddr:   natKey.SourceAddr,
+		t := tuple.TupleKey4{
+			SourceAddr: natKey.SourceAddr,
 			SourcePort: natKey.SourcePort,
+			DestAddr:   natKey.DestAddr,
+			DestPort:   natKey.DestPort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_OUT,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey4Global{TupleKey4: t}
 	}
 
 	{ // ipv6
 		natKey := k.(*nat.NatKey6)
-		return &tuple.TupleKey6Global{TupleKey6: tuple.TupleKey6{
-			// Workaround #5848
-			SourceAddr: natKey.DestAddr,
-			DestPort:   natKey.DestPort,
-			DestAddr:   natKey.SourceAddr,
+
+		t := tuple.TupleKey6{
+			SourceAddr: natKey.SourceAddr,
 			SourcePort: natKey.SourcePort,
+			DestAddr:   natKey.DestAddr,
+			DestPort:   natKey.DestPort,
 			NextHeader: natKey.NextHeader,
 			Flags:      tuple.TUPLE_F_OUT,
-		}}
+		}
+
+		// Workaround #5848
+		t.SwapAddresses()
+
+		return &tuple.TupleKey6Global{TupleKey6: t}
 	}
 }

--- a/pkg/tuple/ipv4.go
+++ b/pkg/tuple/ipv4.go
@@ -99,6 +99,13 @@ func (k TupleKey4) Dump(sb *strings.Builder, reverse bool) bool {
 	return true
 }
 
+// SwapAddresses swaps the tuple source and destination addresses.
+func (t *TupleKey4) SwapAddresses() {
+	tmp := t.SourceAddr
+	t.SourceAddr = t.DestAddr
+	t.DestAddr = tmp
+}
+
 // TupleKey4Global represents the key for IPv4 entries in the global BPF
 // conntrack map.
 // +k8s:deepcopy-gen=true

--- a/pkg/tuple/ipv6.go
+++ b/pkg/tuple/ipv6.go
@@ -99,6 +99,13 @@ func (k TupleKey6) Dump(sb *strings.Builder, reverse bool) bool {
 	return true
 }
 
+// SwapAddresses swaps the tuple source and destination addresses.
+func (t *TupleKey6) SwapAddresses() {
+	tmp := t.SourceAddr
+	t.SourceAddr = t.DestAddr
+	t.DestAddr = tmp
+}
+
 // TupleKey6Global represents the key for IPv6 entries in the global BPF conntrack map.
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapKey


### PR DESCRIPTION
 * [ ] #21394 (@zuzzas)
 * [x] #21088 (@aanm)
 * [x] #21670 (@joestringer)
 * [x] #21626 (@jibi)
 * [ ] #21798 (@lou-lan)
 * [x] #21771 (@squeed)

PRs skipped due to presumably-related CI failures (see https://github.com/cilium/cilium/pull/21809#discussion_r1005730148):

 * #21234 (@nnbu)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 21394 21088 21670 21626 21798 21771 ; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
$ make add-label BRANCH=v1.12 ISSUES=21394,21088,21670,21626,21798,21771 
```
