### PR TITLE
bpf: nodeport: fix drop notification in IPv6 revNAT

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1147,8 +1147,11 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 	ret = rev_nodeport_lb6(ctx, &ifindex, &ext_err);
 	if (IS_ERR(ret))
 		goto drop;
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
+		ret = DROP_INVALID;
 		goto drop;
+	}
+
 	if (is_v4_in_v6((union v6addr *)&ip6->saddr)) {
 		int ret2;
 


### PR DESCRIPTION
If revalidate_data() fails, set the drop reason before bailing out.

Fixes: 0040d667caea ("bpf: Add initial NAT 4->6 datapath implementation")
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>