### PR TITLE
v1.10 backports 2022-11-22

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -699,95 +699,14 @@ drop_err:
 	return ret;
 }
 
-static __always_inline int
-do_netdev_encrypt_fib(struct __ctx_buff *ctx __maybe_unused,
-		      __u16 proto __maybe_unused,
-		      int *encrypt_iface __maybe_unused)
+static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx)
 {
 	int ret = 0;
-	/* Only do FIB lookup if both the BPF helper is supported and we know
-	 * the egress ineterface. If we don't have an egress interface,
-	 * typically in an environment with many egress devs than we have
-	 * to let the stack decide how to egress the packet. EKS is the
-	 * example of an environment with multiple egress interfaces.
-	 */
-#if defined(BPF_HAVE_FIB_LOOKUP) && defined(ENCRYPT_IFACE)
-	struct bpf_fib_lookup fib_params = {};
-	void *data, *data_end;
-	int err;
 
-	if (proto ==  bpf_htons(ETH_P_IP)) {
-		struct iphdr *ip4;
-
-		if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
-			ret = DROP_INVALID;
-			goto drop_err_fib;
-		}
-
-		fib_params.family = AF_INET;
-		fib_params.ipv4_src = ip4->saddr;
-		fib_params.ipv4_dst = ip4->daddr;
-	} else {
-		struct ipv6hdr *ip6;
-
-		if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
-			ret = DROP_INVALID;
-			goto drop_err_fib;
-		}
-
-		fib_params.family = AF_INET6;
-		ipv6_addr_copy((union v6addr *) &fib_params.ipv6_src, (union v6addr *) &ip6->saddr);
-		ipv6_addr_copy((union v6addr *) &fib_params.ipv6_dst, (union v6addr *) &ip6->daddr);
-	}
-
-	fib_params.ifindex = *encrypt_iface;
-
-	err = fib_lookup(ctx, &fib_params, sizeof(fib_params),
-		    BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
-	if (err != 0) {
-		ret = DROP_NO_FIB;
-		goto drop_err_fib;
-	}
-	if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0) {
-		ret = DROP_WRITE_ERROR;
-		goto drop_err_fib;
-	}
-	if (eth_store_saddr(ctx, fib_params.smac, 0) < 0) {
-		ret = DROP_WRITE_ERROR;
-		goto drop_err_fib;
-	}
-	*encrypt_iface = fib_params.ifindex;
-drop_err_fib:
-#endif /* BPF_HAVE_FIB_LOOKUP */
-	return ret;
-}
-
-static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto)
-{
-	int encrypt_iface = 0;
-	int ret = 0;
-#if defined(ENCRYPT_IFACE) && defined(BPF_HAVE_FIB_LOOKUP)
-	encrypt_iface = ENCRYPT_IFACE;
-#endif
 	ret = do_netdev_encrypt_pools(ctx);
 	if (ret)
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
 
-	ret = do_netdev_encrypt_fib(ctx, proto, &encrypt_iface);
-	if (ret)
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
-
-	bpf_clear_meta(ctx);
-#ifdef BPF_HAVE_FIB_LOOKUP
-	/* Redirect only works if we have a fib lookup to set the MAC
-	 * addresses. Otherwise let the stack do the routing and fib
-	 * Note, without FIB lookup implemented the packet may have
-	 * incorrect dmac leaving bpf_host so will need to mark as
-	 * PACKET_HOST or otherwise fixup MAC addresses.
-	 */
-	if (encrypt_iface)
-		return redirect(encrypt_iface, 0);
-#endif
 	return CTX_ACT_OK;
 }
 
@@ -804,7 +723,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx)
 	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, TRACE_PAYLOAD_LEN);
 }
 
-static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto __maybe_unused)
+static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx)
 {
 	return do_netdev_encrypt_encap(ctx);
 }
@@ -823,7 +742,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 		__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
 
 		if (magic == MARK_MAGIC_ENCRYPT)
-			return do_netdev_encrypt(ctx, proto);
+			return do_netdev_encrypt(ctx);
 	} else {
 		int done = do_decrypt(ctx, proto);
 

--- a/operator/k8s_cep_gc.go
+++ b/operator/k8s_cep_gc.go
@@ -175,7 +175,7 @@ func doCiliumEndpointSyncGC(ctx context.Context, once bool, stopCh chan struct{}
 		case err == nil:
 			successfulEndpointObjectGC()
 		case k8serrors.IsNotFound(err), k8serrors.IsConflict(err):
-			// No-op.
+			scopedLog.WithError(err).Debug("Unable to delete CEP, will retry again")
 		default:
 			scopedLog.WithError(err).Warning("Unable to delete orphaned CEP")
 			failedEndpointObjectGC()

--- a/operator/watchers/cilium_endpoint.go
+++ b/operator/watchers/cilium_endpoint.go
@@ -100,6 +100,7 @@ func convertToCiliumEndpoint(obj interface{}) interface{} {
 				Namespace:       concreteObj.Namespace,
 				ResourceVersion: concreteObj.ResourceVersion,
 				OwnerReferences: concreteObj.OwnerReferences,
+				UID:             concreteObj.UID,
 			},
 			Status: cilium_api_v2.EndpointStatus{
 				Identity: concreteObj.Status.Identity,
@@ -121,6 +122,7 @@ func convertToCiliumEndpoint(obj interface{}) interface{} {
 					Namespace:       ciliumEndpoint.Namespace,
 					ResourceVersion: ciliumEndpoint.ResourceVersion,
 					OwnerReferences: ciliumEndpoint.OwnerReferences,
+					UID:             ciliumEndpoint.UID,
 				},
 				Status: cilium_api_v2.EndpointStatus{
 					Identity: ciliumEndpoint.Status.Identity,

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1386,7 +1386,6 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 			// kernels with FIB lookup helpers we do a lookup from
 			// the datapath side and ignore this value.
 			ifaceName = option.Config.EncryptInterface[0]
-			n.enableNeighDiscovery = true
 		}
 
 		if n.enableNeighDiscovery {

--- a/pkg/k8s/init_test.go
+++ b/pkg/k8s/init_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 
 	. "gopkg.in/check.v1"
@@ -37,6 +38,12 @@ import (
 )
 
 func (s *K8sSuite) TestUseNodeCIDR(c *C) {
+	prevAnnotateK8sNode := option.Config.AnnotateK8sNode
+	option.Config.AnnotateK8sNode = true
+	defer func() {
+		option.Config.AnnotateK8sNode = prevAnnotateK8sNode
+	}()
+
 	// Test IPv4
 	node1 := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -88,38 +88,11 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 		}
 		addrs = append(addrs, na)
 	}
-
-	k8sNodeAddHostIP := func(annotation string) {
-		if ciliumInternalIP, ok := k8sNode.Annotations[annotation]; !ok || ciliumInternalIP == "" {
-			scopedLog.Debugf("Missing %s. Annotation required when IPSec Enabled", annotation)
-		} else if ip := net.ParseIP(ciliumInternalIP); ip == nil {
-			scopedLog.Debugf("ParseIP %s error", ciliumInternalIP)
-		} else {
-			na := nodeTypes.Address{
-				Type: addressing.NodeCiliumInternalIP,
-				IP:   ip,
-			}
-			addrs = append(addrs, na)
-			scopedLog.Debugf("Add NodeCiliumInternalIP: %s", ip)
-		}
-	}
-
-	k8sNodeAddHostIP(annotation.CiliumHostIP)
-	k8sNodeAddHostIP(annotation.CiliumHostIPv6)
-
-	encryptKey := uint8(0)
-	if key, ok := k8sNode.Annotations[annotation.CiliumEncryptionKey]; ok {
-		if u, err := strconv.ParseUint(key, 10, 8); err == nil {
-			encryptKey = uint8(u)
-		}
-	}
-
 	newNode := &nodeTypes.Node{
-		Name:          k8sNode.Name,
-		Cluster:       option.Config.ClusterName,
-		IPAddresses:   addrs,
-		Source:        source,
-		EncryptionKey: encryptKey,
+		Name:        k8sNode.Name,
+		Cluster:     option.Config.ClusterName,
+		IPAddresses: addrs,
+		Source:      source,
 	}
 
 	if len(k8sNode.Spec.PodCIDRs) != 0 {
@@ -149,6 +122,40 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 			}
 		}
 	}
+
+	newNode.Labels = k8sNode.GetLabels()
+
+	if !option.Config.AnnotateK8sNode {
+		return newNode
+	}
+
+	// Any code bellow this line will depend on k8s node annotations. If we are
+	// not annotating the node then we should not use any annotations.
+
+	k8sNodeAddHostIP := func(annotation string) {
+		if ciliumInternalIP, ok := k8sNode.Annotations[annotation]; !ok || ciliumInternalIP == "" {
+			scopedLog.Debugf("Missing %s. Annotation required when IPSec Enabled", annotation)
+		} else if ip := net.ParseIP(ciliumInternalIP); ip == nil {
+			scopedLog.Debugf("ParseIP %s error", ciliumInternalIP)
+		} else {
+			na := nodeTypes.Address{
+				Type: addressing.NodeCiliumInternalIP,
+				IP:   ip,
+			}
+			addrs = append(addrs, na)
+			scopedLog.Debugf("Add NodeCiliumInternalIP: %s", ip)
+		}
+	}
+
+	k8sNodeAddHostIP(annotation.CiliumHostIP)
+	k8sNodeAddHostIP(annotation.CiliumHostIPv6)
+
+	if key, ok := k8sNode.Annotations[annotation.CiliumEncryptionKey]; ok {
+		if u, err := strconv.ParseUint(key, 10, 8); err == nil {
+			newNode.EncryptionKey = uint8(u)
+		}
+	}
+
 	// Spec.PodCIDR takes precedence since it's
 	// the CIDR assigned by k8s controller manager
 	// In case it's invalid or empty then we fall back to our annotations.
@@ -197,8 +204,6 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 			newNode.IPv6HealthIP = ip
 		}
 	}
-
-	newNode.Labels = k8sNode.GetLabels()
 
 	return newNode
 }

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -24,12 +24,19 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	nodeAddressing "github.com/cilium/cilium/pkg/node/addressing"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 
 	. "gopkg.in/check.v1"
 )
 
 func (s *K8sSuite) TestParseNode(c *C) {
+	prevAnnotateK8sNode := option.Config.AnnotateK8sNode
+	option.Config.AnnotateK8sNode = true
+	defer func() {
+		option.Config.AnnotateK8sNode = prevAnnotateK8sNode
+	}()
+
 	// PodCIDR takes precedence over annotations
 	k8sNode := &slim_corev1.Node{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -91,6 +98,57 @@ func (s *K8sSuite) TestParseNode(c *C) {
 	c.Assert(n.Name, Equals, "node2")
 	c.Assert(n.IPv4AllocCIDR, NotNil)
 	c.Assert(n.IPv4AllocCIDR.String(), Equals, "10.254.0.0/16")
+	c.Assert(n.IPv6AllocCIDR, NotNil)
+	c.Assert(n.IPv6AllocCIDR.String(), Equals, "f00d:aaaa:bbbb:cccc:dddd:eeee::/112")
+}
+
+func (s *K8sSuite) TestParseNodeWithoutAnnotations(c *C) {
+	prevAnnotateK8sNode := option.Config.AnnotateK8sNode
+	option.Config.AnnotateK8sNode = false
+	defer func() {
+		option.Config.AnnotateK8sNode = prevAnnotateK8sNode
+	}()
+
+	// PodCIDR takes precedence over annotations
+	k8sNode := &slim_corev1.Node{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name: "node1",
+			Annotations: map[string]string{
+				annotation.V4CIDRName: "10.254.0.0/16",
+				annotation.V6CIDRName: "f00d:aaaa:bbbb:cccc:dddd:eeee::/112",
+			},
+			Labels: map[string]string{
+				"type": "m5.xlarge",
+			},
+		},
+		Spec: slim_corev1.NodeSpec{
+			PodCIDR: "10.1.0.0/16",
+		},
+	}
+
+	n := ParseNode(k8sNode, source.Local)
+	c.Assert(n.Name, Equals, "node1")
+	c.Assert(n.IPv4AllocCIDR, NotNil)
+	c.Assert(n.IPv4AllocCIDR.String(), Equals, "10.1.0.0/16")
+	c.Assert(n.IPv6AllocCIDR, IsNil)
+	c.Assert(n.Labels["type"], Equals, "m5.xlarge")
+
+	// No IPv6 annotation but PodCIDR with v6
+	k8sNode = &slim_corev1.Node{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name: "node2",
+			Annotations: map[string]string{
+				annotation.V4CIDRName: "10.254.0.0/16",
+			},
+		},
+		Spec: slim_corev1.NodeSpec{
+			PodCIDR: "f00d:aaaa:bbbb:cccc:dddd:eeee::/112",
+		},
+	}
+
+	n = ParseNode(k8sNode, source.Local)
+	c.Assert(n.Name, Equals, "node2")
+	c.Assert(n.IPv4AllocCIDR, IsNil)
 	c.Assert(n.IPv6AllocCIDR, NotNil)
 	c.Assert(n.IPv6AllocCIDR.String(), Equals, "f00d:aaaa:bbbb:cccc:dddd:eeee::/112")
 }

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -441,11 +441,16 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 	nodeResource.ObjectMeta.Labels = k8sNodeParsed.Labels
 
 	for _, k8sAddress := range k8sNodeAddresses {
-		k8sAddressStr := k8sAddress.IP.String()
-		nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
-			Type: k8sAddress.Type,
-			IP:   k8sAddressStr,
-		})
+		// Do not add CiliumNodeInternalIP from the k8sNodeAddress. The source
+		// of truth is always the local node. The CiliumInternalIP address is
+		// added from n.localNode.IPAddress in the next for-loop.
+		if k8sAddress.Type != addressing.NodeCiliumInternalIP {
+			k8sAddressStr := k8sAddress.IP.String()
+			nodeResource.Spec.Addresses = append(nodeResource.Spec.Addresses, ciliumv2.NodeAddress{
+				Type: k8sAddress.Type,
+				IP:   k8sAddressStr,
+			})
+		}
 	}
 
 	for _, address := range n.localNode.IPAddresses {

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -242,6 +242,7 @@ const (
 	removeTransientRule = "Unable to process chain CILIUM_TRANSIENT_FORWARD with ip" // from https://github.com/cilium/cilium/issues/11276
 	localIDRestoreFail  = "Could not restore all CIDR identities"                    // from https://github.com/cilium/cilium/pull/19556
 	missingIptablesWait = "Missing iptables wait arg (-w):"
+	routerIPMismatch    = "Mismatch of router IPs found during restoration"
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -308,6 +309,7 @@ var badLogMessages = map[string][]string{
 	removeTransientRule: nil,
 	localIDRestoreFail:  nil,
 	missingIptablesWait: nil,
+	routerIPMismatch:    nil,
 	"DATA RACE":         nil,
 }
 


### PR DESCRIPTION
 * #22213 -- operator: fix CEP GC (@aanm)
 * #22069 -- bpf: Remove FIB lookup for IPsec (@pchaigno)
   * :warning: Non-trivial merge conflicts.
 * #22127 -- pkg/k8s: do not read k8s node annotations if they are not written (@aanm)

Skipped:

 * #22193 -- Update start-release.sh (@michi-covalent)
   * See https://github.com/cilium/cilium/pull/22193#issuecomment-1323622254
 * #20350 -- daemon: add cleanup for stale local ciliumendpoints that aren't being managed. (@tommyp1ckles)
   * :warning: Non-trivial merge conflicts. @tommyp1ckles given the size of the PR would you be able
     to backport this one yourself separately?

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 22213 22069 22127; do contrib/backporting/set-labels.py $pr done 1.10; done
```