### PR TITLE
dnsproxy: Remove usage of regex lru

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
-	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	ippkg "github.com/cilium/cilium/pkg/ip"
@@ -374,7 +373,7 @@ func (c regexCache) lookupOrCompileRegex(pattern string) (*regexp.Regexp, error)
 		entry.referenceCount += 1
 		return entry.regex, nil
 	}
-	regex, err := re.CompileRegex(pattern)
+	regex, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Since we now have a separate reference counted cache storing compiled regexes. This will both make more space for other values in the cache, as well as making the huge regexes used in the dnsproxy avaible to gc when they are no longer used.

Signed-off-by: Odin Ugedal <ougedal@palantir.com>

Fixes: https://github.com/cilium/cilium/issues/22241

```release-note
dnsproxy: stop using the regex lru in the dns proxy to avoid keeping large unused regex in memory when no longer needed
```
