### PR TITLE
bpf: fix drop metric in handle_netdev()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -836,12 +836,12 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 #endif
 	ret = do_netdev_encrypt_pools(ctx);
 	if (ret)
-		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP, METRIC_INGRESS);
+		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP, METRIC_EGRESS);
 
 	ret = do_netdev_encrypt_fib(ctx, proto, &encrypt_iface, &ext_err);
 	if (ret)
 		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  CTX_ACT_DROP, METRIC_EGRESS);
 
 	bpf_clear_meta(ctx);
 #ifdef BPF_HAVE_FIB_LOOKUP


### PR DESCRIPTION
If the host firewall sends a drop-notification for an unknown L2 protocol in the from-netdev path, me thinks we need to use METRIC_INGRESS.

Subsequent code in do_netdev() agrees.

Fixes: 88bf29180099 ("bpf: Enforce host policies for IPv4")
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>