### PR TITLE
helm: add cni.waitBeforeUninstall variable

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -138,6 +138,7 @@ contributors across the globe, there is almost always someone available to help.
 | cni.hostConfDirMountPath | string | `"/host/etc/cni/net.d"` | Configure the path to where the CNI configuration directory is mounted inside the agent pod. |
 | cni.install | bool | `true` | Install the CNI configuration and binary files into the filesystem. |
 | cni.logFile | string | `"/var/run/cilium/cilium-cni.log"` | Configure the log file for CNI logging with retention policy of 7 days. Disable CNI file logging by setting this field to empty explicitly. |
+| cni.waitBeforeUninstall | int | 0 | Seconds to wait before uninstalling the CNI plugin during agent `preStop` lifecycle. |
 | containerRuntime | object | `{"integration":"none"}` | Configure container runtime specific integration. |
 | containerRuntime.integration | string | `"none"` | Enables specific integrations for container runtimes. Supported values: - containerd - crio - docker - none - auto (automatically detect the container runtime) |
 | customCalls | object | `{"enabled":false}` | Tail call hooks for custom eBPF programs. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -223,7 +223,13 @@ spec:
           preStop:
             exec:
               command:
+              {{- if gt (int .Values.cni.waitBeforeUninstall) 0 }}
+              - sh
+              - -c
+              - "sleep {{ .Values.cni.waitBeforeUninstall }}; /cni-uninstall.sh"
+              {{- else }}
               - /cni-uninstall.sh
+              {{- end }}
         {{- end }}
         {{- with .Values.resources }}
         resources:
@@ -670,7 +676,7 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.cilium.name | quote }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ add .Values.terminationGracePeriodSeconds (ternary .Values.cni.waitBeforeUninstall 0 .Values.cni.install) }}
       hostNetwork: true
       {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -408,6 +408,10 @@ cni:
   # inside the agent pod.
   hostConfDirMountPath: /host/etc/cni/net.d
 
+  # -- Seconds to wait before uninstalling the CNI plugin during agent 
+  # `preStop` lifecycle.
+  waitBeforeUninstall: 0
+
 # -- Configure how frequently garbage collection should occur for the datapath
 # connection tracking table.
 # conntrackGCInterval: "0s"

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -405,6 +405,10 @@ cni:
   # inside the agent pod.
   hostConfDirMountPath: /host/etc/cni/net.d
 
+  # -- Seconds to wait before uninstalling the CNI plugin during agent 
+  # `preStop` lifecycle.
+  waitBeforeUninstall: 0
+
 # -- Configure how frequently garbage collection should occur for the datapath
 # connection tracking table.
 # conntrackGCInterval: "0s"


### PR DESCRIPTION
Sleeping for a small amount of time before uninstalling the CNI plugin can help with a potential race condition caused by uninstalling the CNI plugin at the same time Deployments managed by this helm chart, such as `hubble-ui` and `hubble-relay` are uninstalled. 
Without this wait period the above pods get stuck in the Terminating phase due to:
```
  Warning  FailedKillPod    6s (x4 over 21s)   kubelet            error killing pod: failed to "KillPodSandbox" for "4eea6ba3-0054-49c5-9458-5defb7f9390f" with KillPodSandboxError: "rpc error: code = Unknown desc = failed to destroy network for sandbox \"7f436e8921d4894c6e68feba090d17ab3f5b7cf2b5e7d2c07b46c091193da016\": cni plugin not initialized"
```

<!-- Description of change -->

Fixes: #22053

```release-note
helm: add cni.waitBeforeUninstall variable to help with a potential race condition during helm delete
```
