### PR TITLE
Keep command help message capital

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -140,7 +140,7 @@ cilium-agent [flags]
       --enable-xdp-prefilter                                    Enable XDP prefiltering
       --enable-xt-socket-fallback                               Enable fallback for missing xt_socket module (default true)
       --encrypt-interface string                                Transparent encryption interface
-      --endpoint-queue-size int                                 size of EventQueue per-endpoint (default 25)
+      --endpoint-queue-size int                                 Size of EventQueue per-endpoint (default 25)
       --endpoint-status strings                                 Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
       --envoy-config-timeout duration                           Timeout duration for Envoy Config acknowledgements (default 2m0s)
       --envoy-log string                                        Path to a separate Envoy log file, if any
@@ -209,7 +209,7 @@ cilium-agent [flags]
       --k8s-service-proxy-name string                           Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --k8s-watcher-endpoint-selector string                    K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
       --keep-config                                             When restoring state, keeps containers' configuration in place
-      --kube-proxy-replacement string                           enable only selected features (will panic if any selected feature cannot be enabled) ("partial"), or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
+      --kube-proxy-replacement string                           Enable only selected features (will panic if any selected feature cannot be enabled) ("partial"), or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
       --kube-proxy-replacement-healthz-bind-address string      The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
       --kvstore string                                          Key-value store type
       --kvstore-connectivity-timeout duration                   Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
@@ -233,7 +233,7 @@ cilium-agent [flags]
       --node-port-bind-protection                               Reject application bind(2) requests to service ports in the NodePort range (default true)
       --node-port-range strings                                 Set the min/max NodePort port range (default [30000,32767])
       --policy-audit-mode                                       Enable policy audit (non-drop) mode
-      --policy-queue-size int                                   size of queues for policy-related events (default 100)
+      --policy-queue-size int                                   Size of queues for policy-related events (default 100)
       --pprof                                                   Enable serving the pprof debugging API
       --pprof-port int                                          Port that the pprof listens on (default 6060)
       --preallocate-bpf-maps                                    Enable BPF map pre-allocation (default true)

--- a/Documentation/cmdref/cilium.md
+++ b/Documentation/cmdref/cilium.md
@@ -11,7 +11,7 @@ CLI for interacting with the local Cilium Agent
 ### Options
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -h, --help            help for cilium
   -H, --host string     URI to server-side API
@@ -37,7 +37,7 @@ CLI for interacting with the local Cilium Agent
 * [cilium node](cilium_node.md)	 - Manage cluster nodes
 * [cilium policy](cilium_policy.md)	 - Manage security policies
 * [cilium prefilter](cilium_prefilter.md)	 - Manage XDP CIDR filters
-* [cilium preflight](cilium_preflight.md)	 - cilium upgrade helper
+* [cilium preflight](cilium_preflight.md)	 - Cilium upgrade helper
 * [cilium recorder](cilium_recorder.md)	 - Introspect or mangle pcap recorder
 * [cilium service](cilium_service.md)	 - Manage services & loadbalancers
 * [cilium status](cilium_status.md)	 - Display status of daemon

--- a/Documentation/cmdref/cilium_bpf.md
+++ b/Documentation/cmdref/cilium_bpf.md
@@ -13,7 +13,7 @@ Direct access to local BPF maps
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_bandwidth.md
+++ b/Documentation/cmdref/cilium_bpf_bandwidth.md
@@ -13,7 +13,7 @@ BPF datapath bandwidth settings
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_bandwidth_list.md
+++ b/Documentation/cmdref/cilium_bpf_bandwidth_list.md
@@ -18,7 +18,7 @@ cilium bpf bandwidth list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_ct.md
+++ b/Documentation/cmdref/cilium_bpf_ct.md
@@ -13,7 +13,7 @@ Connection tracking tables
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_ct_flush.md
+++ b/Documentation/cmdref/cilium_bpf_ct_flush.md
@@ -17,7 +17,7 @@ cilium bpf ct flush ( <endpoint identifier> | global ) [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_ct_list.md
+++ b/Documentation/cmdref/cilium_bpf_ct_list.md
@@ -21,7 +21,7 @@ cilium bpf ct list ( <endpoint identifier> | global ) [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_egress.md
+++ b/Documentation/cmdref/cilium_bpf_egress.md
@@ -13,7 +13,7 @@ Manage the egress routing rules
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_egress_list.md
+++ b/Documentation/cmdref/cilium_bpf_egress_list.md
@@ -27,7 +27,7 @@ cilium bpf egress list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_endpoint.md
+++ b/Documentation/cmdref/cilium_bpf_endpoint.md
@@ -13,7 +13,7 @@ Local endpoint map
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_endpoint_delete.md
+++ b/Documentation/cmdref/cilium_bpf_endpoint_delete.md
@@ -17,7 +17,7 @@ cilium bpf endpoint delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_endpoint_list.md
+++ b/Documentation/cmdref/cilium_bpf_endpoint_list.md
@@ -18,7 +18,7 @@ cilium bpf endpoint list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_fs.md
+++ b/Documentation/cmdref/cilium_bpf_fs.md
@@ -13,7 +13,7 @@ BPF filesystem mount
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_fs_show.md
+++ b/Documentation/cmdref/cilium_bpf_fs_show.md
@@ -24,7 +24,7 @@ cilium bpf fs show
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_ipcache.md
+++ b/Documentation/cmdref/cilium_bpf_ipcache.md
@@ -13,7 +13,7 @@ Manage the IPCache mappings for IP/CIDR <-> Identity
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_ipcache_get.md
+++ b/Documentation/cmdref/cilium_bpf_ipcache_get.md
@@ -17,7 +17,7 @@ cilium bpf ipcache get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_ipcache_list.md
+++ b/Documentation/cmdref/cilium_bpf_ipcache_list.md
@@ -29,7 +29,7 @@ cilium bpf ipcache list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_ipmasq.md
+++ b/Documentation/cmdref/cilium_bpf_ipmasq.md
@@ -13,7 +13,7 @@ ip-masq-agent CIDRs
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_ipmasq_list.md
+++ b/Documentation/cmdref/cilium_bpf_ipmasq_list.md
@@ -22,7 +22,7 @@ cilium bpf ipmasq list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_lb.md
+++ b/Documentation/cmdref/cilium_bpf_lb.md
@@ -13,7 +13,7 @@ Load-balancing configuration
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_lb_list.md
+++ b/Documentation/cmdref/cilium_bpf_lb_list.md
@@ -22,7 +22,7 @@ cilium bpf lb list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_lb_maglev.md
+++ b/Documentation/cmdref/cilium_bpf_lb_maglev.md
@@ -13,7 +13,7 @@ Maglev lookup table
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_lb_maglev_get.md
+++ b/Documentation/cmdref/cilium_bpf_lb_maglev_get.md
@@ -18,7 +18,7 @@ cilium bpf lb maglev get <service id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_lb_maglev_list.md
+++ b/Documentation/cmdref/cilium_bpf_lb_maglev_list.md
@@ -18,7 +18,7 @@ cilium bpf lb maglev list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_metrics.md
+++ b/Documentation/cmdref/cilium_bpf_metrics.md
@@ -13,7 +13,7 @@ BPF datapath traffic metrics
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_metrics_list.md
+++ b/Documentation/cmdref/cilium_bpf_metrics_list.md
@@ -18,7 +18,7 @@ cilium bpf metrics list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_nat.md
+++ b/Documentation/cmdref/cilium_bpf_nat.md
@@ -13,7 +13,7 @@ NAT mapping tables
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_nat_flush.md
+++ b/Documentation/cmdref/cilium_bpf_nat_flush.md
@@ -17,7 +17,7 @@ cilium bpf nat flush [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_nat_list.md
+++ b/Documentation/cmdref/cilium_bpf_nat_list.md
@@ -18,7 +18,7 @@ cilium bpf nat list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_policy.md
+++ b/Documentation/cmdref/cilium_bpf_policy.md
@@ -13,7 +13,7 @@ Manage policy related BPF maps
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_policy_add.md
+++ b/Documentation/cmdref/cilium_bpf_policy_add.md
@@ -18,7 +18,7 @@ cilium bpf policy add <endpoint id> <traffic-direction> <identity> [port/proto] 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_policy_delete.md
+++ b/Documentation/cmdref/cilium_bpf_policy_delete.md
@@ -18,7 +18,7 @@ cilium bpf policy delete <endpoint id> <identity> [port/proto] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_policy_get.md
+++ b/Documentation/cmdref/cilium_bpf_policy_get.md
@@ -20,7 +20,7 @@ cilium bpf policy get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_policy_list.md
+++ b/Documentation/cmdref/cilium_bpf_policy_list.md
@@ -18,7 +18,7 @@ cilium bpf policy list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_recorder.md
+++ b/Documentation/cmdref/cilium_bpf_recorder.md
@@ -13,7 +13,7 @@ PCAP recorder
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_recorder_list.md
+++ b/Documentation/cmdref/cilium_bpf_recorder_list.md
@@ -18,7 +18,7 @@ cilium bpf recorder list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_sha.md
+++ b/Documentation/cmdref/cilium_bpf_sha.md
@@ -13,7 +13,7 @@ Manage compiled BPF template objects
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_sha_get.md
+++ b/Documentation/cmdref/cilium_bpf_sha_get.md
@@ -18,7 +18,7 @@ cilium bpf sha get <sha> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_sha_list.md
+++ b/Documentation/cmdref/cilium_bpf_sha_list.md
@@ -18,7 +18,7 @@ cilium bpf sha list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_srv6.md
+++ b/Documentation/cmdref/cilium_bpf_srv6.md
@@ -13,7 +13,7 @@ Manage the SRv6 routing rules
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_srv6_policy.md
+++ b/Documentation/cmdref/cilium_bpf_srv6_policy.md
@@ -27,7 +27,7 @@ cilium bpf srv6 policy [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_srv6_sid.md
+++ b/Documentation/cmdref/cilium_bpf_srv6_sid.md
@@ -27,7 +27,7 @@ cilium bpf srv6 sid [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_srv6_state.md
+++ b/Documentation/cmdref/cilium_bpf_srv6_state.md
@@ -27,7 +27,7 @@ cilium bpf srv6 state [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_srv6_vrf.md
+++ b/Documentation/cmdref/cilium_bpf_srv6_vrf.md
@@ -27,7 +27,7 @@ cilium bpf srv6 vrf [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_tunnel.md
+++ b/Documentation/cmdref/cilium_bpf_tunnel.md
@@ -13,7 +13,7 @@ Tunnel endpoint map
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_tunnel_list.md
+++ b/Documentation/cmdref/cilium_bpf_tunnel_list.md
@@ -18,7 +18,7 @@ cilium bpf tunnel list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_vtep.md
+++ b/Documentation/cmdref/cilium_bpf_vtep.md
@@ -13,7 +13,7 @@ Manage the VTEP mappings for IP/CIDR <-> VTEP MAC/IP
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_vtep_delete.md
+++ b/Documentation/cmdref/cilium_bpf_vtep_delete.md
@@ -22,7 +22,7 @@ cilium bpf vtep delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_vtep_list.md
+++ b/Documentation/cmdref/cilium_bpf_vtep_list.md
@@ -23,7 +23,7 @@ cilium bpf vtep list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_bpf_vtep_update.md
+++ b/Documentation/cmdref/cilium_bpf_vtep_update.md
@@ -22,7 +22,7 @@ cilium bpf vtep update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_cleanup.md
+++ b/Documentation/cmdref/cilium_cleanup.md
@@ -28,7 +28,7 @@ cilium cleanup [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_completion.md
+++ b/Documentation/cmdref/cilium_completion.md
@@ -59,7 +59,7 @@ cilium completion [shell] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_config.md
+++ b/Documentation/cmdref/cilium_config.md
@@ -22,7 +22,7 @@ cilium config [<option>=(enable|disable) ...] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_config_get.md
+++ b/Documentation/cmdref/cilium_config_get.md
@@ -18,7 +18,7 @@ cilium config get <config name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_debuginfo.md
+++ b/Documentation/cmdref/cilium_debuginfo.md
@@ -21,7 +21,7 @@ cilium debuginfo [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_encrypt.md
+++ b/Documentation/cmdref/cilium_encrypt.md
@@ -13,7 +13,7 @@ Manage transparent encryption
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_encrypt_flush.md
+++ b/Documentation/cmdref/cilium_encrypt_flush.md
@@ -22,7 +22,7 @@ cilium encrypt flush [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_encrypt_status.md
+++ b/Documentation/cmdref/cilium_encrypt_status.md
@@ -18,7 +18,7 @@ cilium encrypt status [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_endpoint.md
+++ b/Documentation/cmdref/cilium_endpoint.md
@@ -13,7 +13,7 @@ Manage endpoints
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_endpoint_config.md
+++ b/Documentation/cmdref/cilium_endpoint_config.md
@@ -25,7 +25,7 @@ endpoint config 5421 DropNotification=false TraceNotification=false PolicyVerdic
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_endpoint_disconnect.md
+++ b/Documentation/cmdref/cilium_endpoint_disconnect.md
@@ -17,7 +17,7 @@ cilium endpoint disconnect <endpoint-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_endpoint_get.md
+++ b/Documentation/cmdref/cilium_endpoint_get.md
@@ -25,7 +25,7 @@ cilium endpoint get 4598, cilium endpoint get pod-name:default:foobar, cilium en
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_endpoint_health.md
+++ b/Documentation/cmdref/cilium_endpoint_health.md
@@ -24,7 +24,7 @@ cilium endpoint health 5421
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_endpoint_labels.md
+++ b/Documentation/cmdref/cilium_endpoint_labels.md
@@ -19,7 +19,7 @@ cilium endpoint labels [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_endpoint_list.md
+++ b/Documentation/cmdref/cilium_endpoint_list.md
@@ -19,7 +19,7 @@ cilium endpoint list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_endpoint_log.md
+++ b/Documentation/cmdref/cilium_endpoint_log.md
@@ -24,7 +24,7 @@ cilium endpoint log 5421
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_endpoint_regenerate.md
+++ b/Documentation/cmdref/cilium_endpoint_regenerate.md
@@ -17,7 +17,7 @@ cilium endpoint regenerate <endpoint-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_fqdn.md
+++ b/Documentation/cmdref/cilium_fqdn.md
@@ -17,7 +17,7 @@ cilium fqdn [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```
@@ -26,5 +26,5 @@ cilium fqdn [flags]
 
 * [cilium](cilium.md)	 - CLI
 * [cilium fqdn cache](cilium_fqdn_cache.md)	 - Manage fqdn proxy cache
-* [cilium fqdn names](cilium_fqdn_names.md)	 - show internal state Cilium has for DNS names / regexes
+* [cilium fqdn names](cilium_fqdn_names.md)	 - Show internal state Cilium has for DNS names / regexes
 

--- a/Documentation/cmdref/cilium_fqdn_cache.md
+++ b/Documentation/cmdref/cilium_fqdn_cache.md
@@ -17,7 +17,7 @@ cilium fqdn cache [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_fqdn_cache_clean.md
+++ b/Documentation/cmdref/cilium_fqdn_cache_clean.md
@@ -19,7 +19,7 @@ cilium fqdn cache clean [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_fqdn_cache_list.md
+++ b/Documentation/cmdref/cilium_fqdn_cache_list.md
@@ -21,7 +21,7 @@ cilium fqdn cache list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_fqdn_names.md
+++ b/Documentation/cmdref/cilium_fqdn_names.md
@@ -2,7 +2,7 @@
 
 ## cilium fqdn names
 
-show internal state Cilium has for DNS names / regexes
+Show internal state Cilium has for DNS names / regexes
 
 ```
 cilium fqdn names [flags]
@@ -17,7 +17,7 @@ cilium fqdn names [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_identity.md
+++ b/Documentation/cmdref/cilium_identity.md
@@ -13,7 +13,7 @@ Manage security identities
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_identity_get.md
+++ b/Documentation/cmdref/cilium_identity_get.md
@@ -19,7 +19,7 @@ cilium identity get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_identity_list.md
+++ b/Documentation/cmdref/cilium_identity_list.md
@@ -19,7 +19,7 @@ cilium identity list [LABELS] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_ip.md
+++ b/Documentation/cmdref/cilium_ip.md
@@ -13,7 +13,7 @@ Manage IP addresses and associated information
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_ip_list.md
+++ b/Documentation/cmdref/cilium_ip_list.md
@@ -20,7 +20,7 @@ cilium ip list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_kvstore.md
+++ b/Documentation/cmdref/cilium_kvstore.md
@@ -8,14 +8,14 @@ Direct access to the kvstore
 
 ```
   -h, --help              help for kvstore
-      --kvstore string    kvstore type
-      --kvstore-opt map   kvstore options
+      --kvstore string    Key-Value Store type
+      --kvstore-opt map   Key-Value Store options
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_kvstore_delete.md
+++ b/Documentation/cmdref/cilium_kvstore_delete.md
@@ -24,11 +24,11 @@ cilium kvstore delete --recursive foo
 ### Options inherited from parent commands
 
 ```
-      --config string     config file (default is $HOME/.cilium.yaml)
+      --config string     Config file (default is $HOME/.cilium.yaml)
   -D, --debug             Enable debug messages
   -H, --host string       URI to server-side API
-      --kvstore string    kvstore type
-      --kvstore-opt map   kvstore options
+      --kvstore string    Key-Value Store type
+      --kvstore-opt map   Key-Value Store options
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_kvstore_get.md
+++ b/Documentation/cmdref/cilium_kvstore_get.md
@@ -25,11 +25,11 @@ cilium kvstore get --recursive foo
 ### Options inherited from parent commands
 
 ```
-      --config string     config file (default is $HOME/.cilium.yaml)
+      --config string     Config file (default is $HOME/.cilium.yaml)
   -D, --debug             Enable debug messages
   -H, --host string       URI to server-side API
-      --kvstore string    kvstore type
-      --kvstore-opt map   kvstore options
+      --kvstore string    Key-Value Store type
+      --kvstore-opt map   Key-Value Store options
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_kvstore_set.md
+++ b/Documentation/cmdref/cilium_kvstore_set.md
@@ -25,11 +25,11 @@ cilium kvstore set foo=bar
 ### Options inherited from parent commands
 
 ```
-      --config string     config file (default is $HOME/.cilium.yaml)
+      --config string     Config file (default is $HOME/.cilium.yaml)
   -D, --debug             Enable debug messages
   -H, --host string       URI to server-side API
-      --kvstore string    kvstore type
-      --kvstore-opt map   kvstore options
+      --kvstore string    Key-Value Store type
+      --kvstore-opt map   Key-Value Store options
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_lrp.md
+++ b/Documentation/cmdref/cilium_lrp.md
@@ -13,7 +13,7 @@ Manage local redirect policies
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_lrp_list.md
+++ b/Documentation/cmdref/cilium_lrp_list.md
@@ -18,7 +18,7 @@ cilium lrp list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_map.md
+++ b/Documentation/cmdref/cilium_map.md
@@ -13,7 +13,7 @@ Access userspace cached content of BPF maps
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_map_events.md
+++ b/Documentation/cmdref/cilium_map_events.md
@@ -25,7 +25,7 @@ cilium map events cilium_ipcache
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_map_get.md
+++ b/Documentation/cmdref/cilium_map_get.md
@@ -24,7 +24,7 @@ cilium map get cilium_ipcache
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_map_list.md
+++ b/Documentation/cmdref/cilium_map_list.md
@@ -25,7 +25,7 @@ cilium map list
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_metrics.md
+++ b/Documentation/cmdref/cilium_metrics.md
@@ -13,7 +13,7 @@ Access metric status
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_metrics_list.md
+++ b/Documentation/cmdref/cilium_metrics_list.md
@@ -19,7 +19,7 @@ cilium metrics list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_monitor.md
+++ b/Documentation/cmdref/cilium_monitor.md
@@ -35,7 +35,7 @@ cilium monitor [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_node.md
+++ b/Documentation/cmdref/cilium_node.md
@@ -13,7 +13,7 @@ Manage cluster nodes
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_node_list.md
+++ b/Documentation/cmdref/cilium_node_list.md
@@ -18,7 +18,7 @@ cilium node list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_policy.md
+++ b/Documentation/cmdref/cilium_policy.md
@@ -13,7 +13,7 @@ Manage security policies
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_policy_delete.md
+++ b/Documentation/cmdref/cilium_policy_delete.md
@@ -19,7 +19,7 @@ cilium policy delete [<labels>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_policy_get.md
+++ b/Documentation/cmdref/cilium_policy_get.md
@@ -18,7 +18,7 @@ cilium policy get [<labels>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_policy_import.md
+++ b/Documentation/cmdref/cilium_policy_import.md
@@ -26,7 +26,7 @@ cilium policy import <path> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_policy_selectors.md
+++ b/Documentation/cmdref/cilium_policy_selectors.md
@@ -18,7 +18,7 @@ cilium policy selectors [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_policy_validate.md
+++ b/Documentation/cmdref/cilium_policy_validate.md
@@ -19,7 +19,7 @@ cilium policy validate <path> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_policy_wait.md
+++ b/Documentation/cmdref/cilium_policy_wait.md
@@ -20,7 +20,7 @@ cilium policy wait <revision> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_prefilter.md
+++ b/Documentation/cmdref/cilium_prefilter.md
@@ -13,7 +13,7 @@ Manage XDP CIDR filters
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_prefilter_delete.md
+++ b/Documentation/cmdref/cilium_prefilter_delete.md
@@ -19,7 +19,7 @@ cilium prefilter delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_prefilter_list.md
+++ b/Documentation/cmdref/cilium_prefilter_list.md
@@ -18,7 +18,7 @@ cilium prefilter list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_prefilter_update.md
+++ b/Documentation/cmdref/cilium_prefilter_update.md
@@ -19,7 +19,7 @@ cilium prefilter update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_preflight.md
+++ b/Documentation/cmdref/cilium_preflight.md
@@ -2,7 +2,7 @@
 
 ## cilium preflight
 
-cilium upgrade helper
+Cilium upgrade helper
 
 ### Synopsis
 
@@ -17,7 +17,7 @@ CLI to help upgrade cilium
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_preflight_fqdn-poller.md
+++ b/Documentation/cmdref/cilium_preflight_fqdn-poller.md
@@ -29,12 +29,12 @@ cilium preflight fqdn-poller [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```
 
 ### SEE ALSO
 
-* [cilium preflight](cilium_preflight.md)	 - cilium upgrade helper
+* [cilium preflight](cilium_preflight.md)	 - Cilium upgrade helper
 

--- a/Documentation/cmdref/cilium_preflight_migrate-identity.md
+++ b/Documentation/cmdref/cilium_preflight_migrate-identity.md
@@ -36,12 +36,12 @@ cilium preflight migrate-identity [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```
 
 ### SEE ALSO
 
-* [cilium preflight](cilium_preflight.md)	 - cilium upgrade helper
+* [cilium preflight](cilium_preflight.md)	 - Cilium upgrade helper
 

--- a/Documentation/cmdref/cilium_preflight_validate-cnp.md
+++ b/Documentation/cmdref/cilium_preflight_validate-cnp.md
@@ -30,12 +30,12 @@ cilium preflight validate-cnp [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```
 
 ### SEE ALSO
 
-* [cilium preflight](cilium_preflight.md)	 - cilium upgrade helper
+* [cilium preflight](cilium_preflight.md)	 - Cilium upgrade helper
 

--- a/Documentation/cmdref/cilium_recorder.md
+++ b/Documentation/cmdref/cilium_recorder.md
@@ -13,7 +13,7 @@ Introspect or mangle pcap recorder
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_recorder_delete.md
+++ b/Documentation/cmdref/cilium_recorder_delete.md
@@ -17,7 +17,7 @@ cilium recorder delete <recorder id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_recorder_get.md
+++ b/Documentation/cmdref/cilium_recorder_get.md
@@ -18,7 +18,7 @@ cilium recorder get <recorder id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_recorder_list.md
+++ b/Documentation/cmdref/cilium_recorder_list.md
@@ -18,7 +18,7 @@ cilium recorder list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_recorder_update.md
+++ b/Documentation/cmdref/cilium_recorder_update.md
@@ -20,7 +20,7 @@ cilium recorder update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_service.md
+++ b/Documentation/cmdref/cilium_service.md
@@ -13,7 +13,7 @@ Manage services & loadbalancers
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_service_delete.md
+++ b/Documentation/cmdref/cilium_service_delete.md
@@ -18,7 +18,7 @@ cilium service delete { <service id> | --all } [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_service_get.md
+++ b/Documentation/cmdref/cilium_service_get.md
@@ -18,7 +18,7 @@ cilium service get <service id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_service_list.md
+++ b/Documentation/cmdref/cilium_service_list.md
@@ -19,7 +19,7 @@ cilium service list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_service_update.md
+++ b/Documentation/cmdref/cilium_service_update.md
@@ -29,7 +29,7 @@ cilium service update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_status.md
+++ b/Documentation/cmdref/cilium_status.md
@@ -27,7 +27,7 @@ cilium status [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/Documentation/cmdref/cilium_version.md
+++ b/Documentation/cmdref/cilium_version.md
@@ -18,7 +18,7 @@ cilium version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.cilium.yaml)
+      --config string   Config file (default is $HOME/.cilium.yaml)
   -D, --debug           Enable debug messages
   -H, --host string     URI to server-side API
 ```

--- a/cilium/cmd/fqdn.go
+++ b/cilium/cmd/fqdn.go
@@ -26,7 +26,7 @@ var fqdnCmd = &cobra.Command{
 
 var fqdnNames = &cobra.Command{
 	Use:   "names",
-	Short: "show internal state Cilium has for DNS names / regexes",
+	Short: "Show internal state Cilium has for DNS names / regexes",
 	Run: func(cmd *cobra.Command, args []string) {
 		listFQDNNames()
 	},

--- a/cilium/cmd/kvstore.go
+++ b/cilium/cmd/kvstore.go
@@ -55,6 +55,6 @@ func setupKvstore(ctx context.Context) {
 func init() {
 	rootCmd.AddCommand(kvstoreCmd)
 	flags := kvstoreCmd.PersistentFlags()
-	flags.StringVar(&kvStore, "kvstore", "", "kvstore type")
-	flags.Var(option.NewNamedMapOptions("kvstore-opts", &kvStoreOpts, nil), "kvstore-opt", "kvstore options")
+	flags.StringVar(&kvStore, "kvstore", "", "Key-Value Store type")
+	flags.Var(option.NewNamedMapOptions("kvstore-opts", &kvStoreOpts, nil), "kvstore-opt", "Key-Value Store options")
 }

--- a/cilium/cmd/preflight.go
+++ b/cilium/cmd/preflight.go
@@ -31,7 +31,7 @@ var (
 // preflightCmd is the command used to manage preflight tasks for upgrades
 var preflightCmd = &cobra.Command{
 	Use:   "preflight",
-	Short: "cilium upgrade helper",
+	Short: "Cilium upgrade helper",
 	Long:  `CLI to help upgrade cilium`,
 }
 

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -48,7 +48,7 @@ func init() {
 
 	cobra.OnInitialize(initConfig)
 	flags := rootCmd.PersistentFlags()
-	flags.StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cilium.yaml)")
+	flags.StringVar(&cfgFile, "config", "", "Config file (default is $HOME/.cilium.yaml)")
 	flags.BoolP("debug", "D", false, "Enable debug messages")
 	flags.StringP("host", "H", "", "URI to server-side API")
 	vp.BindPFlags(flags)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -501,7 +501,7 @@ func initializeFlags() {
 	option.BindEnv(Vp, option.Labels)
 
 	flags.String(option.KubeProxyReplacement, option.KubeProxyReplacementPartial, fmt.Sprintf(
-		"enable only selected features (will panic if any selected feature cannot be enabled) (%q), "+
+		"Enable only selected features (will panic if any selected feature cannot be enabled) (%q), "+
 			"or enable all features (will panic if any feature cannot be enabled) (%q), "+
 			"or completely disable it (ignores any selected feature) (%q)",
 		option.KubeProxyReplacementPartial, option.KubeProxyReplacementStrict,
@@ -867,10 +867,10 @@ func initializeFlags() {
 	flags.Duration(option.DNSProxyConcurrencyProcessingGracePeriod, 0, "Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing")
 	option.BindEnv(Vp, option.DNSProxyConcurrencyProcessingGracePeriod)
 
-	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "size of queues for policy-related events")
+	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "Size of queues for policy-related events")
 	option.BindEnv(Vp, option.PolicyQueueSize)
 
-	flags.Int(option.EndpointQueueSize, defaults.EndpointQueueSize, "size of EventQueue per-endpoint")
+	flags.Int(option.EndpointQueueSize, defaults.EndpointQueueSize, "Size of EventQueue per-endpoint")
 	option.BindEnv(Vp, option.EndpointQueueSize)
 
 	flags.Duration(option.EndpointGCInterval, 5*time.Minute, "Periodically monitor local endpoint health via link status on this interval and garbage collect them if they become unhealthy, set to 0 to disable")
@@ -998,7 +998,7 @@ func initializeFlags() {
 	flags.Var(option.NewNamedMapOptions(option.APIRateLimitName, &option.Config.APIRateLimit, nil), option.APIRateLimitName, "API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)")
 	option.BindEnv(Vp, option.APIRateLimitName)
 
-	flags.Var(option.NewNamedMapOptions(option.BPFMapEventBuffers, &option.Config.BPFMapEventBuffers, option.Config.BPFMapEventBuffersValidator), option.BPFMapEventBuffers, "configuration for BPF map event buffers: (example: --bpf-map-event-buffers cilium_ipcache=true,1024,1h)")
+	flags.Var(option.NewNamedMapOptions(option.BPFMapEventBuffers, &option.Config.BPFMapEventBuffers, option.Config.BPFMapEventBuffersValidator), option.BPFMapEventBuffers, "Configuration for BPF map event buffers: (example: --bpf-map-event-buffers cilium_ipcache=true,1024,1h)")
 	flags.MarkHidden(option.BPFMapEventBuffers)
 
 	flags.Duration(option.CRDWaitTimeout, 5*time.Minute, "Cilium will exit if CRDs are not available within this duration upon startup")

--- a/hubble-relay/cmd/root.go
+++ b/hubble-relay/cmd/root.go
@@ -22,8 +22,8 @@ const configFilePath = "/etc/hubble-relay/config.yaml"
 func New() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:          "hubble-relay",
-		Short:        "hubble-relay is a proxy server for the hubble API",
-		Long:         "hubble-relay is a proxy server for the hubble API.",
+		Short:        "Hubble Relay is a proxy server for the hubble API",
+		Long:         "Hubble Relay is a proxy server for the hubble API.",
 		SilenceUsage: true,
 		Version:      v.GetCiliumVersion().Version,
 	}

--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -26,8 +26,8 @@ var (
 
 func init() {
 	flags := rootCmd.Flags()
-	backportingChecks = flags.Bool("backporting", false, "run backporting checks")
-	nfsFirewallChecks = flags.Bool("nfs-firewall", false, "run extra NFS firewall checks, requires root privileges")
+	backportingChecks = flags.Bool("backporting", false, "Run backporting checks")
+	nfsFirewallChecks = flags.Bool("nfs-firewall", false, "Run extra NFS firewall checks, requires root privileges")
 }
 
 func rootCmdRun(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind codeclean

I see most of the cobra.Command is begin with capital character , Maybe we should update all the place for that.