### PR TITLE
feat(hubble): add L7 verdicts to hubble_policy_verdicts_total metric

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -361,7 +361,8 @@ Added Metrics
 Modified Metrics
 ~~~~~~~~~~~~~~~~~~
 
-* ``hubble_policy_verdicts_total`` now lists L7 flows. The match label has value ``l7/<l7_proto>`` after the detected L7 protocol of the flow.
+* ``hubble_policy_verdicts_total`` now lists L7 flows. The match label has value ``l7/<l7_proto>``
+  after the detected L7 protocol of the flow (for example: ``l7/http``).
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -358,6 +358,11 @@ Added Metrics
 * ``cilium_operator_ipam_interface_candidates``
 * ``cilium_operator_ipam_empty_interface_slots``
 
+Modified Metrics
+~~~~~~~~~~~~~~~~~~
+
+* ``hubble_policy_verdicts_total`` now lists L7 flows. The match label has value ``l7/<l7_proto>`` after the detected L7 protocol of the flow.
+
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~
 

--- a/pkg/hubble/metrics/policy/handler.go
+++ b/pkg/hubble/metrics/policy/handler.go
@@ -5,6 +5,7 @@ package policy
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -83,7 +84,18 @@ func (d *policyHandler) ProcessFlowL7(ctx context.Context, flow *flowpb.Flow) er
 	}
 
 	direction := strings.ToLower(flow.GetTrafficDirection().String())
-	match := "l7"
+	var subType string
+	if l7 := flow.GetL7(); l7 != nil {
+		switch {
+		case l7.GetDns() != nil:
+			subType = "dns"
+		case l7.GetHttp() != nil:
+			subType = "http"
+		case l7.GetKafka() != nil:
+			subType = "kafka"
+		}
+	}
+	match := fmt.Sprintf("l7/%s", subType)
 	action := strings.ToLower(flow.Verdict.String())
 	labels := []string{direction, match, action}
 	labels = append(labels, labelValues...)

--- a/pkg/hubble/metrics/policy/handler_test.go
+++ b/pkg/hubble/metrics/policy/handler_test.go
@@ -41,16 +41,23 @@ func TestPolicyHandler(t *testing.T) {
 	flow.Source = &flowpb.Endpoint{Identity: uint32(identity.ReservedIdentityHost)}
 	h.ProcessFlow(context.Background(), &flow)
 
-	// l7
+	// l7/http
 	flow.EventType = &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog}
 	flow.Verdict = flowpb.Verdict_DROPPED
+	flow.L7 = &flowpb.Layer7{
+		Record: &flowpb.Layer7_Http{Http: &flowpb.HTTP{
+			Code:     0,
+			Method:   "POST",
+			Url:      "http://myhost/some/path",
+			Protocol: "http/1.1",
+		}}}
 	h.ProcessFlow(context.Background(), &flow)
 
 	expected := strings.NewReader(`# HELP hubble_policy_verdicts_total Total number of Cilium network policy verdicts
 # TYPE hubble_policy_verdicts_total counter
 hubble_policy_verdicts_total{action="dropped",direction="egress",match="none"} 1
 hubble_policy_verdicts_total{action="redirected",direction="ingress",match="l3-l4"} 1
-hubble_policy_verdicts_total{action="dropped",direction="ingress",match="l7"} 1
+hubble_policy_verdicts_total{action="dropped",direction="ingress",match="l7/http"} 1
 `)
 	assert.NoError(t, testutil.CollectAndCompare(h.verdicts, expected))
 }

--- a/pkg/hubble/metrics/policy/handler_test.go
+++ b/pkg/hubble/metrics/policy/handler_test.go
@@ -41,10 +41,16 @@ func TestPolicyHandler(t *testing.T) {
 	flow.Source = &flowpb.Endpoint{Identity: uint32(identity.ReservedIdentityHost)}
 	h.ProcessFlow(context.Background(), &flow)
 
+	// l7
+	flow.EventType = &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog}
+	flow.Verdict = flowpb.Verdict_DROPPED
+	h.ProcessFlow(context.Background(), &flow)
+
 	expected := strings.NewReader(`# HELP hubble_policy_verdicts_total Total number of Cilium network policy verdicts
 # TYPE hubble_policy_verdicts_total counter
 hubble_policy_verdicts_total{action="dropped",direction="egress",match="none"} 1
 hubble_policy_verdicts_total{action="redirected",direction="ingress",match="l3-l4"} 1
+hubble_policy_verdicts_total{action="dropped",direction="ingress",match="l7"} 1
 `)
 	assert.NoError(t, testutil.CollectAndCompare(h.verdicts, expected))
 }


### PR DESCRIPTION
Upgrade notes:

> `hubble_policy_verdicts_total` now lists L7 flows. The match label has value `l7/<l7_proto>` after the detected L7 protocol of the flow.



Signed-off-by: Raphaël Pinson <raphael@isovalent.com>

