### PR TITLE
fix:prevent goroutine leakage for pkg/k8s/watchers

### DIFF
--- a/pkg/k8s/watchers/cilium_clusterwide_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_envoy_config.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func (k *K8sWatcher) ciliumClusterwideEnvoyConfigInit(clientset client.Clientset) {
+func (k *K8sWatcher) ciliumClusterwideEnvoyConfigInit(ctx context.Context, clientset client.Clientset) {
 	apiGroup := k8sAPIGroupCiliumClusterwideEnvoyConfigV2
 	_, ccecController := informer.NewInformer(
 		utils.ListerWatcherFromTyped[*cilium_v2.CiliumClusterwideEnvoyConfigList](k.clientset.CiliumV2().CiliumClusterwideEnvoyConfigs()),
@@ -76,7 +76,7 @@ func (k *K8sWatcher) ciliumClusterwideEnvoyConfigInit(clientset client.Clientset
 		apiGroup,
 	)
 
-	go ccecController.Run(wait.NeverStop)
+	go ccecController.Run(ctx.Done())
 	k.k8sAPIGroups.AddAPI(apiGroup)
 }
 

--- a/pkg/k8s/watchers/cilium_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_envoy_config.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func (k *K8sWatcher) ciliumEnvoyConfigInit(ciliumNPClient client.Clientset) {
+func (k *K8sWatcher) ciliumEnvoyConfigInit(ctx context.Context, ciliumNPClient client.Clientset) {
 	apiGroup := k8sAPIGroupCiliumEnvoyConfigV2
 	_, cecController := informer.NewInformer(
 		cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
@@ -79,7 +79,7 @@ func (k *K8sWatcher) ciliumEnvoyConfigInit(ciliumNPClient client.Clientset) {
 		k8sAPIGroupCiliumEnvoyConfigV2,
 	)
 
-	go cecController.Run(wait.NeverStop)
+	go cecController.Run(ctx.Done())
 	k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumEnvoyConfigV2)
 }
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -578,9 +578,9 @@ func (k *K8sWatcher) enableK8sWatchers(ctx context.Context, resourceNames []stri
 		case k8sAPIGroupCiliumEgressGatewayPolicyV2:
 			k.ciliumEgressGatewayPolicyInit(k.clientset)
 		case k8sAPIGroupCiliumClusterwideEnvoyConfigV2:
-			k.ciliumClusterwideEnvoyConfigInit(k.clientset)
+			k.ciliumClusterwideEnvoyConfigInit(ctx, k.clientset)
 		case k8sAPIGroupCiliumEnvoyConfigV2:
-			k.ciliumEnvoyConfigInit(k.clientset)
+			k.ciliumEnvoyConfigInit(ctx, k.clientset)
 		default:
 			log.WithFields(logrus.Fields{
 				logfields.Resource: r,


### PR DESCRIPTION
Use the ctx passed to ciliumClusterwideEnvoyConfigInit instead of wait.NeverStop.
reference https://github.com/cilium/cilium/pull/21913

@tommyp1ckles @aanm @joamaki 