### PR TITLE
securityContext Options for API Server

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -209,10 +209,22 @@
      - Affinity for clustermesh.apiserver
      - object
      - ``{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}``
+   * - clustermesh.apiserver.containerSecurityContext
+     - Specifies the security context of the api server container
+     - object
+     - ``{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}``
+   * - clustermesh.apiserver.etcd.containerSecurityContext
+     - Specifies the security context of the etcd container in the apiserver
+     - object
+     - ``{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}``
    * - clustermesh.apiserver.etcd.image
      - Clustermesh API server etcd image.
      - object
      - ``{"override":null,"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"}``
+   * - clustermesh.apiserver.etcd.init.containerSecurityContext
+     - Specifies the security context of the etcd init container in the apiserver
+     - object
+     - ``{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}``
    * - clustermesh.apiserver.etcd.init.resources
      - Specifies the resources for etcd init container in the apiserver
      - object
@@ -265,6 +277,10 @@
      - Resource requests and limits for the clustermesh-apiserver
      - object
      - ``{}``
+   * - clustermesh.apiserver.securityContext
+     - Specifies the security context of the api server pod
+     - object
+     - ``{"fsGroup":1000,"runAsGroup":1000,"runAsUser":1000}``
    * - clustermesh.apiserver.service.annotations
      - Annotations for the clustermesh-apiserver For GKE LoadBalancer, use annotation cloud.google.com/load-balancer-type: "Internal" For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -297,6 +297,7 @@ conformant
 conntrack
 conntrackGCInterval
 containerRuntime
+containerSecurityContext
 containerd
 contrib
 coord

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -103,7 +103,10 @@ contributors across the globe, there is almost always someone available to help.
 | cluster.id | int | `0` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh, may be 0 if Cluster Mesh is not used. |
 | cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh. |
 | clustermesh.apiserver.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for clustermesh.apiserver |
+| clustermesh.apiserver.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Specifies the security context of the api server container |
+| clustermesh.apiserver.etcd.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Specifies the security context of the etcd container in the apiserver |
 | clustermesh.apiserver.etcd.image | object | `{"override":null,"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"}` | Clustermesh API server etcd image. |
+| clustermesh.apiserver.etcd.init.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Specifies the security context of the etcd init container in the apiserver |
 | clustermesh.apiserver.etcd.init.resources | object | `{}` | Specifies the resources for etcd init container in the apiserver |
 | clustermesh.apiserver.etcd.resources | object | `{}` | Specifies the resources for etcd container in the apiserver |
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
@@ -117,6 +120,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.priorityClassName | string | `""` | The priority class to use for clustermesh-apiserver |
 | clustermesh.apiserver.replicas | int | `1` | Number of replicas run for the clustermesh-apiserver deployment. |
 | clustermesh.apiserver.resources | object | `{}` | Resource requests and limits for the clustermesh-apiserver |
+| clustermesh.apiserver.securityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsUser":1000}` | Specifies the security context of the api server pod |
 | clustermesh.apiserver.service.annotations | object | `{}` | Annotations for the clustermesh-apiserver For GKE LoadBalancer, use annotation cloud.google.com/load-balancer-type: "Internal" For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0 |
 | clustermesh.apiserver.service.nodePort | int | `32379` | Optional port to use as the node port for apiserver access. |
 | clustermesh.apiserver.service.type | string | `"NodePort"` | The type of service used for apiserver access. |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -76,6 +76,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.clustermesh.apiserver.etcd.init.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       containers:
       - name: etcd
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
@@ -111,6 +115,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.clustermesh.apiserver.etcd.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       - name: apiserver
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
@@ -124,6 +132,7 @@ spec:
         - --cluster-id=$(CLUSTER_ID)
         - --kvstore-opt
         - etcd.config=/var/lib/cilium/etcd-config.yaml
+        - --clustermesh-health-port=8080
         env:
         - name: CLUSTER_NAME
           valueFrom:
@@ -147,6 +156,8 @@ spec:
               name: cilium-config
               key: enable-k8s-endpoint-slice
               optional: true
+        - name: GOPS_CONFIG_DIR
+          value: /tmp
         {{- with .Values.clustermesh.apiserver.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}
@@ -154,10 +165,17 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.clustermesh.apiserver.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: etcd-admin-client
           mountPath: /var/lib/cilium/etcd-secrets
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
+          readOnly: false
         terminationMessagePolicy: FallbackToLogsOnError
       volumes:
       - name: etcd-server-secrets
@@ -171,6 +189,8 @@ spec:
           # note: the leading zero means this number is in octal representation: do not remove it
           defaultMode: 0400
       - name: etcd-data-dir
+        emptyDir: {}
+      - name: tmp
         emptyDir: {}
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.clustermesh.apiserver.priorityClassName "system-cluster-critical") }}
@@ -197,6 +217,10 @@ spec:
       {{- end }}
       {{- with .Values.clustermesh.apiserver.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clustermesh.apiserver.securityContext }}
+      securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2147,6 +2147,20 @@ clustermesh:
       useDigest: false
       pullPolicy: "Always"
 
+    # -- Specifies the security context of the api server pod
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+
+    # -- Specifies the security context of the api server container
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+
     etcd:
       # -- Clustermesh API server etcd image.
       image:
@@ -2164,6 +2178,14 @@ clustermesh:
       #     cpu: 1000m
       #     memory: 256Mi
 
+      # -- Specifies the security context of the etcd container in the apiserver
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+
       init:
         # -- Specifies the resources for etcd init container in the apiserver
         resources: {}
@@ -2173,6 +2195,14 @@ clustermesh:
         #   limits:
         #     cpu: 100m
         #     memory: 100Mi
+
+        # -- Specifies the security context of the etcd init container in the apiserver
+        containerSecurityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
 
     service:
       # -- The type of service used for apiserver access.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2144,6 +2144,20 @@ clustermesh:
       useDigest: ${USE_DIGESTS}
       pullPolicy: "${PULL_POLICY}"
 
+    # -- Specifies the security context of the api server pod
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+
+    # -- Specifies the security context of the api server container
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+
     etcd:
       # -- Clustermesh API server etcd image.
       image:
@@ -2161,6 +2175,14 @@ clustermesh:
       #     cpu: 1000m
       #     memory: 256Mi
 
+      # -- Specifies the security context of the etcd container in the apiserver
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+
       init:
         # -- Specifies the resources for etcd init container in the apiserver
         resources: {}
@@ -2170,6 +2192,14 @@ clustermesh:
         #   limits:
         #     cpu: 100m
         #     memory: 100Mi
+
+        # -- Specifies the security context of the etcd init container in the apiserver
+        containerSecurityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
 
     service:
       # -- The type of service used for apiserver access.


### PR DESCRIPTION
This patch adds the option to set a securityContext on the API Server pod and on the different containers

Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

This patch adds the option to set a securityContext on the API Server pod and on the different containers.

```release-note
Add option to configure the securityContexts for the apiserver pod and containers.
```
