### PR TITLE
conformance-gke-{v1.11,v1.10}: Miscellaneous fixes

### DIFF
--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -17,7 +17,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -118,7 +118,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -254,6 +254,8 @@ jobs:
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          # Temporary workaround for https://github.com/cilium/cilium-cli/issues/255
+          kubectl delete ns cilium-test
           cilium uninstall --wait
 
       - name: Install Cilium with tunnel datapath
@@ -283,6 +285,8 @@ jobs:
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          # Temporary workaround for https://github.com/cilium/cilium-cli/issues/255
+          kubectl delete ns cilium-test
           cilium uninstall --wait
 
       - name: Create custom IPsec secret
@@ -317,6 +321,8 @@ jobs:
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          # Temporary workaround for https://github.com/cilium/cilium-cli/issues/255
+          kubectl delete ns cilium-test
           cilium uninstall --wait
           
 

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -17,7 +17,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -118,7 +118,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -264,6 +264,8 @@ jobs:
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          # Temporary workaround for https://github.com/cilium/cilium-cli/issues/255
+          kubectl delete ns cilium-test
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Install Cilium with tunnel datapath
@@ -293,6 +295,8 @@ jobs:
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          # Temporary workaround for https://github.com/cilium/cilium-cli/issues/255
+          kubectl delete ns cilium-test
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Create custom IPsec secret
@@ -327,6 +331,8 @@ jobs:
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          # Temporary workaround for https://github.com/cilium/cilium-cli/issues/255
+          kubectl delete ns cilium-test
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Install Cilium with encryption and tunnel datapath


### PR DESCRIPTION
- Increase timeout from 60 minutes to 75 minutes. Right now a successful run takes a bit over 60 minutes.
- Explicitly delete cilium-test namespace as a temporary workaround until cilium/cilium-cli#255 is fixed.

These are the same set of changes we made to GKE v1.12 workflow in #21613.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>
