### PR TITLE
pkg/k8s/watchers: set ResourceVersion in k8s meta GetOptions{}

### DIFF
--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -139,7 +139,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					}
 
 					scopedLog.Debug("Getting CEP during an initialization")
-					localCEP, err = ciliumClient.CiliumEndpoints(namespace).Get(ctx, podName, meta_v1.GetOptions{})
+					localCEP, err = ciliumClient.CiliumEndpoints(namespace).Get(ctx, podName, meta_v1.GetOptions{ResourceVersion: "0"})
 					// It's only an error if it exists but something else happened
 					switch {
 					case err == nil:
@@ -210,7 +210,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 				// This is unexpected as there should be only 1 writer per CEP, this
 				// controller, and the localCEP created on startup will be used.
 				if localCEP == nil {
-					localCEP, err = ciliumClient.CiliumEndpoints(namespace).Get(ctx, podName, meta_v1.GetOptions{})
+					localCEP, err = ciliumClient.CiliumEndpoints(namespace).Get(ctx, podName, meta_v1.GetOptions{ResourceVersion: "0"})
 					switch {
 					case err == nil:
 						// Backfill the CEP UID as we need to do if the CEP was


### PR DESCRIPTION
Set ResourceVersion=0 will make kube-apiserver serve the request with its own in-memory cache, instead of invoking etcd.KV.Get() to retrieve the information from etcd. The former will only invoke an etcd request only if its own in-memory cache hasn't been ready.

This not only makes the request a little faster, but also reduces burden for k8s etcd, as we can skip #pods GET requests for the latter.

Note that for clients initialized using client-go informer, the RV=0 parameter has already been set by the latter internally.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>