### PR TITLE
datapath: Don't enforce ingress policies at overlay if endpoint routes are enabled

### DIFF
--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -93,7 +93,19 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 	ctx->mark |= MARK_MAGIC_IDENTITY;
 	set_identity_mark(ctx, seclabel);
 
+# if defined(TUNNEL_MODE) && !defined(ENABLE_NODEPORT)
+	/* In tunneling mode, we execute this code to send the packet from
+	 * cilium_vxlan to lxc*. If we're using kube-proxy, we don't want to use
+	 * redirect() because that would bypass conntrack and the reverse DNAT.
+	 * Thus, we send packets to the stack, but since they have the wrong
+	 * Ethernet addresses, we need to mark them as PACKET_HOST or the kernel
+	 * will drop them.
+	 */
+	ctx_change_type(ctx, PACKET_HOST);
+	return CTX_ACT_OK;
+# else
 	return redirect_ep(ctx, ep->ifindex, from_host);
+# endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
 #else
 	/* Jumps to destination pod's BPF program to enforce ingress policies. */
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
@@ -141,7 +153,19 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 	ctx->mark |= MARK_MAGIC_IDENTITY;
 	set_identity_mark(ctx, seclabel);
 
+# if defined(TUNNEL_MODE) && !defined(ENABLE_NODEPORT)
+	/* In tunneling mode, we execute this code to send the packet from
+	 * cilium_vxlan to lxc*. If we're using kube-proxy, we don't want to use
+	 * redirect() because that would bypass conntrack and the reverse DNAT.
+	 * Thus, we send packets to the stack, but since they have the wrong
+	 * Ethernet addresses, we need to mark them as PACKET_HOST or the kernel
+	 * will drop them.
+	 */
+	ctx_change_type(ctx, PACKET_HOST);
+	return CTX_ACT_OK;
+# else
 	return redirect_ep(ctx, ep->ifindex, from_host);
+# endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
 #else
 	/* Jumps to destination pod's BPF program to enforce ingress policies. */
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -766,6 +766,10 @@ func (h *HeaderfileWriter) writeNetdevConfig(w io.Writer, cfg datapath.DeviceCon
 		}
 		fmt.Fprint(w, "\n")
 	}
+
+	if option.Config.EnableEndpointRoutes {
+		fmt.Fprint(w, "#define USE_BPF_PROG_FOR_INGRESS_POLICY 1\n")
+	}
 }
 
 // WriteNetdevConfig writes the BPF configuration for the endpoint to a writer.

--- a/test/k8s/custom_calls.go
+++ b/test/k8s/custom_calls.go
@@ -382,18 +382,11 @@ var _ = SkipDescribeIf(func() bool {
 		// Check the ingress hook in tail_ipv4_to_endpoint()
 		// Similar to the above, with endpointRoutes enabled
 		It("Loads byte-counter and gets consistent values, with per-endpoint routes", func() {
-
 			options := map[string]string{
 				"customCalls.enabled":    "true",
 				"endpointRoutes.enabled": "true",
 			}
-
-			// Packets to pods are processed twice with
-			// per-endpoint routes + VXLAN, account for it
-			// (see GH-14657)
-			expectedByteCount := 2 * pingBytes
-
-			checkByteCounter(options, expectedByteCount, 0, false)
+			checkByteCounter(options, pingBytes, 0, false)
 		})
 	})
 })


### PR DESCRIPTION
This fixes bug https://github.com/cilium/cilium/issues/14657. See commits for details.

There's probably no point in backporting because to fully fix this issue we would also need to backport https://github.com/cilium/cilium/pull/22190.

Fixes: https://github.com/cilium/cilium/pull/13346.
Fixes: https://github.com/cilium/cilium/issues/14657.

```release-note
Fix bug that caused ingress policies to be enforced twice when running with tunneling and endpoint routes.
```