### PR TITLE
pkg/datapath: return specific error message

### DIFF
--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -57,14 +57,14 @@ func NewDeviceManager() (*DeviceManager, error) {
 func NewDeviceManagerAt(netns netns.NsHandle) (*DeviceManager, error) {
 	handle, err := netlink.NewHandleAt(netns)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to setup device manager: %w", err)
 	}
 	return &DeviceManager{
 		devices: make(map[string]struct{}),
 		filter:  deviceFilter(option.Config.GetDevices()),
 		handle:  handle,
 		netns:   netns,
-	}, err
+	}, nil
 }
 
 // Detect tries to detect devices to which BPF programs may be loaded.


### PR DESCRIPTION
By not returning a specific error message in case of an error, it makes it difficult to find out on which location the Cilium agent has failed to start.

Fixes: 8941e963986e ("datapath: Fix race with a deleted device after detection")
Signed-off-by: André Martins <andre@cilium.io>