### PR TITLE
CODEOWNERS: assign operator/pkg/{gateway-api,model} to @cilium/sig-servicemesh

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -356,7 +356,9 @@ jenkinsfiles @cilium/ci-structure
 /MAINTAINERS.md @cilium/contributing
 /netlify.toml @cilium/ci-structure
 /operator/ @cilium/operator
+/operator/pkg/gateway-api @cilium/operator @cilium/sig-servicemesh
 /operator/pkg/ingress @cilium/operator @cilium/sig-servicemesh
+/operator/pkg/model @cilium/operator @cilium/sig-servicemesh
 /pkg/ @cilium/tophat
 /pkg/annotation @cilium/sig-k8s
 /pkg/alibabacloud/ @cilium/alibabacloud


### PR DESCRIPTION
Members of the @cilium/operator team might not have enough context on servicemesh specifics, so request a review from @cilium/sig-servicemesh as well.
