### PR TITLE
Remove deprecated `spec.eni.{min-allocate,pre-allocate,max-above-watermark}` parameters

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -311,6 +311,10 @@ Annotations:
 
 1.13 Upgrade Notes
 ------------------
+* The code for the deprecated ``spec.eni.min-allocate``, ``spec.eni.pre-allocate``
+  ``spec.eni.max-above-watermark`` fields has been removed, those fields are
+  no longer functional. Please use their semantically equivalent ``spec.ipam``
+  replacements instead.
 
 * The kube-proxy replacement in DSR or Hybrid mode with tunneling causes failure upon cilium-agent start.
   In previous versions, cilium-agent automatically used SNAT mode when we set tunneling.

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -293,12 +293,8 @@ func (n *nodeStore) hasMinimumIPsInPool() (minimumReached bool, required, numAva
 	switch {
 	case n.ownNode.Spec.IPAM.MinAllocate != 0:
 		required = n.ownNode.Spec.IPAM.MinAllocate
-	case n.ownNode.Spec.ENI.MinAllocate != 0:
-		required = n.ownNode.Spec.ENI.MinAllocate
 	case n.ownNode.Spec.IPAM.PreAllocate != 0:
 		required = n.ownNode.Spec.IPAM.PreAllocate
-	case n.ownNode.Spec.ENI.PreAllocate != 0:
-		required = n.ownNode.Spec.ENI.PreAllocate
 	case n.conf.HealthCheckingEnabled():
 		required = 2
 	default:

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -217,11 +217,7 @@ func (n *Node) loggerLocked() (logger *logrus.Entry) {
 //
 // n.mutex must be held when calling this function
 func (n *Node) getMaxAboveWatermark() int {
-	if n.resource.Spec.IPAM.MaxAboveWatermark != 0 {
-		return n.resource.Spec.IPAM.MaxAboveWatermark
-	}
-	// OBSOLETE: This can be removed in Cilium 1.9
-	return n.resource.Spec.ENI.MaxAboveWatermark
+	return n.resource.Spec.IPAM.MaxAboveWatermark
 }
 
 // getPreAllocate returns the pre-allocation setting for an AWS node
@@ -231,10 +227,6 @@ func (n *Node) getPreAllocate() int {
 	if n.resource.Spec.IPAM.PreAllocate != 0 {
 		return n.resource.Spec.IPAM.PreAllocate
 	}
-	// OBSOLETE: This can be removed in Cilium 1.9
-	if n.resource.Spec.ENI.PreAllocate != 0 {
-		return n.resource.Spec.ENI.PreAllocate
-	}
 	return defaults.IPAMPreAllocation
 }
 
@@ -242,11 +234,7 @@ func (n *Node) getPreAllocate() int {
 //
 // n.mutex must be held when calling this function
 func (n *Node) getMinAllocate() int {
-	if n.resource.Spec.IPAM.MinAllocate != 0 {
-		return n.resource.Spec.IPAM.MinAllocate
-	}
-	// OBSOLETE: This can be removed in Cilium 1.9
-	return n.resource.Spec.ENI.MinAllocate
+	return n.resource.Spec.IPAM.MinAllocate
 }
 
 // getMaxAllocate returns the maximum-allocation setting of an AWS node

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -570,14 +570,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		if c := n.NetConf; c != nil {
 			if c.IPAM.MinAllocate != 0 {
 				nodeResource.Spec.IPAM.MinAllocate = c.IPAM.MinAllocate
-			} else if c.ENI.MinAllocate != 0 {
-				nodeResource.Spec.IPAM.MinAllocate = c.ENI.MinAllocate
 			}
 
 			if c.IPAM.PreAllocate != 0 {
 				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
-			} else if c.ENI.PreAllocate != 0 {
-				nodeResource.Spec.IPAM.PreAllocate = c.ENI.PreAllocate
 			}
 
 			if c.ENI.FirstInterfaceIndex != nil {

--- a/plugins/cilium-cni/types/types_test.go
+++ b/plugins/cilium-cni/types/types_test.go
@@ -84,7 +84,6 @@ func (t *CNITypesSuite) TestReadCNIConfENIWithPlugins(c *check.C) {
       "cniVersion":"0.3.1",
       "type":"cilium-cni",
       "eni": {
-        "pre-allocate": 5,
         "first-interface-index":1,
         "security-groups":[
           "sg-xxx"
@@ -110,7 +109,6 @@ func (t *CNITypesSuite) TestReadCNIConfENIWithPlugins(c *check.C) {
 			Type:       "cilium-cni",
 		},
 		ENI: eniTypes.ENISpec{
-			PreAllocate:         5,
 			FirstInterfaceIndex: &firstInterfaceIndex,
 			SecurityGroups:      []string{"sg-xxx"},
 			SubnetIDs:           []string{"subnet-xxx"},
@@ -132,7 +130,6 @@ func (t *CNITypesSuite) TestReadCNIConfENI(c *check.C) {
   "type": "cilium-cni",
   "eni": {
     "instance-type": "m4.xlarge",
-    "pre-allocate": 16,
     "first-interface-index": 2,
     "security-groups": [ "sg1", "sg2" ],
     "subnet-ids":[
@@ -160,7 +157,6 @@ func (t *CNITypesSuite) TestReadCNIConfENI(c *check.C) {
 		},
 		ENI: eniTypes.ENISpec{
 			InstanceType:        "m4.xlarge",
-			PreAllocate:         16,
 			FirstInterfaceIndex: &firstInterfaceIndex,
 			SecurityGroups:      []string{"sg1", "sg2"},
 			SubnetIDs:           []string{"subnet-1", "subnet-2"},


### PR DESCRIPTION
Dropped deprecated spec.eni parameters in the codebase.

Fixes: #21858 
