### PR TITLE
doc: fixed broken gettingstarted link on helm chart

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -37,7 +37,7 @@ $ helm install cilium cilium/cilium --namespace=kube-system
 ```
 
 After Cilium is installed, you can explore the features that Cilium has to
-offer from the [Getting Started Guides page](https://docs.cilium.io/en/latest/gettingstarted/).
+offer from the [Getting Started Guides page](https://docs.cilium.io/en/stable/gettingstarted/).
 
 ## Source Code
 

--- a/install/kubernetes/cilium/README.md.gotmpl
+++ b/install/kubernetes/cilium/README.md.gotmpl
@@ -39,7 +39,7 @@ $ helm install cilium cilium/cilium --namespace=kube-system
 ```
 
 After Cilium is installed, you can explore the features that Cilium has to
-offer from the [Getting Started Guides page](https://docs.cilium.io/en/latest/gettingstarted/).
+offer from the [Getting Started Guides page](https://docs.cilium.io/en/stable/gettingstarted/).
 
 {{ template "chart.maintainersSection" . }}
 


### PR DESCRIPTION
Signed-off-by: David Calvert <david@0xdc.me>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

This just fix the broken link in the [README.md](https://github.com/cilium/cilium/tree/master/install/kubernetes/cilium#getting-started) of Cilium Helm chart. 
Not creating an issue because this is a minor change.

```release-note
fixed broken gettingstarted link on helm chart README.md
```
