### PR TITLE
Fix CEP batching FCFS mode to group CEPs per namespace.

### DIFF
--- a/operator/pkg/ciliumendpointslice/manager_test.go
+++ b/operator/pkg/ciliumendpointslice/manager_test.go
@@ -158,18 +158,26 @@ func TestInsertAndRemoveCEPsInCache(t *testing.T) {
 		ces1 := createCES("ces1", "default", []capi_v2a1.CoreCiliumEndpoint{*cep1})
 		ces2 := createCES("ces2", "default", []capi_v2a1.CoreCiliumEndpoint{*cep2, *cep2b})
 		ces3 := createCES("ces3", "default", []capi_v2a1.CoreCiliumEndpoint{*cep3})
+		ces4 := createCES("ces4", "namespace-a", []capi_v2a1.CoreCiliumEndpoint{*cep2, *cep2b})
+		ces5 := createCES("ces5", "namespace-a", []capi_v2a1.CoreCiliumEndpoint{*cep3})
 
-		// All CEPs should be added to the same CES (ces2).
+		// All CEPs should be added to the same CES (ces2) in default namespace.
 		m.InsertCEPInCache(cep4, "default")
-		assert.Equal(t, 3, len(ces2.ces.Endpoints), "The largest CES has 3 CEPs")
+		assert.Equal(t, 3, len(ces2.ces.Endpoints), "The largest CES in default namespace has 3 CEPs")
 		m.InsertCEPInCache(cep5, "default")
-		assert.Equal(t, 4, len(ces2.ces.Endpoints), "The largest CES has 4 CEPs")
+		assert.Equal(t, 4, len(ces2.ces.Endpoints), "The largest CES in default namespace has 4 CEPs")
 		m.InsertCEPInCache(cep1a, "default")
-		assert.Equal(t, 5, len(ces2.ces.Endpoints), "The largest CES has 5 CEPs")
+		assert.Equal(t, 5, len(ces2.ces.Endpoints), "The largest CES in default namespace has 5 CEPs")
+
+		// All CEPs should be added to the same CES (ces4) in namespace-a.
+		m.InsertCEPInCache(cep4, "namespace-a")
+		assert.Equal(t, 3, len(ces4.ces.Endpoints), "The largest CES in namespace-a has 3 CEPs")
+		assert.Equal(t, 5, len(ces2.ces.Endpoints), "The largest CES in default namespace still has 5 CEPs")
 
 		// The rest of CESs should have the same number of CEPs.
 		assert.Equal(t, 1, len(ces1.ces.Endpoints), "A smaller CES still has only 1 CEP")
 		assert.Equal(t, 1, len(ces3.ces.Endpoints), "A smaller CES still has only 1 CEP")
+		assert.Equal(t, 1, len(ces5.ces.Endpoints), "A smaller CES still has only 1 CEP")
 	})
 }
 


### PR DESCRIPTION
Fix CEP (CiliumEndpoint) batching FCFS (First Come First Served) mode to group CEPs per namespace. Initial change was introduced to always add new CEPs to the largest CES (CiliumEndpointSlice), but didn’t take into account splitting them by namespaces, which is a bug. https://github.com/cilium/cilium/pull/20969

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>