### PR TITLE
Revert "relay: Add Go runtime metrics and process metrics"

### DIFF
--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -41,11 +40,6 @@ var (
 
 	registry = prometheus.NewPedanticRegistry()
 )
-
-func init() {
-	prometheus.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	prometheus.MustRegister(collectors.NewGoCollector())
-}
 
 // Server is a proxy that connects to a running instance of hubble gRPC server
 // via unix domain socket.


### PR DESCRIPTION
This reverts commit f0fa683870e1030707ed01b4d4b23b57b2d5c6a8. It appears
to introduce a double-initialization of metrics, causing relay
initialization failures:

```
2022-11-23T16:43:32.966090044Z panic: duplicate metrics collector registration attempted
2022-11-23T16:43:32.966152546Z 
2022-11-23T16:43:32.966159646Z goroutine 1 [running]:
2022-11-23T16:43:32.966228748Z github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0x0?, {0xc0004109c0?, 0x1, 0x6?})
2022-11-23T16:43:32.966334150Z 	/go/src/github.com/cilium/cilium/vendor/github.com/prometheus/client_golang/prometheus/registry.go:406 +0x7f
2022-11-23T16:43:32.966342450Z github.com/prometheus/client_golang/prometheus.MustRegister(...)
2022-11-23T16:43:32.966347351Z 	/go/src/github.com/cilium/cilium/vendor/github.com/prometheus/client_golang/prometheus/registry.go:178
2022-11-23T16:43:32.966352151Z github.com/cilium/cilium/pkg/hubble/relay/server.init.0()
2022-11-23T16:43:32.966356351Z 	/go/src/github.com/cilium/cilium/pkg/hubble/relay/server/server.go:46 +0x87
```

https://github.com/cilium/cilium/actions/runs/3533921447/jobs/5930188684

Related: #22316
