### PR TITLE
Extend tunnel map key with ClusterID

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -252,7 +252,8 @@ struct endpoint_key {
 	};
 	__u8 family;
 	__u8 key;
-	__u16 pad5;
+	__u8 cluster_id;
+	__u8 pad;
 } __packed;
 
 #define ENDPOINT_F_HOST		1 /* Special endpoint representing local host */

--- a/pkg/bpf/endpoint.go
+++ b/pkg/bpf/endpoint.go
@@ -23,10 +23,11 @@ const (
 // +k8s:deepcopy-gen=true
 type EndpointKey struct {
 	// represents both IPv6 and IPv4 (in the lowest four bytes)
-	IP     types.IPv6 `align:"$union0"`
-	Family uint8      `align:"family"`
-	Key    uint8      `align:"key"`
-	Pad2   uint16     `align:"pad5"`
+	IP        types.IPv6 `align:"$union0"`
+	Family    uint8      `align:"family"`
+	Key       uint8      `align:"key"`
+	ClusterID uint8      `align:"cluster_id"`
+	Pad       uint8      `align:"pad"`
 }
 
 // GetKeyPtr returns the unsafe pointer to the BPF key

--- a/pkg/bpf/endpoint.go
+++ b/pkg/bpf/endpoint.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"unsafe"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	ippkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/types"
 )
 
@@ -39,7 +41,7 @@ func (k *EndpointKey) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
 // NewEndpointKey returns an EndpointKey based on the provided IP address. The
 // address family is automatically detected.
-func NewEndpointKey(ip net.IP) EndpointKey {
+func NewEndpointKey(ip net.IP, clusterID uint8) EndpointKey {
 	result := EndpointKey{}
 
 	if ip4 := ip.To4(); ip4 != nil {
@@ -50,6 +52,7 @@ func NewEndpointKey(ip net.IP) EndpointKey {
 		copy(result.IP[:], ip)
 	}
 	result.Key = 0
+	result.ClusterID = clusterID
 
 	return result
 }
@@ -68,7 +71,11 @@ func (k EndpointKey) ToIP() net.IP {
 // String provides a string representation of the EndpointKey.
 func (k EndpointKey) String() string {
 	if ip := k.ToIP(); ip != nil {
-		return net.JoinHostPort(ip.String(), fmt.Sprintf("%d", k.Key))
+		addrCluster := cmtypes.AddrClusterFrom(
+			ippkg.MustAddrFromIP(ip),
+			uint32(k.ClusterID),
+		)
+		return addrCluster.String() + ":" + fmt.Sprintf("%d", k.Key)
 	}
 	return "nil"
 }

--- a/pkg/bpf/endpoint_test.go
+++ b/pkg/bpf/endpoint_test.go
@@ -26,7 +26,7 @@ func (s *BPFTestSuite) TestEndpointKeyToString(c *C) {
 
 	for _, tt := range tests {
 		ip := net.ParseIP(tt.ip)
-		k := NewEndpointKey(ip)
+		k := NewEndpointKey(ip, 0)
 		c.Assert(k.ToIP().String(), Equals, tt.ip)
 	}
 }

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 
 	"github.com/cilium/cilium/pkg/cidr"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -411,7 +412,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc1.IP))
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -421,7 +422,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	}
 
 	if s.enableIPv6 {
-		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc1.IP))
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -450,7 +451,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	// alloc range v1 should map to underlay2
 	if s.enableIPv4 {
-		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc1.IP))
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP2), check.Equals, true)
 
@@ -460,7 +461,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	}
 
 	if s.enableIPv6 {
-		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc1.IP))
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP2), check.Equals, true)
 
@@ -488,15 +489,15 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// alloc range v1 should fail
-	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc1.IP))
 	c.Assert(err, check.Not(check.IsNil))
 
-	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc1.IP))
 	c.Assert(err, check.Not(check.IsNil))
 
 	if s.enableIPv4 {
 		// alloc range v2 should map to underlay1
-		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc2.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc2.IP))
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -513,7 +514,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	if s.enableIPv6 {
 		// alloc range v2 should map to underlay1
-		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc2.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc2.IP))
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -539,10 +540,10 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// alloc range v2 should fail
-	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc2.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc2.IP))
 	c.Assert(err, check.Not(check.IsNil))
 
-	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc2.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc2.IP))
 	c.Assert(err, check.Not(check.IsNil))
 
 	if s.enableIPv4 {
@@ -579,7 +580,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	if s.enableIPv4 {
 		// alloc range v2 should map to underlay1
-		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc2.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc2.IP))
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -591,7 +592,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	if s.enableIPv6 {
 		// alloc range v2 should map to underlay1
-		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc2.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc2.IP))
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -606,17 +607,17 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// alloc range v1 should fail
-	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc1.IP))
 	c.Assert(err, check.Not(check.IsNil))
 
-	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc1.IP))
 	c.Assert(err, check.Not(check.IsNil))
 
 	// alloc range v2 should fail
-	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc2.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc2.IP))
 	c.Assert(err, check.Not(check.IsNil))
 
-	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc2.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc2.IP))
 	c.Assert(err, check.Not(check.IsNil))
 
 	if s.enableIPv4 {
@@ -917,11 +918,11 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 
 	// tunnel map entries must exist
 	if s.enableIPv4 {
-		_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
+		_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc1.IP))
 		c.Assert(err, check.IsNil)
 	}
 	if s.enableIPv6 {
-		_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
+		_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc1.IP))
 		c.Assert(err, check.IsNil)
 	}
 
@@ -938,9 +939,9 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 	c.Assert(err, check.IsNil)
 
 	// tunnel map entries should have been removed
-	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc1.IP))
 	c.Assert(err, check.Not(check.IsNil))
-	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc1.IP))
 	c.Assert(err, check.Not(check.IsNil))
 
 	// Simulate agent restart with address families enabled again
@@ -957,11 +958,11 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 
 	// tunnel map entries must exist
 	if s.enableIPv4 {
-		_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
+		_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip4Alloc1.IP))
 		c.Assert(err, check.IsNil)
 	}
 	if s.enableIPv6 {
-		_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
+		_, err = tunnel.TunnelMap().GetTunnelEndpoint(cmtypes.MustAddrClusterFromIP(ip6Alloc1.IP))
 		c.Assert(err, check.IsNil)
 	}
 

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/cidr"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/mtu"
@@ -29,33 +30,34 @@ var (
 )
 
 func (s *linuxTestSuite) TestTunnelCIDRUpdateRequired(c *check.C) {
-	c1 := cidr.MustParseCIDR("10.1.0.0/16")
-	c2 := cidr.MustParseCIDR("10.2.0.0/16")
+	nilPrefixCluster := cmtypes.PrefixCluster{}
+	c1 := cmtypes.PrefixClusterFromCIDR(cidr.MustParseCIDR("10.1.0.0/16"), 0)
+	c2 := cmtypes.PrefixClusterFromCIDR(cidr.MustParseCIDR("10.2.0.0/16"), 0)
 	ip1 := net.ParseIP("1.1.1.1")
 	ip2 := net.ParseIP("2.2.2.2")
 
-	c.Assert(cidrNodeMappingUpdateRequired(nil, nil, ip1, ip1, 0, 0), check.Equals, false) // disabled -> disabled
-	c.Assert(cidrNodeMappingUpdateRequired(nil, c1, ip1, ip1, 0, 0), check.Equals, true)   // disabled -> c1
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 0), check.Equals, false)   // c1 -> c1
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2, 0, 0), check.Equals, true)    // c1 -> c1 (changed host IP)
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c2, ip2, ip2, 0, 0), check.Equals, true)    // c1 -> c2
-	c.Assert(cidrNodeMappingUpdateRequired(c2, nil, ip2, ip2, 0, 0), check.Equals, false)  // c2 -> disabled
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 1), check.Equals, true)    // key upgrade 0 -> 1
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 1, 0), check.Equals, true)    // key downgrade 1 -> 0
+	c.Assert(cidrNodeMappingUpdateRequired(nilPrefixCluster, nilPrefixCluster, ip1, ip1, 0, 0), check.Equals, false) // disabled -> disabled
+	c.Assert(cidrNodeMappingUpdateRequired(nilPrefixCluster, c1, ip1, ip1, 0, 0), check.Equals, true)                // disabled -> c1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 0), check.Equals, false)                             // c1 -> c1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2, 0, 0), check.Equals, true)                              // c1 -> c1 (changed host IP)
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c2, ip2, ip2, 0, 0), check.Equals, true)                              // c1 -> c2
+	c.Assert(cidrNodeMappingUpdateRequired(c2, nilPrefixCluster, ip2, ip2, 0, 0), check.Equals, false)               // c2 -> disabled
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 1), check.Equals, true)                              // key upgrade 0 -> 1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 1, 0), check.Equals, true)                              // key downgrade 1 -> 0
 
-	c1 = cidr.MustParseCIDR("f00d::a0a:0:0:0/96")
-	c2 = cidr.MustParseCIDR("f00d::b0b:0:0:0/96")
+	c1 = cmtypes.PrefixClusterFromCIDR(cidr.MustParseCIDR("f00d::a0a:0:0:0/96"), 0)
+	c2 = cmtypes.PrefixClusterFromCIDR(cidr.MustParseCIDR("f00d::b0b:0:0:0/96"), 0)
 	ip1 = net.ParseIP("cafe::1")
 	ip2 = net.ParseIP("cafe::2")
 
-	c.Assert(cidrNodeMappingUpdateRequired(nil, nil, ip1, ip1, 0, 0), check.Equals, false) // disabled -> disabled
-	c.Assert(cidrNodeMappingUpdateRequired(nil, c1, ip1, ip1, 0, 0), check.Equals, true)   // disabled -> c1
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 0), check.Equals, false)   // c1 -> c1
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2, 0, 0), check.Equals, true)    // c1 -> c1 (changed host IP)
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c2, ip2, ip2, 0, 0), check.Equals, true)    // c1 -> c2
-	c.Assert(cidrNodeMappingUpdateRequired(c2, nil, ip2, ip2, 0, 0), check.Equals, false)  // c2 -> disabled
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 1), check.Equals, true)    // key upgrade 0 -> 1
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 1, 0), check.Equals, true)    // key downgrade 1 -> 0
+	c.Assert(cidrNodeMappingUpdateRequired(nilPrefixCluster, nilPrefixCluster, ip1, ip1, 0, 0), check.Equals, false) // disabled -> disabled
+	c.Assert(cidrNodeMappingUpdateRequired(nilPrefixCluster, c1, ip1, ip1, 0, 0), check.Equals, true)                // disabled -> c1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 0), check.Equals, false)                             // c1 -> c1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2, 0, 0), check.Equals, true)                              // c1 -> c1 (changed host IP)
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c2, ip2, ip2, 0, 0), check.Equals, true)                              // c1 -> c2
+	c.Assert(cidrNodeMappingUpdateRequired(c2, nilPrefixCluster, ip2, ip2, 0, 0), check.Equals, false)               // c2 -> disabled
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 1), check.Equals, true)                              // key upgrade 0 -> 1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 1, 0), check.Equals, true)                              // key downgrade 1 -> 0
 }
 
 func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -149,7 +149,7 @@ func (k EndpointKey) NewValue() bpf.MapValue { return &EndpointInfo{} }
 // address family is automatically detected
 func NewEndpointKey(ip net.IP) *EndpointKey {
 	return &EndpointKey{
-		EndpointKey: bpf.NewEndpointKey(ip),
+		EndpointKey: bpf.NewEndpointKey(ip, 0),
 	}
 }
 

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -100,7 +100,7 @@ func (m *Map) SetTunnelEndpoint(encryptKey uint8, prefix cmtypes.AddrCluster, en
 		fieldKey:      encryptKey,
 	}).Debug("Updating tunnel map entry")
 
-	return TunnelMap().Update(key, val)
+	return m.Update(key, val)
 }
 
 // GetTunnelEndpoint removes a prefix => tunnel-endpoint mapping
@@ -110,7 +110,7 @@ func (m *Map) GetTunnelEndpoint(prefix cmtypes.AddrCluster) (net.IP, error) {
 		return net.IP{}, err
 	}
 
-	val, err := TunnelMap().Lookup(key)
+	val, err := m.Lookup(key)
 	if err != nil {
 		return net.IP{}, err
 	}
@@ -125,7 +125,7 @@ func (m *Map) DeleteTunnelEndpoint(prefix cmtypes.AddrCluster) error {
 		return err
 	}
 	log.WithField(fieldPrefix, prefix).Debug("Deleting tunnel map entry")
-	return TunnelMap().Delete(key)
+	return m.Delete(key)
 }
 
 // SilentDeleteTunnelEndpoint removes a prefix => tunnel-endpoint mapping.
@@ -136,6 +136,6 @@ func (m *Map) SilentDeleteTunnelEndpoint(prefix cmtypes.AddrCluster) error {
 		return err
 	}
 	log.WithField(fieldPrefix, prefix).Debug("Silently deleting tunnel map entry")
-	_, err = TunnelMap().SilentDelete(key)
+	_, err = m.SilentDelete(key)
 	return err
 }

--- a/pkg/maps/tunnel/tunnel_test.go
+++ b/pkg/maps/tunnel/tunnel_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tunnel
+
+import (
+	"net"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/cilium/ebpf/rlimit"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+type TunnelMapTestSuite struct{}
+
+var _ = Suite(&TunnelMapTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *TunnelMapTestSuite) SetUpSuite(c *C) {
+	testutils.PrivilegedCheck(c)
+	err := rlimit.RemoveMemlock()
+	c.Assert(err, IsNil)
+}
+
+func (s *TunnelMapTestSuite) TestClusterAwareAddressing(c *C) {
+	m := NewTunnelMap("test_cilium_tunnel_map")
+	defer m.Unpin()
+
+	created, err := m.OpenOrCreate()
+	c.Assert(err, IsNil)
+	c.Assert(created, Equals, true)
+
+	prefix0 := cmtypes.MustParseAddrCluster("10.0.0.1")
+	prefix1 := cmtypes.MustParseAddrCluster("10.0.0.1@1")
+	endpoint0 := net.ParseIP("192.168.0.1")
+	endpoint1 := net.ParseIP("192.168.1.1")
+
+	// Test insertion with bare IP
+	err = m.SetTunnelEndpoint(0, prefix0, endpoint0)
+	c.Assert(err, IsNil)
+
+	// Test insertion with AddrCluster
+	err = m.SetTunnelEndpoint(0, prefix1, endpoint1)
+	c.Assert(err, IsNil)
+
+	// Test if tunnel map can distinguish prefix0 and prefix1
+	ip0, err := m.GetTunnelEndpoint(prefix0)
+	c.Assert(err, IsNil)
+	c.Assert(ip0.Equal(endpoint0), Equals, true)
+
+	ip1, err := m.GetTunnelEndpoint(prefix1)
+	c.Assert(err, IsNil)
+	c.Assert(ip1.Equal(endpoint1), Equals, true)
+
+	// Delete prefix0 and check it deletes prefix0 correctly
+	err = m.DeleteTunnelEndpoint(prefix0)
+	c.Assert(err, IsNil)
+
+	_, err = m.GetTunnelEndpoint(prefix0)
+	c.Assert(err, NotNil)
+
+	_, err = m.GetTunnelEndpoint(prefix1)
+	c.Assert(err, IsNil)
+
+	// Delete prefix0 and check it deletes prefix0 correctly
+	err = m.DeleteTunnelEndpoint(prefix1)
+	c.Assert(err, IsNil)
+
+	_, err = m.GetTunnelEndpoint(prefix1)
+	c.Assert(err, NotNil)
+}


### PR DESCRIPTION
This is a part of the Cluster Mesh with overlapping PodCIDR support. When the remote cluster has an overlapping PodCIDR, we must identify the remote endpoint using IP + ClusterID. This PR makes the required changes for the tunnel map to realize that. Note that this PR only adds infrastructure, and currently, we don't "use" that. Please see the commits for more details.

```release-note
Extend tunnel map key with ClusterID
```
