### PR TITLE
test: Enable Envoy trace logs for TLS test

### DIFF
--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -65,6 +65,7 @@ var _ = SkipDescribeIf(func() bool {
 
 		daemonCfg = map[string]string{
 			"tls.secretsBackend": "k8s",
+			"debug.verbose":      "envoy",
 		}
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
 		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, daemonCfg)


### PR DESCRIPTION
Get more detail for Envoy in case TLS test keeps flaking.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
