### PR TITLE
.github/workflows: print author association

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -18,6 +18,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Install Cilium CLI
+        run: |
+          echo author_association=${{ github.event.pull_request.author_association }}
       - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
         with:
           script: |


### PR DESCRIPTION
Some PRs opened by members are being considered as external. This commit will help us identify which author association those PRs have so that we can make adjustments into the detection logic.

Signed-off-by: André Martins <andre@cilium.io>