### PR TITLE
Update Go version in backporting Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -653,6 +653,7 @@ update-go-version: ## Update Go version for all the components (images, CI, dev-
 	$(QUIET) sed -i 's/GOLANG_VERSION=.*/GOLANG_VERSION="$(GO_VERSION)"/g' test/packet/scripts/install.sh
 	@echo "Updated go version in test scripts to $(GO_VERSION)"
 	# Update Go version in Dockerfiles.
+	$(QUIET) sed -i 's/GOLANG_VERSION=.*/GOLANG_VERSION=$(GO_VERSION)/g' contrib/backporting/Dockerfile
 	$(QUIET) sed -i 's/^go_version=.*/go_version=$(GO_IMAGE_VERSION)/g' images/scripts/update-golang-image.sh
 	$(QUIET) $(MAKE) -C images update-golang-image
 	@echo "Updated go version in image Dockerfiles to $(GO_IMAGE_VERSION)"

--- a/contrib/backporting/Dockerfile
+++ b/contrib/backporting/Dockerfile
@@ -1,16 +1,18 @@
 FROM ubuntu:20.04
 
 LABEL maintainer="maintainer@cilium.io"
+ARG GOLANG_VERSION=1.19.3
 
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
 RUN apt-get install -y \
   git \
-  golang \
   jq \
   python3 \
   python3-pip \
   curl \
   vim
+
+RUN curl -SsLk https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz -o - | tar -xz -C /usr/local
 
 RUN set -ex \
   && mkdir -p /hub \
@@ -22,4 +24,5 @@ RUN set -ex \
   && rm -rf /hub
 RUN useradd -m user
 USER user
+ENV PATH /usr/local/go/bin:$PATH
 RUN pip3 install --user PyGithub

--- a/contrib/backporting/Dockerfile
+++ b/contrib/backporting/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 LABEL maintainer="maintainer@cilium.io"
-ARG GOLANG_VERSION=1.19.3
+ARG GOLANG_VERSION=1.19.2
 
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
 RUN apt-get install -y \


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

Trying to run the `dev-doctor` script from the backporting image fails:
```
$ docker run -e GITHUB_TOKEN -v $(pwd):/cilium -v "$HOME/.ssh":/home/user/.ssh -it cilium-backport /bin/bash
user@9c66b4f87c78:/$ cd cilium/
user@9c66b4f87c78:/cilium$ go run ./tools/dev-doctor --backporting
build github.com/cilium/cilium/tools/dev-doctor: cannot load io/fs: malformed module path "io/fs": missing dot in first path element
```

The `golang` package on Ubuntu 20.04 installs Go 1.13. The `io/fs` package was added in Go 1.16:
https://tip.golang.org/doc/go1.16#fs

This installs the latest Go version.

Fixes: #21121
