### PR TITLE
add policy fuzzers

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/fuzz_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/fuzz_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package v2
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+func FuzzCiliumNetworkPolicyParse(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		ff := fuzz.NewConsumer(data)
+		r := &CiliumNetworkPolicy{}
+		ff.GenerateStruct(r)
+		_, _ = r.Parse()
+	})
+}
+
+func FuzzCiliumClusterwideNetworkPolicyParse(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		ff := fuzz.NewConsumer(data)
+		r := &CiliumClusterwideNetworkPolicy{}
+		ff.GenerateStruct(r)
+		_, _ = r.Parse()
+	})
+}

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+func FuzzTest(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		ff := fuzz.NewConsumer(data)
+		label, err := ff.GetString()
+		if err != nil {
+			return
+		}
+		fromBar := &SearchContext{From: labels.ParseSelectLabelArray(label)}
+		r := api.Rule{}
+		err = ff.GenerateStruct(&r)
+		if err != nil {
+			return
+		}
+		err = r.Sanitize()
+		if err != nil {
+			return
+		}
+		rule := &rule{Rule: r}
+		state := traceState{}
+		_, _ = rule.resolveEgressPolicy(testPolicyContext, fromBar, &state, L4PolicyMap{}, nil, nil)
+
+	})
+}


### PR DESCRIPTION
Signed-off-by: AdamKorcz <adam@adalogics.com>

Adds fuzzers that test whether cilium can crash after sanitizing a rule.

To test these fuzzers locally, run `go test -fuzz=FuzzTestName`, for example `go test -fuzz=FuzzCiliumNetworkPolicyParse`