### PR TITLE
daemon, ipcache: Plumb root context to IP identity watcher

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1279,7 +1279,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	// Start watcher for endpoint IP --> identity mappings in key-value store.
 	// this needs to be done *after* init() for the daemon in that function,
 	// we populate the IPCache with the host's IP(s).
-	d.ipcache.InitIPIdentityWatcher()
+	d.ipcache.InitIPIdentityWatcher(d.ctx)
 	identitymanager.Subscribe(d.policy)
 
 	// Start listening to changed devices if requested.

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -390,13 +390,13 @@ var (
 
 // InitIPIdentityWatcher initializes the watcher for ip-identity mapping events
 // in the key-value store.
-func (ipc *IPCache) InitIPIdentityWatcher() {
+func (ipc *IPCache) InitIPIdentityWatcher(ctx context.Context) {
 	setupIPIdentityWatcher.Do(func() {
 		go func() {
 			log.Info("Starting IP identity watcher")
 			watcher = NewIPIdentityWatcher(ipc, kvstore.Client())
 			close(initialized)
-			watcher.Watch(context.TODO())
+			watcher.Watch(ctx)
 		}()
 	})
 }


### PR DESCRIPTION
In the case that the Agent goes down, it can properly signal to the
ipcache package to tear down the IP identity watcher goroutine.

This doesn't resolve any bugs that I'm aware of and just found it via
code inspection.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
