### PR TITLE
Fix note for 'func numWorkerThreads()'

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1438,7 +1438,7 @@ func changedOption(key string, value option.OptionSetting, data interface{}) {
 	d.policy.BumpRevision() // force policy recalculation
 }
 
-// numWorkerThreads returns the number of worker threads with a minimum of 4.
+// numWorkerThreads returns the number of worker threads with a minimum of 2.
 func numWorkerThreads() int {
 	ncpu := runtime.NumCPU()
 	minWorkerThreads := 2


### PR DESCRIPTION

Signed-off-by: yanggang <gang.yang@daocloud.io>
```
numWorkerThreads returns the number of worker threads with a minimum of 4.
```

Follow the code note , allocate the default value is 4 may appropriate.
```
minWorkerThreads := 4
```
