### PR TITLE
.github: pin alpine versions to 3.16 in stable branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -87,6 +87,17 @@
       "matchBaseBranches": [
         "v1.10"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/alpine"
+      ],
+      "allowedVersions": "3.16",
+      "matchBaseBranches": [
+        "v1.12",
+        "v1.11",
+        "v1.10"
+      ]
     }
   ]
 }


### PR DESCRIPTION
We don't need to update alpine docker images in stable versions so we should keep with the 3.16 version.

Signed-off-by: André Martins <andre@cilium.io>