### PR TITLE
bpf: Remove unused `ENABLE_L7_PROXY` macro

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -598,10 +598,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_ICMP_RULE"] = "1"
 	}
 
-	if option.Config.EnableL7Proxy {
-		cDefinesMap["ENABLE_L7_PROXY"] = "1"
-	}
-
 	cDefinesMap["CIDR_IDENTITY_RANGE_START"] = fmt.Sprintf("%d", identity.MinLocalIdentity)
 	cDefinesMap["CIDR_IDENTITY_RANGE_END"] = fmt.Sprintf("%d", identity.MaxLocalIdentity)
 


### PR DESCRIPTION
This macro isn't used anywhere in the BPF codebase so it's safe to remove.

Reverts: 4189d1c74e24c968135ffa39277134925aca7c16 ("vtep: add ENABLE_L7_PROXY to check in datapath")