### PR TITLE
Make fsnotify event more readable.

### DIFF
--- a/pkg/clustermesh/config.go
+++ b/pkg/clustermesh/config.go
@@ -96,12 +96,12 @@ func (cdw *configDirectoryWatcher) watch() error {
 				name := filepath.Base(event.Name)
 				log.WithField(fieldClusterName, name).Debugf("Received fsnotify event: %+v", event)
 				switch {
-				case event.Op&fsnotify.Create == fsnotify.Create,
-					event.Op&fsnotify.Write == fsnotify.Write,
-					event.Op&fsnotify.Chmod == fsnotify.Chmod:
+				case event.Has(fsnotify.Create),
+					event.Has(fsnotify.Write),
+					event.Has(fsnotify.Chmod):
 					cdw.handleAddedFile(name, event.Name)
-				case event.Op&fsnotify.Remove == fsnotify.Remove,
-					event.Op&fsnotify.Rename == fsnotify.Rename:
+				case event.Has(fsnotify.Remove),
+					event.Has(fsnotify.Rename):
 					cdw.lifecycle.remove(name)
 				}
 

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -354,7 +354,7 @@ func (o *objectCache) watchTemplatesDirectory(ctx context.Context) error {
 			if !open {
 				break
 			}
-			if event.Op&fsnotify.Remove == fsnotify.Remove {
+			if event.Has(fsnotify.Remove) {
 				log.WithField(logfields.Path, event.Name).Debug("Detected template removal")
 				templateHash := filepath.Base(filepath.Dir(event.Name))
 				o.delete(templateHash)

--- a/pkg/fswatcher/fswatcher.go
+++ b/pkg/fswatcher/fswatcher.go
@@ -216,10 +216,10 @@ func (w *Watcher) loop() {
 			scopedLog.Debug("Received fsnotify event")
 
 			eventPath := event.Name
-			removed := event.Op&fsnotify.Remove == fsnotify.Remove
-			renamed := event.Op&fsnotify.Rename == fsnotify.Rename
-			created := event.Op&fsnotify.Create == fsnotify.Create
-			written := event.Op&fsnotify.Write == fsnotify.Write
+			removed := event.Has(fsnotify.Remove)
+			renamed := event.Has(fsnotify.Rename)
+			created := event.Has(fsnotify.Create)
+			written := event.Has(fsnotify.Write)
 
 			// If a the eventPath has been removed or renamed, it can no longer
 			// be a valid watchPath. This is needed such that each trackedPath

--- a/pkg/ipmasq/ipmasq.go
+++ b/pkg/ipmasq/ipmasq.go
@@ -145,11 +145,11 @@ func (a *IPMasqAgent) Start() {
 				log.Debugf("Received fsnotify event: %+v", event)
 
 				switch {
-				case event.Op&fsnotify.Create == fsnotify.Create,
-					event.Op&fsnotify.Write == fsnotify.Write,
-					event.Op&fsnotify.Chmod == fsnotify.Chmod,
-					event.Op&fsnotify.Remove == fsnotify.Remove,
-					event.Op&fsnotify.Rename == fsnotify.Rename:
+				case event.Has(fsnotify.Create),
+					event.Has(fsnotify.Write),
+					event.Has(fsnotify.Chmod),
+					event.Has(fsnotify.Remove),
+					event.Has(fsnotify.Rename):
 					if err := a.Update(); err != nil {
 						log.WithError(err).Warn("Failed to update")
 					}


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

[fsnotify pr](https://github.com/fsnotify/fsnotify/pull/477) and [fsnotify release](https://github.com/fsnotify/fsnotify/releases/tag/v1.6.0) . 
Maybe we can change our code follow the style.

