### PR TITLE
hive: Fix CodeQL lints in regex

### DIFF
--- a/pkg/hive/internal/reflect.go
+++ b/pkg/hive/internal/reflect.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	baseNameRegex = regexp.MustCompile(`github.com/cilium/cilium/[\w\/]+/`)
+	baseNameRegex = regexp.MustCompile(`^github\.com/cilium/cilium/[\w\/]+/`)
 )
 
 func TrimName(name string) string {


### PR DESCRIPTION
The CodeQL workflow found two issues with the affected line:

 - https://github.com/cilium/cilium/security/code-scanning/78
 - https://github.com/cilium/cilium/security/code-scanning/79

Tested by running `cilium-agent objects` locally.
