### PR TITLE
monitor: Always print ObservationSource for DNS events

### DIFF
--- a/pkg/monitor/logrecord.go
+++ b/pkg/monitor/logrecord.go
@@ -89,16 +89,10 @@ func (l *LogRecordNotify) DumpInfo() {
 
 		switch {
 		case l.Type == accesslog.TypeRequest:
-			fmt.Printf(" DNS Query: %s %s", l.DNS.Query, qTypeStr)
+			fmt.Printf(" DNS %s: %s %s", l.DNS.ObservationSource, l.DNS.Query, qTypeStr)
 
 		case l.Type == accesslog.TypeResponse:
-			sourceType := "Query"
-			switch l.DNS.ObservationSource {
-			case accesslog.DNSSourceProxy:
-				sourceType = "Proxy"
-			}
-
-			fmt.Printf(" DNS %s: %s %s", sourceType, l.DNS.Query, qTypeStr)
+			fmt.Printf(" DNS %s: %s %s", l.DNS.ObservationSource, l.DNS.Query, qTypeStr)
 
 			ips := make([]string, 0, len(l.DNS.IPs))
 			for _, ip := range l.DNS.IPs {

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -393,8 +393,8 @@ var _ = Describe("RuntimeAgentFQDNPolicies", func() {
 
 		expectFQDNSareApplied("cilium.test", 0)
 
-		allowVerdict := "verdict Forwarded DNS Query: world1.cilium.test"
-		deniedVerdict := "verdict Denied DNS Query: world2.cilium.test"
+		allowVerdict := "verdict Forwarded DNS proxy: world1.cilium.test"
+		deniedVerdict := "verdict Denied DNS proxy: world2.cilium.test"
 
 		By("Testing connectivity to Cilium.test domain")
 		res := vm.ContainerExec(helpers.App1, helpers.CurlFail(world1Target))


### PR DESCRIPTION
Printing "Query" doesn't add much information since we already know that
these events correspond to DNS requests/responses. This commit modifies
the monitor output for DNS events to always print DNS.ObservationSource
instead.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

```release-note
monitor: Always print ObservationSource for DNS events
```
