### PR TITLE
Limit watched flags in the default configuration

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -122,9 +122,9 @@
      - string
      - ``"medium"``
    * - bpf.monitorFlags
-     - Configure which TCP flags trigger notifications when seen for the first time in a connection.
+     - Configure which TCP flags trigger notifications when changed.
      - string
-     - ``"all"``
+     - ``"syn fin rst"``
    * - bpf.monitorInterval
      - Configure the typical time between monitor notifications for active connections.
      - string

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -81,7 +81,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.mapDynamicSizeRatio | float64 | `0.0025` | Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/stable/concepts/ebpf/maps/#ebpf-maps |
 | bpf.masquerade | bool | `false` | Enable native IP masquerade support in eBPF |
 | bpf.monitorAggregation | string | `"medium"` | Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum. |
-| bpf.monitorFlags | string | `"all"` | Configure which TCP flags trigger notifications when seen for the first time in a connection. |
+| bpf.monitorFlags | string | `"syn fin rst"` | Configure which TCP flags trigger notifications when changed. |
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
 | bpf.mountHostBoot | bool | `true` | Enable host boot directory mount for BPF clock source probing |
 | bpf.natMax | int | `524288` | Configure the maximum number of entries for the NAT table. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -276,8 +276,8 @@ data:
   # Only effective when monitor aggregation is set to "medium" or higher.
   monitor-aggregation-interval: {{ include "validateDuration" .Values.bpf.monitorInterval | quote }}
 
-  # The monitor aggregation flags determine which TCP flags which, upon the
-  # first observation, cause monitor notifications to be generated.
+  # The monitor aggregation flags determine which TCP flags trigger monitor
+  # reports when changed.
   #
   # Only effective when monitor aggregation is set to "medium" or higher.
   monitor-aggregation-flags: {{ .Values.bpf.monitorFlags }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -382,9 +382,8 @@ bpf:
   # active connections.
   monitorInterval: "5s"
 
-  # -- Configure which TCP flags trigger notifications when seen for the
-  # first time in a connection.
-  monitorFlags: "all"
+  # -- Configure which TCP flags trigger notifications when changed.
+  monitorFlags: syn fin rst
 
   # -- Allow cluster external access to ClusterIP services.
   lbExternalClusterIP: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -379,9 +379,8 @@ bpf:
   # active connections.
   monitorInterval: "5s"
 
-  # -- Configure which TCP flags trigger notifications when seen for the
-  # first time in a connection.
-  monitorFlags: "all"
+  # -- Configure which TCP flags trigger notifications when changed.
+  monitorFlags: syn fin rst
 
   # -- Allow cluster external access to ClusterIP services.
   lbExternalClusterIP: false


### PR DESCRIPTION
Old value: all
New value: syn, fin, rst (the command-line defaults)

Currently if any TCP flag changes, a new monitor event is generated, while the user expectation is that for an ongoing connection an event should be generated every 5s on average. Many workloads change flags frequently producing orders-of-magnitude more flows.

Before:
```
Nov 29 13:42:01.754: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:01.762: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:01.782: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:01.875: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:01.967: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.039: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:02.040: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.046: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:02.060: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.067: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:02.068: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.175: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:02.200: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.200: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.335: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:02.341: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.349: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:02.355: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.362: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:02.371: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.475: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:02.734: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.741: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:02.932: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:02.939: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
Nov 29 13:42:03.335: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:03.335: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK, PSH)
Nov 29 13:42:03.343: 10.253.166.161:44460 <> system/controller-manager-7c7f9fb679-b6tz2:8443 to-overlay FORWARDED (TCP Flags: ACK)
```

After:
```
Nov 29 15:24:50.775: 10.253.166.161:50414 -> system/controller-manager-7c7f9fb679-b6tz2:8443 to-endpoint FORWARDED (TCP Flags: ACK, PSH)
Nov 29 15:24:55.869: 10.253.166.161:50414 -> system/controller-manager-7c7f9fb679-b6tz2:8443 to-endpoint FORWARDED (TCP Flags: ACK, PSH)
Nov 29 15:25:00.537: 10.253.166.161:50414 -> system/controller-manager-7c7f9fb679-b6tz2:8443 to-endpoint FORWARDED (TCP Flags: ACK)
Nov 29 15:25:05.635: 10.253.166.161:50414 -> system/controller-manager-7c7f9fb679-b6tz2:8443 to-endpoint FORWARDED (TCP Flags: ACK, PSH)
```

```release-note
Default configuration of `monitor-aggregation-flags` now matches command-line defaults
```
