### PR TITLE
cilium: Add deprecation warning for service ids

### DIFF
--- a/cilium/cmd/service_delete.go
+++ b/cilium/cmd/service_delete.go
@@ -39,6 +39,8 @@ var serviceDeleteCmd = &cobra.Command{
 			return
 		}
 
+		warnIdTypeDeprecation()
+
 		requireServiceID(cmd, args)
 		if id, err := strconv.ParseInt(args[0], 0, 64); err != nil {
 			Fatalf("%s", err)

--- a/cilium/cmd/service_update.go
+++ b/cilium/cmd/service_update.go
@@ -33,6 +33,10 @@ var (
 	backendWeights     []uint
 )
 
+func warnIdTypeDeprecation() {
+	fmt.Printf("Deprecation warning: --id parameter will change from int to string in v1.14\n")
+}
+
 // serviceUpdateCmd represents the service_update command
 var serviceUpdateCmd = &cobra.Command{
 	Use:   "update",
@@ -86,6 +90,8 @@ func boolToInt(set bool) int {
 }
 
 func updateService(cmd *cobra.Command, args []string) {
+	warnIdTypeDeprecation()
+
 	id := int64(idU)
 	fa := parseFrontendAddress(frontend)
 	skipFrontendCheck := false

--- a/daemon/cmd/loadbalancer.go
+++ b/daemon/cmd/loadbalancer.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/go-openapi/runtime/middleware"
 
@@ -16,6 +17,14 @@ import (
 	"github.com/cilium/cilium/pkg/service"
 )
 
+var warnIdTypeDeprecationOnce sync.Once
+
+func warnIdTypeDeprecation() {
+	warnIdTypeDeprecationOnce.Do(func() {
+		log.Warning("Deprecation: The type of {id} in /service/{id} will change from int to string in v1.14")
+	})
+}
+
 type putServiceID struct {
 	svc *service.Service
 }
@@ -25,6 +34,8 @@ func NewPutServiceIDHandler(svc *service.Service) PutServiceIDHandler {
 }
 
 func (h *putServiceID) Handle(params PutServiceIDParams) middleware.Responder {
+	warnIdTypeDeprecation()
+
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /service/{id} request")
 
 	if params.Config.ID == 0 {
@@ -126,6 +137,8 @@ func NewDeleteServiceIDHandler(svc *service.Service) DeleteServiceIDHandler {
 }
 
 func (h *deleteServiceID) Handle(params DeleteServiceIDParams) middleware.Responder {
+	warnIdTypeDeprecation()
+
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("DELETE /service/{id} request")
 
 	found, err := h.svc.DeleteServiceByID(loadbalancer.ServiceID(params.ID))
@@ -150,6 +163,8 @@ func NewGetServiceIDHandler(svc *service.Service) GetServiceIDHandler {
 }
 
 func (h *getServiceID) Handle(params GetServiceIDParams) middleware.Responder {
+	warnIdTypeDeprecation()
+
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /service/{id} request")
 
 	if svc, ok := h.svc.GetDeepCopyServiceByID(loadbalancer.ServiceID(params.ID)); ok {


### PR DESCRIPTION
The NodePort service frontends are currently expanded early in the K8sWatcher and the IDs used by datapath are allocated for these expanded frontends in pkg/service. A NodePort frontend is created for the Node IP and other routable IPs on the system. As this is now something that can be reconfigured at runtime when devices change, we would like to make the frontend expansion and the service and backend identifiers implementation details of the datapath and not expose them to the user via the REST API (PUT /service/{id}) or the "cilium service update" command.

In v1.14 we will implement this by changing the {id} from int into a string (something like "1.2.3.4:80:TCP" or "[f00d::1]:80:TCP").

We're expecting this change to only affect standalone load-balancer users that are using the "cilium service" commands directly. We do not expect there to be direct use of the "/service/" REST endpoints. Based on this we deem the backwards incompatible change to the type of the {id} parameter acceptable.

In order to give advance warning to the users, this commit adds deprecation warnings to the cilium-agent logs when the /service endpoints are used and to the cilium command-line utility when "cilium service update" or "cilium service delete" is used.
