### PR TITLE
datapath: Fix L7 reply to outside when endpoint routes disabled

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -109,8 +109,7 @@ function move_local_rules()
 
 function setup_proxy_rules()
 {
-	# Any packet from an ingress proxy uses a separate routing table that routes
-	# the packet back to the cilium host device.
+	# TODO(brb): remove $PROXY_RT_TABLE -related code in v1.14
 	from_ingress_rulespec="fwmark 0xA00/0xF00 pref 10 lookup $PROXY_RT_TABLE"
 
 	# Any packet to an ingress or egress proxy uses a separate routing table
@@ -124,27 +123,16 @@ function setup_proxy_rules()
 			if [ -z "$(ip -4 rule list $to_proxy_rulespec)" ]; then
 				ip -4 rule add $to_proxy_rulespec
 			fi
-			if [ "$ENDPOINT_ROUTES" = "true" ]; then
-				if [ ! -z "$(ip -4 rule list $from_ingress_rulespec)" ]; then
-					ip -4 rule delete $from_ingress_rulespec
-				fi
-			else
-				if [ -z "$(ip -4 rule list $from_ingress_rulespec)" ]; then
-					ip -4 rule add $from_ingress_rulespec
-				fi
-			fi
+
+			ip -4 rule delete $from_ingress_rulespec || true
 		fi
 
 		# Traffic to the host proxy is local
 		ip route replace table $TO_PROXY_RT_TABLE local 0.0.0.0/0 dev lo
-		# Traffic from ingress proxy goes to Cilium address space via the cilium host device
-		if [ "$ENDPOINT_ROUTES" = "true" ]; then
-			ip route delete table $PROXY_RT_TABLE $IP4_HOST/32 dev $HOST_DEV1 2>/dev/null || true
-			ip route delete table $PROXY_RT_TABLE default via $IP4_HOST 2>/dev/null || true
-		else
-			ip route replace table $PROXY_RT_TABLE $IP4_HOST/32 dev $HOST_DEV1
-			ip route replace table $PROXY_RT_TABLE default via $IP4_HOST
-		fi
+
+		# The $PROXY_RT_TABLE is no longer in use, so delete it
+		ip route delete table $PROXY_RT_TABLE $IP4_HOST/32 dev $HOST_DEV1 2>/dev/null || true
+		ip route delete table $PROXY_RT_TABLE default via $IP4_HOST 2>/dev/null || true
 	else
 		ip -4 rule del $to_proxy_rulespec 2> /dev/null || true
 		ip -4 rule del $from_ingress_rulespec 2> /dev/null || true
@@ -155,29 +143,17 @@ function setup_proxy_rules()
 			if [ -z "$(ip -6 rule list $to_proxy_rulespec)" ]; then
 				ip -6 rule add $to_proxy_rulespec
 			fi
-			if [ "$ENDPOINT_ROUTES" = "true" ]; then
-				if [ ! -z "$(ip -6 rule list $from_ingress_rulespec)" ]; then
-					ip -6 rule delete $from_ingress_rulespec
-				fi
-			else
-				if [ -z "$(ip -6 rule list $from_ingress_rulespec)" ]; then
-					ip -6 rule add $from_ingress_rulespec
-				fi
-			fi
+
+			ip -6 rule delete $from_ingress_rulespec || true
 		fi
 
 		IP6_LLADDR=$(ip -6 addr show dev $HOST_DEV2 | grep inet6 | head -1 | awk '{print $2}' | awk -F'/' '{print $1}')
 		if [ -n "$IP6_LLADDR" ]; then
 			# Traffic to the host proxy is local
 			ip -6 route replace table $TO_PROXY_RT_TABLE local ::/0 dev lo
-			# Traffic from ingress proxy goes to Cilium address space via the cilium host device
-			if [ "$ENDPOINT_ROUTES" = "true" ]; then
-				ip -6 route delete table $PROXY_RT_TABLE ${IP6_LLADDR}/128 dev $HOST_DEV1 2>/dev/null || true
-				ip -6 route delete table $PROXY_RT_TABLE default via $IP6_LLADDR dev $HOST_DEV1 2>/dev/null || true
-			else
-				ip -6 route replace table $PROXY_RT_TABLE ${IP6_LLADDR}/128 dev $HOST_DEV1
-				ip -6 route replace table $PROXY_RT_TABLE default via $IP6_LLADDR dev $HOST_DEV1
-			fi
+			# The $PROXY_RT_TABLE is no longer in use, so delete it
+			ip -6 route delete table $PROXY_RT_TABLE ${IP6_LLADDR}/128 dev $HOST_DEV1 2>/dev/null || true
+			ip -6 route delete table $PROXY_RT_TABLE default via $IP6_LLADDR dev $HOST_DEV1 2>/dev/null || true
 		fi
 	else
 		ip -6 rule del $to_proxy_rulespec 2> /dev/null || true


### PR DESCRIPTION
See commit msg.

I'm going to extend the `ci-datapath` in `cilium-cli` to cover the previously troublesome packet path. 

Fix #21954 