### PR TITLE
daemon, fqdn: Fix race between parallel DNS requests for the same name

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"net/netip"
 	"os"
@@ -132,6 +133,10 @@ type Daemon struct {
 	// apply to locally running endpoints.
 	dnsNameManager *fqdn.NameManager
 
+	// dnsProxyContext contains fields relevant to the DNS proxy. See each
+	// field's godoc for more details.
+	dnsProxyContext dnsProxyContext
+
 	// Used to synchronize generation of daemon's BPF programs and endpoint BPF
 	// programs.
 	compilationMutex *lock.RWMutex
@@ -205,6 +210,28 @@ type Daemon struct {
 
 	// BIG-TCP config values
 	bigTCPConfig bigtcp.Configuration
+}
+
+func (d *Daemon) initDNSProxyContext(size int) {
+	d.dnsProxyContext = dnsProxyContext{
+		responseMutexes: make([]*lock.Mutex, size),
+		modulus:         big.NewInt(int64(size)),
+	}
+	for i := range d.dnsProxyContext.responseMutexes {
+		d.dnsProxyContext.responseMutexes[i] = new(lock.Mutex)
+	}
+}
+
+// dnsProxyContext is a meta struct containing fields relevant to the DNS proxy
+// of the daemon, for organizational purposes.
+type dnsProxyContext struct {
+	// responseMutexes is used to serialized the critical path of
+	// notifyOnDNSMsg() to ensure that identity allocation and ipcache
+	// insertion happen atomically between parallel DNS request handling.
+	responseMutexes []*lock.Mutex
+	// modulus is used when computing the hash of the DNS response IPs in order
+	// to map them to the mutexes inside responseMutexes.
+	modulus *big.Int
 }
 
 // GetPolicyRepository returns the policy repository of the daemon

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -867,6 +867,14 @@ func initializeFlags() {
 	flags.Duration(option.DNSProxyConcurrencyProcessingGracePeriod, 0, "Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing")
 	option.BindEnv(Vp, option.DNSProxyConcurrencyProcessingGracePeriod)
 
+	flags.Int(option.DNSProxyLockCount, 128, "Array size containing mutexes which protect against parallel handling of DNS response IPs")
+	flags.MarkHidden(option.DNSProxyLockCount)
+	option.BindEnv(Vp, option.DNSProxyLockCount)
+
+	flags.Duration(option.DNSProxyLockTimeout, 500*time.Millisecond, fmt.Sprintf("Timeout when acquiring the locks controlled by --%s", option.DNSProxyLockCount))
+	flags.MarkHidden(option.DNSProxyLockTimeout)
+	option.BindEnv(Vp, option.DNSProxyLockTimeout)
+
 	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "Size of queues for policy-related events")
 	option.BindEnv(Vp, option.PolicyQueueSize)
 

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	miekgdns "github.com/miekg/dns"
 	. "gopkg.in/check.v1"
 	k8sCache "k8s.io/client-go/tools/cache"
 
@@ -23,14 +24,19 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/proxy/logger"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
@@ -121,7 +127,20 @@ func (ds *DaemonFQDNSuite) SetUpTest(c *C) {
 	})
 	d.endpointManager = WithCustomEndpointManager(&dummyEpSyncher{})
 	d.policy.GetSelectorCache().SetLocalIdentityNotifier(d.dnsNameManager)
+	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{
+		Context:           context.TODO(),
+		IdentityAllocator: d.identityAllocator,
+		PolicyHandler:     d.policy.GetSelectorCache(),
+		DatapathHandler:   d.endpointManager,
+	})
 	ds.d = d
+
+	logger.SetEndpointInfoRegistry(&dummyInfoRegistry{})
+}
+
+type dummyInfoRegistry struct{}
+
+func (*dummyInfoRegistry) FillEndpointInfo(info *accesslog.EndpointInfo, ip net.IP, id identity.NumericIdentity) {
 }
 
 // makeIPs generates count sequential IPv4 IPs
@@ -154,6 +173,91 @@ func (ds *DaemonSuite) BenchmarkFqdnCache(c *C) {
 	c.StartTimer()
 
 	extractDNSLookups(endpoints, "0.0.0.0/0", "*", "")
+}
+
+// Benchmark_notifyOnDNSMsg stresses the main callback function for the DNS
+// proxy path, which is called on every DNS request and response.
+func (ds *DaemonFQDNSuite) Benchmark_notifyOnDNSMsg(c *C) {
+	var (
+		nameManager             = ds.d.dnsNameManager
+		ciliumIOSel             = api.FQDNSelector{MatchName: "cilium.io"}
+		ciliumIOSelMatchPattern = api.FQDNSelector{MatchPattern: "*cilium.io."}
+		ebpfIOSel               = api.FQDNSelector{MatchName: "ebpf.io"}
+		ciliumDNSRecord         = map[string]*fqdn.DNSIPRecords{
+			dns.FQDN("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("192.0.2.3")}},
+		}
+		ebpfDNSRecord = map[string]*fqdn.DNSIPRecords{
+			dns.FQDN("ebpf.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("192.0.2.4")}},
+		}
+
+		wg sync.WaitGroup
+	)
+
+	// Register rules (simulates applied policies).
+	selectorsToAdd := api.FQDNSelectorSlice{ciliumIOSel, ciliumIOSelMatchPattern, ebpfIOSel}
+	nameManager.Lock()
+	for _, sel := range selectorsToAdd {
+		nameManager.RegisterForIdentityUpdatesLocked(sel)
+	}
+	nameManager.Unlock()
+
+	// Initialize the endpoints.
+	endpoints := make([]*endpoint.Endpoint, c.N)
+	for i := range endpoints {
+		endpoints[i] = &endpoint.Endpoint{
+			ID:   uint16(c.N % 65000),
+			IPv4: netip.MustParseAddr(fmt.Sprintf("10.96.%d.%d", (c.N>>16)%8, c.N%256)),
+			SecurityIdentity: &identity.Identity{
+				ID: identity.NumericIdentity(c.N % int(identity.MaximumAllocationIdentity)),
+			},
+			DNSZombies: &fqdn.DNSZombieMappings{
+				Mutex: lock.Mutex{},
+			},
+		}
+		ep := endpoints[i]
+		ep.UpdateLogger(nil)
+		ep.DNSHistory = fqdn.NewDNSCache(0)
+	}
+
+	c.ResetTimer()
+	// Simulate parallel DNS responses from the upstream DNS for cilium.io and
+	// ebpf.io, done by every endpoint.
+	for i := 0; i < c.N; i++ {
+		wg.Add(1)
+		go func(ep *endpoint.Endpoint) {
+			defer wg.Done()
+			// Using a hardcoded string representing endpoint IP:port as this
+			// parameter is only used in logging. Not using the endpoint's IP
+			// so we don't spend any time in the benchmark on converting from
+			// net.IP to string.
+			c.Assert(ds.d.notifyOnDNSMsg(time.Now(), ep, "10.96.64.8:12345", 0, "10.96.64.1:53", &miekgdns.Msg{
+				MsgHdr: miekgdns.MsgHdr{
+					Response: true,
+				},
+				Question: []miekgdns.Question{{
+					Name: dns.FQDN("cilium.io"),
+				}},
+				Answer: []miekgdns.RR{&miekgdns.A{
+					Hdr: miekgdns.RR_Header{Name: dns.FQDN("cilium.io")},
+					A:   ciliumDNSRecord[dns.FQDN("cilium.io")].IPs[0],
+				}}}, "udp", true, &dnsproxy.ProxyRequestContext{}), IsNil)
+
+			c.Assert(ds.d.notifyOnDNSMsg(time.Now(), ep, "10.96.64.4:54321", 0, "10.96.64.1:53", &miekgdns.Msg{
+				MsgHdr: miekgdns.MsgHdr{
+					Response: true,
+				},
+				Compress: false,
+				Question: []miekgdns.Question{{
+					Name: dns.FQDN("ebpf.io"),
+				}},
+				Answer: []miekgdns.RR{&miekgdns.A{
+					Hdr: miekgdns.RR_Header{Name: dns.FQDN("ebpf.io")},
+					A:   ebpfDNSRecord[dns.FQDN("ebpf.io")].IPs[0],
+				}}}, "udp", true, &dnsproxy.ProxyRequestContext{}), IsNil)
+		}(endpoints[i%len(endpoints)])
+	}
+
+	wg.Wait()
 }
 
 func (ds *DaemonFQDNSuite) TestFQDNIdentityReferenceCounting(c *C) {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -634,4 +634,7 @@ const (
 
 	// CGroupId is the numerical cgroup id
 	CGroupID = "cgroupID"
+
+	// Expected is an expected value
+	Expected = "expected"
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -481,6 +481,14 @@ const (
 	// been reached.
 	DNSProxyConcurrencyProcessingGracePeriod = "dnsproxy-concurrency-processing-grace-period"
 
+	// DNSProxyLockCount is the array size containing mutexes which protect
+	// against parallel handling of DNS response IPs.
+	DNSProxyLockCount = "dnsproxy-lock-count"
+
+	// DNSProxyLockTimeout is timeout when acquiring the locks controlled by
+	// DNSProxyLockCount.
+	DNSProxyLockTimeout = "dnsproxy-lock-timeout"
+
 	// MTUName is the name of the MTU option
 	MTUName = "mtu"
 
@@ -1711,6 +1719,14 @@ type DaemonConfig struct {
 	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
 	// been reached.
 	DNSProxyConcurrencyProcessingGracePeriod time.Duration
+
+	// DNSProxyLockCount is the array size containing mutexes which protect
+	// against parallel handling of DNS response IPs.
+	DNSProxyLockCount int
+
+	// DNSProxyLockTimeout is timeout when acquiring the locks controlled by
+	// DNSProxyLockCount.
+	DNSProxyLockTimeout time.Duration
 
 	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
 	// sysctl option if `xt_socket` kernel module is not available.
@@ -3089,6 +3105,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.FQDNProxyResponseMaxDelay = vp.GetDuration(FQDNProxyResponseMaxDelay)
 	c.DNSProxyConcurrencyLimit = vp.GetInt(DNSProxyConcurrencyLimit)
 	c.DNSProxyConcurrencyProcessingGracePeriod = vp.GetDuration(DNSProxyConcurrencyProcessingGracePeriod)
+	c.DNSProxyLockCount = vp.GetInt(DNSProxyLockCount)
+	c.DNSProxyLockTimeout = vp.GetDuration(DNSProxyLockTimeout)
 
 	// Convert IP strings into net.IPNet types
 	subnets, invalid := ip.ParseCIDRs(vp.GetStringSlice(IPv4PodSubnets))


### PR DESCRIPTION
- daemon, cmd: Add benchmark for notifyOnDNSMsg()
- daemon, fqdn: Fix race between parallel DNS requests for the same name

---

First commit adds a new benchmarking function for the DNS proxy callback `notifyOnDNSMsg()` and the second commit will be copied below for ease of review:

It is possible for parallel DNS requests handled by separate goroutines (controlled by --dnsproxy-concurrency-limit) to race if they are for the same DNS name, i.e. both goroutines handling cilium.io.

Here is a diagram for this race:

```
             G1                                    G2

T0 --> NotifyOnDNSMsg()               NotifyOnDNSMsg()            <-- T0

T1 --> UpdateGenerateDNS()            UpdateGenerateDNS()         <-- T1

T2 ----> mutex.Lock()                 +---------------------------+
                                      |No identities need updating|
T3 ----> mutex.Unlock()               +---------------------------+

T4 --> UpsertGeneratedIdentities()    UpsertGeneratedIdentities() <-- T4

T5 ---->  Upsert()                    DNS released back to pod    <-- T5
                                                   |
T6 --> DNS released back to pod                    |
             |                                     |
             |                                     |
             v                                     v
      Traffic flows fine                   Leads to policy drop
```

Note how G2 releases the DNS msg back to the pod at T5 because UpdateGenerateDNS() was a no-op. It's a no-op because G1 had executed UpdateGenerateDNS() first at T1 and performed the necessary identity allocation for the response IPs. Due to G1 performing all the work first, G2 executes T4 also as a no-op and releases the msg back to the pod at T5 before G1 would at T6.

The above results in a policy drop because it is assumed that when the DNS msg is released back to the pod / endpoint, then the ipcache has been updated with the proper IP <-> identity mapping. In other words, because G2 releases the DNS msg back to the pod / endpoint, the app attempts to use the IPs returned in the DNS response, but the ipcache lookup fails in the datapath because the IP <-> identity mappings don't exist. In essence, this is a race between DNS requests to the ipcache.

To fix, we create a critical section when handling the DNS response IPs.  Allocating identities and associating them to IPs in the ipcache is now atomic because of the critical section. This is especially important as we've already seen for multiple DNS requests are in-flight for the same name (i.e. cilium.io).

The critical section is implemented using a fixed sized array of mutexes. Why? Because the other options (listed below) all have flaws which may result in drops.

Other options considered:

1) A map of mutexes keyed on DNS name
2) A map of mutexes keyed on set of DNS response IPs
3) A map of mutexes keyed on endpoint ID
4) A slice of mutexes with hash based on individual IPs from the set of DNS response IPs

(1) could cause a race between the DNS response IPs from `a.com` and the set of DNS response IPs from `b.com` especially if the sets are the same.
(2) could race between a super / subset of DNS response IPs, i.e. only an intersection of sets would have protection. Any IPs that are not in the intersection are vulnerable to race.
(3) could cause a race between different endpoints querying the same name, i.e. two endpoints querying cilium.io.
(4) could work but this is approach is not ideal as the slice scales with the number of unique IPs seen by the DNS proxy. This has memory consumption concerns.

Therefore, we opt for a fixed size array of mutexes where we hash the individual IPs from the set of DNS response IPs. For example, say we attempt to resolve cilium.io and the response IPs are A and B.

   hash(A) % mod = 8
   hash(B) % mod = 3

   where mod is --dnsproxy-lock-size, i.e. size of array

What's returned is a slice containing the above array indices that's sorted in ascending order. This is the order in which the mutexes must be locked and unlocked. To be specific, [3, 8] is the sorted resulted and it means we acquire & release mutex at index 3 and then do the same for mutex at index 8.

What this does is essentially serialize parallel DNS requests which involve the same IP <-> identity mappings in the ipcache.

It's possible that the hash of the IPs collide (map to the same mutex) when the IPs are different, but this is OK because it's overprotecting, rather then underprotecting which the other options above suffer from.  Overprotecting results in a small performance hit because we are potentially serializing completely different / unrelated DNS requests, i.e. no intersection in the response IP sets.

For --dnsproxy-lock-size, a default of 128 was chosen as a reasonable balance between memory usage and hash collisions, for most deployments of Cilium. An increased lock size will result in more memory usage, but faster DNS processing as there are less IP hash collisions, and therefore less mutexes to acquire. A decreased lock size will save memory at the cost of slower DNS processing as the IP hash collisions are more likely, and this tends towards behavior similar to a single, shared mutex. Users who need to tune this value because they have many parallel DNS requests (1000s) can make the trade-off of using more memory to avoid hash collisions. It's worth mentioning that the memory usage is for storing a instance of a mutex which is 64 bits as of Go 1.19 [1].

Benchmark run comparing the code before this commit, changing the fixed sized array to one to simulate a single mutex, and this commit (multiple-locks):

```
$ go test -v -tags integration_tests ./daemon/cmd -check.b -check.bmem -check.f DaemonFQDNSuite.Benchmark_notifyOnDNSMsg -test.benchtime 100x -test.count 8
```

```
$ benchstat no-lock.txt single-lock.txt multiple-locks.txt
name \ time/op    no-lock.txt  single-lock.txt  multiple-locks.txt
_notifyOnDNSMsg   93.2µs ± 9%     179.6µs ± 3%        143.2µs ±28%

name \ alloc/op   no-lock.txt  single-lock.txt  multiple-locks.txt
_notifyOnDNSMsg   36.5kB ± 2%      35.3kB ± 0%         33.8kB ± 1%

name \ allocs/op  no-lock.txt  single-lock.txt  multiple-locks.txt
_notifyOnDNSMsg      485 ± 1%         474 ± 0%            453 ± 1%
```

Reproducing the bug and performance testing on a real cluster included running the 3 different modes and comparing the average processing time of the DNS proxy code. The cluster was 2 nodes with 32 replicas of the following workload:

```sh
# websites.txt contains different common URLs, some duplicated.
while [[ true ]]; do
  curl --parallel --parallel-immediate --parallel-max 5 --config websites.txt
  sleep 0.25s
done
```

No lock:        4.61ms, 18.3ms
Single lock:    7.42ms, 18.3ms
Multiple locks: 5.25ms, 17.9ms

[1]: https://cs.opensource.google/go/go/+/refs/tags/go1.19.3:src/sync/mutex.go;l=34

Co-authored-by: Michi Mutsuzaki <michi@isovalent.com>
Signed-off-by: Chris Tarazi <chris@isovalent.com>

```release-note
Fix race condition in DNS proxy when multiple DNS requests for the same name end up with policy drops, even though the traffic is allowed
```
