### PR TITLE
bgp: bgp-cp additional modularization

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -4,11 +4,13 @@
 package cmd
 
 import (
+	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -33,6 +35,9 @@ var (
 
 		// Provides Clientset, API for accessing Kubernetes objects.
 		k8sClient.Cell,
+
+		// Provide option.Config via hive so cells can depend on the agent config.
+		cell.Provide(func() *option.DaemonConfig { return option.Config }),
 	)
 
 	// ControlPlane implement the per-node control functions. These are pure
@@ -49,6 +54,9 @@ var (
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,
+
+		// The BGP Control Plane
+		bgpv1.Cell,
 	)
 
 	// Datapath provides the privileged operations to apply control-plane

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/api/v1/server/restapi"
 	"github.com/cilium/cilium/pkg/aws/eni"
 	bgpv1 "github.com/cilium/cilium/pkg/bgpv1/agent"
-	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/common"
@@ -1642,6 +1641,7 @@ type daemonParams struct {
 	Datapath       datapath.Datapath
 	WGAgent        *wg.Agent `optional:"true"`
 	LocalNodeStore node.LocalNodeStore
+	BGPController  *bgpv1.Controller
 	Shutdowner     hive.Shutdowner
 }
 
@@ -1865,19 +1865,9 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 		}
 	}
 
-	if option.Config.BGPControlPlaneEnabled() {
-		switch option.Config.IPAM {
-		case ipamOption.IPAMClusterPool:
-		case ipamOption.IPAMClusterPoolV2:
-		case ipamOption.IPAMKubernetes:
-		default:
-			log.Fatalf("BGP control plane cannot be utilized with IPAM mode: %v", option.Config.IPAM)
-		}
-		log.Info("Initializing BGP Control Plane")
-		if err := d.instantiateBGPControlPlane(d.ctx); err != nil {
-			log.Fatalf("failed to initialize BGP control plane: %s", err)
-		}
-	}
+	// Assign the BGP Control to the struct field so non-modularized components can interact with the BGP Controller
+	// like they are used to.
+	d.bgpControlPlaneController = params.BGPController
 
 	log.WithField("bootstrapTime", time.Since(bootstrapTimestamp)).
 		Info("Daemon initialization completed")
@@ -1903,18 +1893,6 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 		log.WithError(err).Error("Error returned from non-returning Serve() call")
 		params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
 	}
-}
-
-func (d *Daemon) instantiateBGPControlPlane(ctx context.Context) error {
-	// goBGP is currently the only supported RouterManager, if more are
-	// implemented replace this hard-coding with a construction switch.
-	rm := gobgp.NewBGPRouterManager()
-	ctrl, err := bgpv1.NewController(d.ctx, d.clientset, rm)
-	if err != nil {
-		return fmt.Errorf("failed to instantiate BGP Control Plane: %v", err)
-	}
-	d.bgpControlPlaneController = ctrl
-	return nil
 }
 
 func (d *Daemon) instantiateAPI() *restapi.CiliumAPIAPI {

--- a/pkg/bgpv1/agent/annotations.go
+++ b/pkg/bgpv1/agent/annotations.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package bgpv1
+package agent
 
 import (
 	"errors"

--- a/pkg/bgpv1/agent/annotations_test.go
+++ b/pkg/bgpv1/agent/annotations_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package bgpv1
+package agent
 
 import (
 	"errors"

--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -10,16 +10,13 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sLabels "k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/workerpool"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/client/informers/externalversions"
@@ -29,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeaddr "github.com/cilium/cilium/pkg/node"
-	nodetypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -129,52 +125,16 @@ type Controller struct {
 // Controller
 type ControllerOpt func(*Controller)
 
-// configureForK8sIPAM will setup an informer which will trigger reconciliation
-// when the Kubernetes Node object has changed and returns a nodeSpecer abstraction
-// to retrieve the Node's PodCIDR prefixes.
-func configureForK8sIPAM(k8sfactory informers.SharedInformerFactory, sig Signaler) (nodeSpecer, error) {
-	name := nodetypes.GetName()
-	nodeLister := k8sfactory.Core().V1().Nodes().Lister()
-	nodeInformer := k8sfactory.Core().V1().Nodes().Informer()
-	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    sig.Event,
-		UpdateFunc: func(_ interface{}, _ interface{}) { sig.Event(struct{}{}) },
-		DeleteFunc: sig.Event,
-	})
-	return &kubernetesNodeSpecer{
-		Name:         name,
-		NodeLister:   nodeLister,
-		nodeInformer: nodeInformer,
-	}, nil
-}
-
-// configureForK8sIPAM will setup an informer which will trigger reconciliation
-// when the CiliumNode object has changed and returns a nodeSpecer abstraction
-// to retrieve the Node's PodCIDR prefixes.
-func configureForClusterPoolIPAM(factory externalversions.SharedInformerFactory, sig Signaler) (nodeSpecer, error) {
-	name := nodetypes.GetName()
-	nodeLister := factory.Cilium().V2().CiliumNodes().Lister()
-	nodeInformer := factory.Cilium().V2().CiliumNodes().Informer()
-	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    sig.Event,
-		UpdateFunc: func(_ interface{}, _ interface{}) { sig.Event(struct{}{}) },
-		DeleteFunc: sig.Event,
-	})
-	return &ciliumNodeSpecer{
-		Name:         name,
-		NodeLister:   nodeLister,
-		nodeInformer: nodeInformer,
-	}, nil
-}
-
 // ControllerParams contains all parameters needed to construct a Controller
 type ControllerParams struct {
 	cell.In
 
 	Lifecycle    hive.Lifecycle
 	Clientset    client.Clientset
+	Sig          Signaler
 	RouteMgr     BGPRouterManager
 	DaemonConfig *option.DaemonConfig
+	NodeSpec     nodeSpecer
 	Opts         []ControllerOpt `group:"bgp-controller-options"`
 }
 
@@ -196,55 +156,23 @@ func NewController(params ControllerParams) (*Controller, error) {
 	log.Info("Initializing BGP Control Plane")
 
 	var (
-		// signaler used to trigger Controller reconciliation.
-		sig = NewSignaler()
 		// we'll use to list and watch BGPPeeringPolicies
 		factory = externalversions.NewSharedInformerFactory(params.Clientset, 0)
 	)
 
 	c := Controller{
-		Sig:    sig,
-		BGPMgr: params.RouteMgr,
-	}
-
-	// setup is dictate by the type of IPAM being used. If Kubernetes IPAM is
-	// being used the BGP Control Plane must watch and retrieve PodCIDR ranges
-	// from the corev1 Kubernetes Node resource.
-	//
-	// if the ClusterPool (both v1 and v2) IPAM mode is in use, the control plane
-	// must watch and retrieve PodCIDR ranges from Cilium's v2 CiliumNode resource.
-	switch params.DaemonConfig.IPAM {
-	case ipamOption.IPAMClusterPoolV2, ipamOption.IPAMClusterPool:
-		var err error
-		selfTweakList := externalversions.WithTweakListOptions(func(lo *metav1.ListOptions) {
-			lo.FieldSelector = "metadata.name=" + nodetypes.GetName()
-		})
-		factory := externalversions.NewSharedInformerFactoryWithOptions(params.Clientset, 0, selfTweakList)
-		c.NodeSpec, err = configureForClusterPoolIPAM(factory, sig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to configure listers and informers for ClusterPool IPAM: %w", err)
-		}
-	case ipamOption.IPAMKubernetes:
-		var err error
-		selfTweakList := informers.WithTweakListOptions(func(lo *metav1.ListOptions) {
-			lo.FieldSelector = "metadata.name=" + nodetypes.GetName()
-		})
-		k8sfactory := informers.NewSharedInformerFactoryWithOptions(params.Clientset, 0, selfTweakList)
-		c.NodeSpec, err = configureForK8sIPAM(k8sfactory, sig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to configure listers and informers for Kubernetes IPAM: %w", err)
-		}
-	default:
-		return nil, fmt.Errorf("failed to determine a compatible IPAM mode, cannot initialize BGP control plane")
+		Sig:      params.Sig,
+		BGPMgr:   params.RouteMgr,
+		NodeSpec: params.NodeSpec,
 	}
 
 	// setup policy lister and informer.
 	c.PolicyLister = factory.Cilium().V2alpha1().CiliumBGPPeeringPolicies().Lister()
 	c.policyInformer = factory.Cilium().V2alpha1().CiliumBGPPeeringPolicies().Informer()
 	c.policyInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    sig.Event,
-		UpdateFunc: func(_ interface{}, _ interface{}) { sig.Event(struct{}{}) },
-		DeleteFunc: sig.Event,
+		AddFunc:    c.Sig.Event,
+		UpdateFunc: func(_ interface{}, _ interface{}) { c.Sig.Event(struct{}{}) },
+		DeleteFunc: c.Sig.Event,
 	})
 
 	// apply any options.
@@ -262,11 +190,6 @@ func (c *Controller) Start(_ hive.HookContext) error {
 	c.workerpool = workerpool.New(3)
 	c.workerpool.Submit("policy-informer", func(ctx context.Context) error {
 		c.policyInformer.Run(ctx.Done())
-		return nil
-	})
-
-	c.workerpool.Submit("nodespecer", func(ctx context.Context) error {
-		c.NodeSpec.Run(ctx)
 		return nil
 	})
 
@@ -318,7 +241,7 @@ func (c *Controller) Run(ctx context.Context) {
 	l.Info("Cilium BGP Control Plane Controller now running...")
 	for {
 		select {
-		case <-c.ctx.Done():
+		case <-ctx.Done():
 			killCTX, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancel()
 
@@ -328,7 +251,7 @@ func (c *Controller) Run(ctx context.Context) {
 			return
 		case <-c.Sig.Sig:
 			l.Info("Cilium BGP Control Plane Controller woken for reconciliation")
-			if err := c.Reconcile(c.ctx); err != nil {
+			if err := c.Reconcile(ctx); err != nil {
 				l.WithError(err).Error("Encountered error during reconciliation")
 			} else {
 				l.Debug("Successfully completed reconciliation")

--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -318,7 +318,7 @@ func (c *Controller) Run(ctx context.Context) {
 	l.Info("Cilium BGP Control Plane Controller now running...")
 	for {
 		select {
-		case <-ctx.Done():
+		case <-c.ctx.Done():
 			killCTX, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancel()
 
@@ -328,7 +328,7 @@ func (c *Controller) Run(ctx context.Context) {
 			return
 		case <-c.Sig.Sig:
 			l.Info("Cilium BGP Control Plane Controller woken for reconciliation")
-			if err := c.Reconcile(ctx); err != nil {
+			if err := c.Reconcile(c.ctx); err != nil {
 				l.WithError(err).Error("Encountered error during reconciliation")
 			} else {
 				l.Debug("Successfully completed reconciliation")

--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -15,7 +15,10 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/cilium/cilium/pkg/bgpv1"
+	"github.com/cilium/workerpool"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -89,7 +92,7 @@ type ControlPlaneState struct {
 	PodCIDRs []string
 	// Parsed 'cilium.io/bgp-virtual-router' annotations of the the node this
 	// control plane is running on.
-	Annotations bgpv1.AnnotationMap
+	Annotations AnnotationMap
 	// The current IPv4 address of the agent, reachable externally.
 	IPv4 net.IP
 	// The current IPv6 address of the agent, reachable externally.
@@ -105,6 +108,8 @@ type Controller struct {
 	// PolicyLister provides cached and indexed lookups of
 	// for CilumBGPPeeringPolicy API objects.
 	PolicyLister v2alpha1.CiliumBGPPeeringPolicyLister
+	// policyInformer keeps the controller informed of any policy changes.
+	policyInformer cache.SharedIndexInformer
 	// Sig informs the Controller that a Kubernetes
 	// event of interest has occurred.
 	//
@@ -116,6 +121,8 @@ type Controller struct {
 	// BGPMgr is an implementation of the BGPRouterManager interface
 	// and provides a declarative API for configuring BGP peers.
 	BGPMgr BGPRouterManager
+
+	workerpool *workerpool.WorkerPool
 }
 
 // ControllerOpt is a signature for defining configurable options for a
@@ -125,10 +132,7 @@ type ControllerOpt func(*Controller)
 // configureForK8sIPAM will setup an informer which will trigger reconciliation
 // when the Kubernetes Node object has changed and returns a nodeSpecer abstraction
 // to retrieve the Node's PodCIDR prefixes.
-//
-// ensure the provided stop channel is closed to cancel the shared Informer's
-// go routine.
-func configureForK8sIPAM(k8sfactory informers.SharedInformerFactory, sig Signaler, stop chan struct{}) (nodeSpecer, error) {
+func configureForK8sIPAM(k8sfactory informers.SharedInformerFactory, sig Signaler) (nodeSpecer, error) {
 	name := nodetypes.GetName()
 	nodeLister := k8sfactory.Core().V1().Nodes().Lister()
 	nodeInformer := k8sfactory.Core().V1().Nodes().Informer()
@@ -137,20 +141,17 @@ func configureForK8sIPAM(k8sfactory informers.SharedInformerFactory, sig Signale
 		UpdateFunc: func(_ interface{}, _ interface{}) { sig.Event(struct{}{}) },
 		DeleteFunc: sig.Event,
 	})
-	go nodeInformer.Run(stop)
 	return &kubernetesNodeSpecer{
-		Name:       name,
-		NodeLister: nodeLister,
+		Name:         name,
+		NodeLister:   nodeLister,
+		nodeInformer: nodeInformer,
 	}, nil
 }
 
 // configureForK8sIPAM will setup an informer which will trigger reconciliation
 // when the CiliumNode object has changed and returns a nodeSpecer abstraction
 // to retrieve the Node's PodCIDR prefixes.
-//
-// ensure the provided stop channel is closed to cancel the shared Informer's
-// go routine.
-func configureForClusterPoolIPAM(factory externalversions.SharedInformerFactory, sig Signaler, stop chan struct{}) (nodeSpecer, error) {
+func configureForClusterPoolIPAM(factory externalversions.SharedInformerFactory, sig Signaler) (nodeSpecer, error) {
 	name := nodetypes.GetName()
 	nodeLister := factory.Cilium().V2().CiliumNodes().Lister()
 	nodeInformer := factory.Cilium().V2().CiliumNodes().Informer()
@@ -159,11 +160,22 @@ func configureForClusterPoolIPAM(factory externalversions.SharedInformerFactory,
 		UpdateFunc: func(_ interface{}, _ interface{}) { sig.Event(struct{}{}) },
 		DeleteFunc: sig.Event,
 	})
-	go nodeInformer.Run(stop)
 	return &ciliumNodeSpecer{
-		Name:       name,
-		NodeLister: nodeLister,
+		Name:         name,
+		NodeLister:   nodeLister,
+		nodeInformer: nodeInformer,
 	}, nil
+}
+
+// ControllerParams contains all parameters needed to construct a Controller
+type ControllerParams struct {
+	cell.In
+
+	Lifecycle    hive.Lifecycle
+	Clientset    client.Clientset
+	RouteMgr     BGPRouterManager
+	DaemonConfig *option.DaemonConfig
+	Opts         []ControllerOpt `group:"bgp-controller-options"`
 }
 
 // NewController constructs a new BGP Control Plane Controller.
@@ -174,20 +186,26 @@ func configureForClusterPoolIPAM(factory externalversions.SharedInformerFactory,
 // The constructor requires an implementation of BGPRouterManager to be provided.
 // This implementation defines which BGP backend will be used (GoBGP, FRR, Bird, etc...)
 // NOTE: only GoBGP currently implemented.
-//
-// Cancel the provided CTX to stop the Controller.
-func NewController(ctx context.Context, clientset client.Clientset, rtMgr BGPRouterManager, opts ...ControllerOpt) (*Controller, error) {
+func NewController(params ControllerParams) (*Controller, error) {
+	// If the BGP control plane is disabled, just return nil. This way the hive dependency graph is always static
+	// regardless of config. The lifecycle has not been appended so no work will be done.
+	if !params.DaemonConfig.BGPControlPlaneEnabled() {
+		return nil, nil
+	}
+
+	log.Info("Initializing BGP Control Plane")
+
 	var (
 		// signaler used to trigger Controller reconciliation.
 		sig = NewSignaler()
-		// stop channel used to cancel informers.
-		stop = make(chan struct{}, 1)
 		// we'll use to list and watch BGPPeeringPolicies
-		factory = externalversions.NewSharedInformerFactory(clientset, 0)
-		// an abtraction over obtaining Node Spec information depending on
-		// IPAM configuration.
-		nodeSpecer nodeSpecer
+		factory = externalversions.NewSharedInformerFactory(params.Clientset, 0)
 	)
+
+	c := Controller{
+		Sig:    sig,
+		BGPMgr: params.RouteMgr,
+	}
 
 	// setup is dictate by the type of IPAM being used. If Kubernetes IPAM is
 	// being used the BGP Control Plane must watch and retrieve PodCIDR ranges
@@ -195,14 +213,14 @@ func NewController(ctx context.Context, clientset client.Clientset, rtMgr BGPRou
 	//
 	// if the ClusterPool (both v1 and v2) IPAM mode is in use, the control plane
 	// must watch and retrieve PodCIDR ranges from Cilium's v2 CiliumNode resource.
-	switch option.Config.IPAM {
+	switch params.DaemonConfig.IPAM {
 	case ipamOption.IPAMClusterPoolV2, ipamOption.IPAMClusterPool:
 		var err error
 		selfTweakList := externalversions.WithTweakListOptions(func(lo *metav1.ListOptions) {
 			lo.FieldSelector = "metadata.name=" + nodetypes.GetName()
 		})
-		factory := externalversions.NewSharedInformerFactoryWithOptions(clientset, 0, selfTweakList)
-		nodeSpecer, err = configureForClusterPoolIPAM(factory, sig, stop)
+		factory := externalversions.NewSharedInformerFactoryWithOptions(params.Clientset, 0, selfTweakList)
+		c.NodeSpec, err = configureForClusterPoolIPAM(factory, sig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to configure listers and informers for ClusterPool IPAM: %w", err)
 		}
@@ -211,8 +229,8 @@ func NewController(ctx context.Context, clientset client.Clientset, rtMgr BGPRou
 		selfTweakList := informers.WithTweakListOptions(func(lo *metav1.ListOptions) {
 			lo.FieldSelector = "metadata.name=" + nodetypes.GetName()
 		})
-		k8sfactory := informers.NewSharedInformerFactoryWithOptions(clientset, 0, selfTweakList)
-		nodeSpecer, err = configureForK8sIPAM(k8sfactory, sig, stop)
+		k8sfactory := informers.NewSharedInformerFactoryWithOptions(params.Clientset, 0, selfTweakList)
+		c.NodeSpec, err = configureForK8sIPAM(k8sfactory, sig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to configure listers and informers for Kubernetes IPAM: %w", err)
 		}
@@ -221,31 +239,60 @@ func NewController(ctx context.Context, clientset client.Clientset, rtMgr BGPRou
 	}
 
 	// setup policy lister and informer.
-	policyLister := factory.Cilium().V2alpha1().CiliumBGPPeeringPolicies().Lister()
-	policyInformer := factory.Cilium().V2alpha1().CiliumBGPPeeringPolicies().Informer()
-	policyInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	c.PolicyLister = factory.Cilium().V2alpha1().CiliumBGPPeeringPolicies().Lister()
+	c.policyInformer = factory.Cilium().V2alpha1().CiliumBGPPeeringPolicies().Informer()
+	c.policyInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    sig.Event,
 		UpdateFunc: func(_ interface{}, _ interface{}) { sig.Event(struct{}{}) },
 		DeleteFunc: sig.Event,
 	})
-	go policyInformer.Run(stop)
-
-	c := Controller{
-		NodeSpec:     nodeSpecer,
-		PolicyLister: policyLister,
-		Sig:          sig,
-		BGPMgr:       rtMgr,
-	}
 
 	// apply any options.
-	for _, opt := range opts {
+	for _, opt := range params.Opts {
 		opt(&c)
 	}
 
-	// stop channel is passed here, if ctx is canceled the passed stop chan
-	// is closed as well.
-	go c.Run(ctx, stop)
+	params.Lifecycle.Append(&c)
+
 	return &c, nil
+}
+
+// Start is called by hive after all of our dependencies have been started.
+func (c *Controller) Start(_ hive.HookContext) error {
+	c.workerpool = workerpool.New(3)
+	c.workerpool.Submit("policy-informer", func(ctx context.Context) error {
+		c.policyInformer.Run(ctx.Done())
+		return nil
+	})
+
+	c.workerpool.Submit("nodespecer", func(ctx context.Context) error {
+		c.NodeSpec.Run(ctx)
+		return nil
+	})
+
+	c.workerpool.Submit("controller", func(ctx context.Context) error {
+		c.Run(ctx)
+		return nil
+	})
+
+	return nil
+}
+
+// Stop is called by hive upon shutdown, after all of our dependants have been stopped.
+// We should perform a graceful shutdown and return as soon as done or when the stop context is done.
+func (c *Controller) Stop(ctx hive.HookContext) error {
+	doneChan := make(chan struct{})
+	go func() {
+		c.workerpool.Close()
+		close(doneChan)
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-doneChan:
+	}
+
+	return nil
 }
 
 // Run places the Controller into its control loop.
@@ -257,7 +304,7 @@ func NewController(ctx context.Context, clientset client.Clientset, rtMgr BGPRou
 //
 // A cancel of the provided ctx will kill the control loop along with the running
 // informers.
-func (c *Controller) Run(ctx context.Context, stop chan struct{}) {
+func (c *Controller) Run(ctx context.Context) {
 	var (
 		l = log.WithFields(logrus.Fields{
 			"component": "Controller.Run",
@@ -275,7 +322,6 @@ func (c *Controller) Run(ctx context.Context, stop chan struct{}) {
 			killCTX, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancel()
 
-			close(stop)               // kills the informers
 			c.FullWithdrawal(killCTX) // kill any BGP sessions
 
 			l.Info("Cilium BGP Control Plane Controller shut down")
@@ -392,7 +438,7 @@ func (c *Controller) Reconcile(ctx context.Context) error {
 		return fmt.Errorf("failed to retrieve Node's annotations: %w", err)
 	}
 
-	annoMap, err := bgpv1.NewAnnotationMap(annotations)
+	annoMap, err := NewAnnotationMap(annotations)
 	if err != nil {
 		return fmt.Errorf("failed to parse annotations: %w", err)
 	}

--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -10,17 +10,13 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	k8sLabels "k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/workerpool"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/client/informers/externalversions"
-	"github.com/cilium/cilium/pkg/k8s/client/listers/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	slimlabels "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	slimmetav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/logging"
@@ -95,17 +91,21 @@ type ControlPlaneState struct {
 	IPv6 net.IP
 }
 
+type policyLister interface {
+	List() []*v2alpha1api.CiliumBGPPeeringPolicy
+}
+
 // Controller is the agent side BGP Control Plane controller.
 //
 // Controller listens for events and drives BGP related sub-systems
 // to maintain a desired state.
 type Controller struct {
 	NodeSpec nodeSpecer
-	// PolicyLister provides cached and indexed lookups of
-	// for CilumBGPPeeringPolicy API objects.
-	PolicyLister v2alpha1.CiliumBGPPeeringPolicyLister
-	// policyInformer keeps the controller informed of any policy changes.
-	policyInformer cache.SharedIndexInformer
+	// PolicyResource provides a store of cached policies and allows us to observe changes to the objects in its
+	// store.
+	PolicyResource resource.Resource[*v2alpha1api.CiliumBGPPeeringPolicy]
+	// PolicyLister is an interface which allows for the listing of all known policies
+	PolicyLister policyLister
 	// Sig informs the Controller that a Kubernetes
 	// event of interest has occurred.
 	//
@@ -119,6 +119,8 @@ type Controller struct {
 	BGPMgr BGPRouterManager
 
 	workerpool *workerpool.WorkerPool
+	// Shutdowner can be used to trigger a shutdown of hive
+	Shutdowner hive.Shutdowner
 }
 
 // ControllerOpt is a signature for defining configurable options for a
@@ -129,13 +131,14 @@ type ControllerOpt func(*Controller)
 type ControllerParams struct {
 	cell.In
 
-	Lifecycle    hive.Lifecycle
-	Clientset    client.Clientset
-	Sig          Signaler
-	RouteMgr     BGPRouterManager
-	DaemonConfig *option.DaemonConfig
-	NodeSpec     nodeSpecer
-	Opts         []ControllerOpt `group:"bgp-controller-options"`
+	Lifecycle      hive.Lifecycle
+	Shutdowner     hive.Shutdowner
+	Sig            Signaler
+	RouteMgr       BGPRouterManager
+	PolicyResource resource.Resource[*v2alpha1api.CiliumBGPPeeringPolicy]
+	DaemonConfig   *option.DaemonConfig
+	NodeSpec       nodeSpecer
+	Opts           []ControllerOpt `group:"bgp-controller-options"`
 }
 
 // NewController constructs a new BGP Control Plane Controller.
@@ -155,25 +158,13 @@ func NewController(params ControllerParams) (*Controller, error) {
 
 	log.Info("Initializing BGP Control Plane")
 
-	var (
-		// we'll use to list and watch BGPPeeringPolicies
-		factory = externalversions.NewSharedInformerFactory(params.Clientset, 0)
-	)
-
 	c := Controller{
-		Sig:      params.Sig,
-		BGPMgr:   params.RouteMgr,
-		NodeSpec: params.NodeSpec,
+		Sig:            params.Sig,
+		BGPMgr:         params.RouteMgr,
+		PolicyResource: params.PolicyResource,
+		NodeSpec:       params.NodeSpec,
+		Shutdowner:     params.Shutdowner,
 	}
-
-	// setup policy lister and informer.
-	c.PolicyLister = factory.Cilium().V2alpha1().CiliumBGPPeeringPolicies().Lister()
-	c.policyInformer = factory.Cilium().V2alpha1().CiliumBGPPeeringPolicies().Informer()
-	c.policyInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.Sig.Event,
-		UpdateFunc: func(_ interface{}, _ interface{}) { c.Sig.Event(struct{}{}) },
-		DeleteFunc: c.Sig.Event,
-	})
 
 	// apply any options.
 	for _, opt := range params.Opts {
@@ -186,10 +177,25 @@ func NewController(params ControllerParams) (*Controller, error) {
 }
 
 // Start is called by hive after all of our dependencies have been started.
-func (c *Controller) Start(_ hive.HookContext) error {
-	c.workerpool = workerpool.New(3)
+func (c *Controller) Start(startCtx hive.HookContext) error {
+	var err error
+	c.PolicyLister, err = c.PolicyResource.Store(startCtx)
+	if err != nil {
+		return fmt.Errorf("PolicyResource.Store(): %w", err)
+	}
+
+	c.workerpool = workerpool.New(2)
 	c.workerpool.Submit("policy-informer", func(ctx context.Context) error {
-		c.policyInformer.Run(ctx.Done())
+		c.PolicyResource.Observe(ctx, func(e resource.Event[*v2alpha1api.CiliumBGPPeeringPolicy]) {
+			// Always mark the event as done since we have no way to retry on errors as of yet.
+			e.Done(nil)
+			// Signal the reconciliation logic.
+			c.Sig.Event(struct{}{})
+		}, func(err error) {
+			if err != nil {
+				c.Shutdowner.Shutdown(hive.ShutdownWithError(err))
+			}
+		})
 		return nil
 	})
 
@@ -326,10 +332,7 @@ func (c *Controller) Reconcile(ctx context.Context) error {
 	)
 
 	// retrieve all CiliumBGPPeeringPolicies
-	policies, err := c.PolicyLister.List(k8sLabels.NewSelector())
-	if err != nil {
-		return fmt.Errorf("failed to list CiliumBGPPeeringPolicies")
-	}
+	policies := c.PolicyLister.List()
 	l.WithField("count", len(policies)).Debug("Successfully listed CiliumBGPPeeringPolicies")
 
 	// perform policy selection based on node.

--- a/pkg/bgpv1/agent/controller_test.go
+++ b/pkg/bgpv1/agent/controller_test.go
@@ -9,8 +9,6 @@ import (
 	"net"
 	"testing"
 
-	k8sLabels "k8s.io/apimachinery/pkg/labels"
-
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/mock"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -66,7 +64,7 @@ func TestControllerSanity(t *testing.T) {
 		annotations func() (map[string]string, error)
 		podCIDRs    func() ([]string, error)
 		// a mock List method for the controller's PolicyLister
-		plist func(k8sLabels.Selector) (ret []*v2alpha1api.CiliumBGPPeeringPolicy, err error)
+		plist func() []*v2alpha1api.CiliumBGPPeeringPolicy
 		// a mock ConfigurePeers method for the controller's BGPRouterManager
 		configurePeers func(context.Context, *v2alpha1api.CiliumBGPPeeringPolicy, *agent.ControlPlaneState) error
 		// error nil or not
@@ -86,8 +84,8 @@ func TestControllerSanity(t *testing.T) {
 			podCIDRs: func() ([]string, error) {
 				return []string{}, nil
 			},
-			plist: func(_ k8sLabels.Selector) (ret []*v2alpha1api.CiliumBGPPeeringPolicy, err error) {
-				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}, nil
+			plist: func() []*v2alpha1api.CiliumBGPPeeringPolicy {
+				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}
 			},
 			configurePeers: func(_ context.Context, p *v2alpha1api.CiliumBGPPeeringPolicy, c *agent.ControlPlaneState) error {
 				// pointer check, not deep equal
@@ -108,8 +106,8 @@ func TestControllerSanity(t *testing.T) {
 		// was called erroneously
 		{
 			name: "podcidr listing error",
-			plist: func(_ k8sLabels.Selector) (ret []*v2alpha1api.CiliumBGPPeeringPolicy, err error) {
-				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}, nil
+			plist: func() []*v2alpha1api.CiliumBGPPeeringPolicy {
+				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}
 			},
 			labels: func() (map[string]string, error) {
 				return map[string]string{
@@ -126,8 +124,8 @@ func TestControllerSanity(t *testing.T) {
 		},
 		{
 			name: "annotations listing error",
-			plist: func(_ k8sLabels.Selector) (ret []*v2alpha1api.CiliumBGPPeeringPolicy, err error) {
-				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}, nil
+			plist: func() []*v2alpha1api.CiliumBGPPeeringPolicy {
+				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}
 			},
 			labels: func() (map[string]string, error) {
 				return map[string]string{
@@ -144,8 +142,8 @@ func TestControllerSanity(t *testing.T) {
 		},
 		{
 			name: "label listening error",
-			plist: func(_ k8sLabels.Selector) (ret []*v2alpha1api.CiliumBGPPeeringPolicy, err error) {
-				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}, nil
+			plist: func() []*v2alpha1api.CiliumBGPPeeringPolicy {
+				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}
 			},
 			labels: func() (map[string]string, error) {
 				return map[string]string{
@@ -161,26 +159,9 @@ func TestControllerSanity(t *testing.T) {
 			err: errors.New(""),
 		},
 		{
-			name: "policy list error",
-			plist: func(_ k8sLabels.Selector) (ret []*v2alpha1api.CiliumBGPPeeringPolicy, err error) {
-				return nil, errors.New("")
-			},
-			labels: func() (map[string]string, error) {
-				return map[string]string{
-					"bgp-policy": "a",
-				}, nil
-			},
-			annotations: func() (map[string]string, error) {
-				return map[string]string{}, nil
-			},
-			podCIDRs: func() ([]string, error) {
-				return []string{}, nil
-			},
-			err: errors.New(""),
-		}, {
 			name: "configure peers error",
-			plist: func(_ k8sLabels.Selector) (ret []*v2alpha1api.CiliumBGPPeeringPolicy, err error) {
-				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}, nil
+			plist: func() []*v2alpha1api.CiliumBGPPeeringPolicy {
+				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}
 			},
 			labels: func() (map[string]string, error) {
 				return map[string]string{
@@ -208,7 +189,7 @@ func TestControllerSanity(t *testing.T) {
 				Labels_:      tt.labels,
 				PodCIDRs_:    tt.podCIDRs,
 			}
-			policyLister := &mock.MockCiliumBGPPeeringPolicyLister{
+			policyLister := &agent.MockCiliumBGPPeeringPolicyLister{
 				List_: tt.plist,
 			}
 			rtmgr := &mock.MockBGPRouterManager{

--- a/pkg/bgpv1/agent/controller_test.go
+++ b/pkg/bgpv1/agent/controller_test.go
@@ -32,6 +32,8 @@ type fakeNodeSpecer struct {
 	Annotations_ func() (map[string]string, error)
 }
 
+func (f *fakeNodeSpecer) Run(ctx context.Context) {}
+
 func (f *fakeNodeSpecer) PodCIDRs() ([]string, error) {
 	return f.PodCIDRs_()
 }

--- a/pkg/bgpv1/agent/mock.go
+++ b/pkg/bgpv1/agent/mock.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package agent
+
+import (
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+)
+
+var _ policyLister = (*MockCiliumBGPPeeringPolicyLister)(nil)
+
+type MockCiliumBGPPeeringPolicyLister struct {
+	List_ func() []*v2alpha1.CiliumBGPPeeringPolicy
+}
+
+func (m *MockCiliumBGPPeeringPolicyLister) List() []*v2alpha1.CiliumBGPPeeringPolicy {
+	return m.List_()
+}

--- a/pkg/bgpv1/agent/nodespecer.go
+++ b/pkg/bgpv1/agent/nodespecer.go
@@ -5,100 +5,108 @@ package agent
 
 import (
 	"context"
-	"fmt"
 
-	v1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-
-	v2 "github.com/cilium/cilium/pkg/k8s/client/listers/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
 )
 
-// nodeSpecer abstracts the underlying mechanism to list information about the
+type nodeSpecer interface {
+	Annotations() (map[string]string, error)
+	Labels() (map[string]string, error)
+	PodCIDRs() ([]string, error)
+}
+
+type localNodeStoreSpecerParams struct {
+	cell.In
+
+	Lifecycle      hive.Lifecycle
+	Config         *option.DaemonConfig
+	LocalNodeStore node.LocalNodeStore
+	Signaler       Signaler
+	Shutdowner     hive.Shutdowner
+}
+
+func NewLocalNodeStoreSpecer(params localNodeStoreSpecerParams) (nodeSpecer, error) {
+	specer := &localNodeStoreSpecer{
+		LocalNodeStore: params.LocalNodeStore,
+		Signaler:       params.Signaler,
+		Shutdowner:     params.Shutdowner,
+	}
+	specer.ctx, specer.cancel = context.WithCancel(context.Background())
+	params.Lifecycle.Append(specer)
+	return specer, nil
+}
+
+// localNodeStoreSpecer abstracts the underlying mechanism to list information about the
 // Node resource Cilium is running on.
 //
-// The BGP Control Plane needs to obtain Node information however, it may need
-// to query the Kubernetes Node or the Cilium Node object depending on IPAM
-// configuration.
-type nodeSpecer interface {
-	PodCIDRs() ([]string, error)
-	Labels() (map[string]string, error)
-	Annotations() (map[string]string, error)
-	Run(ctx context.Context)
+// The localNodeStoreSpecer observes changes to the local node info and signals the Signaler
+// when it changes.
+type localNodeStoreSpecer struct {
+	LocalNodeStore node.LocalNodeStore
+	Signaler       Signaler
+	Shutdowner     hive.Shutdowner
+
+	ctx      context.Context
+	cancel   context.CancelFunc
+	doneChan chan struct{}
 }
 
-type kubernetesNodeSpecer struct {
-	Name         string
-	NodeLister   v1.NodeLister
-	nodeInformer cache.SharedIndexInformer
+func (s *localNodeStoreSpecer) Start(ctx hive.HookContext) error {
+	s.LocalNodeStore.Observe(s.ctx, func(_ types.Node) {
+		s.Signaler.Event(nil)
+	}, func(err error) {
+		if err != nil {
+			s.Shutdowner.Shutdown(hive.ShutdownWithError(err))
+		}
+
+		close(s.doneChan)
+	})
+
+	return nil
 }
 
-func (s *kubernetesNodeSpecer) Run(ctx context.Context) {
-	go s.nodeInformer.Run(ctx.Done())
-}
+func (s *localNodeStoreSpecer) Stop(ctx hive.HookContext) error {
+	s.cancel()
 
-func (s *kubernetesNodeSpecer) Annotations() (map[string]string, error) {
-	n, err := s.NodeLister.Get(s.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
+	select {
+	case <-s.doneChan:
+	case <-s.ctx.Done():
 	}
+
+	return nil
+}
+
+func (s *localNodeStoreSpecer) Annotations() (map[string]string, error) {
+	n := s.LocalNodeStore.Get()
 	return n.Annotations, nil
 }
 
-func (s *kubernetesNodeSpecer) Labels() (map[string]string, error) {
-	n, err := s.NodeLister.Get(s.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
-	}
+func (s *localNodeStoreSpecer) Labels() (map[string]string, error) {
+	n := s.LocalNodeStore.Get()
 	return n.Labels, nil
 }
 
-func (s *kubernetesNodeSpecer) PodCIDRs() ([]string, error) {
-	n, err := s.NodeLister.Get(s.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
-	}
-	if n.Spec.PodCIDRs != nil {
-		return n.Spec.PodCIDRs, nil
-	}
-	if n.Spec.PodCIDR != "" {
-		return []string{n.Spec.PodCIDR}, nil
-	}
-	return []string{}, nil
-}
+func (s *localNodeStoreSpecer) PodCIDRs() ([]string, error) {
+	n := s.LocalNodeStore.Get()
 
-type ciliumNodeSpecer struct {
-	Name         string
-	NodeLister   v2.CiliumNodeLister
-	nodeInformer cache.SharedIndexInformer
-}
-
-func (s *ciliumNodeSpecer) Run(ctx context.Context) {
-	go s.nodeInformer.Run(ctx.Done())
-}
-
-func (s *ciliumNodeSpecer) Annotations() (map[string]string, error) {
-	n, err := s.NodeLister.Get(s.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
+	var podCIDRs []string
+	if n.IPv4AllocCIDR != nil {
+		podCIDRs = append(podCIDRs, n.IPv4AllocCIDR.String())
+		for _, secCidr := range n.IPv4SecondaryAllocCIDRs {
+			podCIDRs = append(podCIDRs, secCidr.String())
+		}
 	}
-	return n.Annotations, nil
-}
 
-func (s *ciliumNodeSpecer) Labels() (map[string]string, error) {
-	n, err := s.NodeLister.Get(s.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
+	if n.IPv6AllocCIDR != nil {
+		podCIDRs = append(podCIDRs, n.IPv6AllocCIDR.String())
+		for _, secCidr := range n.IPv6SecondaryAllocCIDRs {
+			podCIDRs = append(podCIDRs, secCidr.String())
+		}
 	}
-	return n.Labels, nil
-}
 
-func (s *ciliumNodeSpecer) PodCIDRs() ([]string, error) {
-	n, err := s.NodeLister.Get(s.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node %v: %v", s.Name, err)
-	}
-	if n.Spec.IPAM.PodCIDRs != nil {
-		return n.Spec.IPAM.PodCIDRs, nil
-	}
-	return []string{}, nil
+	return podCIDRs, nil
 }

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -6,7 +6,13 @@ package bgpv1
 import (
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/k8s/utils"
 )
 
 var Cell = cell.Module(
@@ -19,7 +25,21 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(agent.NewSignaler),
 	// Local Node Store Specer provides the module with information about the current node.
 	cell.ProvidePrivate(agent.NewLocalNodeStoreSpecer),
+	// BGP Peering Policy resource provides the module with a stream of events for the BGPPeeringPolicy resource.
+	cell.ProvidePrivate(newBGPPeeringPolicyResource),
 	// goBGP is currently the only supported RouterManager, if more are
 	// implemented, provide the manager via a Cell that pics implementation based on configuration.
 	cell.ProvidePrivate(gobgp.NewBGPRouterManager),
 )
+
+func newBGPPeeringPolicyResource(lc hive.Lifecycle, c client.Clientset) resource.Resource[*v2alpha1api.CiliumBGPPeeringPolicy] {
+	var listerWatcher v2alpha1.CiliumBGPPeeringPolicyInterface
+	if c.IsEnabled() {
+		listerWatcher = c.CiliumV2alpha1().CiliumBGPPeeringPolicies()
+	}
+
+	return resource.New[*v2alpha1api.CiliumBGPPeeringPolicy](
+		lc, utils.ListerWatcherFromTyped[*v2alpha1api.CiliumBGPPeeringPolicyList](
+			listerWatcher,
+		))
+}

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -13,7 +13,12 @@ var Cell = cell.Module(
 	"bgp-cp",
 	"BGP Control Plane",
 
+	// The Controller which is the entry point of the module
 	cell.Provide(agent.NewController),
+	// Signaler is used by all cells that observe resources to signal the controller to start reconciliation.
+	cell.ProvidePrivate(agent.NewSignaler),
+	// Local Node Store Specer provides the module with information about the current node.
+	cell.ProvidePrivate(agent.NewLocalNodeStoreSpecer),
 	// goBGP is currently the only supported RouterManager, if more are
 	// implemented, provide the manager via a Cell that pics implementation based on configuration.
 	cell.ProvidePrivate(gobgp.NewBGPRouterManager),

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bgpv1
+
+import (
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+var Cell = cell.Module(
+	"bgp-cp",
+	"BGP Control Plane",
+
+	cell.Provide(agent.NewController),
+	// goBGP is currently the only supported RouterManager, if more are
+	// implemented, provide the manager via a Cell that pics implementation based on configuration.
+	cell.ProvidePrivate(gobgp.NewBGPRouterManager),
+)

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -30,6 +30,8 @@ var Cell = cell.Module(
 	// goBGP is currently the only supported RouterManager, if more are
 	// implemented, provide the manager via a Cell that pics implementation based on configuration.
 	cell.ProvidePrivate(gobgp.NewBGPRouterManager),
+	// Provides the reconcilers used by the route manager to update the config
+	gobgp.ConfigReconcilers,
 )
 
 func newBGPPeeringPolicyResource(lc hive.Lifecycle, c client.Clientset) resource.Resource[*v2alpha1api.CiliumBGPPeeringPolicy] {

--- a/pkg/bgpv1/gobgp/diffstore.go
+++ b/pkg/bgpv1/gobgp/diffstore.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gobgp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/stream"
+
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+// DiffStore is a super set of the resource.Store. The diffStore tracks all changes made to the diff store since the
+// last time the user synced up. This allows a user to get a list of just the changed objects while still being able
+// to query the full store for a full sync.
+type DiffStore[T k8sRuntime.Object] interface {
+	resource.Store[T]
+
+	// Diff returns a list of items that have been upserted(updated or inserted) and deleted since the last call to Diff.
+	Diff() (upserted []T, deleted []resource.Key, err error)
+}
+
+var _ DiffStore[*k8sRuntime.Unknown] = (*diffStore[*k8sRuntime.Unknown])(nil)
+
+type diffStoreParams[T k8sRuntime.Object] struct {
+	cell.In
+
+	Lifecycle  hive.Lifecycle
+	Shutdowner hive.Shutdowner
+	Resource   resource.Resource[T]
+	Signaler   agent.Signaler
+}
+
+// diffStore takes a resource.Resource[T] and watches for events, it stores all of the keys that have been changed.
+// diffStore can still be used as a normal store, but adds the Diff function to get a Diff of all changes.
+// The diffStore also takes in Signaler which it will signal after the initial sync and every update thereafter.
+type diffStore[T k8sRuntime.Object] struct {
+	resource.Store[T]
+
+	shutdowner hive.Shutdowner
+	resource   resource.Resource[T]
+	signaler   agent.Signaler
+
+	ctx      context.Context
+	cancel   context.CancelFunc
+	doneChan chan struct{}
+
+	initialSync bool
+
+	mu          lock.Mutex
+	updatedKeys map[resource.Key]bool
+}
+
+func NewDiffStore[T k8sRuntime.Object](params diffStoreParams[T]) DiffStore[T] {
+	ds := &diffStore[T]{
+		shutdowner: params.Shutdowner,
+		resource:   params.Resource,
+		signaler:   params.Signaler,
+
+		updatedKeys: make(map[resource.Key]bool),
+		doneChan:    make(chan struct{}),
+	}
+	ds.ctx, ds.cancel = context.WithCancel(context.Background())
+
+	params.Lifecycle.Append(ds)
+
+	return ds
+}
+
+// Start implements hive.HookInterface
+func (ds *diffStore[T]) Start(ctx hive.HookContext) error {
+	var err error
+	ds.Store, err = ds.resource.Store(ctx)
+	if err != nil {
+		return fmt.Errorf("resource.Store(): %w", err)
+	}
+
+	go ds.run()
+	return nil
+}
+
+// Stop implements hive.HookInterface
+func (ds *diffStore[T]) Stop(stopCtx hive.HookContext) error {
+	ds.cancel()
+
+	select {
+	case <-ds.doneChan:
+	case <-stopCtx.Done():
+	}
+
+	return nil
+}
+
+func (ds *diffStore[T]) run() {
+	defer close(ds.doneChan)
+
+	errChan := make(chan error, 2)
+	updateChan := stream.ToChannel[resource.Event[T]](ds.ctx, errChan, ds.resource)
+
+	for event := range updateChan {
+		ds.handleEvent(event)
+	}
+
+	if err := <-errChan; err != nil {
+		// handle stream completion error, if there was one
+		ds.shutdowner.Shutdown(hive.ShutdownWithError(err))
+	}
+
+	close(errChan)
+}
+
+func (ds *diffStore[T]) handleEvent(event resource.Event[T]) {
+	update := func(k resource.Key, t T) error {
+		ds.mu.Lock()
+		ds.updatedKeys[k] = true
+		ds.mu.Unlock()
+
+		// Start triggering the signaler after initialization to reduce reconciliation load.
+		if ds.initialSync {
+			ds.signaler.Event(struct{}{})
+		}
+		return nil
+	}
+
+	event.Handle(
+		func() error {
+			ds.initialSync = true
+			ds.signaler.Event(struct{}{})
+			return nil
+		},
+		update,
+		update,
+	)
+}
+
+// Diff returns a list of items that have been upserted(updated or inserted) and deleted since the last call to Diff.
+func (sd *diffStore[T]) Diff() (upserted []T, deleted []resource.Key, err error) {
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	for k := range sd.updatedKeys {
+		item, found, err := sd.GetByKey(k)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if found {
+			upserted = append(upserted, item)
+		} else {
+			deleted = append(deleted, k)
+		}
+	}
+
+	// Deleting keys doesn't shrink the memory size, so re-create the map to reduce memory usage
+	sd.updatedKeys = make(map[resource.Key]bool, 0)
+
+	return upserted, deleted, err
+}

--- a/pkg/bgpv1/gobgp/diffstore_test.go
+++ b/pkg/bgpv1/gobgp/diffstore_test.go
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gobgp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	slim_fake "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/fake"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+)
+
+type DiffStoreFixture struct {
+	diffStore DiffStore[*slimv1.Service]
+	signaler  agent.Signaler
+	slimCs    *slim_fake.Clientset
+	hive      *hive.Hive
+}
+
+func newDiffStoreFixture() *DiffStoreFixture {
+	fixture := &DiffStoreFixture{}
+
+	// Create a new mocked CRD client set with the pools as initial objects
+	fixture.slimCs = slim_fake.NewSimpleClientset()
+
+	// Construct a new Hive with mocked out dependency cells.
+	fixture.hive = hive.New(
+		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) resource.Resource[*slimv1.Service] {
+			return resource.New[*slimv1.Service](
+				lc, utils.ListerWatcherFromTyped[*slimv1.ServiceList](
+					c.Slim().CoreV1().Services(""),
+				),
+			)
+		}),
+
+		// Provide the mocked client cells directly
+		cell.Provide(func() k8sClient.Clientset {
+			return &k8sClient.FakeClientset{
+				SlimFakeClientset: fixture.slimCs,
+			}
+		}),
+
+		cell.Provide(agent.NewSignaler),
+
+		cell.Invoke(func(
+			signaler agent.Signaler,
+			diffFactory DiffStore[*slimv1.Service],
+		) {
+			fixture.signaler = signaler
+			fixture.diffStore = diffFactory
+		}),
+
+		cell.Provide(NewDiffStore[*slimv1.Service]),
+	)
+
+	return fixture
+}
+
+// Test that adding and deleting objects trigger signals
+func TestDiffSignal(t *testing.T) {
+	fixture := newDiffStoreFixture()
+	tracker := fixture.slimCs.Tracker()
+
+	// Add an initial object.
+	err := tracker.Add(&slimv1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "service-a",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = fixture.hive.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timer := time.NewTimer(5 * time.Second)
+	select {
+	case <-fixture.signaler.Sig:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err := fixture.diffStore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 1 {
+		t.Fatal("Initial upserted not one")
+	}
+
+	if len(deleted) != 0 {
+		t.Fatal("Initial deleted not zero")
+	}
+
+	// Add an object after init
+
+	err = tracker.Add(&slimv1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "service-b",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timer = time.NewTimer(5 * time.Second)
+	select {
+	case <-fixture.signaler.Sig:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err = fixture.diffStore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 1 {
+		t.Fatal("Runtime upserted not one")
+	}
+
+	if len(deleted) != 0 {
+		t.Fatal("Runtime deleted not zero")
+	}
+
+	// Delete an object after init
+
+	err = tracker.Delete(slimv1.SchemeGroupVersion.WithResource("services"), "", "service-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timer = time.NewTimer(5 * time.Second)
+	select {
+	case <-fixture.signaler.Sig:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err = fixture.diffStore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 0 {
+		t.Fatal("Runtime upserted not zero")
+	}
+
+	if len(deleted) != 1 {
+		t.Fatal("Runtime deleted not one")
+	}
+
+	err = fixture.hive.Stop(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Test that multiple events are correctly combined.
+func TestDiffUpsertCoalesce(t *testing.T) {
+	fixture := newDiffStoreFixture()
+	tracker := fixture.slimCs.Tracker()
+
+	err := fixture.hive.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add first object
+	err = tracker.Add(&slimv1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "service-a",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add second object
+	err = tracker.Add(&slimv1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "service-b",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait a second for changes to be processed
+	time.Sleep(time.Second)
+
+	// Check that we have a signal
+	timer := time.NewTimer(5 * time.Second)
+	select {
+	case <-fixture.signaler.Sig:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err := fixture.diffStore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 2 {
+		t.Fatal("Expected 2 upserted objects")
+	}
+
+	if len(deleted) != 0 {
+		t.Fatal("Expected 0 deleted objects")
+	}
+
+	// Update first object
+	err = tracker.Update(
+		slimv1.SchemeGroupVersion.WithResource("services"),
+		&slimv1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "service-a",
+			},
+			Spec: slimv1.ServiceSpec{
+				ClusterIP: "1.2.3.4",
+			},
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tracker.Delete(slimv1.SchemeGroupVersion.WithResource("services"), "", "service-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait a second for changes to be processed
+	time.Sleep(time.Second)
+
+	// Check that we have a signal
+	timer = time.NewTimer(5 * time.Second)
+	select {
+	case <-fixture.signaler.Sig:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err = fixture.diffStore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 1 {
+		t.Fatal("Expected 1 upserted object")
+	}
+
+	if len(deleted) != 1 {
+		t.Fatal("Expected 1 deleted object")
+	}
+
+	// Update first object once
+	err = tracker.Update(
+		slimv1.SchemeGroupVersion.WithResource("services"),
+		&slimv1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "service-a",
+			},
+			Spec: slimv1.ServiceSpec{
+				ClusterIP: "2.3.4.5",
+			},
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update first object twice
+	err = tracker.Update(
+		slimv1.SchemeGroupVersion.WithResource("services"),
+		&slimv1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "service-a",
+			},
+			Spec: slimv1.ServiceSpec{
+				ClusterIP: "3.4.5.6",
+			},
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait a second for changes to be processed
+	time.Sleep(time.Second)
+
+	// Check that we have a signal
+	timer = time.NewTimer(5 * time.Second)
+	select {
+	case <-fixture.signaler.Sig:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
+	upserted, deleted, err = fixture.diffStore.Diff()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(upserted) != 1 {
+		t.Fatal("Expected 1 upserted object")
+	}
+
+	if len(deleted) != 0 {
+		t.Fatal("Expected 1 deleted object")
+	}
+
+	if upserted[0].Spec.ClusterIP != "3.4.5.6" {
+		t.Fatal("Expected to only see the latest update")
+	}
+
+	err = fixture.hive.Stop(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/bgpv1/gobgp/reconcile_test.go
+++ b/pkg/bgpv1/gobgp/reconcile_test.go
@@ -10,7 +10,6 @@ import (
 
 	gobgp "github.com/osrg/gobgp/v3/api"
 
-	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
@@ -107,8 +106,8 @@ func TestPreflightReconciler(t *testing.T) {
 				LocalASN: 64125,
 			}
 			cstate := &agent.ControlPlaneState{
-				Annotations: bgpv1.AnnotationMap{
-					64125: bgpv1.Attributes{
+				Annotations: agent.AnnotationMap{
+					64125: agent.Attributes{
 						RouterID:  tt.newRouterID,
 						LocalPort: tt.newLocalPort,
 					},

--- a/pkg/bgpv1/gobgp/routermgr.go
+++ b/pkg/bgpv1/gobgp/routermgr.go
@@ -75,7 +75,7 @@ type BGPRouterManager struct {
 // NewBGPRouterManager constructs a GoBGP-backed BGPRouterManager.
 //
 // See NewBGPRouterManager for details.
-func NewBGPRouterManager() *BGPRouterManager {
+func NewBGPRouterManager() agent.BGPRouterManager {
 	return &BGPRouterManager{
 		Servers: make(LocalASNMap),
 	}

--- a/pkg/bgpv1/gobgp/routermgr.go
+++ b/pkg/bgpv1/gobgp/routermgr.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 
 	gobgp "github.com/osrg/gobgp/v3/api"
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -35,6 +37,12 @@ var (
 // LocalASNMap maps local ASNs to their associated BgpServers and server
 // configuration info.
 type LocalASNMap map[int]*ServerWithConfig
+
+type bgpRouterManagerIn struct {
+	cell.In
+
+	Reconcilers []ConfigReconciler `group:"bgp-config-reconciler"`
+}
 
 // BGPRouterManager implements the pkg.bgpv1.agent.BGPRouterManager interface.
 //
@@ -69,15 +77,21 @@ type LocalASNMap map[int]*ServerWithConfig
 // BgpServers are abstracted by the ServerWithConfig structure which provides a
 // method set for low-level BGP operations.
 type BGPRouterManager struct {
-	Servers LocalASNMap
+	Servers     LocalASNMap
+	Reconcilers []ConfigReconciler
 }
 
 // NewBGPRouterManager constructs a GoBGP-backed BGPRouterManager.
 //
 // See NewBGPRouterManager for details.
-func NewBGPRouterManager() agent.BGPRouterManager {
+func NewBGPRouterManager(params bgpRouterManagerIn) agent.BGPRouterManager {
+	sort.Slice(params.Reconcilers, func(i, j int) bool {
+		return params.Reconcilers[i].Priority() < params.Reconcilers[j].Priority()
+	})
+
 	return &BGPRouterManager{
-		Servers: make(LocalASNMap),
+		Servers:     make(LocalASNMap),
+		Reconcilers: params.Reconcilers,
 	}
 }
 
@@ -225,7 +239,7 @@ func (m *BGPRouterManager) registerBGPServer(ctx context.Context, c *v2alpha1api
 		return fmt.Errorf("failed to start BGP server for config with local ASN %v: %w", c.LocalASN, err)
 	}
 
-	if err = ReconcileBGPConfig(ctx, m, s, c, cstate); err != nil {
+	if err = m.reconcileBGPConfig(ctx, s, c, cstate); err != nil {
 		return fmt.Errorf("failed initial reconciliation for peer config with local ASN %v: %w", c.LocalASN, err)
 	}
 
@@ -296,11 +310,43 @@ func (m *BGPRouterManager) reconcile(ctx context.Context, rd *reconcileDiff) err
 			continue
 		}
 
-		if err := ReconcileBGPConfig(ctx, m, sc, newc, rd.state); err != nil {
+		if err := m.reconcileBGPConfig(ctx, sc, newc, rd.state); err != nil {
 			l.WithError(err).Errorf("Encountered error reconciling virtual router with local ASN %v, shutting down this server", newc.LocalASN)
 			sc.Server.Stop()
 			delete(m.Servers, asn)
 		}
 	}
+	return nil
+}
+
+// reconcileBGPConfig will utilize the current set of ConfigReconcilerFunc(s)
+// to push a BgpServer to its desired configuration.
+//
+// If any ConfigReconcilerFunc fails so will ReconcileBGPConfig and the caller
+// is left to decide how to handle the possible inconsistent state of the
+// BgpServer left over.
+//
+// Providing a ServerWithConfig that has a nil `Config` field indicates that
+// this is the first time this BgpServer is being configured, each
+// ConfigReconcilerFunc must be prepared to handle this.
+//
+// The two CiliumBGPVirtualRouter(s) being compared must have the same local
+// ASN, unless `sc.Config` is nil, or else an error is returned.
+//
+// On success the provided `newc` will be written to `sc.Config`. The caller
+// should then store `sc` until next reconciliation.
+func (m *BGPRouterManager) reconcileBGPConfig(ctx context.Context, sc *ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, cstate *agent.ControlPlaneState) error {
+	if sc.Config != nil {
+		if sc.Config.LocalASN != newc.LocalASN {
+			return fmt.Errorf("cannot reconcile two BgpServers with different local ASNs")
+		}
+	}
+	for _, r := range m.Reconcilers {
+		if err := r.Reconcile(ctx, m, sc, newc, cstate); err != nil {
+			return fmt.Errorf("reconciliation of virtual router with local ASN %v failed: %w", newc.LocalASN, err)
+		}
+	}
+	// all reconcilers succeeded so update Server's config with new peering config.
+	sc.Config = newc
 	return nil
 }

--- a/pkg/bgpv1/mock/mocks.go
+++ b/pkg/bgpv1/mock/mocks.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	v2alpha1listers "github.com/cilium/cilium/pkg/k8s/client/listers/cilium.io/v2alpha1"
 )
 
 var _ v1listers.NodeLister = (*MockNodeLister)(nil)
@@ -28,22 +27,6 @@ func (m *MockNodeLister) List(selector k8sLabels.Selector) (ret []*v1.Node, err 
 }
 
 func (m *MockNodeLister) Get(name string) (*v1.Node, error) {
-	return m.Get_(name)
-}
-
-var _ v2alpha1listers.CiliumBGPPeeringPolicyLister = (*MockCiliumBGPPeeringPolicyLister)(nil)
-
-type MockCiliumBGPPeeringPolicyLister struct {
-	List_ func(selector k8sLabels.Selector) (ret []*v2alpha1.CiliumBGPPeeringPolicy, err error)
-	Get_  func(name string) (*v2alpha1.CiliumBGPPeeringPolicy, error)
-	v2alpha1listers.CiliumBGPPeeringPolicyListerExpansion
-}
-
-func (m *MockCiliumBGPPeeringPolicyLister) List(selector k8sLabels.Selector) (ret []*v2alpha1.CiliumBGPPeeringPolicy, err error) {
-	return m.List_(selector)
-}
-
-func (m *MockCiliumBGPPeeringPolicyLister) Get(name string) (*v2alpha1.CiliumBGPPeeringPolicy, error) {
 	return m.Get_(name)
 }
 

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -208,6 +208,7 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 	}
 
 	newNode.Labels = k8sNode.GetLabels()
+	newNode.Annotations = k8sNode.GetAnnotations()
 
 	return newNode
 }

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -43,6 +43,7 @@ func ParseCiliumNode(n *ciliumv2.CiliumNode) (node Node) {
 		ClusterID:       option.Config.ClusterID,
 		Source:          source.CustomResource,
 		Labels:          n.ObjectMeta.Labels,
+		Annotations:     n.ObjectMeta.Annotations,
 		NodeIdentity:    uint32(n.Spec.NodeIdentity),
 		WireguardPubKey: n.ObjectMeta.Annotations[annotation.WireguardPubKey],
 	}
@@ -226,6 +227,9 @@ type Node struct {
 
 	// Node labels
 	Labels map[string]string
+
+	// Node annotations
+	Annotations map[string]string
 
 	// NodeIdentity is the numeric identity allocated for the node
 	NodeIdentity uint32

--- a/pkg/node/types/zz_generated.deepcopy.go
+++ b/pkg/node/types/zz_generated.deepcopy.go
@@ -100,6 +100,13 @@ func (in *Node) DeepCopyInto(out *Node) {
 			(*out)[key] = val
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
This PR does additional refactoring of the BGP Control Plane, breaking up the large cells into a controller cell, signaler, nodespecer, resouces, route manager and config reconcilers. The nodespecer has been simplified with the use of the node local store to de-duplicate logic within the agent and the `DiffStore` has been added which will allow us to perform partial reconciliation for services in a follow-up PR.

Note, this PR is part of a series, #22183 should be merged before this one and this branch rebased on master.