### PR TITLE
workflows: fix skip condition for encryption tests in datapath conformance

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -257,7 +257,7 @@ jobs:
             kind delete cluster
 
       - name: Run encryption tests
-        if: ${{ matrix.encryption }} != 'disabled'
+        if: ${{ matrix.encryption != 'disabled' }}
         uses: cilium/little-vm-helper@c3dbeb9d505b31aa5e960ebb258f4dd5f96f0202
         with:
           provision: 'false'


### PR DESCRIPTION
Currently, the encryption tests are e.g. run on kernel 5.4 [1], even though encryption is disabled [2].

[1] https://github.com/cilium/cilium/actions/runs/3706274238/jobs/6281282090
[2] https://github.com/cilium/cilium/actions/runs/3706274238/workflow#L130

Noticed while debugging #22754.