### PR TITLE
test: remove kube-proxy-replacement: probe from upstream tests

### DIFF
--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -26,8 +26,8 @@ helm template --validate install/kubernetes/cilium \
   --set ipv4.enabled=true \
   --set ipv6.enabled=true \
   --set identityChangeGracePeriod="0s" \
-  --set kubeProxyReplacement=probe \
   --set cni.chainingMode=portmap \
+  --set sessionAffinity=true \
   > cilium.yaml
 
 kubectl apply -f cilium.yaml


### PR DESCRIPTION
This option was removed by 691f1c33c9ad and broke all upstream tests. This commit removes this setting as well to make the tests pass.

Fixes: 691f1c33c9ad ("daemon: Remove KPR=probe")
Signed-off-by: André Martins <andre@cilium.io>