### PR TITLE
ci: remove test namespace deletion workaround in GKE v1.12 workflow

### DIFF
--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -265,8 +265,6 @@ jobs:
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
-          # Temporary workaround for https://github.com/cilium/cilium-cli/issues/255
-          kubectl delete ns cilium-test
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Install Cilium with tunnel datapath
@@ -291,8 +289,6 @@ jobs:
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
-          # Temporary workaround for https://github.com/cilium/cilium-cli/issues/255
-          kubectl delete ns cilium-test
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Create custom IPsec secret
@@ -321,8 +317,6 @@ jobs:
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
-          # Temporary workaround for https://github.com/cilium/cilium-cli/issues/255
-          kubectl delete ns cilium-test
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Install Cilium with encryption and tunnel datapath


### PR DESCRIPTION
Remove the workaround for
https://github.com/cilium/cilium-cli/issues/255 added in commit b6a5b5b26e21 ("conformance-gke-v1.12: Miscellaneous fixes")

The cilium-cli issue was fixed in
https://github.com/cilium/cilium-cli/pull/1137 and has been in cilium-cli since version v0.12.5.
