### PR TITLE
operator/metrics: Adjust bucket sizes

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -191,6 +191,7 @@ func registerMetrics() []prometheus.Collector {
 		Namespace: Namespace,
 		Name:      "ces_queueing_delay_seconds",
 		Help:      "CiliumEndpointSlice queueing delay in seconds",
+		Buckets:   prometheus.ExponentialBucketsRange(.005, 3600, 20),
 	})
 	collectors = append(collectors, CiliumEndpointSliceQueueDelay)
 

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -88,10 +88,7 @@ var (
 	EndpointGCObjects *prometheus.CounterVec
 
 	// CiliumEndpointSliceDensity indicates the number of CEPs batched in a CES and it used to
-	// collect the number of CEPs in CES at various buckets. For example,
-	// number of CESs in the CEP range <0, 10>
-	// number of CESs in the CEP range <11, 20>
-	// number of CESs in the CEP range <21, 30> and so on
+	// collect the number of CEPs in CES at various buckets.
 	CiliumEndpointSliceDensity prometheus.Histogram
 
 	// CiliumEndpointsChangeCount indicates the total number of CEPs changed for every CES request sent to k8s-apiserver.
@@ -169,7 +166,7 @@ func registerMetrics() []prometheus.Collector {
 		Namespace: Namespace,
 		Name:      "number_of_ceps_per_ces",
 		Help:      "The number of CEPs batched in a CES",
-		Buckets:   prometheus.LinearBuckets(0, 10, operatorOption.Config.CESMaxCEPsInCES/10),
+		Buckets:   []float64{1, 10, 25, 50, 100, 200, 500, 1000},
 	})
 	collectors = append(collectors, CiliumEndpointSliceDensity)
 
@@ -191,7 +188,7 @@ func registerMetrics() []prometheus.Collector {
 		Namespace: Namespace,
 		Name:      "ces_queueing_delay_seconds",
 		Help:      "CiliumEndpointSlice queueing delay in seconds",
-		Buckets:   prometheus.ExponentialBucketsRange(.005, 3600, 20),
+		Buckets:   append(prometheus.DefBuckets, 60, 300, 900, 1800, 3600),
 	})
 	collectors = append(collectors, CiliumEndpointSliceQueueDelay)
 

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -169,6 +169,7 @@ func registerMetrics() []prometheus.Collector {
 		Namespace: Namespace,
 		Name:      "number_of_ceps_per_ces",
 		Help:      "The number of CEPs batched in a CES",
+		Buckets:   prometheus.LinearBuckets(0, 10, operatorOption.Config.CESMaxCEPsInCES/10),
 	})
 	collectors = append(collectors, CiliumEndpointSliceDensity)
 


### PR DESCRIPTION
In `CiliumEndpointSliceDensity` histogram buckets configuration option was unset, so defaults were used (they have values form 0 to 10 as seen here: https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#pkg-variables).
This change makes the width of the buckets 10 as documented.

In `CiliumEndpointSliceQueueDelay` also defaults were used. After this change the largest bucket is 1 hour which corresponds to the values observed in large clusters while keeping granularity at small queue delays.

Before:
```
# HELP cilium_operator_number_of_ceps_per_ces The number of CEPs batched in a CES
# TYPE cilium_operator_number_of_ceps_per_ces histogram
cilium_operator_number_of_ceps_per_ces_bucket{le="0.005"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="0.01"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="0.025"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="0.05"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="0.1"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="0.25"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="0.5"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="1"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="2.5"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="5"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="10"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="+Inf"} 0
cilium_operator_number_of_ceps_per_ces_sum 0
cilium_operator_number_of_ceps_per_ces_count 0
```
(`cilium_operator_ces_queueing_delay_seconds` has the same default distribution)

After:
```
# HELP cilium_operator_number_of_ceps_per_ces The number of CEPs batched in a CES
# TYPE cilium_operator_number_of_ceps_per_ces histogram
cilium_operator_number_of_ceps_per_ces_bucket{le="1"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="10"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="25"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="50"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="100"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="200"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="500"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="1000"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="+Inf"} 0
cilium_operator_number_of_ceps_per_ces_sum 0
cilium_operator_number_of_ceps_per_ces_count 0
# HELP cilium_operator_ces_queueing_delay_seconds CiliumEndpointSlice queueing delay in seconds
# TYPE cilium_operator_ces_queueing_delay_seconds histogram
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.005"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.01"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.025"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.05"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.1"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.25"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.5"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="1"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="2.5"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="5"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="10"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="60"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="300"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="900"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="1800"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="3600"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="+Inf"} 0
cilium_operator_ces_queueing_delay_seconds_sum 0
cilium_operator_ces_queueing_delay_seconds_count 0
```

```release-note
Adjust CES bucket sizes for metrics
```