### PR TITLE
pkg/maps,pkg/defaults: allow configuring map events on missing maps.

### DIFF
--- a/cilium/cmd/bpf_bandwidth_list.go
+++ b/cilium/cmd/bpf_bandwidth_list.go
@@ -26,7 +26,7 @@ var bpfBandwidthListCmd = &cobra.Command{
 		common.RequireRootPrivilege("cilium bpf bandwidth list")
 
 		bpfBandwidthList := make(map[string][]string)
-		if err := bwmap.ThrottleMap.Dump(bpfBandwidthList); err != nil {
+		if err := bwmap.ThrottleMap().Dump(bpfBandwidthList); err != nil {
 			fmt.Fprintf(os.Stderr, "error dumping contents of map: %s\n", err)
 			os.Exit(1)
 		}

--- a/cilium/cmd/bpf_tunnel_list.go
+++ b/cilium/cmd/bpf_tunnel_list.go
@@ -26,7 +26,7 @@ var bpfTunnelListCmd = &cobra.Command{
 		common.RequireRootPrivilege("cilium bpf tunnel list")
 
 		tunnelList := make(map[string][]string)
-		if err := tunnel.TunnelMap.Dump(tunnelList); err != nil {
+		if err := tunnel.TunnelMap().Dump(tunnelList); err != nil {
 			os.Exit(1)
 		}
 

--- a/cilium/cmd/bpf_vtep_delete.go
+++ b/cilium/cmd/bpf_vtep_delete.go
@@ -30,7 +30,7 @@ var bpfVtepDeleteCmd = &cobra.Command{
 
 		key := vtep.NewKey(vcidr.IP)
 
-		if err := vtep.VtepMAP.Delete(&key); err != nil {
+		if err := vtep.VtepMap().Delete(&key); err != nil {
 			Fatalf("error deleting contents of map: %s\n", err)
 		}
 	},

--- a/cilium/cmd/bpf_vtep_list.go
+++ b/cilium/cmd/bpf_vtep_list.go
@@ -32,7 +32,7 @@ var bpfVtepListCmd = &cobra.Command{
 		common.RequireRootPrivilege("cilium bpf vtep list")
 
 		bpfVtepList := make(map[string][]string)
-		if err := vtep.VtepMAP.Dump(bpfVtepList); err != nil {
+		if err := vtep.VtepMap().Dump(bpfVtepList); err != nil {
 			fmt.Fprintf(os.Stderr, "error dumping contents of map: %s\n", err)
 			os.Exit(1)
 		}

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -339,7 +339,7 @@ func (d *Daemon) initMaps() error {
 	}
 
 	if option.Config.TunnelingEnabled() {
-		if _, err := tunnel.TunnelMap.OpenOrCreate(); err != nil {
+		if _, err := tunnel.TunnelMap().OpenOrCreate(); err != nil {
 			return err
 		}
 	}
@@ -355,7 +355,7 @@ func (d *Daemon) initMaps() error {
 	}
 
 	if option.Config.EnableVTEP {
-		if _, err := vtep.VtepMAP.OpenOrCreate(); err != nil {
+		if _, err := vtep.VtepMap().OpenOrCreate(); err != nil {
 			return err
 		}
 	}

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -170,7 +170,7 @@ func InitBandwidthManager() {
 
 	log.Info("Setting up BPF bandwidth manager")
 
-	if _, err := bwmap.ThrottleMap.OpenOrCreate(); err != nil {
+	if _, err := bwmap.ThrottleMap().OpenOrCreate(); err != nil {
 		log.WithError(err).Fatal("Failed to access ThrottleMap")
 	}
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -111,7 +111,7 @@ func updateTunnelMapping(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net.IP, first
 			"allocCIDR":      newCIDR,
 		}).Debug("Updating tunnel map entry")
 
-		if err := tunnel.TunnelMap.SetTunnelEndpoint(newEncryptKey, newCIDR.IP, newIP); err != nil {
+		if err := tunnel.TunnelMap().SetTunnelEndpoint(newEncryptKey, newCIDR.IP, newIP); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				"allocCIDR": newCIDR,
 			}).Error("bpf: Unable to update in tunnel endpoint map")
@@ -168,13 +168,13 @@ func deleteTunnelMapping(oldCIDR *cidr.CIDR, quietMode bool) {
 	}).Debug("Deleting tunnel map entry")
 
 	if !quietMode {
-		if err := tunnel.TunnelMap.DeleteTunnelEndpoint(oldCIDR.IP); err != nil {
+		if err := tunnel.TunnelMap().DeleteTunnelEndpoint(oldCIDR.IP); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				"allocCIDR": oldCIDR,
 			}).Error("Unable to delete in tunnel endpoint map")
 		}
 	} else {
-		_ = tunnel.TunnelMap.SilentDeleteTunnelEndpoint(oldCIDR.IP)
+		_ = tunnel.TunnelMap().SilentDeleteTunnelEndpoint(oldCIDR.IP)
 
 	}
 }

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -105,8 +105,8 @@ func (s *linuxPrivilegedBaseTestSuite) SetUpTest(c *check.C, addressing types.No
 	}
 	c.Assert(err, check.IsNil)
 
-	tunnel.TunnelMap = tunnel.NewTunnelMap("test_cilium_tunnel_map")
-	_, err = tunnel.TunnelMap.OpenOrCreate()
+	tunnel.SetTunnelMap(tunnel.NewTunnelMap("test_cilium_tunnel_map"))
+	_, err = tunnel.TunnelMap().OpenOrCreate()
 	c.Assert(err, check.IsNil)
 }
 
@@ -128,7 +128,7 @@ func (s *linuxPrivilegedIPv4AndIPv6TestSuite) SetUpTest(c *check.C) {
 func tearDownTest(c *check.C) {
 	removeDevice(dummyHostDeviceName)
 	removeDevice(dummyExternalDeviceName)
-	err := tunnel.TunnelMap.Unpin()
+	err := tunnel.TunnelMap().Unpin()
 	c.Assert(err, check.IsNil)
 }
 
@@ -411,7 +411,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	if s.enableIPv4 {
-		underlayIP, err := tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc1.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -421,7 +421,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	}
 
 	if s.enableIPv6 {
-		underlayIP, err := tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc1.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -450,7 +450,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	// alloc range v1 should map to underlay2
 	if s.enableIPv4 {
-		underlayIP, err := tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc1.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP2), check.Equals, true)
 
@@ -460,7 +460,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	}
 
 	if s.enableIPv6 {
-		underlayIP, err := tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc1.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP2), check.Equals, true)
 
@@ -488,15 +488,15 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// alloc range v1 should fail
-	_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
 	c.Assert(err, check.Not(check.IsNil))
 
-	_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
 	c.Assert(err, check.Not(check.IsNil))
 
 	if s.enableIPv4 {
 		// alloc range v2 should map to underlay1
-		underlayIP, err := tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc2.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc2.IP)
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -513,7 +513,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	if s.enableIPv6 {
 		// alloc range v2 should map to underlay1
-		underlayIP, err := tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc2.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc2.IP)
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -539,10 +539,10 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// alloc range v2 should fail
-	_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc2.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc2.IP)
 	c.Assert(err, check.Not(check.IsNil))
 
-	_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc2.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc2.IP)
 	c.Assert(err, check.Not(check.IsNil))
 
 	if s.enableIPv4 {
@@ -579,7 +579,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	if s.enableIPv4 {
 		// alloc range v2 should map to underlay1
-		underlayIP, err := tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc2.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc2.IP)
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -591,7 +591,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	if s.enableIPv6 {
 		// alloc range v2 should map to underlay1
-		underlayIP, err := tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc2.IP)
+		underlayIP, err := tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc2.IP)
 		c.Assert(err, check.IsNil)
 		c.Assert(underlayIP.Equal(externalNodeIP1), check.Equals, true)
 
@@ -606,17 +606,17 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// alloc range v1 should fail
-	_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
 	c.Assert(err, check.Not(check.IsNil))
 
-	_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
 	c.Assert(err, check.Not(check.IsNil))
 
 	// alloc range v2 should fail
-	_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc2.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc2.IP)
 	c.Assert(err, check.Not(check.IsNil))
 
-	_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc2.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc2.IP)
 	c.Assert(err, check.Not(check.IsNil))
 
 	if s.enableIPv4 {
@@ -917,11 +917,11 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 
 	// tunnel map entries must exist
 	if s.enableIPv4 {
-		_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc1.IP)
+		_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
 		c.Assert(err, check.IsNil)
 	}
 	if s.enableIPv6 {
-		_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc1.IP)
+		_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
 		c.Assert(err, check.IsNil)
 	}
 
@@ -938,9 +938,9 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 	c.Assert(err, check.IsNil)
 
 	// tunnel map entries should have been removed
-	_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
 	c.Assert(err, check.Not(check.IsNil))
-	_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc1.IP)
+	_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
 	c.Assert(err, check.Not(check.IsNil))
 
 	// Simulate agent restart with address families enabled again
@@ -957,11 +957,11 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 
 	// tunnel map entries must exist
 	if s.enableIPv4 {
-		_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip4Alloc1.IP)
+		_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip4Alloc1.IP)
 		c.Assert(err, check.IsNil)
 	}
 	if s.enableIPv6 {
-		_, err = tunnel.TunnelMap.GetTunnelEndpoint(ip6Alloc1.IP)
+		_, err = tunnel.TunnelMap().GetTunnelEndpoint(ip6Alloc1.IP)
 		c.Assert(err, check.IsNil)
 	}
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -532,9 +532,24 @@ var (
 		"cilium_lxc": "enabled,128,0",
 		// cilium_ipcache is the likely the most useful use of this feature, but also has
 		// the highest churn.
-		"cilium_ipcache":         "enabled,1024,0",
-		"cilium_lb4_services_v2": "enabled,128,0",
-		"cilium_lb4_backends_v2": "enabled,128,0",
-		"cilium_lb4_reverse_nat": "enabled,128,0",
+		"cilium_ipcache":           "enabled,1024,0",
+		"cilium_tunnel_map":        "enabled,128,0",
+		"cilium_lb_affinity_match": "enabled,128,0",
+
+		// ip4
+		"cilium_lb4_services_v2":    "enabled,128,0",
+		"cilium_lb4_backends_v2":    "enabled,128,0",
+		"cilium_lb4_reverse_nat":    "enabled,128,0",
+		"cilium_lb4_backends_v3":    "enabled,128,0",
+		"cilium_lb4_source_range":   "enabled,128,0",
+		"cilium_lb4_affinity_match": "enabled,128,0",
+
+		// ip6
+		"cilium_lb6_services_v2":    "enabled,128,0",
+		"cilium_lb6_backends_v2":    "enabled,128,0",
+		"cilium_lb6_reverse_nat":    "enabled,128,0",
+		"cilium_lb6_backends_v3":    "enabled,128,0",
+		"cilium_lb6_source_range":   "enabled,128,0",
+		"cilium_lb6_affinity_match": "enabled,128,0",
 	}
 )

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/types"
 )
 
@@ -40,7 +41,8 @@ func initAffinity(params InitParams) {
 		AffinityMapMaxEntries,
 		0, 0,
 		bpf.ConvertKeyValue,
-	).WithCache().WithPressureMetric()
+	).WithCache().WithPressureMetric().
+		WithEvents(option.Config.GetEventBufferConfig(AffinityMatchMapName))
 
 	if params.IPv4 {
 		Affinity4Map = bpf.NewMap(

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -75,7 +76,8 @@ func initSVC(params InitParams) {
 			ServiceMapMaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache().WithPressureMetric()
+		).WithCache().WithPressureMetric().
+			WithEvents(option.Config.GetEventBufferConfig(Service4MapV2Name))
 		Backend4Map = bpf.NewMap(Backend4MapName,
 			bpf.MapTypeHash,
 			&Backend4Key{},
@@ -85,7 +87,8 @@ func initSVC(params InitParams) {
 			ServiceBackEndMapMaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache().WithPressureMetric()
+		).WithCache().WithPressureMetric().
+			WithEvents(option.Config.GetEventBufferConfig(Backend4MapName))
 		Backend4MapV2 = bpf.NewMap(Backend4MapV2Name,
 			bpf.MapTypeHash,
 			&Backend4KeyV3{},
@@ -95,7 +98,8 @@ func initSVC(params InitParams) {
 			ServiceBackEndMapMaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache().WithPressureMetric()
+		).WithCache().WithPressureMetric().
+			WithEvents(option.Config.GetEventBufferConfig(Backend4MapV2Name))
 		Backend4MapV3 = bpf.NewMap(Backend4MapV3Name,
 			bpf.MapTypeHash,
 			&Backend4KeyV3{},
@@ -105,7 +109,8 @@ func initSVC(params InitParams) {
 			ServiceBackEndMapMaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache().WithPressureMetric()
+		).WithCache().WithPressureMetric().
+			WithEvents(option.Config.GetEventBufferConfig(Backend4MapV3Name))
 		RevNat4Map = bpf.NewMap(RevNat4MapName,
 			bpf.MapTypeHash,
 			&RevNat4Key{},
@@ -115,7 +120,8 @@ func initSVC(params InitParams) {
 			RevNatMapMaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache().WithPressureMetric()
+		).WithCache().WithPressureMetric().
+			WithEvents(option.Config.GetEventBufferConfig(RevNat4MapName))
 	}
 
 	if params.IPv6 {
@@ -128,7 +134,8 @@ func initSVC(params InitParams) {
 			ServiceMapMaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache().WithPressureMetric()
+		).WithCache().WithPressureMetric().
+			WithEvents(option.Config.GetEventBufferConfig(Service6MapV2Name))
 		Backend6Map = bpf.NewMap(Backend6MapName,
 			bpf.MapTypeHash,
 			&Backend6Key{},
@@ -138,7 +145,8 @@ func initSVC(params InitParams) {
 			ServiceBackEndMapMaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache().WithPressureMetric()
+		).WithCache().WithPressureMetric().
+			WithEvents(option.Config.GetEventBufferConfig(Backend6MapName))
 		Backend6MapV2 = bpf.NewMap(Backend6MapV2Name,
 			bpf.MapTypeHash,
 			&Backend6KeyV3{},
@@ -148,7 +156,8 @@ func initSVC(params InitParams) {
 			ServiceBackEndMapMaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache().WithPressureMetric()
+		).WithCache().WithPressureMetric().
+			WithEvents(option.Config.GetEventBufferConfig(Backend6MapV2Name))
 		Backend6MapV3 = bpf.NewMap(Backend6MapV3Name,
 			bpf.MapTypeHash,
 			&Backend6KeyV3{},
@@ -158,7 +167,8 @@ func initSVC(params InitParams) {
 			ServiceBackEndMapMaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache().WithPressureMetric()
+		).WithCache().WithPressureMetric().
+			WithEvents(option.Config.GetEventBufferConfig(Backend6MapV3Name))
 		RevNat6Map = bpf.NewMap(RevNat6MapName,
 			bpf.MapTypeHash,
 			&RevNat6Key{},
@@ -168,7 +178,8 @@ func initSVC(params InitParams) {
 			RevNatMapMaxEntries,
 			0, 0,
 			bpf.ConvertKeyValue,
-		).WithCache().WithPressureMetric()
+		).WithCache().WithPressureMetric().
+			WithEvents(option.Config.GetEventBufferConfig(RevNat6MapName))
 	}
 }
 


### PR DESCRIPTION
Several maps that had caching enabled did not expose the option to configure bpf map events.
This meant that even if they where configured using the option flag, map events would not work for those map types.
This enables map events for those maps, and configures the default config map to include enabling map event buffers for all remaining state map types (i.e. dynamic maps such as endpoint ones are still not supported). 

Signed-off-by: Tom Hadlaw <tom.hadlaw@isovalent.com>

```release-note
pkg/maps,pkg/defaults: allow configuring map events on missing map types.
```
