### PR TITLE
gateway-api: Support v1alpha2 ReferenceGrant API

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -93,6 +93,7 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${{ env.gateway_api_version }}/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
           kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${{ env.gateway_api_version }}/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
           kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${{ env.gateway_api_version }}/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${{ env.gateway_api_version }}/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
           
           # To make sure that Gateway API CRs are available
           kubectl wait --for condition=Established crd/gatewayclasses.gateway.networking.k8s.io --timeout=${{ env.timeout }}

--- a/operator/pkg/gateway-api/conformance_test.go
+++ b/operator/pkg/gateway-api/conformance_test.go
@@ -52,6 +52,7 @@ func TestConformance(t *testing.T) {
 		Debug:                *flags.ShowDebug,
 		CleanupBaseResources: *flags.CleanupBaseResources,
 		SupportedFeatures: []suite.SupportedFeature{
+			suite.SupportReferenceGrant,
 			suite.SupportHTTPRouteQueryParamMatching, // Extended conformance
 		},
 	})

--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -35,6 +36,7 @@ var (
 
 func init() {
 	utilruntime.Must(gatewayv1beta1.AddToScheme(scheme))
+	utilruntime.Must(gatewayv1alpha2.AddToScheme(scheme))
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(ciliumv2.AddToScheme(scheme))
 }
@@ -89,6 +91,15 @@ func NewController(enableSecretSync bool, secretsNamespace string) (*Controller,
 		Model:  m,
 	}
 	if err = hrReconciler.SetupWithManager(mgr); err != nil {
+		return nil, err
+	}
+
+	rgReconciler := &referenceGrantReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Model:  m,
+	}
+	if err = rgReconciler.SetupWithManager(mgr); err != nil {
 		return nil, err
 	}
 

--- a/operator/pkg/gateway-api/referencegrant.go
+++ b/operator/pkg/gateway-api/referencegrant.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// referenceGrantReconciler reconciles a ReferenceGrant object
+type referenceGrantReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	Model *internalModel
+
+	controllerName string
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *referenceGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&gatewayv1alpha2.ReferenceGrant{}).
+		Complete(r)
+}

--- a/operator/pkg/gateway-api/referencegrant_reconcile.go
+++ b/operator/pkg/gateway-api/referencegrant_reconcile.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
+func (r *referenceGrantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	scopedLog := log.WithContext(ctx).WithFields(logrus.Fields{
+		logfields.Controller: "referencegrant",
+		logfields.Resource:   req.NamespacedName,
+	})
+
+	// TODO(tam): implement the reconcile logic once ReferenceGrant status is available.
+	scopedLog.Info("Successfully reconciled ReferenceGrant")
+	return success()
+}


### PR DESCRIPTION
This commit is to support ReferenceGrant for cross-namespace resources:

- Secret is referenced in Gateway
- Service is referenced in HTTPRoute

The conformance test is also enabled with ReferenceGrant feature.

Signed-off-by: Tam Mach <tam.mach@cilium.io>

