### PR TITLE
bpf: minor nodeport cleanups

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -655,8 +655,7 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx)
 
 		l4_off = ETH_HLEN + hdrlen;
 
-		ret = lb6_extract_key(ctx, &tuple, l4_off, &key, &csum_off,
-				      CT_EGRESS);
+		ret = lb6_extract_key(ctx, &tuple, l4_off, &key, &csum_off);
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
 				goto skip_service_lookup;
@@ -1218,8 +1217,7 @@ static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx)
 
 		l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 
-		ret = lb4_extract_key(ctx, ip4, l4_off, &key, &csum_off,
-				      CT_EGRESS);
+		ret = lb4_extract_key(ctx, ip4, l4_off, &key, &csum_off);
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
 				goto skip_service_lookup;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -863,7 +863,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 
 	l4_off = l3_off + hdrlen;
 
-	ret = lb6_extract_key(ctx, &tuple, l4_off, &key, &csum_off, CT_EGRESS);
+	ret = lb6_extract_key(ctx, &tuple, l4_off, &key, &csum_off);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_NO_SERVICE)
 			goto skip_service_lookup;
@@ -1796,7 +1796,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 
 	l4_off = l3_off + ipv4_hdrlen(ip4);
 
-	ret = lb4_extract_key(ctx, ip4, l4_off, &key, &csum_off, CT_EGRESS);
+	ret = lb4_extract_key(ctx, ip4, l4_off, &key, &csum_off);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_NO_SERVICE)
 			goto skip_service_lookup;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -845,7 +845,6 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 	struct lb6_service *svc;
 	struct lb6_key key = {};
 	struct ct_state ct_state_new = {};
-	union macaddr smac, *mac;
 	bool backend_local;
 	__u32 monitor = 0;
 
@@ -923,6 +922,8 @@ skip_service_lookup:
 
 	if (backend_local || !nodeport_uses_dsr6(&tuple)) {
 		struct ct_state ct_state = {};
+		union macaddr smac = {0};
+		union macaddr *mac;
 
 		ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
 				 CT_EGRESS, &ct_state, &monitor);
@@ -1781,7 +1782,6 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	struct lb4_service *svc;
 	struct lb4_key key = {};
 	struct ct_state ct_state_new = {};
-	union macaddr smac, *mac;
 	bool backend_local;
 	__u32 monitor = 0;
 
@@ -1879,6 +1879,8 @@ skip_service_lookup:
 	 */
 	if (backend_local || !nodeport_uses_dsr4(&tuple)) {
 		struct ct_state ct_state = {};
+		union macaddr smac = {0};
+		union macaddr *mac;
 
 		ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
 				 CT_EGRESS, &ct_state, &monitor);


### PR DESCRIPTION
Just a few trivial cleanups from poking around in the lb code.

But as an added bonus, the first patch seems to help with complexity and brings https://github.com/cilium/cilium/pull/21539 back into play  (see https://github.com/cilium/cilium/pull/22312).