### PR TITLE
Load multiple programs for one CollectionSpec loading

### DIFF
--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -253,7 +253,8 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 
 	for i, interfaceName := range interfaceNames {
 		symbol := symbols[i]
-		finalize, err := replaceDatapath(ctx, interfaceName, objPaths[i], symbol, directions[i], "")
+		progs := []progDefinition{{progName: symbol, direction: directions[i]}}
+		finalize, err := replaceDatapath(ctx, interfaceName, objPaths[i], progs, "")
 		if err != nil {
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
@@ -284,7 +285,18 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 			return err
 		}
 	} else {
-		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, "")
+		progs := []progDefinition{{progName: symbolFromEndpoint, direction: dirIngress}}
+
+		if ep.RequireEgressProg() {
+			progs = append(progs, progDefinition{progName: symbolToEndpoint, direction: dirEgress})
+		} else {
+			err := RemoveTCFilters(ep.InterfaceName(), netlink.HANDLE_MIN_EGRESS)
+			if err != nil {
+				log.WithField("device", ep.InterfaceName()).Error(err)
+			}
+		}
+
+		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, "")
 		if err != nil {
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
@@ -294,34 +306,11 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 			// this log message should only represent failures with respect to
 			// loading the program.
 			if ctx.Err() == nil {
-				scopedLog.WithError(err).Warn("JoinEP: Failed to attach ingress program")
+				scopedLog.WithError(err).Warn("JoinEP: Failed to attach program(s)")
 			}
 			return err
 		}
 		defer finalize()
-
-		if ep.RequireEgressProg() {
-			finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolToEndpoint, dirEgress, "")
-			if err != nil {
-				scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
-					logfields.Path: objPath,
-					logfields.Veth: ep.InterfaceName(),
-				})
-				// Don't log an error here if the context was canceled or timed out;
-				// this log message should only represent failures with respect to
-				// loading the program.
-				if ctx.Err() == nil {
-					scopedLog.WithError(err).Warn("JoinEP: Failed to attach egress program")
-				}
-				return err
-			}
-			defer finalize()
-		} else {
-			err := RemoveTCFilters(ep.InterfaceName(), netlink.HANDLE_MIN_EGRESS)
-			if err != nil {
-				log.WithField("device", ep.InterfaceName()).Error(err)
-			}
-		}
 	}
 
 	if ep.RequireEndpointRoute() {
@@ -347,8 +336,9 @@ func (l *Loader) replaceNetworkDatapath(ctx context.Context, interfaces []string
 	if err := compileNetwork(ctx); err != nil {
 		log.WithError(err).Fatal("failed to compile encryption programs")
 	}
+	progs := []progDefinition{{progName: symbolFromNetwork, direction: dirIngress}}
 	for _, iface := range option.Config.EncryptInterface {
-		finalize, err := replaceDatapath(ctx, iface, networkObj, symbolFromNetwork, dirIngress, "")
+		finalize, err := replaceDatapath(ctx, iface, networkObj, progs, "")
 		if err != nil {
 			log.WithField(logfields.Interface, iface).WithError(err).Fatal("Load encryption network failed")
 		}

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -188,11 +188,15 @@ func (s *LoaderTestSuite) TestReload(c *C) {
 	c.Assert(err, IsNil)
 
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
-	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, "")
+	progs := []progDefinition{
+		{progName: symbolFromEndpoint, direction: dirIngress},
+		{progName: symbolToEndpoint, direction: dirEgress},
+	}
+	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, "")
 	c.Assert(err, IsNil)
 	finalize()
 
-	finalize, err = replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, "")
+	finalize, err = replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, "")
 	c.Assert(err, IsNil)
 	finalize()
 }
@@ -274,9 +278,10 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 	}
 
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
+	progs := []progDefinition{{progName: symbolFromEndpoint, direction: dirIngress}}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, "")
+		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, "")
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -118,7 +118,8 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev, xdpMode string, extraCAr
 	}
 
 	objPath := path.Join(dirs.Output, prog.Output)
-	finalize, err := replaceDatapath(ctx, xdpDev, objPath, symbolFromHostNetdevXDP, "", xdpMode)
+	progs := []progDefinition{{progName: symbolFromHostNetdevXDP, direction: ""}}
+	finalize, err := replaceDatapath(ctx, xdpDev, objPath, progs, xdpMode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a continuation of the effort towards reducing Pod Startup Latency for Kubernetes (#22023). 

This change is a follow-up on #20702 (Parallel reloading of ingress and egress eBPF programs), it introduces the ability to load multiple programs with loading and verifying CollectionSpec just once per objPath. After the change the pod startup latency was reduced by ~300ms (3.6 to 3.3 seconds for 100 nodes).

Signed-off-by: Alex Katsman <alexkats@google.com>