### PR TITLE
Use informer.NewInformer where appropriate

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -301,15 +301,13 @@ func (c *CiliumEndpointSliceController) syncCES(key string) error {
 // Initialize and start CES watcher
 // TODO Watch for CES's, make sure only CES controller Create/Update/Delete the CES not bad actors.
 func ciliumEndpointSliceInit(client csv2a1.CiliumV2alpha1Interface, stopCh <-chan struct{}) cache.Store {
-	cesStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-	cesController := informer.NewInformerWithStore(
+	cesStore, cesController := informer.NewInformer(
 		utils.ListerWatcherFromTyped[*capi_v2a1.CiliumEndpointSliceList](
 			client.CiliumEndpointSlices()),
 		&capi_v2a1.CiliumEndpointSlice{},
 		0,
 		cache.ResourceEventHandlerFuncs{},
 		nil,
-		cesStore,
 	)
 	go cesController.Run(stopCh)
 	cache.WaitForCacheSync(stopCh, cesController.HasSynced)

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -109,8 +109,7 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, clientset cl
 	owner.UpdateCiliumNodeResource()
 	apiGroup := "cilium/v2::CiliumNode"
 	ciliumNodeSelector := fields.ParseSelectorOrDie("metadata.name=" + nodeName)
-	ciliumNodeStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-	ciliumNodeInformer := informer.NewInformerWithStore(
+	_, ciliumNodeInformer := informer.NewInformer(
 		utils.ListerWatcherWithFields(
 			utils.ListerWatcherFromTyped[*ciliumv2.CiliumNodeList](clientset.CiliumV2().CiliumNodes()),
 			ciliumNodeSelector),
@@ -166,7 +165,6 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, clientset cl
 			},
 		},
 		nil,
-		ciliumNodeStore,
 	)
 
 	go ciliumNodeInformer.Run(wait.NeverStop)

--- a/pkg/k8s/watchers/cilium_clusterwide_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_envoy_config.go
@@ -23,9 +23,8 @@ import (
 )
 
 func (k *K8sWatcher) ciliumClusterwideEnvoyConfigInit(clientset client.Clientset) {
-	ccecStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 	apiGroup := k8sAPIGroupCiliumClusterwideEnvoyConfigV2
-	ccecController := informer.NewInformerWithStore(
+	_, ccecController := informer.NewInformer(
 		utils.ListerWatcherFromTyped[*cilium_v2.CiliumClusterwideEnvoyConfigList](k.clientset.CiliumV2().CiliumClusterwideEnvoyConfigs()),
 		&cilium_v2.CiliumClusterwideEnvoyConfig{},
 		0,
@@ -68,7 +67,6 @@ func (k *K8sWatcher) ciliumClusterwideEnvoyConfigInit(clientset client.Clientset
 			},
 		},
 		k8s.ConvertToCiliumClusterwideEnvoyConfig,
-		ccecStore,
 	)
 
 	k.blockWaitGroupToSyncResources(

--- a/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
@@ -15,9 +15,8 @@ import (
 )
 
 func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient client.Clientset) {
-	ccnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 	apiGroup := k8sAPIGroupCiliumClusterwideNetworkPolicyV2
-	ciliumV2ClusterwidePolicyController := informer.NewInformerWithStore(
+	_, ciliumV2ClusterwidePolicyController := informer.NewInformer(
 		utils.ListerWatcherFromTyped[*cilium_v2.CiliumClusterwideNetworkPolicyList](
 			ciliumNPClient.CiliumV2().CiliumClusterwideNetworkPolicies()),
 		&cilium_v2.CiliumClusterwideNetworkPolicy{},
@@ -82,7 +81,6 @@ func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient client.
 			},
 		},
 		k8s.ConvertToCCNP,
-		ccnpStore,
 	)
 
 	k.blockWaitGroupToSyncResources(

--- a/pkg/k8s/watchers/cilium_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_envoy_config.go
@@ -25,9 +25,8 @@ import (
 )
 
 func (k *K8sWatcher) ciliumEnvoyConfigInit(ciliumNPClient client.Clientset) {
-	cecStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 	apiGroup := k8sAPIGroupCiliumEnvoyConfigV2
-	cecController := informer.NewInformerWithStore(
+	_, cecController := informer.NewInformer(
 		cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
 			cilium_v2.CECPluralName, v1.NamespaceAll, fields.Everything()),
 		&cilium_v2.CiliumEnvoyConfig{},
@@ -71,7 +70,6 @@ func (k *K8sWatcher) ciliumEnvoyConfigInit(ciliumNPClient client.Clientset) {
 			},
 		},
 		k8s.ConvertToCiliumEnvoyConfig,
-		cecStore,
 	)
 
 	k.blockWaitGroupToSyncResources(

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -82,10 +82,8 @@ func (r *ruleImportMetadataCache) get(cnp *types.SlimCNP) (policyImportMetadata,
 }
 
 func (k *K8sWatcher) ciliumNetworkPoliciesInit(cs client.Clientset) {
-	cnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-
 	apiGroup := k8sAPIGroupCiliumNetworkPolicyV2
-	ciliumV2Controller := informer.NewInformerWithStore(
+	_, ciliumV2Controller := informer.NewInformer(
 		utils.ListerWatcherFromTyped[*cilium_v2.CiliumNetworkPolicyList](
 			cs.CiliumV2().CiliumNetworkPolicies("")),
 		&cilium_v2.CiliumNetworkPolicy{},
@@ -148,7 +146,6 @@ func (k *K8sWatcher) ciliumNetworkPoliciesInit(cs client.Clientset) {
 			},
 		},
 		k8s.ConvertToCNP,
-		cnpStore,
 	)
 
 	k.blockWaitGroupToSyncResources(k.stop, nil, ciliumV2Controller.HasSynced, k8sAPIGroupCiliumNetworkPolicyV2)


### PR DESCRIPTION
Instead of manually creating a store using `cache.NewStore` and passing it to `informer.NewInformerWithStore`, use `informer.NewInformer` which does that internally.
