### PR TITLE
alibabacloud: don't use ReadAll in metadata response read

### DIFF
--- a/pkg/alibabacloud/metadata/log.go
+++ b/pkg/alibabacloud/metadata/log.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metadata
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "alibabacloud/metadata")
+)


### PR DESCRIPTION
This change limits how big metadata response can be to avoid leaking memory by potential attackers doctoring very big HTTP responses.

Signed-off-by: Maciej Kwiek <maciej@isovalent.com>