### PR TITLE
aws/eni: fix cilium operator crash on IPv6 ENI

### DIFF
--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -21,6 +21,10 @@ watermark is used to maintain a number of IP addresses to be available for use
 on nodes at all time without needing to contact the EC2 API when a new pod is
 scheduled in the cluster.
 
+Note that Cilium currently does not support IPv6-only ENIs. Cilium support for
+IPv6 ENIs is being tracked in :gh-issue:`18405`, and the related feature of
+assigning IPv6 prefixes in :gh-issue:`19251`.
+
 ************
 Architecture
 ************


### PR DESCRIPTION
Cilium operator would crash when being brought up in an AWS region where there was a IPv6-only ENI and no subnet filters, because it would fail to parse the ENI (logs will show `ENI has no IP address` and `Initial synchronization with instances API failed`). 

We work around this issue for the moment by filtering the network interfaces we fetch from AWS with `'private-ip-addresses=*'`, which includes all ENIs with any value in the PrivateIpAddress field. This is the field `parseENI` complains about otherwise. 

In general, though, it seems that the ENI IPAM mode needs to learn to handle IPv6 ENIs. There are unsolved challenges (such as representing the IP pool as a list of addresses, which will not work for IPv6), however,  which cannot be addressed quickly, so we work around it for now.

cc @gandro @chanieljdan @bmcustodio 

```release-note
Prevent cilium operator crash in AWS region with IPv6-only ENIs without subnet filters.
```
