### PR TITLE
Enable icmp error replies with enable-pmtu-discovery flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -121,6 +121,7 @@ cilium-agent [flags]
       --enable-local-redirect-policy                            Enable Local Redirect Policy
       --enable-monitor                                          Enable the monitor unix domain socket server (default true)
       --enable-node-port                                        Enable NodePort type services by Cilium
+      --enable-pmtu-discovery                                   Enable path MTU discovery to send ICMP fragmentation-needed replies to the client
       --enable-policy string                                    Enable policy enforcement (default "default")
       --enable-recorder                                         Enable BPF datapath pcap recorder
       --enable-remote-node-identity                             Enable use of remote node identity

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1565,6 +1565,10 @@
      - cilium-operator update strategy
      - object
      - ``{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}``
+   * - pmtuDiscovery.enabled
+     - Enable path MTU discovery to send ICMP fragmentation-needed replies to the client.
+     - bool
+     - ``false``
    * - podAnnotations
      - Annotations to be added to agent pods
      - object

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -422,6 +422,8 @@ New Options
 * ``nodes-gc-interval``: This option was marked as deprecated and has no effect
   in 1.11. Cilium Node Garbage collector is added back in 1.12 (but for k8s GC instead
   of kvstore), so this flag is moved out of deprecated list.
+* ``enable-pmtu-discovery``: This option enables path MTU discovery to send ICMP
+  fragmentation-needed replies to the client. Use ``pmtuDiscovery`` in Helm chart.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -759,6 +759,7 @@ pluggable
 plugin
 plugins
 pmdabcc
+pmtuDiscovery
 png
 podAnnotations
 podCIDR

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1053,6 +1053,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableBGPControlPlane, false, "Enable the BGP control plane.")
 	option.BindEnv(Vp, option.EnableBGPControlPlane)
 
+	flags.Bool(option.EnablePMTUDiscovery, false, "Enable path MTU discovery to send ICMP fragmentation-needed replies to the client")
+	option.BindEnv(Vp, option.EnablePMTUDiscovery)
+
 	if err := Vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}
@@ -1288,8 +1291,9 @@ func initEnv() {
 		}
 	case datapathOption.DatapathModeLBOnly:
 		log.Info("Running in LB-only mode")
-		option.Config.LoadBalancerPMTUDiscovery =
-			option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled
+		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
+			option.Config.EnablePMTUDiscovery = true
+		}
 		option.Config.KubeProxyReplacement = option.KubeProxyReplacementPartial
 		option.Config.EnableSocketLB = true
 		// Socket-LB tracing relies on metadata that's retrieved from Kubernetes.

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -442,6 +442,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.unmanagedPodWatcher.intervalSeconds | int | `15` | Interval, in seconds, to check if there are any pods that are not managed by Cilium. |
 | operator.unmanagedPodWatcher.restart | bool | `true` | Restart any pod that are not managed by Cilium. |
 | operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}` | cilium-operator update strategy |
+| pmtuDiscovery.enabled | bool | `false` | Enable path MTU discovery to send ICMP fragmentation-needed replies to the client. |
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -874,6 +874,10 @@ data:
   enable-bgp-control-plane: "false"
 {{- end }}
 
+{{- if .Values.pmtuDiscovery.enabled }}
+  enable-pmtu-discovery: "true"
+{{- end }}
+
 {{- if not .Values.securityContext.privileged }}
   procfs: "/host/proc"
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -324,6 +324,11 @@ bgpControlPlane:
   # -- Enables the BGP control plane.
   enabled: false
 
+pmtuDiscovery:
+  # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
+  # the client.
+  enabled: false
+
 bpf:
   # -- Configure the mount point for the BPF filesystem
   root: /sys/fs/bpf

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -321,6 +321,11 @@ bgpControlPlane:
   # -- Enables the BGP control plane.
   enabled: false
 
+pmtuDiscovery:
+  # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
+  # the client.
+  enabled: false
+
 bpf:
   # -- Configure the mount point for the BPF filesystem
   root: /sys/fs/bpf

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -359,7 +359,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		if option.Config.NodePortMode == option.NodePortModeDSR ||
 			option.Config.NodePortMode == option.NodePortModeHybrid {
 			cDefinesMap["ENABLE_DSR"] = "1"
-			if option.Config.LoadBalancerPMTUDiscovery {
+			if option.Config.EnablePMTUDiscovery {
 				cDefinesMap["ENABLE_DSR_ICMP_ERRORS"] = "1"
 			}
 			if option.Config.NodePortMode == option.NodePortModeHybrid {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1097,6 +1097,10 @@ const (
 	// EnableRuntimeDeviceDetection is the name of the option to enable detection
 	// of new and removed datapath devices during the agent runtime.
 	EnableRuntimeDeviceDetection = "enable-runtime-device-detection"
+
+	// EnablePMTUDiscovery enables path MTU discovery to send ICMP
+	// fragmentation-needed replies to the client (when needed).
+	EnablePMTUDiscovery = "enable-pmtu-discovery"
 )
 
 // Default string arguments
@@ -1878,9 +1882,9 @@ type DaemonConfig struct {
 	LoadBalancerRSSv6CIDR string
 	LoadBalancerRSSv6     net.IPNet
 
-	// LoadBalancerPMTUDiscovery indicates whether LB should reply with ICMP
-	// frag needed messages to client (when needed)
-	LoadBalancerPMTUDiscovery bool
+	// EnablePMTUDiscovery indicates whether to send ICMP fragmentation-needed
+	// replies to the client (when needed).
+	EnablePMTUDiscovery bool
 
 	// Maglev backend table size (M) per service. Must be prime number.
 	MaglevTableSize int
@@ -2935,6 +2939,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableIPv6Masquerade = vp.GetBool(EnableIPv6Masquerade) && c.EnableIPv6
 	c.EnableBPFMasquerade = vp.GetBool(EnableBPFMasquerade)
 	c.DeriveMasqIPAddrFromDevice = vp.GetString(DeriveMasqIPAddrFromDevice)
+	c.EnablePMTUDiscovery = viper.GetBool(EnablePMTUDiscovery)
 
 	c.populateLoadBalancerSettings(vp)
 	c.populateDevices(vp)


### PR DESCRIPTION
ICMP error replies (packet size too big) are sent
in dsr_reply_icmp4 and dsr_reply_icmp6 functions.
These replies are sent only when cilium is enabled
in LBOnly mode and NodePortAcceleration is set to true.

This change allows icmp error replies to be sent to the
client in cilium CNI mode when enable-pmtu-discovery
flag is set to true. By default, this flag is false.

Fixes: #21795
Signed-off-by: Nishant Burte <nburte@google.com>