### PR TITLE
eni: fix new node not triggering creation of ENI with fix deadlock

### DIFF
--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -119,8 +120,8 @@ func startSynchronizingCiliumNodes(ctx context.Context, clientset k8sClient.Clie
 
 	if nodeManager != nil {
 		nodeManagerSyncHandler = syncHandlerConstructor(
-			func(name string) {
-				nodeManager.Delete(name)
+			func(node *cilium_v2.CiliumNode) {
+				nodeManager.Delete(node)
 			},
 			func(node *cilium_v2.CiliumNode) {
 				// node is deep copied before it is stored in pkg/aws/eni
@@ -130,10 +131,10 @@ func startSynchronizingCiliumNodes(ctx context.Context, clientset k8sClient.Clie
 
 	if withKVStore {
 		kvStoreSyncHandler = syncHandlerConstructor(
-			func(name string) {
+			func(node *cilium_v2.CiliumNode) {
 				nodeDel := ciliumNodeName{
 					cluster: option.Config.ClusterName,
-					name:    name,
+					name:    node.Name,
 				}
 				ciliumNodeKVStore.DeleteLocalKey(ctx, &nodeDel)
 			},
@@ -253,7 +254,7 @@ func startSynchronizingCiliumNodes(ctx context.Context, clientset k8sClient.Clie
 	return nil
 }
 
-func syncHandlerConstructor(notFoundHandler func(name string), foundHandler func(node *cilium_v2.CiliumNode)) func(key string) error {
+func syncHandlerConstructor(notFoundHandler func(node *cilium_v2.CiliumNode), foundHandler func(node *cilium_v2.CiliumNode)) func(key string) error {
 	return func(key string) error {
 		_, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {
@@ -264,7 +265,11 @@ func syncHandlerConstructor(notFoundHandler func(name string), foundHandler func
 
 		// Delete handling
 		if !exists || errors.IsNotFound(err) {
-			notFoundHandler(name)
+			notFoundHandler(&cilium_v2.CiliumNode{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: name,
+				},
+			})
 			return nil
 		}
 		if err != nil {
@@ -273,8 +278,18 @@ func syncHandlerConstructor(notFoundHandler func(name string), foundHandler func
 		}
 		cn, ok := obj.(*cilium_v2.CiliumNode)
 		if !ok {
-			log.Errorf("Object stored in store is not *cilium_v2.CiliumNode but %T", obj)
-			return err
+			tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+			if !ok {
+				return fmt.Errorf("couldn't get object from tombstone %T", obj)
+			}
+			cn, ok = tombstone.Obj.(*cilium_v2.CiliumNode)
+			if !ok {
+				return fmt.Errorf("tombstone contained object that is not a *cilium_v2.CiliumNode %T", obj)
+			}
+		}
+		if cn.DeletionTimestamp != nil {
+			notFoundHandler(cn)
+			return nil
 		}
 		foundHandler(cn)
 		return nil

--- a/pkg/alibabacloud/eni/instances.go
+++ b/pkg/alibabacloud/eni/instances.go
@@ -56,6 +56,13 @@ func (m *InstancesManager) CreateNode(obj *v2.CiliumNode, node *ipam.Node) ipam.
 	return &Node{k8sObj: obj, manager: m, node: node, instanceID: node.InstanceID()}
 }
 
+// HasInstance returns whether the instance is in instances
+func (m *InstancesManager) HasInstance(instanceID string) bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return m.instances.Exists(instanceID)
+}
+
 // GetPoolQuota returns the number of available IPs in all IP pools
 func (m *InstancesManager) GetPoolQuota() ipamTypes.PoolQuotaMap {
 	pool := ipamTypes.PoolQuotaMap{}
@@ -191,4 +198,11 @@ func (m *InstancesManager) FindSecurityGroupByTags(vpcID string, required ipamTy
 	}
 
 	return securityGroups
+}
+
+// DeleteInstance delete instance from m.instances
+func (m *InstancesManager) DeleteInstance(instanceID string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.instances.Delete(instanceID)
 }

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -61,6 +61,13 @@ func (m *InstancesManager) CreateNode(obj *v2.CiliumNode, n *ipam.Node) ipam.Nod
 	return NewNode(n, obj, m)
 }
 
+// HasInstance returns whether the instance is in instances
+func (m *InstancesManager) HasInstance(instanceID string) bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return m.instances.Exists(instanceID)
+}
+
 // GetPoolQuota returns the number of available IPs in all IP pools
 func (m *InstancesManager) GetPoolQuota() ipamTypes.PoolQuotaMap {
 	pool := ipamTypes.PoolQuotaMap{}
@@ -230,4 +237,11 @@ func (m *InstancesManager) ForeachInstance(instanceID string, fn ipamTypes.Inter
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 	m.instances.ForeachInterface(instanceID, fn)
+}
+
+// DeleteInstance delete instance from m.instances
+func (m *InstancesManager) DeleteInstance(instanceID string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.instances.Delete(instanceID)
 }

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -68,6 +68,7 @@ func (e *ENISuite) TestGetNodeNames(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
+	node1 := newCiliumNode("node1")
 	mngr.Update(newCiliumNode("node1"))
 
 	names := mngr.GetNames()
@@ -79,7 +80,7 @@ func (e *ENISuite) TestGetNodeNames(c *check.C) {
 	names = mngr.GetNames()
 	c.Assert(len(names), check.Equals, 2)
 
-	mngr.Delete("node1")
+	mngr.Delete(node1)
 
 	names = mngr.GetNames()
 	c.Assert(len(names), check.Equals, 1)
@@ -94,12 +95,13 @@ func (e *ENISuite) TestNodeManagerGet(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
-	mngr.Update(newCiliumNode("node1"))
+	node1 := newCiliumNode("node1")
+	mngr.Update(node1)
 
 	c.Assert(mngr.Get("node1"), check.Not(check.IsNil))
 	c.Assert(mngr.Get("node2"), check.IsNil)
 
-	mngr.Delete("node1")
+	mngr.Delete(node1)
 	c.Assert(mngr.Get("node1"), check.IsNil)
 	c.Assert(mngr.Get("node2"), check.IsNil)
 }

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -46,6 +46,13 @@ func (m *InstancesManager) CreateNode(obj *v2.CiliumNode, n *ipam.Node) ipam.Nod
 	return &Node{manager: m, node: n}
 }
 
+// HasInstance returns whether the instance is in instances
+func (m *InstancesManager) HasInstance(instanceID string) bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return m.instances.Exists(instanceID)
+}
+
 // GetPoolQuota returns the number of available IPs in all IP pools
 func (m *InstancesManager) GetPoolQuota() (quota ipamTypes.PoolQuotaMap) {
 	m.mutex.RLock()
@@ -90,4 +97,11 @@ func (m *InstancesManager) Resync(ctx context.Context) time.Time {
 	m.mutex.Unlock()
 
 	return resyncStart
+}
+
+// DeleteInstance delete instance from m.instances
+func (m *InstancesManager) DeleteInstance(instanceID string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.instances.Delete(instanceID)
 }

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -417,19 +417,19 @@ func (n *NodesPodCIDRManager) update(node *v2.CiliumNode) bool {
 
 // Delete deletes the node from the allocator and releases the associated
 // CIDRs of that node.
-func (n *NodesPodCIDRManager) Delete(nodeName string) {
+func (n *NodesPodCIDRManager) Delete(node *v2.CiliumNode) {
 	n.Mutex.Lock()
 	defer n.Mutex.Unlock()
 	if !n.canAllocatePodCIDRs {
-		delete(n.nodesToAllocate, nodeName)
+		delete(n.nodesToAllocate, node.Name)
 	}
 
-	found := n.releaseIPNets(nodeName)
+	found := n.releaseIPNets(node.Name)
 	if !found {
 		return
 	}
 	// Mark the node to be deleted in k8s.
-	n.ciliumNodesToK8s[nodeName] = &ciliumNodeK8sOp{
+	n.ciliumNodesToK8s[node.Name] = &ciliumNodeK8sOp{
 		op: k8sOpDelete,
 	}
 	n.k8sReSync.Trigger()

--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -491,7 +491,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Delete(c *C) {
 		ciliumNodesToK8s    map[string]*ciliumNodeK8sOp
 	}
 	type args struct {
-		nodeName string
+		node *v2.CiliumNode
 	}
 	tests := []struct {
 		testSetup   func() *fields
@@ -542,7 +542,11 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Delete(c *C) {
 				c.Assert(atomic.LoadInt32(&reSyncCalls), Equals, int32(1))
 			},
 			args: args{
-				nodeName: "node-1",
+				node: &v2.CiliumNode{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "node-1",
+					},
+				},
 			},
 		},
 		{
@@ -559,7 +563,11 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Delete(c *C) {
 				c.Assert(atomic.LoadInt32(&reSyncCalls), Equals, int32(0))
 			},
 			args: args{
-				nodeName: "node-1",
+				node: &v2.CiliumNode{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "node-1",
+					},
+				},
 			},
 		},
 	}
@@ -577,7 +585,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Delete(c *C) {
 				nodes:               tt.fields.nodes,
 				ciliumNodesToK8s:    tt.fields.ciliumNodesToK8s,
 			}
-			n.Delete(tt.args.nodeName)
+			n.Delete(tt.args.node)
 
 			if tt.testPostRun != nil {
 				tt.testPostRun(tt.fields)

--- a/pkg/ipam/allocator/provider.go
+++ b/pkg/ipam/allocator/provider.go
@@ -22,6 +22,6 @@ type AllocatorProvider interface {
 type NodeEventHandler interface {
 	Create(resource *v2.CiliumNode) bool
 	Update(resource *v2.CiliumNode) bool
-	Delete(nodeName string)
+	Delete(resource *v2.CiliumNode)
 	Resync(context.Context, time.Time)
 }

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -58,6 +58,13 @@ func (a *allocationImplementationMock) Resync(ctx context.Context) time.Time {
 	return time.Now()
 }
 
+func (a *allocationImplementationMock) HasInstance(instanceID string) bool {
+	return true
+}
+
+func (a *allocationImplementationMock) DeleteInstance(instanceID string) {
+}
+
 type nodeOperationsMock struct {
 	allocator *allocationImplementationMock
 
@@ -166,7 +173,8 @@ func (e *IPAMSuite) TestGetNodeNames(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
-	mngr.Update(newCiliumNode("node1", 0, 0, 0))
+	node1 := newCiliumNode("node1", 0, 0, 0)
+	mngr.Update(node1)
 
 	names := mngr.GetNames()
 	c.Assert(len(names), check.Equals, 1)
@@ -177,7 +185,7 @@ func (e *IPAMSuite) TestGetNodeNames(c *check.C) {
 	names = mngr.GetNames()
 	c.Assert(len(names), check.Equals, 2)
 
-	mngr.Delete("node1")
+	mngr.Delete(node1)
 
 	names = mngr.GetNames()
 	c.Assert(len(names), check.Equals, 1)
@@ -193,12 +201,13 @@ func (e *IPAMSuite) TestNodeManagerGet(c *check.C) {
 
 	// instances.Resync(context.TODO())
 
-	mngr.Update(newCiliumNode("node1", 0, 0, 0))
+	node1 := newCiliumNode("node1", 0, 0, 0)
+	mngr.Update(node1)
 
 	c.Assert(mngr.Get("node1"), check.Not(check.IsNil))
 	c.Assert(mngr.Get("node2"), check.IsNil)
 
-	mngr.Delete("node1")
+	mngr.Delete(node1)
 	c.Assert(mngr.Get("node1"), check.IsNil)
 	c.Assert(mngr.Get("node2"), check.IsNil)
 }

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -482,3 +482,20 @@ func (m *InstanceMap) NumInstances() (size int) {
 	m.mutex.RUnlock()
 	return
 }
+
+// Exists returns whether the instance ID is in the instanceMap
+func (m *InstanceMap) Exists(instanceID string) (exists bool) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	if instance := m.data[instanceID]; instance != nil {
+		return true
+	}
+	return false
+}
+
+// Delete instance from m.data
+func (m *InstanceMap) Delete(instanceID string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	delete(m.data, instanceID)
+}


### PR DESCRIPTION
1. Sync the instances network interface information from instances api when a new node is created but not in `instanceManager.instances`. This is fix errors
 in `ResyncInterfacesAndIPs` "Instance not found! Please delete corresponding
ciliumnode if instance has already been deleted" when new node created in cloud provider then add to cluster and before resync triggered.

2. Delete instance from `instanceManager.instances` on node deleted. This will cause `NodeManager.Update()` to invoke `instancesAPIResync` if this instance rejoins the cluster. This ensures that `Node.recalculate()` does not use stale data for instances which rejoin the cluster after their EC2 configuration has changed.

3. Fixes daedlock that report in #21477

Fixes: #20678

Signed-off-by: xiaoqing <xiaoqingnb@gmail.com>
