### PR TITLE
.github: add debug for codeql

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -49,5 +49,6 @@ jobs:
       uses: github/codeql-action/init@b2a92eb56d8cb930006a1c6ed86b0782dd8a4297
       with:
         languages: go
+        debug: true
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@b2a92eb56d8cb930006a1c6ed86b0782dd8a4297


### PR DESCRIPTION
Following GH's support request to enable debug in codeql workflow to understand the reason behind the failure reported in https://github.com/cilium/cilium/issues/22488

Signed-off-by: André Martins <andre@cilium.io>