### PR TITLE
option: Fix Populate entries using "viper" package.

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3079,8 +3079,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.ToFQDNsProxyPort = vp.GetInt(ToFQDNsProxyPort)
 	c.ToFQDNsPreCache = vp.GetString(ToFQDNsPreCache)
 	c.ToFQDNsEnableDNSCompression = vp.GetBool(ToFQDNsEnableDNSCompression)
-	c.ToFQDNsIdleConnectionGracePeriod = viper.GetDuration(ToFQDNsIdleConnectionGracePeriod)
-	c.FQDNProxyResponseMaxDelay = viper.GetDuration(FQDNProxyResponseMaxDelay)
+	c.ToFQDNsIdleConnectionGracePeriod = vp.GetDuration(ToFQDNsIdleConnectionGracePeriod)
+	c.FQDNProxyResponseMaxDelay = vp.GetDuration(FQDNProxyResponseMaxDelay)
 	c.DNSProxyConcurrencyLimit = vp.GetInt(DNSProxyConcurrencyLimit)
 	c.DNSProxyConcurrencyProcessingGracePeriod = vp.GetDuration(DNSProxyConcurrencyProcessingGracePeriod)
 


### PR DESCRIPTION
option.DaemonConfig.Populate() must use the passed in '*viper.Viper' instead of 'viper' as a package. Otherwise populated values will be zeroes.

This made Cilium Agent to not wait for FQDN proxy results to be plumbed into the datapath before returning the DNS response, which caused test flakes due to test traffic possibly hitting the datapath or Envoy before policy had reached there.

#22346 was just merged, and has not released yet, so do not need to highlight this fix in release notes. Copied the `needs-backport` labels from #22346.

Fixes: #22346
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
