### PR TITLE
contrib: exclude non-running pods in k8s-unmanaged script

### DIFF
--- a/contrib/k8s/k8s-unmanaged.sh
+++ b/contrib/k8s/k8s-unmanaged.sh
@@ -3,8 +3,8 @@
 # Copyright Authors of Cilium
 
 function all_ceps { kubectl get cep --all-namespaces -o json | jq -r '.items[].metadata | .namespace + "/" + .name'; }
-function all_pods { kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.spec.hostNetwork==true | not) | .metadata | .namespace + "/" + .name'; }
+function all_pods { kubectl get pods --all-namespaces -o json | jq -r '.items[] | select((.status.phase=="Running" or .status.phase=="Pending") and (.spec.hostNetwork==true | not)) | .metadata | .namespace + "/" + .name'; }
  
-echo "Skipping pods with host networking enabled..."
+echo "Skipping pods with host networking enabled or with status not in Running or Pending phase..."
 
 sort <(all_ceps) <(all_pods) | uniq -u


### PR DESCRIPTION
CEPs are cleaned up for pods in a non-running state. By excluding these pods in the k8s-unmanaged script the output will be in line with expectations. Otherwise, e.g. Completed pods will show as unmanaged by cilium.

[Reference PR ](https://github.com/cilium/cilium-cli/pull/1236) in cilium-cli repository where the same fix was applied for cli command `cilium status`.

Signed-off-by: flxman felix.farjsjo@gmail.com
