### PR TITLE
docs: Reword note in Azure CNI chaining documentation

### DIFF
--- a/Documentation/installation/cni-chaining-azure-cni.rst
+++ b/Documentation/installation/cni-chaining-azure-cni.rst
@@ -12,10 +12,11 @@ Azure CNI
 
 .. note::
 
-   This is not the best option to run Cilium on AKS or Azure. Please refer to
-   :ref:`k8s_install_quick` for the best guide to run Cilium in Azure Cloud.
-   Follow this guide if you specifically want to run Cilium in combination with
-   the Azure CNI in a chaining configuration.
+   For most users, the best way to run Cilium on AKS is either
+   AKS BYO CNI as described in :ref:`k8s_install_quick`
+   or `Azure CNI Powered by Cilium <https://aka.ms/aks/cilium-dataplane>`_.
+   This guide provides alternative instructions to run Cilium with Azure CNI
+   in a chaining configuration.
 
 .. include:: cni-chaining-limitations.rst
 


### PR DESCRIPTION
Clarify that Azure CNI chaining is different than [Azure CNI Powered by Cilium](https://aka.ms/aks/cilium-dataplane)

```release-note
Clarify in documentation that Azure CNI chaining is different from Azure CNI powered by Cilium.
```