### PR TITLE
fix: correction in PR #21825

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2947,7 +2947,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableIPv6Masquerade = vp.GetBool(EnableIPv6Masquerade) && c.EnableIPv6
 	c.EnableBPFMasquerade = vp.GetBool(EnableBPFMasquerade)
 	c.DeriveMasqIPAddrFromDevice = vp.GetString(DeriveMasqIPAddrFromDevice)
-	c.EnablePMTUDiscovery = viper.GetBool(EnablePMTUDiscovery)
+	c.EnablePMTUDiscovery = vp.GetBool(EnablePMTUDiscovery)
 
 	c.populateLoadBalancerSettings(vp)
 	c.populateDevices(vp)


### PR DESCRIPTION
This change corrects a typo from PR #21825 and changes the use of method 'GetBool' from 'viper' package to 'vp'.

Signed-off-by: Nishant Burte <nburte@google.com>