### PR TITLE
identity: add per-node identities

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -121,6 +121,7 @@ cilium-agent [flags]
       --enable-local-redirect-policy                            Enable Local Redirect Policy
       --enable-monitor                                          Enable the monitor unix domain socket server (default true)
       --enable-node-port                                        Enable NodePort type services by Cilium
+      --enable-per-node-identity                                Enable use of remote node identity
       --enable-pmtu-discovery                                   Enable path MTU discovery to send ICMP fragmentation-needed replies to the client
       --enable-policy string                                    Enable policy enforcement (default "default")
       --enable-recorder                                         Enable BPF datapath pcap recorder

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1585,6 +1585,10 @@
      - cilium-operator update strategy
      - object
      - ``{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}``
+   * - perNodeIdentity
+     - Enable per-node identities.
+     - bool
+     - ``false``
    * - pmtuDiscovery.enabled
      - Enable path MTU discovery to send ICMP fragmentation-needed replies to the client.
      - bool

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -321,6 +321,16 @@ Removed Options
 * The ineffective ``disable-conntrack``, ``endpoint-interface-name-prefix`` options deprecated in
   version 1.12 have been removed.
 
+New Options
+~~~~~~~~~~~
+
+* ``per-node-identities``: This option enables allocation of security identity based on Node
+  labels instead of previously used ``reserved:remote-node``. The change might impact those who
+  are using ``remote-node-identities=true`` and have a network policy allowing access to the endpoints
+  using ``fromEntities: remote-node``. If this is the case then during the upgrade users will have to
+  specify new CNP/CCNP field ``fromNodes``/``toNodes`` together with ``fromEntities: remote-node``
+  until all nodes are upgraded.
+
 Added Metrics
 ~~~~~~~~~~~~~
 

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -407,6 +407,22 @@ in the cluster that Cilium is running on.
 
         .. literalinclude:: ../../../examples/policies/l3/entities/nodes.json
 
+Access to/from custom nodes in the cluster
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Allow all endpoints with the label ``env=dev`` to receive traffic from nodes with
+a label ``node=worker``.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../../examples/policies/l3/entities/from_nodes.yaml
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../../examples/policies/l3/entities/from_nodes.json
+
 Access to/from outside cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -755,6 +755,7 @@ pcap
 peerService
 perf
 periodSeconds
+perNodeIdentity
 pipelining
 playbook
 pluggable

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -614,6 +614,7 @@ func NewDaemon(ctx context.Context, cleaner *daemonCleanup,
 	nodeMngr = nodeMngr.WithIPCache(d.ipcache)
 	nodeMngr = nodeMngr.WithSelectorCacheUpdater(d.policy.GetSelectorCache()) // must be after initPolicy
 	nodeMngr = nodeMngr.WithPolicyTriggerer(epMgr)                            // must be after initPolicy
+	nodeMngr = nodeMngr.WithIdentityAllocator(d.identityAllocator)
 
 	proxy.Allocator = d.identityAllocator
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -264,6 +264,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableRemoteNodeIdentity, defaults.EnableRemoteNodeIdentity, "Enable use of remote node identity")
 	option.BindEnv(Vp, option.EnableRemoteNodeIdentity)
 
+	flags.Bool(option.EnablePerNodeIdentity, defaults.EnablePerNodeIdentity, "Enable use of remote node identity")
+	option.BindEnv(Vp, option.EnablePerNodeIdentity)
+
 	flags.String(option.EncryptInterface, "", "Transparent encryption interface")
 	option.BindEnv(Vp, option.EncryptInterface)
 

--- a/examples/policies/l3/entities/from_nodes.json
+++ b/examples/policies/l3/entities/from_nodes.json
@@ -1,0 +1,9 @@
+[{
+    "labels": [{"key": "name", "value": "to-dev-from-worker-nodes"}],
+    "endpointSelector": {"matchLabels": {"env":"dev"}},
+    "ingress": [{
+        "fromNodes": [
+            {"matchLabels": {"role": "worker"}}
+        ]
+    }]
+}]

--- a/examples/policies/l3/entities/from_nodes.yaml
+++ b/examples/policies/l3/entities/from_nodes.yaml
@@ -1,0 +1,12 @@
+apiversion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "to-dev-from-worker-nodes"
+spec:
+  endpointSelector:
+    matchLabels:
+      env: dev
+  ingress:
+    - fromNodes:
+      - matchLabels:
+          role: worker

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -447,6 +447,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.unmanagedPodWatcher.intervalSeconds | int | `15` | Interval, in seconds, to check if there are any pods that are not managed by Cilium. |
 | operator.unmanagedPodWatcher.restart | bool | `true` | Restart any pod that are not managed by Cilium. |
 | operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}` | cilium-operator update strategy |
+| perNodeIdentity | bool | `false` | Enable per-node identities. |
 | pmtuDiscovery.enabled | bool | `false` | Enable path MTU discovery to send ICMP fragmentation-needed replies to the client. |
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -710,6 +710,7 @@ data:
   enable-well-known-identities: "false"
 {{- end }}
   enable-remote-node-identity: {{ .Values.remoteNodeIdentity | quote }}
+  enable-per-node-identity: {{ .Values.perNodeIdentity | quote }}
 
 {{- if hasKey .Values "synchronizeK8sNodes" }}
   synchronize-k8s-nodes: {{ .Values.synchronizeK8sNodes | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1529,6 +1529,9 @@ proxy:
 # ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity
 remoteNodeIdentity: true
 
+# -- Enable per-node identities.
+perNodeIdentity: false
+
 # -- Enable resource quotas for priority classes used in the cluster.
 resourceQuotas:
   enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1526,6 +1526,9 @@ proxy:
 # ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity
 remoteNodeIdentity: true
 
+# -- Enable per-node identities.
+perNodeIdentity: false
+
 # -- Enable resource quotas for priority classes used in the cluster.
 resourceQuotas:
   enabled: false

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -451,6 +451,9 @@ const (
 	// EnableRemoteNodeIdentity is the default value for option.EnableRemoteNodeIdentity
 	EnableRemoteNodeIdentity = false
 
+	// EnablePerNodeIdentity is the default value for option.EnablePerNodeIdentity
+	EnablePerNodeIdentity = false
+
 	// IPAMExpiration is the timeout after which an IP subject to expiratio
 	// is being released again if no endpoint is being created in time.
 	IPAMExpiration = 10 * time.Minute

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -328,6 +328,62 @@ spec:
                             type: object
                         type: object
                       type: array
+                    toNodes:
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     toPorts:
                       description: "ToPorts is a list of destination ports identified
                         by port number and protocol which the endpoint subject to
@@ -1096,6 +1152,62 @@ spec:
                             type: object
                         type: object
                       type: array
+                    toNodes:
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     toPorts:
                       description: "ToPorts is a list of destination ports identified
                         by port number and protocol which the endpoint subject to
@@ -1506,6 +1618,62 @@ spec:
                         - none
                         - kube-apiserver
                         type: string
+                      type: array
+                    fromNodes:
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       type: array
                     fromRequires:
                       description: "FromRequires is a list of additional constraints
@@ -2160,6 +2328,62 @@ spec:
                         - kube-apiserver
                         type: string
                       type: array
+                    fromNodes:
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     fromRequires:
                       description: "FromRequires is a list of additional constraints
                         which must be met in order for the selected endpoints to be
@@ -2682,6 +2906,62 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                              type: object
+                          type: object
+                        type: array
+                      toNodes:
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                         type: array
@@ -3467,6 +3747,62 @@ spec:
                               type: object
                           type: object
                         type: array
+                      toNodes:
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        type: array
                       toPorts:
                         description: "ToPorts is a list of destination ports identified
                           by port number and protocol which the endpoint subject to
@@ -3881,6 +4217,62 @@ spec:
                           - none
                           - kube-apiserver
                           type: string
+                        type: array
+                      fromNodes:
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         type: array
                       fromRequires:
                         description: "FromRequires is a list of additional constraints
@@ -4542,6 +4934,62 @@ spec:
                           - none
                           - kube-apiserver
                           type: string
+                        type: array
+                      fromNodes:
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         type: array
                       fromRequires:
                         description: "FromRequires is a list of additional constraints

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -332,6 +332,62 @@ spec:
                             type: object
                         type: object
                       type: array
+                    toNodes:
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     toPorts:
                       description: "ToPorts is a list of destination ports identified
                         by port number and protocol which the endpoint subject to
@@ -1100,6 +1156,62 @@ spec:
                             type: object
                         type: object
                       type: array
+                    toNodes:
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     toPorts:
                       description: "ToPorts is a list of destination ports identified
                         by port number and protocol which the endpoint subject to
@@ -1510,6 +1622,62 @@ spec:
                         - none
                         - kube-apiserver
                         type: string
+                      type: array
+                    fromNodes:
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       type: array
                     fromRequires:
                       description: "FromRequires is a list of additional constraints
@@ -2164,6 +2332,62 @@ spec:
                         - kube-apiserver
                         type: string
                       type: array
+                    fromNodes:
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     fromRequires:
                       description: "FromRequires is a list of additional constraints
                         which must be met in order for the selected endpoints to be
@@ -2686,6 +2910,62 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                              type: object
+                          type: object
+                        type: array
+                      toNodes:
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                         type: array
@@ -3471,6 +3751,62 @@ spec:
                               type: object
                           type: object
                         type: array
+                      toNodes:
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        type: array
                       toPorts:
                         description: "ToPorts is a list of destination ports identified
                           by port number and protocol which the endpoint subject to
@@ -3885,6 +4221,62 @@ spec:
                           - none
                           - kube-apiserver
                           type: string
+                        type: array
+                      fromNodes:
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         type: array
                       fromRequires:
                         description: "FromRequires is a list of additional constraints
@@ -4546,6 +4938,62 @@ spec:
                           - none
                           - kube-apiserver
                           type: string
+                        type: array
+                      fromNodes:
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         type: array
                       fromRequires:
                         description: "FromRequires is a list of additional constraints

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -109,6 +109,13 @@ func parseToCiliumIngressCommonRule(namespace string, es api.EndpointSelector, i
 		}
 	}
 
+	if ing.FromNodes != nil {
+		retRule.FromNodes = make([]api.EndpointSelector, len(ing.FromNodes))
+		for j, node := range ing.FromNodes {
+			retRule.FromNodes[j] = api.NewESFromK8sLabelSelector("", node.LabelSelector)
+		}
+	}
+
 	if ing.FromCIDR != nil {
 		retRule.FromCIDR = make([]api.CIDR, len(ing.FromCIDR))
 		copy(retRule.FromCIDR, ing.FromCIDR)
@@ -211,6 +218,13 @@ func parseToCiliumEgressCommonRule(namespace string, es api.EndpointSelector, eg
 	if egr.ToEntities != nil {
 		retRule.ToEntities = make([]api.Entity, len(egr.ToEntities))
 		copy(retRule.ToEntities, egr.ToEntities)
+	}
+
+	if egr.ToNodes != nil {
+		retRule.ToNodes = make([]api.EndpointSelector, len(egr.ToNodes))
+		for j, node := range egr.ToNodes {
+			retRule.ToNodes[j] = api.NewESFromK8sLabelSelector("", node.LabelSelector)
+		}
 	}
 
 	if egr.ToGroups != nil {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -204,7 +204,8 @@ func (n *NodeDiscovery) StartDiscovery() {
 		}
 	}()
 
-	n.Manager.NodeUpdated(n.localNode)
+	// update the ipcache
+	go n.Manager.NodeUpdated(n.localNode)
 	close(n.localStateInitialized)
 
 	n.updateLocalNode()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -894,6 +894,9 @@ const (
 	// EnableRemoteNodeIdentity enables use of the remote-node identity
 	EnableRemoteNodeIdentity = "enable-remote-node-identity"
 
+	// EnablePerNodeIdentity enables use of the per-node identity
+	EnablePerNodeIdentity = "enable-per-node-identity"
+
 	// PolicyAuditModeArg argument enables policy audit mode.
 	PolicyAuditModeArg = "policy-audit-mode"
 
@@ -2030,6 +2033,9 @@ type DaemonConfig struct {
 	// EnableRemoteNodeIdentity enables use of the remote-node identity
 	EnableRemoteNodeIdentity bool
 
+	// EablePerNodeIdentity enables use of the per-node identity
+	EnablePerNodeIdentity bool
+
 	// Azure options
 
 	// PolicyAuditMode enables non-drop mode for installed policies. In
@@ -2448,6 +2454,12 @@ func (c *DaemonConfig) RemoteNodeIdentitiesEnabled() bool {
 	return c.EnableRemoteNodeIdentity
 }
 
+// PerNodeIdentitiesEnabled returns true if per-node identity feature
+// is enabled
+func (c *DaemonConfig) PerNodeIdentitiesEnabled() bool {
+	return c.EnablePerNodeIdentity
+}
+
 // NodeEncryptionEnabled returns true if node encryption is enabled
 func (c *DaemonConfig) NodeEncryptionEnabled() bool {
 	return c.EncryptNode
@@ -2801,6 +2813,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableSocketLB = vp.GetBool(EnableHostReachableServices) || vp.GetBool(EnableSocketLB)
 	c.EnableSocketLBTracing = vp.GetBool(EnableSocketLBTracing)
 	c.EnableRemoteNodeIdentity = vp.GetBool(EnableRemoteNodeIdentity)
+	c.EnablePerNodeIdentity = vp.GetBool(EnablePerNodeIdentity)
 	c.EnableBPFTProxy = vp.GetBool(EnableBPFTProxy)
 	c.EnableXTSocketFallback = vp.GetBool(EnableXTSocketFallbackName)
 	c.EnableAutoDirectRouting = vp.GetBool(EnableAutoDirectRoutingName)

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -27,6 +27,12 @@ func (f *Config) RemoteNodeIdentitiesEnabled() bool {
 	return true
 }
 
+// PerNodeIdentitiesEnabled returns true if the per-node identity feature
+// is enabled
+func (f *Config) PerNodeIdentitiesEnabled() bool {
+	return true
+}
+
 // EncryptionEnabled returns true if encryption is enabled
 func (f *Config) EncryptionEnabled() bool {
 	return true

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -99,6 +99,9 @@ type EgressCommonRule struct {
 	// +kubebuilder:validation:Optional
 	ToGroups []ToGroups `json:"toGroups,omitempty"`
 
+	// +kubebuilder:validation:Optional
+	ToNodes []EndpointSelector `json:"toNodes,omitempty"`
+
 	// TODO: Move this to the policy package
 	// (https://github.com/cilium/cilium/issues/8353)
 	aggregatedSelectors EndpointSelectorSlice `json:"-"`
@@ -299,6 +302,7 @@ func (e *EgressCommonRule) getDestinationEndpointSelectorsWithRequirements(
 		}
 	} else {
 		res = append(res, e.ToEndpoints...)
+		res = append(res, e.ToNodes...)
 	}
 	return append(res, e.aggregatedSelectors...)
 }

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -72,6 +72,9 @@ type IngressCommonRule struct {
 	// +kubebuilder:validation:Optional
 	FromEntities EntitySlice `json:"fromEntities,omitempty"`
 
+	// +kubebuilder:validation:Optional
+	FromNodes []EndpointSelector `json:"fromNodes,omitempty"`
+
 	// TODO: Move this to the policy package
 	// (https://github.com/cilium/cilium/issues/8353)
 	aggregatedSelectors EndpointSelectorSlice `json:"-"`
@@ -198,6 +201,7 @@ func (i *IngressCommonRule) GetSourceEndpointSelectorsWithRequirements(requireme
 		}
 	} else {
 		res = append(res, i.FromEndpoints...)
+		res = append(res, i.FromNodes...)
 	}
 
 	return append(res, i.aggregatedSelectors...)

--- a/pkg/policy/api/zz_generated.deepcopy.go
+++ b/pkg/policy/api/zz_generated.deepcopy.go
@@ -158,6 +158,13 @@ func (in *EgressCommonRule) DeepCopyInto(out *EgressCommonRule) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ToNodes != nil {
+		in, out := &in.ToNodes, &out.ToNodes
+		*out = make([]EndpointSelector, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.aggregatedSelectors != nil {
 		in, out := &in.aggregatedSelectors, &out.aggregatedSelectors
 		*out = make(EndpointSelectorSlice, len(*in))
@@ -468,6 +475,13 @@ func (in *IngressCommonRule) DeepCopyInto(out *IngressCommonRule) {
 		in, out := &in.FromEntities, &out.FromEntities
 		*out = make(EntitySlice, len(*in))
 		copy(*out, *in)
+	}
+	if in.FromNodes != nil {
+		in, out := &in.FromNodes, &out.FromNodes
+		*out = make([]EndpointSelector, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.aggregatedSelectors != nil {
 		in, out := &in.aggregatedSelectors, &out.aggregatedSelectors

--- a/pkg/policy/api/zz_generated.deepequal.go
+++ b/pkg/policy/api/zz_generated.deepequal.go
@@ -257,6 +257,23 @@ func (in *EgressCommonRule) DeepEqual(other *EgressCommonRule) bool {
 		}
 	}
 
+	if ((in.ToNodes != nil) && (other.ToNodes != nil)) || ((in.ToNodes == nil) != (other.ToNodes == nil)) {
+		in, other := &in.ToNodes, &other.ToNodes
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if !inElement.DeepEqual(&(*other)[i]) {
+					return false
+				}
+			}
+		}
+	}
+
 	if ((in.aggregatedSelectors != nil) && (other.aggregatedSelectors != nil)) || ((in.aggregatedSelectors == nil) != (other.aggregatedSelectors == nil)) {
 		in, other := &in.aggregatedSelectors, &other.aggregatedSelectors
 		if other == nil {
@@ -648,6 +665,23 @@ func (in *IngressCommonRule) DeepEqual(other *IngressCommonRule) bool {
 		in, other := &in.FromEntities, &other.FromEntities
 		if other == nil || !in.DeepEqual(other) {
 			return false
+		}
+	}
+
+	if ((in.FromNodes != nil) && (other.FromNodes != nil)) || ((in.FromNodes == nil) != (other.FromNodes == nil)) {
+		in, other := &in.FromNodes, &other.FromNodes
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if !inElement.DeepEqual(&(*other)[i]) {
+					return false
+				}
+			}
 		}
 	}
 

--- a/test/k8s/manifests/cnp-from-nodes.yaml
+++ b/test/k8s/manifests/cnp-from-nodes.yaml
@@ -1,0 +1,12 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "from-nodes"
+spec:
+  endpointSelector:
+    matchLabels:
+      {}
+  ingress:
+  - fromNodes:
+    - matchLabels:
+        cilium.io/ci-node: k8s1


### PR DESCRIPTION
With this one can specify this CNP and allow access only from/to specific nodes:
```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "from-nodes"
spec:
  endpointSelector:
    matchLabels:
      {}
  ingress:
  - fromNodes:
    - matchLabels:
        cilium.io/ci-node: k8s1
  egress:
  - toNodes:
    - matchLabels:
        cilium.io/ci-node: k8s1
```

instead of 

```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "from-nodes"
spec:
  endpointSelector:
    matchLabels:
      {}
  ingress:
  - fromEntities:
    - remote-node:
```
where all remote-nodes (as well as nodes from all remote clusters) are allowed.

---

This feature reuses existing global way to allocate identity just like how endpoint identities work, i.e. each cilium-agent waits for global identity allocator to be initialized and then allocates inside nodeDiscovery identity for each remote-node and saves it to a local ipcache.

When packets are sent out they still have ID 6 (remote-node), but corresponding cilium-agent knows better and checks [ipcache](https://github.com/cilium/cilium/blob/7fb2d89f05a4f875e12d6b906f5f3e2219cbdc18/bpf/bpf_overlay.c#L259) (here for tunneling mode) where it finds the right identity. This way continuous upgrade is possible -- old nodes will find an ID == 6 and upgraded nodes might find something like `211584`. 

During upgrade user might have to specify both:
```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "from-nodes"
spec:
  endpointSelector:
    matchLabels:
      {}
  ingress:
  - fromEntities:
    - remote-node
  - fromNodes:
    - matchLabels:
        cilium.io/ci-node: k8s1
```
so that old nodes as well as upgraded nodes correctly allow/block packets.


Fixes: #[21615](https://github.com/cilium/cilium/issues/21615)

Signed-off-by: Ondrej Blazek <ondrej.blazek@firma.seznam.cz>