### PR TITLE
Add CNPs stale node updates GC controlplane test

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -62,8 +62,6 @@ var (
 		Short: "Run " + binaryName,
 	}
 
-	shutdownSignal = make(chan struct{})
-
 	leaderElectionResourceLockName = "cilium-operator-resource-lock"
 
 	// Use a Go context so we can tell the leaderelection code when we
@@ -117,10 +115,11 @@ func Execute() {
 }
 
 func registerOperatorHooks(lc hive.Lifecycle, llc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner) {
+	apiServerShutdownSignal := make(chan struct{})
 
 	lc.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {
-			go runOperator(llc, clientset, shutdowner)
+			go runOperator(llc, clientset, shutdowner, apiServerShutdownSignal)
 			return nil
 		},
 		OnStop: func(ctx hive.HookContext) error {
@@ -128,6 +127,7 @@ func registerOperatorHooks(lc hive.Lifecycle, llc *LeaderLifecycle, clientset k8
 				return err
 			}
 			doCleanup()
+			close(apiServerShutdownSignal)
 			return nil
 		},
 	})
@@ -186,7 +186,6 @@ func initEnv() {
 
 func doCleanup() {
 	IsLeader.Store(false)
-	close(shutdownSignal)
 
 	// Cancelling this conext here makes sure that if the operator hold the
 	// leader lease, it will be released.
@@ -228,14 +227,14 @@ func checkStatus(clientset k8sClient.Clientset) error {
 // runOperator implements the logic of leader election for cilium-operator using
 // built-in leader election capbility in kubernetes.
 // See: https://github.com/kubernetes/client-go/blob/master/examples/leader-election/main.go
-func runOperator(lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner) {
+func runOperator(lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner, apiServerShutdownSignal chan struct{}) {
 	log.Infof("Cilium Operator %s", version.Version)
 
 	allSystemsGo := make(chan struct{})
 	IsLeader.Store(false)
 
 	// Configure API server for the operator.
-	srv, err := api.NewServer(shutdownSignal, allSystemsGo, getAPIServerAddr()...)
+	srv, err := api.NewServer(apiServerShutdownSignal, allSystemsGo, getAPIServerAddr()...)
 	if err != nil {
 		log.WithError(err).Fatalf("Unable to create operator apiserver")
 	}

--- a/test/controlplane/ciliumnetworkpolicies/status_updates_gc.go
+++ b/test/controlplane/ciliumnetworkpolicies/status_updates_gc.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumnetworkpolicies
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/cidr"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/test/controlplane"
+	"github.com/cilium/cilium/test/controlplane/suite"
+)
+
+var (
+	initialObjects = []k8sRuntime.Object{
+		&corev1.Node{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Node",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "cnp-status-update-control-plane",
+				Labels: map[string]string{"kubernetes.io/hostname": "cnp-status-update-control-plane"},
+			},
+			Spec: corev1.NodeSpec{
+				PodCIDR:  cidr.MustParseCIDR("10.244.0.0/24").String(),
+				PodCIDRs: []string{cidr.MustParseCIDR("10.244.0.0/24").String()},
+				Taints: []corev1.Taint{
+					{Effect: corev1.TaintEffectNoSchedule, Key: "node-role.kubernetes.io/control-plane"},
+				},
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{},
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "172.18.0.3"},
+					{Type: corev1.NodeHostName, Address: "cnp-status-update-control-plane"},
+				},
+			},
+		},
+		&corev1.Node{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Node",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "cnp-status-update-worker",
+				Labels: map[string]string{"kubernetes.io/hostname": "cnp-status-update-worker"},
+			},
+			Spec: corev1.NodeSpec{
+				PodCIDR:  cidr.MustParseCIDR("10.244.1.0/24").String(),
+				PodCIDRs: []string{cidr.MustParseCIDR("10.244.1.0/24").String()},
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{},
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "172.18.0.2"},
+					{Type: corev1.NodeHostName, Address: "cnp-status-update-worker"},
+				},
+			},
+		},
+	}
+
+	dummyCNP = &v2.CiliumNetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cilium.io/v2",
+			Kind:       "CiliumNetworkPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cnp-status-update-policy",
+			Namespace: "cnp-status-update-namespace",
+			UID:       k8sTypes.UID("39668ba4-eb30-4e35-baa0-4db34aa639ad"),
+		},
+		Spec: &api.Rule{
+			EndpointSelector: api.EndpointSelector{
+				LabelSelector: &v1.LabelSelector{
+					MatchLabels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		Status: v2.CiliumNetworkPolicyStatus{
+			Nodes: map[string]v2.CiliumNetworkPolicyNodeStatus{
+				"cnp-status-update-control-plane": {
+					Enforcing:   true,
+					LastUpdated: v1.Time{Time: time.Now()},
+					Revision:    2,
+					OK:          true,
+				},
+				"cnp-status-update-worker": {
+					Enforcing:   true,
+					LastUpdated: v1.Time{Time: time.Now()},
+					Revision:    2,
+					OK:          true,
+				},
+			},
+		},
+	}
+
+	dummyCCNP = &v2.CiliumClusterwideNetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cilium.io/v2",
+			Kind:       "CiliumClusterwideNetworkPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cnp-status-update-policy",
+			UID:  k8sTypes.UID("39668ba4-eb30-4e35-baa0-4db34aa639ad"),
+		},
+		Spec: &api.Rule{
+			EndpointSelector: api.EndpointSelector{
+				LabelSelector: &v1.LabelSelector{
+					MatchLabels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		Status: v2.CiliumNetworkPolicyStatus{
+			Nodes: map[string]v2.CiliumNetworkPolicyNodeStatus{
+				"cnp-status-update-control-plane": {
+					Enforcing:   true,
+					LastUpdated: v1.Time{Time: time.Now()},
+					Revision:    2,
+					OK:          true,
+				},
+				"cnp-status-update-worker": {
+					Enforcing:   true,
+					LastUpdated: v1.Time{Time: time.Now()},
+					Revision:    2,
+					OK:          true,
+				},
+			},
+		},
+	}
+)
+
+func getDummyCNP(test *suite.ControlPlaneTest) (*v2.CiliumNetworkPolicy, error) {
+	cnpObj, err := test.Get(
+		schema.GroupVersionResource{Group: "cilium.io", Version: "v2", Resource: "ciliumnetworkpolicies"},
+		dummyCNP.Namespace,
+		dummyCNP.Name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find CiliumNetworkPolicy %s/%s: %w", dummyCNP.Namespace, dummyCNP.Name, err)
+	}
+
+	cnp, ok := cnpObj.(*v2.CiliumNetworkPolicy)
+	if !ok {
+		return nil, errors.New("type assertion failed for CNP obj")
+	}
+
+	return cnp, nil
+}
+
+func getDummyCCNP(test *suite.ControlPlaneTest) (*v2.CiliumClusterwideNetworkPolicy, error) {
+	ccnpObj, err := test.Get(
+		schema.GroupVersionResource{Group: "cilium.io", Version: "v2", Resource: "ciliumclusterwidenetworkpolicies"},
+		"",
+		dummyCCNP.Name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find CiliumClusterwideNetworkPolicy %s: %w", dummyCCNP.Name, err)
+	}
+
+	ccnp, ok := ccnpObj.(*v2.CiliumClusterwideNetworkPolicy)
+	if !ok {
+		return nil, errors.New("type assertion failed for CCNP obj")
+	}
+
+	return ccnp, nil
+}
+
+func validateCNPs(test *suite.ControlPlaneTest) error {
+	cnp, err := getDummyCNP(test)
+	if err != nil {
+		return err
+	}
+	if len(cnp.Status.Nodes) != len(dummyCNP.Status.Nodes) {
+		return fmt.Errorf("number of updates in CNP Status Nodes should be: %d, found: %d", len(dummyCNP.Status.Nodes), len(cnp.Status.Nodes))
+	}
+
+	ccnp, err := getDummyCCNP(test)
+	if err != nil {
+		return err
+	}
+	if len(ccnp.Status.Nodes) != len(dummyCCNP.Status.Nodes) {
+		return fmt.Errorf("number of updates in CCNP Status Nodes should be: %d, found: %d", len(dummyCCNP.Status.Nodes), len(ccnp.Status.Nodes))
+	}
+
+	return nil
+}
+
+func applyDummyCNPs(test *suite.ControlPlaneTest) error {
+	test.UpdateObjects(dummyCNP)
+	test.UpdateObjects(dummyCCNP)
+
+	// validate CNPs before starting the controlplane test,
+	// to be sure that they have been correctly stored.
+	return validateCNPs(test)
+}
+
+func validateCNPsAfterGC(test *suite.ControlPlaneTest) error {
+	cnp, err := getDummyCNP(test)
+	if err != nil {
+		return err
+	}
+	if len(cnp.Status.Nodes) != 0 {
+		return fmt.Errorf(
+			"unexpected updates in CiliumNetworkPolicy %s/%s Status Nodes found after GC: %v",
+			dummyCNP.Namespace,
+			dummyCNP.Name,
+			cnp.Status.Nodes,
+		)
+	}
+
+	ccnp, err := getDummyCCNP(test)
+	if err != nil {
+		return err
+	}
+	if len(ccnp.Status.Nodes) != 0 {
+		return fmt.Errorf(
+			"unexpected updates in CiliumClusterwideNetworkPolicy %s Status Nodes found after GC: %v",
+			dummyCCNP.Name,
+			cnp.Status.Nodes,
+		)
+	}
+
+	return nil
+}
+
+func init() {
+	suite.AddTestCase("CNPStatusNodesGC", func(t *testing.T) {
+		k8sVersions := controlplane.K8sVersions()
+		// We only need to test the last k8s version
+		test := suite.NewControlPlaneTest(t, "cnp-status-update-control-plane", k8sVersions[len(k8sVersions)-1])
+
+		// When running with GC disabled, the Nodes Status updates should not be deleted.
+		test.
+			UpdateObjects(initialObjects...).
+			SetupEnvironment(func(_ *option.DaemonConfig, operatorCfg *operatorOption.OperatorConfig) {
+				operatorCfg.SkipCNPStatusStartupClean = true
+			}).
+			StartAgent().
+			StartOperator().
+			Execute(func() error { return applyDummyCNPs(test) }).
+			Eventually(func() error { return validateCNPs(test) })
+
+		test.StopAgent()
+		test.StopOperator()
+		test.DeleteObjects()
+
+		// When running with GC enabled, the Nodes Status updates should eventually be deleted.
+		test.
+			UpdateObjects(initialObjects...).
+			SetupEnvironment(func(_ *option.DaemonConfig, operatorCfg *operatorOption.OperatorConfig) {
+				operatorCfg.SkipCNPStatusStartupClean = false
+			}).
+			StartAgent().
+			StartOperator().
+			Execute(func() error { return applyDummyCNPs(test) }).
+			Eventually(func() error { return validateCNPsAfterGC(test) })
+
+		test.StopAgent()
+		test.StopOperator()
+	})
+}

--- a/test/controlplane/controlplane_test.go
+++ b/test/controlplane/controlplane_test.go
@@ -6,6 +6,7 @@ package controlplane_test
 import (
 	"testing"
 
+	_ "github.com/cilium/cilium/test/controlplane/ciliumnetworkpolicies"
 	_ "github.com/cilium/cilium/test/controlplane/identities"
 	_ "github.com/cilium/cilium/test/controlplane/node"
 	_ "github.com/cilium/cilium/test/controlplane/node/ciliumnodes"


### PR DESCRIPTION
Add a controlplane unit test to verify that the stale policy enforcement updates are cleared from the Status section of CNPs and CCNPs when the option `skip-cnp-status-startup-cleaning` is set to `false` (and thus the GC is enabled).

Also, to enable controlplane unit tests as this one, a small change has been done in the operator initialization, in order to avoid panicking when starting it multiple times in controlplane tests. See the commit message for more details.

Relates: https://github.com/cilium/cilium/pull/20366
