### PR TITLE
hubble: Update the reason label for hubble_drop_total metric

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -370,6 +370,9 @@ Modified Metrics
 
 * ``hubble_policy_verdicts_total`` now lists L7 flows. The match label has value ``l7/<l7_proto>``
   after the detected L7 protocol of the flow (for example: ``l7/http``).
+* Values for the ``reason`` label have been updated in  ``hubble_drop_total`` metric.
+  Please see `the API documentation <https://github.com/cilium/cilium/tree/master/api/v1/flow#flow-DropReason>`_
+  for the complete list of drop reasons.
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/examples/kubernetes/addons/prometheus/files/grafana-dashboards/hubble-dashboard.json
+++ b/examples/kubernetes/addons/prometheus/files/grafana-dashboards/hubble-dashboard.json
@@ -1681,7 +1681,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hubble_drop_total{reason=\"Policy denied\"}[1m])) by (pod, reason)",
+          "expr": "sum(rate(hubble_drop_total{reason=\"POLICY_DENIED\"}[1m])) by (pod, reason)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{reason}}",
@@ -1767,7 +1767,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hubble_drop_total{reason=\"Policy denied\"}[1m])) by (pod, protocol)",
+          "expr": "sum(rate(hubble_drop_total{reason=\"POLICY_DENIED\"}[1m])) by (pod, protocol)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{protocol}}",
@@ -1853,7 +1853,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, sum(rate(hubble_drop_total{reason=\"Policy denied\"}[1m])) by (pod, source))",
+          "expr": "topk(10, sum(rate(hubble_drop_total{reason=\"POLICY_DENIED\"}[1m])) by (pod, source))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{source}}",
@@ -1939,7 +1939,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, sum(rate(hubble_drop_total{reason=\"Policy denied\"}[1m])) by (pod, destination))",
+          "expr": "topk(10, sum(rate(hubble_drop_total{reason=\"POLICY_DENIED\"}[1m])) by (pod, destination))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{destination}}",

--- a/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+++ b/examples/kubernetes/addons/prometheus/monitoring-example.yaml
@@ -11298,7 +11298,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hubble_drop_total{reason=\"Policy denied\"}[1m])) by (pod, reason)",
+              "expr": "sum(rate(hubble_drop_total{reason=\"POLICY_DENIED\"}[1m])) by (pod, reason)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{reason}}",
@@ -11384,7 +11384,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hubble_drop_total{reason=\"Policy denied\"}[1m])) by (pod, protocol)",
+              "expr": "sum(rate(hubble_drop_total{reason=\"POLICY_DENIED\"}[1m])) by (pod, protocol)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{protocol}}",
@@ -11470,7 +11470,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10, sum(rate(hubble_drop_total{reason=\"Policy denied\"}[1m])) by (pod, source))",
+              "expr": "topk(10, sum(rate(hubble_drop_total{reason=\"POLICY_DENIED\"}[1m])) by (pod, source))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{source}}",
@@ -11556,7 +11556,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10, sum(rate(hubble_drop_total{reason=\"Policy denied\"}[1m])) by (pod, destination))",
+              "expr": "topk(10, sum(rate(hubble_drop_total{reason=\"POLICY_DENIED\"}[1m])) by (pod, destination))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{destination}}",

--- a/pkg/hubble/metrics/drop/handler.go
+++ b/pkg/hubble/metrics/drop/handler.go
@@ -11,7 +11,6 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
-	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
 
 type dropHandler struct {
@@ -53,7 +52,7 @@ func (d *dropHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error 
 		return err
 	}
 
-	labels := append(contextLabels, monitorAPI.DropReason(uint8(flow.GetDropReason())), v1.FlowProtocol(flow))
+	labels := append(contextLabels, flow.GetDropReasonDesc().String(), v1.FlowProtocol(flow))
 
 	d.drops.WithLabelValues(labels...).Inc()
 	return nil

--- a/pkg/hubble/metrics/drop/handler_test.go
+++ b/pkg/hubble/metrics/drop/handler_test.go
@@ -80,7 +80,7 @@ func TestDropHandler(t *testing.T) {
 		assert.Equal(t, "TCP", *metric.Label[1].Value)
 
 		assert.Equal(t, "reason", *metric.Label[2].Name)
-		assert.Equal(t, "Policy denied", *metric.Label[2].Value)
+		assert.Equal(t, "POLICY_DENIED", *metric.Label[2].Value)
 
 		assert.Equal(t, "source", *metric.Label[3].Name)
 		assert.Equal(t, "foo", *metric.Label[3].Value)


### PR DESCRIPTION
Use DropReasonDesc as the reason label instead of using the deprecated DropReason field and then converting it using the monitor API. Use of the monitor API is confusing in one specific case where the drop reason is unknown, as the reason label gets set to "Success". With this change, the reason label is set to "DROP_REASON_UNKNOWN" in case the drop reason is unknown.

Ref: #22402
Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

```release-note
hubble: Update the reason label for hubble_drop_total metric
```
