### PR TITLE
test: Move log-gatherer image to Quay

### DIFF
--- a/test/k8s/manifests/log-gatherer.yaml
+++ b/test/k8s/manifests/log-gatherer.yaml
@@ -28,7 +28,7 @@ spec:
         - "10000"
         command:
         - sleep
-        image: docker.io/cilium/log-gatherer:v1.1
+        image: quay.io/cilium/log-gatherer:v1.1
         imagePullPolicy: IfNotPresent
         name: log-gatherer
         securityContext:


### PR DESCRIPTION
[Some CI jobs](https://jenkins.cilium.io/job/Cilium-PR-K8s-1.24-kernel-4.19/911/testReport/junit/Suite-k8s-1/24/K8sKafkaPolicyTest_Kafka_Policy_Tests_KafkaPolicies/) are failing because we are getting rate-limited on docker.io for the log-gatherer image. André copied it to Quay and we can now use that instead of docker.io.