### PR TITLE
Fix when install k8s-1.25 ,no need cni install

### DIFF
--- a/test/provision/helpers.bash
+++ b/test/provision/helpers.bash
@@ -56,7 +56,9 @@ function install_k8s_using_binary {
     mkdir -p /opt/cni/bin
     mkdir -p /etc/systemd/system/kubelet.service.d
 
-    curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins${OS}-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+    if [[ -n "$CNI_VERSION" ]]; then
+    	curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins${OS}-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+    fi
 
     wget -q https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubectl,kubeadm,kubelet}
     chmod 777 ku*


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

In k8s1.25 install case , we don't need to define the kubernetes CNI version once we have stable releases.
So omit the cni-install step when the parameter 'KUBERNETES_CNI_VERSION' is nil..
