### PR TITLE
workflows: Bump timeout of master GKE workflow

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -121,7 +121,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
The timeout was bumped to 75min already for the v1.12 version of the GKE workflow, but not for the master version (cf. b6a5b5b26 ("conformance-gke-v1.12: Miscellaneous fixes")).

The workflow is currently often failing with a timeout on the last of the four connectivity test runs. Each connectivity test takes between 13 and 14min on GKE. Adding 15min to the workflow should therefore be enough to finish.