### PR TITLE
helm: Support configuring Cilium shared Ingress Service type and nodePorts

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1252,11 +1252,15 @@
    * - ingressController.service
      - Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources.
      - object
-     - ``{"annotations":{},"labels":{},"name":"cilium-ingress"}``
+     - ``{"annotations":{},"insecureNodePort":null,"labels":{},"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}``
    * - ingressController.service.annotations
      - Annotations to be added for the shared LB service
      - object
      - ``{}``
+   * - ingressController.service.insecureNodePort
+     - Configure a specific nodePort for insecure HTTP traffic on the shared LB service
+     - string
+     - ``nil``
    * - ingressController.service.labels
      - Labels to be added for the shared LB service
      - object
@@ -1265,6 +1269,14 @@
      - Service name
      - string
      - ``"cilium-ingress"``
+   * - ingressController.service.secureNodePort
+     - Configure a specific nodePort for secure HTTPS traffic on the shared LB service
+     - string
+     - ``nil``
+   * - ingressController.service.type
+     - Service type for the shared LB service
+     - string
+     - ``"LoadBalancer"``
    * - installIptablesRules
      - Configure whether to install iptables rules to allow for TPROXY (L7 proxy injection), iptables-based masquerading and compatibility with kube-proxy.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -530,6 +530,7 @@ inlined
 inlines
 inlining
 inodes
+insecureNodePort
 installIptablesRules
 installNoConntrackIptablesRules
 installRoutes
@@ -882,6 +883,7 @@ seccomp
 secretName
 secretsBackend
 secretsNamespace
+secureNodePort
 securityContext
 selftest
 selftests

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -363,10 +363,13 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.secretsNamespace.create | bool | `true` | Create secrets namespace for Ingress. |
 | ingressController.secretsNamespace.name | string | `"cilium-secrets"` | Name of Ingress secret namespace. |
 | ingressController.secretsNamespace.sync | bool | `true` | Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally. |
-| ingressController.service | object | `{"annotations":{},"labels":{},"name":"cilium-ingress"}` | Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources. |
+| ingressController.service | object | `{"annotations":{},"insecureNodePort":null,"labels":{},"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}` | Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources. |
 | ingressController.service.annotations | object | `{}` | Annotations to be added for the shared LB service |
+| ingressController.service.insecureNodePort | string | `nil` | Configure a specific nodePort for insecure HTTP traffic on the shared LB service |
 | ingressController.service.labels | object | `{}` | Labels to be added for the shared LB service |
 | ingressController.service.name | string | `"cilium-ingress"` | Service name |
+| ingressController.service.secureNodePort | string | `nil` | Configure a specific nodePort for secure HTTPS traffic on the shared LB service |
+| ingressController.service.type | string | `"LoadBalancer"` | Service type for the shared LB service |
 | installIptablesRules | bool | `true` | Configure whether to install iptables rules to allow for TPROXY (L7 proxy injection), iptables-based masquerading and compatibility with kube-proxy. |
 | installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup. |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |

--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -18,10 +18,12 @@ spec:
   - name: http
     port: 80
     protocol: TCP
+    nodePort: {{ .Values.ingressController.service.insecureNodePort }}
   - name: https
     port: 443
     protocol: TCP
-  type: LoadBalancer
+    nodePort: {{ .Values.ingressController.service.secureNodePort }}
+  type: {{ .Values.ingressController.service.type }}
 ---
 apiVersion: v1
 kind: Endpoints

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -581,6 +581,12 @@ ingressController:
     labels: {}
     # -- Annotations to be added for the shared LB service
     annotations: {}
+    # -- Service type for the shared LB service
+    type: LoadBalancer
+    # -- Configure a specific nodePort for insecure HTTP traffic on the shared LB service
+    insecureNodePort: ~
+    # -- Configure a specific nodePort for secure HTTPS traffic on the shared LB service
+    secureNodePort : ~
 
 gatewayAPI:
   # -- Enable support for Gateway API in cilium

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -578,6 +578,12 @@ ingressController:
     labels: {}
     # -- Annotations to be added for the shared LB service
     annotations: {}
+    # -- Service type for the shared LB service
+    type: LoadBalancer
+    # -- Configure a specific nodePort for insecure HTTP traffic on the shared LB service
+    insecureNodePort: ~
+    # -- Configure a specific nodePort for secure HTTPS traffic on the shared LB service
+    secureNodePort : ~
 
 gatewayAPI:
   # -- Enable support for Gateway API in cilium


### PR DESCRIPTION
This enables exposing cilium's envoy outside the cluster using nodePorts. I was initially looking to use hostPorts without any Services at all, but this will work for many use-cases requiring a non-LoadBalancer service.

In #21390 they specifically requested hostPorts, but nodePorts can serve a very similar purpose, so this may address the concerns in that issue.

Example usage:
```
ingressController:
  enabled: true
  loadbalancerMode: shared
  service:
    type: NodePort
    insecureNodePort: 32080
    secureNodePort: 32443
```
And in KIND:

```
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  extraPortMappings:
    # cilium-ingress nodePorts
    - containerPort: 32080
      hostPort: 80
      protocol: TCP
    - containerPort: 32443
      hostPort: 443
      protocol: TCP
networking:
  # for cilium
  disableDefaultCNI: true
  # for cilium kubeProxyReplacement
  kubeProxyMode: "none"
```

Once Cilium is installed using this PR's chart, you can create an Ingress and curl localhost:80/443 and everything works as expected.

```release-note
helm: Support configuring Cilium shared Ingress Service type and nodePorts
```
