### PR TITLE
pkg: Follow Go convention on capitalization

### DIFF
--- a/pkg/alibabacloud/api/api.go
+++ b/pkg/alibabacloud/api/api.go
@@ -47,7 +47,7 @@ var maxAttachRetries = wait.Backoff{
 type Client struct {
 	vpcClient  *vpc.Client
 	ecsClient  *ecs.Client
-	limiter    *helpers.ApiLimiter
+	limiter    *helpers.APILimiter
 	metricsAPI MetricsAPI
 	filters    map[string]string
 }
@@ -63,7 +63,7 @@ func NewClient(vpcClient *vpc.Client, client *ecs.Client, metrics MetricsAPI, ra
 	return &Client{
 		vpcClient:  vpcClient,
 		ecsClient:  client,
-		limiter:    helpers.NewApiLimiter(metrics, rateLimit, burst),
+		limiter:    helpers.NewAPILimiter(metrics, rateLimit, burst),
 		metricsAPI: metrics,
 		filters:    filters,
 	}

--- a/pkg/api/helpers/rate_limit.go
+++ b/pkg/api/helpers/rate_limit.go
@@ -10,8 +10,8 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// ApiLimiter allows to rate limit API calls
-type ApiLimiter struct {
+// APILimiter allows to rate limit API calls
+type APILimiter struct {
 	metrics MetricsAPI
 	limiter *rate.Limiter
 }
@@ -21,18 +21,18 @@ type MetricsAPI interface {
 	ObserveRateLimit(operation string, duration time.Duration)
 }
 
-// NewApiLimiter returns a new API limiter with the specific rate limit and
+// NewAPILimiter returns a new API limiter with the specific rate limit and
 // burst configuration. The MetricsAPI interface is called to allow for metrics
 // accounting.
-func NewApiLimiter(metrics MetricsAPI, rateLimit float64, burst int) *ApiLimiter {
-	return &ApiLimiter{
+func NewAPILimiter(metrics MetricsAPI, rateLimit float64, burst int) *APILimiter {
+	return &APILimiter{
 		metrics: metrics,
 		limiter: rate.NewLimiter(rate.Limit(rateLimit), burst),
 	}
 }
 
 // Limit applies the rate limiting configuration for the given operation
-func (l *ApiLimiter) Limit(ctx context.Context, operation string) {
+func (l *APILimiter) Limit(ctx context.Context, operation string) {
 	r := l.limiter.Reserve()
 	if delay := r.Delay(); delay != time.Duration(0) && delay != rate.InfDuration {
 		l.metrics.ObserveRateLimit(operation, delay)

--- a/pkg/api/helpers/rate_limit_test.go
+++ b/pkg/api/helpers/rate_limit_test.go
@@ -24,7 +24,7 @@ var _ = check.Suite(&HelpersSuite{})
 
 func (e *HelpersSuite) TestRateLimitBurst(c *check.C) {
 	metricsAPI := mock.NewMockMetrics()
-	limiter := NewApiLimiter(metricsAPI, 1, 10)
+	limiter := NewAPILimiter(metricsAPI, 1, 10)
 	c.Assert(limiter, check.Not(check.IsNil))
 
 	// Exhaust bucket (rate limit should not kick in)
@@ -42,7 +42,7 @@ func (e *HelpersSuite) TestRateLimitBurst(c *check.C) {
 
 func (e *HelpersSuite) TestRateLimitWait(c *check.C) {
 	metricsAPI := mock.NewMockMetrics()
-	limiter := NewApiLimiter(metricsAPI, 100, 1)
+	limiter := NewAPILimiter(metricsAPI, 100, 1)
 	c.Assert(limiter, check.Not(check.IsNil))
 
 	// Exhaust bucket

--- a/pkg/api/metrics/metrics.go
+++ b/pkg/api/metrics/metrics.go
@@ -13,7 +13,7 @@ import (
 // API usage
 type PrometheusMetrics struct {
 	registry    *prometheus.Registry
-	ApiDuration *prometheus.HistogramVec
+	APIDuration *prometheus.HistogramVec
 	RateLimit   *prometheus.HistogramVec
 }
 
@@ -22,7 +22,7 @@ type PrometheusMetrics struct {
 func NewPrometheusMetrics(namespace, subsystem string, registry *prometheus.Registry) *PrometheusMetrics {
 	m := &PrometheusMetrics{registry: registry}
 
-	m.ApiDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	m.APIDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Subsystem: subsystem,
 		Name:      "api_duration_seconds",
@@ -36,7 +36,7 @@ func NewPrometheusMetrics(namespace, subsystem string, registry *prometheus.Regi
 		Help:      "Duration of client-side rate limiter blocking",
 	}, []string{"operation"})
 
-	registry.MustRegister(m.ApiDuration)
+	registry.MustRegister(m.APIDuration)
 	registry.MustRegister(m.RateLimit)
 
 	return m
@@ -45,7 +45,7 @@ func NewPrometheusMetrics(namespace, subsystem string, registry *prometheus.Regi
 // ObserveAPICall must be called on every API call made with the operation
 // performed, the status code received and the duration of the call
 func (p *PrometheusMetrics) ObserveAPICall(operation, status string, duration float64) {
-	p.ApiDuration.WithLabelValues(operation, status).Observe(duration)
+	p.APIDuration.WithLabelValues(operation, status).Observe(duration)
 }
 
 // ObserveRateLimit must be called in case an API call was subject to rate limiting

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -30,7 +30,7 @@ import (
 // Client represents an EC2 API client
 type Client struct {
 	ec2Client           *ec2.Client
-	limiter             *helpers.ApiLimiter
+	limiter             *helpers.APILimiter
 	metricsAPI          MetricsAPI
 	subnetsFilters      []ec2_types.Filter
 	instancesFilters    []ec2_types.Filter
@@ -54,7 +54,7 @@ func NewClient(ec2Client *ec2.Client, metrics MetricsAPI, rateLimit float64, bur
 	return &Client{
 		ec2Client:           ec2Client,
 		metricsAPI:          metrics,
-		limiter:             helpers.NewApiLimiter(metrics, rateLimit, burst),
+		limiter:             helpers.NewAPILimiter(metrics, rateLimit, burst),
 		subnetsFilters:      subnetsFilters,
 		instancesFilters:    instancesFilters,
 		eniTagSpecification: eniTagSpecification,

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -41,7 +41,7 @@ type Client struct {
 	virtualnetworks network.VirtualNetworksClient
 	vmss            compute.VirtualMachineScaleSetVMsClient
 	vmscalesets     compute.VirtualMachineScaleSetsClient
-	limiter         *helpers.ApiLimiter
+	limiter         *helpers.APILimiter
 	metricsAPI      MetricsAPI
 	usePrimary      bool
 }
@@ -86,7 +86,7 @@ func NewClient(cloudName, subscriptionID, resourceGroup, userAssignedIdentityID 
 		vmss:            compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(azureEnv.ResourceManagerEndpoint, subscriptionID),
 		vmscalesets:     compute.NewVirtualMachineScaleSetsClientWithBaseURI(azureEnv.ResourceManagerEndpoint, subscriptionID),
 		metricsAPI:      metrics,
-		limiter:         helpers.NewApiLimiter(metrics, rateLimit, burst),
+		limiter:         helpers.NewAPILimiter(metrics, rateLimit, burst),
 		usePrimary:      usePrimary,
 	}
 


### PR DESCRIPTION
Signed-off-by: yulng <wei.yang@daocloud.io>
According to the golang-lint specification, generic nouns need to be capitalized
Use API instead of Api
Thanks
