### PR TITLE
ctmap: Add missing FromL7LB flag

### DIFF
--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -519,6 +519,7 @@ const (
 	NodePort
 	ProxyRedirect
 	DSR
+	FromL7LB
 	MaxFlags
 )
 
@@ -549,6 +550,9 @@ func (c *CtEntry) flagsString() string {
 	}
 	if (c.Flags & DSR) != 0 {
 		sb.WriteString("DSR ")
+	}
+	if (c.Flags & FromL7LB) != 0 {
+		sb.WriteString("FromL7LB ")
 	}
 
 	unknownFlags := c.Flags


### PR DESCRIPTION
'FromL7LB' was not added for string conversion when it was added to the map, do it now.

Fixes: #18894
