### PR TITLE
add more configuration to .github/renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
   "separateMajorMinor": true,
   "separateMultipleMajor": true,
   "separateMinorPatch": true,
+  "pruneStaleBranches": true,
   "baseBranches": [
     "master",
     "v1.12",
@@ -18,5 +19,74 @@
   "labels": [
     "kind/enhancement",
     "release-note/misc"
+  ],
+  "packageRules": [
+    {
+      "groupName": "base-images",
+      "matchFiles": [
+        "images/builder/Dockerfile",
+        "images/runtime/Dockerfile"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/ubuntu"
+      ],
+      "allowedVersions": "22.04",
+      "matchBaseBranches": [
+        "master"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/ubuntu"
+      ],
+      "allowedVersions": "20.04",
+      "matchBaseBranches": [
+        "v1.12",
+        "v1.11",
+        "v1.10"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/golang",
+        "go"
+      ],
+      "allowedVersions": "1.19",
+      "matchBaseBranches": [
+        "master"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/golang",
+        "go"
+      ],
+      "allowedVersions": "1.18",
+      "matchBaseBranches": [
+        "v1.12"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/golang",
+        "go"
+      ],
+      "allowedVersions": "1.17",
+      "matchBaseBranches": [
+        "v1.11"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/golang",
+        "go"
+      ],
+      "allowedVersions": "1.16",
+      "matchBaseBranches": [
+        "v1.10"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
- Add package rules for the base images since those are always updated together.
- Pin ubuntu's and golang's versions depending on the branch.
- Prune renovate's stale branches from the repository.

Signed-off-by: André Martins <andre@cilium.io>