### PR TITLE
Fix incorrect env var name used in docs for Helm installation on Rancher Desktop

### DIFF
--- a/Documentation/installation/rancher-desktop-override.yaml
+++ b/Documentation/installation/rancher-desktop-override.yaml
@@ -1,6 +1,6 @@
 env:
   # needed for cilium
-  K3S_EXEC: '--flannel-backend=none --disable-network-policy'
+  INSTALL_K3S_EXEC: '--flannel-backend=none --disable-network-policy'
 provision:
   # needs root to mount
   - mode: system


### PR DESCRIPTION
Signed-off-by: Eric Hausig <eric.hausig+github@gmail.com>

Fixes: #21834

