### PR TITLE
v1.10 backports 2022-10-19

### DIFF
--- a/Documentation/concepts/kubernetes/policy.rst
+++ b/Documentation/concepts/kubernetes/policy.rst
@@ -16,9 +16,8 @@ distributing the policies across all nodes and Cilium will automatically apply
 the policies. Three formats are available to configure network policies natively
 with Kubernetes:
 
-- The standard `NetworkPolicy` resource which at the time of this writing,
-  supports to specify L3/L4 ingress policies with limited egress support marked
-  as beta.
+- The standard `NetworkPolicy` resource which supports L3 and L4 policies
+  at ingress or egress of the Pod.
 
 - The extended `CiliumNetworkPolicy` format which is available as a
   `CustomResourceDefinition` which supports specification of policies
@@ -46,13 +45,15 @@ For more information, see the official `NetworkPolicy documentation
 
 Known missing features for Kubernetes Network Policy:
 
-+-------------------------------+------------------+
-| Feature                       | Tracking Issue   |
-+===============================+==================+
-| ``ipBlock`` set with a pod IP | :gh-issue:`9209` |
-+-------------------------------+------------------+
-| SCTP                          | :gh-issue:`5719` |
-+-------------------------------+------------------+
++-------------------------------+-------------------+
+| Feature                       | Tracking Issue    |
++===============================+===================+
+| ``ipBlock`` set with a pod IP | :gh-issue:`9209`  |
++-------------------------------+-------------------+
+| SCTP                          | :gh-issue:`5719`  |
++-------------------------------+-------------------+
+| Port ranges (endPort)         | :gh-issue:`16622` |
++-------------------------------+-------------------+
 
 .. _CiliumNetworkPolicy:
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -339,6 +339,7 @@ enableIdentityMark
 enableK
 enableXTSocketFallback
 enablement
+endPort
 endian
 endianness
 endpointGCInterval

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -169,6 +169,9 @@ func runCNPNodeStatusGC(name string, clusterwide bool, ciliumNodeStore *store.Sh
 						cnpItemsList = make([]cilium_v2.CiliumNetworkPolicy, 0)
 						for _, ccnp := range ccnpList.Items {
 							cnpItemsList = append(cnpItemsList, cilium_v2.CiliumNetworkPolicy{
+								ObjectMeta: meta_v1.ObjectMeta{
+									Name: ccnp.Name,
+								},
 								Status: ccnp.Status,
 							})
 						}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -364,8 +364,8 @@ func (mgr *EndpointManager) unexpose(ep *endpoint.Endpoint) {
 		if err = mgr.ReleaseID(ep); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				"state":               previousState,
-				logfields.ContainerID: ep.GetShortContainerID(),
-				logfields.K8sPodName:  ep.GetK8sNamespaceAndPodName(),
+				logfields.ContainerID: identifiers[endpointid.ContainerIdPrefix],
+				logfields.K8sPodName:  identifiers[endpointid.PodNamePrefix],
 			}).Warning("Unable to release endpoint ID")
 		}
 	}


### PR DESCRIPTION
 * [ ] #21394 (@zuzzas)
 * [ ] #21670 (@joestringer)
 * [x] #21771 (@squeed)

PRs skipped due conflicts:

 * #21234 (@nnbu)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 21394 21670 21771; do contrib/backporting/set-labels.py $pr done 1.10; done
```
or with
```
$ make add-label BRANCH=v1.10 ISSUES=21394,21670,21771
```