### PR TITLE
fix:remove ioutil to accomodate newer Go versions

### DIFF
--- a/daemon/cmd/map_test.go
+++ b/daemon/cmd/map_test.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -73,7 +72,7 @@ func Test_getMapNameEvents(t *testing.T) {
 	}
 	fp := &fakeProducer{}
 	resp.WriteResponse(mw, fp)
-	d, err := ioutil.ReadAll(w.Body)
+	d, err := io.ReadAll(w.Body)
 	assert.NoError(err)
 	assert.Equal(`{"action":"update","desired-action":"sync","key":"\u003cnil\u003e","last-error":"\u003cnil\u003e","timestamp":"2006-01-02T15:04:05.000Z","value":"\u003cnil\u003e"}`+"\n", string(d))
 }


### PR DESCRIPTION
 Remove ioutil for accomodate newer Go versions
We should clean all io/util package according the url: **https://go.dev/doc/go1.16#ioutil**
