### PR TITLE
allow appending ReadCNIConfiguration into the default CNI plugins

### DIFF
--- a/daemon/cmd/cni_test.go
+++ b/daemon/cmd/cni_test.go
@@ -6,41 +6,370 @@ package cmd
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/option"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
 func TestInstallCNIConfFile(t *testing.T) {
 	workdir := t.TempDir()
-	opts := &option.DaemonConfig{
-		Debug:                          false,
-		CNILogFile:                     "/opt\"/cni.log", // test escaping :-)
-		CNIChainingMode:                "none",
-		CNIExclusive:                   true,
-		WriteCNIConfigurationWhenReady: path.Join(workdir, "05-cilium.conflist"),
+	readCNIDir := t.TempDir()
+	cases := []struct {
+		name                string
+		opts                *option.DaemonConfig
+		inputFiles          map[string]string
+		expectedOutputFiles map[string]string
+		expectedFailure     bool
+	}{
+		{
+			name: "render the CNI conf file according to CNIChainingMode",
+			opts: &option.DaemonConfig{
+				Debug:                          false,
+				CNILogFile:                     "/opt\"/cni.log", // test escaping :-)
+				CNIChainingMode:                "none",
+				CNIExclusive:                   true,
+				WriteCNIConfigurationWhenReady: path.Join(workdir, "05-cilium.conflist"),
+			},
+			inputFiles: map[string]string{
+				path.Join(workdir, "other.conflist"): `{}`,
+				path.Join(workdir, "05-cilium.conf"): `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}`,
+			},
+			expectedOutputFiles: map[string]string{
+				"05-cilium.conflist": `
+{
+  "cniVersion": "0.3.1",
+  "name": "cilium",
+  "plugins": [
+    {
+       "type": "cilium-cni",
+       "enable-debug": false,
+       "log-file": "/opt\"/cni.log"
+    }
+  ]
+}`,
+				"other.conflist.cilium_bak": `{}`,
+			},
+		},
+		{
+			name: "write ReadCNIConfiguration directly into WriteCNIConfigurationWhenReady when WriteCNIConfigurationChainingMode = false",
+			opts: &option.DaemonConfig{
+				Debug:                             false,
+				CNIChainingMode:                   "generic-veth",
+				CNIExclusive:                      true,
+				WriteCNIConfigurationWhenReady:    path.Join(workdir, "05-cilium.conflist"),
+				WriteCNIConfigurationChainingMode: false,
+				ReadCNIConfiguration:              path.Join(readCNIDir, "05-cilium-origin.conflist"),
+			},
+			inputFiles: map[string]string{
+				path.Join(workdir, "other.conflist"): `
+{
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+				path.Join(readCNIDir, "05-cilium-origin.conflist"): `
+{
+  "cniVersion": "0.3.1",
+  "name": "generic-veth",
+  "plugins": [
+    {
+       "name": "calico",
+       "type": "calico"
+    },
+    {
+	   "name": "cilium-cni",
+	   "type": "cilium-cni"
+    }
+  ]
+}`,
+			},
+			expectedOutputFiles: map[string]string{
+				"05-cilium.conflist": `
+{
+  "cniVersion": "0.3.1",
+  "name": "generic-veth",
+  "plugins": [
+    {
+       "name": "calico",
+       "type": "calico"
+    },
+    {
+	   "name": "cilium-cni",
+	   "type": "cilium-cni"
+    }
+  ]
+}`,
+				"other.conflist.cilium_bak": `
+{
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+			},
+		},
+		{
+			name: "write ReadCNIConfiguration with CNIChainingMode into WriteCNIConfigurationWhenReady when WriteCNIConfigurationChainingMode = true and no other CNI configuration files exist",
+			opts: &option.DaemonConfig{
+				Debug:                             false,
+				CNIChainingMode:                   "generic-veth",
+				CNIExclusive:                      true,
+				WriteCNIConfigurationWhenReady:    path.Join(workdir, "05-cilium.conflist"),
+				WriteCNIConfigurationChainingMode: true,
+				ReadCNIConfiguration:              path.Join(readCNIDir, "05-cilium-origin.conf"),
+			},
+			inputFiles: map[string]string{
+				path.Join(workdir, "other.conflist.cilium_bak"): `
+{
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+				path.Join(readCNIDir, "05-cilium-origin.conf"): `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}`,
+			},
+			expectedOutputFiles: map[string]string{
+				"05-cilium.conflist": `
+{
+  "cniVersion": "0.3.1",
+  "name": "generic-veth",
+  "plugins": [
+    {
+       "name": "cilium-cni",
+       "type": "cilium-cni"
+    }
+  ]
+}`,
+				"other.conflist.cilium_bak": `
+{
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+			},
+		},
+		{
+			name: "insert ReadCNIConfiguration into the default CNI plugin and write it into WriteCNIConfigurationWhenReady when WriteCNIConfigurationChainingMode = true",
+			opts: &option.DaemonConfig{
+				Debug:                             false,
+				CNIChainingMode:                   "generic-veth",
+				CNIExclusive:                      true,
+				WriteCNIConfigurationWhenReady:    path.Join(workdir, "05-cilium.conflist"),
+				WriteCNIConfigurationChainingMode: true,
+				ReadCNIConfiguration:              path.Join(readCNIDir, "05-cilium-origin.conf"),
+			},
+			inputFiles: map[string]string{
+				path.Join(workdir, "default.conf"): `
+{
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+				path.Join(readCNIDir, "05-cilium-origin.conf"): `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}`,
+			},
+			expectedOutputFiles: map[string]string{
+				"05-cilium.conflist": `
+{
+  "cniVersion": "0.3.1",
+  "name": "generic-veth",
+  "plugins": [
+    {
+       "name": "calico",
+       "type": "calico"
+    },
+    {
+	   "name": "cilium-cni",
+	   "type": "cilium-cni"
+    }
+  ]
+}`,
+				"default.conf.cilium_bak": `
+{
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+			},
+		},
+		{
+			name: "insert ReadCNIConfiguration into the file specified by DefaultCNIConfiguration and write it into WriteCNIConfigurationWhenReady when WriteCNIConfigurationChainingMode = true",
+			opts: &option.DaemonConfig{
+				Debug:                             false,
+				CNIChainingMode:                   "generic-veth",
+				CNIExclusive:                      true,
+				WriteCNIConfigurationWhenReady:    path.Join(workdir, "05-cilium.conflist"),
+				WriteCNIConfigurationChainingMode: true,
+				ReadCNIConfiguration:              path.Join(readCNIDir, "05-cilium-origin.conf"),
+				DefaultCNIConfiguration:           path.Join(workdir, "default.conf"),
+			},
+			inputFiles: map[string]string{
+				path.Join(workdir, "default.conf"): `
+{
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+				path.Join(workdir, "another.conf"): `
+{
+      "cniVersion": "0.3.0",
+      "name": "portmap",
+      "type": "portmap"
+}`,
+				path.Join(readCNIDir, "05-cilium-origin.conf"): `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}`,
+			},
+			expectedOutputFiles: map[string]string{
+				"05-cilium.conflist": `
+{
+  "cniVersion": "0.3.1",
+  "name": "generic-veth",
+  "plugins": [
+    {
+       "name": "calico",
+       "type": "calico"
+    },
+    {
+	   "name": "cilium-cni",
+	   "type": "cilium-cni"
+    }
+  ]
+}`,
+				"default.conf.cilium_bak": `
+{
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+				"another.conf.cilium_bak": `
+{
+      "cniVersion": "0.3.0",
+      "name": "portmap",
+      "type": "portmap"
+}`,
+			},
+		},
+		{
+			name: "insert ReadCNIConfiguration into the file specified by DefaultCNIConfiguration and write it into WriteCNIConfigurationWhenReady when WriteCNIConfigurationChainingMode = true and CNIExclusive = false",
+			opts: &option.DaemonConfig{
+				Debug:                             false,
+				CNIChainingMode:                   "generic-veth",
+				CNIExclusive:                      false,
+				WriteCNIConfigurationWhenReady:    path.Join(workdir, "05-cilium.conflist"),
+				WriteCNIConfigurationChainingMode: true,
+				ReadCNIConfiguration:              path.Join(readCNIDir, "05-cilium-origin.conf"),
+				DefaultCNIConfiguration:           path.Join(workdir, "default.conf"),
+			},
+			inputFiles: map[string]string{
+				path.Join(workdir, "default.conf"): `
+{
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+				path.Join(workdir, "another.conf"): `
+{
+      "cniVersion": "0.3.0",
+      "name": "portmap",
+      "type": "portmap"
+}`,
+				path.Join(readCNIDir, "05-cilium-origin.conf"): `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}`,
+			},
+			expectedOutputFiles: map[string]string{
+				"05-cilium.conflist": `
+{
+  "cniVersion": "0.3.1",
+  "name": "generic-veth",
+  "plugins": [
+    {
+       "name": "calico",
+       "type": "calico"
+    },
+    {
+	   "name": "cilium-cni",
+	   "type": "cilium-cni"
+    }
+  ]
+}`,
+				"default.conf.cilium_bak": `
+{
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+				"another.conf": `
+{
+      "cniVersion": "0.3.0",
+      "name": "portmap",
+      "type": "portmap"
+}`,
+			},
+		},
 	}
 
-	touch(t, workdir, "other.conflist")
-	touch(t, workdir, "05-cilium.conf") // older config file we no longer create
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_ = os.RemoveAll(workdir)
+			_ = os.RemoveAll(readCNIDir)
+			_ = os.MkdirAll(workdir, 0o777)
+			_ = os.MkdirAll(readCNIDir, 0o777)
+			for filename, contents := range c.inputFiles {
+				err := os.WriteFile(filename, []byte(contents), 0o644)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	err := installCNIConfFile(opts)
-	assert.NoError(t, err)
+			for i := 0; i < 2; i++ {
+				// i == 0; it is to simulate the first starting
+				// i == 1; it is to simulate the restarting of agent
+				err := installCNIConfFile(c.opts)
+				if (c.expectedFailure && err == nil) || (!c.expectedFailure && err != nil) {
+					t.Fatalf("expected failure: %t, got %v", c.expectedFailure, err)
+				}
 
-	filenames := ls(t, workdir)
+				filenames := ls(t, workdir)
 
-	assert.ElementsMatch(t, filenames, []string{
-		"05-cilium.conflist",
-		"other.conflist.cilium_bak",
-	})
+				expectedFileNames := make([]string, 0)
+				for filename, _ := range c.expectedOutputFiles {
+					expectedFileNames = append(expectedFileNames, filename)
+				}
+				assert.ElementsMatch(t, filenames, expectedFileNames)
 
-	data, err := os.ReadFile(path.Join(workdir, "05-cilium.conflist"))
-	assert.NoError(t, err)
-	val := gjson.GetBytes(data, "plugins.0.type")
-	assert.Equal(t, val.String(), "cilium-cni")
+				for filename, value := range c.expectedOutputFiles {
+					data, err := os.ReadFile(path.Join(workdir, filename))
+					assert.NoError(t, err)
+					require.JSONEqf(t, value, string(data), "expected %s, got %s", value, string(data))
+				}
+			}
+
+		})
+	}
 
 }
 
@@ -148,6 +477,369 @@ func TestCleanupOtherCNI(t *testing.T) {
 		"42-keep.json",
 		"44-dontkeep.json.cilium_bak",
 	})
+}
+
+func TestGetDefaultCNINetwork(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cases := []struct {
+		name            string
+		dir             string
+		inFilename      string
+		outFilename     string
+		fileContents    string
+		expectedFailure bool
+	}{
+		{
+			name:            "inexistent directory",
+			dir:             "/inexistent/directory",
+			expectedFailure: true,
+		},
+		{
+			name:            "empty directory",
+			dir:             tempDir,
+			expectedFailure: true,
+		},
+		{
+			// Only .conf and .conflist files are detectable
+			name:            "undetectable file",
+			dir:             tempDir,
+			expectedFailure: true,
+			inFilename:      "undetectable.file",
+			fileContents: `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}`,
+		},
+		{
+			name:            "empty file",
+			dir:             tempDir,
+			expectedFailure: true,
+			inFilename:      "empty.conf",
+		},
+		{
+			name:            "regular file",
+			dir:             tempDir,
+			expectedFailure: false,
+			inFilename:      "regular.conf",
+			outFilename:     "regular.conf",
+			fileContents: `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}`,
+		},
+		{
+			name:            "another regular file",
+			dir:             tempDir,
+			expectedFailure: false,
+			inFilename:      "regular2.conf",
+			outFilename:     "regular.conf",
+			fileContents: `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.fileContents != "" {
+				err := os.WriteFile(filepath.Join(c.dir, c.inFilename), []byte(c.fileContents), 0o644)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			result, _, err := getDefaultCNINetworkList(c.dir)
+			if (c.expectedFailure && err == nil) || (!c.expectedFailure && err != nil) {
+				t.Fatalf("expected failure: %t, got %v", c.expectedFailure, err)
+			}
+
+			if c.fileContents != "" && c.outFilename != "" {
+				if c.outFilename != filepath.Base(result) {
+					t.Fatalf("expected %s, got %s", c.outFilename, result)
+				}
+			}
+		})
+	}
+}
+
+func TestInsertConfList(t *testing.T) {
+	cases := []struct {
+		name            string
+		cniChainMode    string
+		original        string
+		inserted        string
+		expected        string
+		expectedFailure bool
+	}{
+		{
+			name:         "insert the plugin into the file suffixed with .conf",
+			cniChainMode: "generic-veth",
+			original: `
+ {
+      "cniVersion": "0.2.1",
+      "name": "calico",
+      "type": "calico"
+}`,
+			inserted: `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}
+`,
+			expected: `
+{
+    "cniVersion": "0.3.1",
+    "name": "generic-veth",
+    "plugins": [
+        {
+            "name": "calico",
+            "type": "calico"
+        },
+        {
+            "name": "cilium-cni",
+            "type": "cilium-cni"
+        }
+    ]
+}`,
+		},
+		{
+			name:         "insert the plugin into the file suffixed with .conflist",
+			cniChainMode: "generic-veth",
+			original: `
+ {
+    "cniVersion": "0.3.1",
+    "name": "generic-veth",
+    "plugins":
+    [
+        {
+            "name": "calico",
+            "type": "calico"
+        },
+        {
+            "name": "cilium-cni",
+            "type": "cilium-cni",
+			"enable-debug": true
+        }
+    ]
+}`,
+			inserted: `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}
+`,
+			expected: `
+{
+    "cniVersion": "0.3.1",
+    "name": "generic-veth",
+    "plugins":
+    [
+        {
+            "name": "calico",
+            "type": "calico"
+        },
+        {
+            "name": "cilium-cni",
+            "type": "cilium-cni"
+        }
+    ]
+}`,
+		},
+		{
+			name:         "insert the plugins suffixed with .conflist into the file suffixed with .conflist",
+			cniChainMode: "generic-veth",
+			original: `
+ {
+    "cniVersion": "0.3.1",
+    "name": "generic-veth",
+    "plugins":
+    [
+        {
+            "name": "calico",
+            "type": "calico"
+        },
+        {
+            "name": "isto-cni",
+            "type": "isto-cni"
+        }
+    ]
+}`,
+			inserted: `
+{
+    "cniVersion": "0.3.1",
+    "name": "generic-veth",
+    "plugins":
+    [
+        {
+            "name": "portmap",
+            "type": "portmap"
+        },
+        {
+            "name": "cilium-cni",
+            "type": "cilium-cni",
+			"enable-debug": true
+        }
+    ]
+}
+`,
+			expected: `
+{
+    "cniVersion": "0.3.1",
+    "name": "generic-veth",
+    "plugins":
+    [
+        {
+            "name": "calico",
+            "type": "calico"
+        },
+        {
+            "name": "isto-cni",
+            "type": "isto-cni"
+        },
+        {
+            "name": "portmap",
+            "type": "portmap"
+        },
+        {
+            "enable-debug": true,
+            "name": "cilium-cni",
+            "type": "cilium-cni"
+        }
+    ]
+}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result, err := insertConfList(c.cniChainMode, []byte(c.original), []byte(c.inserted))
+			if (c.expectedFailure && err == nil) || (!c.expectedFailure && err != nil) {
+				t.Fatalf("expected failure: %t, got %v", c.expectedFailure, err)
+			}
+
+			if c.expected != "" {
+				require.JSONEqf(t, c.expected, string(result), "expected %s, got %s", c.expected, string(result))
+			}
+		})
+	}
+}
+
+func TestGetCNINetworkListFromFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cases := []struct {
+		name            string
+		inFilename      string
+		fileContents    string
+		outFileContents string
+		expectedFailure bool
+	}{
+		{
+			name:       "the correct content for the file suffixed with .conf",
+			inFilename: "cilium.conf",
+			fileContents: `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni",
+	"type": "cilium-cni"
+}`,
+			outFileContents: `
+ {
+    "cniVersion": "0.3.1",
+    "name": "cilium-cni",
+    "plugins":
+    [
+        {
+            "cniVersion": "0.3.1",
+            "name": "cilium-cni",
+            "type": "cilium-cni"
+        }
+    ]
+}
+`,
+			expectedFailure: false,
+		},
+		{
+			name:       "the correct content for the file suffixed with .conflist",
+			inFilename: "cilium.conflist",
+			fileContents: `
+{
+  "cniVersion": "0.2.0",
+  "name": "generic-veth",
+  "plugins": [
+    {
+      "name": "cilium",
+      "type": "cilium-cni"
+    }
+  ]
+}`,
+			outFileContents: `
+{
+  "cniVersion": "0.2.0",
+  "name": "generic-veth",
+  "plugins": [
+    {
+      "name": "cilium",
+      "type": "cilium-cni"
+    }
+  ]
+}
+`,
+			expectedFailure: false,
+		},
+		{
+			name:            "unexpected content in the file suffixed with .conf",
+			expectedFailure: true,
+			inFilename:      "cilium.conf",
+			fileContents: `
+{
+	"cniVersion": "0.3.1",
+	"name": "cilium-cni"
+}`,
+		},
+		{
+			name:            "no plugins in the file suffixed with .conflist",
+			expectedFailure: true,
+			inFilename:      "cilium.conflist",
+			fileContents: `
+{
+  "cniVersion": "0.2.0",
+  "name": "generic-veth",
+  "plugins": [
+  ]
+}
+`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.fileContents != "" {
+				err := os.WriteFile(filepath.Join(tempDir, c.inFilename), []byte(c.fileContents), 0o644)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			result, err := getCNINetworkListFromFile(filepath.Join(tempDir, c.inFilename))
+			if (c.expectedFailure && err == nil) || (!c.expectedFailure && err != nil) {
+				t.Fatalf("expected failure: %t, got %v", c.expectedFailure, err)
+			}
+
+			if c.expectedFailure == false {
+				require.JSONEqf(t, c.outFileContents, string(result), "expected %s, got %s", c.outFileContents, string(result))
+			}
+		})
+	}
 }
 
 func touch(t *testing.T, dir, name string) {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -721,6 +721,9 @@ func initializeFlags() {
 	flags.String(option.ReadCNIConfiguration, "", fmt.Sprintf("CNI configuration file to use as a source for --%s. If not supplied, a suitable one will be generated.", option.WriteCNIConfigurationWhenReady))
 	option.BindEnv(Vp, option.ReadCNIConfiguration)
 
+	flags.String(option.DefaultCNIConfiguration, "", "location of the default CNI configuration file")
+	option.BindEnv(Vp, option.DefaultCNIConfiguration)
+
 	flags.Bool(option.Restore, true, "Restores state, if possible, from previous daemon")
 	option.BindEnv(Vp, option.Restore)
 
@@ -880,6 +883,9 @@ func initializeFlags() {
 
 	flags.String(option.WriteCNIConfigurationWhenReady, "", "Write the CNI configuration to the specified path when agent is ready")
 	option.BindEnv(Vp, option.WriteCNIConfigurationWhenReady)
+
+	flags.Bool(option.WriteCNIConfigurationChainingMode, false, fmt.Sprintf("Allow writing the CNI configuration from %s with the default CNI configuration using chaining mode into %s", option.ReadCNIConfiguration, option.WriteCNIConfigurationWhenReady))
+	option.BindEnv(Vp, option.WriteCNIConfigurationChainingMode)
 
 	flags.Duration(option.PolicyTriggerInterval, defaults.PolicyTriggerInterval, "Time between triggers of policy updates (regenerations for all endpoints)")
 	flags.MarkHidden(option.PolicyTriggerInterval)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1175,6 +1175,17 @@ const (
 	// running and able to schedule endpoints.
 	WriteCNIConfigurationWhenReady = "write-cni-conf-when-ready"
 
+	// DefaultCNIConfiguration is an original default CNI configuration file. If
+	// WriteCNIConfigurationChainingMode is true, its content will be appended
+	// with ReadCNIConfiguration and be written into WriteCNIConfigurationWhenReady
+	DefaultCNIConfiguration = "default-cni-conf"
+
+	// WriteCNIConfigurationChainingMode means writing the CNI configuration
+	// of ReadCNIConfiguration into the file WriteCNIConfigurationWhenReady with the configurations
+	// of DefaultCNIConfiguration in a chaining mode.
+	// If false, it will write the CNI configuration of ReadCNIConfiguration into a single file
+	WriteCNIConfigurationChainingMode = "write-cni-conf-chaining-mode"
+
 	// CNIExclusive tells the agent to remove other CNI configuration files
 	CNIExclusive = "cni-exclusive"
 
@@ -1828,6 +1839,16 @@ type DaemonConfig struct {
 	// allows to keep a Kubernetes node NotReady until Cilium is up and
 	// running and able to schedule endpoints.
 	WriteCNIConfigurationWhenReady string
+
+	// DefaultCNIConfiguration is an original CNI configuration file. If
+	// WriteCNIConfigurationChainingMode is true, its content will be appened
+	// with ReadCNIConfiguration and be written into WriteCNIConfigurationWhenReady
+	DefaultCNIConfiguration string
+
+	// WriteCNIConfigurationChainingMode means writing the CNI configuration
+	// of ReadCNIConfiguration into a chained cni configuration file. If false, it will write
+	// the CNI configuration into a single file
+	WriteCNIConfigurationChainingMode bool
 
 	// CNIExclusive, if true, directs the agent to remove all other CNI configuration files
 	CNIExclusive bool
@@ -2919,6 +2940,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.TracePayloadlen = vp.GetInt(TracePayloadlen)
 	c.Version = vp.GetString(Version)
 	c.WriteCNIConfigurationWhenReady = vp.GetString(WriteCNIConfigurationWhenReady)
+	c.WriteCNIConfigurationChainingMode = vp.GetBool(WriteCNIConfigurationChainingMode)
+	c.DefaultCNIConfiguration = vp.GetString(DefaultCNIConfiguration)
 	c.CNIExclusive = vp.GetBool(CNIExclusive)
 	c.CNILogFile = vp.GetString(CNILogFile)
 	c.PolicyTriggerInterval = vp.GetDuration(PolicyTriggerInterval)

--- a/vendor/github.com/containernetworking/cni/libcni/api.go
+++ b/vendor/github.com/containernetworking/cni/libcni/api.go
@@ -1,0 +1,679 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package libcni
+
+// Note this is the actual implementation of the CNI specification, which
+// is reflected in the https://github.com/containernetworking/cni/blob/master/SPEC.md file
+// it is typically bundled into runtime providers (i.e. containerd or cri-o would use this
+// before calling runc or hcsshim).  It is also bundled into CNI providers as well, for example,
+// to add an IP to a container, to parse the configuration of the CNI and so on.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/create"
+	"github.com/containernetworking/cni/pkg/utils"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+var (
+	CacheDir = "/var/lib/cni"
+)
+
+const (
+	CNICacheV1 = "cniCacheV1"
+)
+
+// A RuntimeConf holds the arguments to one invocation of a CNI plugin
+// excepting the network configuration, with the nested exception that
+// the `runtimeConfig` from the network configuration is included
+// here.
+type RuntimeConf struct {
+	ContainerID string
+	NetNS       string
+	IfName      string
+	Args        [][2]string
+	// A dictionary of capability-specific data passed by the runtime
+	// to plugins as top-level keys in the 'runtimeConfig' dictionary
+	// of the plugin's stdin data.  libcni will ensure that only keys
+	// in this map which match the capabilities of the plugin are passed
+	// to the plugin
+	CapabilityArgs map[string]interface{}
+
+	// DEPRECATED. Will be removed in a future release.
+	CacheDir string
+}
+
+type NetworkConfig struct {
+	Network *types.NetConf
+	Bytes   []byte
+}
+
+type NetworkConfigList struct {
+	Name         string
+	CNIVersion   string
+	DisableCheck bool
+	Plugins      []*NetworkConfig
+	Bytes        []byte
+}
+
+type CNI interface {
+	AddNetworkList(ctx context.Context, net *NetworkConfigList, rt *RuntimeConf) (types.Result, error)
+	CheckNetworkList(ctx context.Context, net *NetworkConfigList, rt *RuntimeConf) error
+	DelNetworkList(ctx context.Context, net *NetworkConfigList, rt *RuntimeConf) error
+	GetNetworkListCachedResult(net *NetworkConfigList, rt *RuntimeConf) (types.Result, error)
+	GetNetworkListCachedConfig(net *NetworkConfigList, rt *RuntimeConf) ([]byte, *RuntimeConf, error)
+
+	AddNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) (types.Result, error)
+	CheckNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) error
+	DelNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) error
+	GetNetworkCachedResult(net *NetworkConfig, rt *RuntimeConf) (types.Result, error)
+	GetNetworkCachedConfig(net *NetworkConfig, rt *RuntimeConf) ([]byte, *RuntimeConf, error)
+
+	ValidateNetworkList(ctx context.Context, net *NetworkConfigList) ([]string, error)
+	ValidateNetwork(ctx context.Context, net *NetworkConfig) ([]string, error)
+}
+
+type CNIConfig struct {
+	Path     []string
+	exec     invoke.Exec
+	cacheDir string
+}
+
+// CNIConfig implements the CNI interface
+var _ CNI = &CNIConfig{}
+
+// NewCNIConfig returns a new CNIConfig object that will search for plugins
+// in the given paths and use the given exec interface to run those plugins,
+// or if the exec interface is not given, will use a default exec handler.
+func NewCNIConfig(path []string, exec invoke.Exec) *CNIConfig {
+	return NewCNIConfigWithCacheDir(path, "", exec)
+}
+
+// NewCNIConfigWithCacheDir returns a new CNIConfig object that will search for plugins
+// in the given paths use the given exec interface to run those plugins,
+// or if the exec interface is not given, will use a default exec handler.
+// The given cache directory will be used for temporary data storage when needed.
+func NewCNIConfigWithCacheDir(path []string, cacheDir string, exec invoke.Exec) *CNIConfig {
+	return &CNIConfig{
+		Path:     path,
+		cacheDir: cacheDir,
+		exec:     exec,
+	}
+}
+
+func buildOneConfig(name, cniVersion string, orig *NetworkConfig, prevResult types.Result, rt *RuntimeConf) (*NetworkConfig, error) {
+	var err error
+
+	inject := map[string]interface{}{
+		"name":       name,
+		"cniVersion": cniVersion,
+	}
+	// Add previous plugin result
+	if prevResult != nil {
+		inject["prevResult"] = prevResult
+	}
+
+	// Ensure every config uses the same name and version
+	orig, err = InjectConf(orig, inject)
+	if err != nil {
+		return nil, err
+	}
+
+	return injectRuntimeConfig(orig, rt)
+}
+
+// This function takes a libcni RuntimeConf structure and injects values into
+// a "runtimeConfig" dictionary in the CNI network configuration JSON that
+// will be passed to the plugin on stdin.
+//
+// Only "capabilities arguments" passed by the runtime are currently injected.
+// These capabilities arguments are filtered through the plugin's advertised
+// capabilities from its config JSON, and any keys in the CapabilityArgs
+// matching plugin capabilities are added to the "runtimeConfig" dictionary
+// sent to the plugin via JSON on stdin.  For example, if the plugin's
+// capabilities include "portMappings", and the CapabilityArgs map includes a
+// "portMappings" key, that key and its value are added to the "runtimeConfig"
+// dictionary to be passed to the plugin's stdin.
+func injectRuntimeConfig(orig *NetworkConfig, rt *RuntimeConf) (*NetworkConfig, error) {
+	var err error
+
+	rc := make(map[string]interface{})
+	for capability, supported := range orig.Network.Capabilities {
+		if !supported {
+			continue
+		}
+		if data, ok := rt.CapabilityArgs[capability]; ok {
+			rc[capability] = data
+		}
+	}
+
+	if len(rc) > 0 {
+		orig, err = InjectConf(orig, map[string]interface{}{"runtimeConfig": rc})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return orig, nil
+}
+
+// ensure we have a usable exec if the CNIConfig was not given one
+func (c *CNIConfig) ensureExec() invoke.Exec {
+	if c.exec == nil {
+		c.exec = &invoke.DefaultExec{
+			RawExec:       &invoke.RawExec{Stderr: os.Stderr},
+			PluginDecoder: version.PluginDecoder{},
+		}
+	}
+	return c.exec
+}
+
+type cachedInfo struct {
+	Kind           string                 `json:"kind"`
+	ContainerID    string                 `json:"containerId"`
+	Config         []byte                 `json:"config"`
+	IfName         string                 `json:"ifName"`
+	NetworkName    string                 `json:"networkName"`
+	CniArgs        [][2]string            `json:"cniArgs,omitempty"`
+	CapabilityArgs map[string]interface{} `json:"capabilityArgs,omitempty"`
+	RawResult      map[string]interface{} `json:"result,omitempty"`
+	Result         types.Result           `json:"-"`
+}
+
+// getCacheDir returns the cache directory in this order:
+// 1) global cacheDir from CNIConfig object
+// 2) deprecated cacheDir from RuntimeConf object
+// 3) fall back to default cache directory
+func (c *CNIConfig) getCacheDir(rt *RuntimeConf) string {
+	if c.cacheDir != "" {
+		return c.cacheDir
+	}
+	if rt.CacheDir != "" {
+		return rt.CacheDir
+	}
+	return CacheDir
+}
+
+func (c *CNIConfig) getCacheFilePath(netName string, rt *RuntimeConf) (string, error) {
+	if netName == "" || rt.ContainerID == "" || rt.IfName == "" {
+		return "", fmt.Errorf("cache file path requires network name (%q), container ID (%q), and interface name (%q)", netName, rt.ContainerID, rt.IfName)
+	}
+	return filepath.Join(c.getCacheDir(rt), "results", fmt.Sprintf("%s-%s-%s", netName, rt.ContainerID, rt.IfName)), nil
+}
+
+func (c *CNIConfig) cacheAdd(result types.Result, config []byte, netName string, rt *RuntimeConf) error {
+	cached := cachedInfo{
+		Kind:           CNICacheV1,
+		ContainerID:    rt.ContainerID,
+		Config:         config,
+		IfName:         rt.IfName,
+		NetworkName:    netName,
+		CniArgs:        rt.Args,
+		CapabilityArgs: rt.CapabilityArgs,
+	}
+
+	// We need to get type.Result into cachedInfo as JSON map
+	// Marshal to []byte, then Unmarshal into cached.RawResult
+	data, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(data, &cached.RawResult)
+	if err != nil {
+		return err
+	}
+
+	newBytes, err := json.Marshal(&cached)
+	if err != nil {
+		return err
+	}
+
+	fname, err := c.getCacheFilePath(netName, rt)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(fname), 0700); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(fname, newBytes, 0600)
+}
+
+func (c *CNIConfig) cacheDel(netName string, rt *RuntimeConf) error {
+	fname, err := c.getCacheFilePath(netName, rt)
+	if err != nil {
+		// Ignore error
+		return nil
+	}
+	return os.Remove(fname)
+}
+
+func (c *CNIConfig) getCachedConfig(netName string, rt *RuntimeConf) ([]byte, *RuntimeConf, error) {
+	var bytes []byte
+
+	fname, err := c.getCacheFilePath(netName, rt)
+	if err != nil {
+		return nil, nil, err
+	}
+	bytes, err = ioutil.ReadFile(fname)
+	if err != nil {
+		// Ignore read errors; the cached result may not exist on-disk
+		return nil, nil, nil
+	}
+
+	unmarshaled := cachedInfo{}
+	if err := json.Unmarshal(bytes, &unmarshaled); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal cached network %q config: %w", netName, err)
+	}
+	if unmarshaled.Kind != CNICacheV1 {
+		return nil, nil, fmt.Errorf("read cached network %q config has wrong kind: %v", netName, unmarshaled.Kind)
+	}
+
+	newRt := *rt
+	if unmarshaled.CniArgs != nil {
+		newRt.Args = unmarshaled.CniArgs
+	}
+	newRt.CapabilityArgs = unmarshaled.CapabilityArgs
+
+	return unmarshaled.Config, &newRt, nil
+}
+
+func (c *CNIConfig) getLegacyCachedResult(netName, cniVersion string, rt *RuntimeConf) (types.Result, error) {
+	fname, err := c.getCacheFilePath(netName, rt)
+	if err != nil {
+		return nil, err
+	}
+	data, err := ioutil.ReadFile(fname)
+	if err != nil {
+		// Ignore read errors; the cached result may not exist on-disk
+		return nil, nil
+	}
+
+	// Load the cached result
+	result, err := create.CreateFromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to the config version to ensure plugins get prevResult
+	// in the same version as the config.  The cached result version
+	// should match the config version unless the config was changed
+	// while the container was running.
+	result, err = result.GetAsVersion(cniVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert cached result to config version %q: %w", cniVersion, err)
+	}
+	return result, nil
+}
+
+func (c *CNIConfig) getCachedResult(netName, cniVersion string, rt *RuntimeConf) (types.Result, error) {
+	fname, err := c.getCacheFilePath(netName, rt)
+	if err != nil {
+		return nil, err
+	}
+	fdata, err := ioutil.ReadFile(fname)
+	if err != nil {
+		// Ignore read errors; the cached result may not exist on-disk
+		return nil, nil
+	}
+
+	cachedInfo := cachedInfo{}
+	if err := json.Unmarshal(fdata, &cachedInfo); err != nil || cachedInfo.Kind != CNICacheV1 {
+		return c.getLegacyCachedResult(netName, cniVersion, rt)
+	}
+
+	newBytes, err := json.Marshal(&cachedInfo.RawResult)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal cached network %q config: %w", netName, err)
+	}
+
+	// Load the cached result
+	result, err := create.CreateFromBytes(newBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to the config version to ensure plugins get prevResult
+	// in the same version as the config.  The cached result version
+	// should match the config version unless the config was changed
+	// while the container was running.
+	result, err = result.GetAsVersion(cniVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert cached result to config version %q: %w", cniVersion, err)
+	}
+	return result, nil
+}
+
+// GetNetworkListCachedResult returns the cached Result of the previous
+// AddNetworkList() operation for a network list, or an error.
+func (c *CNIConfig) GetNetworkListCachedResult(list *NetworkConfigList, rt *RuntimeConf) (types.Result, error) {
+	return c.getCachedResult(list.Name, list.CNIVersion, rt)
+}
+
+// GetNetworkCachedResult returns the cached Result of the previous
+// AddNetwork() operation for a network, or an error.
+func (c *CNIConfig) GetNetworkCachedResult(net *NetworkConfig, rt *RuntimeConf) (types.Result, error) {
+	return c.getCachedResult(net.Network.Name, net.Network.CNIVersion, rt)
+}
+
+// GetNetworkListCachedConfig copies the input RuntimeConf to output
+// RuntimeConf with fields updated with info from the cached Config.
+func (c *CNIConfig) GetNetworkListCachedConfig(list *NetworkConfigList, rt *RuntimeConf) ([]byte, *RuntimeConf, error) {
+	return c.getCachedConfig(list.Name, rt)
+}
+
+// GetNetworkCachedConfig copies the input RuntimeConf to output
+// RuntimeConf with fields updated with info from the cached Config.
+func (c *CNIConfig) GetNetworkCachedConfig(net *NetworkConfig, rt *RuntimeConf) ([]byte, *RuntimeConf, error) {
+	return c.getCachedConfig(net.Network.Name, rt)
+}
+
+func (c *CNIConfig) addNetwork(ctx context.Context, name, cniVersion string, net *NetworkConfig, prevResult types.Result, rt *RuntimeConf) (types.Result, error) {
+	c.ensureExec()
+	pluginPath, err := c.exec.FindInPath(net.Network.Type, c.Path)
+	if err != nil {
+		return nil, err
+	}
+	if err := utils.ValidateContainerID(rt.ContainerID); err != nil {
+		return nil, err
+	}
+	if err := utils.ValidateNetworkName(name); err != nil {
+		return nil, err
+	}
+	if err := utils.ValidateInterfaceName(rt.IfName); err != nil {
+		return nil, err
+	}
+
+	newConf, err := buildOneConfig(name, cniVersion, net, prevResult, rt)
+	if err != nil {
+		return nil, err
+	}
+
+	return invoke.ExecPluginWithResult(ctx, pluginPath, newConf.Bytes, c.args("ADD", rt), c.exec)
+}
+
+// AddNetworkList executes a sequence of plugins with the ADD command
+func (c *CNIConfig) AddNetworkList(ctx context.Context, list *NetworkConfigList, rt *RuntimeConf) (types.Result, error) {
+	var err error
+	var result types.Result
+	for _, net := range list.Plugins {
+		result, err = c.addNetwork(ctx, list.Name, list.CNIVersion, net, result, rt)
+		if err != nil {
+			return nil, fmt.Errorf("plugin %s failed (add): %w", pluginDescription(net.Network), err)
+		}
+	}
+
+	if err = c.cacheAdd(result, list.Bytes, list.Name, rt); err != nil {
+		return nil, fmt.Errorf("failed to set network %q cached result: %w", list.Name, err)
+	}
+
+	return result, nil
+}
+
+func (c *CNIConfig) checkNetwork(ctx context.Context, name, cniVersion string, net *NetworkConfig, prevResult types.Result, rt *RuntimeConf) error {
+	c.ensureExec()
+	pluginPath, err := c.exec.FindInPath(net.Network.Type, c.Path)
+	if err != nil {
+		return err
+	}
+
+	newConf, err := buildOneConfig(name, cniVersion, net, prevResult, rt)
+	if err != nil {
+		return err
+	}
+
+	return invoke.ExecPluginWithoutResult(ctx, pluginPath, newConf.Bytes, c.args("CHECK", rt), c.exec)
+}
+
+// CheckNetworkList executes a sequence of plugins with the CHECK command
+func (c *CNIConfig) CheckNetworkList(ctx context.Context, list *NetworkConfigList, rt *RuntimeConf) error {
+	// CHECK was added in CNI spec version 0.4.0 and higher
+	if gtet, err := version.GreaterThanOrEqualTo(list.CNIVersion, "0.4.0"); err != nil {
+		return err
+	} else if !gtet {
+		return fmt.Errorf("configuration version %q does not support the CHECK command", list.CNIVersion)
+	}
+
+	if list.DisableCheck {
+		return nil
+	}
+
+	cachedResult, err := c.getCachedResult(list.Name, list.CNIVersion, rt)
+	if err != nil {
+		return fmt.Errorf("failed to get network %q cached result: %w", list.Name, err)
+	}
+
+	for _, net := range list.Plugins {
+		if err := c.checkNetwork(ctx, list.Name, list.CNIVersion, net, cachedResult, rt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *CNIConfig) delNetwork(ctx context.Context, name, cniVersion string, net *NetworkConfig, prevResult types.Result, rt *RuntimeConf) error {
+	c.ensureExec()
+	pluginPath, err := c.exec.FindInPath(net.Network.Type, c.Path)
+	if err != nil {
+		return err
+	}
+
+	newConf, err := buildOneConfig(name, cniVersion, net, prevResult, rt)
+	if err != nil {
+		return err
+	}
+
+	return invoke.ExecPluginWithoutResult(ctx, pluginPath, newConf.Bytes, c.args("DEL", rt), c.exec)
+}
+
+// DelNetworkList executes a sequence of plugins with the DEL command
+func (c *CNIConfig) DelNetworkList(ctx context.Context, list *NetworkConfigList, rt *RuntimeConf) error {
+	var cachedResult types.Result
+
+	// Cached result on DEL was added in CNI spec version 0.4.0 and higher
+	if gtet, err := version.GreaterThanOrEqualTo(list.CNIVersion, "0.4.0"); err != nil {
+		return err
+	} else if gtet {
+		cachedResult, err = c.getCachedResult(list.Name, list.CNIVersion, rt)
+		if err != nil {
+			return fmt.Errorf("failed to get network %q cached result: %w", list.Name, err)
+		}
+	}
+
+	for i := len(list.Plugins) - 1; i >= 0; i-- {
+		net := list.Plugins[i]
+		if err := c.delNetwork(ctx, list.Name, list.CNIVersion, net, cachedResult, rt); err != nil {
+			return fmt.Errorf("plugin %s failed (delete): %w", pluginDescription(net.Network), err)
+		}
+	}
+	_ = c.cacheDel(list.Name, rt)
+
+	return nil
+}
+
+func pluginDescription(net *types.NetConf) string {
+	if net == nil {
+		return "<missing>"
+	}
+	pluginType := net.Type
+	out := fmt.Sprintf("type=%q", pluginType)
+	name := net.Name
+	if name != "" {
+		out += fmt.Sprintf(" name=%q", name)
+	}
+	return out
+}
+
+// AddNetwork executes the plugin with the ADD command
+func (c *CNIConfig) AddNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) (types.Result, error) {
+	result, err := c.addNetwork(ctx, net.Network.Name, net.Network.CNIVersion, net, nil, rt)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = c.cacheAdd(result, net.Bytes, net.Network.Name, rt); err != nil {
+		return nil, fmt.Errorf("failed to set network %q cached result: %w", net.Network.Name, err)
+	}
+
+	return result, nil
+}
+
+// CheckNetwork executes the plugin with the CHECK command
+func (c *CNIConfig) CheckNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) error {
+	// CHECK was added in CNI spec version 0.4.0 and higher
+	if gtet, err := version.GreaterThanOrEqualTo(net.Network.CNIVersion, "0.4.0"); err != nil {
+		return err
+	} else if !gtet {
+		return fmt.Errorf("configuration version %q does not support the CHECK command", net.Network.CNIVersion)
+	}
+
+	cachedResult, err := c.getCachedResult(net.Network.Name, net.Network.CNIVersion, rt)
+	if err != nil {
+		return fmt.Errorf("failed to get network %q cached result: %w", net.Network.Name, err)
+	}
+	return c.checkNetwork(ctx, net.Network.Name, net.Network.CNIVersion, net, cachedResult, rt)
+}
+
+// DelNetwork executes the plugin with the DEL command
+func (c *CNIConfig) DelNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) error {
+	var cachedResult types.Result
+
+	// Cached result on DEL was added in CNI spec version 0.4.0 and higher
+	if gtet, err := version.GreaterThanOrEqualTo(net.Network.CNIVersion, "0.4.0"); err != nil {
+		return err
+	} else if gtet {
+		cachedResult, err = c.getCachedResult(net.Network.Name, net.Network.CNIVersion, rt)
+		if err != nil {
+			return fmt.Errorf("failed to get network %q cached result: %w", net.Network.Name, err)
+		}
+	}
+
+	if err := c.delNetwork(ctx, net.Network.Name, net.Network.CNIVersion, net, cachedResult, rt); err != nil {
+		return err
+	}
+	_ = c.cacheDel(net.Network.Name, rt)
+	return nil
+}
+
+// ValidateNetworkList checks that a configuration is reasonably valid.
+// - all the specified plugins exist on disk
+// - every plugin supports the desired version.
+//
+// Returns a list of all capabilities supported by the configuration, or error
+func (c *CNIConfig) ValidateNetworkList(ctx context.Context, list *NetworkConfigList) ([]string, error) {
+	version := list.CNIVersion
+
+	// holding map for seen caps (in case of duplicates)
+	caps := map[string]interface{}{}
+
+	errs := []error{}
+	for _, net := range list.Plugins {
+		if err := c.validatePlugin(ctx, net.Network.Type, version); err != nil {
+			errs = append(errs, err)
+		}
+		for c, enabled := range net.Network.Capabilities {
+			if !enabled {
+				continue
+			}
+			caps[c] = struct{}{}
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("%v", errs)
+	}
+
+	// make caps list
+	cc := make([]string, 0, len(caps))
+	for c := range caps {
+		cc = append(cc, c)
+	}
+
+	return cc, nil
+}
+
+// ValidateNetwork checks that a configuration is reasonably valid.
+// It uses the same logic as ValidateNetworkList)
+// Returns a list of capabilities
+func (c *CNIConfig) ValidateNetwork(ctx context.Context, net *NetworkConfig) ([]string, error) {
+	caps := []string{}
+	for c, ok := range net.Network.Capabilities {
+		if ok {
+			caps = append(caps, c)
+		}
+	}
+	if err := c.validatePlugin(ctx, net.Network.Type, net.Network.CNIVersion); err != nil {
+		return nil, err
+	}
+	return caps, nil
+}
+
+// validatePlugin checks that an individual plugin's configuration is sane
+func (c *CNIConfig) validatePlugin(ctx context.Context, pluginName, expectedVersion string) error {
+	c.ensureExec()
+	pluginPath, err := c.exec.FindInPath(pluginName, c.Path)
+	if err != nil {
+		return err
+	}
+	if expectedVersion == "" {
+		expectedVersion = "0.1.0"
+	}
+
+	vi, err := invoke.GetVersionInfo(ctx, pluginPath, c.exec)
+	if err != nil {
+		return err
+	}
+	for _, vers := range vi.SupportedVersions() {
+		if vers == expectedVersion {
+			return nil
+		}
+	}
+	return fmt.Errorf("plugin %s does not support config version %q", pluginName, expectedVersion)
+}
+
+// GetVersionInfo reports which versions of the CNI spec are supported by
+// the given plugin.
+func (c *CNIConfig) GetVersionInfo(ctx context.Context, pluginType string) (version.PluginInfo, error) {
+	c.ensureExec()
+	pluginPath, err := c.exec.FindInPath(pluginType, c.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	return invoke.GetVersionInfo(ctx, pluginPath, c.exec)
+}
+
+// =====
+func (c *CNIConfig) args(action string, rt *RuntimeConf) *invoke.Args {
+	return &invoke.Args{
+		Command:     action,
+		ContainerID: rt.ContainerID,
+		NetNS:       rt.NetNS,
+		PluginArgs:  rt.Args,
+		IfName:      rt.IfName,
+		Path:        strings.Join(c.Path, string(os.PathListSeparator)),
+	}
+}

--- a/vendor/github.com/containernetworking/cni/libcni/conf.go
+++ b/vendor/github.com/containernetworking/cni/libcni/conf.go
@@ -1,0 +1,270 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package libcni
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+type NotFoundError struct {
+	Dir  string
+	Name string
+}
+
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf(`no net configuration with name "%s" in %s`, e.Name, e.Dir)
+}
+
+type NoConfigsFoundError struct {
+	Dir string
+}
+
+func (e NoConfigsFoundError) Error() string {
+	return fmt.Sprintf(`no net configurations found in %s`, e.Dir)
+}
+
+func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
+	conf := &NetworkConfig{Bytes: bytes, Network: &types.NetConf{}}
+	if err := json.Unmarshal(bytes, conf.Network); err != nil {
+		return nil, fmt.Errorf("error parsing configuration: %w", err)
+	}
+	if conf.Network.Type == "" {
+		return nil, fmt.Errorf("error parsing configuration: missing 'type'")
+	}
+	return conf, nil
+}
+
+func ConfFromFile(filename string) (*NetworkConfig, error) {
+	bytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %w", filename, err)
+	}
+	return ConfFromBytes(bytes)
+}
+
+func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
+	rawList := make(map[string]interface{})
+	if err := json.Unmarshal(bytes, &rawList); err != nil {
+		return nil, fmt.Errorf("error parsing configuration list: %w", err)
+	}
+
+	rawName, ok := rawList["name"]
+	if !ok {
+		return nil, fmt.Errorf("error parsing configuration list: no name")
+	}
+	name, ok := rawName.(string)
+	if !ok {
+		return nil, fmt.Errorf("error parsing configuration list: invalid name type %T", rawName)
+	}
+
+	var cniVersion string
+	rawVersion, ok := rawList["cniVersion"]
+	if ok {
+		cniVersion, ok = rawVersion.(string)
+		if !ok {
+			return nil, fmt.Errorf("error parsing configuration list: invalid cniVersion type %T", rawVersion)
+		}
+	}
+
+	disableCheck := false
+	if rawDisableCheck, ok := rawList["disableCheck"]; ok {
+		disableCheck, ok = rawDisableCheck.(bool)
+		if !ok {
+			return nil, fmt.Errorf("error parsing configuration list: invalid disableCheck type %T", rawDisableCheck)
+		}
+	}
+
+	list := &NetworkConfigList{
+		Name:         name,
+		DisableCheck: disableCheck,
+		CNIVersion:   cniVersion,
+		Bytes:        bytes,
+	}
+
+	var plugins []interface{}
+	plug, ok := rawList["plugins"]
+	if !ok {
+		return nil, fmt.Errorf("error parsing configuration list: no 'plugins' key")
+	}
+	plugins, ok = plug.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("error parsing configuration list: invalid 'plugins' type %T", plug)
+	}
+	if len(plugins) == 0 {
+		return nil, fmt.Errorf("error parsing configuration list: no plugins in list")
+	}
+
+	for i, conf := range plugins {
+		newBytes, err := json.Marshal(conf)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal plugin config %d: %w", i, err)
+		}
+		netConf, err := ConfFromBytes(newBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse plugin config %d: %w", i, err)
+		}
+		list.Plugins = append(list.Plugins, netConf)
+	}
+
+	return list, nil
+}
+
+func ConfListFromFile(filename string) (*NetworkConfigList, error) {
+	bytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %w", filename, err)
+	}
+	return ConfListFromBytes(bytes)
+}
+
+func ConfFiles(dir string, extensions []string) ([]string, error) {
+	// In part, adapted from rkt/networking/podenv.go#listFiles
+	files, err := ioutil.ReadDir(dir)
+	switch {
+	case err == nil: // break
+	case os.IsNotExist(err):
+		return nil, nil
+	default:
+		return nil, err
+	}
+
+	confFiles := []string{}
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		fileExt := filepath.Ext(f.Name())
+		for _, ext := range extensions {
+			if fileExt == ext {
+				confFiles = append(confFiles, filepath.Join(dir, f.Name()))
+			}
+		}
+	}
+	return confFiles, nil
+}
+
+func LoadConf(dir, name string) (*NetworkConfig, error) {
+	files, err := ConfFiles(dir, []string{".conf", ".json"})
+	switch {
+	case err != nil:
+		return nil, err
+	case len(files) == 0:
+		return nil, NoConfigsFoundError{Dir: dir}
+	}
+	sort.Strings(files)
+
+	for _, confFile := range files {
+		conf, err := ConfFromFile(confFile)
+		if err != nil {
+			return nil, err
+		}
+		if conf.Network.Name == name {
+			return conf, nil
+		}
+	}
+	return nil, NotFoundError{dir, name}
+}
+
+func LoadConfList(dir, name string) (*NetworkConfigList, error) {
+	files, err := ConfFiles(dir, []string{".conflist"})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+
+	for _, confFile := range files {
+		conf, err := ConfListFromFile(confFile)
+		if err != nil {
+			return nil, err
+		}
+		if conf.Name == name {
+			return conf, nil
+		}
+	}
+
+	// Try and load a network configuration file (instead of list)
+	// from the same name, then upconvert.
+	singleConf, err := LoadConf(dir, name)
+	if err != nil {
+		// A little extra logic so the error makes sense
+		if _, ok := err.(NoConfigsFoundError); len(files) != 0 && ok {
+			// Config lists found but no config files found
+			return nil, NotFoundError{dir, name}
+		}
+
+		return nil, err
+	}
+	return ConfListFromConf(singleConf)
+}
+
+func InjectConf(original *NetworkConfig, newValues map[string]interface{}) (*NetworkConfig, error) {
+	config := make(map[string]interface{})
+	err := json.Unmarshal(original.Bytes, &config)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal existing network bytes: %w", err)
+	}
+
+	for key, value := range newValues {
+		if key == "" {
+			return nil, fmt.Errorf("keys cannot be empty")
+		}
+
+		if value == nil {
+			return nil, fmt.Errorf("key '%s' value must not be nil", key)
+		}
+
+		config[key] = value
+	}
+
+	newBytes, err := json.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return ConfFromBytes(newBytes)
+}
+
+// ConfListFromConf "upconverts" a network config in to a NetworkConfigList,
+// with the single network as the only entry in the list.
+func ConfListFromConf(original *NetworkConfig) (*NetworkConfigList, error) {
+	// Re-deserialize the config's json, then make a raw map configlist.
+	// This may seem a bit strange, but it's to make the Bytes fields
+	// actually make sense. Otherwise, the generated json is littered with
+	// golang default values.
+
+	rawConfig := make(map[string]interface{})
+	if err := json.Unmarshal(original.Bytes, &rawConfig); err != nil {
+		return nil, err
+	}
+
+	rawConfigList := map[string]interface{}{
+		"name":       original.Network.Name,
+		"cniVersion": original.Network.CNIVersion,
+		"plugins":    []interface{}{rawConfig},
+	}
+
+	b, err := json.Marshal(rawConfigList)
+	if err != nil {
+		return nil, err
+	}
+	return ConfListFromBytes(b)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -259,6 +259,7 @@ github.com/cncf/xds/go/xds/core/v3
 github.com/cncf/xds/go/xds/type/matcher/v3
 # github.com/containernetworking/cni v1.1.2
 ## explicit; go 1.14
+github.com/containernetworking/cni/libcni
 github.com/containernetworking/cni/pkg/invoke
 github.com/containernetworking/cni/pkg/skel
 github.com/containernetworking/cni/pkg/types


### PR DESCRIPTION
<!-- Description of change -->
1. If CILIUM_CUSTOM_CNI_CONF = true, cni_install.sh will not generate the 05-cilium.conf. but cilium-agent will skip writing the ReadCNIConfiguration into WriteCNIConfigurationWhenReady, too.  We hope that cni_install.sh skips generating the file 05-cilium.conf but cilium-agent can write the ReadCNIConfiguration into WriteCNIConfigurationWhenReady ( In the previous version, cilium-agent will write the ReadCNIConfiguration when CILIUM_CUSTOM_CNI_CONF is true). here we change the logic, if opts.ReadCNIConfiguration is not empty, cilium-agent will generate the CNI conf.
```
if os.Getenv("CILIUM_CUSTOM_CNI_CONF") == "true" && opts.ReadCNIConfiguration == "" {
		return
	}
```

3. We have two our own CNI plugins, `tnet.conf yyy-istio.conf`.  They are managed by their applications. We hope cilium-agent can append ReadCNIConfiguration (the cilium CNI conf) into `tnet.conf` because it depends on tnet.conf.  

- ReadCNIConfiguration is not empty (`tnet.conflist`) ---> WriteCNIConfigurationChainingMode = false ---> write ReadCNIConfiguration directly into WriteCNIConfigurationWhenReady (`net.conflist`)
- ReadCNIConfiguration (`origin.conf`) is not empty ---> WriteCNIConfigurationChainingMode = true ---> DefaultCNIConfiguration (`tnet.conf`)  is not empty and DefaultCNIConfiguration exists --> Insert ReadCNIConfiguration (`origin.conf`)  into DefaultCNIConfiguration (`tnet.conf`) and write it into WriteCNIConfigurationWhenReady (`tnet.conflist`)  --> final files under /etc/cni/net.d: `tnet.conflist tnet.conf.cilium_bak yyy-istio.conf`
    
- ReadCNIConfiguration (`origin.conf`) is not empty ---> WriteCNIConfigurationChainingMode = true ---> DefaultCNIConfiguration is not empty but it doesn't exist ---> WriteCNIConfigurationWhenReady (`tnet.conflist`) exists --> Insert ReadCNIConfiguration (`origin.conf`)  into WriteCNIConfigurationWhenReady  (`tnet.conflist`)  (this is to silution cilium-agent restarting) --->   final files under /etc/cni/net.d: `tnet.conflist tnet.conf.cilium_bak yyy-istio.conf`
- ReadCNIConfiguration  (`origin.conf`) is not empty ---> WriteCNIConfigurationChainingMode = true ---> DefaultCNIConfiguration is empty ---> WriteCNIConfigurationWhenReady (`tnet.conflist`)doesn't exist --> Read the default CNI plugin (`tnet.conf `because it is before `yyy-istio.conf` after sorting by name ) --->  Insert ReadCNIConfiguration (`origin.conf`) into the default CNI plugin `tnet.conf ` and write it into WriteCNIConfigurationWhenReady (`tnet.conflist`) --->   final files under /etc/cni/net.d: `tnet.conflist tnet.conf.cilium_bak yyy-istio.conf`



```release-note
allow appending ReadCNIConfiguration into the default CNI plugins
```


