### PR TITLE
Revert "install: move cni config management to the agent"

### DIFF
--- a/Documentation/network/kubernetes/configuration.rst
+++ b/Documentation/network/kubernetes/configuration.rst
@@ -129,15 +129,17 @@ CNI
 delegate networking configuration. You can find additional information on the
 :term:`CNI` project website.
 
+.. note:: Kubernetes `` >= 1.3.5`` requires the ``loopback`` :term:`CNI` plugin to be
+          installed on all worker nodes. The binary is typically provided by
+          most Kubernetes distributions. See section :ref:`install_cni` for
+          instructions on how to install :term:`CNI` in case the ``loopback`` binary
+          is not already installed on your worker nodes.
+
 CNI configuration is automatically being taken care of when deploying Cilium
-via the provided :term:`DaemonSet`. Specifically, the agent writes the CNI
-configuration file once startup has completed and it is ready to handle
-PodSandbox creation.
+via the provided :term:`DaemonSet`. The script ``cni-install.sh`` is automatically run
+via the ``postStart`` mechanism when the ``cilium`` pod is started.
 
-The script ``cni-install.sh`` is automatically run via the ``postStart`` mechanism
-when the ``cilium`` pod is started. This installs the CNI binaries.
-
-.. note:: In order for CNI binary and configuration file installation to work,
+.. note:: In order for the ``cni-install.sh`` script to work properly, the
           ``kubelet`` task must either be running on the host filesystem of the
           worker node, or the ``/etc/cni/net.d`` and ``/opt/cni/bin``
           directories must be mounted into the container where ``kubelet`` is
@@ -148,60 +150,65 @@ The CNI auto installation is performed as follows:
 1. The ``/etc/cni/net.d`` and ``/opt/cni/bin`` directories are mounted from the
    host filesystem into the pod where Cilium is running.
 
-2. The file ``/etc/cni/net.d/05-cilium.conflist`` is written in case it does not
+2. The file ``/etc/cni/net.d/05-cilium.conf`` is written in case it does not
    exist yet.
 
 3. The binary ``cilium-cni`` is installed to ``/opt/cni/bin``. Any existing
    binary with the name ``cilium-cni`` is overwritten.
 
+.. _install_cni:
+
+Manually installing CNI
+-----------------------
+
+This step is typically already included in all Kubernetes distributions or
+Kubernetes installers but can be performed manually:
+
+.. code-block:: shell-session
+
+    sudo mkdir -p /opt/cni
+    wget https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
+    sudo tar -xvf cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz -C /opt/cni
+    rm cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
+
+
 Adjusting CNI configuration
 ---------------------------
 
 The CNI configuration file is automatically written and maintained by the
-cilium pod. It is written after the agent has finished initialization and
-is ready to handle pod sandbox creation. In addition, the agent will remove
-any other CNI configuration files by default.
+scripts ``cni-install.sh`` and ``cni-uninstall.sh`` which are running as
+``postStart`` and ``preStop`` hooks of the Cilium pod.
 
-There are a number of Helm variables that adjust CNI configuration management.
-For a full description, see the helm documentation. A brief summary:
+If you want to provide your own custom CNI configuration file, set the
+``CILIUM_CUSTOM_CNI_CONF`` environment variable to avoid overwriting the
+configuration file by adding the following to the ``env:`` section of the
+``cilium`` DaemonSet:
 
-+----------------+----------------------------------------+---------+
-| Helm variable  | Description                            | Default |
-+================+========================================+=========+
-| cni.customConf | Disable CNI configuration management   | false   |
-+----------------+----------------------------------------+---------+
-| cni.exclusive  | Remove other CNI configuration files   | true    |
-+----------------+----------------------------------------+---------+
-| cni.install    | Install CNI configuration and binaries | true    |
-+----------------+----------------------------------------+---------+
+.. code-block:: yaml
 
+        - name: CILIUM_CUSTOM_CNI_CONF
+          value: "true"
 
-If you want to provide your own custom CNI configuration file, you can do
-so by passing a path to a cni template file, either on disk or provided
-via a configMap. The Helm options that configure this are:
+The CNI installation can be configured with environment variables. These
+environment variables can be specified in the :term:`DaemonSet` file like this:
 
-+------------------+----------------------------------------------------------------+
-| Helm variable    | Description                                                    |
-+==================+================================================================+
-| cni.readCniConf  | Path (inside the agent) to a source CNI configuration file     |
-+------------------+----------------------------------------------------------------+
-| cni.configMap    | Name of a ConfigMap containing a source CNI configuration file |
-+------------------+----------------------------------------------------------------+
-| cni.configMapKey | Install CNI configuration and binaries                         |
-+------------------+----------------------------------------------------------------+
+.. code-block:: yaml
 
-These Helm variables are converted to a smaller set of cilium ConfigMap keys:
+    env:
+      - name: "CNI_CONF_NAME"
+        value: "05-cilium.conf"
 
-+---------------------------+--------------------------------------------------------+
-| ConfigMap key             | Description                                            |
-+===========================+========================================================+
-| write-cni-conf-when-ready | Path to write the CNI configuration file               |
-+---------------------------+--------------------------------------------------------+
-| read-cni-conf             | Path to read the source CNI configuration file         |
-+---------------------------+--------------------------------------------------------+
-| cni-exclusive             | Whether or not to remove other CNI configuration files |
-+---------------------------+--------------------------------------------------------+
+The following variables are supported:
 
++---------------------+--------------------------------------+------------------------+
+| Option              | Description                          | Default                |
++---------------------+--------------------------------------+------------------------+
+| HOST_PREFIX         | Path prefix of all host mounts       | /host                  |
++---------------------+--------------------------------------+------------------------+
+| CNI_DIR             | Path to mounted CNI plugin directory | ${HOST_PREFIX}/opt/cni |
++---------------------+--------------------------------------+------------------------+
+| CNI_CONF_NAME       | Name of configuration file           | 05-cilium.conf         |
++---------------------+--------------------------------------+------------------------+
 
 CRD Validation
 ==============

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -318,12 +318,6 @@ Removed Options
 * The ineffective ``disable-conntrack``, ``endpoint-interface-name-prefix`` options deprecated in
   version 1.12 have been removed.
 
-New Options
-~~~~~~~~~~~
-
-* ``cni-exclusive``: If set, this tells the agent to remove non-Cilium CNI configuration files
-* ``cni-log-file``: A file, relative to the host, where the CNI plugin can write logs.
-
 Added Metrics
 ~~~~~~~~~~~~~
 

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -61,6 +61,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
 
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/cni-install.sh \
+     plugins/cilium-cni/cni-uninstall.sh \
        /tmp/install/${TARGETOS}/${TARGETARCH}
 
 #

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -188,6 +188,18 @@ spec:
               fieldPath: metadata.namespace
         - name: CILIUM_CLUSTERMESH_CONFIG
           value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: cni-chaining-mode
+              optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: custom-cni-conf
+              optional: true
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.k8sServiceHost | quote }}
@@ -198,6 +210,20 @@ spec:
         {{- end }}
         {{- with .Values.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+        {{- if .Values.cni.install }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - "/cni-install.sh"
+              - "--enable-debug={{ .Values.debug.enabled }}"
+              - "--cni-exclusive={{ .Values.cni.exclusive }}"
+              - "--log-file={{ .Values.cni.logFile }}"
+          preStop:
+            exec:
+              command:
+              - /cni-uninstall.sh
         {{- end }}
         {{- with .Values.resources }}
         resources:
@@ -612,19 +638,6 @@ spec:
             done
         terminationMessagePolicy: FallbackToLogsOnError
       {{- end }} # wait-for-kube-proxy
-      {{ if .Values.cni.install }}
-      - name: install-cni-binary
-        image: {{ include "cilium.image" .Values.image | quote }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        securityContext:
-          privileged: true
-        command:
-          - "/cni-install.sh"
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - name: cni-path
-          mountPath: /host/opt/cni/bin
-      {{- end }} # install-cni-binary
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -244,6 +244,12 @@ data:
   clean-cilium-bpf-state: "true"
 {{- end }}
 
+{{- if hasKey .Values.cni "customConf" }}
+  # Users who wish to specify their own custom CNI configuration file must set
+  # custom-cni-conf to "true", otherwise Cilium may overwrite the configuration.
+  custom-cni-conf: "{{ .Values.cni.customConf }}"
+{{- end }}
+
 {{- if hasKey .Values "bpfClockProbe" }}
   enable-bpf-clock-probe: {{ .Values.bpfClockProbe | quote }}
 {{- else if eq $defaultBpfClockProbe "true" }}
@@ -438,6 +444,16 @@ data:
 {{- end }}
 
 {{- if ne .Values.cni.chainingMode "none" }}
+  # Enable chaining with another CNI plugin
+  #
+  # Supported modes:
+  #  - none
+  #  - aws-cni
+  #  - flannel
+  #  - generic-veth
+  #  - portmap (Enables HostPort support for Cilium)
+  cni-chaining-mode: {{ .Values.cni.chainingMode }}
+
 {{- if hasKey .Values "enableIdentityMark" }}
   enable-identity-mark: {{ .Values.enableIdentityMark | quote }}
 {{- else if (ne $enableIdentityMark "true") }}
@@ -670,36 +686,12 @@ data:
 {{- if and .Values.endpointRoutes .Values.endpointRoutes.enabled }}
   enable-endpoint-routes: {{ .Values.endpointRoutes.enabled | quote }}
 {{- end }}
-
-  ## CNI configuration
-{{- if and .Values.cni.install  (not .Values.cni.customConf)  }}
-  # direct Cilium agent to write a CNI configuration to disk on startup
-  write-cni-conf-when-ready: {{ print .Values.cni.hostConfDirMountPath "/05-cilium.conflist" | quote }}
-
-{{- if hasKey .Values.cni "configMap" }}
-  # user-supplied CNI configuration via a ConfigMap
+{{- if .Values.cni.configMap }}
   read-cni-conf: {{ .Values.cni.confFileMountPath }}/{{ .Values.cni.configMapKey }}
-{{- else if hasKey .Values.cni "readCniConf" }}
-  # user-supplied CNI configuration from disk
+  write-cni-conf-when-ready: {{ .Values.cni.hostConfDirMountPath }}/05-cilium.conflist
+{{- else if .Values.cni.readCniConf }}
   read-cni-conf: {{ .Values.cni.readCniConf }}
 {{- end }}
-
-  # Enable chaining with another CNI plugin
-  #
-  # Supported modes:
-  #  - none
-  #  - aws-cni
-  #  - flannel
-  #  - generic-veth
-  #  - portmap (Enables HostPort support for Cilium)
-  cni-chaining-mode: {{ .Values.cni.chainingMode | quote }}
-{{- if .Values.cni.logFile }}
-  cni-log-file: {{ .Values.cni.logFile}}
-{{- end }}
-  # if cni-exclusive is set to true, Cilium will remove any pre-existing CNI configurations
-  cni-exclusive: {{ .Values.cni.exclusive | quote}}
-{{- end }}
-
 {{- if .Values.kubeConfigPath }}
   k8s-kubeconfig-path: {{ .Values.kubeConfigPath | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -465,7 +465,7 @@ cni:
   # This can be useful if you want to manage your CNI
   # configuration outside of a Kubernetes environment. This parameter is
   # mutually exclusive with the 'cni.configMap' parameter.
-  # readCniConf: /host/etc/cni/net.d/05-cilium.conf.template
+  # readCniConf: /host/etc/cni/net.d/05-cilium.conf
 
   # -- When defined, configMap will mount the provided value as ConfigMap and
   # interpret the cniConf variable as CNI configuration file and write it

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -462,7 +462,7 @@ cni:
   # This can be useful if you want to manage your CNI
   # configuration outside of a Kubernetes environment. This parameter is
   # mutually exclusive with the 'cni.configMap' parameter.
-  # readCniConf: /host/etc/cni/net.d/05-cilium.conf.template
+  # readCniConf: /host/etc/cni/net.d/05-cilium.conf
 
   # -- When defined, configMap will mount the provided value as ConfigMap and
   # interpret the cniConf variable as CNI configuration file and write it

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -1,30 +1,257 @@
 #!/bin/bash
 
-# This script copies over the cilium-cni and localhost CNI plugin binaries
-# to the host.
-
 set -e
 
+HOST_PREFIX=${HOST_PREFIX:-/host}
+
+case "$CILIUM_CNI_CHAINING_MODE" in
+"flannel")
+	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
+	;;
+"generic-veth")
+	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
+	;;
+"portmap")
+	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
+	;;
+"aws-cni")
+	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
+	;;
+*)
+	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conf}
+	;;
+esac
+
+ENABLE_DEBUG=false
+CNI_EXCLUSIVE=true
+LOG_FILE="/var/run/cilium/cilium-cni.log"
+
+while test $# -gt 0; do
+  case "$1" in
+    --enable-debug*)
+      # shellcheck disable=SC2001
+      # the below sed is to support both formats "--flag value" and "--flag=value"
+      ENABLE_DEBUG=$(echo "$1" | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --cni-exclusive*)
+      # shellcheck disable=SC2001
+      # the below sed is to support both formats "--flag value" and "--flag=value"
+      CNI_EXCLUSIVE=$(echo "$1" | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --log-file*)
+      # shellcheck disable=SC2001
+      # the below sed is to support both formats "--flag value" and "--flag=value"
+      LOG_FILE=$(echo "$1" | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 BIN_NAME=cilium-cni
-CNI_BIN_DIR=/host/opt/cni/bin
+CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
+CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
+CNI_CONF_DIR="$(dirname "$CILIUM_CNI_CONF")"
+CILIUM_CUSTOM_CNI_CONF=${CILIUM_CUSTOM_CNI_CONF:-false}
 
-function atomic_cp {
-  local src="$1"
-  local dst="$2"
-
-  cp "${src}" "${dst}.tmp"
-  mv "${dst}.tmp" "${dst}"
-}
+if [ ! -d "${CNI_DIR}/bin" ]; then
+	mkdir -p "${CNI_DIR}/bin"
+fi
 
 # Install the CNI loopback driver if not installed already
-if [ ! -f "${CNI_BIN_DIR}/loopback" ]; then
+if [ ! -f "${CNI_DIR}/bin/loopback" ]; then
 	echo "Installing loopback driver..."
 
 	# Don't fail hard if this fails as it is usually not required
-	cp /cni/loopback "${CNI_BIN_DIR}/loopback" || true
+	cp /cni/loopback "${CNI_DIR}/bin/" || true
 fi
 
-echo "Installing ${BIN_NAME} to ${CNI_BIN_DIR} ..."
+echo "Installing ${BIN_NAME} to ${CNI_DIR}/bin/ ..."
 
+# Move an eventual old existing binary out of the way, we can't delete it
+# as it might be in use right now.
+if [ -f "${CNI_DIR}/bin/${BIN_NAME}" ]; then
+	rm -f "${CNI_DIR}/bin/${BIN_NAME}.old" || true
+	mv "${CNI_DIR}/bin/${BIN_NAME}" "${CNI_DIR}/bin/${BIN_NAME}.old"
+fi
 
-atomic_cp "/opt/cni/bin/${BIN_NAME}" "${CNI_BIN_DIR}/${BIN_NAME}"
+cp "/opt/cni/bin/${BIN_NAME}" "${CNI_DIR}/bin/"
+
+# The CILIUM_CUSTOM_CNI_CONF env is set by the `cni.customConf` Helm option.
+# It stops this script from touching the host's CNI config directory.
+# However, the agent will still write to the location specified by the
+# `--write-cni-conf-when-ready` flag when `cni.configMap` is set.
+if [ "${CILIUM_CUSTOM_CNI_CONF}" == "true" ]; then
+	echo "User is managing Cilium's CNI config externally, exiting..."
+	exit 0
+fi
+
+# Remove any active Cilium CNI configurations left over from previous installs
+# to make sure the one we're installing later will take effect.
+# Ignore the file specified by CNI_CONF_NAME. The agent will use this
+# filename to write a user-specified CNI config and races against this script.
+echo "Removing active Cilium CNI configurations from ${CNI_CONF_DIR}})..."
+find "${CNI_CONF_DIR}" -maxdepth 1 -type f \
+  -name '*cilium*' -and \( \
+    -name '*.conf' -or \
+    -name '*.conflist' \
+  \) \
+  -not -name "${CNI_CONF_NAME}" \
+  -delete
+
+# Check that a CNI configuration already exists in certain chaining modes.
+# Exit if it does not - provoking a restart later on. This is required to
+# wait until the main CNI has been initialized, e.g. by another pod.
+# *.cilium_bak files are also accepted in case this script already ran on
+# the host.
+case "$CILIUM_CNI_CHAINING_MODE" in
+"aws-cni")
+  tries=30
+  while [[ $tries -gt 0 ]]; do
+  if test -n "$(find "${CNI_CONF_DIR}" -maxdepth 1 -type f -name '*.conf' -or -name '*.conflist' -or -name '*.cilium_bak' )"; then
+      echo "Found existing CNI config for chaining"
+      break
+    else
+      echo "Could not find existing AWS VPC CNI config for chaining, will retry..."
+      tries=$((tries-1))
+      sleep 5
+    fi
+  done
+  if [[ $tries -eq 0 ]]; then
+    echo "Existing CNI config is required for chaining but does not exist yet, exiting..."
+    exit 1
+  fi
+  ;;
+*)
+  echo "Existing CNI config is not required"
+  ;;
+esac
+
+# Rename all remaining CNI configurations to *.cilium_bak. This ensures only
+# Cilium's CNI plugin will remain active. This makes sure Pods are not
+# scheduled by another CNI when the Cilium agent is down during upgrades
+# or restarts. See GH-14128 and related issues for more context.
+if [ "${CNI_EXCLUSIVE}" != "false" ]; then
+  find "$(dirname "${CILIUM_CNI_CONF}")" \
+     -maxdepth 1 \
+     -type f \
+     \( -name '*.conf' \
+     -or -name '*.conflist' \
+     -or -name '*.json' \
+     \) \
+     -not \( -name '*.cilium_bak' \
+     -or -name "${CNI_CONF_NAME}" \) \
+     -exec mv {} {}.cilium_bak \;
+fi
+
+echo "Installing new ${CILIUM_CNI_CONF}..."
+case "$CILIUM_CNI_CHAINING_MODE" in
+"flannel")
+	cat > "${CNI_CONF_NAME}" <<EOF
+{
+  "cniVersion": "0.3.1",
+  "name": "flannel",
+  "plugins": [
+    {
+      "type": "flannel",
+      "delegate": {
+         "hairpinMode": true,
+         "isDefaultGateway": true
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {
+        "portMappings": true
+      }
+    },
+    {
+       "name": "cilium",
+       "type": "cilium-cni",
+       "enable-debug": ${ENABLE_DEBUG},
+       "log-file": "${LOG_FILE}"
+    }
+  ]
+}
+EOF
+	;;
+
+"portmap")
+	cat > "${CNI_CONF_NAME}" <<EOF
+{
+  "cniVersion": "0.3.1",
+  "name": "portmap",
+  "plugins": [
+    {
+       "name": "cilium",
+       "type": "cilium-cni",
+       "enable-debug": ${ENABLE_DEBUG},
+       "log-file": "${LOG_FILE}"
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}
+EOF
+	;;
+
+"aws-cni")
+  if [ -f "${CNI_CONF_DIR}/10-aws.conflist.cilium_bak" ]; then
+    jq --argjson 'ENABLE_DEBUG' "$ENABLE_DEBUG" --arg 'LOG_FILE' "$LOG_FILE" \
+          '.plugins += [{"name": "cilium", "type": "cilium-cni", "enable-debug": $ENABLE_DEBUG, "log-file": $LOG_FILE}]' \
+          "${CNI_CONF_DIR}/10-aws.conflist.cilium_bak" > "${CNI_CONF_NAME}"
+  else
+    cat > "${CNI_CONF_NAME}" <<EOF
+{
+  "cniVersion": "0.3.1",
+  "name": "aws-cni",
+  "plugins": [
+    {
+      "name": "aws-cni",
+      "type": "aws-cni",
+      "vethPrefix": "eni",
+      "mtu": "9001",
+      "pluginLogFile": "/var/log/aws-routed-eni/plugin.log",
+      "pluginLogLevel": "DEBUG"
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true},
+      "snat": true
+    },
+    {
+       "name": "cilium",
+       "type": "cilium-cni",
+       "enable-debug": ${ENABLE_DEBUG},
+       "log-file": "${LOG_FILE}"
+    }
+  ]
+}
+EOF
+  fi
+  ;;
+
+*)
+	cat > "${CNI_CONF_NAME}" <<EOF
+{
+  "cniVersion": "0.3.1",
+  "name": "cilium",
+  "type": "cilium-cni",
+  "enable-debug": ${ENABLE_DEBUG},
+  "log-file": "${LOG_FILE}"
+}
+EOF
+	;;
+esac
+
+if [ ! -d "$(dirname "$CILIUM_CNI_CONF")" ]; then
+	mkdir -p "$(dirname "$CILIUM_CNI_CONF")"
+fi
+
+mv "${CNI_CONF_NAME}" "${CILIUM_CNI_CONF}"

--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+HOST_PREFIX=${HOST_PREFIX:-/host}
+BIN_NAME=cilium-cni
+CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
+CNI_CONF_DIR=${CNI_CONF_DIR:-${HOST_PREFIX}/etc/cni/net.d}
+CILIUM_CUSTOM_CNI_CONF=${CILIUM_CUSTOM_CNI_CONF:-false}
+
+# Do not interact with the host's CNI directory when the user specified they
+# are managing CNI configs externally.
+if [ "${CILIUM_CUSTOM_CNI_CONF}" != "true" ]; then
+    # .conf/.conflist/.json (undocumented) are read by kubelet/dockershim's CNI implementation.
+    # Remove any active Cilium CNI configurations to prevent scheduling Pods during agent
+    # downtime. Configs belonging to other CNI implementations have already been renamed
+    # to *.cilium_bak during agent startup.
+    echo "Removing active Cilium CNI configurations from ${CNI_CONF_DIR}..."
+    find "${CNI_CONF_DIR}" -maxdepth 1 -type f \
+    -name '*cilium*' -and \( \
+        -name '*.conf' -or \
+        -name '*.conflist' \
+    \) -delete
+fi
+
+echo "Removing ${CNI_DIR}/bin/cilium-cni..."
+rm -f "${CNI_DIR}/bin/${BIN_NAME}"
+rm -f "${CNI_DIR}/bin/${BIN_NAME}.old"


### PR DESCRIPTION
This pull request reverts commit 0d6346dbe5bada046eb72ab2f797fa4c0f86d07e.

This commit is causing issues on AKS where newly-created pods are not getting managed by Cilium for some reason. Reverting to unblock AKS testing.

The revert was successfully tested on 3-nodes clusters on AKS (Azure IPAM mode), EKS, and GKE. Each time, the full connectivity tests were run using the CLI.

cc @squeed 
Fixes: https://github.com/cilium/cilium/pull/21375.
Fixes: https://github.com/cilium/cilium/issues/22013.