### PR TITLE
backoff: support reset backoff period

### DIFF
--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -315,6 +315,7 @@ func (n *NodeManager) Update(resource *v2.CiliumNode) (nodeSynced bool) {
 			Jitter:      true,
 			NodeManager: n,
 			Name:        fmt.Sprintf("ipam-pool-maintainer-%s", resource.Name),
+			ResetAfter:  10 * time.Minute,
 		}
 		poolMaintainer, err := trigger.NewTrigger(trigger.Parameters{
 			Name:            fmt.Sprintf("ipam-pool-maintainer-%s", resource.Name),

--- a/proxylib/npds/client.go
+++ b/proxylib/npds/client.go
@@ -103,7 +103,7 @@ func NewClient(path, nodeId string, updater proxylib.PolicyUpdater) proxylib.Pol
 				}
 			} else {
 				// Reset backoff after successful start
-				backOff = BackOff
+				backOff.Reset()
 			}
 
 			if closing {


### PR DESCRIPTION
reset backoff period when call Wait after a long time, default BackoffResetDuration is 10 minute.

I think this change does not affect calling the `wait` method

Fixes: #21936

Signed-off-by: xiaoqing <xiaoqingnb@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
support reset backoff period
```
