### PR TITLE
ingress: prefer annotation over ingressClassName

### DIFF
--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -12,7 +12,9 @@ Kubernetes Ingress Support
 
 Cilium uses the standard Kubernetes Ingress resource definition, with
 an ``ingressClassName`` of ``cilium``. This can be used for path-based
-routing and for TLS termination.
+routing and for TLS termination. For backwards compatibility, the 
+``kubernetes.io/ingress.class`` annotation with value of ``cilium``
+is also supported.
 
 .. Note::
 

--- a/operator/pkg/ingress/doc.go
+++ b/operator/pkg/ingress/doc.go
@@ -2,8 +2,9 @@
 // Copyright Authors of Cilium
 
 // Package ingress contains all the logic for Cilium Ingress Controller.
-// Only Ingress resources having spec.ingressClassName set to "cilium" are
-// managed and processed by Cilium Ingress Controller.
+// Only Ingress resources having annotations."kubernetes.io/ingress.class"
+// or spec.ingressClassName set to "cilium" are managed and processed by the
+// Cilium Ingress Controller.
 //
 // Two LB modes are supported:
 //   - dedicated LB mode: a dedicated LB is used for each Ingress.

--- a/operator/pkg/model/ingestion/ingress_test.go
+++ b/operator/pkg/model/ingestion/ingress_test.go
@@ -46,6 +46,43 @@ var defaultBackend = slim_networkingv1.Ingress{
 	},
 }
 
+var defaultBackendLegacy = slim_networkingv1.Ingress{
+	ObjectMeta: slim_metav1.ObjectMeta{
+		Name:        "load-balancing",
+		Namespace:   "random-namespace",
+		Annotations: map[string]string{"kubernetes.io/ingress.class": "cilium"},
+	},
+	Spec: slim_networkingv1.IngressSpec{
+		DefaultBackend: &slim_networkingv1.IngressBackend{
+			Service: &slim_networkingv1.IngressServiceBackend{
+				Name: "default-backend",
+				Port: slim_networkingv1.ServiceBackendPort{
+					Number: 8080,
+				},
+			},
+		},
+	},
+}
+
+var defaultBackendLegacyOverride = slim_networkingv1.Ingress{
+	ObjectMeta: slim_metav1.ObjectMeta{
+		Name:        "load-balancing",
+		Namespace:   "random-namespace",
+		Annotations: map[string]string{"kubernetes.io/ingress.class": "cilium"},
+	},
+	Spec: slim_networkingv1.IngressSpec{
+		IngressClassName: stringp("contour"),
+		DefaultBackend: &slim_networkingv1.IngressBackend{
+			Service: &slim_networkingv1.IngressServiceBackend{
+				Name: "default-backend",
+				Port: slim_networkingv1.ServiceBackendPort{
+					Number: 8080,
+				},
+			},
+		},
+	},
+}
+
 var defaultBackendListeners = []model.HTTPListener{
 	{
 		Sources: []model.FullyQualifiedResource{
@@ -1209,6 +1246,14 @@ func TestIngress(t *testing.T) {
 	tests := map[string]testcase{
 		"conformance default backend test": {
 			ingress: defaultBackend,
+			want:    defaultBackendListeners,
+		},
+		"conformance default backend (legacy annotation) test": {
+			ingress: defaultBackendLegacy,
+			want:    defaultBackendListeners,
+		},
+		"conformance default backend (legacy + new) test": {
+			ingress: defaultBackendLegacyOverride,
 			want:    defaultBackendListeners,
 		},
 		"conformance host rules test": {


### PR DESCRIPTION
- [x] All code is covered by unit and/or runtime tests where feasible.

The Kubernetes API documentation says that the ingressClassName field "replaces the deprecated `kubernetes.io/ingress.class` annotation. For backwards compatibility, when that annotation is set, it must be given precedence over this field." Other Kubernetes software relies on this, for example cert-manager and the Hashicorp Vault Helm chart.

This patch makes the Cilium ingress controller conform to the spec, by preferring the annotation if it is set, and then falling back to ingressClassName.

Fixes: #22340

Signed-off-by: Nikhil Jha <hi@nikhiljha.com>

```release-note
Cilium now prefers the `kubernetes.io/ingress.class` annotation over the `spec.ingressClassName` field when handling a new Ingress
```