### PR TITLE
bpf: preserve Instruction Metadata in inlineGlobalData

### DIFF
--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -223,7 +223,14 @@ func inlineGlobalData(spec *ebpf.CollectionSpec) error {
 
 			// Replace the map load with an immediate load. Must be a dword load
 			// to match the instruction width of a map load.
-			prog.Instructions[i] = asm.LoadImm(ins.Dst, int64(imm), asm.DWord)
+			r := asm.LoadImm(ins.Dst, int64(imm), asm.DWord)
+
+			// Preserve metadata of the original instruction. Otherwise, a program's
+			// first instruction could be stripped of its func_info or Symbol
+			// (function start) annotations.
+			r.Metadata = ins.Metadata
+
+			prog.Instructions[i] = r
 		}
 	}
 

--- a/pkg/bpf/collection_test.go
+++ b/pkg/bpf/collection_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bpf
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+)
+
+func TestInlineGlobalData(t *testing.T) {
+	spec := &ebpf.CollectionSpec{
+		ByteOrder: binary.LittleEndian,
+		Maps: map[string]*ebpf.MapSpec{
+			globalDataMap: {
+				Contents: []ebpf.MapKV{{Value: []byte{
+					0x0, 0x0, 0x0, 0x80,
+					0x1, 0x0, 0x0, 0x0,
+				}}},
+			},
+		},
+		Programs: map[string]*ebpf.ProgramSpec{
+			"prog1": {
+				Instructions: asm.Instructions{
+					// Pseudo-load at offset 0. This Instruction would have func_info when
+					// read from an ELF, so validate Metadata preservation after inlining
+					// global data.
+					asm.LoadMapValue(asm.R0, 0, 0).WithReference(globalDataMap).WithSymbol("func1"),
+					// Pseudo-load at offset 4.
+					asm.LoadMapValue(asm.R0, 0, 4).WithReference(globalDataMap),
+					asm.Return(),
+				},
+			},
+		},
+	}
+
+	if err := inlineGlobalData(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	ins := spec.Programs["prog1"].Instructions[0]
+	if want, got := 0x80000000, int(ins.Constant); want != got {
+		t.Errorf("unexpected Instruction constant: want: 0x%x, got: 0x%x", want, got)
+	}
+
+	if want, got := "func1", ins.Symbol(); want != got {
+		t.Errorf("unexpected Symbol value of Instruction: want: %s, got: %s", want, got)
+	}
+
+	ins = spec.Programs["prog1"].Instructions[1]
+	if want, got := 0x1, int(ins.Constant); want != got {
+		t.Errorf("unexpected Instruction constant: want: 0x%x, got: 0x%x", want, got)
+	}
+}


### PR DESCRIPTION
This commit copies an Instruction's Metadata field when replacing it. Add a test that exercises the global data inlining happy path.

With ebpf-go adding the instruction metadata concept, func_info and line_info marshaling started being driven by an Instruction's Metadata. Accidentally stripping a func_info from the first Instruction in a program will result in the following verifier error:

`invalid argument: missing bpf_line_info for func#0`

The verifier rejects line_infos for subprogs that don't start with a func_info.

```release-note
Preserve instruction metadata when inlining global constants
```

cc @rgo3 @jrajahalme 