### PR TITLE
Update Cilium install guide about EKS aws-node DaemonSet potential connectivity problem on uninstall

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -304,6 +304,13 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
            cilium install
            cilium status --wait
 
+       .. note::
+
+           If you have to uninstall Cilium and later install it again, that could cause
+           connectivity issues due to ``aws-node`` DaemonSet flushing Linux routing tables.
+           The issues can be fixed by restarting all pods, alternatively to avoid such issues
+           you can delete ``aws-node`` DaemonSet prior to installing Cilium.
+
     .. group-tab:: OpenShift
 
        .. include:: ../installation/requirements-openshift.rst

--- a/Documentation/installation/k8s-install-helm.rst
+++ b/Documentation/installation/k8s-install-helm.rst
@@ -153,14 +153,14 @@ Install Cilium
 
        .. include:: requirements-eks.rst
 
-       **Delete VPC CNI (``aws-node`` DaemonSet)**
+       **Patch VPC CNI (aws-node DaemonSet)**
 
        Cilium will manage ENIs instead of VPC CNI, so the ``aws-node``
-       DaemonSet has to be deleted to prevent conflict behavior.
+       DaemonSet has to be patched to prevent conflict behavior.
 
        .. code-block:: shell-session
 
-          kubectl -n kube-system delete daemonset aws-node
+          kubectl -n kube-system patch daemonset aws-node --type='strategic' -p='{"spec":{"template":{"spec":{"nodeSelector":{"io.cilium/aws-node-enabled":"true"}}}}}'
 
        **Install Cilium:**
 


### PR DESCRIPTION
Recently we discovered that aws-node daemonset can cause connectivity issues due to flushing Linux routing tables
if Cilium is uninstalled via the cli and installed again. We have fixed it[1] for the EKS tests and now this PR updates the docs
to align helm installation with current practices (i.e. patch aws-node DaemonSet instead of delete) and also adds a note in
the getting started section when installing via cilium cli.

This is also related to re-enabling ci-eks ( #16938 )
For more information about the issue itself please see the commit descriptions in the PR below.

[1] https://github.com/cilium/cilium/pull/22590
