### PR TITLE
metrics: support toggle bootstrap times metric via daemon config

### DIFF
--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/prometheus/client_golang/prometheus"
 
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/metrics"
 	"github.com/cilium/cilium/pkg/api"
@@ -71,12 +70,16 @@ type bootstrapStatistics struct {
 }
 
 func (b *bootstrapStatistics) updateMetrics() {
+	if !option.Config.MetricsConfig.BootstrapTimesEnabled {
+		return
+	}
+
 	for scope, stat := range b.getMap() {
 		if stat.SuccessTotal() != time.Duration(0) {
-			metricBootstrapTimes.WithLabelValues(scope, metrics.LabelValueOutcomeSuccess).Observe(stat.SuccessTotal().Seconds())
+			metrics.BootstrapTimes.WithLabelValues(scope, metrics.LabelValueOutcomeSuccess).Observe(stat.SuccessTotal().Seconds())
 		}
 		if stat.FailureTotal() != time.Duration(0) {
-			metricBootstrapTimes.WithLabelValues(scope, metrics.LabelValueOutcomeFail).Observe(stat.FailureTotal().Seconds())
+			metrics.BootstrapTimes.WithLabelValues(scope, metrics.LabelValueOutcomeFail).Observe(stat.FailureTotal().Seconds())
 		}
 	}
 }
@@ -102,22 +105,5 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"fqdn":            &b.fqdn,
 		"enableConntrack": &b.enableConntrack,
 		"kvstore":         &b.kvstore,
-	}
-}
-
-var (
-	metricBootstrapTimes prometheus.ObserverVec
-)
-
-func registerBootstrapMetrics() {
-	metricBootstrapTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: metrics.SubsystemAgent,
-		Name:      "bootstrap_seconds",
-		Help:      "Duration of bootstrap sequence",
-	}, []string{metrics.LabelScope, metrics.LabelOutcome})
-
-	if err := metrics.Register(metricBootstrapTimes); err != nil {
-		log.WithError(err).Fatal("unable to register prometheus metric")
 	}
 }

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -57,7 +57,6 @@ var (
 
 func init() {
 	setupSleepBeforeFatal()
-	registerBootstrapMetrics()
 
 	Vp = agentHive.Viper()
 	agentHive.RegisterFlags(RootCmd.PersistentFlags())

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -218,6 +218,9 @@ const (
 var (
 	registry = prometheus.NewPedanticRegistry()
 
+	// BootstrapTimes is the durations of cilium-agent bootstrap sequence.
+	BootstrapTimes = NoOpObserverVec
+
 	// APIInteractions is the total time taken to process an API call made
 	// to the cilium-agent
 	APIInteractions = NoOpObserverVec
@@ -525,6 +528,7 @@ var (
 )
 
 type Configuration struct {
+	BootstrapTimesEnabled                   bool
 	APIInteractionsEnabled                  bool
 	NodeConnectivityStatusEnabled           bool
 	NodeConnectivityLatencyEnabled          bool
@@ -604,6 +608,7 @@ type Configuration struct {
 
 func DefaultMetrics() map[string]struct{} {
 	return map[string]struct{}{
+		Namespace + "_" + SubsystemAgent + "_bootstrap_seconds":                      {},
 		Namespace + "_" + SubsystemAgent + "_api_process_time_seconds":               {},
 		Namespace + "_endpoint_regenerations_total":                                  {},
 		Namespace + "_endpoint_state":                                                {},
@@ -681,6 +686,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 		switch metricName {
 		default:
 			logrus.WithField("metric", metricName).Warning("Metric does not exist, skipping")
+
+		case Namespace + "_" + SubsystemAgent + "_bootstrap_seconds":
+			BootstrapTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemAgent,
+				Name:      "bootstrap_seconds",
+				Help:      "Duration of bootstrap sequence",
+			}, []string{LabelScope, LabelOutcome})
+
+			collectors = append(collectors, BootstrapTimes)
+			c.BootstrapTimesEnabled = true
 
 		case Namespace + "_" + SubsystemAgent + "_api_process_time_seconds":
 			APIInteractions = prometheus.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
With this patch, we can toggle the `cilium_agent_bootstrap_seconds` metric with `--metrics` option. Such as, disable this metric with `--metrics="-cilium_agent_bootstrap_seconds"`, which could save a lot of prometheus storage space for large clusters.

Signed-off-by: ArthurChiao <arthurchiao@hotmail.com>

