### PR TITLE
Add pod-asymmetric src/dest label context.

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -526,10 +526,14 @@ Context Options
 ^^^^^^^^^^^^^^^
 
 Hubble metrics support configuration via context options.
-Currently there are 3 supported context options for all metrics:
+Supported context options for all metrics:
 
-- ``sourceContext`` - Configures the ``source`` label on metrics.
-- ``destinationContext`` - Configures the ``destination`` label on metrics.
+- ``sourceContext`` - Configures the ``source`` label on metrics for both egress and ingress traffic.
+- ``sourceEgressContext`` - Configures the ``source`` label on metrics for egress traffic (takes precedence over ``sourceContext``).
+- ``sourceIngressContext`` - Configures the ``source`` label on metrics for ingress traffic (takes precedence over ``sourceContext``).
+- ``destinationContext`` - Configures the ``destination`` label on metrics for both egress and ingress traffic.
+- ``destinationEgressContext`` - Configures the ``destination`` label on metrics for egress traffic (takes precedence over ``destinationContext``).
+- ``destinationIngressContext`` - Configures the ``destination`` label on metrics for ingress traffic (takes precedence over ``destinationContext``).
 - ``labelsContext`` - Configures a list of labels to be enabled on metrics.
 
 There are also some context options that are specific to certain metrics.

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -48,11 +48,15 @@ const (
 
 // ContextOptionsHelp is the help text for context options
 const ContextOptionsHelp = `
- sourceContext          ::= identifier , { "|", identifier }
- destinationContext     ::= identifier , { "|", identifier }
- labels                 ::= label , { ",", label }
- identifier             ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
- label                  ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
+ sourceContext             ::= identifier , { "|", identifier }
+ destinationContext        ::= identifier , { "|", identifier }
+ sourceEgressContext       ::= identifier , { "|", identifier }
+ sourceIngressContext      ::= identifier , { "|", identifier }
+ destinationEgressContext  ::= identifier , { "|", identifier }
+ destinationIngressContext ::= identifier , { "|", identifier }
+ labels                    ::= label , { ",", label }
+ identifier                ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
+ label                     ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 
 var (
@@ -126,10 +130,19 @@ func (cs ContextIdentifierList) String() string {
 // ContextOptions is the set of options to define whether and how to include
 // sending and/or receiving context information
 type ContextOptions struct {
-	// Destination is the destination context to include in metrics
+	// Destination is the destination context to include in metrics for both egress and ingress traffic
 	Destination ContextIdentifierList
-	// Source is the source context to include in metrics
+	// Destination is the destination context to include in metrics for egress traffic (overrides Destination)
+	DestinationEgress ContextIdentifierList
+	// Destination is the destination context to include in metrics for ingress traffic (overrides Destination)
+	DestinationIngress ContextIdentifierList
+
+	// Source is the source context to include in metrics for both egress and ingress traffic
 	Source ContextIdentifierList
+	// Source is the source context to include in metrics for egress traffic (overrides Source)
+	SourceEgress ContextIdentifierList
+	// Source is the source context to include in metrics for ingress traffic (overrides Source)
+	SourceIngress ContextIdentifierList
 
 	// Labels is the full set of labels that have been allowlisted when using the
 	// ContextLabels ContextIdentifier.
@@ -196,8 +209,28 @@ func ParseContextOptions(options Options) (*ContextOptions, error) {
 			if err != nil {
 				return nil, err
 			}
+		case "destinationegresscontext":
+			o.DestinationEgress, err = parseContext(value)
+			if err != nil {
+				return nil, err
+			}
+		case "destinationingresscontext":
+			o.DestinationIngress, err = parseContext(value)
+			if err != nil {
+				return nil, err
+			}
 		case "sourcecontext":
 			o.Source, err = parseContext(value)
+			if err != nil {
+				return nil, err
+			}
+		case "sourceegresscontext":
+			o.SourceEgress, err = parseContext(value)
+			if err != nil {
+				return nil, err
+			}
+		case "sourceingresscontext":
+			o.SourceIngress, err = parseContext(value)
 			if err != nil {
 				return nil, err
 			}
@@ -357,7 +390,14 @@ func (o *ContextOptions) getLabelValues(invert bool, flow *pb.Flow) (labels []st
 	}
 
 	var sourceLabel string
-	for _, contextID := range o.Source {
+	var sourceContextIdentifiers = o.Source
+	if o.SourceIngress != nil && flow.GetTrafficDirection() == pb.TrafficDirection_INGRESS {
+		sourceContextIdentifiers = o.SourceIngress
+	} else if o.SourceEgress != nil && flow.GetTrafficDirection() == pb.TrafficDirection_EGRESS {
+		sourceContextIdentifiers = o.SourceEgress
+	}
+
+	for _, contextID := range sourceContextIdentifiers {
 		sourceLabel = getContextIDLabelValue(contextID, flow, true)
 		// always use first non-empty context
 		if sourceLabel != "" {
@@ -366,7 +406,13 @@ func (o *ContextOptions) getLabelValues(invert bool, flow *pb.Flow) (labels []st
 	}
 
 	var destinationLabel string
-	for _, contextID := range o.Destination {
+	var destinationContextIdentifiers = o.Destination
+	if o.DestinationIngress != nil && flow.GetTrafficDirection() == pb.TrafficDirection_INGRESS {
+		destinationContextIdentifiers = o.DestinationIngress
+	} else if o.DestinationEgress != nil && flow.GetTrafficDirection() == pb.TrafficDirection_EGRESS {
+		destinationContextIdentifiers = o.DestinationEgress
+	}
+	for _, contextID := range destinationContextIdentifiers {
 		destinationLabel = getContextIDLabelValue(contextID, flow, false)
 		// always use first non-empty context
 		if destinationLabel != "" {

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -131,6 +131,70 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.Nil(t, err)
 	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{IP: &pb.IP{Destination: "10.0.0.2"}}), []string{"10.0.0.2"})
 
+	opts, err = ParseContextOptions(Options{
+		"sourceContext":       "pod-short",
+		"sourceEgressContext": "pod",
+	})
+	assert.Nil(t, err)
+	assert.EqualValues(t,
+		[]string{"foo/foo-123"},
+		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123"}, TrafficDirection: pb.TrafficDirection_EGRESS}))
+
+	opts, err = ParseContextOptions(Options{
+		"sourceContext":       "pod-short",
+		"sourceEgressContext": "pod",
+	})
+	assert.Nil(t, err)
+	assert.EqualValues(t,
+		[]string{"foo/foo"},
+		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123"}, TrafficDirection: pb.TrafficDirection_INGRESS}))
+
+	opts, err = ParseContextOptions(Options{
+		"sourceContext":        "pod-short",
+		"sourceEgressContext":  "pod",
+		"sourceIngressContext": "pod",
+	})
+	assert.Nil(t, err)
+	assert.EqualValues(t,
+		[]string{"foo/foo"},
+		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123"}, TrafficDirection: pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
+
+	opts, err = ParseContextOptions(Options{
+		"destinationContext":        "pod-short",
+		"destinationIngressContext": "pod",
+	})
+	assert.Nil(t, err)
+	assert.EqualValues(t,
+		[]string{"foo/bar-bar"},
+		mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar-bar-123-123"}, TrafficDirection: pb.TrafficDirection_EGRESS}))
+
+	opts, err = ParseContextOptions(Options{
+		"destinationContext":        "pod-short",
+		"destinationIngressContext": "pod",
+	})
+	assert.Nil(t, err)
+	assert.EqualValues(t,
+		[]string{"foo/bar-bar-123-123"},
+		mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar-bar-123-123"}, TrafficDirection: pb.TrafficDirection_INGRESS}))
+
+	opts, err = ParseContextOptions(Options{
+		"destinationContext":        "pod-short",
+		"destinationEgressContext":  "pod",
+		"destinationIngressContext": "pod",
+	})
+	assert.Nil(t, err)
+	assert.EqualValues(t,
+		[]string{"foo/bar-bar"},
+		mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar-bar-123-123"}, TrafficDirection: pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
+
+	opts, err = ParseContextOptions(Options{
+		"destinationEgressContext":  "pod",
+		"destinationIngressContext": "pod",
+	})
+	assert.Nil(t, err)
+	assert.Nil(t,
+		mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar-bar-123-123"}, TrafficDirection: pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
+
 	opts, err = ParseContextOptions(Options{"sourceContext": "namespace|dns", "destinationContext": "identity|pod-short|ip"})
 	assert.Nil(t, err)
 	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -20,11 +20,15 @@ Metrics:
   http_request_duration_seconds - Median, 90th and 99th percentile of request duration.
 
 Options:
- sourceContext          ::= identifier , { "|", identifier }
- destinationContext     ::= identifier , { "|", identifier }
- labels                 ::= label , { ",", label }
- identifier             ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
- label                  ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
+ sourceContext             ::= identifier , { "|", identifier }
+ destinationContext        ::= identifier , { "|", identifier }
+ sourceEgressContext       ::= identifier , { "|", identifier }
+ sourceIngressContext      ::= identifier , { "|", identifier }
+ destinationEgressContext  ::= identifier , { "|", identifier }
+ destinationIngressContext ::= identifier , { "|", identifier }
+ labels                    ::= label , { ",", label }
+ identifier                ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
+ label                     ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 	assert.Equal(t, expected, plugin.HelpText())
 }


### PR DESCRIPTION
Signed-off-by: Marek Chodor <mchodor@google.com>

Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Introduce new context labeling option `pod-asymmetric` which is meant to limit the number of data series while preserving the ability to inspect traffic from/to a single pod.

It makes the decision whether a certain flow will be labeled with `pod` or `pod-short` based on traffic direction.

* For **egress** traffic it will annotate the source as `pod` and the destination as `pod-short`. So in metrics we will see that a certain source pod is sending data to a given workload.
* For **ingress** traffic it will annotate the source as `pod-short` and the destination as `pod`. So in metrics we will see that a certain destination pod is receiving data from a given workload. 

This approach will greatly reduce the number of data series in both cilium-agent prometheus counters and in prometheus datastore.

Let's assume we have a cluster of 100 nodes. In this cluster there are 2 deployments called frontend and backend. Both of them are running in 2000 replicas. Frontend app is calling a random instance of backend app through service. With a lot of traffic we can assume that each frontend pod will call each backend pod at least once.

* If we configure hubble-metrics with `sourceContext=pod;destinationContext=pod` it will result in **80M** data series in total (2000 frontend_pods * 2000 backend_pods * 2{ingress&egress}). That is 80 000 data series per cilium-agent instance. Having that many data series will result in higher resources usage of cilium-agent pods and will introduce a lot of stress on datastore (prometheus).
* If we configure hubble-metrics with `sourceContext=pod-short;destinationContext=pod-short` it will result in **2** data series in total (1 frontend_workload * 1 backend_workload * 2{ingress&egress}). It will be impossible to see traffic from/to a single pod then.
* If we configure hubble-metrics with `sourceContext=pod;destinationContext=pod-short` it will result in **4k** data series in total (2000 frontend_pods * 1 backend_workload * 2{ingress&egress}). It will be only possible to track traffic from a single frontend pod, but not traffic to a single backend pod. Similar will be for `sourceContext=pod-short;destinationContext=pod` but we will be only able to see traffic for a single backend pod.
* if we configure hubble-metrics with `sourceContext=pod-asymmetric;destinationContext=pod-asymmetric` it will result in **4k** data series in total (2000 frontend_pods * 1 backend_workload * 1{egress} + 1 frontend_workload * 2000 backend_pods * 1{ingress}). This is 40 data series per cilium agent instance. It's the same number of data series as with `pod -> pod-short` or `pod-short -> pod` but it decides one of these approaches based on the traffic direction so we can inspect metrics both from a single frontend pod and to a single backend pod.

```release-note
Add pod-asymmetric context labeling that either uses pod or pod-short based on traffic direction.
```
