### PR TITLE
workflows: Install Go 1.19.4 for CodeQL lint

### DIFF
--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -40,6 +40,10 @@ jobs:
     permissions:
       security-events: write
     steps:
+    - name: Install Go
+      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+      with:
+        go-version: 1.19.4
     - name: Checkout repo
       uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       with:


### PR DESCRIPTION
CodeQL has started failing with:

```
  Installed Go version 1.18 does not match requested Go version 1.19
```

Manually install newer Go 1.19.4 before running CodeQL.
