### PR TITLE
Policy: Add TLS SNI support

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:1a8102930aa1ec5d82312abc9
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:bdb324791884636aea84b789466c3a538b1d4970@sha256:ab9cc7e4b986a1669482b7713645b60de1cc0f38c045959fb6be2ef6865a41da as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:7c5c1c44c8e8c3c264326f891bb8bdc8a7fc7de2@sha256:bef1e1ac2eaf09c8ae7fd1bc47e52a11fdf8cce6653ff22faee3a3d498d3d523 as cilium-envoy
 
 #
 # Hubble CLI

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1332,6 +1332,13 @@ func getPortNetworkPolicyRule(sel policy.CachedSelector, wildcard bool, l7Parser
 	if l7Rules.OriginatingTLS != nil {
 		r.UpstreamTlsContext = getCiliumTLSContext(l7Rules.OriginatingTLS)
 	}
+	if len(l7Rules.ServerNames) > 0 {
+		r.ServerNames = make([]string, 0, len(l7Rules.ServerNames))
+		for sni := range l7Rules.ServerNames {
+			r.ServerNames = append(r.ServerNames, sni)
+		}
+		sort.Strings(r.ServerNames)
+	}
 
 	// Assume none of the rules have side-effects so that rule evaluation can
 	// be stopped as soon as the first allowing rule is found. 'canShortCircuit'
@@ -1532,7 +1539,7 @@ func getDirectionNetworkPolicy(ep logger.EndpointUpdater, l4Policy policy.L4Poli
 					if !cs {
 						canShortCircuit = false
 					}
-					if len(rule.RemotePolicies) == 0 && rule.L7 == nil && rule.DownstreamTlsContext == nil && rule.UpstreamTlsContext == nil {
+					if len(rule.RemotePolicies) == 0 && rule.L7 == nil && rule.DownstreamTlsContext == nil && rule.UpstreamTlsContext == nil && len(rule.ServerNames) == 0 {
 						// Got an allow-all rule, which can short-circuit all of
 						// the other rules.
 						allowAll = true

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -669,6 +669,13 @@ spec:
                                   Key-value pair rules apply.
                                 type: string
                             type: object
+                          serverNames:
+                            description: ServerNames is a list of allowed TLS SNI
+                              values. If not empty, then TLS must be present and one
+                              of the provided SNIs must be indicated in the TLS handshake.
+                            items:
+                              type: string
+                            type: array
                           terminatingTLS:
                             description: TerminatingTLS is the TLS context for the
                               connection terminated by the L7 proxy.  For egress policy
@@ -1945,6 +1952,13 @@ spec:
                                   Key-value pair rules apply.
                                 type: string
                             type: object
+                          serverNames:
+                            description: ServerNames is a list of allowed TLS SNI
+                              values. If not empty, then TLS must be present and one
+                              of the provided SNIs must be indicated in the TLS handshake.
+                            items:
+                              type: string
+                            type: array
                           terminatingTLS:
                             description: TerminatingTLS is the TLS context for the
                               connection terminated by the L7 proxy.  For egress policy
@@ -3032,6 +3046,14 @@ spec:
                                     Key-value pair rules apply.
                                   type: string
                               type: object
+                            serverNames:
+                              description: ServerNames is a list of allowed TLS SNI
+                                values. If not empty, then TLS must be present and
+                                one of the provided SNIs must be indicated in the
+                                TLS handshake.
+                              items:
+                                type: string
+                              type: array
                             terminatingTLS:
                               description: TerminatingTLS is the TLS context for the
                                 connection terminated by the L7 proxy.  For egress
@@ -4327,6 +4349,14 @@ spec:
                                     Key-value pair rules apply.
                                   type: string
                               type: object
+                            serverNames:
+                              description: ServerNames is a list of allowed TLS SNI
+                                values. If not empty, then TLS must be present and
+                                one of the provided SNIs must be indicated in the
+                                TLS handshake.
+                              items:
+                                type: string
+                              type: array
                             terminatingTLS:
                               description: TerminatingTLS is the TLS context for the
                                 connection terminated by the L7 proxy.  For egress

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -673,6 +673,13 @@ spec:
                                   Key-value pair rules apply.
                                 type: string
                             type: object
+                          serverNames:
+                            description: ServerNames is a list of allowed TLS SNI
+                              values. If not empty, then TLS must be present and one
+                              of the provided SNIs must be indicated in the TLS handshake.
+                            items:
+                              type: string
+                            type: array
                           terminatingTLS:
                             description: TerminatingTLS is the TLS context for the
                               connection terminated by the L7 proxy.  For egress policy
@@ -1949,6 +1956,13 @@ spec:
                                   Key-value pair rules apply.
                                 type: string
                             type: object
+                          serverNames:
+                            description: ServerNames is a list of allowed TLS SNI
+                              values. If not empty, then TLS must be present and one
+                              of the provided SNIs must be indicated in the TLS handshake.
+                            items:
+                              type: string
+                            type: array
                           terminatingTLS:
                             description: TerminatingTLS is the TLS context for the
                               connection terminated by the L7 proxy.  For egress policy
@@ -3036,6 +3050,14 @@ spec:
                                     Key-value pair rules apply.
                                   type: string
                               type: object
+                            serverNames:
+                              description: ServerNames is a list of allowed TLS SNI
+                                values. If not empty, then TLS must be present and
+                                one of the provided SNIs must be indicated in the
+                                TLS handshake.
+                              items:
+                                type: string
+                              type: array
                             terminatingTLS:
                               description: TerminatingTLS is the TLS context for the
                                 connection terminated by the L7 proxy.  For egress
@@ -4331,6 +4353,14 @@ spec:
                                     Key-value pair rules apply.
                                   type: string
                               type: object
+                            serverNames:
+                              description: ServerNames is a list of allowed TLS SNI
+                                values. If not empty, then TLS must be present and
+                                one of the provided SNIs must be indicated in the
+                                TLS handshake.
+                              items:
+                                type: string
+                              type: array
                             terminatingTLS:
                               description: TerminatingTLS is the TLS context for the
                                 connection terminated by the L7 proxy.  For egress

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -23,7 +23,7 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.26.3"
+	CustomResourceDefinitionSchemaVersion = "1.26.4"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -140,6 +140,13 @@ type PortRule struct {
 	// +kubebuilder:validation:Optional
 	OriginatingTLS *TLSContext `json:"originatingTLS,omitempty"`
 
+	// ServerNames is a list of allowed TLS SNI values. If not empty, then
+	// TLS must be present and one of the provided SNIs must be indicated in the
+	// TLS handshake.
+	//
+	// +kubebuilder:validation:Optional
+	ServerNames []string `json:"serverNames,omitempty"`
+
 	// Rules is a list of additional port level rules which must be met in
 	// order for the PortRule to allow the traffic. If omitted or empty,
 	// no layer 7 rules are enforced.

--- a/pkg/policy/api/zz_generated.deepcopy.go
+++ b/pkg/policy/api/zz_generated.deepcopy.go
@@ -707,6 +707,11 @@ func (in *PortRule) DeepCopyInto(out *PortRule) {
 		*out = new(TLSContext)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ServerNames != nil {
+		in, out := &in.ServerNames, &out.ServerNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Rules != nil {
 		in, out := &in.Rules, &out.Rules
 		*out = new(L7Rules)

--- a/pkg/policy/api/zz_generated.deepequal.go
+++ b/pkg/policy/api/zz_generated.deepequal.go
@@ -957,6 +957,23 @@ func (in *PortRule) DeepEqual(other *PortRule) bool {
 		}
 	}
 
+	if ((in.ServerNames != nil) && (other.ServerNames != nil)) || ((in.ServerNames == nil) != (other.ServerNames == nil)) {
+		in, other := &in.ServerNames, &other.ServerNames
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	if (in.Rules == nil) != (other.Rules == nil) {
 		return false
 	} else if in.Rules != nil {


### PR DESCRIPTION
Add new `serverNames` field to Cilium Network Policy to restrict the allowed TLS SNIs. This is implemented as an Envoy redirect, but does not need TLS termination, as TLS SNI extension is in clear in the Client Hello message.

As a follow-up, a test case will be added to https://github.com/cilium/cilium-cli

```release-note
CiliumNetworkPolicy now supports enforcement of SNI in TLS connections.
```
