### PR TITLE
ipam/crd: Fix agent fatal on router initialization

### DIFF
--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -153,6 +153,10 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 	scopedLog = scopedLog.WithField(fieldENIID, eniID)
 	scopedLog.Info("Created new ENI")
 
+	if bestSubnet.CIDR != nil {
+		eni.VSwitch.CIDRBlock = bestSubnet.CIDR.String()
+	}
+
 	err = n.manager.api.AttachNetworkInterface(ctx, instanceID, eniID)
 	if err != nil {
 		err2 := n.manager.api.DeleteNetworkInterface(ctx, eniID)

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -464,6 +464,10 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 	scopedLog = scopedLog.WithField(fieldEniID, eniID)
 	scopedLog.Info("Created new ENI")
 
+	if subnet.CIDR != nil {
+		eni.Subnet.CIDR = subnet.CIDR.String()
+	}
+
 	var attachmentID string
 	for attachRetries := 0; attachRetries < maxAttachRetries; attachRetries++ {
 		attachmentID, err = n.manager.api.AttachNetworkInterface(ctx, index, n.node.InstanceID(), eniID)


### PR DESCRIPTION
Currently, when a cilium-agent in eni/alibabacloud mode initializes router info, it might encounter the following fatal:

```
level=fatal msg="Error while creating daemon" error="failed to create router info invalid ip: " subsys=daemon
```

The gateway IP of routing info is derived from the CIDR of the subnet, the eni.Subnet.CIDR in InstanceMap is set as empty after ENI creation. In normal cases it will be filled by a later resyncTrigger after maintainIPPool. But if another goroutine (periodic resync or pool maintainer of another node) happens to sync local InstanceMap cache to k8s, cilium-agent would be informed of that ENI IP pool with empty cidr and router IP allocation would fatal due to empty gateway IP.

This patch fixes this by filling the CIDR right after ENI creation.

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

```release-note
ipam/crd: Fix router initialization fatal when ENI data race happens
```
