### PR TITLE
correct the stale documentation link

### DIFF
--- a/examples/minikube/README.rst
+++ b/examples/minikube/README.rst
@@ -1,4 +1,3 @@
 Getting Started with Cilium on minikube
 =======================================
-
-https://cilium.readthedocs.io/en/latest/gettingstarted/minikube
+https://docs.cilium.io/en/latest/gettingstarted/k8s-install-default/#create-the-cluster - click on the "minikube" tab.


### PR DESCRIPTION
PR corrects the bad documentation link that currently leads to a 404 page.

Signed-off-by: Dmitry Savintsev <dmitris@users.noreply.github.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
