### PR TITLE
Extend ipcache key with ClusterID

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -236,7 +236,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		const union v6addr *daddr = (union v6addr *)&ip6->daddr;
 		struct remote_endpoint_info *info;
 
-		info = lookup_ip6_remote_endpoint(daddr);
+		info = lookup_ip6_remote_endpoint(daddr, 0);
 		if (info && info->sec_label) {
 			*dst_id = info->sec_label;
 			tunnel_endpoint = info->tunnel_endpoint;
@@ -760,7 +760,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	if (1) {
 		struct remote_endpoint_info *info;
 
-		info = lookup_ip4_remote_endpoint(ip4->daddr);
+		info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 		if (info && info->sec_label) {
 			*dst_id = info->sec_label;
 			tunnel_endpoint = info->tunnel_endpoint;
@@ -1602,7 +1602,7 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 		union v6addr *src = (union v6addr *)&ip6->saddr;
 		struct remote_endpoint_info *info;
 
-		info = lookup_ip6_remote_endpoint(src);
+		info = lookup_ip6_remote_endpoint(src, 0);
 		if (info != NULL) {
 			__u32 sec_label = info->sec_label;
 
@@ -1942,7 +1942,7 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 	if (identity_is_reserved(src_identity)) {
 		struct remote_endpoint_info *info;
 
-		info = lookup_ip4_remote_endpoint(ip4->saddr);
+		info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 		if (info != NULL) {
 			__u32 sec_label = info->sec_label;
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -97,7 +97,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 			 */
 			info = ipcache_lookup6(&IPCACHE_MAP,
 					       (union v6addr *)&ip6->saddr,
-					       V6_CACHE_KEY_LEN);
+					       V6_CACHE_KEY_LEN, 0);
 			if (info)
 				*identity = info->sec_label;
 		}
@@ -257,7 +257,7 @@ skip_vtep:
 			struct remote_endpoint_info *info;
 
 			info = ipcache_lookup4(&IPCACHE_MAP, ip4->saddr,
-					       V4_CACHE_KEY_LEN);
+					       V4_CACHE_KEY_LEN, 0);
 			if (info)
 				*identity = info->sec_label;
 		}

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -165,7 +165,7 @@ sock4_skip_xlate(struct lb4_service *svc, __be32 address)
 		struct remote_endpoint_info *info;
 
 		info = ipcache_lookup4(&IPCACHE_MAP, address,
-				       V4_CACHE_KEY_LEN);
+				       V4_CACHE_KEY_LEN, 0);
 		if (info == NULL || info->sec_label != HOST_ID)
 			return true;
 	}
@@ -195,7 +195,7 @@ sock4_wildcard_lookup(struct lb4_key *key __maybe_unused,
 	if (in_hostns && is_v4_loopback(key->address))
 		goto wildcard_lookup;
 
-	info = ipcache_lookup4(&IPCACHE_MAP, key->address, V4_CACHE_KEY_LEN);
+	info = ipcache_lookup4(&IPCACHE_MAP, key->address, V4_CACHE_KEY_LEN, 0);
 	if (info != NULL && (info->sec_label == HOST_ID ||
 	    (include_remote_hosts && identity_is_remote_node(info->sec_label))))
 		goto wildcard_lookup;
@@ -718,7 +718,7 @@ sock6_skip_xlate(struct lb6_service *svc, const union v6addr *address)
 		struct remote_endpoint_info *info;
 
 		info = ipcache_lookup6(&IPCACHE_MAP, address,
-				       V6_CACHE_KEY_LEN);
+				       V6_CACHE_KEY_LEN, 0);
 		if (info == NULL || info->sec_label != HOST_ID)
 			return true;
 	}
@@ -748,7 +748,7 @@ sock6_wildcard_lookup(struct lb6_key *key __maybe_unused,
 	if (in_hostns && is_v6_loopback(&key->address))
 		goto wildcard_lookup;
 
-	info = ipcache_lookup6(&IPCACHE_MAP, &key->address, V6_CACHE_KEY_LEN);
+	info = ipcache_lookup6(&IPCACHE_MAP, &key->address, V6_CACHE_KEY_LEN, 0);
 	if (info != NULL && (info->sec_label == HOST_ID ||
 	    (include_remote_hosts && identity_is_remote_node(info->sec_label))))
 		goto wildcard_lookup;

--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -75,7 +75,7 @@ bool egress_gw_reply_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint,
 	if (!egress_policy)
 		return false;
 
-	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
+	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);
 	if (!info || info->tunnel_endpoint == 0)
 		return false;
 

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -54,7 +54,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	trace->reason = (enum trace_reason)ret;
 
 	/* Retrieve destination identity. */
-	info = lookup_ip6_remote_endpoint(&orig_dip);
+	info = lookup_ip6_remote_endpoint(&orig_dip, 0);
 	if (info && info->sec_label)
 		dst_id = info->sec_label;
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
@@ -110,7 +110,7 @@ ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id,
 
 	/* Retrieve destination identity. */
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *)&ip6->daddr);
-	info = lookup_ip6_remote_endpoint(&tuple.daddr);
+	info = lookup_ip6_remote_endpoint(&tuple.daddr, 0);
 	if (info && info->sec_label)
 		dst_id = info->sec_label;
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
@@ -136,7 +136,7 @@ ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id,
 	trace->reason = (enum trace_reason)ret;
 
 	/* Retrieve source identity. */
-	info = lookup_ip6_remote_endpoint(&orig_sip);
+	info = lookup_ip6_remote_endpoint(&orig_sip, 0);
 	if (info && info->sec_label)
 		*src_id = info->sec_label;
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
@@ -272,7 +272,7 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	trace->reason = (enum trace_reason)ret;
 
 	/* Retrieve destination identity. */
-	info = lookup_ip4_remote_endpoint(ip4->daddr);
+	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 	if (info && info->sec_label)
 		dst_id = info->sec_label;
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
@@ -327,7 +327,7 @@ ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id,
 		return DROP_INVALID;
 
 	/* Retrieve destination identity. */
-	info = lookup_ip4_remote_endpoint(ip4->daddr);
+	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 	if (info && info->sec_label)
 		dst_id = info->sec_label;
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
@@ -356,7 +356,7 @@ ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id,
 	trace->reason = (enum trace_reason)ret;
 
 	/* Retrieve source identity. */
-	info = lookup_ip4_remote_endpoint(ip4->saddr);
+	info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 	if (info && info->sec_label)
 		*src_id = info->sec_label;
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -168,7 +168,7 @@ _Pragma("unroll")							\
 struct ipcache_key {
 	struct bpf_lpm_trie_key lpm_key;
 	__u16 pad1;
-	__u8 pad2;
+	__u8 cluster_id;
 	__u8 family;
 	union {
 		struct {

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -620,7 +620,7 @@ static __always_inline bool snat_v4_prepare_state(struct __ctx_buff *ctx,
 #endif /* defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY) */
 
 	local_ep = __lookup_ip4_endpoint(ip4->saddr);
-	remote_ep = lookup_ip4_remote_endpoint(ip4->daddr);
+	remote_ep = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 
 	/* Check if this packet belongs to reply traffic coming from a
 	 * local endpoint.

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -730,7 +730,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	}
 
 	dst = (union v6addr *)&ip6->daddr;
-	info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN);
+	info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN, 0);
 	if (info && info->tunnel_endpoint != 0) {
 		ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 					  WORLD_ID,
@@ -1029,7 +1029,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __u32 *ifind
 			union v6addr *dst = (union v6addr *)&ip6->daddr;
 			struct remote_endpoint_info *info;
 
-			info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN);
+			info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN, 0);
 			if (info != NULL && info->tunnel_endpoint != 0) {
 				return __encap_with_nodeid(ctx, info->tunnel_endpoint,
 							   SECLABEL, info->sec_label,
@@ -1690,7 +1690,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
+	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);
 	if (info && info->tunnel_endpoint != 0) {
 		/* The dir == NAT_DIR_EGRESS branch is executed for
 		 * N/S LB requests which needs to be fwd-ed to a remote
@@ -2010,7 +2010,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 		{
 			struct remote_endpoint_info *info;
 
-			info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
+			info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);
 			if (info != NULL && info->tunnel_endpoint != 0) {
 				tunnel_endpoint = info->tunnel_endpoint;
 				dst_id = info->sec_label;

--- a/bpf/sockops/bpf_redir.c
+++ b/bpf/sockops/bpf_redir.c
@@ -54,7 +54,7 @@ int cil_redir_proxy(struct sk_msg_md *msg)
 	 * socket to avoid extra overhead. This would require the agent though
 	 * to flush the sock ops map on policy changes.
 	 */
-	info = lookup_ip4_remote_endpoint(key.dip4);
+	info = lookup_ip4_remote_endpoint(key.dip4, 0);
 	if (info != NULL && info->sec_label)
 		dst_id = info->sec_label;
 	else

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -75,7 +75,7 @@ static inline void bpf_sock_ops_ipv4(struct bpf_sock_ops *skops)
 	if (1) {
 		struct remote_endpoint_info *info;
 
-		info = lookup_ip4_remote_endpoint(key.dip4);
+		info = lookup_ip4_remote_endpoint(key.dip4, 0);
 		if (info != NULL && info->sec_label)
 			dst_id = info->sec_label;
 		else

--- a/bpf/tests/nat_test.c
+++ b/bpf/tests/nat_test.c
@@ -88,7 +88,8 @@ static __always_inline struct endpoint_info *mock__lookup_ip4_endpoint(__maybe_u
 	return NULL;
 }
 
-static __always_inline struct remote_endpoint_info *mock_lookup_ip4_remote_endpoint(__maybe_unused __u32 ip)
+static __always_inline struct remote_endpoint_info *
+mock_lookup_ip4_remote_endpoint(__maybe_unused __u32 ip, __maybe_unused __u8 cluster_id)
 {
 	return NULL;
 }

--- a/bpf/tests/wildcard_lookup.c
+++ b/bpf/tests/wildcard_lookup.c
@@ -123,7 +123,7 @@ int test_v4_check(__maybe_unused struct xdp_md *ctx)
 	test_init();
 
 	TEST("setup", {
-		info = ipcache_lookup4(&IPCACHE_MAP, bpf_htonl(HOST_IP), V4_CACHE_KEY_LEN);
+		info = ipcache_lookup4(&IPCACHE_MAP, bpf_htonl(HOST_IP), V4_CACHE_KEY_LEN, 0);
 		assert(info);
 	});
 
@@ -348,7 +348,7 @@ int test_v6_check(__maybe_unused struct xdp_md *ctx)
 	test_init();
 
 	TEST("setup", {
-		info = ipcache_lookup6(&IPCACHE_MAP, &HOST_IP6, V6_CACHE_KEY_LEN);
+		info = ipcache_lookup6(&IPCACHE_MAP, &HOST_IP6, V6_CACHE_KEY_LEN, 0);
 		assert(info);
 	});
 

--- a/pkg/clustermesh/types/addressing.go
+++ b/pkg/clustermesh/types/addressing.go
@@ -218,3 +218,27 @@ func (ac AddrCluster) As20() (ac20 [20]byte) {
 func (ac AddrCluster) AsNetIP() net.IP {
 	return ac.addr.AsSlice()
 }
+
+// PrefixCluster is a type that holds a pair of prefix and ClusterID.
+// We should use this type as much as possible when we implement
+// prefix + Cluster addressing. We should avoid managing prefix and
+// ClusterID separately. Otherwise, it is very hard for code readers
+// to see where we are using cluster-aware addressing.
+type PrefixCluster struct {
+	prefix    netip.Prefix
+	clusterID uint32
+}
+
+func PrefixClusterFrom(addr netip.Addr, bits int, clusterID uint32) PrefixCluster {
+	return PrefixCluster{
+		prefix:    netip.PrefixFrom(addr, bits),
+		clusterID: clusterID,
+	}
+}
+
+func (pc PrefixCluster) String() string {
+	if pc.clusterID == 0 {
+		return pc.prefix.String()
+	}
+	return pc.prefix.String() + "@" + strconv.FormatUint(uint64(pc.clusterID), 10)
+}

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -138,7 +138,7 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 
 	// Update BPF Maps.
 
-	key := ipcacheMap.NewKey(cidr.IP, cidr.Mask)
+	key := ipcacheMap.NewKey(cidr.IP, cidr.Mask, 0)
 
 	switch modType {
 	case ipcache.Upsert:


### PR DESCRIPTION
This is a part of the Cluster Mesh with overlapping PodCIDR support. When the remote cluster has an overlapping PodCIDR, we must identify the remote endpoint using IP + ClusterID. This PR makes the required changes for ipcache to realize that. Note that this PR only adds infrastructure, and currently, we don't "use" that. Please review commit by commit.

```release-note
Extend ipcache key with ClusterID
```
