### PR TITLE
bgp: BGP Control Plane modularization

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -4,11 +4,13 @@
 package cmd
 
 import (
+	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -33,6 +35,9 @@ var (
 
 		// Provides Clientset, API for accessing Kubernetes objects.
 		k8sClient.Cell,
+
+		// Provide option.Config via hive so cells can depend on the agent config.
+		cell.Provide(func() *option.DaemonConfig { return option.Config }),
 	)
 
 	// ControlPlane implement the per-node control functions. These are pure
@@ -49,6 +54,9 @@ var (
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,
+
+		// The BGP Control Plane
+		bgpv1.Cell,
 	)
 
 	// Datapath provides the privileged operations to apply control-plane

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/api/v1/server/restapi"
 	"github.com/cilium/cilium/pkg/aws/eni"
 	bgpv1 "github.com/cilium/cilium/pkg/bgpv1/agent"
-	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/common"
@@ -1642,6 +1641,7 @@ type daemonParams struct {
 	Datapath       datapath.Datapath
 	WGAgent        *wg.Agent `optional:"true"`
 	LocalNodeStore node.LocalNodeStore
+	BGPController  *bgpv1.Controller
 	Shutdowner     hive.Shutdowner
 }
 
@@ -1865,19 +1865,9 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 		}
 	}
 
-	if option.Config.BGPControlPlaneEnabled() {
-		switch option.Config.IPAM {
-		case ipamOption.IPAMClusterPool:
-		case ipamOption.IPAMClusterPoolV2:
-		case ipamOption.IPAMKubernetes:
-		default:
-			log.Fatalf("BGP control plane cannot be utilized with IPAM mode: %v", option.Config.IPAM)
-		}
-		log.Info("Initializing BGP Control Plane")
-		if err := d.instantiateBGPControlPlane(d.ctx); err != nil {
-			log.Fatalf("failed to initialize BGP control plane: %s", err)
-		}
-	}
+	// Assign the BGP Control to the struct field so non-modularized components can interact with the BGP Controller
+	// like they are used to.
+	d.bgpControlPlaneController = params.BGPController
 
 	log.WithField("bootstrapTime", time.Since(bootstrapTimestamp)).
 		Info("Daemon initialization completed")
@@ -1903,18 +1893,6 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 		log.WithError(err).Error("Error returned from non-returning Serve() call")
 		params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
 	}
-}
-
-func (d *Daemon) instantiateBGPControlPlane(ctx context.Context) error {
-	// goBGP is currently the only supported RouterManager, if more are
-	// implemented replace this hard-coding with a construction switch.
-	rm := gobgp.NewBGPRouterManager()
-	ctrl, err := bgpv1.NewController(d.ctx, d.clientset, rm)
-	if err != nil {
-		return fmt.Errorf("failed to instantiate BGP Control Plane: %v", err)
-	}
-	d.bgpControlPlaneController = ctrl
-	return nil
 }
 
 func (d *Daemon) instantiateAPI() *restapi.CiliumAPIAPI {

--- a/pkg/bgpv1/agent/annotations.go
+++ b/pkg/bgpv1/agent/annotations.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package bgpv1
+package agent
 
 import (
 	"errors"

--- a/pkg/bgpv1/agent/annotations_test.go
+++ b/pkg/bgpv1/agent/annotations_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package bgpv1
+package agent
 
 import (
 	"errors"

--- a/pkg/bgpv1/agent/controller_test.go
+++ b/pkg/bgpv1/agent/controller_test.go
@@ -32,6 +32,8 @@ type fakeNodeSpecer struct {
 	Annotations_ func() (map[string]string, error)
 }
 
+func (f *fakeNodeSpecer) Run(ctx context.Context) {}
+
 func (f *fakeNodeSpecer) PodCIDRs() ([]string, error) {
 	return f.PodCIDRs_()
 }

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bgpv1
+
+import (
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+var Cell = cell.Module(
+	"bgp-cp",
+	"BGP Control Plane",
+
+	cell.Provide(agent.NewController),
+	// goBGP is currently the only supported RouterManager, if more are
+	// implemented, provide the manager via a Cell that picks implementation based on configuration.
+	cell.ProvidePrivate(gobgp.NewBGPRouterManager),
+)

--- a/pkg/bgpv1/gobgp/reconcile_test.go
+++ b/pkg/bgpv1/gobgp/reconcile_test.go
@@ -10,7 +10,6 @@ import (
 
 	gobgp "github.com/osrg/gobgp/v3/api"
 
-	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
@@ -107,8 +106,8 @@ func TestPreflightReconciler(t *testing.T) {
 				LocalASN: 64125,
 			}
 			cstate := &agent.ControlPlaneState{
-				Annotations: bgpv1.AnnotationMap{
-					64125: bgpv1.Attributes{
+				Annotations: agent.AnnotationMap{
+					64125: agent.Attributes{
 						RouterID:  tt.newRouterID,
 						LocalPort: tt.newLocalPort,
 					},

--- a/pkg/bgpv1/gobgp/routermgr.go
+++ b/pkg/bgpv1/gobgp/routermgr.go
@@ -75,7 +75,7 @@ type BGPRouterManager struct {
 // NewBGPRouterManager constructs a GoBGP-backed BGPRouterManager.
 //
 // See NewBGPRouterManager for details.
-func NewBGPRouterManager() *BGPRouterManager {
+func NewBGPRouterManager() agent.BGPRouterManager {
 	return &BGPRouterManager{
 		Servers: make(LocalASNMap),
 	}


### PR DESCRIPTION
This work converts the BGP Control Plane controller and BGP Route Manager into hive cells, leaving as much of the existing code intact. These cells are now hooked into the agent hive directly. The daemon now takes the Controller as parameter both to preserve the behavior of setting the controller as a field value on the daemon and so the BGP controllers lifecycle events are invoked.

This is the first PR in a series of prep work for SVC announcements. Future PRs will break up the single cell into more granular pieces which should improve the test ability and extensibility of the BGP Control Plane.