### PR TITLE
fix(docs): fix websocket annotation value

### DIFF
--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -70,7 +70,7 @@ Supported Ingress Annotations
      - 10
    * - ``io.cilium/websocket``
      - Enable websocket
-     - 0 (disabled)
+     - disabled
 
 Additionally, cloud-provider specific annotations for the LoadBalancer service
 are supported. Please refer to the `Kubernetes documentation <https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer>`_


### PR DESCRIPTION
While the actual code uses `0` and `1` as scalars for internal implementation of enabled or disabled flags for WebSockets, these values are only used internally, and the documentation is misleading in directing the user to use these values as the value of the annotation, when they must be the actual strings `enabled` or `disabled` that are mapped by the actual code at runtime. 

Exposing this internal implementation detail not only is vulnerable to internal implementation changes by a developer assuming no user will see this, but also is very misleading to users. We struggled for hours to enable Websockets because the documentation noted '0' as the value for disabled (if entered as strings [as is standard in k8s annotations] the function would silently fail), only until we went to the actual source code to see the code path taken did we see the `enable|disable` strings. 

Signed-off-by: Basit Mustafa <basit.mustafa@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

This change updates the documentation to expose the external string values required for the annotation for enabling/disabling websockets on the Ingress object, rather than the internal scalar/int values used in the code that were being exposed and were not valid but if entered as strings (as is standard in k8s annotations) the function would silently fail. 

Fixes: #issue-number

```release-note
Clarify annotation value in documentation for disable/enable websockets (io.cilium/websocket)
```
