### PR TITLE
relay: Add Go runtime metrics and process metrics

### DIFF
--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -40,6 +41,11 @@ var (
 
 	registry = prometheus.NewPedanticRegistry()
 )
+
+func init() {
+	prometheus.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	prometheus.MustRegister(collectors.NewGoCollector())
+}
 
 // Server is a proxy that connects to a running instance of hubble gRPC server
 // via unix domain socket.


### PR DESCRIPTION
Currently the agent has a GoCollector and ProcessCollector but relay does not, this updates the relay for consistency and enhanced debuggability.

```release-note
relay: Add Go runtime metrics and process metrics
```
