### PR TITLE
envoy: Update to add auth extensions

### DIFF
--- a/Documentation/network/servicemesh/l7-traffic-management.rst
+++ b/Documentation/network/servicemesh/l7-traffic-management.rst
@@ -44,7 +44,9 @@ following extensions:
 - ``envoy.clusters.dynamic_forward_proxy``
 - ``envoy.filters.http.dynamic_forward_proxy``
 - ``envoy.filters.http.ext_authz``
+- ``envoy.filters.http.jwt_authn``
 - ``envoy.filters.http.local_ratelimit``
+- ``envoy.filters.http.oauth2``
 - ``envoy.filters.http.ratelimit``
 - ``envoy.filters.http.router``
 - ``envoy.filters.http.set_metadata``

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:1a8102930aa1ec5d82312abc9
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:7c5c1c44c8e8c3c264326f891bb8bdc8a7fc7de2@sha256:bef1e1ac2eaf09c8ae7fd1bc47e52a11fdf8cce6653ff22faee3a3d498d3d523 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:ff9a74a473dd5c1f6bfd7ce10938dab648f70c09@sha256:35afe14537ebf9fcfe4ab3d9488ec7f884bc2661da73383294f9b72deee82cfe as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
Update envoy image to the build of
https://github.com/cilium/proxy/commit/ff9a74a473dd5c1f6bfd7ce10938dab648f70c09 which adds 'envoy.filters.http.jwt_authn' and 'envoy.filters.http.oauth2' to the build so that these can be used in (Clusterwide)CiliumEnvoyConfig resources.

This does not block any planned functionality for 1.13, but should be made available in 1.13, so marked this as a release blocker for 1.13.

```release-note
Added 'envoy.filters.http.jwt_authn' and 'envoy.filters.http.oauth2' to the build to be used in CiliumEnvoyConfig resources.
```
