### PR TITLE
.github/workflows: use right event type for auto labeler

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -4,16 +4,15 @@ on:
   pull_request_target:
     types:
       - opened
-      - synchronize
       - reopened
 
 jobs:
   labeler:
     if: |
       (
-        (github.event.issue.author_association != 'OWNER') &&
-        (github.event.issue.author_association != 'COLLABORATOR') &&
-        (github.event.issue.author_association != 'MEMBER')
+        (github.event.pull_request.author_association != 'OWNER') &&
+        (github.event.pull_request.author_association != 'COLLABORATOR') &&
+        (github.event.pull_request.author_association != 'MEMBER')
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
A pull_request_target workflow generates pull_request events and not issue events. This was causing all PRs to have the label 'kind/community-contribution' added to them.

Also remove the 'synchronize' event type since it's not necessary to re-run this workflow for every push the PR author does.

Fixes: 473ddda1e329 (".github: add PR labeler for external contributions")
Signed-off-by: André Martins <andre@cilium.io>

**NOTE**: Re-enable workflow once this PR is merged https://github.com/cilium/cilium/actions/workflows/external-contribution-labeler.yaml