### PR TITLE
helm: support `providedTls` in `clustermesh.config`

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
@@ -8,7 +8,13 @@ endpoints:
 {{ else }}
 - https://{{ $cluster.address | required "missing clustermesh.apiserver.config.clusters.address" }}:{{ $cluster.port }}
 {{- end }}
+{{- if $cluster.providedTls }}
+trusted-ca-file: {{ $cluster.providedTls.caFile }}
+cert-file: {{ $cluster.providedTls.certFile }}
+key-file: {{ $cluster.providedTls.keyFile }}
+{{- else }}
 trusted-ca-file: /var/lib/cilium/clustermesh/{{ $cluster.name }}.etcd-client-ca.crt
-key-file: /var/lib/cilium/clustermesh/{{ $cluster.name }}.etcd-client.key
 cert-file: /var/lib/cilium/clustermesh/{{ $cluster.name }}.etcd-client.crt
+key-file: /var/lib/cilium/clustermesh/{{ $cluster.name }}.etcd-client.key
+{{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -8,8 +8,10 @@ metadata:
 data:
   {{- range .Values.clustermesh.config.clusters }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain) | b64enc }}
+  {{- if not .providedTls }}
   {{ .name }}.etcd-client-ca.crt: {{ $.Values.clustermesh.apiserver.tls.ca.cert }}
   {{ .name }}.etcd-client.key: {{ .tls.key }}
   {{ .name }}.etcd-client.crt: {{ .tls.cert }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2099,6 +2099,11 @@ clustermesh:
     #   tls:
     #     cert: ""
     #     key: ""
+    # # -- path to the cluster client certificate, private key and certificate authority.
+    #   providedTls:
+    #     caFile: ""
+    #     certFile: ""
+    #     keyFile: ""
 
   apiserver:
     # -- Clustermesh API server image.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2096,6 +2096,11 @@ clustermesh:
     #   tls:
     #     cert: ""
     #     key: ""
+    # # -- path to the cluster client certificate, private key and certificate authority.
+    #   providedTls:
+    #     caFile: ""
+    #     certFile: ""
+    #     keyFile: ""
 
   apiserver:
     # -- Clustermesh API server image.


### PR DESCRIPTION
Currently, `clustermesh.config` only support pass cluster client TLS (certificate, private key and CA) in base64 encoded form via helm values. This is not allowed by some org because private key is a sensitive info.

So this PR provide an alternative way provide client TLS by specify path to already mounted TLS files.

```yaml
extraVolumeMounts:
- name: clustermesh-client-tls
  mountPath: /var/lib/cilium/clustermesh/client/

extraVolumes:
- name: clustermesh-client-tls
  secret:
    secretName:  clustermesh-client-tls
    optional:    true
    defaultMode: 0644

clustermesh:
  useAPIServer: true

  config:
    enabled: true
    clusters:
      - name: cluster1
        ... # other configs
        providedTls:
          caFile:   /var/lib/cilium/clustermesh/client/ca.crt
          certFile: /var/lib/cilium/clustermesh/client/tls.crt
          keyFile:  /var/lib/cilium/clustermesh/client/tls.key
```

Please ensure your pull request adheres to the following guidelines:
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
helm: support `providedTls` in `clustermesh.config`
```
