### PR TITLE
test, jenkinsfile: Clean up natnetworks in CI after test run

### DIFF
--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -246,7 +246,7 @@ pipeline {
                     sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
                     sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
                     sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
-                    sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                    sh 'cd ${TESTDIR}; ./vagrant_cleanup.sh || true'
                     archiveArtifacts artifacts: '*.zip'
                     junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'src/github.com/cilium/cilium/test/*.xml'
                 }

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -144,7 +144,7 @@ pipeline {
                     sh 'cd ${TESTDIR}; ./archive_test_results_eks.sh || true'
                     sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
                     sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
-                    sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                    sh 'cd ${TESTDIR}; ./vagrant_cleanup.sh || true'
                     archiveArtifacts artifacts: '*.zip'
                     junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'src/github.com/cilium/cilium/test/*.xml'
                 }

--- a/test/vagrant_cleanup.sh
+++ b/test/vagrant_cleanup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+K8S_NODES="${K8S_NODES:-2}"
+
+vagrant destroy -f
+
+i=1
+while [ "$i" -le "$K8S_NODES" ]; do
+    VBoxManage natnetwork remove --netname natnet$i
+    i=$((i+1))
+done
+
+VBoxManage natnetwork list


### PR DESCRIPTION
We currently have a flake in CI that is caused by some incorrect VirtualBox natnetwork configuration. It is currently unclear why the natnetworks are sometimes created with an incorrect configuration.

Unfortunately, because we don't delete natnetworks at the end of each CI job, those incorrect natnetworks remains for subsequent runs and the tests end up failing with the same flake on every single CI job executed on that node.

This pull request adds a cleanup step for natnetworks in our CI. We still won't run natnetworks when running tests locally, for the same reason we don't clean up VMs. This change doesn't fix the flake but it should limit its impact to a single CI job instead of all jobs running on a node.

Related: https://github.com/cilium/cilium/issues/17353#issuecomment-1348278551.