### PR TITLE
daemon, fqdn, metrics: Add better metric for DNS proxy latency

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -428,13 +428,23 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		}
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, upstream).Observe(
 			stat.UpstreamTime.Total().Seconds())
+		metrics.ProxyUpstreamTimeV2.WithLabelValues(metricError, metrics.L7DNS, upstream).Observe(
+			stat.UpstreamTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(
+			stat.ProcessingTime.Total().Seconds())
+		metrics.ProxyUpstreamTimeV2.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(
 			stat.ProcessingTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, semaphoreTime).Observe(
 			stat.SemaphoreAcquireTime.Total().Seconds())
+		metrics.ProxyUpstreamTimeV2.WithLabelValues(metricError, metrics.L7DNS, semaphoreTime).Observe(
+			stat.SemaphoreAcquireTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyCheckTime).Observe(
 			stat.PolicyCheckTime.Total().Seconds())
+		metrics.ProxyUpstreamTimeV2.WithLabelValues(metricError, metrics.L7DNS, policyCheckTime).Observe(
+			stat.PolicyCheckTime.Total().Seconds())
 		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, dataplaneTime).Observe(
+			stat.DataplaneTime.Total().Seconds())
+		metrics.ProxyUpstreamTimeV2.WithLabelValues(metricError, metrics.L7DNS, dataplaneTime).Observe(
 			stat.DataplaneTime.Total().Seconds())
 	}
 


### PR DESCRIPTION
Use the "summary" type and prefer it over the "histogram" type. The
latter is inaccurate when calculating the average latency because it
groups measurements into buckets, which inherently means we are losing
the raw information. This is unintuitive when visualizing these sorts of
metrics.

A "summary" type includes quantiles like "histogram", but doesn't group
values into buckets. "Summary" also keeps the raw information which
allows us to accurately calculate averages. This is most intuitive for
understanding the different processing times of the DNS proxy.

Co-authored-by: Michi Mutsuzaki <michi@isovalent.com>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
