### PR TITLE
datapath: fix NodePort to remote hostns backend with tunnel config

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2643,9 +2643,8 @@ func (c *DaemonConfig) K8sGatewayAPIEnabled() bool {
 // the current configuration.
 func (c *DaemonConfig) DirectRoutingDeviceRequired() bool {
 	// BPF NodePort and BPF Host Routing are using the direct routing device now.
-	// When tunneling is enabled, node-to-node redirection will be done by tunneling.
 	BPFHostRoutingEnabled := !c.EnableHostLegacyRouting
-	return (c.EnableNodePort || BPFHostRoutingEnabled || Config.EnableWireguard) && !c.TunnelingEnabled()
+	return (c.EnableNodePort || BPFHostRoutingEnabled || Config.EnableWireguard)
 }
 
 func (c *DaemonConfig) validateIPv6ClusterAllocCIDR() error {


### PR DESCRIPTION
When forwarding external service requests to a remote backend in
hostNetwork, the NodePort code in tail_nodeport_nat_egress_ipv4() doesn't
redirect into the tunnel (as it's effectively a host-to-host connection).

Therefore it uses IPV4_DIRECT_ROUTING as src address. So if we're not
populating IPV4_DIRECT_ROUTING, such forwarded requests end up being SNATed
with 0.0.0.0.

Fixes: https://github.com/cilium/cilium/issues/22557
Fixes: https://github.com/cilium/cilium/commit/5283ec938a5f2663126061e3f43bc85c0ded3af1 ("datapath: Introduce DirectRoutingDeviceRequired helper")
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>