### PR TITLE
bpf_sockops string constant can use const eSockops replace

### DIFF
--- a/pkg/sockops/sockops.go
+++ b/pkg/sockops/sockops.go
@@ -276,7 +276,7 @@ func bpfLoadMapProg(object string, load string) error {
 		return err
 	}
 
-	_mapID, err := bpftoolGetMapID("bpf_sockops", sockMap)
+	_mapID, err := bpftoolGetMapID(eSockops, sockMap)
 	mapID := strconv.Itoa(_mapID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: tanberBro <pengfei.song@daocloud.io>

bpf_sockops string constant can use const eSockops replace