### PR TITLE
test: Allow rerunning K8sUpdates locally

### DIFF
--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -81,11 +81,12 @@ var _ = Describe("K8sUpdates", func() {
 		ExpectAllPodsTerminated(kubectl)
 
 		// Download the stable helm chart from GitHub
-		versionPath := filepath.Join(kubectl.BasePath(), "../old-charts/%s", helpers.CiliumStableVersion)
+		versionPath := filepath.Join(kubectl.BasePath(), "../old-charts", helpers.CiliumStableVersion)
 		stableChartPath = filepath.Join(versionPath, fmt.Sprintf("cilium-%s/install/kubernetes/cilium", helpers.CiliumStableHelmChartVersion))
 
-		cmd := kubectl.ExecMiddle(fmt.Sprintf("mkdir -p %s && "+
-			"cd %s &&"+
+		cmd := kubectl.Exec(fmt.Sprintf("mkdir -p %s && "+
+			"cd %s && "+
+			"rm -rf * && "+
 			"wget https://github.com/cilium/cilium/archive/refs/heads/%s.zip &&"+
 			"unzip %s.zip",
 			versionPath,


### PR DESCRIPTION
The K8sUpdates test cannot be run several times locally because, on the second run, the unzip will complain that the destination files already exist and require user input.

This pull request fixes it by removing all content of the just-created destination folder.

The path to that folder is also changed from e.g.:

    ../old-charts/%s/v1.11    (sic)

to:

    ../old-charts/v1.11

Fixes: https://github.com/cilium/cilium/pull/19710.