### PR TITLE
Add --pprof-debug args to cilium-bugtool

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -43,6 +43,7 @@ cilium-bugtool [OPTIONS] [flags]
       --k8s-mode                             Require Kubernetes pods to be found or fail
       --k8s-namespace string                 Kubernetes namespace for Cilium pod (default "kube-system")
       --parallel-workers int                 Maximum number of parallel worker tasks, use 0 for number of CPUs
+      --pprof-debug int                      Debug pprof args (default 1)
       --pprof-port int                       Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061, apiserver:6063 (default 6060)
       --pprof-trace-seconds int              Amount of seconds used for pprof CPU traces (default 180)
   -t, --tmp string                           Path to store extracted files. Use '-' to send to stdout. (default "/tmp")

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -70,6 +70,7 @@ var (
 	enableMarkdown           bool
 	archivePrefix            string
 	getPProf                 bool
+	pprofDebug               int
 	envoyDump                bool
 	pprofPort                int
 	traceSeconds             int
@@ -80,6 +81,7 @@ var (
 func init() {
 	BugtoolRootCmd.Flags().BoolVar(&archive, "archive", true, "Create archive when false skips deletion of the output directory")
 	BugtoolRootCmd.Flags().BoolVar(&getPProf, "get-pprof", false, "When set, only gets the pprof traces from the cilium-agent binary")
+	BugtoolRootCmd.Flags().IntVar(&pprofDebug, "pprof-debug", 1, "Debug pprof args")
 	BugtoolRootCmd.Flags().BoolVar(&envoyDump, "envoy-dump", true, "When set, dump envoy configuration from unix socket")
 	BugtoolRootCmd.Flags().IntVar(&pprofPort,
 		"pprof-port", defaults.PprofPortAgent,
@@ -201,7 +203,7 @@ func runTool() {
 	}
 
 	if getPProf {
-		err := pprofTraces(cmdDir)
+		err := pprofTraces(cmdDir, pprofDebug)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to create debug directory %s\n", err)
 			os.Exit(1)
@@ -471,7 +473,7 @@ func dumpEnvoy(rootDir string) error {
 	return downloadToFile(c, "http://admin/config_dump?include_eds", filepath.Join(rootDir, "envoy-config.json"))
 }
 
-func pprofTraces(rootDir string) error {
+func pprofTraces(rootDir string, pprofDebug int) error {
 	var wg sync.WaitGroup
 	var profileErr error
 	pprofHost := fmt.Sprintf("localhost:%d", pprofPort)
@@ -491,7 +493,7 @@ func pprofTraces(rootDir string) error {
 		return err
 	}
 
-	url = fmt.Sprintf("http://%s/debug/pprof/heap?debug=1", pprofHost)
+	url = fmt.Sprintf("http://%s/debug/pprof/heap?debug=%d", pprofHost, pprofDebug)
 	dir = filepath.Join(rootDir, "pprof-heap")
 	err = downloadToFile(httpClient, url, dir)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

[pprof debug](https://pkg.go.dev/runtime/pprof#pkg-notes)

```
The debug parameter enables additional output.
Passing debug=0 writes the gzip-compressed protocol buffer described in https://github.com/google/pprof/tree/master/proto#overview.
Passing debug=1 writes the legacy text format with comments translating addresses to function names and line numbers, so that a programmer can read the profile without tools.

The predefined profiles may assign meaning to other debug values; for example, when printing the "goroutine" profile, 
debug=2 means to print the goroutine stacks in the same form that a Go program uses when dying due to an unrecovered panic.
```

I propose adding --pprof-debug parameter for friendly export of pprof data.
