### PR TITLE
test: service: fix formatting of error msg in doFragmentedRequest()

### DIFF
--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -375,7 +375,7 @@ func doFragmentedRequest(kubectl *helpers.Kubectl, srcPod string, srcPort, dstPo
 	ExpectWithOffset(2, []int{fragmentedPacketsAfterK8s1, fragmentedPacketsAfterK8s2}).To(SatisfyAny(
 		Equal([]int{fragmentedPacketsBeforeK8s1, fragmentedPacketsBeforeK8s2 + delta}),
 		Equal([]int{fragmentedPacketsBeforeK8s1 + delta, fragmentedPacketsBeforeK8s2}),
-	), "Failed to account for INGRESS IPv4 fragments in BPF metrics", dstIP)
+	), "Failed to account for INGRESS IPv4 fragments to %s in BPF metrics", dstIP)
 }
 
 func testNodePort(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, bpfNodePort, testFromOutside bool, fails int) {


### PR DESCRIPTION
Fix up the string formatting to include the `dstIP` parameter.

Spotted in a Jenkins run:

/home/jenkins/workspace/Cilium-PR-K8s-1.26-kernel-net-next/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:515 Failed to account for INGRESS IPv4 fragments in BPF metrics%!(EXTRA string=10.100.188.224)

Fixes: 938b4940f92b ("bpf: add metrics for fragmented IPv4 packets")
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>