### PR TITLE
Improve fqdn events logging management

### DIFF
--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -232,16 +232,20 @@ func (lr *LogRecord) Log() {
 	flowdebug.Log(lr.getLogFields(), "Logging flow record")
 
 	logMutex.Lock()
-	defer logMutex.Unlock()
-
 	lr.Metadata = metadata
+	n := notifier
+	logMutex.Unlock()
 
-	if notifier != nil {
-		notifier.NewProxyLogRecord(lr)
+	if n != nil {
+		n.NewProxyLogRecord(lr)
 	}
 }
 
-// LogRecordNotifier is the interface to implement LogRecord notifications
+// LogRecordNotifier is the interface to implement LogRecord notifications.
+// Each type that wants to implement this interface must support concurrent calls
+// to the interface methods.
+// Besides, the number of concurrent calls may be very high, so long critical sections
+// should be avoided (i.e.: avoid using a single lock for slow logging operations).
 type LogRecordNotifier interface {
 	// NewProxyLogRecord is called for each new log record
 	NewProxyLogRecord(l *LogRecord) error

--- a/pkg/proxy/logger/logger_test.go
+++ b/pkg/proxy/logger/logger_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/monitor/agent"
+	"github.com/cilium/cilium/pkg/monitor/agent/listener"
+	"github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/monitor/payload"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/u8proto"
+
+	"github.com/miekg/dns"
+)
+
+// mockLogRecord is a log entry similar to the one used in fqdn.go for
+// DNS related events notification.
+var mockLogRecord = NewLogRecord(
+	accesslog.TypeResponse,
+	false,
+	func(lr *LogRecord) {
+		lr.LogRecord.TransportProtocol = accesslog.TransportProtocol(
+			u8proto.ProtoIDs[strings.ToLower("udp")],
+		)
+	},
+	LogTags.Verdict(
+		accesslog.VerdictForwarded,
+		"just a benchmark",
+	),
+	LogTags.Addressing(AddressingInfo{
+		DstIPPort:   "15478",
+		DstIdentity: 16,
+		SrcIPPort:   "53",
+		SrcIdentity: 1,
+	}),
+	LogTags.DNS(&accesslog.LogRecordDNS{
+		Query: "data.test.svc.cluster.local",
+		IPs: []net.IP{
+			net.IPv4(1, 1, 1, 1),
+			net.IPv4(2, 2, 2, 2),
+			net.IPv4(3, 3, 3, 3),
+		},
+		TTL: 43200,
+		CNAMEs: []string{
+			"alt1.test.svc.cluster.local",
+			"alt2.test.svc.cluster.local",
+		},
+		ObservationSource: accesslog.DNSSourceProxy,
+		RCode:             dns.RcodeSuccess,
+		QTypes:            []uint16{dns.TypeA, dns.TypeAAAA},
+		AnswerTypes:       []uint16{dns.TypeA, dns.TypeAAAA},
+	}),
+)
+
+// MockMonitorListener is a mock type used to implement the listener.MonitorListener interface
+// for benchmarking purposes.
+// Specifically, it mimics the behavior of agent.listenerv1_2
+type MockMonitorListener struct {
+	queue chan *payload.Payload
+}
+
+// NewMockMonitorListener returns a MockMonitorListener ready to be used in the benchmarks below.
+func NewMockMonitorListener(queueSize int) *MockMonitorListener {
+	return &MockMonitorListener{
+		queue: make(chan *payload.Payload, queueSize),
+	}
+}
+
+// Drain will start the draining of the listener internal queue using a separate goroutine.
+func (ml *MockMonitorListener) Drain(ctx context.Context, wg *sync.WaitGroup) {
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case pl := <-ml.queue:
+				var bb bytes.Buffer
+				_ = pl.EncodeBinary(gob.NewEncoder(&bb))
+			}
+		}
+	}()
+}
+
+// Enqueue sends the payload passed as parameter to the listener internal queue for processing.
+func (ml *MockMonitorListener) Enqueue(pl *payload.Payload) {
+	select {
+	case ml.queue <- pl:
+	default:
+		// listener queue is full, dropping message
+	}
+}
+
+// Version returns the API version supported by this listener.
+func (ml *MockMonitorListener) Version() listener.Version {
+	return listener.Version1_2
+}
+
+// Close stops the listener. It is a no-op for MockMonitorListener.
+func (ml *MockMonitorListener) Close() {
+}
+
+// MockLogNotifier is a mock type used to implement the LogRecordNotifier interface for
+// benchmarking purposes.
+// Specifically, it mimics the behavior of the Daemon and its implementation of the
+// NewProxyLogRecord method.
+type MockLogNotifier struct {
+	monitorAgent *agent.Agent
+}
+
+// NewMockLogNotifier returns a MockLogNotifier ready to be used in the benchmarks below.
+func NewMockLogNotifier() *MockLogNotifier {
+	return &MockLogNotifier{agent.NewAgent(context.Background())}
+}
+
+// NewProxyLogRecord sends the event to the monitor agent to notify the listeners.
+func (n *MockLogNotifier) NewProxyLogRecord(l *LogRecord) error {
+	return n.monitorAgent.SendEvent(api.MessageTypeAccessLog, l.LogRecord)
+}
+
+// RegisterNewListener adds a listener to the MockLogNotifier.
+func (n *MockLogNotifier) RegisterNewListener(l listener.MonitorListener) {
+	n.monitorAgent.RegisterNewListener(l)
+}
+
+var benchCases = []struct {
+	name     string
+	nRecords int
+}{
+	{
+		name:     "OneRecord",
+		nRecords: 1,
+	},
+	{
+		name:     "TenRecords",
+		nRecords: 10,
+	},
+	{
+		name:     "HundredRecords",
+		nRecords: 100,
+	},
+	{
+		name:     "ThousandRecords",
+		nRecords: 1000,
+	},
+}
+
+func BenchmarkLogNotifierWithNoListeners(b *testing.B) {
+	SetNotifier(NewMockLogNotifier())
+
+	for _, bm := range benchCases {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				// Each goroutine will deliver a single notification concurrently.
+				// This is done to simulate what happens when a high rate of DNS
+				// related events trigger one `notifyOnDNSMsg` callback each and
+				// consequently the event logging.
+				var wg sync.WaitGroup
+				for j := 0; j < bm.nRecords; j++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						mockLogRecord.Log()
+					}()
+				}
+				wg.Wait()
+			}
+		})
+	}
+}
+
+func BenchmarkLogNotifierWithListeners(b *testing.B) {
+	listener := NewMockMonitorListener(option.Config.MonitorQueueSize)
+	notifier := NewMockLogNotifier()
+	notifier.RegisterNewListener(listener)
+	SetNotifier(notifier)
+
+	for _, bm := range benchCases {
+		b.Run(bm.name, func(b *testing.B) {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			listener.Drain(ctx, &wg)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Each goroutine will deliver a single notification concurrently.
+				// This is done to simulate what happens when a high rate of DNS
+				// related events trigger one `notifyOnDNSMsg` callback each and
+				// consequently the event logging.
+				var logWg sync.WaitGroup
+				for j := 0; j < bm.nRecords; j++ {
+					logWg.Add(1)
+					go func() {
+						defer logWg.Done()
+						mockLogRecord.Log()
+					}()
+				}
+				logWg.Wait()
+			}
+			b.StopTimer()
+
+			// wait for listener cleanup
+			cancel()
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
Currently, the `Log` method of fqdn related `LogRecord` is holding the lock for the entire record operation.
The record operation can be broken up in the following parts:

- add metadata to the record
- check if the notifier is set
- call `NewProxyLogRecord` on the notifier if not nil

The lock is needed both to copy metadata and to get the currently set notifier.
Instead, the call to `NewProxyLogRecord` can be executed without holding the lock, given that each concrete type that satisfies the `LogRecordNotifier` interface supports concurrent notifications.

Currently there is only one concrete implementation of that interface, the agent monitor. The agent monitor supports two kinds of clients: listeners and consumers.
Since listeners expect the notifications to be first JSON marshaled and then Gob encoded, the log record operation is not negligible both in terms of time taken and computational resources.

So, in case of:

- a very high rate of fqdn related events
- low computational resources available for the pod

the queue of goroutines waiting on that lock may grow significantly. In that scenario, the total memory used because of all the enqueued goroutines may grow unacceptably.

As an example, this can be observed when cilium agent pods are assigned limited computational resources and the rate of DNS requests is very high but consistently failing for a prolonged period of time.

First, this PR avoid the encoding if there are no active listeners.
Then, since the agent monitor already supports concurrent events handling, the commit shortens the critical section, allowing for concurrent execution of the actual log entries recording.
Doing so, the number of goroutines waiting for the `LogRecord` lock is lowered in high load - low resources scenarios, both with and without active listeners.