### PR TITLE
refactoring of fetching cilium manifests in OKD installation

### DIFF
--- a/Documentation/installation/k8s-install-openshift-okd.rst
+++ b/Documentation/installation/k8s-install-openshift-okd.rst
@@ -131,15 +131,13 @@ Next, obtain Cilium manifest from ``cilium/cilium-olm`` repository and copy to `
 
 .. parsed-literal::
 
-   cilium_olm_rev="master"
    cilium_version="\ |release|\ "
+   git_dir="/tmp/cilium-olm"
 
-   curl --silent --location --fail --show-error "https://github.com/cilium/cilium-olm/archive/${cilium_olm_rev}.tar.gz" --output /tmp/cilium-olm.tgz
-   tar -C /tmp -xf /tmp/cilium-olm.tgz
+   git clone https://github.com/cilium/cilium-olm.git ${git_dir}
+   cp ${git_dir}/manifests/cilium.v${cilium_version}/* "${CLUSTER_NAME}/manifests"
 
-   cp /tmp/cilium-olm-${cilium_olm_rev}/manifests/cilium.v${cilium_version}/* "${CLUSTER_NAME}/manifests"
-
-   rm -rf -- /tmp/cilium-olm.tgz "/tmp/cilium-olm-${cilium_olm_rev}"
+   test -d ${git_dir} && rm -rf -- ${git_dir}
 
 At this stage manifest directory contains all that is needed to install Cilium.
 To get a list of the Cilium manifests, run:


### PR DESCRIPTION
Since the page https://github.com/cilium/cilium-olm/archive/ does not exist anymore, for fetching the cilium manifests a git clone is performed instead of the curl to the non-existing site.

Signed-off-by: Zisis Lianas <zl@consol.de>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
