### PR TITLE
fix: package name of test folder

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package ciliumTest
+package test_test
 
 import (
 	"fmt"


### PR DESCRIPTION
Signed-off-by: yulng wei.yang@daocloud.io

1 According to the code specification, the package name should be lower case.
2 Refer to the official documentation of gingko to modify package name
https://onsi.github.io/ginkgo/

https://github.com/cilium/cilium/pull/22259

@joestringer 
