### PR TITLE
pkg/bandwidth: enlarge sysctl settings only if they are below baseline

### DIFF
--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -120,6 +121,11 @@ func Write(name string, val string) error {
 	return writeSysctl(name, val)
 }
 
+// WriteInt writes the given integer type sysctl parameter.
+func WriteInt(name string, val int64) error {
+	return writeSysctl(name, strconv.FormatInt(val, 10))
+}
+
 // Read reads the given sysctl parameter.
 func Read(name string) (string, error) {
 	path, err := parameterPath(name)
@@ -132,6 +138,21 @@ func Read(name string) (string, error) {
 	}
 
 	return strings.TrimRight(string(val), "\n"), nil
+}
+
+// ReadInt reads the given sysctl parameter, return an int64 value.
+func ReadInt(name string) (int64, error) {
+	s, err := Read(name)
+	if err != nil {
+		return -1, err
+	}
+
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return -1, err
+	}
+
+	return i, nil
 }
 
 // ApplySettings applies all settings in sysSettings.


### PR DESCRIPTION
On bandwidth manager enabled, several sysctl parameters of the node will be overwritten by Cilium's baseline ones on agent start.

Problem arises when baseline values are smaller than the current system settings. Such as, a node has a deliberately tuned setting netdev_max_backlog=8000, but bandwidth manager will overwrite it with its beseline value 1000, which may lead to packet drop issues in high throughput cases that the node is targeted for.

This patch fixes that problem by inspecting the current settings, and only overwrite them when they are below our baseline.

Fixes: #20878

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>

```release-note
Do not let the bandwidth manager decrease existing sysctl values.
```
