### PR TITLE
hubble: Set drop reason to POLICY_DENIED for L7 dropped flows

### DIFF
--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -122,8 +122,13 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 
 	decoded.Time = pbTimestamp
 	decoded.Verdict = decodeVerdict(r.Verdict)
-	decoded.DropReason = 0
-	decoded.DropReasonDesc = flowpb.DropReason_DROP_REASON_UNKNOWN
+	if decoded.Verdict == flowpb.Verdict_DROPPED {
+		decoded.DropReason = uint32(flowpb.DropReason_POLICY_DENIED)
+		decoded.DropReasonDesc = flowpb.DropReason_POLICY_DENIED
+	} else {
+		decoded.DropReason = uint32(flowpb.DropReason_DROP_REASON_UNKNOWN)
+		decoded.DropReasonDesc = flowpb.DropReason_DROP_REASON_UNKNOWN
+	}
 	decoded.IP = ip
 	decoded.L4 = l4
 	decoded.Source = srcEndpoint


### PR DESCRIPTION
Set drop reason to POLICY_DENIED for L7 dropped flows instead of setting it to DROP_REASON_UNKNOWN.

Fixes: #22402
Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

```release-note
hubble: Set drop reason to POLICY_DENIED for L7 dropped flows
```
