### PR TITLE
bpf: Check for SRH type on SRv6 decapsulation

### DIFF
--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -231,6 +231,10 @@ srv6_decapsulation(struct __ctx_buff *ctx)
 		if ((void *)srh + sizeof(struct srv6_srh) + sizeof(struct in6_addr) > data_end)
 			return DROP_INVALID;
 
+		/* We only support the SRH extension header for now. */
+		if (srh->rthdr.type != IPV6_SRCRT_TYPE_4)
+			return DROP_INVALID;
+
 		shrink = sizeof(struct srv6_srh) + sizeof(struct in6_addr);
 
 		switch (srh->rthdr.nexthdr) {


### PR DESCRIPTION
In SRv6 SRH mode, we currently only support SRv6 encapsulated packets that have a single IPv6 extension header, the Routing SRH one. We should drop the packets with a notification if we receive anything that has other extension headers.

Fixes: https://github.com/cilium/cilium/issues/21722.