### PR TITLE
daemon: Do not remove PERM L2 entries in L4LB

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1858,16 +1858,18 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 		log.WithError(err).Warn("Failed to send agent start monitor message")
 	}
 
-	if !d.datapath.Node().NodeNeighDiscoveryEnabled() {
-		// Remove all non-GC'ed neighbor entries that might have previously set
-		// by a Cilium instance.
-		d.datapath.Node().NodeCleanNeighbors(false)
-	} else {
-		// If we came from an agent upgrade, migrate entries.
-		d.datapath.Node().NodeCleanNeighbors(true)
-		// Start periodical refresh of the neighbor table from the agent if needed.
-		if option.Config.ARPPingRefreshPeriod != 0 && !option.Config.ARPPingKernelManaged {
-			d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.Node())
+	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
+		if !d.datapath.Node().NodeNeighDiscoveryEnabled() {
+			// Remove all non-GC'ed neighbor entries that might have previously set
+			// by a Cilium instance.
+			d.datapath.Node().NodeCleanNeighbors(false)
+		} else {
+			// If we came from an agent upgrade, migrate entries.
+			d.datapath.Node().NodeCleanNeighbors(true)
+			// Start periodical refresh of the neighbor table from the agent if needed.
+			if option.Config.ARPPingRefreshPeriod != 0 && !option.Config.ARPPingKernelManaged {
+				d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.Node())
+			}
 		}
 	}
 


### PR DESCRIPTION
In the L4LB mode, the PERM L2 entries are managed by users. So, in this mode Cilium should not mess with them.

Discovered while converting https://github.com/cilium/cilium/pull/22653.