### PR TITLE
v1.11 backports 2022-11-09

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -12,10 +12,11 @@ Azure CNI
 
 .. note::
 
-   This is not the best option to run Cilium on AKS or Azure. Please refer to
-   :ref:`k8s_install_quick` for the best guide to run Cilium in Azure Cloud.
-   Follow this guide if you specifically want to run Cilium in combination with
-   the Azure CNI in a chaining configuration.
+   For most users, the best way to run Cilium on AKS is either
+   AKS BYO CNI as described in :ref:`k8s_install_quick`
+   or `Azure CNI Powered by Cilium <https://aka.ms/aks/cilium-dataplane>`_.
+   This guide provides alternative instructions to run Cilium with Azure CNI
+   in a chaining configuration.
 
 .. include:: cni-chaining-limitations.rst
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -459,7 +459,6 @@ enabled would look as follows:
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set tunnel=disabled \\
-        --set autoDirectNodeRoutes=true \\
         --set kubeProxyReplacement=strict \\
         --set loadBalancer.mode=dsr \\
         --set k8sServiceHost=REPLACE_WITH_API_SERVER_IP \\
@@ -488,7 +487,6 @@ mode would look as follows:
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set tunnel=disabled \\
-        --set autoDirectNodeRoutes=true \\
         --set kubeProxyReplacement=strict \\
         --set loadBalancer.mode=hybrid \\
         --set k8sServiceHost=REPLACE_WITH_API_SERVER_IP \\
@@ -515,7 +513,6 @@ looks as follows:
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set tunnel=disabled \\
-        --set autoDirectNodeRoutes=true \\
         --set kubeProxyReplacement=strict \\
         --set hostServices.hostNamespaceOnly=true
 
@@ -552,7 +549,6 @@ modes and can be enabled as follows for ``loadBalancer.mode=hybrid`` in this exa
     helm install cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --set tunnel=disabled \\
-        --set autoDirectNodeRoutes=true \\
         --set kubeProxyReplacement=strict \\
         --set loadBalancer.acceleration=native \\
         --set loadBalancer.mode=hybrid \\
@@ -739,7 +735,6 @@ Finally, the deployment can be upgraded and later rolled-out with the
   helm upgrade cilium |CHART_RELEASE| \\
         --namespace kube-system \\
         --reuse-values \\
-        --set autoDirectNodeRoutes=true \\
         --set kubeProxyReplacement=strict \\
         --set loadBalancer.acceleration=native \\
         --set loadBalancer.mode=snat \\

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -47,18 +47,20 @@ iproute2                 >= 5.9.0 [#iproute2_foot]_ yes
 .. [#iproute2_foot] Requires support for eBPF templating as documented
    :ref:`below <iproute2_requirements>`.
 
-Linux Distribution Compatibility Matrix
-=======================================
+Linux Distribution Compatibility & Considerations 
+=================================================
 
 The following table lists Linux distributions that are known to work
-well with Cilium.
+well with Cilium. Some distributions require a few initial tweaks. Please make
+sure to read each distribution's specific notes below before attempting to
+run Cilium.
 
 ========================== ====================
 Distribution               Minimum Version
 ========================== ====================
 `Amazon Linux 2`_          all
 `Container-Optimized OS`_  all
-`CentOS`_                  >= 7.0 [#centos_foot]_
+`CentOS`_                  >= 7.0
 Debian_                    >= 9 Stretch
 `Fedora Atomic/Core`_      >= 25
 Flatcar_                   all
@@ -81,22 +83,64 @@ RancherOS_                 >= 1.5.5
 .. _Opensuse: https://www.opensuse.org/
 .. _RancherOS: https://rancher.com/rancher-os/
 
-.. [#centos_foot] CentOS 7 requires a third-party kernel provided by `ElRepo <http://elrepo.org/tiki/tiki-index.php>`_
-    whereas CentOS 8 ships with a supported kernel.
-
 .. note:: The above list is based on feedback by users. If you find an unlisted
           Linux distribution that works well, please let us know by opening a
           GitHub issue or by creating a pull request that updates this guide.
 
-.. note:: Systemd 245 and above (``systemctl --version``) overrides ``rp_filter`` setting
-          of Cilium network interfaces. This introduces connectivity issues
-          (see :gh-issue:`10645` for details). To avoid that, configure
-          ``rp_filter`` in systemd using the following commands:
 
-          .. code-block:: shell-session
+CentOS 7
+~~~~~~~~
 
-              echo 'net.ipv4.conf.lxc*.rp_filter = 0' > /etc/sysctl.d/99-override_cilium_rp_filter.conf
-              systemctl restart systemd-sysctl
+CentOS 7 requires a third-party kernel provided by `ElRepo <http://elrepo.org/tiki/tiki-index.php>`_
+whereas CentOS 8 ships with a supported kernel. Note that some more advanced
+features may not be available on CentOS 7 even with a third-party kernel. For
+full details on which kernel config options must be enabled in order to use
+various features, see the section on :ref:`admin_kernel_version` requirements
+below.
+
+
+systemd-based distributions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some distributions need to be configured not to manage "foreign" routes. This
+is the case in Ubuntu 22.04, for example (see :gh-issue:`18706`). This can
+usually be done by setting
+
+.. code-block:: text
+
+   ManageForeignRoutes=no
+   ManageForeignRoutingPolicyRules=no
+
+in ``/etc/systemd/networkd.conf``, but please refer to your distribution's
+documentation for the right way to perform this override.
+
+
+Flatcar
+~~~~~~~
+
+Flatcar is known to manipulate network interfaces created and managed by
+Cilium. This is especially true in the official Flatcar image for AWS EKS, and
+causes connectivity issues and potentially prevents the Cilium agent from
+booting when Cilium is running in ENI mode. To avoid this, disable DHCP on
+these interfaces and mark them as unmanaged by adding
+
+.. code-block:: text
+
+        [Match]
+        Name=eth[1-9]*
+
+        [Network]
+        DHCP=no
+
+        [Link]
+        Unmanaged=yes
+
+to ``/etc/systemd/network/01-no-dhcp.network`` and then
+
+.. code-block:: shell-session
+
+        systemctl daemon-reload
+        systemctl restart systemd-networkd
 
 .. _admin_kernel_version:
 

--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -47,8 +47,11 @@ var (
 	// ciliumNodeStore contains all CiliumNodes present in k8s.
 	ciliumNodeStore cache.Store
 
-	k8sCiliumNodesCacheSynced = make(chan struct{})
+	k8sCiliumNodesCacheSynced    = make(chan struct{})
+	ciliumNodeManagerQueueSynced = make(chan struct{})
 )
+
+type ciliumNodeManagerQueueSyncedKey struct{}
 
 func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.NodeEventHandler, withKVStore bool) error {
 	var (
@@ -58,10 +61,10 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 		kvStoreSyncHandler     func(key string) error
 		connectedToKVStore     = make(chan struct{})
 
-		resourceEventHandler  = cache.ResourceEventHandlerFuncs{}
-		ciliumNodeConvertFunc = k8s.ConvertToCiliumNode
-		nodeManagerQueue      = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-		kvStoreQueue          = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+		resourceEventHandler   = cache.ResourceEventHandlerFuncs{}
+		ciliumNodeConvertFunc  = k8s.ConvertToCiliumNode
+		ciliumNodeManagerQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+		kvStoreQueue           = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	)
 
 	// KVStore is enabled -> we will run the event handler to sync objects into
@@ -152,7 +155,7 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 					return
 				}
 				if nodeManager != nil {
-					nodeManagerQueue.Add(key)
+					ciliumNodeManagerQueue.Add(key)
 				}
 				if withKVStore {
 					kvStoreQueue.Add(key)
@@ -170,7 +173,7 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 							return
 						}
 						if nodeManager != nil {
-							nodeManagerQueue.Add(key)
+							ciliumNodeManagerQueue.Add(key)
 						}
 						if withKVStore {
 							kvStoreQueue.Add(key)
@@ -189,7 +192,7 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 					return
 				}
 				if nodeManager != nil {
-					nodeManagerQueue.Add(key)
+					ciliumNodeManagerQueue.Add(key)
 				}
 				if withKVStore {
 					kvStoreQueue.Add(key)
@@ -218,13 +221,14 @@ func startSynchronizingCiliumNodes(ctx context.Context, nodeManager allocator.No
 	go func() {
 		cache.WaitForCacheSync(wait.NeverStop, ciliumNodeInformer.HasSynced)
 		close(k8sCiliumNodesCacheSynced)
+		ciliumNodeManagerQueue.Add(ciliumNodeManagerQueueSyncedKey{})
 		log.Info("CiliumNodes caches synced with Kubernetes")
 		// Only handle events if nodeManagerSyncHandler is not nil. If it is nil
 		// then there isn't any event handler set for CiliumNodes events.
 		if nodeManagerSyncHandler != nil {
 			go func() {
 				// infinite loop. run in a go routine to unblock code execution
-				for processNextWorkItem(nodeManagerQueue, nodeManagerSyncHandler) {
+				for processNextWorkItem(ciliumNodeManagerQueue, nodeManagerSyncHandler) {
 				}
 			}()
 		}
@@ -284,6 +288,11 @@ func processNextWorkItem(queue workqueue.RateLimitingInterface, syncHandler func
 		return false
 	}
 	defer queue.Done(key)
+
+	if _, ok := key.(ciliumNodeManagerQueueSyncedKey); ok {
+		close(ciliumNodeManagerQueueSynced)
+		return true
+	}
 
 	err := syncHandler(key.(string))
 	if err == nil {

--- a/operator/main.go
+++ b/operator/main.go
@@ -521,7 +521,7 @@ func onOperatorStartLeading(ctx context.Context) {
 		// Once the CiliumNodes are synchronized with the operator we will
 		// be able to watch for K8s Node events which they will be used
 		// to create the remaining CiliumNodes.
-		<-k8sCiliumNodesCacheSynced
+		<-ciliumNodeManagerQueueSynced
 
 		// We don't want CiliumNodes that don't have podCIDRs to be
 		// allocated with a podCIDR already being used by another node.


### PR DESCRIPTION
* #21831 -- docs: Remove `autoDirectNodeRoutes` where not needed (@pchaigno)
 * #21064 -- Add a section with distro-specific considerations (@bmcustodio)
     - Minor conflict on `Documentation/operations/system_requirements.rst`.
 * #21526 -- ipam: Fix overlapping/duplicate PodCIDR allocation when nodes are added while operator is down (@dylandreimerink)
     - Non-trivial conflicts. Please review carefully :warning:
 * #21897 -- docs: Reword note in Azure CNI chaining documentation (@wedaly)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 21831 21064 21526 21897; do contrib/backporting/set-labels.py $pr done 1.11; done
```