### PR TITLE
gha: Pin ubuntu-20.04 for conformance-test-ipv6

### DIFF
--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -49,7 +49,7 @@ jobs:
   conformance-test-ipv6:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.tested == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
This commit is to avoid ubuntu version drift for runner, till the proper
version upgrade is done.

Signed-off-by: Tam Mach <tam.mach@cilium.io>

