### PR TITLE
hive: Allow multiple calls to `Hive.Shutdown`

### DIFF
--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -278,8 +278,12 @@ func (h *Hive) Shutdown(opts ...ShutdownOption) {
 	for _, opt := range opts {
 		opt.apply(&o)
 	}
-	h.shutdown <- o.err
-	close(h.shutdown)
+
+	// If there already is an error in the channel, no-op
+	select {
+	case h.shutdown <- o.err:
+	default:
+	}
 }
 
 func (h *Hive) PrintObjects() {


### PR DESCRIPTION
This PR adds additional logic to the `Hive.Shutdown` function which will turn any subsequent call after the first one into no-ops. Before, we would attempt to write any error to the already closed channel triggering a panic.