### PR TITLE
operator: Wait for informers to shut down when stopping

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -18,6 +18,7 @@ import (
 	"path"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -625,7 +626,7 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, servi
 		synchronizeIdentities(clientset)
 		synchronizeNodes(clientset)
 		synchronizeCiliumEndpoints(clientset)
-		operatorWatchers.StartSynchronizingServices(context.Background(), clientset, services, false, cfg)
+		operatorWatchers.StartSynchronizingServices(context.Background(), &sync.WaitGroup{}, clientset, services, false, cfg)
 	}
 
 	go func() {

--- a/operator/cmd/allocator_test.go
+++ b/operator/cmd/allocator_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,6 +36,9 @@ func TestPodCIDRAllocatorOverlap(t *testing.T) {
 }
 
 func podCIDRAllocatorOverlapTestRun(t *testing.T) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -87,7 +91,7 @@ func podCIDRAllocatorOverlapTestRun(t *testing.T) {
 
 	// start synchronization.
 	cns := newCiliumNodeSynchronizer(fakeSet, podCidrManager, false)
-	if err := cns.Start(ctx); err != nil {
+	if err := cns.Start(ctx, &wg); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -26,7 +26,6 @@ import (
 	k8sTesting "k8s.io/client-go/testing"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
-	"github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s/version"
@@ -158,9 +157,6 @@ func (cpt *ControlPlaneTest) StartOperator() *ControlPlaneTest {
 	if cpt.operatorHandle != nil {
 		cpt.t.Fatal("StartOperator() already called")
 	}
-
-	watchers.PodStoreSynced = make(chan struct{})
-	watchers.UnmanagedPodStoreSynced = make(chan struct{})
 
 	cpt.operatorHandle = &operatorHandle{
 		t: cpt.t,


### PR DESCRIPTION
Now that the control-plane tests are running multiple test cases against
the operator we're seeing more flakes due to global variables that
left behind goroutines from previous test cases. For example:

```
  panic: close of closed channel

  goroutine 697 [running]:
    github.com/cilium/cilium/operator/watchers.UnmanagedKubeDNSPodsInit({0x3ad76a8?, 0xc00083ed40?})
        /home/vagrant/go/src/github.com/cilium/cilium/operator/watchers/pod.go:140 +0x268
```

The proper fix would be to refactor the operator to not use global variables
and implement it as cells with their own Start and Stop hooks that don't leave goroutines behind,

Since that refactoring will take significant time, we can apply band aid to the flaky test
problem by propagating a Context and WaitGroup to the places where goroutines are left behind
(as indicated by goleak check).

This commit does not apply this to every feature in operator due to gaps in test coverage
(e.g. operator/pkg/ingress was not modified).

Fixes: #22748
