### PR TITLE
Make cilium pprof listen address configurable

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -234,8 +234,9 @@ cilium-agent [flags]
       --node-port-range strings                                 Set the min/max NodePort port range (default [30000,32767])
       --policy-audit-mode                                       Enable policy audit (non-drop) mode
       --policy-queue-size int                                   Size of queues for policy-related events (default 100)
-      --pprof                                                   Enable serving the pprof debugging API
-      --pprof-port int                                          Port that the pprof listens on (default 6060)
+      --pprof                                                   Enable serving pprof debugging API
+      --pprof-address string                                    Address that pprof listens on (default "localhost")
+      --pprof-port int                                          Port that pprof listens on (default 6060)
       --preallocate-bpf-maps                                    Enable BPF map pre-allocation (default true)
       --prepend-iptables-chains                                 Prepend custom iptables chains instead of appending (default true)
       --procfs string                                           Root's proc filesystem path (default "/proc")

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -66,11 +66,11 @@ cilium-operator-alibabacloud [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-pprof                            Enable pprof debugging endpoint
+      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --pprof                                     Enable pprof debugging endpoint
-      --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -74,11 +74,11 @@ cilium-operator-aws [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-pprof                            Enable pprof debugging endpoint
+      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --pprof                                     Enable pprof debugging endpoint
-      --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -69,11 +69,11 @@ cilium-operator-azure [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-pprof                            Enable pprof debugging endpoint
+      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --pprof                                     Enable pprof debugging endpoint
-      --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -65,11 +65,11 @@ cilium-operator-generic [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-pprof                            Enable pprof debugging endpoint
+      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --pprof                                     Enable pprof debugging endpoint
-      --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -79,11 +79,11 @@ cilium-operator [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-pprof                            Enable pprof debugging endpoint
+      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --pprof                                     Enable pprof debugging endpoint
-      --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -925,6 +925,18 @@
      - Labels to be added to hubble-relay pods
      - object
      - ``{}``
+   * - hubble.relay.pprof.address
+     - Configure pprof listen address for hubble-relay
+     - string
+     - ``"localhost"``
+   * - hubble.relay.pprof.enabled
+     - Enable pprof for hubble-relay
+     - bool
+     - ``false``
+   * - hubble.relay.pprof.port
+     - Configure pprof listen port for hubble-relay
+     - int
+     - ``6062``
    * - hubble.relay.priorityClassName
      - The priority class to use for hubble-relay
      - string
@@ -1609,6 +1621,18 @@
      - Labels to be added to cilium-operator pods
      - object
      - ``{}``
+   * - operator.pprof.address
+     - Configure pprof listen address for cilium-operator
+     - string
+     - ``"localhost"``
+   * - operator.pprof.enabled
+     - Enable pprof for cilium-operator
+     - bool
+     - ``false``
+   * - operator.pprof.port
+     - Configure pprof listen port for cilium-operator
+     - int
+     - ``6061``
    * - operator.priorityClassName
      - The priority class to use for cilium-operator
      - string
@@ -1709,10 +1733,18 @@
      - The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes
      - string
      - ``"default"``
+   * - pprof.address
+     - Configure pprof listen address for cilium-agent
+     - string
+     - ``"localhost"``
    * - pprof.enabled
-     - Enable Go pprof debugging
+     - Enable pprof for cilium-agent
      - bool
      - ``false``
+   * - pprof.port
+     - Configure pprof listen port for cilium-agent
+     - int
+     - ``6060``
    * - preflight.affinity
      - Affinity for cilium-preflight
      - object

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -347,7 +347,8 @@ Removed Options
   :ref:`kubeproxy-free` for more info.
 * The ``CiliumEgressNATPolicy`` CRD deprecated in version 1.12 has been removed. It is superseded
   by the ``CiliumEgressGatewayPolicy`` CRD.
-
+* The ``pprof``, ``pprof-port`` flags for cilium-operator have been renamed
+  to ``operator-pprof`` and ``operator-pprof-port`` respectively.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~
@@ -387,13 +388,17 @@ Removed Metrics/Labels
 Helm Options
 ~~~~~~~~~~~~
 
-* The way Linux capabilities are configured has been revamped in this release. 
+* The way Linux capabilities are configured has been revamped in this release.
   All capabilities of every container in the ``cilium-agent`` DaemonSet is
   configured from Helm's values, defaulting to the old behavior. If you have not
   been using ``securityContext.extraCapabilities`` you do not need to do anything.
   If you were leveraging ``securityContext.extraCapabilities``, you need to review
   ``securityContext.capabilities.cilium_agent``.
-* ``bpf.hostLegacyRouting`` will be set to true automatically if ``cni.chainingMode`` is set to any other value than ``none`` (default) 
+* ``bpf.hostLegacyRouting`` will be set to true automatically if ``cni.chainingMode`` is set to any other value than ``none`` (default)
+* The top-level ``pprof`` section now only configures pprof for cilium agent.
+  The cilium-operator pprof configuration is now managed via the ``operator.pprof`` section.
+  Additionally, a``hubble.relay.pprof`` section has been added.
+* All pprof configuration now support configuring the pprof listen address, defaulting to localhost.
 
 CRD Changes
 ~~~~~~~~~~~

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -243,7 +243,10 @@ func runApiserver() error {
 	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
 	option.BindEnv(vp, option.PProf)
 
-	flags.Int(option.PProfPort, defaults.PprofPortAPIServer, "Port that the pprof listens on")
+	flags.String(option.PProfAddress, defaults.PprofAddressAPIServer, "Address that pprof listens on")
+	option.BindEnv(vp, option.PProfAddress)
+
+	flags.Int(option.PProfPort, defaults.PprofPortAPIServer, "Port that pprof listens on")
 	option.BindEnv(vp, option.PProfPort)
 
 	vp.BindPFlags(flags)
@@ -620,7 +623,7 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, servi
 	}()
 
 	if option.Config.PProf {
-		pprof.Enable(option.Config.PProfPort)
+		pprof.Enable(option.Config.PProfAddress, option.Config.PProfPort)
 	}
 
 	log.Info("Initialization complete")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -750,10 +750,13 @@ func initializeFlags() {
 	flags.Bool(option.Version, false, "Print version information")
 	option.BindEnv(Vp, option.Version)
 
-	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
+	flags.Bool(option.PProf, false, "Enable serving pprof debugging API")
 	option.BindEnv(Vp, option.PProf)
 
-	flags.Int(option.PProfPort, defaults.PprofPortAgent, "Port that the pprof listens on")
+	flags.String(option.PProfAddress, defaults.PprofAddressAgent, "Address that pprof listens on")
+	option.BindEnv(Vp, option.PProfAddress)
+
+	flags.Int(option.PProfPort, defaults.PprofPortAgent, "Port that pprof listens on")
 	option.BindEnv(Vp, option.PProfPort)
 
 	flags.Bool(option.EnableXDPPrefilter, false, "Enable XDP prefiltering")
@@ -1201,7 +1204,7 @@ func initEnv() {
 	}
 
 	if option.Config.PProf {
-		pprof.Enable(option.Config.PProfPort)
+		pprof.Enable(option.Config.PProfAddress, option.Config.PProfPort)
 	}
 
 	if option.Config.PreAllocateMaps {

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -25,6 +25,7 @@ import (
 const (
 	keyClusterName            = "cluster-name"
 	keyPprof                  = "pprof"
+	keyPprofAddress           = "pprof-address"
 	keyPprofPort              = "pprof-port"
 	keyGops                   = "gops"
 	keyGopsPort               = "gops-port"
@@ -62,8 +63,11 @@ func New(vp *viper.Viper) *cobra.Command {
 	flags.Bool(
 		keyPprof, false, "Enable serving the pprof debugging API",
 	)
+	flags.String(
+		keyPprofAddress, defaults.PprofAddress, "Address that pprof listens on",
+	)
 	flags.Int(
-		keyPprofPort, defaults.PprofPort, "Port that the pprof listens on",
+		keyPprofPort, defaults.PprofPort, "Port that pprof listens on",
 	)
 	flags.Bool(
 		keyGops, true, "Run gops agent",
@@ -204,7 +208,7 @@ func runServe(vp *viper.Viper) error {
 	}
 
 	if vp.GetBool(keyPprof) {
-		pprof.Enable(vp.GetInt(keyPprofPort))
+		pprof.Enable(vp.GetString(keyPprofAddress), vp.GetInt(keyPprofPort))
 	}
 	gopsEnabled := vp.GetBool(keyGops)
 	if gopsEnabled {

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -282,6 +282,9 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | hubble.relay.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | hubble.relay.podLabels | object | `{}` | Labels to be added to hubble-relay pods |
+| hubble.relay.pprof.address | string | `"localhost"` | Configure pprof listen address for hubble-relay |
+| hubble.relay.pprof.enabled | bool | `false` | Enable pprof for hubble-relay |
+| hubble.relay.pprof.port | int | `6062` | Configure pprof listen port for hubble-relay |
 | hubble.relay.priorityClassName | string | `""` | The priority class to use for hubble-relay |
 | hubble.relay.prometheus | object | `{"enabled":false,"port":9966,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for hubble-relay on the configured port at /metrics |
 | hubble.relay.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble-relay |
@@ -453,6 +456,9 @@ contributors across the globe, there is almost always someone available to help.
 | operator.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | operator.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | operator.podLabels | object | `{}` | Labels to be added to cilium-operator pods |
+| operator.pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-operator |
+| operator.pprof.enabled | bool | `false` | Enable pprof for cilium-operator |
+| operator.pprof.port | int | `6061` | Configure pprof listen port for cilium-operator |
 | operator.priorityClassName | string | `""` | The priority class to use for cilium-operator |
 | operator.prometheus | object | `{"enabled":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
 | operator.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-operator |
@@ -478,7 +484,9 @@ contributors across the globe, there is almost always someone available to help.
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes |
-| pprof.enabled | bool | `false` | Enable Go pprof debugging |
+| pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-agent |
+| pprof.enabled | bool | `false` | Enable pprof for cilium-agent |
+| pprof.port | int | `6060` | Configure pprof listen port for cilium-agent |
 | preflight.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-preflight |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
 | preflight.extraEnv | list | `[]` | Additional preflight environment variables. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -668,9 +668,18 @@ data:
   arping-refresh-period: {{ include "validateDuration" .Values.l2NeighDiscovery.refreshPeriod | quote }}
 {{- end }}
 
-{{- if and .Values.pprof .Values.pprof.enabled }}
+{{- if .Values.pprof.enabled }}
   pprof: {{ .Values.pprof.enabled | quote }}
+  pprof-address: {{ .Values.pprof.address | quote }}
+  pprof-port: {{ .Values.pprof.port | quote }}
 {{- end }}
+
+{{- if .Values.operator.pprof.enabled }}
+  operator-pprof: {{ .Values.operator.pprof.enabled | quote }}
+  operator-pprof-address: {{ .Values.operator.pprof.address | quote }}
+  operator-pprof-port: {{ .Values.operator.pprof.port | quote }}
+{{- end }}
+
 {{- if .Values.logSystemLoad }}
   log-system-load: {{ .Values.logSystemLoad | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -18,6 +18,11 @@ data:
     peer-service: unix://{{ .Values.hubble.socketPath }}
     {{- end }}
     listen-address: {{ .Values.hubble.relay.listenHost }}:{{ .Values.hubble.relay.listenPort }}
+    {{- if .Values.hubble.relay.pprof.enabled }}
+    pprof: {{ .Values.hubble.relay.pprof.enabled | quote }}
+    pprof-address: {{ .Values.hubble.relay.pprof.address | quote }}
+    pprof-port: {{ .Values.hubble.relay.pprof.port | quote }}
+    {{- end }}
     {{- if .Values.hubble.relay.prometheus.enabled }}
     metrics-listen-address: ":{{ .Values.hubble.relay.prometheus.port }}"
     {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1116,6 +1116,14 @@ hubble:
         # -- Metrics relabeling configs for the ServiceMonitor hubble-relay
         metricRelabelings: ~
 
+    pprof:
+      # -- Enable pprof for hubble-relay
+      enabled: false
+      # -- Configure pprof listen address for hubble-relay
+      address: localhost
+      # -- Configure pprof listen port for hubble-relay
+      port: 6062
+
   ui:
     # -- Whether to enable the Hubble UI.
     enabled: false
@@ -1558,8 +1566,12 @@ nodePort:
 policyEnforcementMode: "default"
 
 pprof:
-  # -- Enable Go pprof debugging
+  # -- Enable pprof for cilium-agent
   enabled: false
+  # -- Configure pprof listen address for cilium-agent
+  address: localhost
+  # -- Configure pprof listen port for cilium-agent
+  port: 6060
 
 # -- Configure prometheus metrics on the configured port at /metrics
 prometheus:
@@ -1911,6 +1923,14 @@ operator:
 
   # -- Timeout for identity heartbeats.
   identityHeartbeatTimeout: "30m0s"
+
+  pprof:
+    # -- Enable pprof for cilium-operator
+    enabled: false
+    # -- Configure pprof listen address for cilium-operator
+    address: localhost
+    # -- Configure pprof listen port for cilium-operator
+    port: 6061
 
   # -- Enable prometheus metrics for cilium-operator on the configured port at
   # /metrics

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1113,6 +1113,14 @@ hubble:
         # -- Metrics relabeling configs for the ServiceMonitor hubble-relay
         metricRelabelings: ~
 
+    pprof:
+      # -- Enable pprof for hubble-relay
+      enabled: false
+      # -- Configure pprof listen address for hubble-relay
+      address: localhost
+      # -- Configure pprof listen port for hubble-relay
+      port: 6062
+
   ui:
     # -- Whether to enable the Hubble UI.
     enabled: false
@@ -1555,8 +1563,12 @@ nodePort:
 policyEnforcementMode: "default"
 
 pprof:
-  # -- Enable Go pprof debugging
+  # -- Enable pprof for cilium-agent
   enabled: false
+  # -- Configure pprof listen address for cilium-agent
+  address: localhost
+  # -- Configure pprof listen port for cilium-agent
+  port: 6060
 
 # -- Configure prometheus metrics on the configured port at /metrics
 prometheus:
@@ -1908,6 +1920,14 @@ operator:
 
   # -- Timeout for identity heartbeats.
   identityHeartbeatTimeout: "30m0s"
+
+  pprof:
+    # -- Enable pprof for cilium-operator
+    enabled: false
+    # -- Configure pprof listen address for cilium-operator
+    address: localhost
+    # -- Configure pprof listen port for cilium-operator
+    port: 6061
 
   # -- Enable prometheus metrics for cilium-operator on the configured port at
   # /metrics

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -262,7 +262,7 @@ func runOperator(lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner 
 	}
 
 	if operatorOption.Config.PProf {
-		pprof.Enable(operatorOption.Config.PProfPort)
+		pprof.Enable(operatorOption.Config.PProfAddress, operatorOption.Config.PProfPort)
 	}
 
 	if clientset.IsEnabled() {

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -109,10 +109,13 @@ const (
 	OperatorPrometheusServeAddr = "operator-prometheus-serve-addr"
 
 	// PProf enabled pprof debugging endpoint
-	PProf = "pprof"
+	PProf = "operator-pprof"
+
+	// PProfAddress is the port that the pprof listens on
+	PProfAddress = "operator-pprof-address"
 
 	// PProfPort is the port that the pprof listens on
-	PProfPort = "pprof-port"
+	PProfPort = "operator-pprof-port"
 
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices = "synchronize-k8s-services"
@@ -379,6 +382,9 @@ type OperatorConfig struct {
 	// PProf enables pprof debugging endpoint
 	PProf bool
 
+	// PProfAddress is the address that the pprof listens on
+	PProfAddress string
+
 	// PProfPort is the port that the pprof listens on
 	PProfPort int
 
@@ -614,6 +620,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.OperatorAPIServeAddr = vp.GetString(OperatorAPIServeAddr)
 	c.OperatorPrometheusServeAddr = vp.GetString(OperatorPrometheusServeAddr)
 	c.PProf = vp.GetBool(PProf)
+	c.PProfAddress = vp.GetString(PProfAddress)
 	c.PProfPort = vp.GetInt(PProfPort)
 	c.SyncK8sServices = vp.GetBool(SyncK8sServices)
 	c.SyncK8sNodes = vp.GetBool(SyncK8sNodes)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -17,6 +17,12 @@ const (
 	// ClusterMeshHealthPort is the default value for option.ClusterMeshHealthPort
 	ClusterMeshHealthPort = 80
 
+	// PprofAddressAgent is the default value for pprof in the agent
+	PprofAddressAgent = "localhost"
+
+	// PprofAddressAPIServer is the default value for pprof in the clustermesh-apiserver
+	PprofAddressAPIServer = "localhost"
+
 	// PprofPortAgent is the default value for pprof in the agent
 	PprofPortAgent = 6060
 

--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -19,6 +19,8 @@ const (
 	DialTimeout = 5 * time.Second
 	// GopsPort is the default port for gops to listen on.
 	GopsPort = 9893
+	// PprofAddress is the default port for pprof to listen on.
+	PprofAddress = "localhost"
 	// PprofPort is the default port for pprof to listen on.
 	PprofPort = 6062
 	// RetryTimeout is the duration to wait between reconnection attempts.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -425,6 +425,9 @@ const (
 	// PProf enables serving the pprof debugging API
 	PProf = "pprof"
 
+	// PProfAddress is the port that the pprof listens on
+	PProfAddress = "pprof-address"
+
 	// PProfPort is the port that the pprof listens on
 	PProfPort = "pprof-port"
 
@@ -1669,6 +1672,7 @@ type DaemonConfig struct {
 	TracePayloadlen            int
 	Version                    string
 	PProf                      bool
+	PProfAddress               string
 	PProfPort                  int
 	PrometheusServeAddr        string
 	ToFQDNsMinTTL              int
@@ -2955,6 +2959,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.MonitorQueueSize = vp.GetInt(MonitorQueueSizeName)
 	c.MTU = vp.GetInt(MTUName)
 	c.PProf = vp.GetBool(PProf)
+	c.PProfAddress = vp.GetString(PProfAddress)
 	c.PProfPort = vp.GetInt(PProfPort)
 	c.PreAllocateMaps = vp.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = vp.GetBool(PrependIptablesChainsName)

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -17,8 +17,8 @@ import (
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "pprof")
 
 // Enable runs an HTTP server to serve the pprof API
-func Enable(port int) {
-	var apiAddress = net.JoinHostPort("localhost", strconv.Itoa(port))
+func Enable(host string, port int) {
+	var apiAddress = net.JoinHostPort(host, strconv.Itoa(port))
 	go func() {
 		if err := http.ListenAndServe(apiAddress, nil); err != nil {
 			log.WithError(err).Warn("Unable to serve pprof API")


### PR DESCRIPTION
Cilium's profiles cannot be gathered by other tools running outside the cilium pod if it's only listening on localhost. To enable continuous profiling with tools like Parca or Phlare which operate on a scrape model, we should make the pprof listen address configurable.

```release-note
Make cilium pprof listen address configurable
```
