### PR TITLE
k8s: don't consider 4xx a successful interaction

### DIFF
--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -337,9 +337,8 @@ func (*k8sMetrics) Increment(_ context.Context, code string, method string, host
 	// more info:
 	// https://github.com/kubernetes/client-go/blob/v0.18.0-rc.1/rest/request.go#L700-L703
 	if code != "<error>" {
-		// Consider success if status code is 2xx or 4xx
-		if strings.HasPrefix(code, "2") ||
-			strings.HasPrefix(code, "4") {
+		// Consider success only if status code is 2xx
+		if strings.HasPrefix(code, "2") {
 			k8smetrics.LastSuccessInteraction.Reset()
 		}
 	}


### PR DESCRIPTION
While a 404 Not Found or a 409 Conflict can be considered successful interactions with the k8s API, a blanket accept for all 4xx codes is problematic. Since LastSuccessInteraction is exclusively used as an optimisation, we should err on the cautious side: accept the potential increase in heartbeats to avoid missing being unable to effecticely communicate with the k8s API.

As an example of how this can go wrong, in #20915 we have an issue around receiving 401 Unauthorized from the EKS control plane. At sufficient scale, we never see a need to run the heartbeat. Running the heartbeat, however, would close and reopen the connections on receiving a 401, and thus restore connectivity to the k8s API.

We currently only use the LastSuccessInteraction to as an optimisation to not perform unnecessary k8s API heartbeats, this "metric" (possibly a misnomer) is not used or exposed and changing its semantics is acceptable.

Signed-off-by: David Bimmler <david.bimmler@isovalent.com>

cc @aanm for insight, @gandro for visibility