### PR TITLE
docs: Update Cilium Sphinx RTD Theme reference

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==5.1.1
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@1ef7632859fc0476767eaf794b457bf94540e14b
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@3bd69f33e7b2af2d0173fd997ec7ad21ce19ae3b
 # We use semver to parse Cilium's version in the config file
 semver==2.13.0
 # Sphinx extensions


### PR DESCRIPTION
Follow-up to [**cilium/sphinx_rtd_theme#20: Fix hidden search bar on all media types**](https://github.com/cilium/sphinx_rtd_theme/pull/20).

This updates **Documentation/requirements.txt** to reference a new commit hash on the theme's `v1.0` branch. This will trigger an RTD build. The new build should contain changes fixing the hidden search bar. 

I read @qmonnet's [post](https://github.com/cilium/cilium/pull/21436#pullrequestreview-1119912309) about requirements-min/requirements.txt before submitting.

Fixes: #21938