### PR TITLE
Series of cleanups to ENI tests

### DIFF
--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -68,16 +68,6 @@ func (e *ENISuite) TestGetNodeNames(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
-	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testGetNodeNames-1", eniID1)
-	c.Assert(err, check.IsNil)
-	eniID2, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
-	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testGetNodeNames-2", eniID2)
-	c.Assert(err, check.IsNil)
-	instances.Resync(context.TODO())
-
 	mngr.Update(newCiliumNode("node1"))
 
 	names := mngr.GetNames()
@@ -103,12 +93,6 @@ func (e *ENISuite) TestNodeManagerGet(c *check.C) {
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
-
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
-	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerGet-1", eniID1)
-	c.Assert(err, check.IsNil)
-	instances.Resync(context.TODO())
 
 	mngr.Update(newCiliumNode("node1"))
 

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -127,8 +127,7 @@ func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node wait for IPs to become available
-	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5.large"),
-		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(8))
+	cn := newCiliumNode("node1", withTestDefaults(), withInstanceID(instanceID), withInstanceType("m5.large"), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
 
@@ -170,8 +169,7 @@ func (e *ENISuite) TestNodeManagerPrefixDelegation(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node wait for IPs to become available
-	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5a.large"),
-		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(8))
+	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5a.large"), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
 
@@ -224,8 +222,8 @@ func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 	sgTags := map[string]string{
 		"test-sg-1": "yes",
 	}
-	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5.large"),
-		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withSecurityGroupTags(sgTags), withIPAMPreAllocate(8))
+	cn := newCiliumNode("node1", withTestDefaults(), withInstanceID(instanceID), withInstanceType("m5.large"),
+		withSecurityGroupTags(sgTags), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
 
@@ -279,8 +277,7 @@ func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node wait for IPs to become available
-	cn := newCiliumNode("node2", withInstanceID(instanceID), withInstanceType("m5.4xlarge"),
-		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(-1), withIPAMMinAllocate(10))
+	cn := newCiliumNode("node2", withInstanceID(instanceID), withInstanceType("m5.4xlarge"), withIPAMPreAllocate(-1), withIPAMMinAllocate(10))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 
@@ -334,8 +331,8 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, wait for IPs to become available
-	cn := newCiliumNode("node2", withInstanceID(instanceID), withInstanceType("m3.large"), withAvailabilityZone("us-west-1"),
-		withVpcID("vpc-1"), withIPAMPreAllocate(1), withIPAMMinAllocate(10))
+	cn := newCiliumNode("node2", withTestDefaults(), withInstanceID(instanceID), withInstanceType("m3.large"),
+		withIPAMPreAllocate(1), withIPAMMinAllocate(10))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 
@@ -397,8 +394,8 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, wait for IPs to become available
-	cn := newCiliumNode("node3", withInstanceID(instanceID), withInstanceType("m4.xlarge"),
-		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(2), withIPAMMinAllocate(10), withIPAMMaxAboveWatermark(3))
+	cn := newCiliumNode("node3", withTestDefaults(), withInstanceID(instanceID), withInstanceType("m4.xlarge"),
+		withIPAMPreAllocate(2), withIPAMMinAllocate(10), withIPAMMaxAboveWatermark(3))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
 
@@ -502,9 +499,8 @@ func (e *ENISuite) TestNodeManagerENIExcludeInterfaceTags(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node wait for IPs to become available
-	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5.large"),
-		withExcludeInterfaceTags(map[string]string{"cilium.io/no_manage": "true"}), withAvailabilityZone("us-west-1"),
-		withVpcID("vpc-1"), withIPAMPreAllocate(8))
+	cn := newCiliumNode("node1", withTestDefaults(), withInstanceID(instanceID), withInstanceType("m5.large"),
+		withExcludeInterfaceTags(map[string]string{"cilium.io/no_manage": "true"}), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
 
@@ -564,8 +560,8 @@ func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, wait for IPs to become available
-	cn := newCiliumNode("node2", withInstanceID(instanceID), withInstanceType("t2.xlarge"),
-		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(8), withIPAMMinAllocate(20))
+	cn := newCiliumNode("node2", withTestDefaults(), withInstanceID(instanceID), withInstanceType("t2.xlarge"),
+		withIPAMPreAllocate(8), withIPAMMinAllocate(20))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
 
@@ -631,8 +627,8 @@ func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
 		c.Assert(err, check.IsNil)
 		instancesManager.Resync(context.TODO())
 		s := &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("i-testNodeManagerManyNodes-%d", i)}
-		s.cn = newCiliumNode(s.name, withInstanceID(s.instanceName), withInstanceType("c3.xlarge"), withAvailabilityZone("us-west-1"),
-			withVpcID("vpc-1"), withFirstInterfaceIndex(1), withIPAMPreAllocate(1), withIPAMMinAllocate(minAllocate))
+		s.cn = newCiliumNode(s.name, withTestDefaults(), withInstanceID(s.instanceName), withInstanceType("c3.xlarge"),
+			withFirstInterfaceIndex(1), withIPAMPreAllocate(1), withIPAMMinAllocate(minAllocate))
 		state[i] = s
 		mngr.Update(s.cn)
 	}
@@ -697,8 +693,8 @@ func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, ENI attachement will fail
-	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m4.large"),
-		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withFirstInterfaceIndex(1), withIPAMPreAllocate(8))
+	cn := newCiliumNode("node1", withTestDefaults(), withInstanceID(instanceID), withInstanceType("m4.large"),
+		withFirstInterfaceIndex(1), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 
 	// Wait for node to be declared notRunning
@@ -742,8 +738,7 @@ func (e *ENISuite) TestInstanceBeenDeleted(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
-	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m4.large"),
-		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(8))
+	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m4.large"), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
 
@@ -798,8 +793,8 @@ func benchmarkAllocWorker(c *check.C, workers int64, delay time.Duration, rateLi
 		c.Assert(err, check.IsNil)
 		instances.Resync(context.TODO())
 		s := &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("i-benchmarkAllocWorker-%d", i)}
-		s.cn = newCiliumNode(s.name, withInstanceID(s.instanceName), withInstanceType("m4.large"),
-			withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(1), withIPAMMinAllocate(10))
+		s.cn = newCiliumNode(s.name, withTestDefaults(), withInstanceID(s.instanceName), withInstanceType("m4.large"),
+			withIPAMPreAllocate(1), withIPAMMinAllocate(10))
 		state[i] = s
 		mngr.Update(s.cn)
 	}
@@ -879,6 +874,13 @@ func newCiliumNode(name string, opts ...func(*v2.CiliumNode)) *v2.CiliumNode {
 	return cn
 }
 
+func withTestDefaults() func(*v2.CiliumNode) {
+	return func(cn *v2.CiliumNode) {
+		cn.Spec.ENI.AvailabilityZone = testSubnet.AvailabilityZone
+		cn.Spec.ENI.VpcID = testVpc.ID
+	}
+}
+
 func withInstanceID(instanceID string) func(*v2.CiliumNode) {
 	return func(cn *v2.CiliumNode) {
 		cn.Spec.InstanceID = instanceID
@@ -894,18 +896,6 @@ func withInstanceType(instanceType string) func(*v2.CiliumNode) {
 func withFirstInterfaceIndex(firstInterface int) func(*v2.CiliumNode) {
 	return func(cn *v2.CiliumNode) {
 		cn.Spec.ENI.FirstInterfaceIndex = &firstInterface
-	}
-}
-
-func withAvailabilityZone(az string) func(*v2.CiliumNode) {
-	return func(cn *v2.CiliumNode) {
-		cn.Spec.ENI.AvailabilityZone = az
-	}
-}
-
-func withVpcID(vpcID string) func(*v2.CiliumNode) {
-	return func(cn *v2.CiliumNode) {
-		cn.Spec.ENI.VpcID = vpcID
 	}
 }
 

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -112,12 +112,14 @@ func (e *ENISuite) TestNodeManagerGet(c *check.C) {
 // - PreAllocate 8
 // - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
+	const instanceID = "i-testNodeManagerDefaultAllocation-0"
+
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerDefaultAllocation-0", eniID1)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
@@ -125,7 +127,7 @@ func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node wait for IPs to become available
-	cn := newCiliumNode("node1", withInstanceID("i-testNodeManagerDefaultAllocation-0"), withInstanceType("m5.large"),
+	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5.large"),
 		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
@@ -153,12 +155,14 @@ func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 // - PreAllocate 8
 // - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerPrefixDelegation(c *check.C) {
+	const instanceID = "i-testNodeManagerDefaultAllocation-0"
+
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, true)
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerDefaultAllocation-0", eniID1)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, true)
@@ -166,7 +170,7 @@ func (e *ENISuite) TestNodeManagerPrefixDelegation(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node wait for IPs to become available
-	cn := newCiliumNode("node1", withInstanceID("i-testNodeManagerDefaultAllocation-0"), withInstanceType("m5a.large"),
+	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5a.large"),
 		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
@@ -202,12 +206,14 @@ func (e *ENISuite) TestNodeManagerPrefixDelegation(c *check.C) {
 // - PreAllocate 8
 // - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
+	const instanceID = "i-testNodeManagerDefaultAllocation-0"
+
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerDefaultAllocation-0", eniID1)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
@@ -218,7 +224,7 @@ func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 	sgTags := map[string]string{
 		"test-sg-1": "yes",
 	}
-	cn := newCiliumNode("node1", withInstanceID("i-testNodeManagerDefaultAllocation-0"), withInstanceType("m5.large"),
+	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5.large"),
 		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withSecurityGroupTags(sgTags), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
@@ -258,12 +264,14 @@ func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 // - PreAllocate -1
 // - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
+	const instanceID = "i-testNodeManagerMinAllocate20-1"
+
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerMinAllocate20-1", eniID1)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
@@ -271,7 +279,7 @@ func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node wait for IPs to become available
-	cn := newCiliumNode("node2", withInstanceID("i-testNodeManagerMinAllocate20-1"), withInstanceType("m5.4xlarge"),
+	cn := newCiliumNode("node2", withInstanceID(instanceID), withInstanceType("m5.4xlarge"),
 		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(-1), withIPAMMinAllocate(10))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
@@ -311,12 +319,14 @@ func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 // - PreAllocate 1
 // - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
+	const instanceID = "i-testNodeManagerMinAllocateAndPreallocate-1"
+
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerMinAllocateAndPreallocate-1", eniID1)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
@@ -324,7 +334,7 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, wait for IPs to become available
-	cn := newCiliumNode("node2", withInstanceID("i-testNodeManagerMinAllocateAndPreallocate-1"), withInstanceType("m3.large"), withAvailabilityZone("us-west-1"),
+	cn := newCiliumNode("node2", withInstanceID(instanceID), withInstanceType("m3.large"), withAvailabilityZone("us-west-1"),
 		withVpcID("vpc-1"), withIPAMPreAllocate(1), withIPAMMinAllocate(10))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
@@ -371,13 +381,15 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 // - MaxAboveWatermark 3
 // - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
+	const instanceID = "i-testNodeManagerReleaseAddress-1"
+
 	operatorOption.Config.ExcessIPReleaseDelay = 2
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerReleaseAddress-1", eniID1)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, true, false)
@@ -385,7 +397,7 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, wait for IPs to become available
-	cn := newCiliumNode("node3", withInstanceID("i-testNodeManagerReleaseAddress-1"), withInstanceType("m4.xlarge"),
+	cn := newCiliumNode("node3", withInstanceID(instanceID), withInstanceType("m4.xlarge"),
 		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(2), withIPAMMinAllocate(10), withIPAMMaxAboveWatermark(3))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
@@ -470,6 +482,8 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 // - FirstInterfaceIndex 0
 // - ExcludeInterfaceTags {cilium.io/no_manage=true}
 func (e *ENISuite) TestNodeManagerENIExcludeInterfaceTags(c *check.C) {
+	const instanceID = "i-testNodeManagerDefaultAllocation-0"
+
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
@@ -480,7 +494,7 @@ func (e *ENISuite) TestNodeManagerENIExcludeInterfaceTags(c *check.C) {
 		"cilium.io/no_manage": "true",
 	})
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerDefaultAllocation-0", eniID1)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
@@ -488,7 +502,7 @@ func (e *ENISuite) TestNodeManagerENIExcludeInterfaceTags(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node wait for IPs to become available
-	cn := newCiliumNode("node1", withInstanceID("i-testNodeManagerDefaultAllocation-0"), withInstanceType("m5.large"),
+	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5.large"),
 		withExcludeInterfaceTags(map[string]string{"cilium.io/no_manage": "true"}), withAvailabilityZone("us-west-1"),
 		withVpcID("vpc-1"), withIPAMPreAllocate(8))
 	mngr.Update(cn)
@@ -535,12 +549,14 @@ func (e *ENISuite) TestNodeManagerENIExcludeInterfaceTags(c *check.C) {
 // - PreAllocate 8
 // - FirstInterfaceIndex 0
 func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
+	const instanceID = "i-testNodeManagerExceedENICapacity-1"
+
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerExceedENICapacity-1", eniID1)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
@@ -548,7 +564,7 @@ func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, wait for IPs to become available
-	cn := newCiliumNode("node2", withInstanceID("i-testNodeManagerExceedENICapacity-1"), withInstanceType("t2.xlarge"),
+	cn := newCiliumNode("node2", withInstanceID(instanceID), withInstanceType("t2.xlarge"),
 		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(8), withIPAMMinAllocate(20))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second), check.IsNil)
@@ -664,13 +680,15 @@ func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
 //
 // - FirstInterfaceIndex 1
 func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
+	const instanceID = "i-testNodeManagerInstanceNotRunning-0"
+
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	metricsMock := metricsmock.NewMockMetrics()
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testNodeManagerInstanceNotRunning-0", eniID1)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
@@ -679,7 +697,7 @@ func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
 	c.Assert(mngr, check.Not(check.IsNil))
 
 	// Announce node, ENI attachement will fail
-	cn := newCiliumNode("node1", withInstanceID("i-testNodeManagerInstanceNotRunning-0"), withInstanceType("m4.large"),
+	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m4.large"),
 		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withFirstInterfaceIndex(1), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 
@@ -706,23 +724,25 @@ func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
 // - m4.large (2x ENIs, 2x10-2 IPs)
 // - FirstInterfaceIndex 0
 func (e *ENISuite) TestInstanceBeenDeleted(c *check.C) {
+	const instanceID = "i-testInstanceBeenDeleted-0"
+
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api)
 	c.Assert(instances, check.Not(check.IsNil))
 	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, "i-testInstanceBeenDeleted-0", eniID1)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	eniID2, _, err := ec2api.CreateNetworkInterface(context.TODO(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	c.Assert(err, check.IsNil)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 1, "i-testInstanceBeenDeleted-0", eniID2)
+	_, err = ec2api.AttachNetworkInterface(context.TODO(), 1, instanceID, eniID2)
 	c.Assert(err, check.IsNil)
 	instances.Resync(context.TODO())
 	mngr, err := ipam.NewNodeManager(instances, k8sapi, metricsapi, 10, false, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
-	cn := newCiliumNode("node1", withInstanceID("i-testInstanceBeenDeleted-0"), withInstanceType("m4.large"),
+	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m4.large"),
 		withAvailabilityZone("us-west-1"), withVpcID("vpc-1"), withIPAMPreAllocate(8))
 	mngr.Update(cn)
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second), check.IsNil)
@@ -734,11 +754,11 @@ func (e *ENISuite) TestInstanceBeenDeleted(c *check.C) {
 
 	// Delete all enis attached to instance, this mocks the operation of
 	// deleting the instance. The deletion should be detected.
-	err = ec2api.DetachNetworkInterface(context.TODO(), "i-testInstanceBeenDeleted-0", eniID1)
+	err = ec2api.DetachNetworkInterface(context.TODO(), instanceID, eniID1)
 	c.Assert(err, check.IsNil)
 	err = ec2api.DeleteNetworkInterface(context.TODO(), eniID1)
 	c.Assert(err, check.IsNil)
-	err = ec2api.DetachNetworkInterface(context.TODO(), "i-testInstanceBeenDeleted-0", eniID2)
+	err = ec2api.DetachNetworkInterface(context.TODO(), instanceID, eniID2)
 	c.Assert(err, check.IsNil)
 	err = ec2api.DeleteNetworkInterface(context.TODO(), eniID2)
 	c.Assert(err, check.IsNil)

--- a/pkg/aws/eni/node_test.go
+++ b/pkg/aws/eni/node_test.go
@@ -17,25 +17,25 @@ func (e *ENISuite) TestGetMaximumAllocatableIPv4(c *check.C) {
 	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, 0)
 
 	// With instance-type = m5.large and first-interface-index = 0, we should be able to allocate up to 3x10-3 addresses
-	n.k8sObj = newCiliumNode("node", "i-testnode", "m5.large", "eu-west-1", "test-vpc", 0, 0, 0, 0)
+	n.k8sObj = newCiliumNode("node", withInstanceType("m5.large"), withFirstInterfaceIndex(0))
 	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, 27)
 
 	// With instance-type = m5.large and first-interface-index = 1, we should be able to allocate up to 2x10-2 addresses
-	n.k8sObj = newCiliumNode("node", "i-testnode", "m5.large", "eu-west-1", "test-vpc", 1, 0, 0, 0)
+	n.k8sObj = newCiliumNode("node", withInstanceType("m5.large"), withFirstInterfaceIndex(1))
 	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, 18)
 
 	// With instance-type = m5.large and first-interface-index = 4, we should return 0 as there is only 3 interfaces
-	n.k8sObj = newCiliumNode("node", "i-testnode", "m5.large", "eu-west-1", "test-vpc", 4, 0, 0, 0)
+	n.k8sObj = newCiliumNode("node", withInstanceType("m5.large"), withFirstInterfaceIndex(4))
 	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, 0)
 
 	// With instance-type = foo we should return 0
-	n.k8sObj = newCiliumNode("node", "i-testnode", "foo", "eu-west-1", "test-vpc", 0, 0, 0, 0)
+	n.k8sObj = newCiliumNode("node", withInstanceType("foo"))
 	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, 0)
 }
 
 // TestGetUsedIPWithPrefixes tests the logic computing used IPs on a node when prefix delegation is enabled.
 func (e *ENISuite) TestGetUsedIPWithPrefixes(c *check.C) {
-	cn := newCiliumNode("node1", "i-testNodeManagerDefaultAllocation-0", "m5a.large", "us-west-1", "vpc-1", 0, 8, 0, 0)
+	cn := newCiliumNode("node1", withInstanceType("m5a.large"))
 	n := &Node{k8sObj: cn}
 	eniName := "eni-1"
 	prefixes := []string{"10.10.128.0/28", "10.10.128.16/28"}


### PR DESCRIPTION
⚠️ Please review commit-by-commit, it's easier to understand what is happening that way.

**Motivation**: Working on a feature, I would've had to add yet another argument to the `newCiliumNode` test helper and then work through the churn of updating all the call sites. Thought the [functional options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) pattern would fit nicely here as an alternative.

**Change**: Replaced the `newCiliumNode` helper with the above pattern, so that instead of 
`n := newCiliumNode("node1", "i-someID", and, then, lots, of, parameters, 42, "something")` we can now focus on the essential and write `n := newCiliumNode("node1", withInstanceID("i-someID"))`. That's commits 1-4.

The rest are minor cleanups to improve readability.

Since this changes only test code, there is no need for a release note.
