### PR TITLE
bpf: nodeport: fix tracing for handle_nat_fwd()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1111,7 +1111,6 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 #ifdef ENABLE_HOST_FIREWALL
 	__s8 ext_err = 0;
 #endif
-	bool traced = false;
 
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 */
@@ -1208,14 +1207,6 @@ out:
 			return send_drop_notify_error(ctx, 0, ret,
 						      CTX_ACT_DROP,
 						      METRIC_EGRESS);
-
-		/*
-		 * Depending on the condition, handle_nat_fwd may return
-		 * without tail calling. Since we have packet tracing inside
-		 * the handle_nat_fwd, we need to avoid tracing the packet
-		 * twice.
-		 */
-		traced = true;
 	}
 #endif
 #ifdef ENABLE_HEALTH_CHECK
@@ -1224,9 +1215,8 @@ out:
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
 					      METRIC_EGRESS);
 #endif
-	if (!traced)
-		send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0,
-				  0, trace.reason, trace.monitor);
+	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0,
+			  0, trace.reason, trace.monitor);
 
 	return ret;
 }

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1178,6 +1178,19 @@ drop:
 	return send_drop_notify_error_ext(ctx, 0, ret, ext_err, CTX_ACT_DROP, METRIC_EGRESS);
 }
 
+static __always_inline int handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
+{
+#if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
+	union v6addr addr = { .p1 = 0 };
+
+	BPF_V6(addr, ROUTER_IP);
+#else
+	union v6addr addr = IPV6_DIRECT_ROUTING;
+#endif
+
+	return nodeport_nat_ipv6_fwd(ctx, &addr);
+}
+
 declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
 			       is_defined(ENABLE_IPV6)),
 			 __and(is_defined(ENABLE_HOST_FIREWALL),
@@ -1187,15 +1200,14 @@ int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 {
 	int ret;
 	enum trace_point obs_point;
+
 #if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
-	union v6addr addr = { .p1 = 0 };
-	BPF_V6(addr, ROUTER_IP);
 	obs_point = TRACE_TO_OVERLAY;
 #else
-	union v6addr addr = IPV6_DIRECT_ROUTING;
 	obs_point = TRACE_TO_NETWORK;
 #endif
-	ret = nodeport_nat_ipv6_fwd(ctx, &addr);
+
+	ret = handle_nat_fwd_ipv6(ctx);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 
@@ -2152,6 +2164,11 @@ int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 	return ret;
 }
 
+static __always_inline int handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
+{
+	return nodeport_nat_ipv4_fwd(ctx);
+}
+
 declare_tailcall_if(__or3(__and(is_defined(ENABLE_IPV4),
 				is_defined(ENABLE_IPV6)),
 			  __and(is_defined(ENABLE_HOST_FIREWALL),
@@ -2169,7 +2186,7 @@ int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 	obs_point = TRACE_TO_NETWORK;
 #endif
 
-	ret = nodeport_nat_ipv4_fwd(ctx);
+	ret = handle_nat_fwd_ipv4(ctx);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 
@@ -2287,7 +2304,7 @@ static __always_inline int handle_nat_fwd(struct __ctx_buff *ctx)
 					       is_defined(IS_BPF_HOST)),
 					 is_defined(ENABLE_EGRESS_GATEWAY)),
 				   CILIUM_CALL_IPV4_ENCAP_NODEPORT_NAT,
-				   tail_handle_nat_fwd_ipv4);
+				   handle_nat_fwd_ipv4);
 		break;
 #endif /* ENABLE_IPV4 */
 #ifdef ENABLE_IPV6
@@ -2297,7 +2314,7 @@ static __always_inline int handle_nat_fwd(struct __ctx_buff *ctx)
 					__and(is_defined(ENABLE_HOST_FIREWALL),
 					      is_defined(IS_BPF_HOST))),
 				   CILIUM_CALL_IPV6_ENCAP_NODEPORT_NAT,
-				   tail_handle_nat_fwd_ipv6);
+				   handle_nat_fwd_ipv6);
 		break;
 #endif /* ENABLE_IPV6 */
 	default:


### PR DESCRIPTION
We currently attempt to suppress tracing when handle_nat_fwd() returns, assuming that the inner function (ie. handle_nat_fwd_ipv*()) was inlined and already raised a trace message.

But handle_nat_fwd() can return CTX_ACT_OK without even going down the
IPv4 / IPv6 path, in which case we end up missing the TRACE_TO_NETWORK.

Note that the tracing in to-overlay still looks completely confused, but that's a separate issue.

Fixes: 322510d4d9f4 ("bpf: Add missing packet tracing for handle_nat_fwd")
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>