### PR TITLE
k8s/client: respect QPS and burst setting for clientset

### DIFF
--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -306,6 +306,8 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 		config = &rest.Config{Host: apiServerURL, UserAgent: userAgent}
 	}
 
+	config.QPS = qps
+	config.Burst = burst
 	return config, nil
 }
 


### PR DESCRIPTION
When constructing a new clientset, the provided QPS and burst values are currently not considered.

Fixes: 00e40bb41683 ("k8s: Drop k8s.Init and k8s.Configure")
