### PR TITLE
helm: Document missing k8sService kubeConfigPath bpf.mapDynamicSizeRatio

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -49,7 +49,7 @@ cilium-agent [flags]
       --bpf-lb-rss-ipv6-src-cidr string                         BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP
       --bpf-lb-sock                                             Enable socket-based LB for E/W traffic
       --bpf-lb-sock-hostns-only                                 Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).
-      --bpf-map-dynamic-size-ratio float                        Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
+      --bpf-map-dynamic-size-ratio float                        Ratio (0.0-1.0] of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps (default 0.0025)
       --bpf-nat-global-max int                                  Maximum number of entries for the global BPF NAT table (default 524288)
       --bpf-neigh-global-max int                                Maximum number of entries for the global BPF neighbor table (default 524288)
       --bpf-policy-map-max int                                  Maximum number of entries in endpoint policy map (per endpoint) (default 16384)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -109,6 +109,10 @@
      - Configure the maximum number of service entries in the load balancer maps.
      - int
      - ``65536``
+   * - bpf.mapDynamicSizeRatio
+     - Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/stable/concepts/ebpf/maps/#ebpf-maps
+     - float64
+     - ``0.0025``
    * - bpf.masquerade
      - Enable native IP masquerade support in eBPF
      - bool
@@ -1301,6 +1305,14 @@
      - Configure Kubernetes specific configuration
      - object
      - ``{}``
+   * - k8sServiceHost
+     - Kubernetes service host
+     - string
+     - ``""``
+   * - k8sServicePort
+     - Kubernetes service port
+     - string
+     - ``""``
    * - keepDeprecatedLabels
      - Keep the deprecated selector labels when deploying Cilium DaemonSet.
      - bool
@@ -1309,6 +1321,10 @@
      - Keep the deprecated probes when deploying Cilium DaemonSet
      - bool
      - ``false``
+   * - kubeConfigPath
+     - Kubernetes config path
+     - string
+     - ``"~/.kube/config"``
    * - kubeProxyReplacementHealthzBindAddr
      - healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled.
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -588,6 +588,7 @@ kprobe
 kprobes
 kretprobes
 kube
+kubeConfigPath
 kubeProxyReplacement
 kubeProxyReplacementHealthzBindAddr
 kubeadm

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -427,7 +427,6 @@ filenames
 filesystem
 filesystems
 firewalling
-flowBufferSize
 followup
 foobar
 foundational

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -812,7 +812,7 @@ func initializeFlags() {
 	flags.Int(option.SockRevNatEntriesName, option.SockRevNATMapEntriesDefault, "Maximum number of entries for the SockRevNAT BPF map")
 	option.BindEnv(Vp, option.SockRevNatEntriesName)
 
-	flags.Float64(option.MapEntriesGlobalDynamicSizeRatioName, 0.0, "Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)")
+	flags.Float64(option.MapEntriesGlobalDynamicSizeRatioName, 0.0025, "Ratio (0.0-1.0] of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps")
 	option.BindEnv(Vp, option.MapEntriesGlobalDynamicSizeRatioName)
 
 	flags.String(option.CMDRef, "", "Path to cmdref output directory")

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -78,6 +78,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.hostLegacyRouting | bool | `false` | Configure whether direct routing mode should route traffic via host stack (true) or directly and more efficiently out of BPF (false) if the kernel supports it. The latter has the implication that it will also bypass netfilter in the host namespace. |
 | bpf.lbExternalClusterIP | bool | `false` | Allow cluster external access to ClusterIP services. |
 | bpf.lbMapMax | int | `65536` | Configure the maximum number of service entries in the load balancer maps. |
+| bpf.mapDynamicSizeRatio | float64 | `0.0025` | Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/stable/concepts/ebpf/maps/#ebpf-maps |
 | bpf.masquerade | bool | `false` | Enable native IP masquerade support in eBPF |
 | bpf.monitorAggregation | string | `"medium"` | Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum. |
 | bpf.monitorFlags | string | `"all"` | Configure which TCP flags trigger notifications when seen for the first time in a connection. |
@@ -376,8 +377,11 @@ contributors across the globe, there is almost always someone available to help.
 | ipv6.enabled | bool | `false` | Enable IPv6 support. |
 | ipv6NativeRoutingCIDR | string | `""` | Allows to explicitly specify the IPv6 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag. |
 | k8s | object | `{}` | Configure Kubernetes specific configuration |
+| k8sServiceHost | string | `""` | Kubernetes service host |
+| k8sServicePort | string | `""` | Kubernetes service port |
 | keepDeprecatedLabels | bool | `false` | Keep the deprecated selector labels when deploying Cilium DaemonSet. |
 | keepDeprecatedProbes | bool | `false` | Keep the deprecated probes when deploying Cilium DaemonSet |
+| kubeConfigPath | string | `"~/.kube/config"` | Kubernetes config path |
 | kubeProxyReplacementHealthzBindAddr | string | `""` | healthz server bind address for the kube-proxy replacement. To enable set the value to '0.0.0.0:10256' for all ipv4 addresses and this '[::]:10256' for all ipv6 addresses. By default it is disabled. |
 | l2NeighDiscovery.enabled | bool | `true` | Enable L2 neighbor discovery in the agent |
 | l2NeighDiscovery.refreshPeriod | string | `"30s"` | Override the agent's default neighbor resolution refresh period. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -275,12 +275,12 @@ data:
 
 
 
-{{- if hasKey .Values.bpf "mapDynamicSizeRatio" }}
-  # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
+{{- if .Values.bpf.mapDynamicSizeRatio }}
+  # Specifies the ratio (0.0-1.0] of total system memory to use for dynamic
   # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
   bpf-map-dynamic-size-ratio: {{ .Values.bpf.mapDynamicSizeRatio | quote }}
 {{- else if ne $defaultBpfMapDynamicSizeRatio 0.0 }}
-  # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
+  # Specifies the ratio (0.0-1.0] of total system memory to use for dynamic
   # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
   bpf-map-dynamic-size-ratio: {{ $defaultBpfMapDynamicSizeRatio | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -511,15 +511,10 @@ data:
 
   auto-direct-node-routes: {{ .Values.autoDirectNodeRoutes | quote }}
 
-{{- if .Values.bandwidthManager }}
-{{- if typeIs "bool" .Values.bandwidthManager }}
-  # DEPRECATED: this block should be removed in 1.13
-  enable-bandwidth-manager: {{ .Values.bandwidthManager | quote }}
-{{- else }}
+{{- if hasKey .Values "bandwidthManager" }}
 {{- if .Values.bandwidthManager.enabled }}
   enable-bandwidth-manager: {{ .Values.bandwidthManager.enabled | quote }}
   enable-bbr: {{ .Values.bandwidthManager.bbr | quote }}
-{{- end }}
 {{- end }}
 {{- end }}
 
@@ -740,10 +735,6 @@ data:
   # Buffer size of the channel for Hubble to receive monitor events. If this field is not set,
   # the buffer size is set to the default monitor queue size.
   hubble-event-queue-size: {{ .Values.hubble.eventQueueSize | quote }}
-{{- end }}
-{{- if hasKey .Values.hubble "flowBufferSize" }}
-  # DEPRECATED: this block should be removed in 1.11
-  hubble-flow-buffer-size: {{ .Values.hubble.flowBufferSize | quote }}
 {{- end }}
 {{- if hasKey .Values.hubble "eventBufferCapacity" }}
   # Capacity of the buffer to store recent events.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -20,9 +20,13 @@ rbac:
 imagePullSecrets:
 # - name: "image-pull-secret"
 
-# kubeConfigPath: ~/.kube/config
-# k8sServiceHost:
-# k8sServicePort:
+# -- (string) Kubernetes config path
+# @default -- `"~/.kube/config"`
+kubeConfigPath: ""
+# -- (string) Kubernetes service host
+k8sServiceHost: ""
+# -- (string) Kubernetes service port
+k8sServicePort: ""
 
 cluster:
   # -- Name of the cluster. Only required for Cluster Mesh.
@@ -365,9 +369,10 @@ bpf:
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
   policyMapMax: 16384
 
-  # -- Configure auto-sizing for all BPF maps based on available memory.
+  # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
   # ref: https://docs.cilium.io/en/stable/concepts/ebpf/maps/#ebpf-maps
-  #mapDynamicSizeRatio: 0.0025
+  # @default -- `0.0025`
+  mapDynamicSizeRatio: ~
 
   # -- Configure the level of aggregation for monitor notifications.
   # Valid options are none, low, medium, maximum.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -287,12 +287,6 @@ alibabacloud:
   # -- Enable AlibabaCloud ENI integration
   enabled: false
 
-# -- Deprecated in favor of bandwidthManager.enabled. To be removed in 1.13.
-# Optimize TCP and UDP workloads and enable rate-limiting traffic from
-# individual Pods with EDT (Earliest Departure Time) through the
-# "kubernetes.io/egress-bandwidth" Pod annotation.
-#bandwidthManager: false
-
 # -- Enable bandwidth manager to optimize TCP and UDP workloads and allow
 # for rate-limiting traffic from individual Pods with EDT (Earliest Departure
 # Time) through the "kubernetes.io/egress-bandwidth" Pod annotation.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -17,9 +17,13 @@ rbac:
 imagePullSecrets:
 # - name: "image-pull-secret"
 
-# kubeConfigPath: ~/.kube/config
-# k8sServiceHost:
-# k8sServicePort:
+# -- (string) Kubernetes config path
+# @default -- `"~/.kube/config"`
+kubeConfigPath: ""
+# -- (string) Kubernetes service host
+k8sServiceHost: ""
+# -- (string) Kubernetes service port
+k8sServicePort: ""
 
 cluster:
   # -- Name of the cluster. Only required for Cluster Mesh.
@@ -362,9 +366,10 @@ bpf:
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
   policyMapMax: 16384
 
-  # -- Configure auto-sizing for all BPF maps based on available memory.
+  # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
   # ref: https://docs.cilium.io/en/stable/concepts/ebpf/maps/#ebpf-maps
-  #mapDynamicSizeRatio: 0.0025
+  # @default -- `0.0025`
+  mapDynamicSizeRatio: ~
 
   # -- Configure the level of aggregation for monitor notifications.
   # Valid options are none, low, medium, maximum.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -284,12 +284,6 @@ alibabacloud:
   # -- Enable AlibabaCloud ENI integration
   enabled: false
 
-# -- Deprecated in favor of bandwidthManager.enabled. To be removed in 1.13.
-# Optimize TCP and UDP workloads and enable rate-limiting traffic from
-# individual Pods with EDT (Earliest Departure Time) through the
-# "kubernetes.io/egress-bandwidth" Pod annotation.
-#bandwidthManager: false
-
 # -- Enable bandwidth manager to optimize TCP and UDP workloads and allow
 # for rate-limiting traffic from individual Pods with EDT (Earliest Departure
 # Time) through the "kubernetes.io/egress-bandwidth" Pod annotation.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3538,7 +3538,7 @@ func (c *DaemonConfig) calculateBPFMapSizes(vp *viper.Viper) error {
 		c.calculateDynamicBPFMapSizes(vp, vms.Total, dynamicSizeRatio)
 		c.BPFMapsDynamicSizeRatio = dynamicSizeRatio
 	} else if dynamicSizeRatio < 0.0 {
-		return fmt.Errorf("specified dynamic map size ratio %f must be ≥ 0.0", dynamicSizeRatio)
+		return fmt.Errorf("specified dynamic map size ratio %f must be > 0.0", dynamicSizeRatio)
 	} else if dynamicSizeRatio > 1.0 {
 		return fmt.Errorf("specified dynamic map size ratio %f must be ≤ 1.0", dynamicSizeRatio)
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2497,7 +2497,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		addIfNotOverwritten(options, "sessionAffinity", "false")
 	}
 	if DoesNotRunOnNetNextKernel() {
-		addIfNotOverwritten(options, "bandwidthManager", "false")
+		addIfNotOverwritten(options, "bandwidthManager.enabled", "false")
 	}
 
 	if RunsWithHostFirewall() {

--- a/test/k8s/bandwidth.go
+++ b/test/k8s/bandwidth.go
@@ -115,8 +115,8 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOnNetNextKernel, "K8sDatapathBandwidthT
 
 		It("Checks Pod to Pod bandwidth, vxlan tunneling", func() {
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-				"bandwidthManager": "true",
-				"tunnel":           "vxlan",
+				"bandwidthManager.enabled": "true",
+				"tunnel":                   "vxlan",
 			})
 			waitForTestPods()
 			testNetperf(podLabels, testClientPod)
@@ -124,8 +124,8 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOnNetNextKernel, "K8sDatapathBandwidthT
 		})
 		It("Checks Pod to Pod bandwidth, geneve tunneling", func() {
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-				"bandwidthManager": "true",
-				"tunnel":           "geneve",
+				"bandwidthManager.enabled": "true",
+				"tunnel":                   "geneve",
 			})
 			waitForTestPods()
 			testNetperf(podLabels, testClientPod)
@@ -133,9 +133,9 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOnNetNextKernel, "K8sDatapathBandwidthT
 		})
 		It("Checks Pod to Pod bandwidth, direct routing", func() {
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-				"bandwidthManager":     "true",
-				"tunnel":               "disabled",
-				"autoDirectNodeRoutes": "true",
+				"bandwidthManager.enabled": "true",
+				"tunnel":                   "disabled",
+				"autoDirectNodeRoutes":     "true",
 			})
 			waitForTestPods()
 			testNetperf(podLabels, testClientPod)

--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/cilium/cilium/pkg/versioncheck"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 )
@@ -241,6 +242,13 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			"operator.image.repository":              "quay.io/cilium/operator",
 			"hubble.relay.image.repository":          "quay.io/cilium/hubble-relay-ci",
 			"clustermesh.apiserver.image.repository": "quay.io/cilium/clustermesh-apiserver-ci",
+		}
+
+		hasNewHelmValues := versioncheck.MustCompile(">=1.12.90")
+		if hasNewHelmValues(versioncheck.MustVersion(newHelmChartVersion)) {
+			opts["bandwidthManager.enabled"] = "false "
+		} else {
+			opts["bandwidthManager"] = "false "
 		}
 
 		// Eventually allows multiple return values, and performs the assertion


### PR DESCRIPTION
Document missing k8sService kubeConfigPath bpf.mapDynamicSizeRatio

Signed-off-by: Vincent Li <v.li@f5.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Document missing k8sService kubeConfigPath bpf.mapDynamicSizeRatio
```
