### PR TITLE
bpf/tests: fix redundant usage of variable offset

### DIFF
--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -91,7 +91,7 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 
 	{
 		unsigned int data_len = ctx->data_end - ctx->data;
-		int offset = offset = pkt_size - 256 - 320 - data_len;
+		int offset = pkt_size - 256 - 320 - data_len;
 
 		ctx_adjust_troom(ctx, offset);
 


### PR DESCRIPTION
Fix typo when initializing offset