### PR TITLE
docs: Regenerated `cilium-bugtool` docs to fix Travis CI

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -27,24 +27,25 @@ cilium-bugtool [OPTIONS] [flags]
 ### Options
 
 ```
-      --archive                   Create archive when false skips deletion of the output directory (default true)
-      --archive-prefix string     String to prefix to name of archive if created (e.g., with cilium pod-name)
-  -o, --archiveType string        Archive type: tar | gz (default "tar")
-      --config string             Configuration to decide what should be run (default "./.cilium-bugtool.config")
-      --dry-run                   Create configuration file of all commands that would have been executed
-      --enable-markdown           Dump output of commands in markdown format
-      --envoy-dump                When set, dump envoy configuration from unix socket (default true)
-      --exec-timeout duration     The default timeout for any cmd execution in seconds (default 30s)
-      --get-pprof                 When set, only gets the pprof traces from the cilium-agent binary
-  -h, --help                      help for cilium-bugtool
-  -H, --host string               URI to server-side API
-      --k8s-label string          Kubernetes label for Cilium pod (default "k8s-app=cilium")
-      --k8s-mode                  Require Kubernetes pods to be found or fail
-      --k8s-namespace string      Kubernetes namespace for Cilium pod (default "kube-system")
-      --parallel-workers int      Maximum number of parallel worker tasks, use 0 for number of CPUs
-      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061, apiserver:6063 (default 6060)
-      --pprof-trace-seconds int   Amount of seconds used for pprof CPU traces (default 180)
-  -t, --tmp string                Path to store extracted files. Use '-' to send to stdout. (default "/tmp")
+      --archive                              Create archive when false skips deletion of the output directory (default true)
+      --archive-prefix string                String to prefix to name of archive if created (e.g., with cilium pod-name)
+  -o, --archiveType string                   Archive type: tar | gz (default "tar")
+      --cilium-agent-container-name string   Name of the Cilium Agent main container (when k8s-mode is true) (default "cilium-agent")
+      --config string                        Configuration to decide what should be run (default "./.cilium-bugtool.config")
+      --dry-run                              Create configuration file of all commands that would have been executed
+      --enable-markdown                      Dump output of commands in markdown format
+      --envoy-dump                           When set, dump envoy configuration from unix socket (default true)
+      --exec-timeout duration                The default timeout for any cmd execution in seconds (default 30s)
+      --get-pprof                            When set, only gets the pprof traces from the cilium-agent binary
+  -h, --help                                 help for cilium-bugtool
+  -H, --host string                          URI to server-side API
+      --k8s-label string                     Kubernetes label for Cilium pod (default "k8s-app=cilium")
+      --k8s-mode                             Require Kubernetes pods to be found or fail
+      --k8s-namespace string                 Kubernetes namespace for Cilium pod (default "kube-system")
+      --parallel-workers int                 Maximum number of parallel worker tasks, use 0 for number of CPUs
+      --pprof-port int                       Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061, apiserver:6063 (default 6060)
+      --pprof-trace-seconds int              Amount of seconds used for pprof CPU traces (default 180)
+  -t, --tmp string                           Path to store extracted files. Use '-' to send to stdout. (default "/tmp")
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
PR #22160 from a community member broke Travis CI on master. They forgot to regenerate the cmdref after making a modification and the failing CI was ignored. this commit fixes that.

Signed-off-by: Dylan Reimerink <dylan.reimerink@isovalent.com>