### PR TITLE
updates.go: bump stable version to 1.12

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -174,9 +174,9 @@ const (
 
 	// CiliumStableHelmChartVersion should be the chart version that points
 	// to the v1.X branch
-	CiliumStableHelmChartVersion = "1.11"
+	CiliumStableHelmChartVersion = "1.12"
 	CiliumStableVersion          = "v" + CiliumStableHelmChartVersion
-	CiliumLatestHelmChartVersion = "1.11.90"
+	CiliumLatestHelmChartVersion = "1.12.90"
 
 	MonitorLogFileName = "monitor.log"
 


### PR DESCRIPTION
Test upgrade and downgrade from the last stable version which is 1.12

Signed-off-by: André Martins <andre@cilium.io>