### PR TITLE
.github: add kind/community-report to newly open issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a bug encountered while operating Cilium
-labels: ["kind/bug", "needs/triage"]
+labels: ["kind/community-report", "kind/bug", "needs/triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
The majority of the bug reports are opened by community members. Thus, it will be easier to have this added by default and removing it when unnecessary, which is when Cilium contributors open a new GH issue where then can immediately remove labels.

Signed-off-by: André Martins <andre@cilium.io>