### PR TITLE
untangle bpf_host

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -239,13 +239,13 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx, const bool from_host)
 	}
 #endif /* ENABLE_HOST_FIREWALL */
 
+skip_host_firewall:
 #if defined(NO_REDIRECT) && !defined(ENABLE_HOST_ROUTING)
 	/* See IPv4 case for NO_REDIRECT/ENABLE_HOST_ROUTING comments */
 	if (!from_host)
 		return CTX_ACT_OK;
 #endif /* NO_REDIRECT && !ENABLE_HOST_ROUTING */
 
-skip_host_firewall:
 #ifdef ENABLE_SRV6
 	if (!from_host) {
 		if (is_srv6_packet(ip6) && srv6_lookup_sid(&ip6->daddr)) {

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1003,7 +1003,7 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 		int ret = DROP_UNSUPPORTED_L2;
 
 		return send_drop_notify(ctx, SECLABEL, WORLD_ID, 0, ret,
-					CTX_ACT_DROP, METRIC_EGRESS);
+					CTX_ACT_DROP, METRIC_INGRESS);
 #else
 		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, 0, 0, 0,
 				  TRACE_REASON_UNKNOWN, 0);

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -767,7 +767,7 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx,
 
 	ret = do_netdev_encrypt_pools(ctx);
 	if (ret)
-		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP, METRIC_INGRESS);
+		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP, METRIC_EGRESS);
 
 	return CTX_ACT_OK;
 }


### PR DESCRIPTION
The shared code for from-host / from-netdev paths makes it unnecessarily difficult to follow along. And actually only very little of the code is shared. Split it up to make things easier.

Probably easiest to review patch-by-patch.

There's more metrics with questionable direction in these paths. But this is a start.

```release-note
bpf: split up from-host / from-netdev paths in bpf_host
```