### PR TITLE
helm: fix broken documentation URL in helm chart template

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -158,7 +158,7 @@ data:
 {{- if hasKey .Values "policyEnforcementMode" }}
   # The agent can be put into the following three policy enforcement modes
   # default, always and never.
-  # https://docs.cilium.io/en/latest/policy/intro/#policy-enforcement-modes
+  # https://docs.cilium.io/en/latest/security/policy/intro/#policy-enforcement-modes
   enable-policy: "{{ lower .Values.policyEnforcementMode }}"
 {{- end }}
 


### PR DESCRIPTION
Link to OSS documentation for policy-enforcement-modes is incorrect in helm chart template. This is a minor fix to point to correct documentation URL

Signed-off-by: Navin Kukreja <navin.kukreja@isovalent.com>
Co-authored-by: Raphaël Pinson <raphael@isovalent.com>
