### PR TITLE
CODEOWNERS: Assign `pkg/nodediscovery` to the agent team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -427,6 +427,7 @@ jenkinsfiles @cilium/ci-structure
 /pkg/mtu @cilium/sig-datapath
 /pkg/multicast @cilium/sig-datapath
 /pkg/node @cilium/sig-agent
+/pkg/nodediscovery/ @cilium/sig-agent
 /pkg/option @cilium/sig-agent @cilium/cli
 /pkg/pidfile @cilium/sig-agent
 /pkg/policy @cilium/sig-policy


### PR DESCRIPTION
Just noticed as a tophat that the `nodediscovery` package wasn't assigned to anyone explicitly. This pull request affects it to the agent team as that's the closest match.