### PR TITLE
hive: Show actual parsed config in PrintObjects()

### DIFF
--- a/pkg/hive/cell/cell.go
+++ b/pkg/hive/cell/cell.go
@@ -25,7 +25,7 @@ var (
 //   - Config(): Cell providing a configuration struct.
 type Cell interface {
 	// Info provides a structural summary of the cell for printing purposes.
-	Info() Info
+	Info(container) Info
 
 	// Apply the cell to the dependency graph container.
 	Apply(container) error

--- a/pkg/hive/cell/config.go
+++ b/pkg/hive/cell/config.go
@@ -117,25 +117,9 @@ func (c *config[Cfg]) Apply(cont container) error {
 	return cont.Provide(c.provideConfig, dig.Export(true))
 }
 
-type configInfoEntry struct {
-	nameAndType string
-	defValue    string
-}
-
-func (c *config[Cfg]) Info() Info {
-	n := NewInfoNode(fmt.Sprintf("⚙️ %T", c.defaultConfig))
-
-	entries := []configInfoEntry{}
-	maxWidth := 0
-	c.flags.VisitAll(func(f *pflag.Flag) {
-		nameAndType := fmt.Sprintf("%s[%s]", f.Name, f.Value.Type())
-		entries = append(entries, configInfoEntry{nameAndType, f.DefValue})
-		if len(nameAndType) > maxWidth {
-			maxWidth = len(nameAndType)
-		}
+func (c *config[Cfg]) Info(cont container) (info Info) {
+	cont.Invoke(func(cfg Cfg) {
+		info = &InfoStruct{cfg}
 	})
-	for _, entry := range entries {
-		n.AddLeaf(fmt.Sprintf("• %-*s = %s", maxWidth, entry.nameAndType, entry.defValue))
-	}
-	return n
+	return
 }

--- a/pkg/hive/cell/decorator.go
+++ b/pkg/hive/cell/decorator.go
@@ -53,10 +53,10 @@ func (d *decorator) Apply(c container) error {
 	return nil
 }
 
-func (d *decorator) Info() Info {
+func (d *decorator) Info(c container) Info {
 	n := NewInfoNode(fmt.Sprintf("🔀 %s: %T", internal.FuncNameAndLocation(d.decorator), d.decorator))
 	for _, cell := range d.cells {
-		n.Add(cell.Info())
+		n.Add(cell.Info(c))
 		n.AddBreak()
 	}
 	return n

--- a/pkg/hive/cell/info.go
+++ b/pkg/hive/cell/info.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // indentBy is the number of spaces nested elements should be indented by
@@ -62,5 +64,21 @@ func (n *InfoNode) Print(indent int, w io.Writer) {
 
 	for _, child := range n.children {
 		child.Print(indent, w)
+	}
+}
+
+type InfoStruct struct {
+	value any
+}
+
+func (n *InfoStruct) Print(indent int, w io.Writer) {
+	scs := spew.ConfigState{Indent: strings.Repeat(" ", indentBy), SortKeys: true}
+	indentString := strings.Repeat(" ", indent)
+	for i, line := range strings.Split(scs.Sdump(n.value), "\n") {
+		if i == 0 {
+			fmt.Fprintf(w, "%s⚙️ %s\n", indentString, line)
+		} else {
+			fmt.Fprintf(w, "%s%s\n", indentString, line)
+		}
 	}
 }

--- a/pkg/hive/cell/invoke.go
+++ b/pkg/hive/cell/invoke.go
@@ -52,7 +52,7 @@ func (i *invoker) Apply(c container) error {
 	})
 }
 
-func (i *invoker) Info() Info {
+func (i *invoker) Info(container) Info {
 	n := NewInfoNode("")
 	for _, namedFunc := range i.funcs {
 		n.AddLeaf("🛠️ %s: %T", namedFunc.name, namedFunc.fn)

--- a/pkg/hive/cell/module.go
+++ b/pkg/hive/cell/module.go
@@ -70,10 +70,10 @@ func (m *module) Apply(c container) error {
 	return nil
 }
 
-func (m *module) Info() Info {
+func (m *module) Info(c container) Info {
 	n := NewInfoNode("Ⓜ️ " + m.id + " (" + m.title + ")")
 	for _, cell := range m.cells {
-		n.Add(cell.Info())
+		n.Add(cell.Info(c))
 		n.AddBreak()
 	}
 	return n

--- a/pkg/hive/cell/provide.go
+++ b/pkg/hive/cell/provide.go
@@ -24,7 +24,7 @@ func (p *provider) Apply(c container) error {
 	return nil
 }
 
-func (p *provider) Info() Info {
+func (p *provider) Info(container) Info {
 	n := &InfoNode{}
 	for _, ctor := range p.ctors {
 		privateSymbol := ""

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -283,14 +283,14 @@ func (h *Hive) Shutdown(opts ...ShutdownOption) {
 }
 
 func (h *Hive) PrintObjects() {
-	fmt.Printf("Cells:\n\n")
-	for _, c := range h.cells {
-		c.Info().Print(2, os.Stdout)
-		fmt.Println()
-	}
-
 	if err := h.populate(); err != nil {
 		log.WithError(err).Fatal("Failed to populate object graph")
+	}
+
+	fmt.Printf("Cells:\n\n")
+	for _, c := range h.cells {
+		c.Info(h.container).Print(2, os.Stdout)
+		fmt.Println()
 	}
 	h.lifecycle.PrintHooks()
 }


### PR DESCRIPTION
Before the config objects shown in PrintObjects showed the defaults by iterating over the registered flags:

```
    $ ./cilium-agent objects --k8s-api-server foobar

    ⚙️ client.Config:
      • enable-k8s-api-discovery[bool]  = false
      • k8s-api-server[string]          =
      • k8s-client-burst[int]           = 0
      • k8s-client-qps[float32]         = 0
      • k8s-heartbeat-timeout[duration] = 30s
      • k8s-kubeconfig-path[string]     =
```

Above you can see that the "k8s-api-server" flag did not reflect what was provided on command-line

This commit changes the config info to pull the parsed configuration from the dig container and show that using the spew package:

```
    ⚙️ (client.Config) {
      K8sAPIServer: (string) (len=6) "foobar",
      K8sKubeConfigPath: (string) "",
      K8sClientQPS: (float32) 0,
      K8sClientBurst: (int) 0,
      K8sHeartbeatTimeout: (time.Duration) 30s,
      EnableK8sAPIDiscovery: (bool) false
    }
```
