### PR TITLE
add renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "includePaths": ["images/**"],
+  "ignorePresets": [":prHourlyLimit2"],
+  "separateMajorMinor": true,
+  "separateMultipleMajor": true,
+  "separateMinorPatch": true,
+  "baseBranches": [
+    "master",
+    "v1.12",
+    "v1.11",
+    "v1.10"
+  ],
+  "labels": [
+    "kind/enhancement",
+    "release-note/misc"
+  ]
+}


### PR DESCRIPTION
Renovate is a bot utility that allows to update dependencies in the repository. It's similar to dependabot but unfortunately dependabot lacks the ability to update docker images from ARG in Dockerfiles (https://github.com/dependabot/dependabot-core/issues/2057). Thus, we will be adding renovate to update Dockerfile base images while dependabot's GH issue is not fixed.

For future reference the documentation is available in:
- https://github.com/renovatebot/tutorial
- https://docs.renovatebot.com/configuration-options

Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/14050