### PR TITLE
ci: Replace deprecated `hubble observe -o json` with `-o jsonpb`

### DIFF
--- a/test/helpers/hubble.go
+++ b/test/helpers/hubble.go
@@ -14,7 +14,7 @@ const (
 	hubbleSock = "unix:///var/run/cilium/hubble.sock"
 )
 
-// HubbleObserve runs `hubble observe --output=json <args>`. JSON output is
+// HubbleObserve runs `hubble observe --output=jsonpb <args>`. JSON output is
 // enabled such that CmdRes.FilterLines may be used to grep for specific events
 // in the output.
 func (s *SSHMeta) HubbleObserve(args ...string) *CmdRes {
@@ -22,12 +22,12 @@ func (s *SSHMeta) HubbleObserve(args ...string) *CmdRes {
 	if len(args) > 0 {
 		argsCoalesced = strings.Join(args, " ")
 	}
-	hubbleCmd := fmt.Sprintf("hubble observe --server=%q --output=json %s",
+	hubbleCmd := fmt.Sprintf("hubble observe --server=%q --output=jsonpb %s",
 		hubbleSock, argsCoalesced)
 	return s.Exec(hubbleCmd)
 }
 
-// HubbleObserveFollow runs `hubble observe --follow --output=json <args>`. The
+// HubbleObserveFollow runs `hubble observe --follow --output=jsonpb <args>`. The
 // command is running in the background and will be terminated only once ctx
 // is cancelled. JSON output is enabled such that
 // CmdRes.WaitUntilMatchFilterLine may be used to wait for specific events in
@@ -37,7 +37,7 @@ func (s *SSHMeta) HubbleObserveFollow(ctx context.Context, args ...string) *CmdR
 	if len(args) > 0 {
 		argsCoalesced = strings.Join(args, " ")
 	}
-	hubbleCmd := fmt.Sprintf("hubble observe --server=%q --follow --output=json %s",
+	hubbleCmd := fmt.Sprintf("hubble observe --server=%q --follow --output=jsonpb %s",
 		hubbleSock, argsCoalesced)
 	return s.ExecInBackground(ctx, hubbleCmd)
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4314,18 +4314,18 @@ func (kub *Kubectl) HelmTemplate(chartDir, namespace, filename string, options m
 		fmt.Sprintf("--namespace=%s %s > %s", namespace, optionsString, filename))
 }
 
-// HubbleObserve runs `hubble observe --output=json <args>` on 'ns/pod' and
+// HubbleObserve runs `hubble observe --output=jsonpb <args>` on 'ns/pod' and
 // waits for its completion.
 func (kub *Kubectl) HubbleObserve(pod string, args string) *CmdRes {
 	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
 	defer cancel()
-	return kub.ExecPodCmdContext(ctx, CiliumNamespace, pod, fmt.Sprintf("hubble observe --output=json %s", args))
+	return kub.ExecPodCmdContext(ctx, CiliumNamespace, pod, fmt.Sprintf("hubble observe --output=jsonpb %s", args))
 }
 
-// HubbleObserveFollow runs `hubble observe --follow --output=json <args>` on
+// HubbleObserveFollow runs `hubble observe --follow --output=jsonpb <args>` on
 // the Cilium pod 'ns/pod' in the background. The process is stopped when ctx is cancelled.
 func (kub *Kubectl) HubbleObserveFollow(ctx context.Context, pod string, args string) *CmdRes {
-	return kub.ExecPodCmdBackground(ctx, CiliumNamespace, pod, "cilium-agent", fmt.Sprintf("hubble observe --follow --output=json %s", args))
+	return kub.ExecPodCmdBackground(ctx, CiliumNamespace, pod, "cilium-agent", fmt.Sprintf("hubble observe --follow --output=jsonpb %s", args))
 }
 
 // WaitForIPCacheEntry waits until the given ipAddr appears in "cilium bpf ipcache list"

--- a/test/k8s/bgp.go
+++ b/test/k8s/bgp.go
@@ -115,7 +115,7 @@ var _ = SkipDescribeIf(
 					context.TODO(),
 					ciliumPodK8s1,
 					fmt.Sprintf(
-						"hubble observe debug-events --since %v -o json",
+						"hubble observe debug-events --since %v -o jsonpb",
 						testStartTime.Format(time.RFC3339),
 					),
 				)
@@ -127,7 +127,7 @@ var _ = SkipDescribeIf(
 					context.TODO(),
 					ciliumPodK8s2,
 					fmt.Sprintf(
-						"hubble observe debug-events --since %v -o json",
+						"hubble observe debug-events --since %v -o jsonpb",
 						testStartTime.Format(time.RFC3339),
 					),
 				)

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -287,7 +287,7 @@ var _ = SkipDescribeIf(func() bool {
 				switch parser {
 				case policy.ParserTypeDNS:
 					// response DNS L7 flow
-					filter = "{.destination.namespace} {.l7.type} {.l7.dns.query}"
+					filter = "{.flow.destination.namespace} {.flow.l7.type} {.flow.l7.dns.query}"
 					expect = fmt.Sprintf(
 						"%s RESPONSE %s",
 						namespaceForTest,
@@ -299,7 +299,7 @@ var _ = SkipDescribeIf(func() bool {
 						curlCmd = helpers.CurlFail(resource)
 					}
 				case policy.ParserTypeHTTP:
-					filter = "{.destination.namespace} {.l7.type} {.l7.http.url} {.l7.http.code} {.l7.http.method}"
+					filter = "{.flow.destination.namespace} {.flow.l7.type} {.flow.l7.http.url} {.flow.l7.http.code} {.flow.l7.http.method}"
 					expect = fmt.Sprintf(
 						"%s RESPONSE %s 200 GET",
 						namespaceForTest,
@@ -357,7 +357,7 @@ var _ = SkipDescribeIf(func() bool {
 					res := kubectl.HubbleObserve(ciliumPod,
 						fmt.Sprintf("--last 1 --from-pod %s/%s --to-fqdn %q",
 							namespaceForTest, appPods[helpers.App2], "*.cilium.io"))
-					res.ExpectContainsFilterLine("{.destination_names[0]}", "vagrant-cache.ci.cilium.io")
+					res.ExpectContainsFilterLine("{.flow.destination_names[0]}", "vagrant-cache.ci.cilium.io")
 				}
 			}
 

--- a/test/runtime/net_policies.go
+++ b/test/runtime/net_policies.go
@@ -570,11 +570,11 @@ var _ = Describe("RuntimeAgentPolicies", func() {
 
 			By("Testing hubble observe output")
 			err := hubbleRes.WaitUntilMatchFilterLine(
-				`{.source.labels} -> {.destination.ID} {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
+				`{.flow.source.labels} -> {.flow.destination.ID} {.flow.destination.labels} {.flow.IP.destination} : {.flow.verdict} {.flow.event_type.type}`,
 				fmt.Sprintf(`["reserved:host"] -> %s ["container:somelabel"] %s : DROPPED 1`, endpointID, endpointIP.IPV4))
 			Expect(err).To(BeNil(), "Default drop on ingress failed")
 			hubbleRes.ExpectDoesNotContainFilterLine(
-				`{.source.labels} -> {.destination.ID} {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
+				`{.flow.source.labels} -> {.flow.destination.ID} {.flow.destination.labels} {.flow.IP.destination} : {.flow.verdict} {.flow.event_type.type}`,
 				fmt.Sprintf(`["reserved:host"] -> %s ["container:somelabel"] %s : FORWARDED 4`, endpointID, endpointIP.IPV4),
 				"Unexpected ingress traffic to endpoint")
 		})
@@ -592,12 +592,12 @@ var _ = Describe("RuntimeAgentPolicies", func() {
 
 			By("Testing hubble observe output")
 			err := hubbleRes.WaitUntilMatchFilterLine(
-				`{.source.ID} {.source.labels} -> {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
+				`{.flow.source.ID} {.flow.source.labels} -> {.flow.destination.labels} {.flow.IP.destination} : {.flow.verdict} {.flow.event_type.type}`,
 				fmt.Sprintf(`%s ["container:somelabel"] -> ["reserved:host"] %s : DROPPED 1`, endpointID, hostIP))
 			Expect(err).To(BeNil(), "Default drop on egress failed")
 
 			hubbleRes.ExpectDoesNotContainFilterLine(
-				`{.source.labels} {.IP.source} -> {.destination.ID} : {.verdict} {.reply} {.event_type.type}`,
+				`{.flow.source.labels} {.flow.IP.source} -> {.flow.destination.ID} : {.flow.verdict} {.flow.reply} {.flow.event_type.type}`,
 				fmt.Sprintf(`["reserved:host"] %s -> %s : FORWARDED true 4`, hostIP, endpointID),
 				"Unexpected reply traffic to endpoint")
 		})
@@ -634,12 +634,12 @@ var _ = Describe("RuntimeAgentPolicies", func() {
 				By("Testing hubble observe output")
 				// Checks for a ingress policy verdict event (type 5)
 				err := hubbleRes.WaitUntilMatchFilterLine(
-					`{.source.labels} -> {.IP.destination} : {.verdict} {.event_type.type}`,
+					`{.flow.source.labels} -> {.flow.IP.destination} : {.flow.verdict} {.flow.event_type.type}`,
 					fmt.Sprintf(`["reserved:host"] -> %s : AUDIT 5`, endpointIP.IPV4))
 				Expect(err).To(BeNil(), "Default policy verdict on ingress failed")
 				// Checks for the subsequent trace:to-endpoint event (type 4)
 				hubbleRes.ExpectContainsFilterLine(
-					`{.source.labels} -> {.destination.ID} {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
+					`{.flow.source.labels} -> {.flow.destination.ID} {.flow.destination.labels} {.flow.IP.destination} : {.flow.verdict} {.flow.event_type.type}`,
 					fmt.Sprintf(`["reserved:host"] -> %s ["container:somelabel"] %s : FORWARDED 4`, endpointID, endpointIP.IPV4),
 					"No ingress traffic to endpoint")
 
@@ -674,12 +674,12 @@ var _ = Describe("RuntimeAgentPolicies", func() {
 				By("Testing hubble observe output")
 				// Checks for the subsequent trace:to-endpoint event (type 4)
 				err := hubbleRes.WaitUntilMatchFilterLine(
-					`{.source.labels} {.IP.source} -> {.destination.ID} : {.verdict} {.reply} {.event_type.type}`,
+					`{.flow.source.labels} {.flow.IP.source} -> {.flow.destination.ID} : {.flow.verdict} {.flow.reply} {.flow.event_type.type}`,
 					fmt.Sprintf(`["reserved:host"] %s -> %s : FORWARDED true 4`, hostIP, endpointID))
 				Expect(err).To(BeNil(), "No ingress traffic to endpoint")
 				// Checks for a ingress policy verdict event (type 5)
 				hubbleRes.ExpectContainsFilterLine(
-					`{.source.ID} -> {.destination.labels} {.IP.destination} : {.verdict} {.event_type.type}`,
+					`{.flow.source.ID} -> {.flow.destination.labels} {.flow.IP.destination} : {.flow.verdict} {.flow.event_type.type}`,
 					fmt.Sprintf(`%s -> ["reserved:host"] %s : AUDIT 5`, endpointID, hostIP),
 					"Default policy verdict on egress failed")
 
@@ -739,13 +739,13 @@ var _ = Describe("RuntimeAgentPolicies", func() {
 
 			By("Testing hubble observe output")
 			err = hubbleRes.WaitUntilMatchFilterLineTimeout(
-				`{.source.labels} -> {.destination.ID} {.IP.destination} : {.verdict}`,
+				`{.flow.source.labels} -> {.flow.destination.ID} {.flow.IP.destination} : {.flow.verdict}`,
 				fmt.Sprintf(`["reserved:host"] -> %s %s : FORWARDED`, endpointID, endpointIP.IPV4), 10*time.Second)
 			Expect(err).To(BeNil(), "Allow on ingress failed")
 
 			// Drop Reason 133 is "Policy denied"
 			hubbleRes.ExpectDoesNotContainFilterLine(
-				`{.source.labels} -> {.destination.ID} {.IP.destination} : {.verdict} {.drop_reason}`,
+				`{.flow.source.labels} -> {.flow.destination.ID} {.flow.IP.destination} : {.flow.verdict} {.flow.drop_reason}`,
 				fmt.Sprintf(`["reserved:host"] -> %s %s : DROPPED 133`, endpointID, endpointIP.IPV4),
 				"Unexpected drop")
 		})
@@ -774,14 +774,14 @@ var _ = Describe("RuntimeAgentPolicies", func() {
 
 			By("Testing hubble observe output")
 			err = hubbleRes.WaitUntilMatchFilterLineTimeout(
-				`{.source.ID} {.source.labels} -> {.destination.labels} {.IP.destination} : {.verdict}`,
+				`{.flow.source.ID} {.flow.source.labels} -> {.flow.destination.labels} {.flow.IP.destination} : {.flow.verdict}`,
 				fmt.Sprintf(`%s ["container:somelabel"] -> ["reserved:host"] %s : FORWARDED`, endpointID, hostIP),
 				10*time.Second)
 			Expect(err).To(BeNil(), "Allow on ingress failed")
 
 			// Drop Reason 133 is "Policy denied"
 			hubbleRes.ExpectDoesNotContainFilterLine(
-				`{.source.ID} {.source.labels} -> {.destination.labels} {.IP.destination} : {.verdict} {.drop_reason}`,
+				`{.flow.source.ID} {.flow.source.labels} -> {.flow.destination.labels} {.flow.IP.destination} : {.flow.verdict} {.flow.drop_reason}`,
 				fmt.Sprintf(`%s ["container:somelabel"] -> ["reserved:host"] %s : DROPPED 133`, endpointID, hostIP),
 				"Unexpected drop")
 		})


### PR DESCRIPTION
This commit replaces the use of the deprecated `-o json` flag on Hubble observe with `-o jsonpb`. Future versions of Hubble will make `-o json` an alias to `-o jsonpb`, so this commit should be future-proof.

The new output wraps each flow in a `GetFlowsResponse`, meaning the old object is now accessible in the `.flow` attribute. All jsonpath queries in the code have been changed to reflect this change.

Notably, some parts of CI (namely the `hubble-flows-*.json` files used for troubleshooting CI flakes) already used `-o jsonpb` and thus this commit should not cause any change in usual the CI troubleshooting workflow.
