### PR TITLE
Fix k8s podCIDRs for vagrant deployment

### DIFF
--- a/contrib/vagrant/scripts/helpers.bash
+++ b/contrib/vagrant/scripts/helpers.bash
@@ -56,10 +56,10 @@ kubernetes_master="${controllers_ips[0]}"
 # Default values for IPv4 and IPv6
 #
 # CIDR Range for Pods in cluster.
-k8s_cluster_cidr=${K8S_CLUSTER_CIDR:-"10.16.0.0/12,FD02::/96"} # 10.16.0.1-10.31.255.255
+k8s_cluster_cidr=${K8S_CLUSTER_CIDR:-"10.11.0.0/20,FD04::/96"} # 10.11.0.1-10.11.15.255
 # Mask size for node cidr in cluster.
-k8s_node_cidr_v4_mask_size=${K8S_NODE_CIDR_MASK_SIZE:-"16"} # 1st Node: 10.16.0.1-10.16.255.254, 2nd Node: 10.17.0.1-10.17.255.254...
-k8s_node_cidr_v6_mask_size=${K8S_NODE_CIDR_V6_MASK_SIZE:-"112"} # 1st Node: 10.16.0.1-10.16.255.254, 2nd Node: 10.17.0.1-10.17.255.254...
+k8s_node_cidr_v4_mask_size=${K8S_NODE_CIDR_MASK_SIZE:-"24"} # 1st Node: 10.11.0.1-10.11.0.255, 2nd Node: 10.11.1.1-10.11.1.255..
+k8s_node_cidr_v6_mask_size=${K8S_NODE_CIDR_V6_MASK_SIZE:-"112"} # 1st Node: 10.11.0.1-10.11.0.255, 2nd Node: 10.11.1.1-10.11.1.255...
 # CIDR Range for Services in cluster.
 k8s_service_cluster_ip_range=${K8S_SERVICE_CLUSTER_IP_RANGE:-"172.20.0.0/24,FD03::/112"}
 cluster_dns_ip=${K8S_CLUSTER_DNS_IP:-"172.20.0.10"}

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -202,9 +202,9 @@ function write_k8s_install() {
     k8s_dir="${1}"
     filename="${2}"
     filename_2nd_half="${3}"
-    k8s_cluster_cidr=${k8s_cluster_cidr:-"10.16.0.0/12,FD02::/80"}
-    k8s_node_cidr_mask_size=${k8s_node_cidr_mask_size:-"16"}
-    k8s_node_cidr_v6_mask_size=${k8s_node_cidr_v6_mask_size:-"96"}
+    k8s_cluster_cidr=${k8s_cluster_cidr:-"10.11.0.0/20,FD04::/96"}
+    k8s_node_cidr_mask_size=${k8s_node_cidr_mask_size:-"24"}
+    k8s_node_cidr_v6_mask_size=${k8s_node_cidr_v6_mask_size:-"112"}
     k8s_service_cluster_ip_range=${k8s_service_cluster_ip_range:-"172.20.0.0/24,FD03::/112"}
     k8s_cluster_api_server_ip=${k8s_cluster_api_server_ip:-"172.20.0.1"}
     k8s_cluster_api_server_ipv6=${k8s_cluster_api_server_ipv6:-"FD03::1"}
@@ -329,8 +329,8 @@ function write_cilium_cfg() {
         cilium_options_with_kvstore="${cilium_options} ${cilium_kvstore_options}"
         cilium_options+=" --identity-allocation-mode=crd --enable-k8s-event-handover=false"
         cilium_operator_options+=" --k8s-kubeconfig-path /var/lib/cilium/cilium.kubeconfig"
-        cilium_operator_options+=" --cluster-pool-ipv4-cidr=10.${master_ipv4_suffix}.0.0/16"
-        cilium_operator_options+=" --cluster-pool-ipv6-cidr=fd04::/104"
+        cilium_operator_options+=" --cluster-pool-ipv4-cidr=10.${master_ipv4_suffix}.0.0/20"
+        cilium_operator_options+=" --cluster-pool-ipv6-cidr=fd04::/96"
         cilium_operator_options_with_kvstore="${cilium_operator_options} ${cilium_kvstore_options}"
         cilium_operator_options+=" --identity-allocation-mode=crd"
     else


### PR DESCRIPTION
This patch makes podCIDRs of k8s Node and CiliumNode consistent: vagrant@k8s1:~/go/src/github.com/cilium/cilium$ kubectl get nodes k8s1 -o yaml apiVersion: v1
kind: Node
metadata:
...
spec:
  podCIDR: 10.11.0.0/24
  podCIDRs:
  - 10.11.0.0/24
  - fd04::/112 ...

vagrant@k8s1:~/go/src/github.com/cilium/cilium$ kubectl get ciliumnodes.cilium.io -o yaml apiVersion: v1
items:
- apiVersion: cilium.io/v2 kind: CiliumNode ... spec: ... ipam: podCIDRs: - 10.11.0.0/24 - fd04::/112 ...

Fixes: #19594

Signed-off-by: Roman Ptitcyn <romanspb@yahoo.com>
