### PR TITLE
bpf: add drop notification for missed L7 LB tailcall in to-netdev

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1129,7 +1129,8 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 
 			ctx->mark = 0;
 			tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);
-			return DROP_MISSED_TAIL_CALL;
+			return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL,
+						      CTX_ACT_DROP, METRIC_EGRESS);
 		}
 	}
 #endif


### PR DESCRIPTION
cil_to_netdev() is the upper-most function in the program. So don't just return a raw DROP reason to the kernel, but translate it to CTX_ACT_DROP and raise a drop notification.

Fixes: d1d8e7a35b35 ("datapath: Add support for re-entering LXC egress path after L7 LB")
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>
