### PR TITLE
.github: add PR labeler for external contributions

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -1,0 +1,30 @@
+name: PR from External Contribution Detector
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  labeler:
+    if: |
+      (
+        (github.event.issue.author_association != 'OWNER') &&
+        (github.event.issue.author_association != 'COLLABORATOR') &&
+        (github.event.issue.author_association != 'MEMBER')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["kind/community-contribution"]
+            })


### PR DESCRIPTION
Filtering PRs from external contributors will allow committers of the Cilium project to give more attention to those PRs and avoid them to get stale.

Signed-off-by: André Martins <andre@cilium.io>