### PR TITLE
test: net_policies: delete custom IP routes after test completion

### DIFF
--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -794,9 +794,12 @@ var _ = SkipDescribeIf(func() bool {
 						defer GinkgoRecover()
 						defer wg.Done()
 						By("Checking ingress connectivity from world to k8s1 pod")
-						By("Adding a static route to %s on the %s node (outside)", k8s1PodIP, outsideNodeName)
+						By("Adding a static route to %s via %s on the %s node (outside)", k8s1PodIP, k8s1IP, outsideNodeName)
 						res := kubectl.AddIPRoute(outsideNodeName, k8s1PodIP, k8s1IP, true)
 						Expect(res).To(getMatcher(true))
+						defer func() {
+							kubectl.DelIPRoute(outsideNodeName, k8s1PodIP, k8s1IP).ExpectSuccess("Failed to del ip route")
+						}()
 
 						if expectWorldSuccess {
 							testCurlFromOutside(kubectl, &helpers.NodesInfo{
@@ -1640,9 +1643,12 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 						defer GinkgoRecover()
 						defer wg.Done()
 						By("Checking ingress connectivity from world to k8s1 pod")
-						By("Adding a static route to %s on the %s node (outside)", k8s1PodIP, outsideNodeName)
+						By("Adding a static route to %s via %s on the %s node (outside)", k8s1PodIP, k8s1IP, outsideNodeName)
 						res := kubectl.AddIPRoute(outsideNodeName, k8s1PodIP, k8s1IP, true)
 						Expect(res).To(getMatcher(true))
+						defer func() {
+							kubectl.DelIPRoute(outsideNodeName, k8s1PodIP, k8s1IP).ExpectSuccess("Failed to del ip route")
+						}()
 
 						if expectWorldSuccess {
 							testCurlFromOutside(kubectl, &helpers.NodesInfo{

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -498,7 +498,7 @@ var _ = SkipDescribeIf(func() bool {
 				// K8s Services, for the sake of simplicity. Making the backend
 				// pod IP directly routable on the "outside" node is sufficient
 				// to validate the policy under test.
-				res := kubectl.AddIPRoute(outsideNodeName, backendPodIP, hostIPOfBackendPod, true)
+				res := kubectl.AddIPRoute(outsideNodeName, backendPodIP, hostIPOfBackendPod, false)
 				Expect(res).To(getMatcher(true))
 
 				policyVerdictAllowRegex = regexp.MustCompile(
@@ -795,7 +795,7 @@ var _ = SkipDescribeIf(func() bool {
 						defer wg.Done()
 						By("Checking ingress connectivity from world to k8s1 pod")
 						By("Adding a static route to %s via %s on the %s node (outside)", k8s1PodIP, k8s1IP, outsideNodeName)
-						res := kubectl.AddIPRoute(outsideNodeName, k8s1PodIP, k8s1IP, true)
+						res := kubectl.AddIPRoute(outsideNodeName, k8s1PodIP, k8s1IP, false)
 						Expect(res).To(getMatcher(true))
 						defer func() {
 							kubectl.DelIPRoute(outsideNodeName, k8s1PodIP, k8s1IP).ExpectSuccess("Failed to del ip route")
@@ -1644,7 +1644,7 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
 						defer wg.Done()
 						By("Checking ingress connectivity from world to k8s1 pod")
 						By("Adding a static route to %s via %s on the %s node (outside)", k8s1PodIP, k8s1IP, outsideNodeName)
-						res := kubectl.AddIPRoute(outsideNodeName, k8s1PodIP, k8s1IP, true)
+						res := kubectl.AddIPRoute(outsideNodeName, k8s1PodIP, k8s1IP, false)
 						Expect(res).To(getMatcher(true))
 						defer func() {
 							kubectl.DelIPRoute(outsideNodeName, k8s1PodIP, k8s1IP).ExpectSuccess("Failed to del ip route")


### PR DESCRIPTION
Don't let custom IP routes dangling around after the `K8sAgentPolicyTest` suite completed. It can cause side-effects in subsequent tests, such as most likely https://jenkins.cilium.io/job/cilium-master-k8s-1.25-kernel-net-next/2151/.

```release-note
test: net_policies: delete custom IP routes after test completion
```
