### PR TITLE
.github/workflows: install promtool from binary release

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -21,6 +21,7 @@ env:
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m
   LOG_TIME: 30m
+  PROM_VERSION: 2.34.0
 
 jobs:
   check_changes:
@@ -166,8 +167,14 @@ jobs:
           cilium_pod=$(kubectl -n kube-system get po -o name --field-selector=status.phase==Running -l 'k8s-app=cilium' -o jsonpath='{.items[0].metadata.name}' )
           kubectl -n kube-system exec $cilium_pod -- sh -c "apt update && apt install curl -y"
           kubectl -n kube-system exec $cilium_pod -- curl http://localhost:9090/metrics > metrics.prom
-          GO111MODULE=on go get github.com/prometheus/prometheus/cmd/promtool@e4487274853c587717006eeda8804e597d120340 # This is commit hash for v2.24.1
-          cat metrics.prom | $HOME/go/bin/promtool check metrics
+          # Install promtool binary release. `go install` doesn't work due to
+          # https://github.com/prometheus/prometheus/issues/8852 and related issues.
+          curl -sSL --remote-name-all https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/{prometheus-${PROM_VERSION}.linux-amd64.tar.gz,sha256sums.txt}
+          sha256sum --check --ignore-missing sha256sums.txt
+          tar xzvf prometheus-${PROM_VERSION}.linux-amd64.tar.gz prometheus-${PROM_VERSION}.linux-amd64/promtool
+          rm -f prometheus-${PROM_VERSION}.linux-amd64.tar.gz
+          sudo mv prometheus-${PROM_VERSION}.linux-amd64/promtool /usr/bin
+          cat metrics.prom | promtool check metrics
 
       - name: Capture cilium-sysdump
         if: ${{ failure() }}


### PR DESCRIPTION
[ manual backport of upstream commit
  c4be82a9267e55cfd20dd016e2cc69a9f6253e8f (from PR #19169) to fix failure in smoke tests
  on the v1.11 branch due to promtool not installable using `go get` ]

`go get` no longer works to install binaries with Go 1.18 and `go install` unfortunately doesn't work due to
https://github.com/prometheus/prometheus/issues/8852 and related issues.

Thus install promtool from the Prometheus binary release. While at it bump the version to v2.34.0.
