### PR TITLE
CI: Revert "bpf_test: Skip instead of Fatal TestBPF when -bpf-test-path is not set"

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -85,4 +85,4 @@ endif
 
 run_bpf_tests:
 	$(QUIET)$(MAKE) -C ../bpf/tests all
-	$(QUIET)$(GO) test ./bpf_tests -exec sudo -bpf-test-path $(ROOT_DIR)/bpf/tests $(BPF_TEST_FLAGS)
+	$(QUIET)$(GO) test bpf_tests/*.go -exec sudo -bpf-test-path $(ROOT_DIR)/bpf/tests $(BPF_TEST_FLAGS)

--- a/test/bpf_tests/bpf_test.go
+++ b/test/bpf_tests/bpf_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/monitor"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 var (
@@ -49,8 +50,10 @@ var (
 )
 
 func TestBPF(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
 	if testPath == nil || *testPath == "" {
-		t.Skip("Set -bpf-test-path to run BPF tests")
+		t.Fatal("-bpf-test-path is a required flag")
 	}
 
 	entries, err := os.ReadDir(*testPath)


### PR DESCRIPTION
This reverts commit 4b0d3d6c78698463d33b556cb7406ea7a1170f90.

It makes failing CI with error:

bpf_test.go:149: new coll: program test_ct4_rst1_check: load program: invalid argument: nonzero insn_off 25 for the first func info recordprocessed 0 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0

https://github.com/cilium/cilium/actions/runs/34087