### PR TITLE
daemon: convert Daemon.restoredCIDRs to netip.Prefix

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/netip"
 	"os"
 	"path"
 	"path/filepath"
@@ -52,7 +51,6 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/exporter/exporteroption"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -1774,12 +1772,7 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 			// (re-)allocate the restored identities before we release them.
 			time.Sleep(option.Config.IdentityRestoreGracePeriod)
 			log.Debugf("Releasing reference counts for %d restored CIDR identities", len(d.restoredCIDRs))
-
-			prefixes := make([]netip.Prefix, 0, len(d.restoredCIDRs))
-			for _, c := range d.restoredCIDRs {
-				prefixes = append(prefixes, ip.IPNetToPrefix(c))
-			}
-			d.ipcache.ReleaseCIDRIdentitiesByCIDR(prefixes)
+			d.ipcache.ReleaseCIDRIdentitiesByCIDR(d.restoredCIDRs)
 			// release the memory held by restored CIDRs
 			d.restoredCIDRs = nil
 		}

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -83,28 +83,6 @@ func AddrToIPNet(addr netip.Addr) *net.IPNet {
 	}
 }
 
-// IPNetToPrefix is a convenience helper for migrating from the older 'net'
-// standard library types to the newer 'netip' types. Use this to plug the
-// new types in newer code into older types in older code during the migration.
-//
-// Note: This function assumes given prefix.IP is not an IPv4 mapped IPv6
-// address. See the comment of AddrFromIP for more details.
-func IPNetToPrefix(prefix *net.IPNet) netip.Prefix {
-	if prefix == nil {
-		return netip.Prefix{}
-	}
-	ip, ok := AddrFromIP(prefix.IP)
-	if !ok {
-		return netip.Prefix{}
-	}
-	ones, bits := prefix.Mask.Size()
-	if bits != net.IPv4len*8 && bits != net.IPv6len*8 {
-		// invalid mask
-		return netip.Prefix{}
-	}
-	return netip.PrefixFrom(ip, ones)
-}
-
 // IPToNetPrefix is a convenience helper for migrating from the older 'net'
 // standard library types to the newer 'netip' types. Use this to plug the new
 // types in newer code into older types in older code during the migration.

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -41,17 +41,6 @@ func TestAddrToIPNet(t *testing.T) {
 	assert.Equal(t, nilNet, AddrToIPNet(netip.Addr{}))
 }
 
-func TestIPNetToPrefix(t *testing.T) {
-	_, v4IPNet, err := net.ParseCIDR("1.1.1.1/32")
-	assert.NoError(t, err)
-	_, v6IPNet, err := net.ParseCIDR("::ff/128")
-	assert.NoError(t, err)
-	assert.Equal(t, netip.MustParsePrefix(v4IPNet.String()), IPNetToPrefix(v4IPNet))
-	assert.Equal(t, netip.MustParsePrefix(v6IPNet.String()), IPNetToPrefix(v6IPNet))
-
-	assert.Equal(t, netip.Prefix{}, IPNetToPrefix(nil))
-}
-
 func TestIPToNetPrefix(t *testing.T) {
 	v4, _, err := net.ParseCIDR("1.1.1.1/32")
 	assert.NoError(t, err)

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -827,20 +827,6 @@ func IsPublicAddr(ip net.IP) bool {
 	return true
 }
 
-// GetCIDRPrefixesFromIPs returns all of the ips as a slice of *net.IPNet.
-//
-// Deprecated. Consider using IPsToNetPrefixes() instead.
-func GetCIDRPrefixesFromIPs(ips []net.IP) []*net.IPNet {
-	if len(ips) == 0 {
-		return nil
-	}
-	res := make([]*net.IPNet, 0, len(ips))
-	for _, ip := range ips {
-		res = append(res, IPToPrefix(ip))
-	}
-	return res
-}
-
 // IPToPrefix returns the corresponding IPNet for the given IP.
 func IPToPrefix(ip net.IP) *net.IPNet {
 	bits := net.IPv6len * 8

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"sync"
 	"unsafe"
 
@@ -95,6 +96,18 @@ func (k Key) IPNet() *net.IPNet {
 		cidr.Mask = net.CIDRMask(int(prefixLen), 128)
 	}
 	return cidr
+}
+
+func (k Key) Prefix() netip.Prefix {
+	var addr netip.Addr
+	prefixLen := int(k.Prefixlen - getStaticPrefixBits())
+	switch k.Family {
+	case bpf.EndpointKeyIPv4:
+		addr = netip.AddrFrom4(*(*[4]byte)(k.IP[:4]))
+	case bpf.EndpointKeyIPv6:
+		addr = netip.AddrFrom16(k.IP)
+	}
+	return netip.PrefixFrom(addr, prefixLen)
 }
 
 // getPrefixLen determines the length that should be set inside the Key so that


### PR DESCRIPTION
Review by commit. The main change is in the 2nd commit:

This avoids conversions to/from `net.IPNet` when populating and accessing
the restored CIDRs.