### PR TITLE
workflows: Collect a final sysdump on AKS

### DIFF
--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -295,6 +295,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
+          cilium sysdump --output-filename cilium-sysdump-final
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -297,6 +297,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
+          cilium sysdump --output-filename cilium-sysdump-final
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -300,6 +300,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
+          cilium sysdump --output-filename cilium-sysdump-final
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS


### PR DESCRIPTION
Commit b332f4b8f ("workflows: aks: collect sysdumps for each failing test") removed the sysdump collection at the end of the AKS workflows in favor of the collection after each connectivity test failure (i.e., collect-sysdump-on-failure).

In some cases however, issues happen outside or at the very beginning/end of connectivity tests. In those cases, a sysdump is not collected. To ensure we always collect a sysdump, this commit restores the final sysdump collection.