### PR TITLE
operator: fix CEP GC

### DIFF
--- a/operator/cmd/k8s_cep_gc.go
+++ b/operator/cmd/k8s_cep_gc.go
@@ -163,7 +163,7 @@ func doCiliumEndpointSyncGC(ctx context.Context, clientset k8sClient.Clientset, 
 		case err == nil:
 			successfulEndpointObjectGC()
 		case k8serrors.IsNotFound(err), k8serrors.IsConflict(err):
-			// No-op.
+			scopedLog.WithError(err).Debug("Unable to delete CEP, will retry again")
 		default:
 			scopedLog.WithError(err).Warning("Unable to delete orphaned CEP")
 			failedEndpointObjectGC()

--- a/operator/watchers/cilium_endpoint.go
+++ b/operator/watchers/cilium_endpoint.go
@@ -132,6 +132,7 @@ func convertToCiliumEndpoint(obj interface{}) interface{} {
 				Namespace:       concreteObj.Namespace,
 				ResourceVersion: concreteObj.ResourceVersion,
 				OwnerReferences: concreteObj.OwnerReferences,
+				UID:             concreteObj.UID,
 			},
 			Status: cilium_api_v2.EndpointStatus{
 				Identity:   concreteObj.Status.Identity,
@@ -156,6 +157,7 @@ func convertToCiliumEndpoint(obj interface{}) interface{} {
 					Namespace:       ciliumEndpoint.Namespace,
 					ResourceVersion: ciliumEndpoint.ResourceVersion,
 					OwnerReferences: ciliumEndpoint.OwnerReferences,
+					UID:             ciliumEndpoint.UID,
 				},
 				Status: cilium_api_v2.EndpointStatus{
 					Identity:   ciliumEndpoint.Status.Identity,


### PR DESCRIPTION
When CEP was converted to an internal CEP structure, the UID field was not copied, causing the delete requests of CEPs to have their UID precondition set as empty. When kube-apiserver received this delete request it didn't delete the CEP because an empty CEP UID didn't match an existent UID.

Fixes: 6f7bf6c51f7a ("Prevent CiliumEndpoint removal by non-owning agent")

Reported-by: Bruno Custódio <bruno@isovalent.com>
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix GC of CEPs that were not GCed by kube-apiserver
```
