### PR TITLE
fix:should replace errors.New(fmt.Sprintf)

### DIFF
--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -167,7 +167,7 @@ func (cache *NPHDSCache) handleIPUpsert(npHost *envoyAPI.NetworkPolicyHosts, ide
 	}
 	_, updated, _ := cache.Upsert(NetworkPolicyHostsTypeURL, identityStr, &newNpHost)
 	if !updated {
-		return errors.New(fmt.Sprintf("NPHDS cache not updated when expected adding: %s", newNpHost.String()))
+		return fmt.Errorf("NPHDS cache not updated when expected adding: %s", newNpHost.String())
 	}
 	return nil
 }
@@ -215,7 +215,7 @@ func (cache *NPHDSCache) handleIPDelete(npHost *envoyAPI.NetworkPolicyHosts, ide
 		}
 		_, updated, _ := cache.Upsert(NetworkPolicyHostsTypeURL, identityStr, &newNpHost)
 		if !updated {
-			return errors.New(fmt.Sprintf("NPHDS cache not updated when expected deleting: %s", newNpHost.String()))
+			return fmt.Errorf("NPHDS cache not updated when expected deleting: %s", newNpHost.String())
 		}
 	}
 	return nil


### PR DESCRIPTION
should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)

Signed-off-by: yulng <wei.yang@daocloud.io>


