### PR TITLE
workflows: aks: bump timeout to 60m

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -120,7 +120,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -120,7 +120,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -120,7 +120,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -123,7 +123,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
Some test runs are timing out as each of the 2 connectivity test runs takes about 18/19 minutes. So bump the timeout to 1 hour.