### PR TITLE
docs: Clarify wildcards and subdomains in FQDN policies

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -556,7 +556,7 @@ IPs to be allowed are selected via:
 
   * ``*`` within a domain allows 0 or more valid DNS characters, except for the
     ``.`` separator. ``*.cilium.io`` will match ``sub.cilium.io`` but not
-    ``cilium.io``. ``part*ial.com`` will match ``partial.com`` and
+    ``cilium.io`` or ``sub.sub.cilium.io``. ``part*ial.com`` will match ``partial.com`` and
     ``part-extra-ial.com``.
   * ``*`` alone matches all names, and inserts all cached DNS IPs into this
     rule.


### PR DESCRIPTION
Using * in CiliumNetworkPolicy to FQDNs.matchPattern does not include all levels of subdomains. This update to the docs clarifies this limitation.

Issue is highlighted in #22081 

Signed-off-by: flxman <felix.farjsjo@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!
