### PR TITLE
mtu, node: fix build on all non-linux platforms

### DIFF
--- a/pkg/mtu/detect_other.go
+++ b/pkg/mtu/detect_other.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-//go:build darwin
+//go:build !linux
 
 package mtu
 

--- a/pkg/node/address_other.go
+++ b/pkg/node/address_other.go
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-//go:build darwin
+//go:build !linux
 
 package node
 
-import (
-	"net"
-)
+import "net"
 
 func firstGlobalV4Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
 	return net.IP{}, nil


### PR DESCRIPTION
This package is imported as a transitive dependency in cilium-cli which is built for linux, darwin and windows. Make sure the package compiles on all these platforms.

Ref. https://github.com/cilium/cilium-cli/pull/958#issuecomment-1318745049
For #16843

Marking as `needs-backport/1.12` so we can vendor the next v1.12.n release into cilium-cli again.