### PR TITLE
workflows: re-enable eks ipsec tests (DON'T MERGE)

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -280,40 +280,33 @@ jobs:
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
 
-      # EKS testing with encryption is disabled due to https://github.com/cilium/cilium/issues/16938
       - name: Clean up Cilium
-        if: ${{ false }} # see comment above for details
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Create custom IPsec secret
-        if: ${{ false }} # see comment above for details
         run: |
           kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
       - name: Install Cilium with encryption
-        if: ${{ false }} # see comment above for details
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
             --encryption=ipsec
 
       - name: Enable Relay
-        if: ${{ false }} # see comment above for details
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
           # NB: necessary to work against occassional flakes due to https://github.com/cilium/cilium-cli/issues/918
           cilium status --wait
 
       - name: Port forward Relay
-        if: ${{ false }} # see comment above for details
         run: |
           cilium hubble port-forward&
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
-        if: ${{ false }} # see comment above for details
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --force-deploy --test '!client-egress-l7,!echo-ingress-l7'

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -168,7 +168,7 @@ jobs:
           HUBBLE_ENABLE_DEFAULTS="--chart-directory=install/kubernetes/cilium \
             --relay-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci:${SHA} \
             --relay-version=${SHA}"
-          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --test '!/pod-to-world,!/pod-to-cidr'"
+          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --debug --timestamp --collect-sysdump-on-failure"
           echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
           echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
           echo ::set-output name=connectivity_test_defaults::${CONNECTIVITY_TEST_DEFAULTS}
@@ -332,8 +332,8 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
-          name: cilium-sysdump-out.zip
-          path: cilium-sysdump-out.zip
+          name: cilium-sysdumps
+          path: cilium-sysdump-*.zip
           retention-days: 5
 
       - name: Set commit status to success

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -398,6 +398,7 @@ func (n *linuxNodeHandler) updateNodeRoute(prefix *cidr.CIDR, addressFamilyEnabl
 
 	nodeRoute, err := n.createNodeRouteSpec(prefix, isLocalNode)
 	if err != nil {
+		log.WithError(err).WithFields(nodeRoute.LogFields()).Warning("Unable to create node route spec for route update")
 		return err
 	}
 	if err := route.Upsert(nodeRoute); err != nil {

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -234,6 +234,8 @@ func deleteNexthopRoute(route Route, link netlink.Link, routerNet *net.IPNet) er
 func Upsert(route Route) error {
 	var nexthopRouteCreated bool
 
+	log.WithFields(route.LogFields()).Infof("Upsert route")
+
 	link, err := netlink.LinkByName(route.Device)
 	if err != nil {
 		return fmt.Errorf("unable to lookup interface %s: %s", route.Device, err)

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"runtime/debug"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -74,6 +75,11 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool) error {
 		egressPriority = linux_defaults.RulePriorityEgressv2
 		tableID = computeTableIDFromIfaceNumber(info.InterfaceNumber)
 	}
+	log.WithFields(logrus.Fields{
+		"endpointIP": ip,
+	}).Infof("dbg rule tableID %v egressPrio %v", tableID, egressPriority)
+
+	debug.PrintStack()
 
 	// The condition here should mirror the condition in Delete.
 	if info.Masquerade && info.IpamMode == ipamOption.IPAMENI {

--- a/vendor/github.com/vishvananda/netlink/route_linux.go
+++ b/vendor/github.com/vishvananda/netlink/route_linux.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"log"
 	"net"
 	"strconv"
 	"strings"
 	"syscall"
-
+	"runtime/debug"
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
@@ -702,6 +703,8 @@ func (h *Handle) RouteReplace(route *Route) error {
 // RouteDel will delete a route from the system.
 // Equivalent to: `ip route del $route`
 func RouteDel(route *Route) error {
+	log.Printf("deleting %v %v if %v table %v\n", route.Src, route.Gw, route.LinkIndex, route.Table)
+        debug.PrintStack()
 	return pkgHandle.RouteDel(route)
 }
 


### PR DESCRIPTION
Sending the pr in an attempt to reproduce the EKS IPSec issues and gather new logs or to re-enable if all runs prove
successful.