### PR TITLE
proxy: fix a typo in the comment

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -90,7 +90,7 @@ type ProxyPort struct {
 	// acknowledged yet. This is reset to false when the underlying proxy listener
 	// is removed.
 	configured bool
-	// rulesPort congains the proxy port value configured to the datapath rules and
+	// rulesPort contains the proxy port value configured to the datapath rules and
 	// is non-zero when a proxy has been successfully created and the
 	// datapath rules have been created.
 	rulesPort uint16


### PR DESCRIPTION
Fix a typo in the comment.
Signed-off-by: Yang Tian <linuxty@gmail.com>