### PR TITLE
Sign Cilium container images

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -11,7 +11,11 @@ on:
       - images/runtime/**
       - images/builder/**
 
-permissions: read-all
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -90,6 +94,16 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+
+      - name: Sign Container Image
+        if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
 
       - name: Image Release Digest
         if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -11,7 +11,11 @@ on:
         required: true
         default: "beta"
 
-permissions: read-all
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
 
 jobs:
   build-and-push:
@@ -98,6 +102,15 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+
+      - name: Sign Container Image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-${{ github.event.inputs.suffix }}@${{ steps.docker_build_release.outputs.digest }}
 
       - name: Image Release Digest
         shell: bash

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -22,7 +22,11 @@ on:
     types:
      - completed
 
-permissions: read-all
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
@@ -120,6 +124,9 @@ jobs:
           platforms: linux/amd64
           target: import-cache
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+
       # master branch pushes
       - name: CI Build ${{ matrix.name }}
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -182,6 +189,15 @@ jobs:
             NOSTRIP=1
             OPERATOR_VARIANT=${{ matrix.name }}
 
+      - name: Sign Container Images
+        if: ${{ github.event_name != 'pull_request_target' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_master.outputs.digest }}
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_master_detect_race_condition.outputs.digest }}
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_master_unstripped.outputs.digest }}
+
       - name: CI Image Releases digests
         if: ${{ github.event_name != 'pull_request_target' }}
         shell: bash
@@ -243,6 +259,15 @@ jobs:
           build-args: |
             NOSTRIP=1
             OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: Sign Container Images
+        if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr.outputs.digest }}
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr_detect_race_condition.outputs.digest }}
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr_unstripped.outputs.digest }}
 
       - name: CI Image Releases digests
         if: ${{ github.event_name == 'pull_request_target' }}

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -5,7 +5,11 @@ on:
     branches:
       - hf/master/**
 
-permissions: read-all
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
 
 jobs:
   build-and-push:
@@ -93,6 +97,16 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+
+      - name: Sign Container Image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-dev@${{ steps.docker_build_release.outputs.digest }}
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
 
       - name: Image Release Digest
         shell: bash

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -6,7 +6,11 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
 
-permissions: read-all
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
 
 jobs:
   build-and-push:
@@ -91,6 +95,16 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+
+      - name: Sign Container Image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign docker.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
+          cosign sign quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
 
       - name: Image Release Digest
         shell: bash

--- a/Documentation/configuration/index.rst
+++ b/Documentation/configuration/index.rst
@@ -19,3 +19,11 @@ Core Agent
    sctp
    vlan-802.1q
    argocd-issues
+
+Security
+--------
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   verify-image-signatures

--- a/Documentation/configuration/verify-image-signatures.rst
+++ b/Documentation/configuration/verify-image-signatures.rst
@@ -1,0 +1,49 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _verify_image_signatures:
+
+**************************
+Verifying Image Signatures
+**************************
+
+Prerequisites
+=============
+
+You will need to `install cosign`_.
+
+.. _`install cosign`: https://docs.sigstore.dev/cosign/installation/
+
+Verify Signed Container Images
+==============================
+
+Since version 1.13, all Cilium container images are signed using cosign.
+
+Let's verify a Cilium image's signature using the ``cosign verify`` command:
+
+.. code-block:: shell-session
+
+    $ COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository cilium/cilium --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-github-workflow-name "Image Release Build" --certificate-github-workflow-ref refs/tags/[RELEASE TAG] quay.io/cilium/cilium:v1.13 | jq
+    
+
+.. note::
+
+    ``COSIGN_EXPERIMENTAL=1`` is used to allow verification of images signed in 
+    ``KEYLESS`` mode. To learn more about keyless signing, please refer to 
+    `Keyless Signatures`_.
+    
+    ``--certificate-github-workflow-name string`` contains the workflow claim 
+    from the GitHub OIDC Identity token that contains the name of the executed 
+    workflow. For the names of workflows used to build Cilium images, see the 
+    ``build-images`` workflows under `Cilium workflows`_.
+    
+    ``--certificate-github-workflow-ref string`` contains the ref claim from 
+    the GitHub OIDC Identity token that contains the git ref that the workflow 
+    run was based upon.
+    
+
+.. _`Keyless Signatures`: https://github.com/sigstore/cosign/blob/main/KEYLESS.md#keyless-signatures
+.. _`Cilium workflows`: https://github.com/cilium/cilium/tree/master/.github/workflows

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -578,6 +578,7 @@ kata
 keepDeprecatedLabels
 keepDeprecatedProbes
 keyFile
+keyless
 keypair
 keyspace
 keyspaces


### PR DESCRIPTION
Implement container image signing using cosign in build-images workflows. Leveraging image signing gives users confidence that the container images they got from the container registry were the trusted code that the maintainer built and published.

Fixes: cilium#19282



```release-note
Sign Cilium container images using cosign
```
