### PR TITLE
Use &netlink.LinkNotFoundError{} to determine link not found error

### DIFF
--- a/pkg/netns/netns.go
+++ b/pkg/netns/netns.go
@@ -4,6 +4,7 @@
 package netns
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -22,7 +23,7 @@ func RemoveIfFromNetNSIfExists(netNS ns.NetNS, ifName string) error {
 	return netNS.Do(func(_ ns.NetNS) error {
 		l, err := netlink.LinkByName(ifName)
 		if err != nil {
-			if strings.Contains(err.Error(), "Link not found") {
+			if errors.As(err, &netlink.LinkNotFoundError{}) {
 				return nil
 			}
 			return err


### PR DESCRIPTION
Signed-off-by: tanberBro <pengfei.song@daocloud.io>

This error handling is more elegant. like this https://github.com/cilium/cilium/blob/a564d01faf929296809192bc371ed987c5e70df2/daemon/cmd/daemon.go#L333