### PR TITLE
examples: Use https when testing connectivity to 1.1.1.1

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -392,7 +392,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - 1.1.1.1
+            - https://1.1.1.1
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -404,7 +404,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - 1.1.1.1
+            - https://1.1.1.1
   selector:
     matchLabels:
       name: pod-to-external-1111

--- a/examples/kubernetes/connectivity-check/connectivity-check-netpol-only.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-netpol-only.yaml
@@ -269,7 +269,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - 1.1.1.1
+            - https://1.1.1.1
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -281,7 +281,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - 1.1.1.1
+            - https://1.1.1.1
   selector:
     matchLabels:
       name: pod-to-external-1111

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -270,7 +270,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - 1.1.1.1
+            - https://1.1.1.1
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -282,7 +282,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - 1.1.1.1
+            - https://1.1.1.1
   selector:
     matchLabels:
       name: pod-to-external-1111

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -270,7 +270,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - 1.1.1.1
+            - https://1.1.1.1
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -282,7 +282,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - 1.1.1.1
+            - https://1.1.1.1
   selector:
     matchLabels:
       name: pod-to-external-1111

--- a/examples/kubernetes/connectivity-check/network.cue
+++ b/examples/kubernetes/connectivity-check/network.cue
@@ -14,6 +14,6 @@ _trafficCheck: {
 
 deployment: "pod-to-a":             _networkCheck
 deployment: "pod-to-external-1111": _networkCheck & _trafficCheck & {
-	_probeTarget: "1.1.1.1"
+	_probeTarget: "https://1.1.1.1"
 	_probePath:   ""
 }


### PR DESCRIPTION
Same reasoning applies as in
https://github.com/cilium/cilium-cli/pull/1219.

Reported-by: Anton Protopopov <aspsk@isovalent.com>