### PR TITLE
gh/workflows: Add 4.19 kernel to the CI DP conformance

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -119,8 +119,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kernel: ['5.4', '5.10', '5.15', 'bpf-next']
-    timeout-minutes: 120
+        kernel: ['4.19-main', '5.4-main', '5.10-main', '5.15-main', 'bpf-next-main']
+    timeout-minutes: 60
     steps:
       - name: Set up job variables
         id: vars
@@ -169,7 +169,7 @@ jobs:
           done
 
       - name: Run tests
-        uses: cilium/little-vm-helper-action@9eb481cbe6a32bf74273106b315d43aeaa46a2ee
+        uses: cilium/little-vm-helper@4f44430a3c7573023ec58959cd0f88e1d2c00e13
         with:
           test-name: datapath-conformance
           image: kind
@@ -205,7 +205,7 @@ jobs:
 
       - name: Fetch artifacts
         if: ${{ !success() }}
-        uses: cilium/little-vm-helper-action@9eb481cbe6a32bf74273106b315d43aeaa46a2ee
+        uses: cilium/little-vm-helper@4f44430a3c7573023ec58959cd0f88e1d2c00e13
         with:
           provision: 'false'
           cmd: |


### PR DESCRIPTION
Also:
- Switch the LVH GH action location (cilium/little-vm-helper-action is no longer used).
- Use tagged LVH VM image versions (currently it uses `main` (aka the latest)).

The CI green run - https://github.com/cilium/cilium/actions/runs/3416955761/jobs/5687625286.