### PR TITLE
bpf: nodeport: wire up trace aggregation for rev_nodeport_lb6()

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1061,8 +1061,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __u32 *ifind
 							   SECLABEL, info->sec_label,
 							   NOT_VTEP_DST,
 							   TRACE_REASON_CT_REPLY,
-							   TRACE_PAYLOAD_LEN,
-							   ifindex);
+							   monitor, ifindex);
 			}
 		}
 #endif


### PR DESCRIPTION
Pass the `monitor` feedback from the CT lookup to __encap_with_nodeid(). A previous commit already added this for rev_nodeport_lb4(), so aim for commonality here.

Fixes: 428abc92abe8 ("bpf: pipe forwarding reason into traces for TO_OVERLAY")
Signed-off-by: Julian Wiedmann <jwi@isovalent.com>