### PR TITLE
Enable Google Analytics 4

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run pre-requisites for validation
         run: |
           make -C Documentation copy-api # necessary for check-build.sh
-      - uses: docker://cilium/docs-builder:2022-08-24@sha256:d62428f571eae01297eb58a7c11375bd2b33adec313213a6b8841a3a9c0f2959
+      - uses: docker://cilium/docs-builder:2022-12-21@sha256:745e868e60d2aa35f24895668a27ea3b49864f6ab6d54daa9983936462aa5cd4
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -42,6 +42,7 @@ extensions = ['myst_parser',
               'sphinx.ext.extlinks',
               'sphinxcontrib.openapi',
               'sphinx_tabs.tabs',
+              'sphinxcontrib.googleanalytics',
               'sphinxcontrib.spelling',
               'versionwarning.extension']
 
@@ -167,6 +168,7 @@ spelling_filters = [cilium_spellfilters.WireGuardFilter]
 # Ignore some warnings from MyST parser
 suppress_warnings = ['myst.header']
 
+googleanalytics_id = 'G-V9SYWYG92Y'
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
As mentioned in #22007, Google's Universal Analytics (UA) are being deprecated and will stop working in 2023. This upgrades to use GA4.

- Contributes to #22007
- Preview: https://deploy-preview-22220--docs-cilium-io.netlify.app

/cc @xmulligan @qmonnet @michi-covalent 

---

**Edit** 2022/12/20: setting this to DRAFT while waiting for

- #22821
- The new docker image to be created

For context see, https://github.com/cilium/cilium/pull/22220#issuecomment-1360400381.
