### PR TITLE
pkg/k8s: do not read k8s node annotations if they are not written

### DIFF
--- a/pkg/k8s/init_test.go
+++ b/pkg/k8s/init_test.go
@@ -20,10 +20,17 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
 
 func (s *K8sSuite) TestUseNodeCIDR(c *C) {
+	prevAnnotateK8sNode := option.Config.AnnotateK8sNode
+	option.Config.AnnotateK8sNode = true
+	defer func() {
+		option.Config.AnnotateK8sNode = prevAnnotateK8sNode
+	}()
+
 	// Test IPv4
 	node1 := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -463,11 +463,16 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 	nodeResource.ObjectMeta.Annotations = localCN.Annotations
 
 	for _, k8sAddress := range k8sNodeAddresses {
-		k8sAddressStr := k8sAddress.IP.String()
-		nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
-			Type: k8sAddress.Type,
-			IP:   k8sAddressStr,
-		})
+		// Do not add CiliumNodeInternalIP from the k8sNodeAddress. The source
+		// of truth is always the local node. The CiliumInternalIP address is
+		// added from n.localNode.IPAddress in the next for-loop.
+		if k8sAddress.Type != addressing.NodeCiliumInternalIP {
+			k8sAddressStr := k8sAddress.IP.String()
+			nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
+				Type: k8sAddress.Type,
+				IP:   k8sAddressStr,
+			})
+		}
 	}
 
 	for _, address := range n.localNode.IPAddresses {

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -229,6 +229,7 @@ const (
 	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
 	missingIptablesWait = "Missing iptables wait arg (-w):"
 	localIDRestoreFail  = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
+	routerIPMismatch    = "Mismatch of router IPs found during restoration"
 
 	// ...and their exceptions.
 	opCantBeFulfilled        = "Operation cannot be fulfilled on leases.coordination.k8s.io"        // cf. https://github.com/cilium/cilium/issues/16402
@@ -295,6 +296,7 @@ var badLogMessages = map[string][]string{
 	removeTransientRule: nil,
 	missingIptablesWait: nil,
 	localIDRestoreFail:  nil,
+	routerIPMismatch:    nil,
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.


### PR DESCRIPTION
When there is an annotation in the k8s node object, the annotation `io.cilium.network.ipv4-cilium-host` is used as the CiliumInternal IP address of the CiliumNode object in [1]. Whenever Cilium is updating any state into the CiliumNode it retrieves all IP address from k8s node, including the ones from annotations, and appends the local node's IP addresses, including the newly correct internal / router IP address, in [2]. Since this is a list, the annotation's IP address is always used first and all other Cilium agents will wrongly use it for any operation.

[1] https://github.com/cilium/cilium/blob/927bd8c26904ff92e42c61cec6d00ea8ac062c05/pkg/nodediscovery/nodediscovery.go#L453-L459
[2] https://github.com/cilium/cilium/blob/927bd8c26904ff92e42c61cec6d00ea8ac062c05/pkg/nodediscovery/nodediscovery.go#L474-L489

Fixes: 73d6cae2c906 ("install: default AnnotateK8sNode to false")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix bug that could lead to inconsistent pod IP information between agents, sometimes leading to a failure to decrypt IPsec traffic.
```

Fixes https://github.com/cilium/cilium/issues/21735
