### PR TITLE
pkg/controller: fix incorrect backoff time for next retry

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/netip"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -524,6 +525,7 @@ func (ipc *IPCache) TriggerLabelInjection() {
 
 				return err
 			},
+			MaxRetryInterval: 1 * time.Minute,
 		},
 	)
 }


### PR DESCRIPTION
It is observed that on agent start, controller "ipcache-inject-labels" will take several minutes or even longer to succeed, with status like,

```
$ cilium status --brief
error in controller ipcache-inject-labels: failed to inject labels into ipcache: k8s cache not fully synced

$ cilium status --all-controllers | grep "ipcache-inject-labels"
ipcache-inject-labels                         never          4m10s ago 331     failed to inject labels into ipcache: k8s cache not fully synced
```

It can be assured that k8s cache synchronizes quite fast, in about 1~2s.

Digging into the code, we found that the agent received much events (`NodeUpdated`), which will trigger one `ControllerUpdate` per events, and which in turn makes the controller loop increased retry count hundreds of times in several ms (during which period k8s cache is not ready), and when the event storm gone, the controller has to wait hundreds of seconds to hit `case runTimer.After(interval)`, although the k8s cache is already.  Related code in v1.11.10 (same logic in master): https://github.com/cilium/cilium/blob/v1.11.10/pkg/controller/controller.go#L266

This patch fixes the problem by distinguishing different retry types, and increasing backoff time only with the "timerExpired" type. Besides, detailed retry stats are also included into scoped log for better observability.

```release-note
Fix long-time failure of "ipcache-inject-labels" controller due to incorrect backoff time for retry
```

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>