### PR TITLE
backporting: leave `backport/author` PRs alone

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -112,7 +112,7 @@ archive_filename = archive_name + '.tar.gz'
 archive_link = github_repo + 'archive/' + archive_filename
 archive_name = 'cilium-' + archive_name.strip('v')
 project_link = github_repo + 'projects?query=is:open+' + next_release
-backport_format = github_repo + 'pulls?q=is:open+is:pr+label:%s/' + current_release
+backport_format = github_repo + 'pulls?q=is:open+is:pr+-label:backport/author+label:%s/' + current_release
 
 # Store variables in the epilogue so they are globally available.
 rst_epilog = """

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -59,6 +59,14 @@ maintainers when the PR is reviewed. When proposing PRs that have already been
 merged, also add a comment to the PR to ensure that the backporters are
 notified.
 
+Marking PRs to be backported by the author
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For PRs which need to be backported, but are likely to run into conflicts or
+other difficulties, the author has the option of adding the ``backport/author``
+label. This will exclude the PR from backporting automation, and the author is
+expected to perform the backport themselves.
+
 Backporting Guide for the Backporter
 ------------------------------------
 
@@ -349,7 +357,9 @@ Original Committers and Reviewers
 Committers should mark PRs needing backport as ``needs-backport/X.Y``, based on
 the `backport criteria <backport_criteria_>`_. It is up to the reviewers to
 confirm that the backport request is reasonable and, if not, raise concerns on
-the PR as comments.
+the PR as comments. In addition, if conflicts are foreseen or significant
+changes to the PR are necessary for older branches, consider adding the
+``backport/author`` label to mark the PR to be backported by the author.
 
 At some point, changes will be picked up on a backport PR and the committer will
 be notified and asked to approve the backport commits. Confirm that:

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -185,7 +185,8 @@ gitlib::github_api_token
 
 echo "Checking for backports on branch '${STABLE_BRANCH}'"
 
-stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport-done/${STABLE_BRANCH}"))
+# Don't consider PRs with `backport/author`, which the author will backport themselves.
+stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport/author" ))
 echo -e "v$STABLE_BRANCH backports $(date +%Y-%m-%d)\n" | tee $SUMMARY_LOG
 echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
 


### PR DESCRIPTION
The `backport/author` label means that the backport will be performed by the author, and thus the backporting automation should ignore it.

It's okay to not filter by `backport-done/<branch>` because `needs-backport` should not be present at the same time. (Notably, if resiliency was the intention, we should already be filtering `backport-pending` too.)

cc  @gandro who asked for this.