### PR TITLE
install/kubernetes: Re-order lines in Makefile.values

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -96,7 +96,7 @@ main() {
     logecho "Updating VERSION, AUTHORS.md, $ACTS_YAML, helm templates"
     echo $ersion > VERSION
     sed -i 's/"[^"]*"/""/g' install/kubernetes/Makefile.digests
-    logrun make -C install/kubernetes all USE_DIGESTS=false
+    logrun make RELEASE=yes CILIUM_BRANCH="$branch" install/kubernetes all USE_DIGESTS=false
     if grep -q update-helm-values Documentation/Makefile; then
         logrun make -C Documentation update-helm-values
     fi

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -5,20 +5,24 @@ DIGESTS_PATH:=Makefile.digests
 include $(DIGESTS_PATH)
 export USE_DIGESTS ?= $(shell if grep -q '""' $(DIGESTS_PATH); then echo "false"; else echo "true"; fi)
 
-# When branching, update these values
-#export PULL_POLICY:=IfNotPresent
-#export CILIUM_BRANCH:=vX.Y
-#export CILIUM_REPO:=quay.io/cilium/cilium
-#export CLUSTERMESH_APISERVER_REPO:=quay.io/cilium/clustermesh-apiserver
-#export HUBBLE_RELAY_REPO:=quay.io/cilium/hubble-relay
-export PULL_POLICY:=Always
-export CILIUM_BRANCH:=master
-export CILIUM_REPO:=quay.io/cilium/cilium-ci
-export CLUSTERMESH_APISERVER_REPO:=quay.io/cilium/clustermesh-apiserver-ci
+ifeq ($(RELEASE),yes)
+    export PULL_POLICY:=IfNotPresent
+    export CILIUM_REPO:=quay.io/cilium/cilium
+    export CLUSTERMESH_APISERVER_REPO:=quay.io/cilium/clustermesh-apiserver
+    export HUBBLE_RELAY_REPO:=quay.io/cilium/hubble-rela
+else
+    export CILIUM_BRANCH:=master
+    export PULL_POLICY:=Always
+    export CILIUM_REPO:=quay.io/cilium/cilium-ci
+    export CILIUM_OPERATOR_SUFFIX=-ci
+    export CILIUM_VERSION:=latest
+    export CLUSTERMESH_APISERVER_REPO:=quay.io/cilium/clustermesh-apiserver-ci
+    export HUBBLE_RELAY_REPO:=quay.io/cilium/hubble-relay-ci
+endif
 
-# When branching, delete the following lines to defer to the branch's versions
-export CILIUM_VERSION:=latest
-export CILIUM_OPERATOR_SUFFIX=-ci
+ifndef CILIUM_BRANCH
+$(error "CILIUM_BRANCH needs to be defined")
+endif
 
 export CERTGEN_REPO:=quay.io/cilium/certgen
 export CERTGEN_VERSION:=v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd
@@ -32,7 +36,6 @@ export CILIUM_OPERATOR_BASE_REPO:=quay.io/cilium/operator
 export ETCD_REPO:=quay.io/coreos/etcd
 export ETCD_VERSION:=v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3
 
-export HUBBLE_RELAY_REPO:=quay.io/cilium/hubble-relay-ci
 export HUBBLE_UI_BACKEND_REPO:=quay.io/cilium/hubble-ui-backend
 export HUBBLE_UI_BACKEND_VERSION:=v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7
 export HUBBLE_UI_FRONTEND_REPO:=quay.io/cilium/hubble-ui


### PR DESCRIPTION
This will prevent the release manager on missing any changes that need to be done in this file.

Signed-off-by: André Martins <andre@cilium.io>