### PR TITLE
v1.12 backports 2022-11-22

### DIFF
--- a/Documentation/concepts/networking/ipam/eni.rst
+++ b/Documentation/concepts/networking/ipam/eni.rst
@@ -21,6 +21,10 @@ watermark is used to maintain a number of IP addresses to be available for use
 on nodes at all time without needing to contact the EC2 API when a new pod is
 scheduled in the cluster.
 
+Note that Cilium currently does not support IPv6-only ENIs. Cilium support for
+IPv6 ENIs is being tracked in :gh-issue:`18405`, and the related feature of
+assigning IPv6 prefixes in :gh-issue:`19251`.
+
 ************
 Architecture
 ************

--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -416,14 +416,14 @@ Name                             Labels                           Default    Des
 FQDN
 ~~~~
 
-================================== ================================ =========== ========================================================
-Name                               Labels                           Default     Description
-================================== ================================ =========== ========================================================
-``fqdn_gc_deletions_total``                                         Enabled     Number of FQDNs that have been cleaned on FQDN garbage collector job
-``fqdn_active_names``              ``endpoint``                     Enabled     Number of domains inside the DNS cache that have not expired (by TTL), per endpoint
-``fqdn_active_ips``                ``endpoint``                     Enabled     Number of IPs inside the DNS cache associated with a domain that has not expired (by TTL), per endpoint
-``fqdn_alive_zombie_connections``  ``endpoint``                     Enabled     Number of IPs associated with domains that have expired (by TTL) yet still associated with an active connection (aka zombie), per endpoint
-================================== ================================ =========== ========================================================
+================================== ================================ ============ ========================================================
+Name                               Labels                           Default      Description
+================================== ================================ ============ ========================================================
+``fqdn_gc_deletions_total``                                         Enabled      Number of FQDNs that have been cleaned on FQDN garbage collector job
+``fqdn_active_names``              ``endpoint``                     Disabled     Number of domains inside the DNS cache that have not expired (by TTL), per endpoint
+``fqdn_active_ips``                ``endpoint``                     Disabled     Number of IPs inside the DNS cache associated with a domain that has not expired (by TTL), per endpoint
+``fqdn_alive_zombie_connections``  ``endpoint``                     Disabled     Number of IPs associated with domains that have expired (by TTL) yet still associated with an active connection (aka zombie), per endpoint
+================================== ================================ ============ ========================================================
 
 .. _metrics_api_rate_limiting:
 

--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -184,8 +184,18 @@ To expose any metrics, invoke ``cilium-agent`` with the
 passing an empty IP (e.g. ``:9962``) will bind the server to all available
 interfaces (there is usually only one in a container).
 
-Exported Metrics
-^^^^^^^^^^^^^^^^
+To customize ``cilium-agent`` metrics, configure the ``--metrics`` option with
+``"+metric_a -metric_b -metric_c"``, where ``+/-`` means to enable/disable
+the metric. For example, for really large clusters, users may consider to
+disable the following two metrics as they generate too much data:
+
+- ``cilium_node_connectivity_status``
+- ``cilium_node_connectivity_latency_seconds``
+
+You can then configure the agent with ``--metrics="-cilium_node_connectivity_status -cilium_node_connectivity_latency_seconds"``.
+
+Exported Metrics by Default
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Endpoint
 ~~~~~~~~

--- a/Documentation/operations/metrics.rst
+++ b/Documentation/operations/metrics.rst
@@ -430,17 +430,17 @@ Name                               Labels                           Default     
 API Rate Limiting
 ~~~~~~~~~~~~~~~~~
 
-===================================================== ================================ ========== ========================================================
-Name                                                  Labels                           Default    Description
-===================================================== ================================ ========== ========================================================
-``cilium_api_limiter_adjustment_factor``              ``api_call``                     Enabled    Most recent adjustment factor for automatic adjustment
-``cilium_api_limiter_processed_requests_total``       ``api_call``, ``outcome``        Enabled    Total number of API requests processed
-``cilium_api_limiter_processing_duration_seconds``    ``api_call``, ``value``          Enabled    Mean and estimated processing duration in seconds
-``cilium_api_limiter_rate_limit``                     ``api_call``, ``value``          Enabled    Current rate limiting configuration (limit and burst)
-``cilium_api_limiter_requests_in_flight``             ``api_call``  ``value``          Enabled    Current and maximum allowed number of requests in flight
-``cilium_api_limiter_wait_duration_seconds``          ``api_call``, ``value``          Enabled    Mean, min, and max wait duration
-``cilium_api_limiter_wait_history_duration_seconds``  ``api_call``                     Disabled   Histogram of wait duration per API call processed
-===================================================== ================================ ========== ========================================================
+============================================== ================================ ========== ========================================================
+Name                                           Labels                           Default    Description
+============================================== ================================ ========== ========================================================
+``api_limiter_adjustment_factor``              ``api_call``                     Enabled    Most recent adjustment factor for automatic adjustment
+``api_limiter_processed_requests_total``       ``api_call``, ``outcome``        Enabled    Total number of API requests processed
+``api_limiter_processing_duration_seconds``    ``api_call``, ``value``          Enabled    Mean and estimated processing duration in seconds
+``api_limiter_rate_limit``                     ``api_call``, ``value``          Enabled    Current rate limiting configuration (limit and burst)
+``api_limiter_requests_in_flight``             ``api_call``  ``value``          Enabled    Current and maximum allowed number of requests in flight
+``api_limiter_wait_duration_seconds``          ``api_call``, ``value``          Enabled    Mean, min, and max wait duration
+``api_limiter_wait_history_duration_seconds``  ``api_call``                     Disabled   Histogram of wait duration per API call processed
+============================================== ================================ ========== ========================================================
 
 cilium-operator
 ---------------

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -556,7 +556,7 @@ IPs to be allowed are selected via:
 
   * ``*`` within a domain allows 0 or more valid DNS characters, except for the
     ``.`` separator. ``*.cilium.io`` will match ``sub.cilium.io`` but not
-    ``cilium.io``. ``part*ial.com`` will match ``partial.com`` and
+    ``cilium.io`` or ``sub.sub.cilium.io``. ``part*ial.com`` will match ``partial.com`` and
     ``part-extra-ial.com``.
   * ``*`` alone matches all names, and inserts all cached DNS IPs into this
     rule.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -768,100 +768,15 @@ drop_err:
 	return ret;
 }
 
-static __always_inline int
-do_netdev_encrypt_fib(struct __ctx_buff *ctx __maybe_unused,
-		      __u16 proto __maybe_unused,
-		      int *encrypt_iface __maybe_unused,
-		      int *ext_err __maybe_unused)
-{
-	int ret = 0;
-	/* Only do FIB lookup if both the BPF helper is supported and we know
-	 * the egress ineterface. If we don't have an egress interface,
-	 * typically in an environment with many egress devs than we have
-	 * to let the stack decide how to egress the packet. EKS is the
-	 * example of an environment with multiple egress interfaces.
-	 */
-#if defined(BPF_HAVE_FIB_LOOKUP) && defined(ENCRYPT_IFACE)
-	struct bpf_fib_lookup fib_params = {};
-	void *data, *data_end;
-	int err;
-
-	if (proto ==  bpf_htons(ETH_P_IP)) {
-		struct iphdr *ip4;
-
-		if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
-			ret = DROP_INVALID;
-			goto drop_err_fib;
-		}
-
-		fib_params.family = AF_INET;
-		fib_params.ipv4_src = ip4->saddr;
-		fib_params.ipv4_dst = ip4->daddr;
-	} else {
-		struct ipv6hdr *ip6;
-
-		if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
-			ret = DROP_INVALID;
-			goto drop_err_fib;
-		}
-
-		fib_params.family = AF_INET6;
-		ipv6_addr_copy((union v6addr *) &fib_params.ipv6_src, (union v6addr *) &ip6->saddr);
-		ipv6_addr_copy((union v6addr *) &fib_params.ipv6_dst, (union v6addr *) &ip6->daddr);
-	}
-
-	fib_params.ifindex = *encrypt_iface;
-
-	err = fib_lookup(ctx, &fib_params, sizeof(fib_params),
-		    BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
-	if (err != 0) {
-		*ext_err = err;
-		ret = DROP_NO_FIB;
-		goto drop_err_fib;
-	}
-	if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0) {
-		ret = DROP_WRITE_ERROR;
-		goto drop_err_fib;
-	}
-	if (eth_store_saddr(ctx, fib_params.smac, 0) < 0) {
-		ret = DROP_WRITE_ERROR;
-		goto drop_err_fib;
-	}
-	*encrypt_iface = fib_params.ifindex;
-drop_err_fib:
-#endif /* BPF_HAVE_FIB_LOOKUP */
-	return ret;
-}
-
-static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto,
+static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx,
 					     __u32 src_id)
 {
-	int encrypt_iface = 0;
-	int ext_err = 0;
 	int ret = 0;
-#if defined(ENCRYPT_IFACE) && defined(BPF_HAVE_FIB_LOOKUP)
-	encrypt_iface = ENCRYPT_IFACE;
-#endif
+
 	ret = do_netdev_encrypt_pools(ctx);
 	if (ret)
 		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP, METRIC_INGRESS);
 
-	ret = do_netdev_encrypt_fib(ctx, proto, &encrypt_iface, &ext_err);
-	if (ret)
-		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
-
-	bpf_clear_meta(ctx);
-#ifdef BPF_HAVE_FIB_LOOKUP
-	/* Redirect only works if we have a fib lookup to set the MAC
-	 * addresses. Otherwise let the stack do the routing and fib
-	 * Note, without FIB lookup implemented the packet may have
-	 * incorrect dmac leaving bpf_host so will need to mark as
-	 * PACKET_HOST or otherwise fixup MAC addresses.
-	 */
-	if (encrypt_iface)
-		return ctx_redirect(ctx, encrypt_iface, 0);
-#endif
 	return CTX_ACT_OK;
 }
 
@@ -882,7 +797,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 						NOT_VTEP_DST, &trace);
 }
 
-static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto __maybe_unused,
+static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx,
 					     __u32 src_id)
 {
 	return do_netdev_encrypt_encap(ctx, src_id);
@@ -929,7 +844,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 			send_trace_notify(ctx, TRACE_FROM_STACK, identity, 0, 0,
 					  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
 					  TRACE_PAYLOAD_LEN);
-			return do_netdev_encrypt(ctx, proto, identity);
+			return do_netdev_encrypt(ctx, identity);
 		}
 #endif
 

--- a/operator/k8s_cep_gc.go
+++ b/operator/k8s_cep_gc.go
@@ -164,7 +164,7 @@ func doCiliumEndpointSyncGC(ctx context.Context, once bool, stopCh chan struct{}
 		case err == nil:
 			successfulEndpointObjectGC()
 		case k8serrors.IsNotFound(err), k8serrors.IsConflict(err):
-			// No-op.
+			scopedLog.WithError(err).Debug("Unable to delete CEP, will retry again")
 		default:
 			scopedLog.WithError(err).Warning("Unable to delete orphaned CEP")
 			failedEndpointObjectGC()

--- a/operator/watchers/cilium_endpoint.go
+++ b/operator/watchers/cilium_endpoint.go
@@ -134,6 +134,7 @@ func convertToCiliumEndpoint(obj interface{}) interface{} {
 				Namespace:       concreteObj.Namespace,
 				ResourceVersion: concreteObj.ResourceVersion,
 				OwnerReferences: concreteObj.OwnerReferences,
+				UID:             concreteObj.UID,
 			},
 			Status: cilium_api_v2.EndpointStatus{
 				Identity:   concreteObj.Status.Identity,
@@ -158,6 +159,7 @@ func convertToCiliumEndpoint(obj interface{}) interface{} {
 					Namespace:       ciliumEndpoint.Namespace,
 					ResourceVersion: ciliumEndpoint.ResourceVersion,
 					OwnerReferences: ciliumEndpoint.OwnerReferences,
+					UID:             ciliumEndpoint.UID,
 				},
 				Status: cilium_api_v2.EndpointStatus{
 					Identity:   ciliumEndpoint.Status.Identity,

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -137,18 +137,25 @@ func deriveStatus(err error) string {
 // describeNetworkInterfaces lists all ENIs
 func (c *Client) describeNetworkInterfaces(ctx context.Context, subnets ipamTypes.SubnetMap) ([]ec2_types.NetworkInterface, error) {
 	var result []ec2_types.NetworkInterface
-	input := &ec2.DescribeNetworkInterfacesInput{}
+	input := &ec2.DescribeNetworkInterfacesInput{
+		// Filters out ipv6-only ENIs. For now we require that every interface
+		// has a primary IPv4 address.
+		Filters: []ec2_types.Filter{
+			{
+				Name:   aws.String("private-ip-address"),
+				Values: []string{"*"},
+			},
+		},
+	}
 	if len(c.subnetsFilters) > 0 {
 		subnetsIDs := make([]string, 0, len(subnets))
 		for id := range subnets {
 			subnetsIDs = append(subnetsIDs, id)
 		}
-		input.Filters = []ec2_types.Filter{
-			{
-				Name:   aws.String("subnet-id"),
-				Values: subnetsIDs,
-			},
-		}
+		input.Filters = append(input.Filters, ec2_types.Filter{
+			Name:   aws.String("subnet-id"),
+			Values: subnetsIDs,
+		})
 	}
 	paginator := ec2.NewDescribeNetworkInterfacesPaginator(c.ec2Client, input)
 	for paginator.HasMorePages() {
@@ -198,7 +205,16 @@ func (c *Client) describeNetworkInterfacesFromInstances(ctx context.Context) ([]
 		enisListFromInstances = append(enisListFromInstances, k)
 	}
 
-	ENIAttrs := &ec2.DescribeNetworkInterfacesInput{}
+	ENIAttrs := &ec2.DescribeNetworkInterfacesInput{
+		// Filters out ipv6-only ENIs. For now we require that every interface
+		// has a primary IPv4 address.
+		Filters: []ec2_types.Filter{
+			{
+				Name:   aws.String("private-ip-address"),
+				Values: []string{"*"},
+			},
+		},
+	}
 	if len(enisListFromInstances) > 0 {
 		ENIAttrs.NetworkInterfaceIds = enisListFromInstances
 	}

--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -56,14 +56,14 @@ func NewDeviceManager() (*DeviceManager, error) {
 func NewDeviceManagerAt(netns netns.NsHandle) (*DeviceManager, error) {
 	handle, err := netlink.NewHandleAt(netns)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to setup device manager: %w", err)
 	}
 	return &DeviceManager{
 		devices: make(map[string]struct{}),
 		filter:  deviceFilter(option.Config.GetDevices()),
 		handle:  handle,
 		netns:   netns,
-	}, err
+	}, nil
 }
 
 // Detect tries to detect devices to which BPF programs may be loaded.

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1517,7 +1517,6 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 			// kernels with FIB lookup helpers we do a lookup from
 			// the datapath side and ignore this value.
 			ifaceNames = append(ifaceNames, option.Config.EncryptInterface[0])
-			n.enableNeighDiscovery = true
 		}
 
 		if n.enableNeighDiscovery {

--- a/pkg/k8s/init_test.go
+++ b/pkg/k8s/init_test.go
@@ -22,10 +22,17 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
 
 func (s *K8sSuite) TestUseNodeCIDR(c *C) {
+	prevAnnotateK8sNode := option.Config.AnnotateK8sNode
+	option.Config.AnnotateK8sNode = true
+	defer func() {
+		option.Config.AnnotateK8sNode = prevAnnotateK8sNode
+	}()
+
 	// Test IPv4
 	node1 := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -15,10 +15,17 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	nodeAddressing "github.com/cilium/cilium/pkg/node/addressing"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
 
 func (s *K8sSuite) TestParseNode(c *C) {
+	prevAnnotateK8sNode := option.Config.AnnotateK8sNode
+	option.Config.AnnotateK8sNode = true
+	defer func() {
+		option.Config.AnnotateK8sNode = prevAnnotateK8sNode
+	}()
+
 	// PodCIDR takes precedence over annotations
 	k8sNode := &slim_corev1.Node{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -80,6 +87,57 @@ func (s *K8sSuite) TestParseNode(c *C) {
 	c.Assert(n.Name, Equals, "node2")
 	c.Assert(n.IPv4AllocCIDR, NotNil)
 	c.Assert(n.IPv4AllocCIDR.String(), Equals, "10.254.0.0/16")
+	c.Assert(n.IPv6AllocCIDR, NotNil)
+	c.Assert(n.IPv6AllocCIDR.String(), Equals, "f00d:aaaa:bbbb:cccc:dddd:eeee::/112")
+}
+
+func (s *K8sSuite) TestParseNodeWithoutAnnotations(c *C) {
+	prevAnnotateK8sNode := option.Config.AnnotateK8sNode
+	option.Config.AnnotateK8sNode = false
+	defer func() {
+		option.Config.AnnotateK8sNode = prevAnnotateK8sNode
+	}()
+
+	// PodCIDR takes precedence over annotations
+	k8sNode := &slim_corev1.Node{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name: "node1",
+			Annotations: map[string]string{
+				annotation.V4CIDRName: "10.254.0.0/16",
+				annotation.V6CIDRName: "f00d:aaaa:bbbb:cccc:dddd:eeee::/112",
+			},
+			Labels: map[string]string{
+				"type": "m5.xlarge",
+			},
+		},
+		Spec: slim_corev1.NodeSpec{
+			PodCIDR: "10.1.0.0/16",
+		},
+	}
+
+	n := ParseNode(k8sNode, source.Local)
+	c.Assert(n.Name, Equals, "node1")
+	c.Assert(n.IPv4AllocCIDR, NotNil)
+	c.Assert(n.IPv4AllocCIDR.String(), Equals, "10.1.0.0/16")
+	c.Assert(n.IPv6AllocCIDR, IsNil)
+	c.Assert(n.Labels["type"], Equals, "m5.xlarge")
+
+	// No IPv6 annotation but PodCIDR with v6
+	k8sNode = &slim_corev1.Node{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name: "node2",
+			Annotations: map[string]string{
+				annotation.V4CIDRName: "10.254.0.0/16",
+			},
+		},
+		Spec: slim_corev1.NodeSpec{
+			PodCIDR: "f00d:aaaa:bbbb:cccc:dddd:eeee::/112",
+		},
+	}
+
+	n = ParseNode(k8sNode, source.Local)
+	c.Assert(n.Name, Equals, "node2")
+	c.Assert(n.IPv4AllocCIDR, IsNil)
 	c.Assert(n.IPv6AllocCIDR, NotNil)
 	c.Assert(n.IPv6AllocCIDR.String(), Equals, "f00d:aaaa:bbbb:cccc:dddd:eeee::/112")
 }

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -169,7 +169,7 @@ func (k *K8sWatcher) GetCiliumNode(ctx context.Context, nodeName string) (*ciliu
 	}
 	k.ciliumNodeStoreMU.RUnlock()
 
-	if getFromAPIServer {
+	if !exists || getFromAPIServer {
 		// fallback to using the kube-apiserver
 		return k8s.CiliumClient().CiliumV2().CiliumNodes().Get(ctx, nodeName, meta.GetOptions{})
 	}

--- a/pkg/mtu/detect_other.go
+++ b/pkg/mtu/detect_other.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-//go:build darwin
+//go:build !linux
 
 package mtu
 

--- a/pkg/node/address_other.go
+++ b/pkg/node/address_other.go
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-//go:build darwin
+//go:build !linux
 
 package node
 
-import (
-	"net"
-)
+import "net"
 
 func firstGlobalV4Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
 	return net.IP{}, nil

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -462,11 +462,16 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 	nodeResource.ObjectMeta.Annotations = localCN.Annotations
 
 	for _, k8sAddress := range k8sNodeAddresses {
-		k8sAddressStr := k8sAddress.IP.String()
-		nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
-			Type: k8sAddress.Type,
-			IP:   k8sAddressStr,
-		})
+		// Do not add CiliumNodeInternalIP from the k8sNodeAddress. The source
+		// of truth is always the local node. The CiliumInternalIP address is
+		// added from n.localNode.IPAddress in the next for-loop.
+		if k8sAddress.Type != addressing.NodeCiliumInternalIP {
+			k8sAddressStr := k8sAddress.IP.String()
+			nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
+				Type: k8sAddress.Type,
+				IP:   k8sAddressStr,
+			})
+		}
 	}
 
 	for _, address := range n.localNode.IPAddresses {

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -229,6 +229,7 @@ const (
 	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
 	missingIptablesWait = "Missing iptables wait arg (-w):"
 	localIDRestoreFail  = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
+	routerIPMismatch    = "Mismatch of router IPs found during restoration"
 
 	// ...and their exceptions.
 	lrpExists                = "local-redirect service exists for frontend"                         // cf. https://github.com/cilium/cilium/issues/16400
@@ -295,6 +296,7 @@ var badLogMessages = map[string][]string{
 	removeTransientRule: nil,
 	missingIptablesWait: nil,
 	localIDRestoreFail:  nil,
+	routerIPMismatch:    nil,
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.


### PR DESCRIPTION
* #22137 -- pkg/datapath: return specific error message (@aanm)
 * #22178 -- doc: add section to show how to customize cilium-agent metrics (@ArthurChiao)
 * #22075 -- aws/eni: fix cilium operator crash on IPv6 ENI (@bimmlerd)
 * #22232 -- mtu, node: fix build on all non-linux platforms (@tklauser)
 * #22206 -- docs: Clarify wildcards and subdomains in FQDN policies (@felfa01)
 * #22300 -- Update documentation related to metrics; fix incorrect FQDN metrics reference (@christarazi)
 * #22298 -- pkg/k8s: fallback on retrieving CiliumNode from kube-apiserver (@aanm)
 * #22213 -- operator: fix CEP GC (@aanm)
 * #22069 -- bpf: Remove FIB lookup for IPsec (@pchaigno)
   * :warning: Non-trivial merge conflicts.
 * #22127 -- pkg/k8s: do not read k8s node annotations if they are not written (@aanm)
 
Skipped:

 * #22193 -- Update start-release.sh (@michi-covalent)
   * See https://github.com/cilium/cilium/pull/22193#issuecomment-1323622254
 * #20350 -- daemon: add cleanup for stale local ciliumendpoints that aren't being managed. (@tommyp1ckles)
   * :warning: Non-trivial merge conflicts. @tommyp1ckles given the size of the PR would you be able
     to backport this one yourself separately?

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 22137 22178 22075 22232 22206 22300 22298 22213 22069 22127; do contrib/backporting/set-labels.py $pr done 1.12; done
```