### PR TITLE
test: Unquarantine K8sDatapathConfig Encapsulation

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -142,7 +142,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
-	SkipContextIf(helpers.SkipQuarantined, "Encapsulation", func() {
+	Context("Encapsulation", func() {
 		validateBPFTunnelMap := func() {
 			By("Checking that BPF tunnels are in place")
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
@@ -216,7 +216,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}
 		})
 
-		It("Check iptables masquerading with random-fully", func() {
+		SkipItIf(helpers.SkipQuarantined, "Check iptables masquerading with random-fully", func() {
 			options := map[string]string{
 				"bpf.masquerade":       "false",
 				"enableIPv6Masquerade": "true",
@@ -233,7 +233,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				Should(BeTrue(), "IPv6 connectivity test to http://google.com failed")
 		})
 
-		It("Check iptables masquerading without random-fully", func() {
+		SkipItIf(helpers.SkipQuarantined, "Check iptables masquerading without random-fully", func() {
 			options := map[string]string{
 				"bpf.masquerade":       "false",
 				"enableIPv6Masquerade": "true",


### PR DESCRIPTION
The whole group of encapsulation-related tests was quarantined in https://github.com/cilium/cilium/pull/18051. But there was never any reason to quarantine the whole group as only a couple of tests are actually failing.

According to [DataStudio](https://datastudio.google.com/s/nBvri2iDdrc), nowadays only the iptables-masquerading tests are failing. So this commit reenables all tests in that group except for the two iptables-masquerading tests.

Note that this group includes our only coverage of IPsec + VXLAN.