### PR TITLE
Testing fix for EKS flake

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -122,7 +122,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/conformance-eks2.yaml
+++ b/.github/workflows/conformance-eks2.yaml
@@ -122,7 +122,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/conformance-eks2.yaml
+++ b/.github/workflows/conformance-eks2.yaml
@@ -1,4 +1,4 @@
-name: ConformanceEKS (ci-eks)
+name: ConformanceEKS (ci-eks) 2
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:

--- a/.github/workflows/conformance-eks3.yaml
+++ b/.github/workflows/conformance-eks3.yaml
@@ -122,7 +122,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/conformance-eks3.yaml
+++ b/.github/workflows/conformance-eks3.yaml
@@ -1,4 +1,4 @@
-name: ConformanceEKS (ci-eks)
+name: ConformanceEKS (ci-eks) 3
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:

--- a/.github/workflows/conformance-eks4.yaml
+++ b/.github/workflows/conformance-eks4.yaml
@@ -122,7 +122,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/conformance-eks4.yaml
+++ b/.github/workflows/conformance-eks4.yaml
@@ -1,4 +1,4 @@
-name: ConformanceEKS (ci-eks)
+name: ConformanceEKS (ci-eks) 4
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:

--- a/.github/workflows/conformance-eks5.yaml
+++ b/.github/workflows/conformance-eks5.yaml
@@ -122,7 +122,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout master branch to access local actions
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/conformance-eks5.yaml
+++ b/.github/workflows/conformance-eks5.yaml
@@ -1,4 +1,4 @@
-name: ConformanceEKS (ci-eks)
+name: ConformanceEKS (ci-eks) 5
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:


### PR DESCRIPTION
First run produced https://github.com/cilium/cilium/pull/22604.

23 runs successful. 2 with timeouts.