### PR TITLE
bpf: egressgw: clarify IPSec key for tunnel encapsulation

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1020,7 +1020,7 @@ ct_recreate4:
 
 		if (egress_gw_request_needs_redirect(ip4, &tunnel_endpoint)) {
 			/* Send the packet to egress gateway node through a tunnel. */
-			ret = __encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
+			ret = __encap_and_redirect_lxc(ctx, tunnel_endpoint, 0,
 						       SECLABEL, *dst_id, &trace);
 			if (ret == CTX_ACT_OK)
 				goto encrypt_to_stack;


### PR DESCRIPTION
The `encrypt_key` in handle_ipv4_from_lxc() is obtained from a IPCache lookup for the packet's `daddr`. It doesn't make sense to use this key in the context of redirecting EgressGW traffic - here the tunnel's remote endpoint is not `daddr`, but an EgressGW node.

As EgressGW and IPSec are currently mutually exclusive, we can just hard-code this parameter to 0 for now. In the future we would need to look up the IPSec key of the selected EgressGW node.