### PR TITLE
envoy: Skip NPHDS upsert when IP is already included

### DIFF
--- a/pkg/envoy/resources_test.go
+++ b/pkg/envoy/resources_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package envoy
+
+import (
+	envoyAPI "github.com/cilium/proxy/go/cilium/api"
+	. "gopkg.in/check.v1"
+)
+
+type ResourcesSuite struct{}
+
+var _ = Suite(&ResourcesSuite{})
+
+func (s *SortSuite) TestHandleIPUpsert(c *C) {
+	cache := newNPHDSCache(nil)
+
+	msg, err := cache.Lookup(NetworkPolicyHostsTypeURL, "123")
+	c.Assert(err, IsNil)
+	c.Assert(msg, IsNil)
+
+	err = cache.handleIPUpsert(nil, "123", "1.2.3.0/32", 123)
+	c.Assert(err, IsNil)
+
+	msg, err = cache.Lookup(NetworkPolicyHostsTypeURL, "123")
+	c.Assert(err, IsNil)
+	c.Assert(msg, Not(IsNil))
+	npHost := msg.(*envoyAPI.NetworkPolicyHosts)
+	c.Assert(npHost, Not(IsNil))
+	c.Assert(npHost.Policy, Equals, uint64(123))
+	c.Assert(len(npHost.HostAddresses), Equals, 1)
+	c.Assert(npHost.HostAddresses[0], Equals, "1.2.3.0/32")
+
+	// Another address
+	err = cache.handleIPUpsert(npHost, "123", "::1/128", 123)
+	c.Assert(err, IsNil)
+
+	msg, err = cache.Lookup(NetworkPolicyHostsTypeURL, "123")
+	c.Assert(err, IsNil)
+	c.Assert(msg, Not(IsNil))
+	npHost = msg.(*envoyAPI.NetworkPolicyHosts)
+	c.Assert(npHost, Not(IsNil))
+	c.Assert(npHost.Policy, Equals, uint64(123))
+	c.Assert(len(npHost.HostAddresses), Equals, 2)
+	c.Assert(npHost.HostAddresses[0], Equals, "1.2.3.0/32")
+	c.Assert(npHost.HostAddresses[1], Equals, "::1/128")
+
+	// Check that duplicates are not added, and not erroring out
+	err = cache.handleIPUpsert(npHost, "123", "1.2.3.0/32", 123)
+	c.Assert(err, IsNil)
+
+	msg, err = cache.Lookup(NetworkPolicyHostsTypeURL, "123")
+	c.Assert(err, IsNil)
+	c.Assert(msg, Not(IsNil))
+	npHost = msg.(*envoyAPI.NetworkPolicyHosts)
+	c.Assert(npHost, Not(IsNil))
+	c.Assert(npHost.Policy, Equals, uint64(123))
+	c.Assert(len(npHost.HostAddresses), Equals, 2)
+	c.Assert(npHost.HostAddresses[0], Equals, "1.2.3.0/32")
+	c.Assert(npHost.HostAddresses[1], Equals, "::1/128")
+}


### PR DESCRIPTION
Prevent unnecessary warnings like follows by skipping the upsert if the given IP is already included.

level=warning msg="Could not validate NPHDS resource update on upsert" error="invalid NetworkPolicyHosts.HostAddresses[4]: repeated value must contain unique items" ...

Also rely on this new duplicate IP detection to skip upserts when oldID is given and it is the same as the newID. This makes the behavior of this implementation of OnIPIdentityCacheChange() less fragile.

Add tests to verify validation error is not encountered when an IP is inserted twice.

Notes for reviewers on commits:
1. refactor without any functional change
2. return errors instead of logging in the helper functions
3. Fix & new unit tests

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
