### PR TITLE
v1.12 backports 2022-11-07

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -157,8 +157,8 @@ brought up by vagrant:
   test/bpf/verifier-test.sh``.
 * ``IPV4=1``: Run Cilium with IPv4 enabled.
 * ``RUNTIME=x``: Sets up the container runtime to be used inside a kubernetes
-  cluster. Valid options are: ``docker``, ``containerd`` and ``crio``. If not
-  set, it defaults to ``docker``.
+  cluster. Valid options are: ``containerd`` and ``crio``. If not
+  set, it defaults to ``containerd``.
 * ``VM_SET_PROXY=https://127.0.0.1:80/`` Sets up VM's ``https_proxy``.
 * ``INSTALL=1``: Restarts the installation of Cilium, Kubernetes, etc. Only
   useful when the installation was interrupted.

--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -12,10 +12,11 @@ Azure CNI
 
 .. note::
 
-   This is not the best option to run Cilium on AKS or Azure. Please refer to
-   :ref:`k8s_install_quick` for the best guide to run Cilium in Azure Cloud.
-   Follow this guide if you specifically want to run Cilium in combination with
-   the Azure CNI in a chaining configuration.
+   For most users, the best way to run Cilium on AKS is either
+   AKS BYO CNI as described in :ref:`k8s_install_quick`
+   or `Azure CNI Powered by Cilium <https://aka.ms/aks/cilium-dataplane>`_.
+   This guide provides alternative instructions to run Cilium with Azure CNI
+   in a chaining configuration.
 
 .. include:: cni-chaining-limitations.rst
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -472,7 +472,6 @@ enabled would look as follows:
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set tunnel=disabled \\
-        --set autoDirectNodeRoutes=true \\
         --set kubeProxyReplacement=strict \\
         --set loadBalancer.mode=dsr \\
         --set k8sServiceHost=${API_SERVER_IP} \\
@@ -501,7 +500,6 @@ mode would look as follows:
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set tunnel=disabled \\
-        --set autoDirectNodeRoutes=true \\
         --set kubeProxyReplacement=strict \\
         --set loadBalancer.mode=hybrid \\
         --set k8sServiceHost=${API_SERVER_IP} \\
@@ -537,7 +535,6 @@ looks as follows:
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set tunnel=disabled \\
-        --set autoDirectNodeRoutes=true \\
         --set kubeProxyReplacement=strict \\
         --set socketLB.hostNamespaceOnly=true
 
@@ -574,7 +571,6 @@ modes and can be enabled as follows for ``loadBalancer.mode=hybrid`` in this exa
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set tunnel=disabled \\
-        --set autoDirectNodeRoutes=true \\
         --set kubeProxyReplacement=strict \\
         --set loadBalancer.acceleration=native \\
         --set loadBalancer.mode=hybrid \\
@@ -762,7 +758,6 @@ Finally, the deployment can be upgraded and later rolled-out with the
   helm upgrade cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --reuse-values \\
-        --set autoDirectNodeRoutes=true \\
         --set kubeProxyReplacement=strict \\
         --set loadBalancer.acceleration=native \\
         --set loadBalancer.mode=snat \\

--- a/Documentation/gettingstarted/rancher-desktop-override.yaml
+++ b/Documentation/gettingstarted/rancher-desktop-override.yaml
@@ -1,6 +1,6 @@
 env:
   # needed for cilium
-  K3S_EXEC: '--flannel-backend=none --disable-network-policy'
+  INSTALL_K3S_EXEC: '--flannel-backend=none --disable-network-policy'
 provision:
   # needs root to mount
   - mode: system

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -47,18 +47,20 @@ iproute2                 >= 5.9.0 [#iproute2_foot]_ yes
 .. [#iproute2_foot] Requires support for eBPF templating as documented
    :ref:`below <iproute2_requirements>`.
 
-Linux Distribution Compatibility Matrix
-=======================================
+Linux Distribution Compatibility & Considerations 
+=================================================
 
 The following table lists Linux distributions that are known to work
-well with Cilium.
+well with Cilium. Some distributions require a few initial tweaks. Please make
+sure to read each distribution's specific notes below before attempting to
+run Cilium.
 
 ========================== ====================
 Distribution               Minimum Version
 ========================== ====================
 `Amazon Linux 2`_          all
 `Container-Optimized OS`_  all
-`CentOS`_                  >= 7.0 [#centos_foot]_
+`CentOS`_                  >= 7.0
 Debian_                    >= 9 Stretch
 `Fedora Atomic/Core`_      >= 25
 Flatcar_                   all
@@ -81,22 +83,64 @@ RancherOS_                 >= 1.5.5
 .. _Opensuse: https://www.opensuse.org/
 .. _RancherOS: https://rancher.com/rancher-os/
 
-.. [#centos_foot] CentOS 7 requires a third-party kernel provided by `ElRepo <http://elrepo.org/tiki/tiki-index.php>`_
-    whereas CentOS 8 ships with a supported kernel. Note that some more advanced features may not be available on CentOS 7 even with a third-party kernel. For full details on which kernel config options must be enabled in order to use various features, see the section on :ref:`admin_kernel_version` requirements below.
-
 .. note:: The above list is based on feedback by users. If you find an unlisted
           Linux distribution that works well, please let us know by opening a
           GitHub issue or by creating a pull request that updates this guide.
 
-.. note:: Systemd 245 and above (``systemctl --version``) overrides ``rp_filter`` setting
-          of Cilium network interfaces. This introduces connectivity issues
-          (see :gh-issue:`10645` for details). To avoid that, configure
-          ``rp_filter`` in systemd using the following commands:
 
-          .. code-block:: shell-session
+CentOS 7
+~~~~~~~~
 
-              echo 'net.ipv4.conf.lxc*.rp_filter = 0' > /etc/sysctl.d/99-override_cilium_rp_filter.conf
-              systemctl restart systemd-sysctl
+CentOS 7 requires a third-party kernel provided by `ElRepo <http://elrepo.org/tiki/tiki-index.php>`_
+whereas CentOS 8 ships with a supported kernel. Note that some more advanced
+features may not be available on CentOS 7 even with a third-party kernel. For
+full details on which kernel config options must be enabled in order to use
+various features, see the section on :ref:`admin_kernel_version` requirements
+below.
+
+
+systemd-based distributions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some distributions need to be configured not to manage "foreign" routes. This
+is the case in Ubuntu 22.04, for example (see :gh-issue:`18706`). This can
+usually be done by setting
+
+.. code-block:: text
+
+   ManageForeignRoutes=no
+   ManageForeignRoutingPolicyRules=no
+
+in ``/etc/systemd/networkd.conf``, but please refer to your distribution's
+documentation for the right way to perform this override.
+
+
+Flatcar
+~~~~~~~
+
+Flatcar is known to manipulate network interfaces created and managed by
+Cilium. This is especially true in the official Flatcar image for AWS EKS, and
+causes connectivity issues and potentially prevents the Cilium agent from
+booting when Cilium is running in ENI mode. To avoid this, disable DHCP on
+these interfaces and mark them as unmanaged by adding
+
+.. code-block:: text
+
+        [Match]
+        Name=eth[1-9]*
+
+        [Network]
+        DHCP=no
+
+        [Link]
+        Unmanaged=yes
+
+to ``/etc/systemd/network/01-no-dhcp.network`` and then
+
+.. code-block:: shell-session
+
+        systemctl daemon-reload
+        systemctl restart systemd-networkd
 
 .. _admin_kernel_version:
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -11,6 +11,8 @@
 
 #include <linux/icmpv6.h>
 
+#define IS_BPF_LXC 1
+
 #define EVENT_SOURCE LXC_ID
 
 #include "lib/tailcall.h"

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -544,7 +544,7 @@ drop_err:
 }
 #endif /* ENABLE_DSR */
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT)
+declare_tailcall_if(__not(is_defined(IS_BPF_LXC)), CILIUM_CALL_IPV6_NODEPORT_NAT)
 int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 {
 	enum nat_dir dir = (enum nat_dir)ctx_load_meta(ctx, CB_NAT);
@@ -1421,7 +1421,7 @@ drop_err:
 }
 #endif /* ENABLE_DSR */
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_NAT)
+declare_tailcall_if(__not(is_defined(IS_BPF_LXC)), CILIUM_CALL_IPV4_NODEPORT_NAT)
 int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 {
 	enum nat_dir dir = (enum nat_dir)ctx_load_meta(ctx, CB_NAT);

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -27,6 +27,10 @@
 #define __or3_0(y, z)  __or(y, z)
 #define __or3(x, y, z) __eval(__or3_, x)(y, z)
 
+#define __not_0 1
+#define __not_1 0
+#define __not(x) __eval(__not_, x)
+
 /* declare_tailcall_if() and invoke_tailcall_if() is a pair
  * of helpers which based on COND either selects to emit a
  * tail call for the underlying function when true or emits

--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -29,15 +29,6 @@ KUBELET_DEFAULTS_FILE="/etc/default/kubelet"
 if [[ -f "${GKE_KUBERNETES_BIN_DIR}/gke" ]] && [[ $(grep -cF -- '--container-runtime-endpoint' "${KUBELET_DEFAULTS_FILE}") == "1" ]]; then
   echo "GKE *_containerd flavor detected..."
 
-  # kubelet version string format is "Kubernetes v1.24-gke.900"
-  K8S_VERSION=$(kubelet --version)
-
-  # Helper to check if a version string, passed as first parameter, is greater than or
-  # equal the one passed as second parameter.
-  function version_gte() {
-    [[ "$(printf '%s\n' "${2}" "${1}" | sort -V | head -n1)" = "${2}" ]] && return
-  }
-
   # (GKE *_containerd) Upon node restarts, GKE's containerd images seem to reset
   # the /etc directory and our changes to the kubelet and Cilium's CNI
   # configuration are removed. This leaves room for containerd and its CNI to
@@ -128,6 +119,15 @@ EOF
     echo "Kubelet wrapper already exists, skipping..."
   fi
 else
+  # kubelet version string format is "Kubernetes v1.24-gke.900"
+  K8S_VERSION=$(kubelet --version)
+
+  # Helper to check if a version string, passed as first parameter, is greater than or
+  # equal the one passed as second parameter.
+  function version_gte() {
+    [[ "$(printf '%s\n' "${2}" "${1}" | sort -V | head -n1)" = "${2}" ]] && return
+  }
+
   # Dockershim flags have been removed since k8s 1.24.
   if ! version_gte "${K8S_VERSION#"Kubernetes "}" "v1.24"; then
     # (Generic) Alter the kubelet configuration to run in CNI mode

--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -47,8 +47,11 @@ var (
 	// ciliumNodeStore contains all CiliumNodes present in k8s.
 	ciliumNodeStore cache.Store
 
-	k8sCiliumNodesCacheSynced = make(chan struct{})
+	k8sCiliumNodesCacheSynced    = make(chan struct{})
+	ciliumNodeManagerQueueSynced = make(chan struct{})
 )
+
+type ciliumNodeManagerQueueSyncedKey struct{}
 
 func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.NodeEventHandler, withKVStore bool) error {
 	var (
@@ -58,10 +61,10 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 		kvStoreSyncHandler     func(key string) error
 		connectedToKVStore     = make(chan struct{})
 
-		resourceEventHandler  = cache.ResourceEventHandlerFuncs{}
-		ciliumNodeConvertFunc = k8s.ConvertToCiliumNode
-		nodeManagerQueue      = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-		kvStoreQueue          = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+		resourceEventHandler   = cache.ResourceEventHandlerFuncs{}
+		ciliumNodeConvertFunc  = k8s.ConvertToCiliumNode
+		ciliumNodeManagerQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+		kvStoreQueue           = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	)
 
 	// KVStore is enabled -> we will run the event handler to sync objects into
@@ -152,7 +155,7 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 					return
 				}
 				if nodeManager != nil {
-					nodeManagerQueue.Add(key)
+					ciliumNodeManagerQueue.Add(key)
 				}
 				if withKVStore {
 					kvStoreQueue.Add(key)
@@ -170,7 +173,7 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 							return
 						}
 						if nodeManager != nil {
-							nodeManagerQueue.Add(key)
+							ciliumNodeManagerQueue.Add(key)
 						}
 						if withKVStore {
 							kvStoreQueue.Add(key)
@@ -189,7 +192,7 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 					return
 				}
 				if nodeManager != nil {
-					nodeManagerQueue.Add(key)
+					ciliumNodeManagerQueue.Add(key)
 				}
 				if withKVStore {
 					kvStoreQueue.Add(key)
@@ -218,13 +221,14 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 	go func() {
 		cache.WaitForCacheSync(wait.NeverStop, ciliumNodeInformer.HasSynced)
 		close(k8sCiliumNodesCacheSynced)
+		ciliumNodeManagerQueue.Add(ciliumNodeManagerQueueSyncedKey{})
 		log.Info("CiliumNodes caches synced with Kubernetes")
 		// Only handle events if nodeManagerSyncHandler is not nil. If it is nil
 		// then there isn't any event handler set for CiliumNodes events.
 		if nodeManagerSyncHandler != nil {
 			go func() {
 				// infinite loop. run in a go routine to unblock code execution
-				for processNextWorkItem(nodeManagerQueue, nodeManagerSyncHandler) {
+				for processNextWorkItem(ciliumNodeManagerQueue, nodeManagerSyncHandler) {
 				}
 			}()
 		}
@@ -284,6 +288,11 @@ func processNextWorkItem(queue workqueue.RateLimitingInterface, syncHandler func
 		return false
 	}
 	defer queue.Done(key)
+
+	if _, ok := key.(ciliumNodeManagerQueueSyncedKey); ok {
+		close(ciliumNodeManagerQueueSynced)
+		return true
+	}
 
 	err := syncHandler(key.(string))
 	if err == nil {

--- a/operator/main.go
+++ b/operator/main.go
@@ -521,7 +521,7 @@ func onOperatorStartLeading(ctx context.Context) {
 		// Once the CiliumNodes are synchronized with the operator we will
 		// be able to watch for K8s Node events which they will be used
 		// to create the remaining CiliumNodes.
-		<-k8sCiliumNodesCacheSynced
+		<-ciliumNodeManagerQueueSynced
 
 		// We don't want CiliumNodes that don't have podCIDRs to be
 		// allocated with a podCIDR already being used by another node.


### PR DESCRIPTION
* #21505 -- Remove unused sections for bpf_lxc from nodeport header (@alexkats)
   - Trivial conflicts in bpf/bpf_lxc.c and bpf/lib/nodeport.h.
 * #21831 -- docs: Remove `autoDirectNodeRoutes` where not needed (@pchaigno)
 * #21064 -- Add a section with distro-specific considerations (@bmcustodio)
 * #21772 -- nodeinit: Move kubelet version check to expected branch (@dctrwatson)
 * #21526 -- ipam: Fix overlapping/duplicate PodCIDR allocation when nodes are added while operator is down (@dylandreimerink) (core bugfix)
   - Non-trivial conflicts. Please review carefully :warning:
 * #21835 -- Fix incorrect env var name used in docs for Helm installation on Rancher Desktop (@ehausig)
 * #21897 -- docs: Reword note in Azure CNI chaining documentation (@wedaly)
 * #21940 -- Remove `RUNTIME=docker` in dev_setup document (@Shunpoco)

Removed from backports:
 * #21800 -- ipam/crd: Fix ENI leak due to miscounting of empty interface slots (@jaffcheng)
 * #21526 -- ipam: Fix overlapping/duplicate PodCIDR allocation when nodes are added while operator is down (@dylandreimerink) (Unit test commit)
 
Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 21505 21234 21831 21064 21772 21526 21835 21897 21940; do contrib/backporting/set-labels.py $pr done 1.12; done
```