### PR TITLE
Remove `RUNTIME=docker` in dev_setup document

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -151,8 +151,8 @@ brought up by vagrant:
   test/bpf/verifier-test.sh``.
 * ``IPV4=1``: Run Cilium with IPv4 enabled.
 * ``RUNTIME=x``: Sets up the container runtime to be used inside a kubernetes
-  cluster. Valid options are: ``docker``, ``containerd`` and ``crio``. If not
-  set, it defaults to ``docker``.
+  cluster. Valid options are: ``containerd`` and ``crio``. If not
+  set, it defaults to ``containerd``.
 * ``VM_SET_PROXY=https://127.0.0.1:80/`` Sets up VM's ``https_proxy``.
 * ``INSTALL=1``: Restarts the installation of Cilium, Kubernetes, etc. Only
   useful when the installation was interrupted.


### PR DESCRIPTION
We can't use `RUNTIME=docker` option any longer because since v1.24.0, kubernetes doesn't support docker as a container runtime and herlpers.bash was already modified to use containerd or cri-o in #19545.

Fixes: #21935

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

```release-note
Docs: Remove `RUNTIME=docker` option in dev_setup, given that K8s 1.24+ no longer supports it (options: containerd (default), crio).
```
