### PR TITLE
ingress/model: Support multiple certs based on SNI

### DIFF
--- a/operator/pkg/model/translation/translator.go
+++ b/operator/pkg/model/translation/translator.go
@@ -117,18 +117,14 @@ func (i *defaultTranslator) getResources(m *model.Model) []ciliumv2.XDSResource 
 // listener is returned for shared LB mode, tls and non-tls filters are
 // applied by default.
 func (i *defaultTranslator) getListener(m *model.Model) []ciliumv2.XDSResource {
-	var tlsMap = make(map[string]model.TLSSecret)
+	var tlsMap = make(map[model.TLSSecret][]string)
 	for _, h := range m.HTTP {
 		for _, s := range h.TLS {
-			tlsMap[s.Namespace+"/"+s.Name] = s
+			tlsMap[s] = append(tlsMap[s], h.Hostname)
 		}
 	}
-	tls := make([]model.TLSSecret, 0, len(tlsMap))
-	for _, v := range tlsMap {
-		tls = append(tls, v)
-	}
 
-	l, _ := NewListenerWithDefaults("listener", i.secretsNamespace, tls)
+	l, _ := NewListenerWithDefaults("listener", i.secretsNamespace, tlsMap)
 	return []ciliumv2.XDSResource{l}
 }
 


### PR DESCRIPTION
## Description

As per [cert-selection] docs, only the first certificate listed is used, this causes the bug in which the wrong certs are used in either Ingress or Gateway API.

This commit is to add serverNames, which are having values same as host name, in TLS filter chain.

[cert-selection]: https://github.com/envoyproxy/envoy/blob/main/docs/root/intro/arch_overview/security/ssl.rst#certificate-selection

Fixes: #22668

Reported-by: Nikhil Jha <hi@nikhiljha.com>
Signed-off-by: Tam Mach <tam.mach@cilium.io>

```release-note
ingress/model: Support multiple certs based on SNI
```

## Testing

Testing was done before and after changes with below manifest

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: tls-ingress
  namespace: default
spec:
  ingressClassName: cilium
  rules:
  - host: hipstershop.cilium.rocks
    http:
      paths:
      - backend:
          service:
            name: details
            port:
              number: 9080
        path: /details
        pathType: Prefix
  - host: bookinfo.tam.rocks
    http:
      paths:
      - backend:
          service:
            name: productpage
            port:
              number: 9080
        path: /
        pathType: Prefix
  tls:
  - hosts:
    - hipstershop.cilium.rocks
    secretName: demo-cert
  - hosts:
    - bookinfo.tam.rocks
    secretName: demo-tam-cert
```

<details>
<summary>Before</summary>

```
# Error in cilium agent
2022-12-11T11:08:45.476453454Z level=warning msg="Failed to update CiliumEnvoyConfig" ciliumEnvoyConfigName=cilium-ingress error="NACK received: Error adding/updating listener(s) kube-system/cilium-ingress/listener: Failed to load certificate chain from <inline>, at most one certificate of a given type may be specified\n" k8sApiVersion= k8sNamespace=kube-system k8sUID=74722a46-0962-4cf9-9983-06501a9fa0d0 subsys=k8s-watcher

# Generated cilium envoy configuration
...
      transportSocket:
        name: envoy.transport_sockets.tls
        typedConfig:
          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
          commonTlsContext:
            tlsCertificateSdsSecretConfigs:
            - name: cilium-secrets/default-demo-tam-cert
              sdsConfig:
                apiConfigSource:
                  apiType: GRPC
                  grpcServices:
                  - envoyGrpc:
                      clusterName: xds-grpc-cilium
                  transportApiVersion: V3
                resourceApiVersion: V3
            - name: cilium-secrets/default-demo-cert
              sdsConfig:
                apiConfigSource:
                  apiType: GRPC
                  grpcServices:
                  - envoyGrpc:
                      clusterName: xds-grpc-cilium
                  transportApiVersion: V3
                resourceApiVersion: V3
...

```

</details>


<details>
<summary>After</summary>

```
...
# Generated Cilium Envoy config
    - filterChainMatch:
        serverNames:
        - bookinfo.tam.rocks
        transportProtocol: tls
      filters:
      - name: envoy.filters.network.http_connection_manager
        typedConfig:
          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
          httpFilters:
          - name: envoy.filters.http.router
          rds:
            routeConfigName: listener-secure
          statPrefix: listener-secure
          upgradeConfigs:
          - upgradeType: websocket
      transportSocket:
        name: envoy.transport_sockets.tls
        typedConfig:
          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
          commonTlsContext:
            tlsCertificateSdsSecretConfigs:
            - name: cilium-secrets/default-demo-tam-cert
              sdsConfig:
                apiConfigSource:
                  apiType: GRPC
                  grpcServices:
                  - envoyGrpc:
                      clusterName: xds-grpc-cilium
                  transportApiVersion: V3
                resourceApiVersion: V3
    - filterChainMatch:
        serverNames:
        - hipstershop.cilium.rocks
        transportProtocol: tls
      filters:
      - name: envoy.filters.network.http_connection_manager
        typedConfig:
          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
          httpFilters:
          - name: envoy.filters.http.router
          rds:
            routeConfigName: listener-secure
          statPrefix: listener-secure
          upgradeConfigs:
          - upgradeType: websocket
      transportSocket:
        name: envoy.transport_sockets.tls
        typedConfig:
          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
          commonTlsContext:
            tlsCertificateSdsSecretConfigs:
            - name: cilium-secrets/default-demo-cert
              sdsConfig:
                apiConfigSource:
                  apiType: GRPC
                  grpcServices:
                  - envoyGrpc:
                      clusterName: xds-grpc-cilium
                  transportApiVersion: V3
                resourceApiVersion: V3
...


$ curl -s --cacert minica.pem https://hipstershop.cilium.rocks/details/1
{"id":1,"author":"William Shakespeare","year":1595,"type":"paperback","pages":200,"publisher":"PublisherA","language":"English","ISBN-10":"1234567890","ISBN-13":"123-1234567890"}

$ curl -s --cacert minica.pem https://bookinfo.tam.rocks                
<!DOCTYPE html>
<html>
  <head>
    <title>Simple Bookstore App</title>
...

```

</details>

