### PR TITLE
Revert PR #21539

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -680,7 +680,7 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx)
 		 * the CT entry for destination endpoints where we can't encode the
 		 * state in the address.
 		 */
-		svc = lb6_lookup_service(&key, is_defined(ENABLE_NODEPORT), false);
+		svc = lb6_lookup_service(&key, is_defined(ENABLE_NODEPORT));
 		if (svc) {
 #if defined(ENABLE_L7_LB)
 			if (lb6_svc_is_l7loadbalancer(svc)) {
@@ -1236,7 +1236,7 @@ static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx)
 				return ret;
 		}
 
-		svc = lb4_lookup_service(&key, is_defined(ENABLE_NODEPORT), false);
+		svc = lb4_lookup_service(&key, is_defined(ENABLE_NODEPORT));
 		if (svc) {
 #if defined(ENABLE_L7_LB)
 			if (lb4_svc_is_l7loadbalancer(svc)) {

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -218,7 +218,7 @@ sock4_wildcard_lookup(struct lb4_key *key __maybe_unused,
 	return NULL;
 wildcard_lookup:
 	key->address = 0;
-	return lb4_lookup_service(key, true, true);
+	return lb4_lookup_service(key, true);
 }
 #endif /* ENABLE_NODEPORT */
 
@@ -322,7 +322,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	 * service entries via wildcarded lookup for NodePort and
 	 * HostPort services.
 	 */
-	svc = lb4_lookup_service(&key, true, true);
+	svc = lb4_lookup_service(&key, true);
 	if (!svc)
 		svc = sock4_wildcard_lookup_full(&key, in_hostns);
 	if (!svc)
@@ -479,7 +479,7 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 	    !ctx_in_hostns(ctx_full, NULL))
 		return 0;
 
-	svc = lb4_lookup_service(&key, true, true);
+	svc = lb4_lookup_service(&key, true);
 	if (!svc)
 		/* Perform a wildcard lookup for the case where the caller
 		 * tries to bind to loopback or an address with host identity
@@ -576,7 +576,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 			.dport		= val->port,
 		};
 
-		svc = lb4_lookup_service(&svc_key, true, true);
+		svc = lb4_lookup_service(&svc_key, true);
 		if (!svc)
 			svc = sock4_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx_full, NULL));
@@ -754,7 +754,7 @@ sock6_wildcard_lookup(struct lb6_key *key __maybe_unused,
 	return NULL;
 wildcard_lookup:
 	memset(&key->address, 0, sizeof(key->address));
-	return lb6_lookup_service(key, true, true);
+	return lb6_lookup_service(key, true);
 }
 #endif /* ENABLE_NODEPORT */
 
@@ -844,7 +844,7 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 
 	ctx_get_v6_src_address(ctx, &key.address);
 
-	svc = lb6_lookup_service(&key, true, true);
+	svc = lb6_lookup_service(&key, true);
 	if (!svc) {
 		svc = sock6_wildcard_lookup(&key, false, false, true);
 		if (!svc)
@@ -972,7 +972,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	ctx_get_v6_address(ctx, &key.address);
 	memcpy(&orig_key, &key, sizeof(key));
 
-	svc = lb6_lookup_service(&key, true, true);
+	svc = lb6_lookup_service(&key, true);
 	if (!svc)
 		svc = sock6_wildcard_lookup_full(&key, in_hostns);
 	if (!svc)
@@ -1145,7 +1145,7 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 			.dport		= val->port,
 		};
 
-		svc = lb6_lookup_service(&svc_key, true, true);
+		svc = lb6_lookup_service(&svc_key, true);
 		if (!svc)
 			svc = sock6_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx, NULL));

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -565,7 +565,7 @@ lb6_to_lb4_service(const struct lb6_service *svc __maybe_unused)
 
 static __always_inline
 struct lb6_service *lb6_lookup_service(struct lb6_key *key,
-	   const bool scope_switch, const bool check_svc_backends)
+				       const bool scope_switch)
 {
 	struct lb6_service *svc;
 
@@ -575,11 +575,10 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 	if (svc) {
 		if (!scope_switch || !lb6_svc_is_local_scope(svc))
 			/* Packets for L7 LB are redirected even when there are no backends. */
-			return (svc->count || !check_svc_backends ||
-				lb6_svc_is_l7loadbalancer(svc)) ? svc : NULL;
+			return (svc->count || lb6_svc_is_l7loadbalancer(svc)) ? svc : NULL;
 		key->scope = LB_LOOKUP_SCOPE_INT;
 		svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
-		if (svc && (svc->count || !check_svc_backends || lb6_svc_is_l7loadbalancer(svc)))
+		if (svc && (svc->count || lb6_svc_is_l7loadbalancer(svc)))
 			return svc;
 	}
 
@@ -852,8 +851,6 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 
 	ipv6_addr_copy(&client_id.client_ip, &tuple->saddr);
 #endif
-	if (unlikely(svc->count == 0))
-		return DROP_NO_SERVICE;
 
 	/* See lb4_local comments re svc endpoint lookup process */
 	ret = ct_lookup6(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
@@ -930,7 +927,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		if (backend && !state->syn)
 			goto update_state;
 		key->backend_slot = 0;
-		svc = lb6_lookup_service(key, false, true);
+		svc = lb6_lookup_service(key, false);
 		if (!svc)
 			goto drop_no_service;
 		backend_id = lb6_select_backend_id(ctx, key, tuple, svc);
@@ -1007,7 +1004,7 @@ static __always_inline void lb6_ctx_restore_state(struct __ctx_buff *ctx,
  */
 static __always_inline
 struct lb6_service *lb6_lookup_service(struct lb6_key *key __maybe_unused,
-	   const bool scope_switch __maybe_unused, const bool check_svc_backends __maybe_unused)
+				       const bool scope_switch __maybe_unused)
 {
 	return NULL;
 }
@@ -1214,7 +1211,7 @@ lb4_to_lb6_service(const struct lb4_service *svc __maybe_unused)
 
 static __always_inline
 struct lb4_service *lb4_lookup_service(struct lb4_key *key,
-				  const bool scope_switch, const bool check_svc_backends)
+				       const bool scope_switch)
 {
 	struct lb4_service *svc;
 
@@ -1224,11 +1221,11 @@ struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 	if (svc) {
 		if (!scope_switch || !lb4_svc_is_local_scope(svc))
 			/* Packets for L7 LB are redirected even when there are no backends. */
-			return (svc->count || !check_svc_backends || lb4_to_lb6_service(svc) ||
+			return (svc->count || lb4_to_lb6_service(svc) ||
 				lb4_svc_is_l7loadbalancer(svc)) ? svc : NULL;
 		key->scope = LB_LOOKUP_SCOPE_INT;
 		svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
-		if (svc && (svc->count || !check_svc_backends || lb4_svc_is_l7loadbalancer(svc)))
+		if (svc && (svc->count || lb4_svc_is_l7loadbalancer(svc)))
 			return svc;
 	}
 
@@ -1526,9 +1523,6 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		.client_ip = saddr,
 	};
 #endif
-	if (unlikely(svc->count == 0))
-		return DROP_NO_SERVICE;
-
 	ret = ct_lookup4(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
@@ -1615,7 +1609,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		if (backend && !state->syn)
 			goto update_state;
 		key->backend_slot = 0;
-		svc = lb4_lookup_service(key, false, true);
+		svc = lb4_lookup_service(key, false);
 		if (!svc)
 			goto drop_no_service;
 		backend_id = lb4_select_backend_id(ctx, key, tuple, svc);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -874,7 +874,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	svc = lb6_lookup_service(&key, false, false);
+	svc = lb6_lookup_service(&key, false);
 	if (svc) {
 		const bool skip_l3_xlate = DSR_ENCAP_MODE == DSR_ENCAP_IPIP;
 
@@ -1806,7 +1806,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	svc = lb4_lookup_service(&key, false, false);
+	svc = lb4_lookup_service(&key, false);
 	if (svc) {
 		const bool skip_l3_xlate = DSR_ENCAP_MODE == DSR_ENCAP_IPIP;
 

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -67,7 +67,7 @@ static inline void bpf_sock_ops_ipv4(struct bpf_sock_ops *skops)
 	 * pulled in as needed.
 	 */
 	sk_lb4_key(&lb4_key, &key);
-	svc = lb4_lookup_service(&lb4_key, true, true);
+	svc = lb4_lookup_service(&lb4_key, true);
 	if (svc)
 		return;
 

--- a/bpf/tests/hairpin_flow.c
+++ b/bpf/tests/hairpin_flow.c
@@ -52,7 +52,11 @@ struct {
  *            \---------------------------/
  */
 
-int build_packet(struct __ctx_buff *ctx)
+/* Test that sending a packet from a pod to its own service gets source nat-ed
+ * and that it is forwarded to the correct veth.
+ */
+SETUP("tc", "hairpin_flow_1_forward_v4")
+int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	__u8 src[ETH_ALEN] = mac_one;
@@ -61,6 +65,15 @@ int build_packet(struct __ctx_buff *ctx)
 	struct iphdr *l3;
 	struct tcphdr *l4;
 	void *data;
+	__u16 revnat_id = 1;
+	struct lb4_key lb_svc_key = {};
+	struct lb4_service lb_svc_value = {};
+	struct lb4_reverse_nat revnat_value = {};
+	struct lb4_backend backend = {};
+	struct ipcache_key cache_key = {};
+	struct remote_endpoint_info cache_value = {};
+	struct endpoint_key ep_key = {};
+	struct endpoint_info ep_value = {};
 
 	/* Init packet builder */
 	pktgen__init(&builder, ctx);
@@ -96,30 +109,6 @@ int build_packet(struct __ctx_buff *ctx)
 
 	/* Calc lengths, set protocol fields and calc checksums */
 	pktgen__finish(&builder);
-
-	return 0;
-}
-
-/* Test that sending a packet from a pod to its own service gets source nat-ed
- * and that it is forwarded to the correct veth.
- */
-SETUP("tc", "hairpin_flow_1_forward_v4")
-int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
-{
-	__u16 revnat_id = 1;
-	struct lb4_key lb_svc_key = {};
-	struct lb4_service lb_svc_value = {};
-	struct lb4_reverse_nat revnat_value = {};
-	struct lb4_backend backend = {};
-	struct ipcache_key cache_key = {};
-	struct remote_endpoint_info cache_value = {};
-	struct endpoint_key ep_key = {};
-	struct endpoint_info ep_value = {};
-	int ret;
-
-	ret = build_packet(ctx);
-	if (ret)
-		return ret;
 
 	/* Register a fake LB backend with endpoint ID 124 for our service */
 	lb_svc_key.address = v4_svc_one;
@@ -315,71 +304,6 @@ int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	if (l4->dest != tcp_src_one)
 		test_fatal("dst TCP port incorrect");
-
-	test_finish();
-}
-
-/* Test that a packet for a SVC without any backend gets dropped. */
-SETUP("tc", "tc_drop_no_backend")
-int tc_drop_no_backend_setup(struct __ctx_buff *ctx)
-{
-	/* Fake Service matching our packet. */
-	struct lb4_key lb_svc_key = {
-		.address = v4_svc_one,
-		.dport = tcp_svc_one,
-		.scope = LB_LOOKUP_SCOPE_EXT
-	};
-	/* Service with no backends */
-	struct lb4_service lb_svc_value = {
-		.count = 0,
-		.flags = SVC_FLAG_ROUTABLE,
-	};
-	struct policy_key policy_key = {
-		.egress = 1,
-	};
-	struct policy_entry policy_value = {
-		.deny = 0,
-	};
-
-	int ret;
-
-	ret = build_packet(ctx);
-	if (ret)
-		return ret;
-
-	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
-	lb_svc_key.scope = LB_LOOKUP_SCOPE_INT;
-	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
-
-	/* avoid policy drop */
-	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
-
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, &entry_call_map, 0);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
-}
-
-CHECK("tc", "tc_drop_no_backend")
-int tc_drop_no_backend_check(struct __ctx_buff *ctx)
-{
-	__u32 expected_status = TC_ACT_SHOT;
-	__u32 *status_code;
-	void *data_end;
-	void *data;
-
-	test_init();
-
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(__u32) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-
-	if (*status_code != expected_status)
-		test_fatal("status code is %lu, expected %lu", *status_code, expected_status);
 
 	test_finish();
 }

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -36,14 +36,13 @@ struct {
 	},
 };
 
-#define FRONTEND_IP 0x0F00010A /* 10.0.1.15 */
-#define FRONTEND_PORT 80
 #define BACKEND_IP 0x0F00020A /* 10.2.0.15 */
 #define BACKEND_PORT 8080
 
 static long (*bpf_xdp_adjust_tail)(struct xdp_md *xdp_md, int delta) = (void *)65;
 
-static int build_packet(struct __ctx_buff *ctx)
+SETUP("xdp", "forward_to_other_node")
+int test1_setup(struct __ctx_buff *ctx)
 {
 	/* Create room for our packet to be crafted */
 	unsigned int data_len = ctx->data_end - ctx->data;
@@ -78,7 +77,7 @@ static int build_packet(struct __ctx_buff *ctx)
 		.ttl = 64,
 		.protocol = IPPROTO_TCP,
 		.saddr = 0x0F00000A, /* 10.0.0.15 */
-		.daddr = FRONTEND_IP,
+		.daddr = 0x0F00010A /* 10.0.1.15 */
 	};
 	memcpy(data, &l3, sizeof(struct iphdr));
 	data += sizeof(struct iphdr);
@@ -91,7 +90,7 @@ static int build_packet(struct __ctx_buff *ctx)
 
 	struct tcphdr l4 = {
 		.source = 23445,
-		.dest = FRONTEND_PORT,
+		.dest = 80,
 		.seq = 2922048129,
 		.doff = 0, /* no options */
 		.syn = 1,
@@ -109,22 +108,10 @@ static int build_packet(struct __ctx_buff *ctx)
 	offset = (long)data - (long)ctx->data_end;
 	bpf_xdp_adjust_tail(ctx, offset);
 
-	return 0;
-}
-
-SETUP("xdp", "xdp_lb4_forward_to_other_node")
-int test1_setup(struct __ctx_buff *ctx)
-{
-	int ret;
-
-	ret = build_packet(ctx);
-	if (ret)
-		return ret;
-
 	/* Register a fake LB backend with endpoint ID 124 matching our packet. */
 	struct lb4_key lb_svc_key = {
-		.address = FRONTEND_IP,
-		.dport = FRONTEND_PORT,
+		.address = 0x0F00010A,
+		.dport = 80,
 		.scope = LB_LOOKUP_SCOPE_EXT
 	};
 	/* Create a service with only one backend */
@@ -161,7 +148,7 @@ int test1_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("xdp", "xdp_lb4_forward_to_other_node")
+CHECK("xdp", "forward_to_other_node")
 int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -221,57 +208,6 @@ int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	if (memcmp(body, msg, sizeof(msg)) != 0)
 		test_fatal("body changed");
-
-	test_finish();
-}
-
-SETUP("xdp", "xdp_lb4_drop_no_backend")
-int test2_setup(struct __ctx_buff *ctx)
-{
-	/* Fake Service matching our packet. */
-	struct lb4_key lb_svc_key = {
-		.address = FRONTEND_IP,
-		.dport = FRONTEND_PORT,
-		.scope = LB_LOOKUP_SCOPE_EXT
-	};
-	/* Service with no backends */
-	struct lb4_service lb_svc_value = {
-		.count = 0,
-		.flags = SVC_FLAG_ROUTABLE,
-	};
-	int ret;
-
-	ret = build_packet(ctx);
-	if (ret)
-		return ret;
-
-	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
-	lb_svc_key.scope = LB_LOOKUP_SCOPE_INT;
-	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
-
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, &entry_call_map, 0);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
-}
-
-CHECK("xdp", "xdp_lb4_drop_no_backend")
-int test2_check(__maybe_unused const struct __ctx_buff *ctx)
-{
-	void *data_end = (void *)(long)ctx->data_end;
-	void *data = (void *)(long)ctx->data;
-	__u32 expected_status = XDP_DROP;
-	__u32 *status_code;
-
-	test_init();
-
-	if (data + sizeof(__u32) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-
-	if (*status_code != expected_status)
-		test_fatal("status code is %lu, expected %lu", *status_code, expected_status);
 
 	test_finish();
 }


### PR DESCRIPTION
This reverts commits from PR #21539:
- 5b8a06e8312c54a636c72d2b23c3ba04fc5b42f4
- 1a6596883b8825504a37519f609f8989e07b80a7
- 433a2f8feba24e4864f9e9625c0ded407468db86

Rationale: the PR introduced a complexity issue on kernel 4.19 resulting in consistent failures on `K8sDatapathConfig Host firewall` tests.

Full details in issue: #21979.