### PR TITLE
workflows: Bump timeout of ConformanceKind workflow

### DIFF
--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -28,7 +28,7 @@ env:
 jobs:
   installation-and-connectivity:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
With the connectivity tests now taking almost 10min, the 30min timeout of the ConformanceKind workflow doesn't leave a lot of time for Cilium installation, image waiting time, etc. The workflow is thus often timing out.

This pull request bumps the timeout to 45min.