### PR TITLE
ingestion/gateway-api: Map backend weight to model

### DIFF
--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -201,6 +201,7 @@ func toBackend(be gatewayv1beta1.HTTPBackendRef, defaultNamespace string) model.
 		Name:      string(be.Name),
 		Namespace: ns,
 		Port:      port,
+		Weight:    be.Weight,
 	}
 }
 


### PR DESCRIPTION
### Description

This commit is to make sure the weightage value is propagated to internal model.

Relates: 58c8aff11062f944e9f3a18569c647c64edd1bc9

Reported-by: Nico Vibert <nicolas.vibert@isovalent.com>
Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

Verification is done by checking envoy config dump, then run-time behavior is confirmed.

<details>
<summary>HTTP route config </summary>

```yaml
---
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: example-route-1
spec:
  parentRefs:
  - name: my-example-gateway
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /echo
    backendRefs:
    - kind: Service
      name: echo-1
      port: 8080
      weight: 100
    - kind: Service
      name: echo-2
      port: 8090
      weight: 0

```

</details>

<details>
<summary>Envoy Config dump</summary>

```
# Before (weight values are always 1)
"route": {
 "weighted_clusters": {
  "clusters": [
   {
    "name": "default/echo-1:8080",
    "weight": 1
   },
   {
    "name": "default/echo-2:8090",
    "weight": 1
   }
  ],
  "total_weight": 2
 },
           
# After
"route": {
 "weighted_clusters": {
  "clusters": [
   {
    "name": "default/echo-1:8080",
    "weight": 100
   },
   {
    "name": "default/echo-2:8090",
    "weight": 0
   }
  ],
  "total_weight": 100
 },        
```

</details>


<details>
<summary>Runtime behavior</summary>

```
$ curl -s http://$lb/echo | grep "Hostname: echo-"
Hostname: echo-1-7b499f4578-7j9dr

...
$ curl -s http://$lb/echo | grep "Hostname: echo-"
Hostname: echo-1-7b499f4578-7j9dr

```

</details>