### PR TITLE
policy: replace RWMutex with Mutex

### DIFF
--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -24,7 +24,7 @@ type rule struct {
 
 type ruleMetadata struct {
 	// mutex protects all fields in this type.
-	Mutex lock.RWMutex
+	Mutex lock.Mutex
 
 	// IdentitySelected is a cache that maps from an identity to whether
 	// this rule selects that identity.


### PR DESCRIPTION
This is only locked using write locks, so replacing it with a normal mutex would reduce the overhead by a tiny bit.

This could probably see a lot of improvements by rewriting to a proper rwmutex and use read locking, but I think we should have some kind of benchmark to ensure that that change would be net positive; and I think this is a positive step towards that.

Signed-off-by: Odin Ugedal <ougedal@palantir.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
policy: Replace RWMutex with Mutex to reduce locking times by a tiny bit.
```

Not sure if we want such a release note ^ or just skip it?