### PR TITLE
test/l4lb: pass k8s api server to the standalone proxy

### DIFF
--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not


### PR DESCRIPTION
This test deploys the standalone agent in a funny way; using the existing helm chart, but not configuring it fully. This breaks the config-resolver, which expects to be able to reach a functioning in-cluster apiserver.

So, just pass the correct apiserver to the config resolver.

Signed-off-by: Casey Callendrello <c1@caseyc.net>
