### PR TITLE
.github/workflows: bump ubuntu version for code-ql

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -18,7 +18,7 @@ jobs:
   check_changes:
     name: Deduce required tests from code changes
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}
     steps:
@@ -36,7 +36,7 @@ jobs:
   analyze:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.go-changes == 'true' || github.event_name != 'pull_request' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
     steps:


### PR DESCRIPTION
codeql seems to fail on running due different golang versions. Let's see if using the last ubuntu version it will help with these flakes.

related to https://github.com/cilium/cilium/issues/22488

Signed-off-by: André Martins <andre@cilium.io>