### PR TITLE
test/control-plane: Add nil checks to shutdown logic

### DIFF
--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -29,10 +29,17 @@ type agentHandle struct {
 }
 
 func (h *agentHandle) tearDown() {
-	if err := h.hive.Stop(context.TODO()); err != nil {
-		h.t.Fatalf("Failed to stop the agent: %s", err)
+	// If hive is nil, we have not yet started.
+	if h.hive != nil {
+		if err := h.hive.Stop(context.TODO()); err != nil {
+			h.t.Fatalf("Failed to stop the agent: %s", err)
+		}
 	}
-	h.d.Close()
+
+	if h.d != nil {
+		h.d.Close()
+	}
+
 	os.RemoveAll(h.tempDir)
 	node.Uninitialize()
 }


### PR DESCRIPTION
The `agentHandle.tearDown` function always assumes it is called after its `hive` and `d` fields are set. The call to this shutdown logic is deferred. If we encounter an error before setting these fields, the deferred logic would cause an nil pointer deference panic which masks the original error. See #22224.

This PR adds nil checks so `tearDown` can always be called.