### PR TITLE
fix: Fail CCNP preflight check if using empty endpoint selectors

### DIFF
--- a/cilium/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium/cmd/preflight_k8s_valid_cnp.go
@@ -63,7 +63,7 @@ const (
 )
 
 func validateCNPs(clientset k8sClient.Clientset, shutdowner hive.Shutdowner) error {
-	defer shutdowner.Shutdown(nil)
+	defer shutdowner.Shutdown()
 
 	if !clientset.IsEnabled() {
 		return fmt.Errorf("Kubernetes client not configured. Please provide configuration via --%s or --%s",

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -107,7 +107,7 @@ func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
 
 var (
 	// We can remove the check for this warning once 1.9 is the oldest supported Cilium version.
-	warnWildcardToFromEndpointMessage = "It seems you have a CiliumClusterwideNetworkPolicy " +
+	errWildcardToFromEndpointMessage = "It seems you have a CiliumClusterwideNetworkPolicy " +
 		"with a wildcard to/from endpoint selector. The behavior of this selector has been " +
 		"changed. The selector now only allows traffic to/from Cilium managed K8s endpoints, " +
 		"instead of acting as a truly empty endpoint selector allowing all traffic. To " +
@@ -159,9 +159,9 @@ func checkWildCardToFromEndpoint(ccnp *unstructured.Unstructured) error {
 	if resCCNP.Spec != nil {
 		if containsWildcardToFromEndpoint(resCCNP.Spec) {
 			logOnce.Do(func() {
-				logger.Warning(warnWildcardToFromEndpointMessage)
+				logger.Error(errWildcardToFromEndpointMessage)
 			})
-			return nil
+			return fmt.Errorf("use of empty toEndpoints/fromEndpoints selector")
 		}
 	}
 
@@ -169,9 +169,9 @@ func checkWildCardToFromEndpoint(ccnp *unstructured.Unstructured) error {
 		for _, rule := range resCCNP.Specs {
 			if containsWildcardToFromEndpoint(rule) {
 				logOnce.Do(func() {
-					logger.Warning(warnWildcardToFromEndpointMessage)
+					logger.Error(errWildcardToFromEndpointMessage)
 				})
-				return nil
+				return fmt.Errorf("use of empty toEndpoints/fromEndpoints selector")
 			}
 		}
 	}


### PR DESCRIPTION
Fail `validate-cnp` preflight check if a CiliumClusterwideNetworkPolicy is using an empty toEndpoints/fromEndpoints selector

Previously, 'validate-cnp' preflight check would log a verbose warning if it detected a CCNP with an empty toEndpoints/fromEndpoints selector and pass the check with the following output:
```
time="2022-11-03T15:50:04Z" level=info msg="Validation OK!" CiliumClusterwideNetworkPolicy=test-empty-endpointselector
time="2022-11-03T15:50:04Z" level=info msg="All CCNPs and CNPs valid!"
```
This could be misleading and tempt the user to ignore the warning. The preflight check will now fail with the following output:
```
time="2022-11-03T16:05:30Z" level=error msg="Unexpected validation error" CiliumClusterwideNetworkPolicy=test-empty-endpointselector error="use of empty toEndpoints/fromEndpoints selector"
time="2022-11-03T16:05:30Z" level=error msg="Start hook failed" error="Found invalid CiliumClusterwideNetworkPolicy" function="cilium/cmd.validateCNPCmd.func1.1 (preflight_k8s_valid_cnp.go:41)" subsys=hive
time="2022-11-03T16:05:30Z" level=info msg="Stop hook executed" duration="21.858µs" function="pkg/k8s/client.(*compositeClientset).onStop-fm (<autogenerated>:1)" subsys=hive
time="2022-11-03T16:05:30Z" level=fatal msg="failed to start: Found invalid CiliumClusterwideNetworkPolicy"
```
Fixes: #17471

```release-note
Fail validate-cnp preflight check if a CiliumClusterwideNetworkPolicy is using an empty toEndpoints/fromEndpoints selector
```

Signed-off by: Tim Horner <timothy.horner@isovalent.com>
