### PR TITLE
docs: Add Getting Started guide for Gateway API support

### DIFF
--- a/Documentation/network/servicemesh/demo-app.rst
+++ b/Documentation/network/servicemesh/demo-app.rst
@@ -1,0 +1,26 @@
+Deploy the Demo App
+===================
+
+.. code-block:: shell-session
+
+    $ kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.11/samples/bookinfo/platform/kube/bookinfo.yaml
+
+This is just deploying the demo app, it's not adding any Istio components. You
+can confirm that with Cilium Service Mesh there is no Envoy sidecar created
+alongside each of the demo app microservices.
+
+.. code-block:: shell-session
+
+    $ kubectl get pods
+    NAME                              READY   STATUS    RESTARTS   AGE
+    details-v1-5498c86cf5-kjzkj       1/1     Running   0          2m39s
+    productpage-v1-65b75f6885-ff59g   1/1     Running   0          2m39s
+    ratings-v1-b477cf6cf-kv7bh        1/1     Running   0          2m39s
+    reviews-v1-79d546878f-r5bjz       1/1     Running   0          2m39s
+    reviews-v2-548c57f459-pld2f       1/1     Running   0          2m39s
+    reviews-v3-6dd79655b9-nhrnh       1/1     Running   0          2m39s
+
+.. Note::
+
+    With the sidecar implementation the output would show 2/2 READY. One for
+    the microservice and one for the Envoy sidecar.

--- a/Documentation/network/servicemesh/gateway-api/gateway-api.rst
+++ b/Documentation/network/servicemesh/gateway-api/gateway-api.rst
@@ -1,0 +1,36 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _gs_gateway_api:
+
+*******************
+Gateway API Support
+*******************
+
+Cilium supports Gateway API v0.5.1 for below resources, all the Core conformance
+tests, plus the ReferenceGrant extended tests, are passed.
+
+- `GatewayClass <https://gateway-api.sigs.k8s.io/api-types/gatewayclass/>`_
+- `Gateway <https://gateway-api.sigs.k8s.io/api-types/gateway/>`_
+- `HTTPRoute <https://gateway-api.sigs.k8s.io/api-types/httproute/>`_
+- `ReferenceGrant <https://gateway-api.sigs.k8s.io/api-types/referencegrant/>`_
+
+.. include:: installation.rst
+
+Examples
+########
+
+Please refer to one of the below examples on how to use and leverage
+Cilium's Gateway API features:
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   http
+   https
+
+More examples can be found `upstream repository <https://github.com/kubernetes-sigs/gateway-api/tree/v0.5.1/examples/v1beta1>`_.

--- a/Documentation/network/servicemesh/gateway-api/http.rst
+++ b/Documentation/network/servicemesh/gateway-api/http.rst
@@ -1,0 +1,111 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _gs_gateway_http:
+
+************
+HTTP Example
+************
+
+In this example, we will deploy a simple HTTP service and expose it to the
+Cilium Gateway API.
+
+The demo application is from the ``bookinfo`` demo microservices app from
+the Istio project.
+
+.. include:: ../demo-app.rst
+
+Deploy the Cilium Gateway
+=========================
+
+You'll find the example Gateway and HTTPRoute definition in ``basic-http.yaml``.
+
+.. literalinclude:: ../../../../examples/kubernetes/gateway/basic-http.yaml
+
+.. parsed-literal::
+
+    $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/gateway/basic-http.yaml
+
+The above example creates a Gateway named ``my-gateway`` that listens on port 80.
+Two routes are defined, one for ``/details`` to the ``details`` service, and
+one for ``/`` to the ``productpage`` service.
+
+Your cloud provider will automatically provision an external IP address for the
+gateway, but it may take up to 20 minutes.
+
+.. code-block:: shell-session
+
+    $ kubectl get gateway my-gateway
+    NAME         CLASS    ADDRESS        READY   AGE
+    my-gateway   cilium   10.100.26.37   True    2d7h
+
+.. Note::
+
+    Some providers e.g. EKS use a fully-qualified domain name rather than an IP address.
+
+Make HTTP Requests
+==================
+
+Now that the Gateway is ready, you can make HTTP requests to the services.
+
+.. code-block:: shell-session
+
+    $ GATEWAY=$(kubectl get gateway my-gateway -o jsonpath='{.status.addresses[0].value}')
+    $ curl --fail -s http://"$GATEWAY"/details/1 | jq
+    {
+      "id": 1,
+      "author": "William Shakespeare",
+      "year": 1595,
+      "type": "paperback",
+      "pages": 200,
+      "publisher": "PublisherA",
+      "language": "English",
+      "ISBN-10": "1234567890",
+      "ISBN-13": "123-1234567890"
+    }
+    $ curl -v -H 'magic: foo' http://"$GATEWAY"\?great\=example
+    ...
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Simple Bookstore App</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="static/bootstrap/css/bootstrap.min.css">
+
+    <!-- Optional theme -->
+    <link rel="stylesheet" href="static/bootstrap/css/bootstrap-theme.min.css">
+
+      </head>
+      <body>
+
+
+    <p>
+        <h3>Hello! This is a simple bookstore application consisting of three services as shown below</h3>
+    </p>
+
+    <table class="table table-condensed table-bordered table-hover"><tr><th>name</th><td>http://details:9080</td></tr><tr><th>endpoint</th><td>details</td></tr><tr><th>children</th><td><table class="table table-condensed table-bordered table-hover"><tr><th>name</th><th>endpoint</th><th>children</th></tr><tr><td>http://details:9080</td><td>details</td><td></td></tr><tr><td>http://reviews:9080</td><td>reviews</td><td><table class="table table-condensed table-bordered table-hover"><tr><th>name</th><th>endpoint</th><th>children</th></tr><tr><td>http://ratings:9080</td><td>ratings</td><td></td></tr></table></td></tr></table></td></tr></table>
+
+    <p>
+        <h4>Click on one of the links below to auto generate a request to the backend as a real user or a tester
+        </h4>
+    </p>
+    <p><a href="/productpage?u=normal">Normal user</a></p>
+    <p><a href="/productpage?u=test">Test user</a></p>
+
+
+
+    <!-- Latest compiled and minified JavaScript -->
+    <script src="static/jquery.min.js"></script>
+
+    <!-- Latest compiled and minified JavaScript -->
+    <script src="static/bootstrap/js/bootstrap.min.js"></script>
+
+      </body>
+    </html>

--- a/Documentation/network/servicemesh/gateway-api/https.rst
+++ b/Documentation/network/servicemesh/gateway-api/https.rst
@@ -1,0 +1,109 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _gs_gateway_https:
+
+*************
+HTTPS Example
+*************
+
+This example builds on the previous :ref:`gs_gateway_http` and add TLS
+termination for two HTTP routes. For simplicity, the second route to ``productpage``
+is omitted.
+
+.. literalinclude:: ../../../../examples/kubernetes/gateway/basic-https.yaml
+
+.. include:: ../tls-cert.rst
+
+Deploy the Gateway and HTTPRoute
+================================
+
+The Gateway configuration for this demo provides the similar routing to the
+``details`` and ``productpage`` services.
+
+
+.. tabs::
+
+    .. group-tab:: Self-signed Certificate
+
+        .. parsed-literal::
+
+            $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/gateway/basic-https.yaml
+
+    .. group-tab:: Cert Manager
+
+        .. parsed-literal::
+
+            $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/gateway/basic-https.yaml
+
+        To tell cert-manager that this Ingress needs a certificate, annotate the
+        Gateway with the name of the CA issuer we previously created:
+
+        .. code-block:: shell-session
+
+            $ kubectl annotate gateway tls-gateway cert-manager.io/issuer=ca-issuer
+
+        This creates a Certificate object along with a Secret containing the TLS
+        certificate.
+
+        .. code-block:: shell-session
+
+            $ kubectl get certificate,secret demo-cert
+            NAME                                    READY   SECRET      AGE
+            certificate.cert-manager.io/demo-cert   True    demo-cert   29s
+            NAME               TYPE                DATA   AGE
+            secret/demo-cert   kubernetes.io/tls   3      29s
+
+External IP address will be shown up in Gateway. Also, the host names should be shown up in
+related HTTPRoutes.
+
+.. code-block:: shell-session
+
+    $ kubectl get gateway tls-gateway
+    NAME          CLASS    ADDRESS         READY   AGE
+    tls-gateway   cilium   10.104.247.23   True    29s
+
+    $ kubectl httproutes  https-app-route-1 https-app-route-2
+    NAME                HOSTNAMES                      AGE
+    https-app-route-1   ["bookinfo.cilium.rocks"]      29s
+    https-app-route-2   ["hipstershop.cilium.rocks"]   29s
+
+Update ``/etc/hosts`` with the host names and IP address of the Gateway:
+
+.. code-block:: shell-session
+
+    $ sudo perl -ni -e 'print if !/\.cilium\.rocks$/d' /etc/hosts; sudo tee -a /etc/hosts \
+      <<<"$(kubectl get gateway tls-gateway -o jsonpath='{.status.addresses[0].value}') bookinfo.cilium.rocks hipstershop.cilium.rocks"
+
+Make HTTPS Requests
+===================
+
+.. tabs::
+
+    .. group-tab:: Self-signed Certificate
+
+        By specifying the CA's certificate on a curl request, you can say that you trust certificates
+        signed by that CA.
+
+        .. code-block:: shell-session
+
+            $ curl --cacert minica.pem -v https://bookinfo.cilium.rocks/details/1
+            $ curl --cacert minica.pem -v https://hipstershop.cilium.rocks/
+
+        If you prefer, instead of supplying the CA you can specify ``-k`` to tell the
+        curl client not to validate the server's certificate. Without either, you
+        will get an error that the certificate was signed by an unknown authority.
+
+        Specifying -v on the curl request, you can see that the TLS handshake took
+        place successfully.
+
+    .. group-tab:: Cert Manager
+
+        .. code-block:: shell-session
+
+            $ curl https://bookinfo.cilium.rocks/details/1
+            $ curl https://hipstershop.cilium.rocks/
+

--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -1,0 +1,71 @@
+Prerequisites
+#############
+
+* Cilium must be configured with ``kubeProxyReplacement`` as partial
+  or strict. Please refer to :ref:`kube-proxy replacement <kubeproxy-free>`
+  for more details.
+* The below CRDs from Gateway API v0.5.1 ``must`` be pre-installed.
+  Please refer to this `docs <https://gateway-api.sigs.k8s.io/guides/?h=crds#getting-started-with-gateway-api>`_
+  for installation steps. Alternatively, the below snippet could be used.
+
+    - `GatewayClass <https://gateway-api.sigs.k8s.io/api-types/gatewayclass/>`_
+    - `Gateway <https://gateway-api.sigs.k8s.io/api-types/gateway/>`_
+    - `HTTPRoute <https://gateway-api.sigs.k8s.io/api-types/httproute/>`_
+    - `ReferenceGrant <https://gateway-api.sigs.k8s.io/api-types/referencegrant/>`_
+
+    .. code-block:: shell-session
+
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.5.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.5.1/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.5.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.5.1/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+
+* Similar to Ingress, Gateway API controller creates a service of LoadBalancer type,
+  so your environment will need to support this.
+
+Installation
+############
+
+.. tabs::
+
+    .. group-tab:: Helm
+
+        Cilium Gateway API Controller can be enabled with helm flag ``gatewayAPI.enabled``
+        set as true. Please refer to :ref:`k8s_install_helm` for a fresh installation.
+
+        .. parsed-literal::
+
+            $ helm upgrade cilium |CHART_RELEASE| \\
+                --namespace kube-system \\
+                --reuse-values \\
+                --set gatewayAPI.enabled=true
+
+            $ kubectl -n kube-system rollout restart deployment/cilium-operator
+            $ kubectl -n kube-system rollout restart ds/cilium
+
+        Next you can check the status of the Cilium agent and operator:
+
+        .. code-block:: shell-session
+
+            $ cilium status
+
+        .. include:: ../../../installation/cli-download.rst
+
+    .. group-tab:: Cilium CLI
+
+        .. include:: ../../../installation/cli-download.rst
+
+        Cilium Gateway API Controller can be enabled with the below command
+
+        .. code-block:: shell-session
+
+            $ cilium install \\
+                --kube-proxy-replacement=strict \\
+                --helm-set gatewayAPI.enabled=true
+
+        Next you can check the status of the Cilium agent and operator:
+
+        .. code-block:: shell-session
+
+            $ cilium status
+

--- a/Documentation/network/servicemesh/http.rst
+++ b/Documentation/network/servicemesh/http.rst
@@ -13,33 +13,7 @@ Ingress HTTP Example
 The example ingress configuration routes traffic to backend services from the
 ``bookinfo`` demo microservices app from the Istio project.
 
-
-Deploy the Demo App
-===================
-
-.. code-block:: shell-session
-
-    $ kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.11/samples/bookinfo/platform/kube/bookinfo.yaml
-
-This is just deploying the demo app, it's not adding any Istio components. You
-can confirm that with Cilium Service Mesh there is no Envoy sidecar created
-alongside each of the demo app microservices.
-
-.. code-block:: shell-session
-
-    $ kubectl get pods
-    NAME                              READY   STATUS    RESTARTS   AGE
-    details-v1-5498c86cf5-kjzkj       1/1     Running   0          2m39s
-    productpage-v1-65b75f6885-ff59g   1/1     Running   0          2m39s
-    ratings-v1-b477cf6cf-kv7bh        1/1     Running   0          2m39s
-    reviews-v1-79d546878f-r5bjz       1/1     Running   0          2m39s
-    reviews-v2-548c57f459-pld2f       1/1     Running   0          2m39s
-    reviews-v3-6dd79655b9-nhrnh       1/1     Running   0          2m39s
-
-.. Note::
-
-    With the sidecar implementation the output would show 2/2 READY. One for
-    the microservice and one for the Envoy sidecar.
+.. include:: demo-app.rst
 
 Deploy the First Ingress
 ========================

--- a/Documentation/network/servicemesh/index.rst
+++ b/Documentation/network/servicemesh/index.rst
@@ -15,3 +15,4 @@ Service Mesh
 
    ingress
    l7-traffic-management
+   gateway-api/gateway-api

--- a/Documentation/network/servicemesh/tls-cert.rst
+++ b/Documentation/network/servicemesh/tls-cert.rst
@@ -32,7 +32,11 @@ Create TLS Certificate and Private Key
         .. code-block:: shell-session
 
             $ helm repo add jetstack https://charts.jetstack.io
-            $ helm install cert-manager jetstack/cert-manager --version v1.7.1 --namespace cert-manager --set installCRDs=true --create-namespace
+            $ helm install cert-manager jetstack/cert-manager --version v1.10.0 \
+                --namespace cert-manager \
+                --set installCRDs=true \
+                --create-namespace \
+                --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
 
         Now, create a CA Issuer:
 

--- a/Documentation/network/servicemesh/tls-cert.rst
+++ b/Documentation/network/servicemesh/tls-cert.rst
@@ -1,0 +1,41 @@
+Create TLS Certificate and Private Key
+======================================
+
+.. tabs::
+
+    .. group-tab:: Self-signed Certificate
+
+        For demonstration purposes we will use a TLS certificate signed by a made-up,
+        `self-signed <https://cert-manager.io/docs/faq/terminology/#what-does-self-signed-mean-is-my-ca-self-signed>`_
+        certificate authority (CA). One easy way to do this is with `minica <https://github.com/jsha/minica>`_.
+        We want a certificate that will validate ``bookinfo.cilium.rocks`` and
+        ``hipstershop.cilium.rocks``, as these are the host names used in this example.
+
+        .. code-block:: shell-session
+
+            $ minica -domains '*.cilium.rocks'
+
+        On first run, ``minica`` generates a CA certificate and key (``minica.pem`` and
+        ``minica-key.pem``). It also creates a directory called ``_.cilium.rocks``
+        containing a key and certificate file that we will use for the TLS configuration.
+
+        Create a Kubernetes secret with this demo key and certificate:
+
+        .. code-block:: shell-session
+
+            $ kubectl create secret tls demo-cert --key=_.cilium.rocks/key.pem --cert=_.cilium.rocks/cert.pem
+
+    .. group-tab:: Cert Manager
+
+        Let us install cert-manager:
+
+        .. code-block:: shell-session
+
+            $ helm repo add jetstack https://charts.jetstack.io
+            $ helm install cert-manager jetstack/cert-manager --version v1.7.1 --namespace cert-manager --set installCRDs=true --create-namespace
+
+        Now, create a CA Issuer:
+
+        .. parsed-literal::
+
+            $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/servicemesh/ca-issuer.yaml

--- a/Documentation/network/servicemesh/tls-termination.rst
+++ b/Documentation/network/servicemesh/tls-termination.rst
@@ -15,48 +15,7 @@ termination.
 
 .. literalinclude:: ../../../examples/kubernetes/servicemesh/tls-ingress.yaml
 
-Create TLS Certificate and Private Key
-======================================
-
-.. tabs::
-
-    .. group-tab:: Self-signed Certificate
-
-        For demonstration purposes we will use a TLS certificate signed by a made-up,
-        `self-signed <https://cert-manager.io/docs/faq/terminology/#what-does-self-signed-mean-is-my-ca-self-signed>`_
-        certificate authority (CA). One easy way to do this is with `minica <https://github.com/jsha/minica>`_.
-        We want a certificate that will validate ``bookinfo.cilium.rocks`` and
-        ``hipstershop.cilium.rocks``, as these are the host names used in this ingress
-        example.
-
-        .. code-block:: shell-session
-
-            $ minica -domains '*.cilium.rocks'
-
-        On first run, ``minica`` generates a CA certificate and key (``minica.pem`` and
-        ``minica-key.pem``). It also creates a directory called ``_.cilium.rocks``
-        containing a key and certificate file that we will use for the ingress service.
-
-        Create a Kubernetes secret with this demo key and certificate:
-
-        .. code-block:: shell-session
-
-            $ kubectl create secret tls demo-cert --key=_.cilium.rocks/key.pem --cert=_.cilium.rocks/cert.pem
-
-    .. group-tab:: Cert Manager
-
-        Let us install cert-manager:
-
-        .. code-block:: shell-session
-
-            $ helm repo add jetstack https://charts.jetstack.io
-            $ helm install cert-manager jetstack/cert-manager --version v1.7.1 --namespace cert-manager --set installCRDs=true --create-namespace
-
-        Now, create a CA Issuer:
-
-        .. parsed-literal::
-
-            $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/servicemesh/ca-issuer.yaml
+.. include:: tls-cert.rst
 
 Deploy the Ingress
 ==================

--- a/examples/kubernetes/gateway/basic-https.yaml
+++ b/examples/kubernetes/gateway/basic-https.yaml
@@ -1,0 +1,59 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: tls-gateway
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - name: https-1
+    protocol: HTTPS
+    port: 443
+    hostname: "bookinfo.cilium.rocks"
+    tls:
+      certificateRefs:
+      - kind: Secret
+        name: demo-cert
+  - name: https-2
+    protocol: HTTPS
+    port: 443
+    hostname: "hipstershop.cilium.rocks"
+    tls:
+      certificateRefs:
+      - kind: Secret
+        name: demo-cert
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: https-app-route-1
+spec:
+  parentRefs:
+  - name: tls-gateway
+  hostnames:
+  - "bookinfo.cilium.rocks"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /details
+    backendRefs:
+    - name: details
+      port: 9080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: https-app-route-2
+spec:
+  parentRefs:
+  - name: tls-gateway
+  hostnames:
+  - "hipstershop.cilium.rocks"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: productpage
+      port: 9080


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/pull/21749

The changes can be reviewed in https://deploy-preview-21908--docs-cilium-io.netlify.app/

```release-note
docs: Add Getting Started guide for Gateway API support
```
