### PR TITLE
Revert "Mount host /boot into cilium-agent container"

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -93,10 +93,6 @@
      - Configure the maximum number of entries in the TCP connection tracking table.
      - int
      - ``524288``
-   * - bpf.hostBoot
-     - Configure the path to the host boot directory
-     - string
-     - ``"/boot"``
    * - bpf.hostLegacyRouting
      - Configure whether direct routing mode should route traffic via host stack (true) or directly and more efficiently out of BPF (false) if the kernel supports it. The latter has the implication that it will also bypass netfilter in the host namespace.
      - bool
@@ -129,10 +125,6 @@
      - Configure the typical time between monitor notifications for active connections.
      - string
      - ``"5s"``
-   * - bpf.mountHostBoot
-     - Enable host boot directory mount for BPF clock source probing
-     - bool
-     - ``true``
    * - bpf.natMax
      - Configure the maximum number of entries for the NAT table.
      - int

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -483,7 +483,6 @@ herokuapp
 hexData
 hoc
 hostAliases
-hostBoot
 hostConfDirMountPath
 hostFirewall
 hostLegacyRouting
@@ -685,7 +684,6 @@ monitorAggregation
 monitorFlags
 monitorInterval
 mountCgroup
-mountHostBoot
 mountPath
 mov
 mul

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -74,7 +74,6 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.clockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
 | bpf.ctAnyMax | int | `262144` | Configure the maximum number of entries for the non-TCP connection tracking table. |
 | bpf.ctTcpMax | int | `524288` | Configure the maximum number of entries in the TCP connection tracking table. |
-| bpf.hostBoot | string | `"/boot"` | Configure the path to the host boot directory |
 | bpf.hostLegacyRouting | bool | `false` | Configure whether direct routing mode should route traffic via host stack (true) or directly and more efficiently out of BPF (false) if the kernel supports it. The latter has the implication that it will also bypass netfilter in the host namespace. |
 | bpf.lbExternalClusterIP | bool | `false` | Allow cluster external access to ClusterIP services. |
 | bpf.lbMapMax | int | `65536` | Configure the maximum number of service entries in the load balancer maps. |
@@ -83,7 +82,6 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.monitorAggregation | string | `"medium"` | Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum. |
 | bpf.monitorFlags | string | `"all"` | Configure which TCP flags trigger notifications when seen for the first time in a connection. |
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
-| bpf.mountHostBoot | bool | `true` | Enable host boot directory mount for BPF clock source probing |
 | bpf.natMax | int | `524288` | Configure the maximum number of entries for the NAT table. |
 | bpf.neighMax | int | `524288` | Configure the maximum number of entries for the neighbor table. |
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -286,13 +286,6 @@ spec:
         - mountPath: /host/proc/sys/kernel
           name: host-proc-sys-kernel
         {{- end}}
-        {{- if .Values.bpf.mountHostBoot }}
-        # Required to run 'bpftool -j feature probe'
-        # during kernel feature probing
-        - mountPath: /boot
-          name: host-boot
-          readOnly: true
-        {{- end}}
         {{- /* CRI-O already mounts the BPF filesystem */ -}}
         {{- if not (eq .Values.containerRuntime.integration "crio") }}
         - name: bpf-maps
@@ -792,12 +785,6 @@ spec:
       - name: host-proc-sys-kernel
         hostPath:
           path: /proc/sys/kernel
-          type: Directory
-      {{- end }}
-      {{- if .Values.bpf.mountHostBoot }}
-      - name: host-boot
-        hostPath:
-          path: {{ .Values.bpf.hostBoot }}
           type: Directory
       {{- end }}
       {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -334,12 +334,6 @@ bpf:
   # -- Enable BPF clock source probing for more efficient tick retrieval.
   clockProbe: false
 
-  # -- Configure the path to the host boot directory
-  hostBoot: /boot
-
-  # -- Enable host boot directory mount for BPF clock source probing
-  mountHostBoot: true
-
   # -- Enables pre-allocation of eBPF map values. This increases
   # memory usage but can reduce latency.
   preallocateMaps: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -331,12 +331,6 @@ bpf:
   # -- Enable BPF clock source probing for more efficient tick retrieval.
   clockProbe: false
 
-  # -- Configure the path to the host boot directory
-  hostBoot: /boot
-
-  # -- Enable host boot directory mount for BPF clock source probing
-  mountHostBoot: true
-
   # -- Enables pre-allocation of eBPF map values. This increases
   # memory usage but can reduce latency.
   preallocateMaps: false

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -215,7 +215,7 @@ func (p *ProbeManager) SystemConfigProbes() error {
 	var notFound bool
 	if !p.KernelConfigAvailable() {
 		notFound = true
-		log.Warn("Kernel Config file not found: If agent fail to start, Please check kernel requirements https://docs.cilium.io/en/stable/operations/system_requirements")
+		log.Info("Kernel config file not found: if the agent fails to start, check the system requirements at https://docs.cilium.io/en/stable/operations/system_requirements")
 	}
 	requiredParams := p.GetRequiredConfig()
 	for param, kernelOption := range requiredParams {


### PR DESCRIPTION
This reverts commit 3996c4757432db90f207c222d2a68fdab676d472.

Since commit ad36f5c9a1 ("implement Go-based kernel HZ (jiffy) measurement"), `bpftool feature probe` is no longer used as a means of detecting the kernel's CONFIG_HZ value. Instead, /proc/schedstat is read, a method that doesn't depend on finding and parsing a large kernel configuration. The kernel config is no longer considered at all.

This also means mounting /boot is no longer required to detect this value reliably, so it no longer needs to be mounted into the agent container.

Related: #21833
Related: #21113

cc @agrevtcev