### PR TITLE
bpf: allow to enable host_routing and endpoint routes simultaneously

### DIFF
--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -14,6 +14,17 @@
 #include "icmp6.h"
 #include "csum.h"
 
+/*
+ * When the host routing is enabled we need to check policies at source, as in
+ * this case the skb is delivered directly to pod's namespace and the ingress
+ * policy (the cil_to_container BPF program) is bypassed.
+ */
+#if defined(ENABLE_ENDPOINT_ROUTES) && defined(ENABLE_HOST_ROUTING)
+#  ifndef FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
+#  define FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
+#  endif
+#endif
+
 #ifdef ENABLE_IPV6
 static __always_inline int ipv6_l3(struct __ctx_buff *ctx, int l3_off,
 				   const __u8 *smac, const __u8 *dmac,

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -457,8 +457,8 @@ func finishKubeProxyReplacementInit() error {
 		case option.Config.IptablesMasqueradingEnabled():
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
 		// All cases below still need to be implemented ...
-		case option.Config.EnableEndpointRoutes:
-			msg = fmt.Sprintf("BPF host routing is currently not supported with %s.", option.EnableEndpointRoutes)
+		case option.Config.EnableEndpointRoutes && option.Config.EnableIPv6:
+			msg = fmt.Sprintf("BPF host routing is currently not supported with %s when IPv6 is enabled.", option.EnableEndpointRoutes)
 		default:
 			if probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnRedirectNeigh) != nil ||
 				probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnRedirectPeer) != nil {


### PR DESCRIPTION
What the title says, see the commit message for details

Fixes: #14240

<!-- Description of change -->

```release-note
Enable endpoint routes + veth fast redirect support
```
