### PR TITLE
v1.11 backports 2022-12-06

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -4,16 +4,15 @@ on:
   pull_request_target:
     types:
       - opened
-      - synchronize
       - reopened
 
 jobs:
   labeler:
     if: |
       (
-        (github.event.issue.author_association != 'OWNER') &&
-        (github.event.issue.author_association != 'COLLABORATOR') &&
-        (github.event.issue.author_association != 'MEMBER')
+        (github.event.pull_request.author_association != 'OWNER') &&
+        (github.event.pull_request.author_association != 'COLLABORATOR') &&
+        (github.event.pull_request.author_association != 'MEMBER')
       )
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -1,0 +1,30 @@
+name: PR from External Contribution Detector
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  labeler:
+    if: |
+      (
+        (github.event.issue.author_association != 'OWNER') &&
+        (github.event.issue.author_association != 'COLLABORATOR') &&
+        (github.event.issue.author_association != 'MEMBER')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["kind/community-contribution"]
+            })

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -24,6 +24,8 @@ cilium-operator-alibabacloud [flags]
       --cluster-pool-ipv6-cidr strings            IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
       --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
       --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-cleanup-burst int              Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
+      --cnp-status-cleanup-qps float              Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
       --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                             Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                         Configuration directory that contains a file for each option

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -67,6 +67,7 @@ cilium-operator-alibabacloud [flags]
       --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                         When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter map                    Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -25,6 +25,8 @@ cilium-operator-aws [flags]
       --cluster-pool-ipv6-cidr strings            IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
       --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
       --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-cleanup-burst int              Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
+      --cnp-status-cleanup-qps float              Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
       --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                             Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                         Configuration directory that contains a file for each option

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -71,6 +71,7 @@ cilium-operator-aws [flags]
       --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                         When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter map                    Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -27,6 +27,8 @@ cilium-operator-azure [flags]
       --cluster-pool-ipv6-cidr strings            IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
       --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
       --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-cleanup-burst int              Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
+      --cnp-status-cleanup-qps float              Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
       --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                             Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                         Configuration directory that contains a file for each option

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -70,6 +70,7 @@ cilium-operator-azure [flags]
       --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                         When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter map                    Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -66,6 +66,7 @@ cilium-operator-generic [flags]
       --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                         When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter map                    Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -23,6 +23,8 @@ cilium-operator-generic [flags]
       --cluster-pool-ipv6-cidr strings            IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
       --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
       --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-cleanup-burst int              Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
+      --cnp-status-cleanup-qps float              Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
       --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                             Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                         Configuration directory that contains a file for each option

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -30,6 +30,8 @@ cilium-operator [flags]
       --cluster-pool-ipv6-cidr strings            IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
       --cluster-pool-ipv6-mask-size int           Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
       --cnp-node-status-gc-interval duration      GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-cleanup-burst int              Maximum burst of requests to clean up status nodes updates in CNPs (default 20)
+      --cnp-status-cleanup-qps float              Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps (default 10)
       --cnp-status-update-interval duration       Interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
       --config string                             Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                         Configuration directory that contains a file for each option

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -76,6 +76,7 @@ cilium-operator [flags]
       --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                         When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)
       --subnet-tags-filter map                    Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag

--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -229,9 +229,22 @@ different value and then proceed with the steps below.
    to approve the build that was created by GitHub Actions `here <https://github.com/cilium/cilium/actions?query=workflow:%22Base+Image+Release+Build%22>`__.
    Note that at this step cilium-builder build failure is expected since we have yet to update the runtime digest.
 
-#. Wait for build to complete. The build will automatically generate one commit
-   and push it to your branch with all the necessary changes across files in the
-   repository. Once this is done the CI can be executed.
+#. Wait for build to complete. If the PR was opened from an external fork the
+   build will fail while trying to push the changes, this is expected.
+
+#. If the PR was opened from an external fork, run the following commands and
+   re-push the changes to your branch. Once this is done the CI can be executed.
+
+   .. code-block:: shell-session
+
+       $ make -C images/ update-runtime-image
+       $ git commit -sam "images: update cilium-{runtime,builder}" --amend
+       $ make -C images/ update-builder-image
+       $ git commit -sam "images: update cilium-{runtime,builder}" --amend
+
+#. If the PR was opened from the main repository, the build will automatically
+   generate one commit and push it to your branch with all the necessary changes
+   across files in the repository. Once this is done the CI can be executed.
 
 #. Update the versions of the images that are pulled into the CI VMs.
 

--- a/Documentation/gettingstarted/cassandra.rst
+++ b/Documentation/gettingstarted/cassandra.rst
@@ -67,10 +67,10 @@ above, as well as a Kubernetes Service *cassandra-svc* for the Cassandra cluster
 .. parsed-literal::
 
     $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes-cassandra/cass-sw-app.yaml
-    deployment.extensions/cass-server created
+    deployment.apps/cass-server created
     service/cassandra-svc created
-    deployment.extensions/empire-hq created
-    deployment.extensions/empire-outpost created
+    deployment.apps/empire-hq created
+    deployment.apps/empire-outpost created
 
 Kubernetes will deploy the pods and service in the background.
 Running ``kubectl get svc,pods`` will inform you about the progress of the operation.

--- a/Documentation/gettingstarted/gsg_sw_demo.rst
+++ b/Documentation/gettingstarted/gsg_sw_demo.rst
@@ -19,7 +19,7 @@ It also includes a deathstar-service, which load-balances traffic to all pods wi
 
     $ kubectl create -f \ |SCM_WEB|\/examples/minikube/http-sw-app.yaml
     service/deathstar created
-    deployment.extensions/deathstar created
+    deployment.apps/deathstar created
     pod/tiefighter created
     pod/xwing created
 

--- a/Documentation/gettingstarted/memcached.rst
+++ b/Documentation/gettingstarted/memcached.rst
@@ -61,11 +61,11 @@ above, as well as a Kubernetes Service *memcached-server* for the Memcached serv
 .. parsed-literal::
 
     $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes-memcached/memcd-sw-app.yaml
-    deployment.extensions/memcached-server created
+    deployment.apps/memcached-server created
     service/memcached-server created
-    deployment.extensions/a-wing created
-    deployment.extensions/x-wing created
-    deployment.extensions/alliance-tracker created
+    deployment.apps/a-wing created
+    deployment.apps/x-wing created
+    deployment.apps/alliance-tracker created
 
 Kubernetes will deploy the pods and service in the background.
 Running ``kubectl get svc,pods`` will inform you about the progress of the operation.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1197,6 +1197,10 @@
      - Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod.
      - bool
      - ``true``
+   * - operator.skipCNPStatusStartupClean
+     - Skip CNP node status clean up at operator startup.
+     - bool
+     - ``false``
    * - operator.skipCRDCreation
      - Skip CRDs creation for cilium-operator
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -810,6 +810,7 @@ sha
 sidecarImageRegex
 sig
 skb
+skipCNPStatusStartupClean
 skipCRDCreation
 skipteardown
 sleepAfterInit

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -334,14 +334,14 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	// Once we stop returning errors from StartDNSProxy this should live in
 	// StartProxySupport
 	port, listenerName, err := proxy.GetProxyPort(policy.ParserTypeDNS, false)
+	if err != nil {
+		return err
+	}
 	if option.Config.ToFQDNsProxyPort != 0 {
 		port = uint16(option.Config.ToFQDNsProxyPort)
 	} else if port == 0 {
 		// Try locate old DNS proxy port number from the datapath
 		port = d.datapath.GetProxyPort(listenerName)
-	}
-	if err != nil {
-		return err
 	}
 	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
 		option.Config.DNSMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,

--- a/examples/kubernetes/addons/prometheus/README.md
+++ b/examples/kubernetes/addons/prometheus/README.md
@@ -27,14 +27,14 @@ Next, install all monitoring tools and configurations by running:
 $ kubectl create -f examples/kubernetes/addons/prometheus/monitoring-example.yaml
 namespace/monitoring created
 configmap/prometheus created
-deployment.extensions/prometheus created
+deployment.apps/prometheus created
 service/prometheus created
 service/prometheus-open created
 clusterrolebinding.rbac.authorization.k8s.io/prometheus created
 clusterrole.rbac.authorization.k8s.io/prometheus created
 serviceaccount/prometheus-k8s created
 configmap/grafana-config created
-deployment.extensions/grafana created
+deployment.apps/grafana created
 service/grafana created
 configmap/grafana-dashboards created
 job.batch/grafana-dashboards-import created

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -350,6 +350,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.securityContext | object | `{}` | Security context to be added to cilium-operator pods |
 | operator.serviceAccountName | string | `"cilium-operator"` | For using with an existing serviceAccount. |
 | operator.setNodeNetworkStatus | bool | `true` | Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod. |
+| operator.skipCNPStatusStartupClean | bool | `false` | Skip CNP node status clean up at operator startup. |
 | operator.skipCRDCreation | bool | `false` | Skip CRDs creation for cilium-operator |
 | operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | operator.unmanagedPodWatcher.intervalSeconds | int | `15` | Interval, in seconds, to check if there are any pods that are not managed by Cilium. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -113,6 +113,10 @@ data:
   nodes-gc-interval: "{{ .Values.operator.nodeGCInterval | default "0s" }}"
 {{- end }}
 
+{{- if hasKey .Values.operator "skipCNPStatusStartupClean" }}
+  skip-cnp-status-startup-clean: "{{ .Values.operator.skipCNPStatusStartupClean }}"
+{{- end }}
+
 {{- if hasKey .Values "disableEndpointCRD" }}
   # Disable the usage of CiliumEndpoint CRD
   disable-endpoint-crd: "{{ .Values.disableEndpointCRD }}"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1465,6 +1465,9 @@ operator:
   # -- Interval for cilium node garbage collection.
   nodeGCInterval: "5m0s"
 
+  # -- Skip CNP node status clean up at operator startup.
+  skipCNPStatusStartupClean: false
+
   # -- Interval for identity garbage collection.
   identityGCInterval: "15m0s"
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1462,6 +1462,9 @@ operator:
   # -- Interval for cilium node garbage collection.
   nodeGCInterval: "5m0s"
 
+  # -- Skip CNP node status clean up at operator startup.
+  skipCNPStatusStartupClean: false
+
   # -- Interval for identity garbage collection.
   identityGCInterval: "15m0s"
 

--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -377,7 +377,7 @@ func runCNPNodeStatusGC(name string, clusterwide bool, nodeStore cache.Store) {
 							return err
 						}
 
-						cnpItemsList = make([]cilium_v2.CiliumNetworkPolicy, 0)
+						cnpItemsList = make([]cilium_v2.CiliumNetworkPolicy, 0, len(ccnpList.Items))
 						for _, ccnp := range ccnpList.Items {
 							cnpItemsList = append(cnpItemsList, cilium_v2.CiliumNetworkPolicy{
 								ObjectMeta: meta_v1.ObjectMeta{

--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -406,12 +406,12 @@ func runCNPNodeStatusGC(name string, clusterwide bool, nodeStore cache.Store) {
 						nodesToDelete := map[string]v1.Time{}
 						for n, status := range cnp.Status.Nodes {
 							if _, exists, err := nodeStore.GetByKey(n); !exists && err == nil {
-								// To avoid concurrency issues where a is
+								// To avoid concurrency issues where a node is
 								// created and adds its CNP Status before the operator
 								// node watcher receives an event that the node
 								// was created, we will only delete the node
 								// from the CNP Status if the last time it was
-								// update was before the lastRun.
+								// updated was before the lastRun.
 								if status.LastUpdated.Before(&lastRun) {
 									nodesToDelete[n] = status.LastUpdated
 									delete(cnp.Status.Nodes, n)

--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -499,3 +499,101 @@ func updateCNP(ctx context.Context, ciliumClient v2.CiliumV2Interface, cnp *cili
 		}
 	}
 }
+
+func RunCNPStatusNodesCleaner(ctx context.Context, ciliumClient v2.CiliumV2Interface) {
+	go clearCNPStatusNodes(ctx, false, ciliumClient)
+	go clearCNPStatusNodes(ctx, true, ciliumClient)
+}
+
+func clearCNPStatusNodes(ctx context.Context, clusterwide bool, ciliumClient v2.CiliumV2Interface) {
+	body, err := json.Marshal([]k8s.JSONPatch{
+		{
+			OP:   "remove",
+			Path: "/status/nodes",
+		},
+	})
+	if err != nil {
+		log.WithError(err).Debug("Unable to json marshal")
+		return
+	}
+
+	continueID := ""
+	nCNPs, nGcCNPs := 0, 0
+	for {
+		if clusterwide {
+			ccnpList, err := ciliumClient.CiliumClusterwideNetworkPolicies().List(
+				ctx,
+				meta_v1.ListOptions{
+					Limit:    10,
+					Continue: continueID,
+				})
+			if err != nil {
+				log.WithError(err).Debug("Unable to list CCNPs")
+				return
+			}
+			nCNPs += len(ccnpList.Items)
+			continueID = ccnpList.Continue
+
+			for _, cnp := range ccnpList.Items {
+				if len(cnp.Status.Nodes) == 0 {
+					continue
+				}
+
+				_, err = ciliumClient.CiliumClusterwideNetworkPolicies().Patch(ctx,
+					cnp.Name, types.JSONPatchType, body, meta_v1.PatchOptions{}, "status")
+
+				if err != nil {
+					if errors.IsInvalid(err) {
+						// An "Invalid" error may be returned if /status/nodes path does not exist.
+						// In that case, we simply ignore it, since there are no updates to clean up.
+						continue
+					}
+					log.WithError(err).Debug("Unable to PATCH while clearing status nodes in CCNP")
+				}
+				nGcCNPs++
+			}
+		} else {
+			cnpList, err := ciliumClient.CiliumNetworkPolicies(core_v1.NamespaceAll).List(
+				ctx,
+				meta_v1.ListOptions{
+					Limit:    10,
+					Continue: continueID,
+				})
+			if err != nil {
+				log.WithError(err).Debug("Unable to list CNPs")
+				return
+			}
+			nCNPs += len(cnpList.Items)
+			continueID = cnpList.Continue
+
+			for _, cnp := range cnpList.Items {
+				if len(cnp.Status.Nodes) == 0 {
+					continue
+				}
+
+				namespace := utils.ExtractNamespace(&cnp.ObjectMeta)
+				_, err = ciliumClient.CiliumNetworkPolicies(namespace).Patch(ctx,
+					cnp.Name, types.JSONPatchType, body, meta_v1.PatchOptions{}, "status")
+				if err != nil {
+					if errors.IsInvalid(err) {
+						// An "Invalid" error may be returned if /status/nodes path does not exist.
+						// In that case, we simply ignore it, since there are no updates to clean up.
+						continue
+					}
+					log.WithError(err).Debug("Unable to PATCH while clearing status nodes in CNP")
+				}
+				nGcCNPs++
+			}
+		}
+
+		if continueID == "" {
+			break
+		}
+	}
+
+	if clusterwide {
+		log.Infof("Garbage collected status/nodes in Cilium Clusterwide Network Policies found=%d, gc=%d", nCNPs, nGcCNPs)
+	} else {
+		log.Infof("Garbage collected status/nodes in Cilium Network Policies found=%d, gc=%d", nCNPs, nGcCNPs)
+	}
+}

--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -423,7 +423,7 @@ func runCNPNodeStatusGC(name string, clusterwide bool, nodeStore cache.Store) {
 							wg.Add(1)
 							cnpCpy := cnp.DeepCopy()
 							removeNodeFromCNP <- func() {
-								updateCNP(ciliumK8sClient.CiliumV2(), cnpCpy, nodesToDelete)
+								updateCNP(ctx, ciliumK8sClient.CiliumV2(), cnpCpy, nodesToDelete)
 								wg.Done()
 							}
 						}
@@ -438,10 +438,9 @@ func runCNPNodeStatusGC(name string, clusterwide bool, nodeStore cache.Store) {
 				return nil
 			},
 		})
-
 }
 
-func updateCNP(ciliumClient v2.CiliumV2Interface, cnp *cilium_v2.CiliumNetworkPolicy, nodesToDelete map[string]v1.Time) {
+func updateCNP(ctx context.Context, ciliumClient v2.CiliumV2Interface, cnp *cilium_v2.CiliumNetworkPolicy, nodesToDelete map[string]v1.Time) {
 	if len(nodesToDelete) == 0 {
 		return
 	}
@@ -482,10 +481,10 @@ func updateCNP(ciliumClient v2.CiliumV2Interface, cnp *cilium_v2.CiliumNetworkPo
 		// If the namespace is empty the policy is the clusterwide policy
 		// and not the namespaced CiliumNetworkPolicy.
 		if ns == "" {
-			_, err = ciliumClient.CiliumClusterwideNetworkPolicies().Patch(context.TODO(),
+			_, err = ciliumClient.CiliumClusterwideNetworkPolicies().Patch(ctx,
 				cnp.GetName(), types.JSONPatchType, removeStatusNodeJSON, meta_v1.PatchOptions{}, "status")
 		} else {
-			_, err = ciliumClient.CiliumNetworkPolicies(ns).Patch(context.TODO(),
+			_, err = ciliumClient.CiliumNetworkPolicies(ns).Patch(ctx,
 				cnp.GetName(), types.JSONPatchType, removeStatusNodeJSON, meta_v1.PatchOptions{}, "status")
 		}
 		if err != nil {

--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -22,6 +22,7 @@ import (
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"golang.org/x/time/rate"
 
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -500,12 +501,12 @@ func updateCNP(ctx context.Context, ciliumClient v2.CiliumV2Interface, cnp *cili
 	}
 }
 
-func RunCNPStatusNodesCleaner(ctx context.Context, ciliumClient v2.CiliumV2Interface) {
-	go clearCNPStatusNodes(ctx, false, ciliumClient)
-	go clearCNPStatusNodes(ctx, true, ciliumClient)
+func RunCNPStatusNodesCleaner(ctx context.Context, ciliumClient v2.CiliumV2Interface, rateLimit *rate.Limiter) {
+	go clearCNPStatusNodes(ctx, false, ciliumClient, rateLimit)
+	go clearCNPStatusNodes(ctx, true, ciliumClient, rateLimit)
 }
 
-func clearCNPStatusNodes(ctx context.Context, clusterwide bool, ciliumClient v2.CiliumV2Interface) {
+func clearCNPStatusNodes(ctx context.Context, clusterwide bool, ciliumClient v2.CiliumV2Interface, rateLimit *rate.Limiter) {
 	body, err := json.Marshal([]k8s.JSONPatch{
 		{
 			OP:   "remove",
@@ -521,6 +522,11 @@ func clearCNPStatusNodes(ctx context.Context, clusterwide bool, ciliumClient v2.
 	nCNPs, nGcCNPs := 0, 0
 	for {
 		if clusterwide {
+			if err := rateLimit.Wait(ctx); err != nil {
+				log.WithError(err).Debug("Error while rate limiting CCNP List requests")
+				return
+			}
+
 			ccnpList, err := ciliumClient.CiliumClusterwideNetworkPolicies().List(
 				ctx,
 				meta_v1.ListOptions{
@@ -539,6 +545,11 @@ func clearCNPStatusNodes(ctx context.Context, clusterwide bool, ciliumClient v2.
 					continue
 				}
 
+				if err := rateLimit.Wait(ctx); err != nil {
+					log.WithError(err).Debug("Error while rate limiting CCNP PATCH requests")
+					return
+				}
+
 				_, err = ciliumClient.CiliumClusterwideNetworkPolicies().Patch(ctx,
 					cnp.Name, types.JSONPatchType, body, meta_v1.PatchOptions{}, "status")
 
@@ -553,6 +564,11 @@ func clearCNPStatusNodes(ctx context.Context, clusterwide bool, ciliumClient v2.
 				nGcCNPs++
 			}
 		} else {
+			if err := rateLimit.Wait(ctx); err != nil {
+				log.WithError(err).Debug("Error while rate limiting CNP List requests")
+				return
+			}
+
 			cnpList, err := ciliumClient.CiliumNetworkPolicies(core_v1.NamespaceAll).List(
 				ctx,
 				meta_v1.ListOptions{
@@ -572,6 +588,12 @@ func clearCNPStatusNodes(ctx context.Context, clusterwide bool, ciliumClient v2.
 				}
 
 				namespace := utils.ExtractNamespace(&cnp.ObjectMeta)
+
+				if err := rateLimit.Wait(ctx); err != nil {
+					log.WithError(err).Debug("Error while rate limiting CNP PATCH requests")
+					return
+				}
+
 				_, err = ciliumClient.CiliumNetworkPolicies(namespace).Patch(ctx,
 					cnp.Name, types.JSONPatchType, body, meta_v1.PatchOptions{}, "status")
 				if err != nil {

--- a/operator/cnp_event.go
+++ b/operator/cnp_event.go
@@ -36,8 +36,8 @@ func init() {
 	}
 }
 
-// enableCNPWatcher waits for the CiliumNetowrkPolicy CRD availability and then
-// garbage collects stale CiliumNetowrkPolicy status field entries.
+// enableCNPWatcher waits for the CiliumNetworkPolicy CRD availability and then
+// garbage collects stale CiliumNetworkPolicy status field entries.
 func enableCNPWatcher() error {
 	enableCNPStatusUpdates := kvstoreEnabled() && option.Config.K8sEventHandover && !option.Config.DisableCNPStatusUpdates
 	if enableCNPStatusUpdates {

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -63,6 +63,9 @@ func init() {
 	flags.Duration(operatorOption.CNPNodeStatusGCInterval, 2*time.Minute, "GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status")
 	option.BindEnv(operatorOption.CNPNodeStatusGCInterval)
 
+	flags.Bool(operatorOption.SkipCNPStatusStartupClean, false, `If set to true, the operator will not clean up CNP node status updates at startup`)
+	option.BindEnv(operatorOption.SkipCNPStatusStartupClean)
+
 	flags.Duration(operatorOption.CNPStatusUpdateInterval, 1*time.Second, "Interval between CNP status updates sent to the k8s-apiserver per-CNP")
 	option.BindEnv(operatorOption.CNPStatusUpdateInterval)
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -66,6 +66,14 @@ func init() {
 	flags.Bool(operatorOption.SkipCNPStatusStartupClean, false, `If set to true, the operator will not clean up CNP node status updates at startup`)
 	option.BindEnv(operatorOption.SkipCNPStatusStartupClean)
 
+	flags.Float64(operatorOption.CNPStatusCleanupQPS, operatorOption.CNPStatusCleanupQPSDefault,
+		"Rate used for limiting the clean up of the status nodes updates in CNP, expressed as qps")
+	option.BindEnv(operatorOption.CNPStatusCleanupQPS)
+
+	flags.Int(operatorOption.CNPStatusCleanupBurst, operatorOption.CNPStatusCleanupBurstDefault,
+		"Maximum burst of requests to clean up status nodes updates in CNPs")
+	option.BindEnv(operatorOption.CNPStatusCleanupBurst)
+
 	flags.Duration(operatorOption.CNPStatusUpdateInterval, 1*time.Second, "Interval between CNP status updates sent to the k8s-apiserver per-CNP")
 	option.BindEnv(operatorOption.CNPStatusUpdateInterval)
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -508,7 +508,9 @@ func onOperatorStartLeading(ctx context.Context) {
 		log.WithError(err).Fatal("Unable to setup node watcher")
 	}
 
-	if option.Config.DisableCNPStatusUpdates {
+	if operatorOption.Config.SkipCNPStatusStartupClean {
+		log.Info("Skipping clean up of CNP and CCNP node status updates")
+	} else {
 		// If CNP status updates are disabled, we clean up all the
 		// possible updates written when the option was enabled.
 		// This is done to avoid accumulating stale updates and thus

--- a/operator/main.go
+++ b/operator/main.go
@@ -508,6 +508,14 @@ func onOperatorStartLeading(ctx context.Context) {
 		log.WithError(err).Fatal("Unable to setup node watcher")
 	}
 
+	if option.Config.DisableCNPStatusUpdates {
+		// If CNP status updates are disabled, we clean up all the
+		// possible updates written when the option was enabled.
+		// This is done to avoid accumulating stale updates and thus
+		// hindering scalability for large clusters.
+		RunCNPStatusNodesCleaner(ctx, k8s.CiliumClient().CiliumV2())
+	}
+
 	if operatorOption.Config.CNPNodeStatusGCInterval != 0 {
 		RunCNPNodeStatusGC(ciliumNodeStore)
 	}

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -52,6 +52,10 @@ const (
 	// being sent to the K8s apiserver for a given CNP.
 	CNPStatusUpdateInterval = "cnp-status-update-interval"
 
+	// SkipCNPStatusStartupClean specifies if the cleanup of all the CNP
+	// NodeStatus updates at startup must be skipped.
+	SkipCNPStatusStartupClean = "skip-cnp-status-startup-clean"
+
 	// EnableMetrics enables prometheus metrics.
 	EnableMetrics = "enable-metrics"
 
@@ -240,6 +244,10 @@ type OperatorConfig struct {
 	// NodeGCInterval is the GC interval for CiliumNodes
 	NodeGCInterval time.Duration
 
+	// SkipCNPStatusStartupClean disables the cleanup of all the CNP
+	// NodeStatus updates at startup.
+	SkipCNPStatusStartupClean bool
+
 	// EnableMetrics enables prometheus metrics.
 	EnableMetrics bool
 
@@ -424,6 +432,7 @@ func (c *OperatorConfig) Populate() {
 	c.CNPNodeStatusGCInterval = viper.GetDuration(CNPNodeStatusGCInterval)
 	c.CNPStatusUpdateInterval = viper.GetDuration(CNPStatusUpdateInterval)
 	c.NodeGCInterval = viper.GetDuration(NodesGCInterval)
+	c.SkipCNPStatusStartupClean = viper.GetBool(SkipCNPStatusStartupClean)
 	c.EnableMetrics = viper.GetBool(EnableMetrics)
 	c.EndpointGCInterval = viper.GetDuration(EndpointGCInterval)
 	c.IdentityGCInterval = viper.GetDuration(IdentityGCInterval)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -29,6 +29,12 @@ const (
 
 	// CESSlicingModeDefault is default method for grouping CEP in a CES.
 	CESSlicingModeDefault = "cesSliceModeIdentity"
+
+	// CNPStatusCleanupQPSDefault is the default rate for the CNP NodeStatus updates GC.
+	CNPStatusCleanupQPSDefault = 10
+
+	// CNPStatusCleanupBurstDefault is the default maximum burst for the CNP NodeStatus updates GC.
+	CNPStatusCleanupBurstDefault = 20
 )
 
 const (
@@ -55,6 +61,15 @@ const (
 	// SkipCNPStatusStartupClean specifies if the cleanup of all the CNP
 	// NodeStatus updates at startup must be skipped.
 	SkipCNPStatusStartupClean = "skip-cnp-status-startup-clean"
+
+	// CNPStatusCleanupQPS is the rate at which the cleanup operation of the status
+	// nodes updates in CNPs is carried out. It is expressed as queries per second,
+	// and for each query a single CNP status update will be deleted.
+	CNPStatusCleanupQPS = "cnp-status-cleanup-qps"
+
+	// CNPStatusCleanupBurst is the maximum burst of queries allowed for the cleanup
+	// operation of the status nodes updates in CNPs.
+	CNPStatusCleanupBurst = "cnp-status-cleanup-burst"
 
 	// EnableMetrics enables prometheus metrics.
 	EnableMetrics = "enable-metrics"
@@ -248,6 +263,15 @@ type OperatorConfig struct {
 	// NodeStatus updates at startup.
 	SkipCNPStatusStartupClean bool
 
+	// CNPStatusCleanupQPS is the rate at which the cleanup operation of the status
+	// nodes updates in CNPs is carried out. It is expressed as queries per second,
+	// and for each query a single CNP status update will be deleted.
+	CNPStatusCleanupQPS float64
+
+	// CNPStatusCleanupBurst is the maximum burst of queries allowed for the cleanup
+	// operation of the status nodes updates in CNPs.
+	CNPStatusCleanupBurst int
+
 	// EnableMetrics enables prometheus metrics.
 	EnableMetrics bool
 
@@ -433,6 +457,8 @@ func (c *OperatorConfig) Populate() {
 	c.CNPStatusUpdateInterval = viper.GetDuration(CNPStatusUpdateInterval)
 	c.NodeGCInterval = viper.GetDuration(NodesGCInterval)
 	c.SkipCNPStatusStartupClean = viper.GetBool(SkipCNPStatusStartupClean)
+	c.CNPStatusCleanupQPS = viper.GetFloat64(CNPStatusCleanupQPS)
+	c.CNPStatusCleanupBurst = viper.GetInt(CNPStatusCleanupBurst)
 	c.EnableMetrics = viper.GetBool(EnableMetrics)
 	c.EndpointGCInterval = viper.GetDuration(EndpointGCInterval)
 	c.IdentityGCInterval = viper.GetDuration(IdentityGCInterval)

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -107,7 +107,7 @@ func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
 
 var (
 	// We can remove the check for this warning once 1.9 is the oldest supported Cilium version.
-	warnWildcardToFromEndpointMessage = "It seems you have a CiliumClusterwideNetworkPolicy " +
+	errWildcardToFromEndpointMessage = "It seems you have a CiliumClusterwideNetworkPolicy " +
 		"with a wildcard to/from endpoint selector. The behavior of this selector has been " +
 		"changed. The selector now only allows traffic to/from Cilium managed K8s endpoints, " +
 		"instead of acting as a truly empty endpoint selector allowing all traffic. To " +
@@ -159,9 +159,9 @@ func checkWildCardToFromEndpoint(ccnp *unstructured.Unstructured) error {
 	if resCCNP.Spec != nil {
 		if containsWildcardToFromEndpoint(resCCNP.Spec) {
 			logOnce.Do(func() {
-				logger.Warning(warnWildcardToFromEndpointMessage)
+				logger.Error(errWildcardToFromEndpointMessage)
 			})
-			return nil
+			return fmt.Errorf("use of empty toEndpoints/fromEndpoints selector")
 		}
 	}
 
@@ -169,9 +169,9 @@ func checkWildCardToFromEndpoint(ccnp *unstructured.Unstructured) error {
 		for _, rule := range resCCNP.Specs {
 			if containsWildcardToFromEndpoint(rule) {
 				logOnce.Do(func() {
-					logger.Warning(warnWildcardToFromEndpointMessage)
+					logger.Error(errWildcardToFromEndpointMessage)
 				})
-				return nil
+				return fmt.Errorf("use of empty toEndpoints/fromEndpoints selector")
 			}
 		}
 	}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -264,9 +264,8 @@ func (*k8sMetrics) Increment(_ context.Context, code string, method string, host
 	// more info:
 	// https://github.com/kubernetes/client-go/blob/v0.18.0-rc.1/rest/request.go#L700-L703
 	if code != "<error>" {
-		// Consider success if status code is 2xx or 4xx
-		if strings.HasPrefix(code, "2") ||
-			strings.HasPrefix(code, "4") {
+		// Consider success only if status code is 2xx
+		if strings.HasPrefix(code, "2") {
 			k8smetrics.LastSuccessInteraction.Reset()
 		}
 	}


### PR DESCRIPTION
 * [ ] #22002 -- docs: fix deployment resource type output (@cleverhu)
 * [x] #22296 -- daemon/cmd: Fix error handling for getting proxy port (@christarazi)
 * [x] #22304 -- docs: add instructions to build the base images from external forks (@aanm)
 * [x] #20366 -- Clear stale CNP status nodes if updates have been disabled (@pippolo84)
 * [x] #21990 -- fix: Fail CCNP preflight check if using empty endpoint selectors (@thorn3r)
 * [x] #22393 -- k8s: don't consider 4xx a successful interaction (@bimmlerd)
 * [x] #22461 -- .github: add PR labeler for external contributions (@aanm)
 * [x] #22508 -- .github/workflows: use right event type for auto labeler (@aanm)

**Most of these had conflicts due to various moves and refactors.**

PRs skipped due conflicts:

 * #20350 -- daemon: add cleanup for stale local ciliumendpoints that aren't being managed. (@tommyp1ckles)
 * #22321 -- docs: Update Cilium Sphinx RTD Theme reference (@kimstacy)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 20350 22002 22321 22296 22304 20366 21990 22393 22461 22508; do contrib/backporting/set-labels.py $pr done 1.11; done
```