### PR TITLE
Fix cilium-bugtool --k8s-mode

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -452,7 +452,7 @@ func k8sCommands(allCommands []string, pods []string) []string {
 				cmd = fmt.Sprintf("%s -H %s", cmd, host)
 			}
 
-			if !strings.Contains(cmd, "kubectl exec") {
+			if !strings.Contains(cmd, "kubectl exec") && !strings.Contains(cmd, "kubectl cp") {
 				cmd = podPrefix(pod, cmd)
 			}
 			commands = append(commands, cmd)

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -417,7 +417,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 	} else { // Found k8s pods
 		for _, pod := range k8sPods {
 			dst := filepath.Join(cmdDir, fmt.Sprintf("%s-%s", pod, defaults.StateDir))
-			kubectlArg := fmt.Sprintf("%s/%s:%s", k8sNamespace, pod, stateDir)
+			kubectlArg := fmt.Sprintf("-c %s %s/%s:%s", ciliumAgentContainerName, k8sNamespace, pod, stateDir)
 			// kubectl cp kube-system/cilium-xrzwr:/var/run/cilium/state cilium-xrzwr-state
 			commands = append(commands, fmt.Sprintf("kubectl cp %s %s", kubectlArg, dst))
 			for _, cmd := range ciliumCommands {

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -57,23 +57,24 @@ for sensitive information.
 )
 
 var (
-	archive         bool
-	archiveType     string
-	k8s             bool
-	dumpPath        string
-	host            string
-	k8sNamespace    string
-	k8sLabel        string
-	execTimeout     time.Duration
-	configPath      string
-	dryRunMode      bool
-	enableMarkdown  bool
-	archivePrefix   string
-	getPProf        bool
-	envoyDump       bool
-	pprofPort       int
-	traceSeconds    int
-	parallelWorkers int
+	archive                  bool
+	archiveType              string
+	k8s                      bool
+	dumpPath                 string
+	host                     string
+	k8sNamespace             string
+	k8sLabel                 string
+	execTimeout              time.Duration
+	configPath               string
+	dryRunMode               bool
+	enableMarkdown           bool
+	archivePrefix            string
+	getPProf                 bool
+	envoyDump                bool
+	pprofPort                int
+	traceSeconds             int
+	parallelWorkers          int
+	ciliumAgentContainerName string
 )
 
 func init() {
@@ -100,6 +101,7 @@ func init() {
 	BugtoolRootCmd.Flags().BoolVar(&enableMarkdown, "enable-markdown", false, "Dump output of commands in markdown format")
 	BugtoolRootCmd.Flags().StringVarP(&archivePrefix, "archive-prefix", "", "", "String to prefix to name of archive if created (e.g., with cilium pod-name)")
 	BugtoolRootCmd.Flags().IntVar(&parallelWorkers, "parallel-workers", 0, "Maximum number of parallel worker tasks, use 0 for number of CPUs")
+	BugtoolRootCmd.Flags().StringVarP(&ciliumAgentContainerName, "cilium-agent-container-name", "", "cilium-agent", "Name of the Cilium Agent main container (when k8s-mode is true)")
 }
 
 func getVerifyCiliumPods() (k8sPods []string) {
@@ -294,7 +296,7 @@ func createDir(dbgDir string, newDir string) string {
 }
 
 func podPrefix(pod, cmd string) string {
-	return fmt.Sprintf("kubectl exec %s -n %s -- %s", pod, k8sNamespace, cmd)
+	return fmt.Sprintf("kubectl exec %s -c %s -n %s -- %s", pod, ciliumAgentContainerName, k8sNamespace, cmd)
 }
 
 func runAll(commands []string, cmdDir string, k8sPods []string) {


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

Running `cilium-bugtool --k8s-mode` produces an incomplete dump.
It doesn't copy `/var/run/cilium/state` from the pods.

To reproduce:
```
git clone https://github.com/cilium/cilium
cd cilium/bugtool
make
./cilium-bugtool --k8s-mode
```
You'll see `file name too long` errors in the command output.
If you inspect the `tar` archive, you'll notice it doesn't contain the state directories.

This PR fixes 2 issues (see commit descriptions for more details):
- specify container name for `kubectl exec`
- run `kubectl cp` on the host and not in the pods

To validate it works, checkout this branch, then:
```
cd cilium/bugtool
make
./cilium-bugtool --k8s-mode
```

And inspect the `tar` archive.
