### PR TITLE
Test: Specify `test/k8s` directory during creating preload vm

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -595,7 +595,7 @@ sudo rm -rfv /var/lib/kubelet || true
 
 if [[ "${PRELOAD_VM}" == "true" ]]; then
     cd ${SRC_FOLDER}
-    ./test/provision/container-images.sh test_images .
+    ./test/provision/container-images.sh test_images test/k8s
     ./test/provision/container-images.sh cilium_images .
     echo "VM preloading is finished, skipping the rest"
     exit 0


### PR DESCRIPTION
This commit specify `test/k8s` directory when the k8s_install.sh calls `./test/provision/container-images.sh test_images`. This specification enables the function to get proper image names.

Fixes: #21241
(Although the issue was already closed, I still caught the error and found the reason)


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
test: Speify `test/k8s` directory on `k8s_install.sh` to modify pulling images
```