### PR TITLE
daemon: Close the identityAllocator on shutdown

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1377,6 +1377,8 @@ func (d *Daemon) Close() {
 	if d.datapathRegenTrigger != nil {
 		d.datapathRegenTrigger.Shutdown()
 	}
+	d.identityAllocator.Close()
+	identitymanager.RemoveAll()
 	d.nodeDiscovery.Close()
 	d.cgroupManager.Close()
 }

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/identity/cache"
-	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labelsfilter"
@@ -196,12 +195,6 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 
 	// Restore the policy enforcement mode.
 	policy.SetPolicyEnabled(ds.oldPolicyEnabled)
-
-	// Release the identity allocator reference created by NewDaemon. This
-	// is done manually here as we have no Close() function daemon
-	ds.d.identityAllocator.Close()
-
-	identitymanager.RemoveAll()
 
 	err := ds.hive.Stop(ctx)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
@aanm reports an issue where during shutdown in a unit test, the
identityAllocator may be closed, then an identity allocation attempt is
made by the ipcache async logic, then the ipcache is shut down. We could
solve this issue only for unit tests by shifting the identityAllocator
shutdown until after the rest of the daemon is shut down and only in the
test cleanup logic. However, it seems like identityAllocator cleanup
should actually be in the main daemon Close() function now that we have
one. Shift it in there to close after the ipcache shuts down, so that
the previously-mentioned issue is resolved both for test runs and during
the real agent shutdown.

Fixes: #21852
