### PR TITLE
Revert "dependabot: monthly update of cloud provider SDK Go modules"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,27 +12,12 @@ updates:
         # k8s dependencies will be updated manually along with tests
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
-        # cloud provider SDKs are updated too frequently, update them monthly (see below)
+        # cloud provider SDKs are updated too frequently, update them manually
       - dependency-name: "github.com/aliyun/alibaba-cloud-sdk-go"
       - dependency-name: "github.com/aws/*"
       - dependency-name: "github.com/Azure/*"
         # need to update the gops binary in the runtime image in lockstep
       - dependency-name: "github.com/google/gops"
-    labels:
-    - kind/enhancement
-    - release-note/misc
-
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
-    rebase-strategy: "disabled"
-    allow:
-        # cloud provider SDKs are updated too frequently, update them monthly
-      - dependency-name: "github.com/aliyun/alibaba-cloud-sdk-go"
-      - dependency-name: "github.com/aws/*"
-      - dependency-name: "github.com/Azure/*"
     labels:
     - kind/enhancement
     - release-note/misc

--- a/contrib/scripts/go-mod-update-cloud-providers.sh
+++ b/contrib/scripts/go-mod-update-cloud-providers.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script updates all vendored cloud provider SDK Go modules to their latest
+# version.
+#
+# These dependencies are not updated automatically by dependabot like
+# other Go dependencies due to the frequency of thes updates requiring developer
+# time for review and also the frequent need to rebase these PRs (see
+# https://github.com/cilium/cilium/pull/18067). Instead, we manually update the
+# dependencies all at once on a monthly basis using this script.
+
+set -e
+set -o pipefail
+
+for mod in \
+	github.com/Azure/azure-sdk-for-go \
+	github.com/Azure/go-autorest/autorest \
+	github.com/Azure/go-autorest/autorest/adal \
+	github.com/Azure/go-autorest/autorest/azure/auth \
+	github.com/Azure/go-autorest/autorest/to \
+	github.com/aliyun/alibaba-cloud-sdk-go \
+	github.com/aws/aws-sdk-go-v2 \
+	github.com/aws/aws-sdk-go-v2/config \
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds \
+	github.com/aws/aws-sdk-go-v2/service/ec2 \
+	github.com/aws/smithy-go
+do
+	go get $mod@latest
+done
+go mod tidy
+go mod vendor


### PR DESCRIPTION
This reverts commit 5a6fb94d9c62895e53f17c41aab7f819b977f532.

Currently, it is not possible to have "duplicated updates" (i.e.: multiple updates with the same <package-ecosystem, directory, target-branch> tuple) in dependabot configuration: https://github.com/dependabot/dependabot-core/issues/1778.

In order to avoid the following error while parsing dependabot config:

The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'

(seen [here](https://github.com/cilium/cilium/pull/22317/checks?check_run_id=9913343660)), the commit is reverted.
