### PR TITLE
daemon/policy: Reduce overhead of policy deletion

### DIFF
--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 )
 
 // ruleSlice is a wrapper around a slice of *rule, which allows for functions
@@ -147,4 +148,13 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint) (bool, error) {
 	}
 
 	return endpointSelected, nil
+}
+
+// AsPolicyRules return the internal policyapi.Rule objects as a policyapi.Rules object
+func (rules ruleSlice) AsPolicyRules() policyapi.Rules {
+	policyRules := make(policyapi.Rules, 0, len(rules))
+	for _, r := range rules {
+		policyRules = append(policyRules, &r.Rule)
+	}
+	return policyRules
 }


### PR DESCRIPTION
This reduce the overhead of deleting policies, since it will now only loop through the policies in the repository once instead of twice.

We are seeing issues in production where this event loop is so busy that it's unable to keep up when the host has cpu spikes. That causes it to lag behind when it comes to getting the correct policies etc.

Signed-off-by: Odin Ugedal <ougedal@palantir.com>

```release-note
Improve policy deletion overhead by about 50% in large environments with a large number of policy rules
```
