### PR TITLE
delete redundant type conversion

### DIFF
--- a/pkg/mac/mac.go
+++ b/pkg/mac/mac.go
@@ -113,7 +113,7 @@ func GenerateRandMAC() (MAC, error) {
 	// Set locally administered addresses bit and reset multicast bit
 	buf[0] = (buf[0] | 0x02) & 0xfe
 
-	return MAC(buf), nil
+	return buf, nil
 }
 
 // HaveMACAddrs returns true if all given network interfaces have L2 addr.


### PR DESCRIPTION
Signed-off-by: tanberBro <pengfei.song@daocloud.io>

buf does not need to be forced to MAC type, redundant type conversion


