### PR TITLE
update generic-veth: set routes with RouteMTU

### DIFF
--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -50,6 +50,7 @@ import (
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/portmap"
 	"github.com/cilium/cilium/plugins/cilium-cni/types"
+	ciliumcniutils "github.com/cilium/cilium/plugins/cilium-cni/utils"
 )
 
 const (
@@ -106,19 +107,6 @@ func ipv4IsEnabled(ipam *models.IPAMResponse) bool {
 	}
 
 	return true
-}
-
-func getConfigFromCiliumAgent(client *client.Client) (*models.DaemonConfigurationStatus, error) {
-	configResult, err := client.ConfigGet()
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve configuration from cilium-agent: %w", err)
-	}
-
-	if configResult == nil || configResult.Status == nil {
-		return nil, fmt.Errorf("received empty configuration object from cilium-agent")
-	}
-
-	return configResult.Status, nil
 }
 
 func allocateIPsWithCiliumAgent(client *client.Client, cniArgs types.ArgsSpec) (*models.IPAMResponse, func(context.Context), error) {
@@ -445,7 +433,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	addLabels := models.Labels{}
 
-	conf, err = getConfigFromCiliumAgent(c)
+	conf, err = ciliumcniutils.GetConfigFromCiliumAgent(c)
 	if err != nil {
 		return
 	}
@@ -650,7 +638,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("unable to connect to Cilium daemon: %s", client.Hint(err))
 	}
 
-	conf, err := getConfigFromCiliumAgent(c)
+	conf, err := ciliumcniutils.GetConfigFromCiliumAgent(c)
 	if err != nil {
 		return err
 	}

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -24,6 +24,7 @@ type NetConf struct {
 	cniTypes.NetConf
 	MTU          int                    `json:"mtu"`
 	Args         Args                   `json:"args"`
+	ChainingMode ChainingMode           `json:"chaining-mode,omitempty"`
 	ENI          eniTypes.ENISpec       `json:"eni,omitempty"`
 	Azure        azureTypes.AzureSpec   `json:"azure,omitempty"`
 	IPAM         IPAM                   `json:"ipam,omitempty"` // Shadows the JSON field "ipam" in cniTypes.NetConf.
@@ -31,6 +32,10 @@ type NetConf struct {
 	EnableDebug  bool                   `json:"enable-debug"`
 	LogFormat    string                 `json:"log-format"`
 	LogFile      string                 `json:"log-file"`
+}
+
+type ChainingMode struct {
+	ConfigRouteMTU bool `json:"config-route-mtu,omitempty"`
 }
 
 // IPAM is the Cilium specific CNI IPAM configuration

--- a/plugins/cilium-cni/utils/utils.go
+++ b/plugins/cilium-cni/utils/utils.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/client"
+)
+
+func GetConfigFromCiliumAgent(client *client.Client) (*models.DaemonConfigurationStatus, error) {
+	configResult, err := client.ConfigGet()
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve configuration from cilium-agent: %w", err)
+	}
+
+	if configResult == nil || configResult.Status == nil {
+		return nil, fmt.Errorf("received empty configuration object from cilium-agent")
+	}
+
+	return configResult.Status, nil
+}


### PR DESCRIPTION
```release-note
update generic-veth: set routes with RouteMTU
```

Signed-off-by: Su Fei <fesu@ebay.com>

When setting cilium cni-chaining-mode to generic-veth, our own cni plugin will set up the links and routes. It will not change the mtu values. So by default, it will be 1500. Cilium-cni is only to create the endpoint objects.
The configuration is like this.
```
{
  "name": "generic-veth",
  "cniVersion": "0.2.0",
  "plugins": [
    {
      "name": "ttnet",
      "type": "ttnet",
      "bridge": "cbr0",
      "addIf": "eth0",
      "isGateway": true,
      "ipMasq": true,
      "upstreamIf" : "eth0"
    },
    {
       "name": "cilium",
       "type": "cilium-cni",
       "enable-debug": true,
       "log-file": "/var/run/cilium/cilium-cni.log"
    }
  ]
}
```

host eth0 ( mtu 1500). <---> cilium_vlan (mtu 1500) ---> pod etho (mtu 1500)
At this time, the pod network cannot be pingable if the size is set to larger than 1500 (for example, 2000)
```
/# ping 172.18.253.36 -s 2000
PING 172.18.253.36 (172.18.253.36) 2000(2028) bytes of data
^C
--- 172.18.253.36 ping statistics ---
2 packets transmitted, 0 packets received, 100.0% packet loss
```
That is because when the packets arrive at the host eth0, the packets is larger than its mtu, it will drop this packets.

If the cilium-cni is a standalone plugin, this issue explained above will not happen, because cilium-cni will set the mtu which is gotten from `host eth0 mtu -  tunnel overhead`  for routes inside the containers' namespaces 

for example:
```
default via 172.18.253.1 dev eth0 mtu 1450
```

For cni-chaining-mode generic-veth, cilium-cni should set the MTU ( `host eth0 mtu -  tunnel overhead` ) for the routes inside the containers' namespaces in the same way.



