### PR TITLE
Create new ENIs in initial subnet by default

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -315,6 +315,12 @@ Annotations:
 * The kube-proxy replacement in DSR or Hybrid mode with tunneling causes failure upon cilium-agent start.
   In previous versions, cilium-agent automatically used SNAT mode when we set tunneling.
 
+* In the ENI IPAM mode, the default subnet in which ENIs are created has changed
+  from the subnet (in the same VPC and AZ) with the most addresses available to
+  the subnet in which the primary ENI of the node is attached. Note that this
+  default only matters if no explicit selection of the subnet occurs, i.e.
+  specifying subnet IDs or tags still takes precedence.
+
 Removed Options
 ~~~~~~~~~~~~~~~
 

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -408,14 +408,8 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 	isPrefixDelegated := n.node.Ops().IsPrefixDelegated()
 	n.mutex.RUnlock()
 
-	var bestSubnet *ipamTypes.Subnet
-	if len(resource.Spec.ENI.SubnetIDs) > 0 {
-		bestSubnet = n.manager.FindSubnetByIDs(resource.Spec.ENI.VpcID, resource.Spec.ENI.AvailabilityZone, resource.Spec.ENI.SubnetIDs)
-	} else {
-		bestSubnet = n.manager.FindSubnetByTags(resource.Spec.ENI.VpcID, resource.Spec.ENI.AvailabilityZone, resource.Spec.ENI.SubnetTags)
-	}
-
-	if bestSubnet == nil {
+	subnet := n.findSuitableSubnet(resource.Spec.ENI, limits)
+	if subnet == nil {
 		return 0,
 			unableToFindSubnet,
 			fmt.Errorf(
@@ -426,7 +420,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 				resource.Spec.ENI.SubnetTags,
 			)
 	}
-	allocation.PoolID = ipamTypes.PoolID(bestSubnet.ID)
+	allocation.PoolID = ipamTypes.PoolID(subnet.ID)
 
 	securityGroupIDs, err := n.getSecurityGroupIDs(ctx, resource.Spec.ENI)
 	if err != nil {
@@ -448,19 +442,19 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 
 	scopedLog = scopedLog.WithFields(logrus.Fields{
 		"securityGroupIDs":  securityGroupIDs,
-		"subnetID":          bestSubnet.ID,
+		"subnetID":          subnet.ID,
 		"addresses":         toAllocate,
 		"isPrefixDelegated": isPrefixDelegated,
 	})
 	scopedLog.Info("No more IPs available, creating new ENI")
 
-	eniID, eni, err := n.manager.api.CreateNetworkInterface(ctx, int32(toAllocate), bestSubnet.ID, desc, securityGroupIDs, isPrefixDelegated)
+	eniID, eni, err := n.manager.api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, isPrefixDelegated)
 	if err != nil {
 		if isPrefixDelegated && isSubnetAtCapacity(err) {
 			// Subnet might be out of available /28 prefixes, but /32 IP addresses might be available.
 			// We should attempt to allocate /32 IPs.
 			scopedLog.WithField(logfields.Node, n.k8sObj.Name).Warning("Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore")
-			eniID, eni, err = n.manager.api.CreateNetworkInterface(ctx, int32(toAllocate), bestSubnet.ID, desc, securityGroupIDs, false)
+			eniID, eni, err = n.manager.api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, false)
 		}
 		if err != nil {
 			return 0, unableToCreateENI, fmt.Errorf("%s %s", errUnableToCreateENI, err)
@@ -799,4 +793,30 @@ func (n *Node) getEffectiveIPLimits(eni *eniTypes.ENI, limits int) (effectiveLim
 		effectiveLimits += len(eni.Prefixes) * (option.ENIPDBlockSizeIPv4 - 1)
 	}
 	return effectiveLimits
+}
+
+// findSuitableSubnet attempts to find a subnet to allocate an ENI in according to the following heuristic.
+//  0. In general, the subnet has to be in the same VPC and match the availability zone of the
+//     node. If there are multiple candidates, we choose the subnet with the most addresses
+//     available.
+//  1. If we have explicit ID or tag constraints, chose a matching subnet. ID constraints take
+//     precedence.
+//  2. If we have no explicit constraints, try to use the subnet the first ENI of the node was
+//     created in, to avoid putting the ENI in a surprising subnet if possible.
+//  3. If none of these work, fall back to just choosing the subnet with the most addresses
+//     available.
+func (n *Node) findSuitableSubnet(spec eniTypes.ENISpec, limits ipamTypes.Limits) *ipamTypes.Subnet {
+	var subnet *ipamTypes.Subnet
+	if len(spec.SubnetIDs) > 0 {
+		return n.manager.FindSubnetByIDs(spec.VpcID, spec.AvailabilityZone, spec.SubnetIDs)
+	} else if len(spec.SubnetTags) > 0 {
+		return n.manager.FindSubnetByTags(spec.VpcID, spec.AvailabilityZone, spec.SubnetTags)
+	}
+
+	subnet = n.manager.GetSubnet(spec.NodeSubnetID)
+	if subnet != nil && subnet.AvailableAddresses >= limits.IPv4 {
+		return subnet
+	}
+
+	return n.manager.FindSubnetByTags(spec.VpcID, spec.AvailabilityZone, nil)
 }

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -98,6 +98,12 @@ type ENISpec struct {
 	// +kubebuilder:validation:Optional
 	SubnetTags map[string]string `json:"subnet-tags,omitempty"`
 
+	// NodeSubnetID is the subnet of the primary ENI the instance was brought up
+	// with. It is used as a sensible default subnet to create ENIs in.
+	//
+	// +kubebuilder:validation:Optional
+	NodeSubnetID string `json:"node-subnet-id,omitempty"`
+
 	// VpcID is the VPC ID to use when allocating ENIs.
 	//
 	// +kubebuilder:validation:Optional

--- a/pkg/aws/eni/types/zz_generated.deepequal.go
+++ b/pkg/aws/eni/types/zz_generated.deepequal.go
@@ -272,6 +272,9 @@ func (in *ENISpec) DeepEqual(other *ENISpec) bool {
 		}
 	}
 
+	if in.NodeSubnetID != other.NodeSubnetID {
+		return false
+	}
 	if in.VpcID != other.VpcID {
 		return false
 	}

--- a/pkg/aws/metadata/metadata.go
+++ b/pkg/aws/metadata/metadata.go
@@ -39,7 +39,7 @@ func getMetadata(client *imds.Client, path string) (string, error) {
 }
 
 // GetInstanceMetadata returns required AWS metadatas
-func GetInstanceMetadata() (instanceID, instanceType, availabilityZone, vpcID string, err error) {
+func GetInstanceMetadata() (instanceID, instanceType, availabilityZone, vpcID, subnetID string, err error) {
 	client, err := newClient()
 	if err != nil {
 		return
@@ -61,6 +61,12 @@ func GetInstanceMetadata() (instanceID, instanceType, availabilityZone, vpcID st
 	}
 	vpcIDPath := fmt.Sprintf("network/interfaces/macs/%s/vpc-id", eth0MAC)
 	vpcID, err = getMetadata(client, vpcIDPath)
+	if err != nil {
+		return
+	}
+
+	subnetIDPath := fmt.Sprintf("network/interfaces/macs/%s/subnet-id", eth0MAC)
+	subnetID, err = getMetadata(client, subnetIDPath)
 	if err != nil {
 		return
 	}

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -546,7 +546,7 @@ type AllocationAction struct {
 	PoolID ipamTypes.PoolID
 
 	// AvailableForAllocation is the number IPs available for allocation.
-	// If InterfaeID is set, then this number corresponds to the number of
+	// If InterfaceID is set, then this number corresponds to the number of
 	// IPs available for allocation on that interface. This number may be
 	// lower than the number of IPs required to resolve the deficit.
 	AvailableForAllocation int

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -185,6 +185,11 @@ spec:
                       field is obsolete, please use Spec.IPAM.MinAllocate"
                     minimum: 0
                     type: integer
+                  node-subnet-id:
+                    description: NodeSubnetID is the subnet of the primary ENI the
+                      instance was brought up with. It is used as a sensible default
+                      subnet to create ENIs in.
+                    type: string
                   pre-allocate:
                     description: "PreAllocate defines the number of IP addresses that
                       must be available for allocation in the IPAMspec. It defines

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -546,7 +546,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 	case ipamOption.IPAMENI:
 		// set ENI field in the node only when the ENI ipam is specified
 		nodeResource.Spec.ENI = eniTypes.ENISpec{}
-		instanceID, instanceType, availabilityZone, vpcID, err := metadata.GetInstanceMetadata()
+		instanceID, instanceType, availabilityZone, vpcID, subnetID, err := metadata.GetInstanceMetadata()
 		if err != nil {
 			log.WithError(err).Fatal("Unable to retrieve InstanceID of own EC2 instance")
 		}
@@ -618,6 +618,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		nodeResource.Spec.InstanceID = instanceID
 		nodeResource.Spec.ENI.InstanceType = instanceType
 		nodeResource.Spec.ENI.AvailabilityZone = availabilityZone
+		nodeResource.Spec.ENI.NodeSubnetID = subnetID
 
 	case ipamOption.IPAMAzure:
 		if providerID == "" {


### PR DESCRIPTION
When no Subnet IDs/tags are configured, Cilium used to allocate new ENIs in the subnet which the most addresses available that is in the same VPC and AZ. This can lead to suprises, see #20553. Instead, try to allocate the new ENI in the same subnet as the primary one.

In order to do so, save the initial subnet ID in the Spec to have access to it while making the decision where to allocate the new ENI.

Fixes: #20553

```release-note
In ENI IPAM mode, try to allocate new ENIs in the same subnet as the primary ENI instead of the subnet with the most available addresses.
```
