### PR TITLE
Fix: share etcd logger accross all client fix memory leak, possibly due to cluster mesh

### DIFF
--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -6,6 +6,7 @@ package clustermesh
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -207,12 +208,13 @@ func (cm *ClusterMesh) Close() {
 
 func (cm *ClusterMesh) newRemoteCluster(name, path string) *remoteCluster {
 	rc := &remoteCluster{
-		name:        name,
-		configPath:  path,
-		mesh:        cm,
-		changed:     make(chan bool, configNotificationsChannelSize),
-		controllers: controller.NewManager(),
-		swg:         lock.NewStoppableWaitGroup(),
+		name:           name,
+		configPath:     path,
+		mesh:           cm,
+		changed:        make(chan bool, configNotificationsChannelSize),
+		controllers:    controller.NewManager(),
+		swg:            lock.NewStoppableWaitGroup(),
+		releaseTimeout: 5 * time.Second, // timeout to release old kvstore backend when reconnecting to remote cluster
 	}
 
 	return rc

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -90,7 +90,7 @@ func (o *testObserver) OnDelete(k store.NamedKey) {
 
 func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	kvstore.SetupDummy("etcd")
-	defer kvstore.Client().Close()
+	defer kvstore.Client().Close(context.TODO())
 
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -145,7 +145,7 @@ func (rc *remoteCluster) releaseOldConnection() {
 			remoteServices.Close(context.TODO())
 		}
 		if backend != nil {
-			backend.Close()
+			backend.Close(context.TODO())
 		}
 	}()
 }
@@ -169,7 +169,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				err, isErr := <-errChan
 				if isErr {
 					if backend != nil {
-						backend.Close()
+						backend.Close(context.TODO())
 					}
 					rc.getLogger().WithError(err).Warning("Unable to establish etcd connection to remote cluster")
 					return err
@@ -185,7 +185,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 					Observer:                rc.mesh.conf.NodeObserver(),
 				})
 				if err != nil {
-					backend.Close()
+					backend.Close(context.TODO())
 					return err
 				}
 
@@ -204,7 +204,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				})
 				if err != nil {
 					remoteNodes.Close(context.TODO())
-					backend.Close()
+					backend.Close(context.TODO())
 					return err
 				}
 				rc.swg.Stop()
@@ -213,7 +213,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				if err != nil {
 					remoteServices.Close(context.TODO())
 					remoteNodes.Close(context.TODO())
-					backend.Close()
+					backend.Close(context.TODO())
 					return err
 				}
 

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -109,7 +109,7 @@ func (s *ClusterMeshServicesTestSuite) TearDownTest(c *C) {
 
 	os.RemoveAll(s.testDir)
 	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 func (s *ClusterMeshServicesTestSuite) expectEvent(c *C, action k8s.CacheAction, id k8s.ServiceID, fn func(event k8s.ServiceEvent) bool) {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -156,7 +156,7 @@ func (s *EndpointSuite) SetUpTest(c *C) {
 
 func (s *EndpointSuite) TearDownTest(c *C) {
 	s.mgr.Close()
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 func (s *EndpointSuite) TestEndpointStatus(c *C) {

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -133,7 +133,7 @@ func (d *DummyOwner) UpdateIdentities(added, deleted cache.IdentityCache) {}
 func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	// Setup dependencies for endpoint.
 	kvstore.SetupDummy("etcd")
-	defer kvstore.Client().Close()
+	defer kvstore.Client().Close(context.TODO())
 
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -90,7 +90,7 @@ func (e *IdentityAllocatorEtcdSuite) SetUpTest(c *C) {
 }
 
 func (e *IdentityAllocatorEtcdSuite) TearDownTest(c *C) {
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type IdentityAllocatorConsulSuite struct {
@@ -104,7 +104,7 @@ func (e *IdentityAllocatorConsulSuite) SetUpTest(c *C) {
 }
 
 func (e *IdentityAllocatorConsulSuite) TearDownTest(c *C) {
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type dummyOwner struct {

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -48,7 +48,7 @@ func (e *AllocatorEtcdSuite) SetUpTest(c *C) {
 
 func (e *AllocatorEtcdSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type AllocatorConsulSuite struct {
@@ -64,7 +64,7 @@ func (e *AllocatorConsulSuite) SetUpTest(c *C) {
 
 func (e *AllocatorConsulSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 // FIXME: this should be named better, it implements pkg/allocator.Backend

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -193,7 +193,7 @@ type BackendOperations interface {
 	Watch(ctx context.Context, w *Watcher)
 
 	// Close closes the kvstore client
-	Close()
+	Close(ctx context.Context)
 
 	// GetCapabilities returns the capabilities of the backend
 	GetCapabilities() Capabilities

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -726,7 +726,7 @@ func (c *consulClient) listPrefix(ctx context.Context, prefix string) (KeyValueP
 }
 
 // Close closes the consul session
-func (c *consulClient) Close() {
+func (c *consulClient) Close(ctx context.Context) {
 	close(c.statusCheckErrors)
 	if c.controllers != nil {
 		c.controllers.RemoveAll()

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -676,8 +676,16 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 	// Timeout if the server does not reply within 15 seconds and close the
 	// connection. Ideally it should be lower than staleLockTimeout
 	config.DialKeepAliveTimeout = clientOptions.KeepAliveTimeout
+
+	// This is the top-level context that is cancelled in Close() to
+	// interrupt any ongoing low-level operations
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	config.Context = ctx
+
 	c, err := client.New(*config)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -730,6 +738,8 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 	}()
 
 	handleSessionError := func(err error) {
+		// Cancel any ongoing session grants
+		cancel()
 		ec.RWMutex.Lock()
 		ec.sessionErr = err
 		ec.RWMutex.Unlock()

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1633,9 +1633,9 @@ func (e *etcdClient) ListPrefix(ctx context.Context, prefix string) (v KeyValueP
 }
 
 // Close closes the etcd session
-func (e *etcdClient) Close() {
+func (e *etcdClient) Close(ctx context.Context) {
 	close(e.stopStatusChecker)
-	sessionErr := e.waitForInitialSession(context.Background())
+	sessionErr := e.waitForInitialSession(ctx)
 	if e.controllers != nil {
 		e.controllers.RemoveAll()
 	}

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -32,7 +32,7 @@ func (e *EtcdSuite) SetUpTest(c *C) {
 }
 
 func (e *EtcdSuite) TearDownTest(c *C) {
-	Client().Close()
+	Client().Close(context.TODO())
 }
 
 type MaintenanceMocker struct {
@@ -351,7 +351,7 @@ func (e *EtcdLockedSuite) SetUpSuite(c *C) {
 func (e *EtcdLockedSuite) TearDownSuite(c *C) {
 	err := e.etcdClient.Close()
 	c.Assert(err, IsNil)
-	Client().Close()
+	Client().Close(context.TODO())
 }
 
 func (e *EtcdLockedSuite) TestGetIfLocked(c *C) {
@@ -1958,7 +1958,7 @@ func (e *EtcdRateLimiterSuite) TestRateLimiter(c *C) {
 			err = kvlocker.Unlock(context.TODO())
 			c.Assert(err, IsNil)
 		}
-		Client().Close()
+		Client().Close(context.TODO())
 
 		// Clean created KV Pairs if populateKVPairs is disabled and cleanKVPairs is enabled.
 		if !op.populateKVPairs && op.cleanKVPairs {
@@ -1993,7 +1993,7 @@ func (e *EtcdRateLimiterSuite) TestRateLimiter(c *C) {
 			err = kvlocker.Unlock(context.TODO())
 			c.Assert(err, IsNil)
 		}
-		Client().Close()
+		Client().Close(context.TODO())
 
 		if op.needCondKey {
 			_, err = e.etcdClient.Delete(context.Background(), condKey)

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -43,7 +43,7 @@ func (e *StoreEtcdSuite) SetUpTest(c *C) {
 
 func (e *StoreEtcdSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type StoreConsulSuite struct {
@@ -58,7 +58,7 @@ func (e *StoreConsulSuite) SetUpTest(c *C) {
 
 func (e *StoreConsulSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 	time.Sleep(sharedKeyDeleteDelay + 5*time.Second)
 }
 


### PR DESCRIPTION
What type of PR is this?
/kind bug

Which issue(s) this PR fixes:
https://github.com/cilium/cilium/issues/13446

What this PR does / why we need it:
Currently cilium creates one etcd client per cluster_mesh. When cluster_mesh reconnecting etcd, it will close old client, and create a new one.  If clients aren't provided a logger they'll each create their own. These loggers can account for >= 30% cilium-agent memory. 

such as in https://github.com/cilium/cilium/issues/13446
![avatar](https://user-images.githubusercontent.com/11253021/103031661-068a9880-453d-11eb-818f-cbb4b64c2ad4.png)

reference:
https://github.com/kubernetes/kubernetes/pull/111477