### PR TITLE
gha: Add retry mechanism for conformance ingress (shared)

### DIFF
--- a/.github/workflows/conformance-ingress-shared.yaml
+++ b/.github/workflows/conformance-ingress-shared.yaml
@@ -80,9 +80,11 @@ jobs:
       - name: Checkout ingress-controller-conformance
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         with:
-          repository: kubernetes-sigs/ingress-controller-conformance
+          # Use the forked repo with retry mechanism
+          # Please refer to https://github.com/sayboras/ingress-controller-conformance/pull/2 for more details.
+          repository: sayboras/ingress-controller-conformance
           path: ingress-controller-conformance
-          ref: a38bfcddfc7b10a7b479c1f274b87380c7390c96
+          ref: 32a743e3fd060ffbe124d0e8cad67ca7763700bb
           persist-credentials: false
 
       - name: Install Ingress conformance test tool


### PR DESCRIPTION
## Description

This is to make sure http retry was done as part of the test.

Fixes: #21710
Fixes: #21993
Signed-off-by: Tam Mach <tam.mach@cilium.io>

## Testing

~Testing was done with a temp commit enabling cron schedule every 1hour~. Updated: scheduled trigger is not working with forked repo/PR. 

https://github.com/cilium/cilium/actions/workflows/conformance-ingress-shared.yaml?query=branch%3Atam%2Fconformance-ingress-shared-flaky

- 7 consecutive successful runs in https://github.com/cilium/cilium/actions/runs/3670457354
- 15+ consecutive successful runs in https://github.com/cilium/cilium/actions/runs/3672185085

Handy script to re-run workflow:

```bash
#!/bin/bash
for i in {1..10}
do
   echo "Re-run the job $i times"
   gh run rerun 3672185085
   sleep 30m
done
```