### PR TITLE
test/control-plane: Add nil check for agentHandle.Close receiver

### DIFF
--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -29,6 +29,10 @@ type agentHandle struct {
 }
 
 func (h *agentHandle) tearDown() {
+	if h == nil {
+		return
+	}
+
 	// If hive is nil, we have not yet started.
 	if h.hive != nil {
 		if err := h.hive.Stop(context.TODO()); err != nil {


### PR DESCRIPTION
In PR #22225 an attempt was made to resolve a nil pointer dereference issue which presents itself when we shutdown the control plane due to an error in initialization. However, it turns out that the property isn't the only value which can be nil, the receiver can also be nil.

This PR adds a nil check on the pointer to agentHandle itself so that we might figure out why the control plane exits once the nil defer panic is gone.