### PR TITLE
bpf: Remove FIB lookup for IPsec

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1516,7 +1516,6 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 			// kernels with FIB lookup helpers we do a lookup from
 			// the datapath side and ignore this value.
 			ifaceNames = append(ifaceNames, option.Config.EncryptInterface[0])
-			n.enableNeighDiscovery = true
 		}
 
 		if n.enableNeighDiscovery {


### PR DESCRIPTION
When we know the encryption interface, we can jump directly from bpf_host to that interface using `bpf_redirect`. For that to work, we however need to rewrite the MAC addresses. This is currently done in bpf_host with a FIB lookup to retrieve the MAC addresses.

The performance gain we get from that redirect is however expected to be negligible because we already traversed the stack several times for IPsec and we also spent a fair amount of cycles just encrypting the payloads.

This pull request therefore removes the redirect and related FIB lookup. This change makes the logic for IPsec a little simpler (less error cases without the FIB lookup). It also makes the logic more consistent across setups (the FIB lookup was currently only possible on AKS & GKE). Finally, a later change to IPsec will break the FIB lookup on AKS anyway.