### PR TITLE
resource: Add DiffStore

### DIFF
--- a/pkg/k8s/resource/diffstore.go
+++ b/pkg/k8s/resource/diffstore.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/stream"
+
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+// DiffStoreFactory creates diffStores. All stores from the same factory share the same underlying store, but each
+// diff store tracks the diff since the last time it was checked.
+type DiffStoreFactory[T k8sRuntime.Object] interface {
+	// NewStore creates a new store from this factory, all DiffStores share the same underlying store but each
+	// records its own diff list.
+	NewStore() DiffStore[T]
+
+	// Observe returns a channel which will be signalled every time there is at least one pending change.
+	// Multiple changes are coalesced. Calling `done` will drain and close the channel, it should be called when no
+	// longer using `onDiff` to free resources.
+	Observe() (onDiff <-chan struct{}, done func())
+}
+
+var _ DiffStoreFactory[*k8sRuntime.Unknown] = (*diffStoreFactory[*k8sRuntime.Unknown])(nil)
+
+type diffStoreParams[T k8sRuntime.Object] struct {
+	cell.In
+
+	LS         hive.Lifecycle
+	Shutdowner hive.Shutdowner
+	Resource   Resource[T]
+}
+
+type diffStoreFactory[T k8sRuntime.Object] struct {
+	params diffStoreParams[T]
+
+	store Store[T]
+
+	ctx      context.Context
+	cancel   context.CancelFunc
+	doneChan chan struct{}
+
+	inSync bool
+
+	mu         lock.Mutex
+	onDiff     []chan struct{}
+	diffStores []*diffStore[T]
+}
+
+// NewDiffStoreFactory
+func NewDiffStoreFactory[T k8sRuntime.Object](params diffStoreParams[T]) DiffStoreFactory[T] {
+	dsf := &diffStoreFactory[T]{
+		params:   params,
+		doneChan: make(chan struct{}),
+	}
+
+	dsf.ctx, dsf.cancel = context.WithCancel(context.Background())
+
+	params.LS.Append(dsf)
+
+	return dsf
+}
+
+// NewStore creates a new store from this factory, all DiffStores share the same underlying store but each
+// records its own diff list.
+func (dsf *diffStoreFactory[T]) NewStore() DiffStore[T] {
+	dsf.mu.Lock()
+	defer dsf.mu.Unlock()
+
+	store := &diffStore[T]{
+		factory:     dsf,
+		store:       dsf.store,
+		changedKeys: make(map[Key]bool),
+	}
+	dsf.diffStores = append(dsf.diffStores, store)
+	return store
+}
+
+// Observe returns a channel which will be signalled every time there is at least one pending change.
+// Multiple changes are coalesced. Calling `done` will drain and close the channel, it should be called when no
+// longer using `onDiff` to free resources.
+func (dsf *diffStoreFactory[T]) Observe() (onDiff <-chan struct{}, done func()) {
+	newOnDiff := make(chan struct{}, 1)
+	dsf.onDiff = append(dsf.onDiff, newOnDiff)
+	done = func() {
+		// Close
+		close(newOnDiff)
+		// And drain
+		select {
+		case <-newOnDiff:
+		default:
+		}
+	}
+	return newOnDiff, done
+}
+
+// Start implements hive.Hook
+func (dsf *diffStoreFactory[T]) Start(_ hive.HookContext) error {
+	go dsf.run()
+	return nil
+}
+
+// Stop implements hive.Hook
+func (dsf *diffStoreFactory[T]) Stop(stopCtx hive.HookContext) error {
+	dsf.cancel()
+
+	select {
+	case <-dsf.doneChan:
+	case <-stopCtx.Done():
+	}
+
+	return nil
+}
+
+func (dsf *diffStoreFactory[T]) run() {
+	defer close(dsf.doneChan)
+
+	var err error
+	dsf.store, err = dsf.params.Resource.Store(dsf.ctx)
+	if err != nil {
+		dsf.params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
+		return
+	}
+
+	dsf.mu.Lock()
+	for _, store := range dsf.diffStores {
+		store.store = dsf.store
+	}
+	dsf.mu.Unlock()
+
+	errChan := make(chan error, 2)
+	updateChan := stream.ToChannel[Event[T]](dsf.ctx, errChan, dsf.params.Resource)
+
+	for {
+		select {
+		case event, ok := <-updateChan:
+			if !ok {
+				break
+			}
+
+			event.Handle(
+				func() error {
+					dsf.inSync = true
+					dsf.signalObservers()
+					return nil
+				},
+				dsf.handleChange,
+				dsf.handleChange,
+			)
+		case err := <-errChan:
+			dsf.params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
+			return
+		}
+	}
+}
+
+func (dsf *diffStoreFactory[T]) handleChange(k Key, _ T) error {
+	dsf.mu.Lock()
+	defer dsf.mu.Unlock()
+
+	for _, store := range dsf.diffStores {
+		store.markChanged(k)
+	}
+
+	if dsf.inSync {
+		dsf.signalObservers()
+	}
+
+	return nil
+}
+
+func (dsf *diffStoreFactory[T]) signalObservers() {
+	for _, onDiff := range dsf.onDiff {
+		select {
+		case onDiff <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// DiffStore is a super set of the Store. The diffStore tracks all changes made to the diff store since the
+// last time the user synced up. This allows a user to get a list of just the changed objects while still being able
+// to query the full store for a full sync.
+type DiffStore[T k8sRuntime.Object] interface {
+	Store[T]
+
+	// Diff returns a list of items that have been upserted(updated or inserted) and deleted since the last call to Diff.
+	Diff() (upserted []T, deleted []Key, err error)
+	// MarkChanged marks a key as having been changed so it will appear in the Diff again. This can be used in case
+	// of a failure to process so a next call to Diff gets the chance to process the key again.
+	MarkChanged(Key)
+}
+
+var _ DiffStore[*k8sRuntime.Unknown] = (*diffStore[*k8sRuntime.Unknown])(nil)
+
+// diffStore takes a Resource[T] and watches for events, it stores all of the keys that have been changed.
+// diffStore can still be used as a normal store, but adds the Diff function to get a Diff of all changes.
+// The diffStore also takes in Signaler which it will signal after the initial sync and every update thereafter.
+type diffStore[T k8sRuntime.Object] struct {
+	store Store[T]
+
+	factory *diffStoreFactory[T]
+
+	mu          lock.Mutex
+	changedKeys map[Key]bool
+}
+
+// Diff returns a list of items that have been upserted(updated or inserted) and deleted since the last call to Diff.
+func (sd *diffStore[T]) Diff() (upserted []T, deleted []Key, err error) {
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	for k := range sd.changedKeys {
+		item, found, err := sd.store.GetByKey(k)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if found {
+			upserted = append(upserted, item)
+		} else {
+			deleted = append(deleted, k)
+		}
+	}
+
+	sd.changedKeys = make(map[Key]bool, 0)
+
+	return upserted, deleted, err
+}
+
+// MarkChanged marks a key as having been changed so it will appear in the Diff again. This can be used in case
+// of a failure to process so a next call to Diff gets the chance to process the key again.
+func (sd *diffStore[T]) MarkChanged(key Key) {
+	sd.markChanged(key)
+
+	// Signal all observers to re-trigger an observer activated Diff.
+	sd.factory.signalObservers()
+}
+
+func (sd *diffStore[T]) markChanged(key Key) {
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+	sd.changedKeys[key] = true
+}
+
+// List returns all items currently in the store.
+func (sd *diffStore[T]) List() []T {
+	return sd.store.List()
+}
+
+// IterKeys returns a key iterator.
+func (sd *diffStore[T]) IterKeys() KeyIter {
+	return sd.store.IterKeys()
+}
+
+// Get returns the latest version by deriving the key from the given object.
+func (sd *diffStore[T]) Get(obj T) (item T, exists bool, err error) {
+	return sd.store.Get(obj)
+}
+
+// GetByKey returns the latest version of the object with given key.
+func (sd *diffStore[T]) GetByKey(key Key) (item T, exists bool, err error) {
+	return sd.store.GetByKey(key)
+}

--- a/pkg/k8s/resource/diffstore_test.go
+++ b/pkg/k8s/resource/diffstore_test.go
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	slim_fake "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/fake"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+)
+
+type DiffStoreFixture struct {
+	diffFactory  DiffStoreFactory[*v1.Service]
+	observer     <-chan struct{}
+	observerDone func()
+	cs           *slim_fake.Clientset
+	hive         *hive.Hive
+}
+
+func newDiffStoreFixture() *DiffStoreFixture {
+	fixture := &DiffStoreFixture{}
+
+	// Create a new mocked CRD client set with the pools as initial objects
+	fixture.cs = slim_fake.NewSimpleClientset()
+
+	// Construct a new Hive with mocked out dependency cells.
+	fixture.hive = hive.New(
+		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) Resource[*v1.Service] {
+			return New[*v1.Service](
+				lc, utils.ListerWatcherFromTyped[*v1.ServiceList](
+					c.Slim().CoreV1().Services(""),
+				),
+			)
+		}),
+
+		// Provide the mocked client cells directly
+		cell.Provide(func() k8sClient.Clientset {
+			return &k8sClient.FakeClientset{
+				SlimFakeClientset: fixture.cs,
+			}
+		}),
+
+		cell.Invoke(func(
+			diffFactory DiffStoreFactory[*v1.Service],
+		) {
+			fixture.diffFactory = diffFactory
+			fixture.observer, fixture.observerDone = diffFactory.Observe()
+		}),
+
+		cell.Provide(NewDiffStoreFactory[*v1.Service]),
+	)
+
+	return fixture
+}
+
+// Test that adding and deleting objects trigger signals
+func TestDiffSignal(t *testing.T) {
+	fixture := newDiffStoreFixture()
+	tracker := fixture.cs.Tracker()
+
+	// Add an initial object.
+	err := tracker.Add(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc-a",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = fixture.hive.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diffstore := fixture.diffFactory.NewStore()
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-fixture.observer:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err := diffstore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 1 {
+		t.Fatal("Initial upserted not one")
+	}
+
+	if len(deleted) != 0 {
+		t.Fatal("Initial deleted not zero")
+	}
+
+	// Add an object after init
+
+	err = tracker.Add(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc-b",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timer = time.NewTimer(time.Second)
+	select {
+	case <-fixture.observer:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err = diffstore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 1 {
+		t.Fatal("Runtime upserted not one")
+	}
+
+	if len(deleted) != 0 {
+		t.Fatal("Runtime deleted not zero")
+	}
+
+	// Delete an object after init
+
+	err = tracker.Delete(v1.SchemeGroupVersion.WithResource("services"), "", "svc-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timer = time.NewTimer(time.Second)
+	select {
+	case <-fixture.observer:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err = diffstore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 0 {
+		t.Fatal("Runtime upserted not zero")
+	}
+
+	if len(deleted) != 1 {
+		t.Fatal("Runtime deleted not one")
+	}
+
+	err = fixture.hive.Stop(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Test that multiple events are correctly combined.
+func TestDiffUpsertCoalesce(t *testing.T) {
+	fixture := newDiffStoreFixture()
+	tracker := fixture.cs.Tracker()
+
+	err := fixture.hive.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diffstore := fixture.diffFactory.NewStore()
+
+	// Add first object
+	err = tracker.Add(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc-a",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add second object
+	err = tracker.Add(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc-b",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait a second for changes to be processed
+	time.Sleep(time.Second)
+
+	// Check that we have a signal
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-fixture.observer:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err := diffstore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 2 {
+		t.Fatal("Expected 2 upserted objects")
+	}
+
+	if len(deleted) != 0 {
+		t.Fatal("Expected 0 deleted objects")
+	}
+
+	// Update first object
+	err = tracker.Update(
+		v1.SchemeGroupVersion.WithResource("services"),
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "svc-a",
+			},
+			Spec: v1.ServiceSpec{
+				ClusterIP: "1.2.3.4",
+			},
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tracker.Delete(v1.SchemeGroupVersion.WithResource("services"), "", "svc-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait a second for changes to be processed
+	time.Sleep(time.Second)
+
+	// Check that we have a signal
+	timer = time.NewTimer(time.Second)
+	select {
+	case <-fixture.observer:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err = diffstore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 1 {
+		t.Fatal("Expected 1 upserted object")
+	}
+
+	if len(deleted) != 1 {
+		t.Fatal("Expected 1 deleted object")
+	}
+
+	// Update first object once
+	err = tracker.Update(
+		v1.SchemeGroupVersion.WithResource("services"),
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "svc-a",
+			},
+			Spec: v1.ServiceSpec{
+				ClusterIP: "2.3.4.5",
+			},
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update first object twice
+	err = tracker.Update(
+		v1.SchemeGroupVersion.WithResource("services"),
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "svc-a",
+			},
+			Spec: v1.ServiceSpec{
+				ClusterIP: "3.4.5.6",
+			},
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait a second for changes to be processed
+	time.Sleep(time.Second)
+
+	// Check that we have a signal
+	timer = time.NewTimer(time.Second)
+	select {
+	case <-fixture.observer:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err = diffstore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 1 {
+		t.Fatal("Expected 1 upserted object")
+	}
+
+	if len(deleted) != 0 {
+		t.Fatal("Expected 1 deleted object")
+	}
+
+	if upserted[0].Spec.ClusterIP != "3.4.5.6" {
+		t.Fatal("Expected to only see the latest update")
+	}
+
+	err = fixture.hive.Stop(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This commit introduces the `DiffStore` and `DiffStoreFactory`. The goal of the `DiffStore` is to provide a fully working store which can be queried for changes since the last time we queried it. The `DiffStore` will return a coalesced list of upserted(updated / inserted) objects and deleted keys. This is particularly useful for batching incremental updates instead of handling each event in order.

The factory can be constructed as a hive cell and only requires a `Resource[T]` of the same type as dependency. The factory can be observed for changes via a channel gotten by the `Observe` method. All `DiffStore`s created share the same store but each instance maintains its own diff.

`DiffStore` has a `MarkChanged` method which can be used to mark a key as changed so it will re-appear in the `Diff` output next time it is called. This can be used in case of an error when processing as a retry mechanism.