### PR TITLE
test: Dump VirtualBox version used in CI jobs

### DIFF
--- a/test/post_build_agent.sh
+++ b/test/post_build_agent.sh
@@ -7,6 +7,9 @@ ps -ef | grep -i vbox
 echo "output of: \"ps -ef | grep -i vagrant\" "
 ps -ef | grep -i vagrant
 
+echo "output of: \"VBoxManage --version\" "
+VBoxManage --version
+
 echo "output of: \"VBoxManage list runningvms\" "
 VBoxManage list runningvms
 


### PR DESCRIPTION
During the CI servers' provisioning, we don't install a specific VirtualBox version but the latest patch release for a specific minor release (e.g., the latest v6.1). Those patch releases can play a role in subsequent failures and flakes, so let's dump the specific version that was used as part of the Jenkins output.