### PR TITLE
bpf: restrict overlay->lxc fix for kube-proxy to bpf_overlay

### DIFF
--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -93,7 +93,7 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 	ctx->mark |= MARK_MAGIC_IDENTITY;
 	set_identity_mark(ctx, seclabel);
 
-# if defined(TUNNEL_MODE) && !defined(ENABLE_NODEPORT)
+# if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY) && !defined(ENABLE_NODEPORT)
 	/* In tunneling mode, we execute this code to send the packet from
 	 * cilium_vxlan to lxc*. If we're using kube-proxy, we don't want to use
 	 * redirect() because that would bypass conntrack and the reverse DNAT.
@@ -105,7 +105,7 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 	return CTX_ACT_OK;
 # else
 	return redirect_ep(ctx, ep->ifindex, from_host);
-# endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
+# endif /* TUNNEL_MODE && IS_BPF_OVERLAY && !ENABLE_NODEPORT */
 #else
 	/* Jumps to destination pod's BPF program to enforce ingress policies. */
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
@@ -153,7 +153,7 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 	ctx->mark |= MARK_MAGIC_IDENTITY;
 	set_identity_mark(ctx, seclabel);
 
-# if defined(TUNNEL_MODE) && !defined(ENABLE_NODEPORT)
+# if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY) && !defined(ENABLE_NODEPORT)
 	/* In tunneling mode, we execute this code to send the packet from
 	 * cilium_vxlan to lxc*. If we're using kube-proxy, we don't want to use
 	 * redirect() because that would bypass conntrack and the reverse DNAT.
@@ -165,7 +165,7 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 	return CTX_ACT_OK;
 # else
 	return redirect_ep(ctx, ep->ifindex, from_host);
-# endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
+# endif /* TUNNEL_MODE && IS_BPF_OVERLAY && !ENABLE_NODEPORT */
 #else
 	/* Jumps to destination pod's BPF program to enforce ingress policies. */
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);


### PR DESCRIPTION
This was only meant to fix the case when from-overlay calls ipv*_local_delivery(). But as-is it also applies to usage in from-host, from-netdev and from-lxc. Add a check for IS_BPF_OVERLAY to restrict the code section to what was intended.

We also keep the TUNNEL_MODE requirement, to emphasize that this code isn't needed when the tunnel is only in place for EgressGW.

Fixes: 3d2ceaf3b24d ("bpf: Preserve overlay->lxc path with kube-proxy")
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>