### PR TITLE
pin managed clusters' K8s version on stable branches

### DIFF
--- a/.github/workflows/conformance-aks-v1.10.yaml
+++ b/.github/workflows/conformance-aks-v1.10.yaml
@@ -66,6 +66,7 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
+  k8s_version: 1.22
   cilium_cli_version: v0.10.7
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -207,6 +208,7 @@ jobs:
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
+            --kubernetes-version ${{ env.k8s_version }} \
             --network-plugin azure \
             --node-count 2 \
             ${{ env.cost_reduction }} \

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -66,6 +66,7 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
+  k8s_version: 1.23
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -218,6 +219,7 @@ jobs:
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
+            --kubernetes-version ${{ env.k8s_version }} \
             --network-plugin azure \
             --node-count 2 \
             ${{ env.cost_reduction }} \

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -66,6 +66,7 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -220,6 +221,7 @@ jobs:
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
+            --kubernetes-version ${{ env.k8s_version }} \
             --network-plugin none \
             --node-count 2 \
             ${{ env.cost_reduction }} \

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -66,6 +66,7 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -220,6 +221,7 @@ jobs:
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
+            --kubernetes-version ${{ env.k8s_version }} \
             --network-plugin none \
             --node-count 2 \
             ${{ env.cost_reduction }} \

--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  k8s_version: 1.21
   cilium_base_version: "1.10"
   cilium_cli_version: v0.10.7
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -204,6 +205,7 @@ jobs:
             metadata:
               name: ${{ env.clusterName }}
               region: ${{ env.region }}
+              version: "${{ env.k8s_version }}"
               tags:
                usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
                owner: "${{ steps.vars.outputs.owner }}"

--- a/.github/workflows/conformance-aws-cni-v1.10.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.10.yaml
@@ -66,7 +66,7 @@ env:
   cilium_base_version: "1.10"
   cilium_cli_version: v0.10.7
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  eksctl_version: v0.101.0
+  eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  k8s_version: 1.23
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.122.0
@@ -231,6 +232,7 @@ jobs:
             metadata:
               name: ${{ env.clusterName }}
               region: ${{ env.region }}
+              version: "${{ env.k8s_version }}"
               tags:
                usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
                owner: "${{ steps.vars.outputs.owner }}"

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -65,7 +65,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  eksctl_version: v0.101.0
+  eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.122.0
@@ -231,6 +232,7 @@ jobs:
             metadata:
               name: ${{ env.clusterName }}
               region: ${{ env.region }}
+              version: "${{ env.k8s_version }}"
               tags:
                usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
                owner: "${{ steps.vars.outputs.owner }}"

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -65,7 +65,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  eksctl_version: v0.101.0
+  eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/conformance-aws-cni-v1.13.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.13.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.122.0
@@ -231,6 +232,7 @@ jobs:
             metadata:
               name: ${{ env.clusterName }}
               region: ${{ env.region }}
+              version: "${{ env.k8s_version }}"
               tags:
                usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
                owner: "${{ steps.vars.outputs.owner }}"

--- a/.github/workflows/conformance-aws-cni-v1.13.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.13.yaml
@@ -65,7 +65,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  eksctl_version: v0.101.0
+  eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -68,7 +68,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  eksctl_version: v0.101.0
+  eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -65,7 +65,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.10.7
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  eksctl_version: v0.101.0
+  eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/conformance-eks-v1.10.yaml
+++ b/.github/workflows/conformance-eks-v1.10.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  k8s_version: 1.21
   cilium_cli_version: v0.10.7
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.122.0
@@ -218,6 +219,7 @@ jobs:
           metadata:
             name: ${{ env.clusterName }}
             region: ${{ env.region }}
+            version: "${{ env.k8s_version }}"
             tags:
              usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
              owner: "${{ steps.vars.outputs.owner }}"

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  k8s_version: 1.23
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.122.0
@@ -221,6 +222,7 @@ jobs:
           metadata:
             name: ${{ env.clusterName }}
             region: ${{ env.region }}
+            version: "${{ env.k8s_version }}"
             tags:
              usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
              owner: "${{ steps.vars.outputs.owner }}"

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -65,7 +65,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  eksctl_version: v0.101.0
+  eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -65,7 +65,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  eksctl_version: v0.101.0
+  eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.122.0
@@ -221,6 +222,7 @@ jobs:
           metadata:
             name: ${{ env.clusterName }}
             region: ${{ env.region }}
+            version: "${{ env.k8s_version }}"
             tags:
              usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
              owner: "${{ steps.vars.outputs.owner }}"

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -65,7 +65,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  eksctl_version: v0.101.0
+  eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   region: us-east-2
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   eksctl_version: v0.122.0
@@ -221,6 +222,7 @@ jobs:
           metadata:
             name: ${{ env.clusterName }}
             region: ${{ env.region }}
+            version: "${{ env.k8s_version }}"
             tags:
              usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
              owner: "${{ steps.vars.outputs.owner }}"

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -68,7 +68,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  eksctl_version: v0.101.0
+  eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
 jobs:

--- a/.github/workflows/conformance-externalworkloads-v1.10.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.10.yaml
@@ -65,6 +65,7 @@ env:
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
+  k8s_version: 1.21
   cilium_cli_version: v0.10.7
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -235,6 +236,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \

--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -65,6 +65,7 @@ env:
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
+  k8s_version: 1.23
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -247,6 +248,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -65,6 +65,7 @@ env:
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -247,6 +248,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \

--- a/.github/workflows/conformance-externalworkloads-v1.13.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.13.yaml
@@ -65,6 +65,7 @@ env:
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -247,6 +248,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \

--- a/.github/workflows/conformance-gke-v1.10.yaml
+++ b/.github/workflows/conformance-gke-v1.10.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
+  k8s_version: 1.21
   cilium_cli_version: v0.10.7
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -211,6 +212,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
+  k8s_version: 1.23
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -222,6 +223,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -222,6 +223,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -63,6 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -223,6 +224,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \

--- a/.github/workflows/conformance-multicluster-v1.10.yaml
+++ b/.github/workflows/conformance-multicluster-v1.10.yaml
@@ -66,6 +66,7 @@ env:
   clusterNameBase: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh
   zone: us-west2-a
   firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
+  k8s_version: 1.21
   cilium_cli_version: v0.10.7
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -214,6 +215,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName1 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \
@@ -229,6 +231,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName2 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -66,6 +66,7 @@ env:
   clusterNameBase: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh
   zone: us-west2-a
   firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
+  k8s_version: 1.23
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -226,6 +227,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName1 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \
@@ -241,6 +243,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName2 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \

--- a/.github/workflows/conformance-multicluster-v1.12.yaml
+++ b/.github/workflows/conformance-multicluster-v1.12.yaml
@@ -66,6 +66,7 @@ env:
   clusterNameBase: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh
   zone: us-west2-a
   firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -226,6 +227,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName1 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \
@@ -241,6 +243,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName2 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \

--- a/.github/workflows/conformance-multicluster-v1.13.yaml
+++ b/.github/workflows/conformance-multicluster-v1.13.yaml
@@ -66,6 +66,7 @@ env:
   clusterNameBase: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh
   zone: us-west2-a
   firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
+  k8s_version: 1.24
   cilium_cli_version: v0.12.11
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -226,6 +227,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName1 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \
@@ -241,6 +243,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName2 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \


### PR DESCRIPTION
Please review per commit.

Resources:

- AKS
  - Run `az aks get-versions --location westeurope --output table`
  - https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions

- EKS
  - Run `eksctl version -o json | jq -r '.EKSServerSupportedVersions[]'`
    (note: this asssumes `eksctl` is up to date, as this is static info)
  - https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
  - https://eksctl.io/usage/schema/#metadata-version

- GKE
  - Run `gcloud container get-server-config --format="yaml(channels)"`
  - https://cloud.google.com/kubernetes-engine/versioning
  - https://cloud.google.com/kubernetes-engine/docs/release-schedule