### PR TITLE
Return an error DSR + tunneling on KubeProxyReplacement

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -312,6 +312,9 @@ Annotations:
 1.13 Upgrade Notes
 ------------------
 
+* The kube-proxy replacement in DSR or Hybrid mode with tunneling causes failure upon cilium-agent start.
+  In previous versions, cilium-agent automatically used SNAT mode when we set tunneling.
+
 Removed Options
 ~~~~~~~~~~~~~~~
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -218,10 +218,7 @@ func initKubeProxyReplacementOptions() (bool, error) {
 	if option.Config.EnableNodePort {
 		if option.Config.TunnelingEnabled() &&
 			option.Config.NodePortMode != option.NodePortModeSNAT {
-
-			log.Warnf("Disabling NodePort's %q mode feature due to tunneling mode being enabled",
-				option.Config.NodePortMode)
-			option.Config.NodePortMode = option.NodePortModeSNAT
+			return false, fmt.Errorf("Node Port %q mode cannot be used with tunneling.", option.Config.NodePortMode)
 		}
 
 		if option.Config.NodePortMode == option.NodePortModeDSR &&


### PR DESCRIPTION
Because we don't support using node port DSR or Hybrid mode with tunneling, we return an error instead of changing the configuration.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #22003

```release-note
Fatal when enabling DSR and tunneling on KubeProxyReplacement
```
