### PR TITLE
clean package "io/ioutil" ,because "io" and "os" can replaced it totally

### DIFF
--- a/pkg/alibabacloud/metadata/metadata.go
+++ b/pkg/alibabacloud/metadata/metadata.go
@@ -6,7 +6,7 @@ package metadata
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -67,7 +67,7 @@ func getMetadata(ctx context.Context, path string) (string, error) {
 	}
 
 	defer resp.Body.Close()
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/netip"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -1116,7 +1116,7 @@ func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
 	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
 	fmt.Printf("\tNumGC = %v\n", m.NumGC)
 
-	bb, err := ioutil.ReadFile(cnpFile)
+	bb, err := os.ReadFile(cnpFile)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -6,7 +6,6 @@ package suite
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/cilium/cilium/daemon/cmd"
@@ -64,7 +63,7 @@ func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) 
 }
 
 func setupTestDirectories() string {
-	tempDir, err := ioutil.TempDir("", "cilium-test-")
+	tempDir, err := os.MkdirTemp("", "cilium-test-")
 	if err != nil {
 		panic(fmt.Sprintf("TempDir() failed: %s", err))
 	}

--- a/test/k8s/bgp.go
+++ b/test/k8s/bgp.go
@@ -6,7 +6,6 @@ package k8sTest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -181,7 +180,7 @@ func applyFRRTemplate(kubectl *helpers.Kubectl, ni *helpers.NodesInfo) string {
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, content).ToNot(BeEmpty())
 
-	render, err := ioutil.TempFile(os.TempDir(), "frr-")
+	render, err := os.CreateTemp(os.TempDir(), "frr-")
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	defer render.Close()
 
@@ -206,7 +205,7 @@ func applyBGPCMTemplate(kubectl *helpers.Kubectl, ip string) string {
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, content).ToNot(BeEmpty())
 
-	render, err := ioutil.TempFile(os.TempDir(), "bgp-cm-")
+	render, err := os.CreateTemp(os.TempDir(), "bgp-cm-")
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	defer render.Close()
 

--- a/tools/crdcheck/main.go
+++ b/tools/crdcheck/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -38,7 +37,7 @@ func main() {
 			return nil
 		}
 
-		fileContent, err := ioutil.ReadFile(path)
+		fileContent, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

We should clean all io/util package according the url: https://go.dev/doc/go1.16#ioutil
/kind cleanup