### PR TITLE
Remove unnecessary imports of pkg/policy

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
+	"github.com/cilium/cilium/pkg/types"
 )
 
 type DaemonSuite struct {
@@ -51,7 +52,7 @@ type DaemonSuite struct {
 
 	// Owners interface mock
 	OnGetPolicyRepository  func() *policy.Repository
-	OnGetNamedPorts        func() (npm policy.NamedPortMultiMap)
+	OnGetNamedPorts        func() (npm types.NamedPortMultiMap)
 	OnQueueEndpointBuild   func(ctx context.Context, epID uint64) (func(), error)
 	OnGetCompilationLock   func() *lock.RWMutex
 	OnSendNotification     func(typ monitorAPI.AgentNotifyMessage) error
@@ -253,7 +254,7 @@ func (ds *DaemonSuite) GetPolicyRepository() *policy.Repository {
 	panic("GetPolicyRepository should not have been called")
 }
 
-func (ds *DaemonSuite) GetNamedPorts() (npm policy.NamedPortMultiMap) {
+func (ds *DaemonSuite) GetNamedPorts() (npm types.NamedPortMultiMap) {
 	if ds.OnGetNamedPorts != nil {
 		return ds.OnGetNamedPorts()
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/apimachinery/pkg/types"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/annotation"
@@ -56,6 +56,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/trigger"
+	"github.com/cilium/cilium/pkg/types"
 )
 
 const (
@@ -231,7 +232,7 @@ type Endpoint struct {
 
 	// k8sPorts contains container ports associated in the pod.
 	// It is used to enforce k8s network policies with port names.
-	k8sPorts policy.NamedPortMap
+	k8sPorts types.NamedPortMap
 
 	// logLimiter rate limits potentially repeating warning logs
 	logLimiter logging.Limiter
@@ -337,11 +338,11 @@ type Endpoint struct {
 
 	noTrackPort uint16
 
-	ciliumEndpointUID types.UID
+	ciliumEndpointUID k8sTypes.UID
 }
 
 type namedPortsGetter interface {
-	GetNamedPorts() (npm policy.NamedPortMultiMap)
+	GetNamedPorts() (npm types.NamedPortMultiMap)
 }
 
 type policyRepoGetter interface {
@@ -1206,7 +1207,7 @@ func (e *Endpoint) SetK8sNamespace(name string) {
 // Reading the 'e.k8sPorts' member (the "map pointer") *itself* requires the endpoint lock!
 // Can't really error out as that might break backwards compatibility.
 func (e *Endpoint) SetK8sMetadata(containerPorts []slim_corev1.ContainerPort) error {
-	k8sPorts := make(policy.NamedPortMap, len(containerPorts))
+	k8sPorts := make(types.NamedPortMap, len(containerPorts))
 	for _, cp := range containerPorts {
 		if cp.Name == "" {
 			continue // silently skip unnamed ports
@@ -1228,7 +1229,7 @@ func (e *Endpoint) SetK8sMetadata(containerPorts []slim_corev1.ContainerPort) er
 }
 
 // GetK8sPorts returns the k8sPorts, which must not be modified by the caller
-func (e *Endpoint) GetK8sPorts() (k8sPorts policy.NamedPortMap, err error) {
+func (e *Endpoint) GetK8sPorts() (k8sPorts types.NamedPortMap, err error) {
 	err = e.rlockAlive()
 	if err != nil {
 		return nil, err

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	"github.com/cilium/cilium/pkg/types"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -52,7 +53,7 @@ type EndpointSuite struct {
 
 	// Owners interface mock
 	OnGetPolicyRepository     func() *policy.Repository
-	OnGetNamedPorts           func() (npm policy.NamedPortMultiMap)
+	OnGetNamedPorts           func() (npm types.NamedPortMultiMap)
 	OnQueueEndpointBuild      func(ctx context.Context, epID uint64) (func(), error)
 	OnRemoveFromEndpointQueue func(epID uint64)
 	OnGetCompilationLock      func() *lock.RWMutex
@@ -91,7 +92,7 @@ func (s *EndpointSuite) GetPolicyRepository() *policy.Repository {
 	return s.repo
 }
 
-func (s *EndpointSuite) GetNamedPorts() (npm policy.NamedPortMultiMap) {
+func (s *EndpointSuite) GetNamedPorts() (npm types.NamedPortMultiMap) {
 	if s.OnGetNamedPorts != nil {
 		return s.OnGetNamedPorts()
 	}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -69,7 +70,7 @@ func (e *Endpoint) GetNamedPortLocked(ingress bool, name string, proto uint8) ui
 	return e.getNamedPortEgress(e.namedPortsGetter.GetNamedPorts(), name, proto)
 }
 
-func (e *Endpoint) getNamedPortIngress(npMap policy.NamedPortMap, name string, proto uint8) uint16 {
+func (e *Endpoint) getNamedPortIngress(npMap types.NamedPortMap, name string, proto uint8) uint16 {
 	port, err := npMap.GetNamedPort(name, proto)
 	if err != nil && e.logLimiter.Allow() {
 		e.getLogger().WithFields(logrus.Fields{
@@ -81,11 +82,11 @@ func (e *Endpoint) getNamedPortIngress(npMap policy.NamedPortMap, name string, p
 	return port
 }
 
-func (e *Endpoint) getNamedPortEgress(npMap policy.NamedPortMultiMap, name string, proto uint8) uint16 {
+func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string, proto uint8) uint16 {
 	port, err := npMap.GetNamedPort(name, proto)
 	// Skip logging for ErrUnknownNamedPort on egress, as the destination POD with the port name
 	// is likely not scheduled yet.
-	if err != nil && !errors.Is(err, policy.ErrUnknownNamedPort) && e.logLimiter.Allow() {
+	if err != nil && !errors.Is(err, types.ErrUnknownNamedPort) && e.logLimiter.Allow() {
 		e.getLogger().WithFields(logrus.Fields{
 			logfields.PortName:         name,
 			logfields.Protocol:         u8proto.U8proto(proto).String(),

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -13,7 +13,6 @@ import (
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
-	"github.com/cilium/cilium/pkg/policy"
 )
 
 // DNSGetter ...
@@ -30,11 +29,6 @@ type EndpointGetter interface {
 	GetEndpointInfo(ip net.IP) (endpoint v1.EndpointInfo, ok bool)
 	// GetEndpointInfo looks up endpoint by id
 	GetEndpointInfoByID(id uint16) (endpoint v1.EndpointInfo, ok bool)
-}
-
-type EndpointsGetter interface {
-	// GetEndpoints returns a map of the current policy.Endpoint(s).
-	GetEndpoints() map[policy.Endpoint]struct{}
 }
 
 // IdentityGetter ...

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -20,8 +20,8 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/types"
 )
 
 // Identity is the identity representation of an IP<->Identity cache.
@@ -52,7 +52,7 @@ type K8sMetadata struct {
 	// PodName is the Kubernetes pod name behind the IP
 	PodName string
 	// NamedPorts is the set of named ports for the pod
-	NamedPorts policy.NamedPortMap
+	NamedPorts types.NamedPortMap
 }
 
 // Configuration is init-time configuration for the IPCache.
@@ -91,7 +91,7 @@ type IPCache struct {
 	// only if an egress policy refers to a port by name.
 	// This map is returned to users so all updates must be made into a fresh map that
 	// is then swapped in place while 'mutex' is being held.
-	namedPorts policy.NamedPortMultiMap
+	namedPorts types.NamedPortMultiMap
 
 	// k8sSyncedChecker knows how to check for whether the K8s watcher cache
 	// has been fully synced.
@@ -221,11 +221,11 @@ func (ipc *IPCache) updateNamedPorts() (namedPortsChanged bool) {
 		return false
 	}
 	// Collect new named Ports
-	npm := make(policy.NamedPortMultiMap, len(ipc.namedPorts))
+	npm := make(types.NamedPortMultiMap, len(ipc.namedPorts))
 	for _, km := range ipc.ipToK8sMetadata {
 		for name, port := range km.NamedPorts {
 			if npm[name] == nil {
-				npm[name] = make(policy.PortProtoSet)
+				npm[name] = make(types.PortProtoSet)
 			}
 			npm[name][port] = struct{}{}
 		}
@@ -272,7 +272,7 @@ func (ipc *IPCache) upsertLocked(
 	newIdentity Identity,
 	force bool,
 ) (namedPortsChanged bool, err error) {
-	var newNamedPorts policy.NamedPortMap
+	var newNamedPorts types.NamedPortMap
 	if k8sMeta != nil {
 		newNamedPorts = k8sMeta.NamedPorts
 	}
@@ -601,7 +601,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 }
 
 // GetNamedPorts returns a copy of the named ports map. May return nil.
-func (ipc *IPCache) GetNamedPorts() (npm policy.NamedPortMultiMap) {
+func (ipc *IPCache) GetNamedPorts() (npm types.NamedPortMultiMap) {
 	ipc.mutex.Lock()
 	if !ipc.needNamedPorts {
 		ipc.needNamedPorts = true

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -316,9 +316,9 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	meta := K8sMetadata{
 		Namespace: "default",
 		PodName:   "app1",
-		NamedPorts: policy.NamedPortMap{
-			"http": policy.PortProto{Port: 80, Proto: uint8(u8proto.TCP)},
-			"dns":  policy.PortProto{Port: 53},
+		NamedPorts: types.NamedPortMap{
+			"http": types.PortProto{Port: 80, Proto: uint8(u8proto.TCP)},
+			"dns":  types.PortProto{Port: 53},
 		},
 	}
 
@@ -344,8 +344,8 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	npm := IPIdentityCache.GetNamedPorts()
 	c.Assert(npm, NotNil)
 	c.Assert(len(npm), Equals, 2)
-	c.Assert(npm["http"], checker.HasKey, policy.PortProto{Port: uint16(80), Proto: uint8(6)})
-	c.Assert(npm["dns"], checker.HasKey, policy.PortProto{Port: uint16(53), Proto: uint8(0)})
+	c.Assert(npm["http"], checker.HasKey, types.PortProto{Port: uint16(80), Proto: uint8(6)})
+	c.Assert(npm["dns"], checker.HasKey, types.PortProto{Port: uint16(53), Proto: uint8(0)})
 
 	// No duplicates.
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
@@ -365,9 +365,9 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	meta2 := K8sMetadata{
 		Namespace: "testing",
 		PodName:   "app2",
-		NamedPorts: policy.NamedPortMap{
-			"https": policy.PortProto{Port: 443, Proto: uint8(u8proto.TCP)},
-			"dns":   policy.PortProto{Port: 53},
+		NamedPorts: types.NamedPortMap{
+			"https": types.PortProto{Port: 443, Proto: uint8(u8proto.TCP)},
+			"dns":   types.PortProto{Port: 53},
 		},
 	}
 
@@ -393,17 +393,17 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	npm = IPIdentityCache.GetNamedPorts()
 	c.Assert(npm, NotNil)
 	c.Assert(len(npm), Equals, 3)
-	c.Assert(npm["http"], checker.HasKey, policy.PortProto{Port: uint16(80), Proto: uint8(6)})
-	c.Assert(npm["dns"], checker.HasKey, policy.PortProto{Port: uint16(53), Proto: uint8(0)})
-	c.Assert(npm["https"], checker.HasKey, policy.PortProto{Port: uint16(443), Proto: uint8(6)})
+	c.Assert(npm["http"], checker.HasKey, types.PortProto{Port: uint16(80), Proto: uint8(6)})
+	c.Assert(npm["dns"], checker.HasKey, types.PortProto{Port: uint16(53), Proto: uint8(0)})
+	c.Assert(npm["https"], checker.HasKey, types.PortProto{Port: uint16(443), Proto: uint8(6)})
 
 	namedPortsChanged = IPIdentityCache.Delete(endpointIP, source.Kubernetes)
 	c.Assert(namedPortsChanged, Equals, true)
 	npm = IPIdentityCache.GetNamedPorts()
 	c.Assert(npm, NotNil)
 	c.Assert(len(npm), Equals, 2)
-	c.Assert(npm["dns"], checker.HasKey, policy.PortProto{Port: uint16(53), Proto: uint8(0)})
-	c.Assert(npm["https"], checker.HasKey, policy.PortProto{Port: uint16(443), Proto: uint8(6)})
+	c.Assert(npm["dns"], checker.HasKey, types.PortProto{Port: uint16(53), Proto: uint8(0)})
+	c.Assert(npm["https"], checker.HasKey, types.PortProto{Port: uint16(443), Proto: uint8(6)})
 
 	// Assure deletion occurs across all mappings.
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
@@ -476,8 +476,8 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	// Test mapping of multiple IPs to same identity.
 	endpointIPs := []string{"192.168.0.1", "20.3.75.3", "27.2.2.2", "127.0.0.1", "127.0.0.1"}
 	identities := []identityPkg.NumericIdentity{5, 67, 29, 29, 29}
-	k8sMeta.NamedPorts = policy.NamedPortMap{
-		"http2": policy.PortProto{Port: 8080, Proto: uint8(u8proto.TCP)},
+	k8sMeta.NamedPorts = types.NamedPortMap{
+		"http2": types.PortProto{Port: 8080, Proto: uint8(u8proto.TCP)},
 	}
 
 	for index := range endpointIPs {
@@ -489,7 +489,7 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 		c.Assert(err, IsNil)
 		npm = IPIdentityCache.GetNamedPorts()
 		c.Assert(npm, NotNil)
-		c.Assert(npm["http2"], checker.HasKey, policy.PortProto{Port: uint16(8080), Proto: uint8(6)})
+		c.Assert(npm["http2"], checker.HasKey, types.PortProto{Port: uint16(8080), Proto: uint8(6)})
 		// only the first changes named ports, as they are all the same
 		c.Assert(namedPortsChanged, Equals, index == 0)
 		cachedIdentity, _ := IPIdentityCache.LookupByIP(endpointIPs[index])

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -21,8 +21,8 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -97,7 +97,7 @@ func newKVReferenceCounter(s store) *kvReferenceCounter {
 // UpsertIPToKVStore updates / inserts the provided IP->Identity mapping into the
 // kvstore, which will subsequently trigger an event in NewIPIdentityWatcher().
 func UpsertIPToKVStore(ctx context.Context, IP, hostIP net.IP, ID identity.NumericIdentity, key uint8,
-	metadata, k8sNamespace, k8sPodName string, npm policy.NamedPortMap) error {
+	metadata, k8sNamespace, k8sPodName string, npm types.NamedPortMap) error {
 	// Sort named ports into a slice
 	namedPorts := make([]identity.NamedPort, 0, len(npm))
 	for name, value := range npm {
@@ -287,7 +287,7 @@ restart:
 					k8sMeta = &K8sMetadata{
 						Namespace:  ipIDPair.K8sNamespace,
 						PodName:    ipIDPair.K8sPodName,
-						NamedPorts: make(policy.NamedPortMap, len(ipIDPair.NamedPorts)),
+						NamedPorts: make(types.NamedPortMap, len(ipIDPair.NamedPorts)),
 					}
 					for _, np := range ipIDPair.NamedPorts {
 						err = k8sMeta.NamedPorts.AddPort(np.Name, int(np.Port), np.Protocol)

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -22,8 +22,8 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/source"
+	ciliumTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -176,14 +176,14 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 	k8sMeta := &ipcache.K8sMetadata{
 		Namespace:  endpoint.Namespace,
 		PodName:    endpoint.Name,
-		NamedPorts: make(policy.NamedPortMap, len(endpoint.NamedPorts)),
+		NamedPorts: make(ciliumTypes.NamedPortMap, len(endpoint.NamedPorts)),
 	}
 	for _, port := range endpoint.NamedPorts {
 		p, err := u8proto.ParseProtocol(port.Protocol)
 		if err != nil {
 			continue
 		}
-		k8sMeta.NamedPorts[port.Name] = policy.PortProto{
+		k8sMeta.NamedPorts[port.Name] = ciliumTypes.PortProto{
 			Port:  port.Port,
 			Proto: uint8(p),
 		}

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -52,9 +52,9 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/source"
+	ciliumTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -813,9 +813,9 @@ func (k *K8sWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPodIP
 				return fmt.Errorf("ContainerPort: invalid port: %d", port.ContainerPort)
 			}
 			if k8sMeta.NamedPorts == nil {
-				k8sMeta.NamedPorts = make(policy.NamedPortMap)
+				k8sMeta.NamedPorts = make(ciliumTypes.NamedPortMap)
 			}
-			k8sMeta.NamedPorts[port.Name] = policy.PortProto{
+			k8sMeta.NamedPorts[port.Name] = ciliumTypes.PortProto{
 				Port:  uint16(port.ContainerPort),
 				Proto: uint8(p),
 			}

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -11,13 +11,13 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/types"
 )
 
 type MockIPCache struct{}
 
-func (m *MockIPCache) GetNamedPorts() policy.NamedPortMultiMap {
+func (m *MockIPCache) GetNamedPorts() types.NamedPortMultiMap {
 	return nil
 }
 

--- a/pkg/types/portmap.go
+++ b/pkg/types/portmap.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package policy
+package types
 
 import (
 	"errors"

--- a/pkg/types/portmap_test.go
+++ b/pkg/types/portmap_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package policy
+package types
 
 import (
 	. "gopkg.in/check.v1"
@@ -9,7 +9,11 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-func (ds *PolicyTestSuite) TestPolicyValidateName(c *C) {
+type PortsTestSuite struct{}
+
+var _ = Suite(&PortsTestSuite{})
+
+func (ds *PortsTestSuite) TestPolicyValidateName(c *C) {
 	name, err := ValidatePortName("Http")
 	c.Assert(err, IsNil)
 	c.Assert(name, Equals, "http")
@@ -32,7 +36,7 @@ func (ds *PolicyTestSuite) TestPolicyValidateName(c *C) {
 	c.Assert(err, Not(IsNil))
 }
 
-func (ds *PolicyTestSuite) TestPolicyNewPortProto(c *C) {
+func (ds *PortsTestSuite) TestPolicyNewPortProto(c *C) {
 	np, err := newPortProto(80, "tcp")
 	c.Assert(err, IsNil)
 	c.Assert(np, Equals, PortProto{Port: uint16(80), Proto: uint8(6)})
@@ -50,7 +54,7 @@ func (ds *PolicyTestSuite) TestPolicyNewPortProto(c *C) {
 	c.Assert(np, Equals, PortProto{Port: uint16(88), Proto: uint8(6)})
 }
 
-func (ds *PolicyTestSuite) TestPolicyNamedPortMap(c *C) {
+func (ds *PortsTestSuite) TestPolicyNamedPortMap(c *C) {
 	npm := make(NamedPortMap)
 
 	err := npm.AddPort("http", 80, "tcp")
@@ -82,7 +86,7 @@ func (ds *PolicyTestSuite) TestPolicyNamedPortMap(c *C) {
 	c.Assert(port, Equals, uint16(0))
 }
 
-func (ds *PolicyTestSuite) TestPolicyPortProtoSet(c *C) {
+func (ds *PortsTestSuite) TestPolicyPortProtoSet(c *C) {
 	a := PortProtoSet{
 		PortProto{Port: 80, Proto: 6}:  struct{}{},
 		PortProto{Port: 443, Proto: 6}: struct{}{},
@@ -98,7 +102,7 @@ func (ds *PolicyTestSuite) TestPolicyPortProtoSet(c *C) {
 	c.Assert(b.Equal(b), Equals, true)
 }
 
-func (ds *PolicyTestSuite) TestPolicyNamedPortMultiMap(c *C) {
+func (ds *PortsTestSuite) TestPolicyNamedPortMultiMap(c *C) {
 	a := NamedPortMultiMap{
 		"http": PortProtoSet{
 			PortProto{Port: 80, Proto: 6}:   struct{}{},


### PR DESCRIPTION
Remove imports of `pkg/policy` from `pkg/ipcache` and `pkg/hubble/parser/getters` to allow `pkg/policy` to do more imports in future.
