### PR TITLE
docs: Update https.rst for Gateway API

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/https.rst
+++ b/Documentation/network/servicemesh/gateway-api/https.rst
@@ -66,7 +66,7 @@ related HTTPRoutes.
     NAME          CLASS    ADDRESS         READY   AGE
     tls-gateway   cilium   10.104.247.23   True    29s
 
-    $ kubectl httproutes  https-app-route-1 https-app-route-2
+    $ kubectl get httproutes https-app-route-1 https-app-route-2
     NAME                HOSTNAMES                      AGE
     https-app-route-1   ["bookinfo.cilium.rocks"]      29s
     https-app-route-2   ["hipstershop.cilium.rocks"]   29s


### PR DESCRIPTION
Missing "get" in kubectl command.

Signed-off-by: Nico Vibert <nicolas.vibert@isovalent.com>