### PR TITLE
endpointmgr: guard against potential nil deref

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -652,6 +652,10 @@ type policyRepoGetter interface {
 // node's known labels.
 func (mgr *EndpointManager) InitHostEndpointLabels(ctx context.Context) {
 	ep := mgr.GetHostEndpoint()
+	if ep == nil {
+		log.Error("Attempted to init host endpoint labels but host endpoint not set.")
+		return
+	}
 	ep.InitWithNodeLabels(ctx, launchTime)
 }
 


### PR DESCRIPTION
There's a potential nil deref within
EndpointManager.InitHostEndpointLabels.

We never run into it due to the correct order of events in daemon_main, but if the code was to shift, it could occur.

This commit simply checks nil, logs and error, and returns.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>
