### PR TITLE
test/Vagrantfile: Debug information for natnetwork

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -71,6 +71,8 @@ while [ "$res" == "0" ]; do
     res=$?
     i=$((i+1))
 done 2>/dev/null
+
+VBoxManage natnetwork list
 SCRIPT
 
 $bootstrap = <<SCRIPT


### PR DESCRIPTION
This commit dumps the natnetwork configuration on the host as part of the VirtualBox provisioning, to help debug a flake with that device.

Related: https://github.com/cilium/cilium/issues/17353