### PR TITLE
v1.10 backports 2022-11-23

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -71,7 +71,7 @@ jobs:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.bpf-tree == 'true' }}
     name: build datapath
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
@@ -83,6 +83,10 @@ jobs:
         with:
           path: $HOME/.clang
           key: llvm-10.0
+      - name: Install LLVM and Clang prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libtinfo5
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1.6.0
         with:

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build_commits:
     name: Check if build works for every commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - name: Configure git
@@ -31,7 +31,12 @@ jobs:
         with:
           path: $HOME/.clang
           key: llvm-10.0
-          
+
+      - name: Install LLVM and Clang prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libtinfo5
+
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1.6.0
         with:

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -48,7 +48,7 @@ jobs:
   conformance-test-ipv6:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.tested == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
* #22315 -- .github: Explicitly set build-commits job runner image version and install libtinfo5 (@chancez)
 * #22324 -- gha: Pin ubuntu-20.04 for conformance-test-ipv6 (@sayboras)
 * #22322 -- .github: fix bpf-checks on ubuntu-latest runner (@julianwiedmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 22315 22324 22322; do contrib/backporting/set-labels.py $pr done 1.10; done
```