### PR TITLE
docs: add FOSSA badge to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
       <img src="https://cdn.jsdelivr.net/gh/cilium/cilium@master/Documentation/images/logo-dark.png" width="350" alt="Cilium Logo">
    </picture>
 
-|cii| |go-report| |clomonitor| |artifacthub| |slack| |go-doc| |rtd| |apache| |bsd| |gpl|
+|cii| |go-report| |clomonitor| |artifacthub| |slack| |go-doc| |rtd| |apache| |bsd| |gpl| |fossa|
 
 Cilium is a networking, observability, and security solution with an eBPF-based
 dataplane. It provides a simple flat Layer 3 network with the ability to span 
@@ -342,3 +342,7 @@ and the `2-Clause BSD License <bsd-license_>`__
 .. |artifacthub| image:: https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cilium
     :alt: Artifact Hub
     :target: https://artifacthub.io/packages/helm/cilium/cilium
+
+.. |fossa| image:: https://app.fossa.com/api/projects/custom%2B162%2Fgit%40github.com%3Acilium%2Fcilium.git.svg?type=shield
+    :alt: FOSSA Status
+    :target: https://app.fossa.com/projects/custom%2B162%2Fgit%40github.com%3Acilium%2Fcilium.git?ref=badge_shield


### PR DESCRIPTION
Add README badge to show status of FOSSA license scanning (provided by CNCF)

Signed-off-by: Liz Rice <liz@lizrice.com>

