### PR TITLE
consolidate_go_stacktrace: Fix relative paths

### DIFF
--- a/contrib/scripts/consolidate_go_stacktrace.py
+++ b/contrib/scripts/consolidate_go_stacktrace.py
@@ -86,7 +86,9 @@ if __name__ == "__main__":
     # If --source-dir flag is specified, make sure it ends with / and
     # use it to overwrite cilium_source prefix.
     source_dir = args.source_dir
-    if source_dir != "" and source_dir[-1] != '/':
+    if source_dir == "":
+        source_dir = "./"
+    elif source_dir != "" and source_dir[-1] != '/':
         source_dir += "/"
 
     # print count of each unique stack, and a sample, sorted by frequency


### PR DESCRIPTION
Previously, relative paths just truncated the beginning of the line, eg.
pkg/foo instead of beginning with the relative path characters
./pkg/foo. Fix this by ensuring the package paths begin with "./" .

Fixes: bafbfb8452db ("consolidate_go_stacktrace.py: Use relative paths by default")
