### PR TITLE
docs: fix deployment resource type output

### DIFF
--- a/Documentation/security/cassandra.rst
+++ b/Documentation/security/cassandra.rst
@@ -67,10 +67,10 @@ above, as well as a Kubernetes Service *cassandra-svc* for the Cassandra cluster
 .. parsed-literal::
 
     $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes-cassandra/cass-sw-app.yaml
-    deployment.extensions/cass-server created
+    deployment.apps/cass-server created
     service/cassandra-svc created
-    deployment.extensions/empire-hq created
-    deployment.extensions/empire-outpost created
+    deployment.apps/empire-hq created
+    deployment.apps/empire-outpost created
 
 Kubernetes will deploy the pods and service in the background.
 Running ``kubectl get svc,pods`` will inform you about the progress of the operation.

--- a/Documentation/security/gsg_sw_demo.rst
+++ b/Documentation/security/gsg_sw_demo.rst
@@ -19,7 +19,7 @@ It also includes a deathstar-service, which load-balances traffic to all pods wi
 
     $ kubectl create -f \ |SCM_WEB|\/examples/minikube/http-sw-app.yaml
     service/deathstar created
-    deployment.extensions/deathstar created
+    deployment.apps/deathstar created
     pod/tiefighter created
     pod/xwing created
 

--- a/Documentation/security/memcached.rst
+++ b/Documentation/security/memcached.rst
@@ -61,11 +61,11 @@ above, as well as a Kubernetes Service *memcached-server* for the Memcached serv
 .. parsed-literal::
 
     $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes-memcached/memcd-sw-app.yaml
-    deployment.extensions/memcached-server created
+    deployment.apps/memcached-server created
     service/memcached-server created
-    deployment.extensions/a-wing created
-    deployment.extensions/x-wing created
-    deployment.extensions/alliance-tracker created
+    deployment.apps/a-wing created
+    deployment.apps/x-wing created
+    deployment.apps/alliance-tracker created
 
 Kubernetes will deploy the pods and service in the background.
 Running ``kubectl get svc,pods`` will inform you about the progress of the operation.

--- a/examples/kubernetes/addons/prometheus/README.md
+++ b/examples/kubernetes/addons/prometheus/README.md
@@ -27,14 +27,14 @@ Next, install all monitoring tools and configurations by running:
 $ kubectl create -f examples/kubernetes/addons/prometheus/monitoring-example.yaml
 namespace/monitoring created
 configmap/prometheus created
-deployment.extensions/prometheus created
+deployment.apps/prometheus created
 service/prometheus created
 service/prometheus-open created
 clusterrolebinding.rbac.authorization.k8s.io/prometheus created
 clusterrole.rbac.authorization.k8s.io/prometheus created
 serviceaccount/prometheus-k8s created
 configmap/grafana-config created
-deployment.extensions/grafana created
+deployment.apps/grafana created
 service/grafana created
 configmap/grafana-dashboards created
 job.batch/grafana-dashboards-import created


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
fix deployment apiversion error
Fixes: #issue-number

```release-note
docs: Fix `kubectl create` output in docs after some deployments have moved from K8s "extensions" to "apps".
```
