### PR TITLE
test: service: wait for frontend entry

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4764,7 +4764,7 @@ func (kub *Kubectl) WaitForServiceFrontend(node, ipAddr string) error {
 }
 
 // WaitForServiceBackend waits until the service backend with the given ipAddr
-// appears in "cilium bpf lb list" on the given node.
+// appears in "cilium bpf lb list --backends" on the given node.
 func (kub *Kubectl) WaitForServiceBackend(node, ipAddr string) error {
 	ciliumPod, err := kub.GetCiliumPodOnNode(node)
 	if err != nil {
@@ -4774,7 +4774,7 @@ func (kub *Kubectl) WaitForServiceBackend(node, ipAddr string) error {
 	body := func() bool {
 		ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
 		defer cancel()
-		cmd := fmt.Sprintf(`cilium bpf lb list | grep -q %s`, ipAddr)
+		cmd := fmt.Sprintf(`cilium bpf lb list --backends | grep -q %s`, ipAddr)
 		return kub.CiliumExecContext(ctx, ciliumPod, cmd).WasSuccessful()
 	}
 

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -589,6 +589,9 @@ func testExternalIPs(kubectl *helpers.Kubectl, ni *helpers.NodesInfo) {
 			fmt.Sprintf(`{"spec":{"externalIPs":["%s","%s"]}}`, svcExternalIP, nodeIP))
 		ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "Error patching external IP service with node 1 IP")
 
+		err = kubectl.WaitForServiceFrontend(ni.K8s1NodeName, nodeIP)
+		ExpectWithOffset(1, err).Should(BeNil(), "Failed waiting for %s frontend entry on %s", nodeIP, ni.K8s1NodeName)
+
 		httpURL := getHTTPLink(svcExternalIP, data.Spec.Ports[0].Port)
 		tftpURL := getTFTPLink(svcExternalIP, data.Spec.Ports[1].Port)
 


### PR DESCRIPTION
Use the `WaitForServiceFrontend()` helper introduced in https://github.com/cilium/cilium/pull/21385/commits/a1b18b05d62419a8eceea758f7d79ae05c7417d0 to wait for the SVC `Patch()` to take effect. Continuing too early can result in CI flakes.

Make a small improvement to `WaitForServiceBackend()` while at it.