### PR TITLE
Bugtool: add flag to exclude object for endpoints

### DIFF
--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -75,6 +75,7 @@ var (
 	traceSeconds             int
 	parallelWorkers          int
 	ciliumAgentContainerName string
+	excludeObjectFiles       bool
 )
 
 func init() {
@@ -102,6 +103,7 @@ func init() {
 	BugtoolRootCmd.Flags().StringVarP(&archivePrefix, "archive-prefix", "", "", "String to prefix to name of archive if created (e.g., with cilium pod-name)")
 	BugtoolRootCmd.Flags().IntVar(&parallelWorkers, "parallel-workers", 0, "Maximum number of parallel worker tasks, use 0 for number of CPUs")
 	BugtoolRootCmd.Flags().StringVarP(&ciliumAgentContainerName, "cilium-agent-container-name", "", "cilium-agent", "Name of the Cilium Agent main container (when k8s-mode is true)")
+	BugtoolRootCmd.Flags().BoolVar(&excludeObjectFiles, "exclude-object-files", false, "Exclude per-endpoint object files. Template object files will be kept")
 }
 
 func getVerifyCiliumPods() (k8sPods []string) {
@@ -225,6 +227,10 @@ func runTool() {
 		defer printDisclaimer()
 
 		runAll(commands, cmdDir, k8sPods)
+
+		if excludeObjectFiles {
+			removeObjectFiles(cmdDir, k8sPods)
+		}
 	}
 
 	removeIfEmpty(cmdDir)
@@ -344,6 +350,33 @@ func runAll(commands []string, cmdDir string, k8sPods []string) {
 	err = wp.Close()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to close worker pool: %v\n", err)
+	}
+}
+
+func removeObjectFiles(cmdDir string, k8sPods []string) {
+	// Remove object files for each endpoint. Endpoints directories are in the
+	// state directory and have numerical names.
+	rmFunc := func(path string) {
+		matches, err := filepath.Glob(filepath.Join(path, "[0-9]*", "*.o"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to exclude object files: %s\n", err)
+		}
+		for _, m := range matches {
+			err = os.Remove(m)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to remove object file: %s\n", err)
+			}
+		}
+	}
+
+	if k8s {
+		for _, pod := range k8sPods {
+			path := filepath.Join(cmdDir, fmt.Sprintf("%s-%s", pod, defaults.StateDir))
+			rmFunc(path)
+		}
+	} else {
+		path := filepath.Join(cmdDir, defaults.StateDir)
+		rmFunc(path)
 	}
 }
 


### PR DESCRIPTION
- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

Add a `--exclude-object-files` flag to bugtool to exclude endpoint object files from the dump.

Fixes: #20450

To test the fix locally, assuming you have a k8s cluster configured, clone this branch and:
```
cd cilium/bugtool
make
./cilium-bugtool --k8s-mode --exclude-object-files
```
then inspect the archive, `*.o` files should still be in the dump, except for endpoints.
