### PR TITLE
v1.10 backport: fix multi option parsing

### DIFF
--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -91,15 +91,20 @@ func isValidKeyValuePair(str string) bool {
 // - strings.Split function will return []string{"c6a.2xlarge=4", "15", "15", "m4.xlarge=2", "4", "8"}.
 // - splitKeyValue function will return []string{"c6a.2xlarge=4,15,15", "m4.xlarge=2,4,8"} instead.
 func splitKeyValue(str string, sep rune, keyValueSep rune) []string {
-	var sepIndexes []int
+	var sepIndexes, kvValueSepIndexes []int
 	// find all indexes of separator character
 	for i := 0; i < len(str); i++ {
-		if int32(str[i]) == sep {
+		switch int32(str[i]) {
+		case sep:
 			sepIndexes = append(sepIndexes, i)
+		case keyValueSep:
+			kvValueSepIndexes = append(kvValueSepIndexes, i)
 		}
 	}
 
-	if len(sepIndexes) == 0 {
+	// there's only a single key-value if there are no separators ("key=value")
+	// or a single key-value separator ("key=option1:value1,option2:value2")
+	if len(sepIndexes) == 0 || len(kvValueSepIndexes) == 1 {
 		return []string{str}
 	}
 

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -100,7 +100,19 @@ func TestGetStringMapString(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "valid kv format with comma in value",
+			name: "valid kv format with a single key and commas in value",
+			args: args{
+				key:   "API_RATE_LIMIT",
+				value: "endpoint-create=rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true",
+			},
+			want: map[string]string{
+				"endpoint-create": "rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true",
+			},
+			wantErr: assert.NoError,
+		},
+
+		{
+			name: "valid kv format with multiple keys with commas in value",
 			args: args{
 				key:   "API_RATE_LIMIT",
 				value: "endpoint-create=rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true,endpoint-delete=rate-limit:10/s,rate-burst:10,parallel-requests:10,auto-adjust:true",


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/22299

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 22299; do contrib/backporting/set-labels.py $pr done 1.10; done
```