### PR TITLE
ipcache: Fix IPcache leak of remote-node IP addresses

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -507,7 +507,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 
 	cachedIdentity, found := ipc.ipToIdentityCache[ip]
 	if !found {
-		scopedLog.Debug("Attempt to remove non-existing IP from ipcache layer")
+		scopedLog.Warn("Attempt to remove non-existing IP from ipcache layer")
 		metrics.IPCacheErrorsTotal.WithLabelValues(
 			metricTypeDelete, metricErrorNoExist,
 		).Inc()

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -526,7 +526,13 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			if skipIPCache(address) {
 				continue
 			}
-			oldNodeIPAddrs = append(oldNodeIPAddrs, address.IP.String())
+			var prefix netip.Prefix
+			if v4 := address.IP.To4(); v4 != nil {
+				prefix = ip.IPToNetPrefix(v4)
+			} else {
+				prefix = ip.IPToNetPrefix(address.IP.To16())
+			}
+			oldNodeIPAddrs = append(oldNodeIPAddrs, prefix.String())
 		}
 		m.deleteIPCache(oldNode.Source, oldNodeIPAddrs, ipsAdded)
 
@@ -640,7 +646,13 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 			continue
 		}
 
-		m.ipcache.Delete(address.IP.String(), n.Source)
+		var prefix netip.Prefix
+		if v4 := address.IP.To4(); v4 != nil {
+			prefix = ip.IPToNetPrefix(v4)
+		} else {
+			prefix = ip.IPToNetPrefix(address.IP.To16())
+		}
+		m.ipcache.Delete(prefix.String(), n.Source)
 	}
 
 	for _, address := range []net.IP{

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -769,7 +769,6 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	ipcacheExpect("upsert", "2001:DB8::20")
 
 	ipcacheExpect("delete", "192.0.2.1")
-	ipcacheExpect("delete", "2001:DB8::1")
 	ipcacheExpect("delete", "192.0.2.2")
 	ipcacheExpect("delete", "2001:DB8::2")
 


### PR DESCRIPTION
The first commit refactors the code a bit to avoid any refactoring changes in the second commit. The second commit fixes the IPcache leak for remote-node IP addresses. The third commit increases the log level on the error from debug to error to ensure we don't miss such bugs in the future. See commits for details.

cc @joestringer, as the author of https://github.com/cilium/cilium/pull/19765:
Note I fixed the bug by changing the deletion logic to follow the `a.b.c.d/32` format, but maybe I should have changed the insert logic to follow the format `a.b.c.d` instead.

As far as I can see, this bug wasn't released anywhere, hence the `release-note/misc` label.

Fixes: https://github.com/cilium/cilium/pull/19765
Fixes: https://github.com/cilium/cilium/pull/4810
Fixes: https://github.com/cilium/cilium/issues/21844