### PR TITLE
Pr/v1.10 backport 2022 11 30

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
@@ -585,28 +585,10 @@ func (p *DNSProxy) CheckAllowed(endpointID uint64, destPort uint16, destID ident
 	return false, nil
 }
 
-func configureConnection(conn *net.Conn, secId identity.NumericIdentity) error {
-	var file *os.File
-	var err error
-
-	switch l4conn := (*conn).(type) {
-	case *net.UDPConn:
-		if file, err = l4conn.File(); err != nil {
-			return fmt.Errorf("can't get file from %v: %w", l4conn, err)
-		}
-	case *net.TCPConn:
-		if file, err = l4conn.File(); err != nil {
-			return fmt.Errorf("can't get file from %v: %w", l4conn, err)
-		}
-	default:
-		return fmt.Errorf("unsupported type %T", l4conn)
-	}
-
-	defer file.Close()
-
+func setSoMark(fd int, secId identity.NumericIdentity) error {
 	mark := linux_defaults.MagicMarkIdentity
 	mark |= int(uint32(secId&0xFFFF)<<16 | uint32((secId&0xFF0000)>>16))
-	err = unix.SetsockoptInt(int(file.Fd()), unix.SOL_SOCKET, unix.SO_MARK, mark)
+	err := unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_MARK, mark)
 	if err != nil {
 		return fmt.Errorf("error setting SO_MARK: %w", err)
 	}
@@ -750,6 +732,19 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	stat.ProcessingTime.End(true)
 	stat.UpstreamTime.Start()
 
+	dialer := net.Dialer{
+		Timeout: 2 * time.Second,
+		Control: func(network, address string, c syscall.RawConn) error {
+			var soerr error
+			if err := c.Control(func(su uintptr) {
+				soerr = setSoMark(int(su), ep.GetIdentity())
+			}); err != nil {
+				return err
+			}
+			return soerr
+		}}
+	client.Dialer = &dialer
+
 	conn, err := client.Dial(targetServerAddr)
 	if err != nil {
 		err := fmt.Errorf("failed to dial connection to %v: %w", targetServerAddr, err)
@@ -760,15 +755,6 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		return
 	}
 	defer conn.Close()
-
-	if err = configureConnection(&conn.Conn, ep.GetIdentity()); err != nil {
-		err := fmt.Errorf("failed to set socket options: %w", err)
-		stat.Err = err
-		scopedLog.WithError(err).Error("Failed to configure connection to the upstream DNS server, cannot service DNS request")
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, &stat)
-		p.sendRefused(scopedLog, w, request)
-		return
-	}
 
 	request.Id = dns.Id() // force a random new ID for this request
 	response, _, err := client.ExchangeWithConn(request, conn)


### PR DESCRIPTION
 * #22361 -- fqdn: dnsproxy: fix forwardng of the original security identity (@aspsk)

```upstream-prs
$ for pr in 22361; do contrib/backporting/set-labels.py $pr done 1.10; done
```
