### PR TITLE
 ingress: Add loadBalancerIP and loadBalancerClass

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1288,7 +1288,7 @@
    * - ingressController.service
      - Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources.
      - object
-     - ``{"annotations":{},"insecureNodePort":null,"labels":{},"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}``
+     - ``{"annotations":{},"insecureNodePort":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}``
    * - ingressController.service.annotations
      - Annotations to be added for the shared LB service
      - object
@@ -1301,6 +1301,14 @@
      - Labels to be added for the shared LB service
      - object
      - ``{}``
+   * - ingressController.service.loadBalancerClass
+     - Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+)
+     - string
+     - ``nil``
+   * - ingressController.service.loadBalancerIP
+     - Configure a specific loadBalancerIP on the shared LB service
+     - string
+     - ``nil``
    * - ingressController.service.name
      - Service name
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -637,6 +637,7 @@ llc
 llvm
 loadBalancer
 loadBalancerClass
+loadBalancerIP
 loadbalancer
 loadbalancerIP
 loadbalancerMode

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -372,10 +372,12 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.secretsNamespace.create | bool | `true` | Create secrets namespace for Ingress. |
 | ingressController.secretsNamespace.name | string | `"cilium-secrets"` | Name of Ingress secret namespace. |
 | ingressController.secretsNamespace.sync | bool | `true` | Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally. |
-| ingressController.service | object | `{"annotations":{},"insecureNodePort":null,"labels":{},"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}` | Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources. |
+| ingressController.service | object | `{"annotations":{},"insecureNodePort":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}` | Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources. |
 | ingressController.service.annotations | object | `{}` | Annotations to be added for the shared LB service |
 | ingressController.service.insecureNodePort | string | `nil` | Configure a specific nodePort for insecure HTTP traffic on the shared LB service |
 | ingressController.service.labels | object | `{}` | Labels to be added for the shared LB service |
+| ingressController.service.loadBalancerClass | string | `nil` | Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+) |
+| ingressController.service.loadBalancerIP | string | `nil` | Configure a specific loadBalancerIP on the shared LB service |
 | ingressController.service.name | string | `"cilium-ingress"` | Service name |
 | ingressController.service.secureNodePort | string | `nil` | Configure a specific nodePort for secure HTTPS traffic on the shared LB service |
 | ingressController.service.type | string | `"LoadBalancer"` | Service type for the shared LB service |

--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -24,6 +24,14 @@ spec:
     protocol: TCP
     nodePort: {{ .Values.ingressController.service.secureNodePort }}
   type: {{ .Values.ingressController.service.type }}
+  {{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.Version -}}
+  {{- if .Values.ingressController.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.ingressController.service.loadBalancerClass }}
+  {{- end }}
+  {{- end -}}
+  {{- if .Values.ingressController.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.ingressController.service.loadBalancerIP }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Endpoints

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -630,6 +630,10 @@ ingressController:
     insecureNodePort: ~
     # -- Configure a specific nodePort for secure HTTPS traffic on the shared LB service
     secureNodePort : ~
+    # -- Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+)
+    loadBalancerClass: ~
+    # -- Configure a specific loadBalancerIP on the shared LB service
+    loadBalancerIP : ~
 
 gatewayAPI:
   # -- Enable support for Gateway API in cilium

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -627,6 +627,10 @@ ingressController:
     insecureNodePort: ~
     # -- Configure a specific nodePort for secure HTTPS traffic on the shared LB service
     secureNodePort : ~
+    # -- Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+)
+    loadBalancerClass: ~
+    # -- Configure a specific loadBalancerIP on the shared LB service
+    loadBalancerIP : ~
 
 gatewayAPI:
   # -- Enable support for Gateway API in cilium


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

This pull request adds configuration options for the `loadBalancerClass` and `loadBalancerIP` fields in the `Service` object created for cilium's ingress controller when `ingressController.loadbalancerMode` is set to `shared`.

Previously, there was no option to configure these options, which makes it difficult for me to use the chart in my situation. I have to manually delete and recreate the service, since the field cannot even be edited with `kubectl edit`.

Sorry about the commit titles. If this change is approved, would appreciate a squash and merge with a better title.

```release-note
ingress: Add loadBalancerIP and loadBalancerClass
```