### PR TITLE
test/Vagrantfile: Don't hide natnetwork errors

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -63,14 +63,14 @@ k8s_nodes="${K8S_NODES:-2}"
 while [ "$i" -le "$k8s_nodes" ]; do
     VBoxManage natnetwork add --netname natnet$i --network 192.168.0.0/16 --ipv6 on --enable
     i=$((i+1))
-done 2>/dev/null
+done
 
 res=0
 while [ "$res" == "0" ]; do
     VBoxManage natnetwork remove --netname natnet$i
     res=$?
     i=$((i+1))
-done 2>/dev/null
+done
 
 VBoxManage natnetwork list
 SCRIPT


### PR DESCRIPTION
Commit ef22668f reworked the natnetwork creations and deletions and for some obscure reason, I thought it was a good idea to dump stderr. This commit removes that bit, to show stderr in the Vagrant output. We may have a few more erroneous-looking logs (because we sometimes try to create natnetworks that already exists) but I think it's worth it to catch any actual configuration error or even to know if natnetwork existed when they shouldn't.

Fixes: https://github.com/cilium/cilium/pull/19523