### PR TITLE
Change start time for policy_implementation_delay to when a CNP is first received by the Agent

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -328,6 +328,12 @@ Annotations:
 * NodeExternalIP of the local node is now correctly included into the ``host``
   :ref:`entity <Entities based>` (it used to belong to the world entity).
 
+* The scope of the ``policy_implementation_delay`` Prometheus metric has been expanded to cover the
+  full interval from when a policy is first received from a cilium-agent, to when the policy has been
+  applied to endpoints. In previous versions, ``policy_implementation_delay`` only covered the work
+  done by the daemon subsystem to implement the policy. As a result, users may notice an expected
+  increase in ``policy_implementation_delay`` after upgrading.
+
 Removed Options
 ~~~~~~~~~~~~~~~
 

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -248,7 +248,7 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *policy.AddOptions) (newR
 // was not able to be imported.
 func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions, resChan chan interface{}) {
 	policyAddStartTime := time.Now()
-	if !opts.ProcessingStartTime.IsZero() {
+	if opts != nil && !opts.ProcessingStartTime.IsZero() {
 		policyAddStartTime = opts.ProcessingStartTime
 	}
 	logger := log.WithField("policyAddRequest", uuid.New().String())

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -248,6 +248,9 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *policy.AddOptions) (newR
 // was not able to be imported.
 func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions, resChan chan interface{}) {
 	policyAddStartTime := time.Now()
+	if !opts.ProcessingStartTime.IsZero() {
+		policyAddStartTime = opts.ProcessingStartTime
+	}
 	logger := log.WithField("policyAddRequest", uuid.New().String())
 
 	if opts != nil && opts.Generated {

--- a/pkg/policy/config.go
+++ b/pkg/policy/config.go
@@ -4,6 +4,8 @@
 package policy
 
 import (
+	"time"
+
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -47,4 +49,8 @@ type AddOptions struct {
 
 	// The source of this policy, one of api, fqdn or k8s
 	Source string
+
+	// The time the policy initially began to be processed in Cilium, such as when the
+	// policy was received from the API server.
+	ProcessingStartTime time.Time
 }


### PR DESCRIPTION
This PR changes the start time used for calculating durations for the policy_implementation_delay metric, to when a CNP is first received from the API server. The start time for this metric is currently set at the start of an internal function within the Daemon, which can be seen as reasonably arbitrary for users. In theory, this will increase the times observed from policy_implementation_delay, but make them more accurate by letting the metric be defined as the time from when a CNP is received to when an endpoint is updated.

Thanks!