### PR TITLE
Add Cilium configuration documentation

### DIFF
--- a/Documentation/configuration/index.rst
+++ b/Documentation/configuration/index.rst
@@ -38,7 +38,7 @@ may look like
 Making Changes
 --------------
 
-You may change the configuration of a running installation in two ways:
+You may change the configuration of a running installation in three ways:
 
 #. Via ``helm upgrade``
 
@@ -51,7 +51,14 @@ You may change the configuration of a running installation in two ways:
 
    The `Cilium CLI <https://github.com/cilium/cilium-cli/>`_ has the ability
    to update individual values in the ``cilium-config`` ConfigMap. This will
-   not effect running pods; pods must be deleted manually to pick up any changes.
+   not affect running pods; pods must be deleted manually to pick up any changes.
+
+#. Via ``CiliumNodeConfig`` objects
+
+   Cilium also supports configuration on sets of nodes. See the
+   :ref:`per-node-configuration` page for more details. Likewise, this also requires
+   that pods be manually deleted for changes to take effect.
+
 
 Core Agent
 ----------
@@ -60,6 +67,7 @@ Core Agent
    :glob:
 
    api-rate-limiting
+   per-node-config
    sctp
    vlan-802.1q
    argocd-issues

--- a/Documentation/configuration/index.rst
+++ b/Documentation/configuration/index.rst
@@ -9,6 +9,50 @@
 Configuration
 =============
 
+Your Cilium installation is configured by one or more Helm values -
+see :ref:`helm_reference`. These helm values are converted to arguments
+for the individual components of a Cilium installation, such as
+:doc:`../cmdref/cilium-agent` and :doc:`../cmdref/cilium-operator`, and
+stored in a ConfigMap.
+
+.. _cilium-config-configmap:
+
+``cilium-config`` ConfigMap
+-----------------------------
+
+These arguments are stored in a shared ConfigMap called ``cilium-config``
+(albeit without the leading ``--``). For example, a typical installation
+may look like
+
+.. code-block:: shell-session
+
+   $ kubectl -n kube-system get configmap cilium-config -o yaml
+   data:
+     agent-not-ready-taint-key: node.cilium.io/agent-not-ready
+     arping-refresh-period: 30s
+     auto-direct-node-routes: "false"
+     (output continues)
+
+.. _making-config-changes:
+
+Making Changes
+--------------
+
+You may change the configuration of a running installation in two ways:
+
+#. Via ``helm upgrade``
+
+   Do so by providing new values to Helm and applying them to the existing
+   installation. By setting the value ``rollOutCiliumPods=true``, the agent
+   pods will be gradually restarted.
+
+
+#. Via ``cilium config set``
+
+   The `Cilium CLI <https://github.com/cilium/cilium-cli/>`_ has the ability
+   to update individual values in the ``cilium-config`` ConfigMap. This will
+   not effect running pods; pods must be deleted manually to pick up any changes.
+
 Core Agent
 ----------
 .. toctree::

--- a/Documentation/configuration/per-node-config.rst
+++ b/Documentation/configuration/per-node-config.rst
@@ -1,0 +1,142 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _per-node-configuration:
+
+**********************
+Per-node configuration
+**********************
+
+.. include:: ../beta.rst
+
+The Cilium agent process (a.k.a. DaemonSet) supports setting configuration
+on a per-node basis. This allows overriding :ref:`cilium-config-configmap`
+for a node or set of nodes. It is managed by CiliumNodeConfig objects.
+
+This feature is useful for:
+
+- Gradually rolling out changes.
+- Selectively enabling features that require specific hardware:
+
+    * :ref:`XDP acceleration`
+    * :ref:`ipv6_big_tcp`
+
+CiliumNodeConfig objects
+------------------------
+
+A CiliumNodeConfig object allows for overriding ConfigMap / Agent arguments.
+It consists of a set of fields and a label selector. The label selector
+defines to which nodes the configuration applies. As is the standard with
+Kubernetes, an empty LabelSelector (e.g. ``{}``) selects all nodes.
+
+.. note::
+    Creating or modifying a CiliumNodeConfig will not cause changes to take effect
+    until pods are deleted and re-created (or their node is restarted).
+
+
+Example: selective XDP enablement
+---------------------------------
+
+To enable :ref:`XDP acceleration` only on nodes with necessary
+hardware, one would label the relevant nodes and override their configuration.
+
+.. code-block:: yaml
+
+    apiVersion: cilium.io/v2alpha1
+    kind: CiliumNodeConfig
+    metadata:
+      namespace: kube-system
+      name: enable-xdp
+    spec:
+      nodeSelector:
+        matchLabels:
+          io.cilium.xdp-offload: "true"
+      defaults:
+        bpf-lb-acceleration: native
+
+Example: KubeProxyReplacement Rollout
+-------------------------------------
+
+To roll out :ref:`kube-proxy replacement <kubeproxy-free>` in a gradual manner,
+you may also wish to use the CiliumNodeConfig feature. This will label all migrated
+nodes with ``io.cilium.migration/kube-proxy-replacement: strict``
+
+.. warning::
+
+    You must have installed Cilium with the Helm values ``k8sServiceHost`` and
+    ``k8sServicePort``. Otherwise Cilium will not be able to reach the Kubernetes
+    APIServer after kube-proxy is uninstalled.
+
+    You can apply these two values to a running cluster via ``helm upgrade``.
+
+#. Patch kube-proxy to only run on unmigrated nodes.
+
+    .. code-block:: shell-session
+
+        kubectl -n kube-system patch daemonset kube-proxy --patch '{"spec": {"template": {"spec": {"affinity": {"nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms": [{"matchExpressions": [{"key": "io.cilium.migration/kube-proxy-replacement", "operator": "NotIn", "values": ["strict"]}]}]}}}}}}}'
+
+#. Configure Cilium to use strict kube-proxy on migrated nodes
+
+    .. code-block:: shell-session
+
+        cat <<EOF | kubectl apply --server-side -f -
+        apiVersion: cilium.io/v2alpha1
+        kind: CiliumNodeConfig
+        metadata:
+          namespace: kube-system
+          name: kube-proxy-replacement-strict
+        spec:
+          nodeSelector:
+            matchLabels:
+              io.cilium.migration/kube-proxy-replacement: strict
+          defaults:
+            kube-proxy-replacement: strict
+            kube-proxy-replacement-healthz-bind-address: "0.0.0.0:10256"
+
+        EOF
+
+#. Select a node to migrate. Optionally, cordon and drain that node:
+
+    .. code-block:: shell-session
+
+        export NODE=kind-worker
+        kubectl label node $NODE --overwrite 'io.cilium.migration/kube-proxy-replacement=strict'
+        kubectl cordon $NODE
+
+#. Delete Cilium DaemonSet to reload configuration:
+
+    .. code-block:: shell-session
+
+        kubectl -n kube-system delete pod -l k8s-app=cilium --field-selector spec.nodeName=$NODE
+
+#. Ensure Cilium has the correct configuration:
+
+    .. code-block:: shell-session
+
+        kubectl -n kube-system exec $(kubectl -n kube-system get pod -l k8s-app=cilium --field-selector spec.nodeName=$NODE -o name) -c cilium-agent -- \
+            cilium config get kube-proxy-replacement
+        strict
+
+#. Uncordon node
+
+    .. code-block:: shell-session
+
+        kubectl uncordon $NODE
+
+#. Cleanup: set default to kube-proxy-replacement:
+
+    .. code-block:: shell-session
+
+        cilium config set --restart=false kube-proxy-replacement strict
+        cilium config set --restart=false kube-proxy-replacement-healthz-bind-address "0.0.0.0:10256"
+        kubectl -n kube-system delete ciliumnodeconfig kube-proxy-replacement-strict
+
+#. Cleanup: delete kube-proxy daemonset, unlabel nodes
+
+    .. code-block:: shell-session
+
+        kubectl -n kube-system delete daemonset kube-proxy
+        kubectl label node --all --overwrite 'io.cilium.migration/kube-proxy-replacement-'

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -39,6 +39,8 @@ in any of the Cilium pods and look for the line reporting the status for
 * eBPF-based kube-proxy replacement
 * eBPF-based masquerading
 
+.. _ipv6_big_tcp:
+
 IPv6 BIG TCP
 ============
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -140,6 +140,7 @@ Tetragon
 Tierney
 Tu
 Twilio
+Uncordon
 Uptime
 VM
 VNet
@@ -1017,8 +1018,10 @@ uninline
 uninstall
 uninstallOnExit
 unix
+unlabel
 unmanaged
 unmanagedPodWatcher
+unmigrated
 unsettable
 untriaged
 untrusted


### PR DESCRIPTION
Two commits:

- An overview of how to configure the Cilium processes (Helm, ConfigMap, etc).
- Intro and examples for CiliumNodeConfig objects.

Fixes https://github.com/cilium/cilium/issues/22576