### PR TITLE
bugtool: Dump envoy metrics for troubleshooting

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -35,6 +35,7 @@ cilium-bugtool [OPTIONS] [flags]
       --dry-run                              Create configuration file of all commands that would have been executed
       --enable-markdown                      Dump output of commands in markdown format
       --envoy-dump                           When set, dump envoy configuration from unix socket (default true)
+      --envoy-metrics                        When set, dump envoy prometheus metrics from unix socket (default true)
       --exclude-object-files                 Exclude per-endpoint object files. Template object files will be kept
       --exec-timeout duration                The default timeout for any cmd execution in seconds (default 30s)
       --get-pprof                            When set, only gets the pprof traces from the cilium-agent binary

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -72,6 +72,7 @@ var (
 	getPProf                 bool
 	pprofDebug               int
 	envoyDump                bool
+	envoyMetrics             bool
 	pprofPort                int
 	traceSeconds             int
 	parallelWorkers          int
@@ -84,6 +85,7 @@ func init() {
 	BugtoolRootCmd.Flags().BoolVar(&getPProf, "get-pprof", false, "When set, only gets the pprof traces from the cilium-agent binary")
 	BugtoolRootCmd.Flags().IntVar(&pprofDebug, "pprof-debug", 1, "Debug pprof args")
 	BugtoolRootCmd.Flags().BoolVar(&envoyDump, "envoy-dump", true, "When set, dump envoy configuration from unix socket")
+	BugtoolRootCmd.Flags().BoolVar(&envoyMetrics, "envoy-metrics", true, "When set, dump envoy prometheus metrics from unix socket")
 	BugtoolRootCmd.Flags().IntVar(&pprofPort,
 		"pprof-port", defaults.PprofPortAgent,
 		fmt.Sprintf(
@@ -212,8 +214,14 @@ func runTool() {
 		}
 	} else {
 		if envoyDump {
-			if err := dumpEnvoy(cmdDir); err != nil {
+			if err := dumpEnvoy(cmdDir, "http://admin/config_dump?include_eds", "envoy-config.json"); err != nil {
 				fmt.Fprintf(os.Stderr, "Unable to dump envoy config: %s\n", err)
+			}
+		}
+
+		if envoyMetrics {
+			if err := dumpEnvoy(cmdDir, "http://admin/stats/prometheus", "envoy-metrics.txt"); err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to retrieve envoy prometheus metrics: %s\n", err)
 			}
 		}
 
@@ -494,7 +502,7 @@ func getCiliumPods(namespace, label string) ([]string, error) {
 	return ciliumPods, nil
 }
 
-func dumpEnvoy(rootDir string) error {
+func dumpEnvoy(rootDir string, resource string, fileName string) error {
 	// curl --unix-socket /var/run/cilium/envoy-admin.sock http:/admin/config_dump\?include_eds > dump.json
 	c := &http.Client{
 		Transport: &http.Transport{
@@ -503,7 +511,7 @@ func dumpEnvoy(rootDir string) error {
 			},
 		},
 	}
-	return downloadToFile(c, "http://admin/config_dump?include_eds", filepath.Join(rootDir, "envoy-config.json"))
+	return downloadToFile(c, resource, filepath.Join(rootDir, fileName))
 }
 
 func pprofTraces(rootDir string, pprofDebug int) error {


### PR DESCRIPTION
Users might not have prometheus metrics endpoint enabled as part of existing Cilium installation. This commit is to add the capability to dump envoy metrics without the need of re-installation with additional helm flag, or updating existing cilium config map. One common use case is to check if there is any connectivity issue (e.g. 503, timeout, etc) for egress traffic.

For example, the below metrics are part of the dump, these two metrics clearly signal some configuration issues with TLS egress.

```bash
envoy_cluster_upstream_rq{envoy_response_code="503",envoy_cluster_name="egress-cluster-tls"} 100
envoy_cluster_upstream_cx_connect_fail{envoy_cluster_name="egress-cluster-tls"} 300
```

Testing was done locally by running curl command in pod manually

```bash
$ kubectl exec -n kube-system ds/cilium -- curl --unix-socket /var/run/cilium/envoy-admin.sock http:/admin/stats/prometheus > metrics_dump.txt
$ cat metrics_dump.txt | wc -l
  2753
```

Signed-off-by: Tam Mach <tam.mach@cilium.io>
