### PR TITLE
clustermesh: Add an infrastructure for connect time parameter exchange and capability negotiation

### DIFF
--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -16,6 +16,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -103,6 +104,15 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	defer os.RemoveAll(dir)
 
 	etcdConfig := []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
+
+	for i, name := range []string{"test2", "cluster1", "cluster2"} {
+		config := cmtypes.CiliumClusterConfig{
+			ID: uint32(i),
+		}
+
+		err = SetClusterConfig(name, &config, kvstore.Client())
+		c.Assert(err, IsNil)
+	}
 
 	config1 := path.Join(dir, "cluster1")
 	err = os.WriteFile(config1, etcdConfig, 0644)

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -29,6 +30,10 @@ import (
 type remoteCluster struct {
 	// name is the name of the cluster
 	name string
+
+	// clusterConfig is a configuration of the remote cluster taken
+	// from remote kvstore.
+	config *cmtypes.CiliumClusterConfig
 
 	// configPath is the path to the etcd configuration to be used to
 	// connect to the etcd cluster of the remote cluster
@@ -123,6 +128,8 @@ func (rc *remoteCluster) releaseOldConnection() {
 	backend := rc.backend
 	rc.backend = nil
 
+	rc.config = nil
+
 	rc.mesh.metricTotalNodes.WithLabelValues(rc.mesh.conf.Name, rc.mesh.conf.NodeName, rc.name).Set(0.0)
 	rc.mesh.metricReadinessStatus.WithLabelValues(rc.mesh.conf.Name, rc.mesh.conf.NodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
 
@@ -177,6 +184,21 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 
 				rc.getLogger().Info("Connection to remote cluster established")
 
+				config, err := GetClusterConfig(rc.name, backend)
+				if err == nil && config == nil {
+					rc.getLogger().Warning("Remote cluster doesn't have cluster configuration, falling back to the old behavior. This is expected when connecting to the old cluster running Cilium without cluster configuration feature.")
+				} else if err == nil {
+					rc.getLogger().Info("Found remote cluster configuration")
+				} else {
+					rc.getLogger().WithError(err).Warning("Unable to get remote cluster configuration")
+					return err
+				}
+
+				if err := rc.mesh.canConnect(rc.name, config); err != nil {
+					rc.getLogger().WithError(err).Error("Unable to connect to the remote cluster")
+					return err
+				}
+
 				remoteNodes, err := store.JoinSharedStore(store.Configuration{
 					Prefix:                  path.Join(nodeStore.NodeStorePrefix, rc.name),
 					KeyCreator:              rc.mesh.conf.NodeKeyCreator,
@@ -226,6 +248,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				rc.remoteNodes = remoteNodes
 				rc.remoteServices = remoteServices
 				rc.backend = backend
+				rc.config = config
 				rc.ipCacheWatcher = ipCacheWatcher
 				rc.remoteIdentityCache = remoteIdentityCache
 				rc.mesh.metricTotalNodes.WithLabelValues(rc.mesh.conf.Name, rc.mesh.conf.NodeName, rc.name).Set(float64(rc.remoteNodes.NumEntries()))

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -55,6 +55,8 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	kvstore.SetupDummy("etcd")
 
 	s.randomName = rand.RandomString()
+	clusterName1 := s.randomName + "1"
+	clusterName2 := s.randomName + "2"
 
 	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName)
 	s.svcCache = k8s.NewServiceCache(fakeDatapath.NewNodeAddressing())
@@ -67,11 +69,19 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	s.testDir = dir
 	c.Assert(err, IsNil)
 
-	config1 := path.Join(dir, s.randomName+"1")
+	for i, cluster := range []string{clusterName1, clusterName2} {
+		config := cmtypes.CiliumClusterConfig{
+			ID: uint32(i),
+		}
+		err := SetClusterConfig(cluster, &config, kvstore.Client())
+		c.Assert(err, IsNil)
+	}
+
+	config1 := path.Join(dir, clusterName1)
 	err = os.WriteFile(config1, etcdConfig, 0644)
 	c.Assert(err, IsNil)
 
-	config2 := path.Join(dir, s.randomName+"2")
+	config2 := path.Join(dir, clusterName2)
 	err = os.WriteFile(config2, etcdConfig, 0644)
 	c.Assert(err, IsNil)
 

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -10,3 +10,7 @@ const (
 	// ClusterIDMax is the maximum value of the cluster ID
 	ClusterIDMax = 255
 )
+
+type CiliumClusterConfig struct {
+	ID uint32 `json:"id,omitempty"`
+}

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -3,6 +3,10 @@
 
 package types
 
+import (
+	"fmt"
+)
+
 const (
 	// ClusterIDMin is the minimum value of the cluster ID
 	ClusterIDMin = 0
@@ -13,4 +17,26 @@ const (
 
 type CiliumClusterConfig struct {
 	ID uint32 `json:"id,omitempty"`
+}
+
+func (c0 *CiliumClusterConfig) IsCompatible(c1 *CiliumClusterConfig) error {
+	if c1 == nil {
+		// When remote cluster doesn't have cluster config, we
+		// currently just bypass the validation for compatibility.
+		// Otherwise, we cannot connect with older cluster which
+		// doesn't support cluster config feature.
+		//
+		// When we introduce a new cluster config can't be ignored,
+		// we should properly check it here and return error. Now
+		// we only have ClusterID which used to be ignored.
+		return nil
+	} else {
+		// Remote cluster has cluster config. Do validations.
+
+		// ID shouldn't be duplicated
+		if c0.ID == c1.ID {
+			return fmt.Errorf("duplicated cluster id")
+		}
+	}
+	return nil
 }

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -39,6 +39,9 @@ const (
 	// the heartbeat
 	HeartbeatPath = BaseKeyPrefix + "/.heartbeat"
 
+	// ClusterConfigPrefix is the kvstore prefix to cluster configuration
+	ClusterConfigPrefix = BaseKeyPrefix + "/cluster-config"
+
 	// HeartbeatWriteInterval is the interval in which the heartbeat key at
 	// HeartbeatPath is updated
 	HeartbeatWriteInterval = time.Minute


### PR DESCRIPTION
Add a new kvstore object `CiliumClusterConfig` with path `cilium/cluster-config/<cluster name>`. The object is created per cluster by clustermesh-apiserver and obtained by cilium-agent at start-up time. The use cases of the objects are

**Getting per-cluster parameter**
ClusterMesh with overlapping PodCIDR support needs this for getting ClusterID on connect time and setup kvstore observers to annotate incoming objects with remote ClusterID. We can put such parameters to `CiliumClusterConfig`.

**Capability negotiation and configuration validation**
When there's a capability mismatch or configuration mismatch between clusters, we may not be able to connect those clusters correctly. Currently, we don't have any mechanism to check such a mismatch. With `CiliumClusterConfig`, we can check that on connect time. Currently, we only check ClusterID duplication but can add any capabilities/configuration in the future.

```release-note
clustermesh: Add an infrastructure to connect time parameter exchange and capability negotiation
```
