### PR TITLE
gha: Bump k8s version in kind conformance tests

### DIFF
--- a/.github/kind-config-ipv6.yaml
+++ b/.github/kind-config-ipv6.yaml
@@ -2,19 +2,19 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.26.0
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
       - |
-        apiVersion: kubeadm.k8s.io/v1beta2
+        apiVersion: kubeadm.k8s.io/v1beta3
         kind: InitConfiguration
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.26.0
 networking:
   ipFamily: ipv6
   disableDefaultCNI: true
-  podSubnet: "fd00:10:244::/64"
+  podSubnet: "fd00:10:244::/48"
   serviceSubnet: "fd00:10:96::/112"

--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -2,17 +2,17 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.26.0
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
       - |
-        apiVersion: kubeadm.k8s.io/v1beta2
+        apiVersion: kubeadm.k8s.io/v1beta3
         kind: InitConfiguration
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.26.0
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -9,7 +9,7 @@ permissions: read-all
 
 env:
   cilium_cli_version: v0.12.11
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.17.0
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  kind_version: v0.11.1
+  kind_version: v0.17.0
   kind_config: .github/kind-config.yaml
   cilium_cli_version: v0.12.11
 

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   cilium_cli_version: v0.12.11
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.17.0
   KIND_CONFIG: .github/kind-config-ipv6.yaml
   # Skip external traffic (e.g. 1.1.1.1 and www.google.com) due to no support for IPv6 in github action
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check-internal.yaml

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   cilium_cli_version: v0.12.11
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.17.0
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m


### PR DESCRIPTION
## Description

This commit is just to bump k8s version from 1.19 to 1.26.x in both
conformance tests (i.e. ipv4 and ipv6). No point running the test on
EOL k8s version (e.g. 1.19). This is suggested in Cilium slack by Timo/
Nicolas/Andre/Chance.

PodSubnet CIDR is increased from /64 to /48, so that each node will be
able to allocate .spec.podCIDR with /64 CIDR range. Without this change,
there will be no .spec.podCIDR/podCIDRs for worker node, which will cause
below issue in Cilium pod. Another change in kind-config* is to upgrade
kubeadm InitConfiguration version from v1beta2 to v1beta3, which is to make
sure that no taint setting is working for control-plane as expected.

```
level=debug msg="stopped waiting for caches to be synced" kubernetesResource="core/v1::Node" subsys=k8s
level=info msg="Retrieved node information from kubernetes node" nodeName=kind-worker subsys=k8s
level=warning msg="Waiting for k8s node information" error="required IPv6 PodCIDR not available" subsys=k8s
```

Signed-off-by: Tam Mach <tam.mach@cilium.io>

## Testing

Related jobs are passed as part of normal PR check:

- [conformance-test](https://github.com/cilium/cilium/actions/runs/3799129833/jobs/6461368473)
- [conformance-test-ipv6](https://github.com/cilium/cilium/actions/runs/3799129830/jobs/6461368147)
- [conformance-kind](https://github.com/cilium/cilium/actions/runs/3799129826/jobs/6461371663)
