### PR TITLE
install/kubernetes: make securityContext SELinux options configurable

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1841,6 +1841,10 @@
      - Run the pod with elevated privileges
      - bool
      - ``false``
+   * - securityContext.seLinuxOptions
+     - SELinux options for the ``cilium-agent`` and init containers
+     - object
+     - ``{"level":"s0","type":"spc_t"}``
    * - serviceAccounts
      - Define serviceAccount names for components.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -879,6 +879,7 @@ scalability
 scalable
 scp
 sctp
+seLinuxOptions
 seccomp
 secretName
 secretsBackend

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -511,6 +511,7 @@ contributors across the globe, there is almost always someone available to help.
 | securityContext.capabilities.cleanCiliumState | list | `["NET_ADMIN","SYS_MODULE","SYS_ADMIN","SYS_RESOURCE"]` | Capabilities for the `clean-cilium-state` init container |
 | securityContext.capabilities.mountCgroup | list | `["SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]` | Capabilities for the `mount-cgroup` init container |
 | securityContext.privileged | bool | `false` | Run the pod with elevated privileges |
+| securityContext.seLinuxOptions | object | `{"level":"s0","type":"spc_t"}` | SELinux options for the `cilium-agent` and init containers |
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
 | serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -261,11 +261,9 @@ spec:
           privileged: true
           {{- else }}
           seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
+            {{- with .Values.securityContext.seLinuxOptions }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           capabilities:
             add:
             {{- with .Values.securityContext.capabilities.ciliumAgent }}
@@ -441,11 +439,9 @@ spec:
           privileged: true
           {{- else }}
           seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
+            {{- with .Values.securityContext.seLinuxOptions }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           capabilities:
             add:
             {{- with .Values.securityContext.capabilities.mountCgroup }}
@@ -483,11 +479,9 @@ spec:
           privileged: true
           {{- else }}
           seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
+            {{- with .Values.securityContext.seLinuxOptions }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           capabilities:
             add:
             {{- with .Values.securityContext.capabilities.applySysctlOverwrites }}
@@ -573,11 +567,9 @@ spec:
           privileged: true
           {{- else }}
           seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
+            {{- with .Values.securityContext.seLinuxOptions }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           capabilities:
             add:
             {{- with .Values.securityContext.capabilities.cleanCiliumState }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -183,6 +183,13 @@ securityContext:
   # runAsUser: 0
   # -- Run the pod with elevated privileges
   privileged: false
+  # -- SELinux options for the `cilium-agent` and init containers
+  seLinuxOptions:
+    level: 's0'
+    # Running with spc_t since we have removed the privileged mode.
+    # Users can change it to a different type as long as they have the
+    # type available on the system.
+    type: 'spc_t'
   capabilities:
     # -- Capabilities for the `cilium-agent` container
     ciliumAgent:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -180,6 +180,13 @@ securityContext:
   # runAsUser: 0
   # -- Run the pod with elevated privileges
   privileged: false
+  # -- SELinux options for the `cilium-agent` and init containers
+  seLinuxOptions:
+    level: 's0'
+    # Running with spc_t since we have removed the privileged mode.
+    # Users can change it to a different type as long as they have the
+    # type available on the system.
+    type: 'spc_t'
   capabilities:
     # -- Capabilities for the `cilium-agent` container
     ciliumAgent:


### PR DESCRIPTION
Make the hardcoded SELinux options in the helm charts configurable.

Fixes #22703