### PR TITLE
test/alibabacloud: Fix flake in TestPrepareIPAllocation

### DIFF
--- a/pkg/alibabacloud/eni/node_test.go
+++ b/pkg/alibabacloud/eni/node_test.go
@@ -143,7 +143,7 @@ func (e *ENISuite) TestPrepareIPAllocation(c *check.C) {
 	mngr.Update(newCiliumNode("node1", "i-1", "ecs.g7ne.large", "cn-hangzhou-i", "vpc-1"))
 	a, err := mngr.Get("node1").Ops().PrepareIPAllocation(log)
 	c.Assert(err, check.IsNil)
-	c.Assert(a.EmptyInterfaceSlots, check.Equals, 2)
+	c.Assert(a.EmptyInterfaceSlots+a.InterfaceCandidates, check.Equals, 2)
 
 	// create one eni
 	toAlloc, _, err := mngr.Get("node1").Ops().CreateInterface(context.Background(), &ipam.AllocationAction{
@@ -156,7 +156,7 @@ func (e *ENISuite) TestPrepareIPAllocation(c *check.C) {
 	// one eni left
 	a, err = mngr.Get("node1").Ops().PrepareIPAllocation(log)
 	c.Assert(err, check.IsNil)
-	c.Assert(a.EmptyInterfaceSlots, check.Equals, 1)
+	c.Assert(a.EmptyInterfaceSlots+a.InterfaceCandidates, check.Equals, 1)
 }
 
 func (e *ENISuite) TestNode_allocENIIndex(c *check.C) {


### PR DESCRIPTION
The node ipam pool is maintained asynchronously after mngr.Update(), checking EmptyInterfaceSlots without synchronization causes the flake.

Check EmptyInterfaceSlots + InterfaceCandidates instead which reverts the logic to the previous version. The seperate checks for these two fields are already covered by TestCandidateAndEmtpyInterfaces.

Fixes: #21964
Fixes: 42fadfd24c0b ("ipam/crd: Fix ENI leak due to miscounting of empty interface slots")
Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>
