### PR TITLE
[v1.10] Fix race condition in DNS proxy when multiple DNS requests for the same name end up with policy drops

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"os"
 	"runtime"
@@ -130,6 +131,10 @@ type Daemon struct {
 	// apply to locally running endpoints.
 	dnsNameManager *fqdn.NameManager
 
+	// dnsProxyContext contains fields relevant to the DNS proxy. See each
+	// field's godoc for more details.
+	dnsProxyContext dnsProxyContext
+
 	// Used to synchronize generation of daemon's BPF programs and endpoint BPF
 	// programs.
 	compilationMutex *lock.RWMutex
@@ -190,6 +195,28 @@ type Daemon struct {
 
 	// CIDRs for which identities were restored during bootstrap
 	restoredCIDRs []*net.IPNet
+}
+
+func (d *Daemon) initDNSProxyContext(size int) {
+	d.dnsProxyContext = dnsProxyContext{
+		responseMutexes: make([]*lock.Mutex, size),
+		modulus:         big.NewInt(int64(size)),
+	}
+	for i := range d.dnsProxyContext.responseMutexes {
+		d.dnsProxyContext.responseMutexes[i] = new(lock.Mutex)
+	}
+}
+
+// dnsProxyContext is a meta struct containing fields relevant to the DNS proxy
+// of the daemon, for organizational purposes.
+type dnsProxyContext struct {
+	// responseMutexes is used to serialized the critical path of
+	// notifyOnDNSMsg() to ensure that identity allocation and ipcache
+	// insertion happen atomically between parallel DNS request handling.
+	responseMutexes []*lock.Mutex
+	// modulus is used when computing the hash of the DNS response IPs in order
+	// to map them to the mutexes inside responseMutexes.
+	modulus *big.Int
 }
 
 // GetPolicyRepository returns the policy repository of the daemon

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -913,7 +913,15 @@ func initializeFlags() {
 	flags.Duration(option.DNSProxyConcurrencyProcessingGracePeriod, 0, "Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing")
 	option.BindEnv(option.DNSProxyConcurrencyProcessingGracePeriod)
 
-	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "size of queues for policy-related events")
+	flags.Int(option.DNSProxyLockCount, 128, "Array size containing mutexes which protect against parallel handling of DNS response IPs")
+	flags.MarkHidden(option.DNSProxyLockCount)
+	option.BindEnv(option.DNSProxyLockCount)
+
+	flags.Duration(option.DNSProxyLockTimeout, 500*time.Millisecond, fmt.Sprintf("Timeout when acquiring the locks controlled by --%s", option.DNSProxyLockCount))
+	flags.MarkHidden(option.DNSProxyLockTimeout)
+	option.BindEnv(option.DNSProxyLockTimeout)
+
+	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "Size of queues for policy-related events")
 	option.BindEnv(option.PolicyQueueSize)
 
 	flags.Int(option.EndpointQueueSize, defaults.EndpointQueueSize, "size of EventQueue per-endpoint")

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -167,6 +169,8 @@ func (d *Daemon) updateSelectorCacheFQDNs(ctx context.Context, selectors map[pol
 // default DNS cache. The proxy binds to all interfaces, and uses the
 // configured DNS proxy port (this may be 0 and so OS-assigned).
 func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, preCachePath string) (err error) {
+	d.initDNSProxyContext(option.Config.DNSProxyLockCount)
+
 	cfg := fqdn.Config{
 		MinTTL:          option.Config.ToFQDNsMinTTL,
 		Cache:           fqdn.NewDNSCache(option.Config.ToFQDNsMinTTL),
@@ -577,6 +581,55 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 
 	if msg.Response && msg.Rcode == dns.RcodeSuccess && len(responseIPs) > 0 {
 		stat.DataplaneTime.Start()
+		// Create a critical section especially for when multiple DNS requests
+		// are in-flight for the same name (i.e. cilium.io).
+		//
+		// In the absence of such a critical section, consider the following
+		// race condition:
+		//
+		//              G1                                    G2
+		//
+		// T0 --> NotifyOnDNSMsg()               NotifyOnDNSMsg()            <-- T0
+		//
+		// T1 --> UpdateGenerateDNS()            UpdateGenerateDNS()         <-- T1
+		//
+		// T2 ----> mutex.Lock()                 +---------------------------+
+		//                                       |No identities need updating|
+		// T3 ----> mutex.Unlock()               +---------------------------+
+		//
+		// T4 --> UpsertGeneratedIdentities()    UpsertGeneratedIdentities() <-- T4
+		//
+		// T5 ---->  Upsert()                    DNS released back to pod    <-- T5
+		//                                                    |
+		// T6 --> DNS released back to pod                    |
+		//              |                                     |
+		//              |                                     |
+		//              v                                     v
+		//       Traffic flows fine                   Leads to policy drop
+		//
+		// Note how G2 releases the DNS msg back to the pod at T5 because
+		// UpdateGenerateDNS() was a no-op. It's a no-op because G1 had executed
+		// UpdateGenerateDNS() first at T1 and performed the necessary identity
+		// allocation for the response IPs. Due to G1 performing all the work
+		// first, G2 executes T4 also as a no-op and releases the msg back to the
+		// pod at T5 before G1 would at T6.
+		mutexAcquireStart := time.Now()
+		mutexes := d.dnsProxyContext.getMutexesForResponseIPs(responseIPs)
+		for _, m := range mutexes {
+			d.dnsProxyContext.responseMutexes[m].Lock()
+			defer d.dnsProxyContext.responseMutexes[m].Unlock()
+		}
+		if d := time.Since(mutexAcquireStart); d >= option.Config.DNSProxyLockTimeout {
+			log.WithFields(logrus.Fields{
+				logfields.DNSName:  qname,
+				logfields.Duration: d,
+				logfields.Expected: option.Config.DNSProxyLockTimeout,
+			}).Warnf("Lock acquisition time took longer than expected. "+
+				"Potentially too many parallel DNS requests being processed, "+
+				"consider adjusting --%s and/or --%s",
+				option.DNSProxyLockCount, option.DNSProxyLockTimeout)
+		}
+
 		// This must happen before the NameManager update below, to ensure that
 		// this data is included in the serialized Endpoint object.
 		// We also need to add to the cache before we purge any matching zombies
@@ -635,6 +688,39 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 
 	stat.ProcessingTime.End(true)
 	return nil
+}
+
+// getMutexesForResponseIPs returns a slice of indices for accessing the
+// mutexes in dnsProxyContext. There's a many-to-one mapping from IP to mutex,
+// meaning multiple IPs may map to a single mutex. The many-to-one property is
+// obtained by hashing each IP inside responseIPs. In order to prevent the
+// caller from acquiring the mutexes in an undesirable order, this function
+// ensures that the slice returned in ascending order. This is the order in
+// which the mutexes should be taken and released. The slice is de-duplicated
+// to avoid acquiring and releasing the same mutex in order.
+func (dpc *dnsProxyContext) getMutexesForResponseIPs(responseIPs []net.IP) []int {
+	// cache stores all unique indices for mutexes. Prevents the same mutex
+	// index from being added to indices which prevents the caller from
+	// attempting to acquire the same mutex multiple times.
+	cache := make(map[int]struct{}, len(responseIPs))
+	indices := make([]int, 0, len(responseIPs))
+	for _, ip := range responseIPs {
+		h := ipToInt(ip)
+		m := h.Mod(h, dpc.modulus)
+		i := int(m.Int64())
+		if _, exists := cache[i]; !exists {
+			cache[i] = struct{}{}
+			indices = append(indices, i)
+		}
+	}
+	sort.Ints(indices)
+	return indices
+}
+
+func ipToInt(addr net.IP) *big.Int {
+	i := big.NewInt(0)
+	i.SetBytes(addr)
+	return i
 }
 
 type getFqdnCache struct {

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -122,6 +122,7 @@ func (f *FakeRefcountingIdentityAllocator) WatchRemoteIdentities(kvstore.Backend
 
 func (ds *DaemonFQDNSuite) SetUpTest(c *C) {
 	d := &Daemon{}
+	d.initDNSProxyContext(128)
 	d.identityAllocator = NewFakeIdentityAllocator(nil)
 	d.policy = policy.NewPolicyRepository(d.identityAllocator, nil, nil)
 	d.dnsNameManager = fqdn.NewNameManager(fqdn.Config{
@@ -313,4 +314,24 @@ func (ds *DaemonFQDNSuite) TestFQDNIdentityReferenceCounting(c *C) {
 	wg.Wait()
 	c.Assert(idAllocator.IdentityReferenceCounter(), checker.DeepEquals, counter.IntCounter{},
 		Commentf("The Daemon code leaked references to one or more identities"))
+}
+
+func (ds *DaemonFQDNSuite) Test_getMutexesForResponseIPs(c *C) {
+	r := make([]net.IP, 0)
+	for i := 0; i < 64; i++ {
+		r = append(r, net.ParseIP(fmt.Sprintf("1.1.1.%d", i)))
+	}
+	m := ds.d.dnsProxyContext.getMutexesForResponseIPs(r)
+	c.Assert(m, HasLen, 64)
+	c.Assert(m[0], Equals, 0)
+	c.Assert(m[len(m)-1], Equals, len(m)-1)
+
+	r = make([]net.IP, 0)
+	for i := 0; i < 64; i++ {
+		r = append(r, net.ParseIP(fmt.Sprintf("1.%d.1.1", i)))
+	}
+	m = ds.d.dnsProxyContext.getMutexesForResponseIPs(r)
+	fmt.Println(m)
+	c.Assert(m, HasLen, 1)
+	c.Assert(m[0], Equals, 1)
 }

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !privileged_tests
 // +build !privileged_tests
 
 package cmd
@@ -23,23 +24,28 @@ import (
 	"sync"
 	"time"
 
+	miekgdns "github.com/miekg/dns"
+	. "gopkg.in/check.v1"
+	k8sCache "k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/proxy"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
-
-	. "gopkg.in/check.v1"
-	k8sCache "k8s.io/client-go/tools/cache"
 )
 
 type DaemonFQDNSuite struct {
@@ -126,6 +132,9 @@ func (ds *DaemonFQDNSuite) SetUpTest(c *C) {
 	d.endpointManager = WithCustomEndpointManager(&dummyEpSyncher{})
 	d.policy.GetSelectorCache().SetLocalIdentityNotifier(d.dnsNameManager)
 	ds.d = d
+
+	proxy.Allocator = d.identityAllocator
+	proxy.SetEndpointLookuper(d.endpointManager)
 }
 
 // makeIPs generates count sequential IPv4 IPs
@@ -158,6 +167,91 @@ func (ds *DaemonSuite) BenchmarkFqdnCache(c *C) {
 	c.StartTimer()
 
 	extractDNSLookups(endpoints, "0.0.0.0/0", "*")
+}
+
+// Benchmark_notifyOnDNSMsg stresses the main callback function for the DNS
+// proxy path, which is called on every DNS request and response.
+func (ds *DaemonFQDNSuite) Benchmark_notifyOnDNSMsg(c *C) {
+	var (
+		nameManager             = ds.d.dnsNameManager
+		ciliumIOSel             = api.FQDNSelector{MatchName: "cilium.io"}
+		ciliumIOSelMatchPattern = api.FQDNSelector{MatchPattern: "*cilium.io."}
+		ebpfIOSel               = api.FQDNSelector{MatchName: "ebpf.io"}
+		ciliumDNSRecord         = map[string]*fqdn.DNSIPRecords{
+			dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("192.0.2.3")}},
+		}
+		ebpfDNSRecord = map[string]*fqdn.DNSIPRecords{
+			dns.FQDN("ebpf.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("192.0.2.4")}},
+		}
+
+		wg sync.WaitGroup
+	)
+
+	// Register rules (simulates applied policies).
+	selectorsToAdd := api.FQDNSelectorSlice{ciliumIOSel, ciliumIOSelMatchPattern, ebpfIOSel}
+	nameManager.Lock()
+	for _, sel := range selectorsToAdd {
+		nameManager.RegisterForIdentityUpdatesLocked(sel)
+	}
+	nameManager.Unlock()
+
+	// Initialize the endpoints.
+	endpoints := make([]*endpoint.Endpoint, c.N)
+	for i := range endpoints {
+		endpoints[i] = &endpoint.Endpoint{
+			ID:   uint16(c.N % 65000),
+			IPv4: addressing.DeriveCiliumIPv4(net.ParseIP(fmt.Sprintf("10.96.%d.%d", (c.N>>16)%8, c.N%256))),
+			SecurityIdentity: &identity.Identity{
+				ID: identity.NumericIdentity(c.N % int(identity.MaximumAllocationIdentity)),
+			},
+			DNSZombies: &fqdn.DNSZombieMappings{
+				Mutex: lock.Mutex{},
+			},
+		}
+		ep := endpoints[i]
+		ep.UpdateLogger(nil)
+		ep.DNSHistory = fqdn.NewDNSCache(0)
+	}
+
+	c.ResetTimer()
+	// Simulate parallel DNS responses from the upstream DNS for cilium.io and
+	// ebpf.io, done by every endpoint.
+	for i := 0; i < c.N; i++ {
+		wg.Add(1)
+		go func(ep *endpoint.Endpoint) {
+			defer wg.Done()
+			// Using a hardcoded string representing endpoint IP:port as this
+			// parameter is only used in logging. Not using the endpoint's IP
+			// so we don't spend any time in the benchmark on converting from
+			// net.IP to string.
+			c.Assert(ds.d.notifyOnDNSMsg(time.Now(), ep, "10.96.64.8:12345", "10.96.64.1:53", &miekgdns.Msg{
+				MsgHdr: miekgdns.MsgHdr{
+					Response: true,
+				},
+				Question: []miekgdns.Question{{
+					Name: dns.FQDN("cilium.io"),
+				}},
+				Answer: []miekgdns.RR{&miekgdns.A{
+					Hdr: miekgdns.RR_Header{Name: dns.FQDN("cilium.io")},
+					A:   ciliumDNSRecord[dns.FQDN("cilium.io")].IPs[0],
+				}}}, "udp", true, &dnsproxy.ProxyRequestContext{}), IsNil)
+
+			c.Assert(ds.d.notifyOnDNSMsg(time.Now(), ep, "10.96.64.4:54321", "10.96.64.1:53", &miekgdns.Msg{
+				MsgHdr: miekgdns.MsgHdr{
+					Response: true,
+				},
+				Compress: false,
+				Question: []miekgdns.Question{{
+					Name: dns.FQDN("ebpf.io"),
+				}},
+				Answer: []miekgdns.RR{&miekgdns.A{
+					Hdr: miekgdns.RR_Header{Name: dns.FQDN("ebpf.io")},
+					A:   ebpfDNSRecord[dns.FQDN("ebpf.io")].IPs[0],
+				}}}, "udp", true, &dnsproxy.ProxyRequestContext{}), IsNil)
+		}(endpoints[i%len(endpoints)])
+	}
+
+	wg.Wait()
 }
 
 func (ds *DaemonFQDNSuite) TestFQDNIdentityReferenceCounting(c *C) {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -582,4 +582,7 @@ const (
 
 	// IPSec old SPI
 	OldSPI = "oldSPI"
+
+	// Expected is an expected value
+	Expected = "expected"
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -468,6 +468,14 @@ const (
 	// been reached.
 	DNSProxyConcurrencyProcessingGracePeriod = "dnsproxy-concurrency-processing-grace-period"
 
+	// DNSProxyLockCount is the array size containing mutexes which protect
+	// against parallel handling of DNS response IPs.
+	DNSProxyLockCount = "dnsproxy-lock-count"
+
+	// DNSProxyLockTimeout is timeout when acquiring the locks controlled by
+	// DNSProxyLockCount.
+	DNSProxyLockTimeout = "dnsproxy-lock-timeout"
+
 	// MTUName is the name of the MTU option
 	MTUName = "mtu"
 
@@ -1587,6 +1595,14 @@ type DaemonConfig struct {
 	// HostDevice will be device used by Cilium to connect to the outside world.
 	HostDevice string
 
+	// DNSProxyLockCount is the array size containing mutexes which protect
+	// against parallel handling of DNS response IPs.
+	DNSProxyLockCount int
+
+	// DNSProxyLockTimeout is timeout when acquiring the locks controlled by
+	// DNSProxyLockCount.
+	DNSProxyLockTimeout time.Duration
+
 	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
 	// sysctl option if `xt_socket` kernel module is not available.
 	EnableXTSocketFallback bool
@@ -2688,6 +2704,8 @@ func (c *DaemonConfig) Populate() {
 	c.ToFQDNsEnableDNSCompression = viper.GetBool(ToFQDNsEnableDNSCompression)
 	c.DNSProxyConcurrencyLimit = viper.GetInt(DNSProxyConcurrencyLimit)
 	c.DNSProxyConcurrencyProcessingGracePeriod = viper.GetDuration(DNSProxyConcurrencyProcessingGracePeriod)
+	c.DNSProxyLockCount = viper.GetInt(DNSProxyLockCount)
+	c.DNSProxyLockTimeout = viper.GetDuration(DNSProxyLockTimeout)
 
 	// Convert IP strings into net.IPNet types
 	subnets, invalid := ip.ParseCIDRs(viper.GetStringSlice(IPv4PodSubnets))

--- a/pkg/proxy/epinfo.go
+++ b/pkg/proxy/epinfo.go
@@ -37,6 +37,13 @@ var (
 	Allocator cache.IdentityAllocator
 )
 
+// SetEndpointLookuper sets the package-level endpointManager. This is only
+// intended for unit testing, hence no mutex to synchronize multiple callers /
+// writers.
+func SetEndpointLookuper(epl EndpointLookup) {
+	endpointManager = epl
+}
+
 // EndpointLookup is any type which maps from IP to the endpoint owning that IP.
 type EndpointLookup interface {
 	LookupIP(ip net.IP) (ep *endpoint.Endpoint)


### PR DESCRIPTION
* #22252 -- daemon, fqdn: Fix race between parallel DNS requests for the same name (@christarazi)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 22252; do contrib/backporting/set-labels.py $pr done 1.10; done
```