### PR TITLE
Load multiple programs at once per object file

### DIFF
--- a/cilium/cmd/bpf_migrate_maps.go
+++ b/cilium/cmd/bpf_migrate_maps.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/cilium/ebpf"
 	"os"
 	"path/filepath"
 
@@ -59,13 +60,21 @@ original locations. If the return code is 0, the :pending maps will be unpinned.
 			}
 
 			if start != "" {
-				if err := bpf.StartBPFFSMigration(bpffsPath, start); err != nil {
+				coll, err := ebpf.LoadCollectionSpec(start)
+				if err != nil {
+					return fmt.Errorf("loading eBPF ELF: %w", err)
+				}
+				if err := bpf.StartBPFFSMigration(coll, bpffsPath); err != nil {
 					return fmt.Errorf("error starting map migration for %q: %v", start, err)
 				}
 			}
 
 			if end != "" {
-				if err := bpf.FinalizeBPFFSMigration(bpffsPath, end, rc != 0); err != nil {
+				coll, err := ebpf.LoadCollectionSpec(end)
+				if err != nil {
+					return fmt.Errorf("loading eBPF ELF: %w", err)
+				}
+				if err := bpf.FinalizeBPFFSMigration(coll, bpffsPath, rc != 0); err != nil {
 					return fmt.Errorf("error finalizing map migration for %q: %v", end, err)
 				}
 			}

--- a/pkg/bpf/bpffs_migrate.go
+++ b/pkg/bpf/bpffs_migrate.go
@@ -24,12 +24,7 @@ const bpffsPending = ":pending"
 // Takes a bpffsPath explicitly since it does not necessarily execute within
 // the same runtime as the agent. It is imported from a Cilium cmd that takes
 // its bpffs path from an env.
-func StartBPFFSMigration(bpffsPath, elfPath string) error {
-	coll, err := ebpf.LoadCollectionSpec(elfPath)
-	if err != nil {
-		return err
-	}
-
+func StartBPFFSMigration(coll *ebpf.CollectionSpec, bpffsPath string) error {
 	for name, spec := range coll.Maps {
 		// Parse iproute2 bpf_elf_map's extra fields, if any.
 		if err := parseExtra(spec, coll); err != nil {
@@ -59,12 +54,7 @@ func StartBPFFSMigration(bpffsPath, elfPath string) error {
 // Takes a bpffsPath explicitly since it does not necessarily execute within
 // the same runtime as the agent. It is imported from a Cilium cmd that takes
 // its bpffs path from an env.
-func FinalizeBPFFSMigration(bpffsPath, elfPath string, revert bool) error {
-	coll, err := ebpf.LoadCollectionSpec(elfPath)
-	if err != nil {
-		return err
-	}
-
+func FinalizeBPFFSMigration(coll *ebpf.CollectionSpec, bpffsPath string, revert bool) error {
 	for name, spec := range coll.Maps {
 		// Parse iproute2 bpf_elf_map's extra fields, if any.
 		if err := parseExtra(spec, coll); err != nil {

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -197,11 +197,15 @@ func (s *LoaderTestSuite) TestReload(c *C) {
 	c.Assert(err, IsNil)
 
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
-	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+	progs := []progDefinition{
+		{progSec: symbolFromEndpoint, progDirection: dirIngress},
+		{progSec: symbolToEndpoint, progDirection: dirEgress},
+	}
+	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, false, "")
 	c.Assert(err, IsNil)
 	finalize()
 
-	finalize, err = replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+	finalize, err = replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, false, "")
 	c.Assert(err, IsNil)
 	finalize()
 }
@@ -283,9 +287,10 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 	}
 
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
+	progs := []progDefinition{{progSec: symbolFromEndpoint, progDirection: dirIngress}}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress, false, "")
+		finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, false, "")
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -118,7 +118,8 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev, xdpMode string, extraCAr
 	}
 
 	objPath := path.Join(dirs.Output, prog.Output)
-	finalize, err := replaceDatapath(ctx, xdpDev, objPath, symbolFromHostNetdevEp, "", true, xdpMode)
+	progs := []progDefinition{{progSec: symbolFromHostNetdevEp, progDirection: ""}}
+	finalize, err := replaceDatapath(ctx, xdpDev, objPath, progs, true, xdpMode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a continuation of the effort towards reducing Pod Startup Latency for Kubernetes (#22023).

This change is basically a backport of #22025, it introduces the ability to load multiple programs, and loading and verifying CollectionSpec just once per objPath. After the change the pod startup latency was reduced by ~300ms.

Signed-off-by: Alex Katsman <alexkats@google.com>