### PR TITLE
nodeport: fix CT accounting in revDNAT path

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1195,8 +1195,7 @@ out:
 #if defined(ENABLE_NODEPORT) && \
 	(!defined(ENABLE_DSR) || \
 	 (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) || \
-	 defined(ENABLE_MASQUERADE) || \
-	 defined(ENABLE_EGRESS_GATEWAY))
+	 defined(ENABLE_MASQUERADE))
 	if (!ctx_snat_done(ctx)) {
 		/*
 		 * handle_nat_fwd tail calls in the majority of cases,

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -51,4 +51,10 @@ static __always_inline int l4_load_port(struct __ctx_buff *ctx, int off,
 {
 	return ctx_load_bytes(ctx, off, port, sizeof(__be16));
 }
+
+static __always_inline int l4_load_ports(struct __ctx_buff *ctx, int off,
+					 __be16 *ports)
+{
+	return ctx_load_bytes(ctx, off, ports, 2 * sizeof(__be16));
+}
 #endif

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1089,15 +1089,16 @@ skip_rev_dnat:
 			if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 				return DROP_WRITE_ERROR;
 		}
-	} else {
-		if (!bpf_skip_recirculation(ctx)) {
-			ctx_skip_nodeport_set(ctx);
-			ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
-			return DROP_MISSED_TAIL_CALL;
-		}
+
+		return CTX_ACT_REDIRECT;
 	}
 
-	return CTX_ACT_REDIRECT;
+	if (bpf_skip_recirculation(ctx))
+		return DROP_NAT_NO_MAPPING;
+
+	ctx_skip_nodeport_set(ctx);
+	ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
+	return DROP_MISSED_TAIL_CALL;
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_REVNAT)
@@ -2075,15 +2076,16 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 			if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 				return DROP_WRITE_ERROR;
 		}
-	} else {
-		if (!bpf_skip_recirculation(ctx)) {
-			ctx_skip_nodeport_set(ctx);
-			ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);
-			return DROP_MISSED_TAIL_CALL;
-		}
+
+		return CTX_ACT_REDIRECT;
 	}
 
-	return CTX_ACT_REDIRECT;
+	if (bpf_skip_recirculation(ctx))
+		return DROP_NAT_NO_MAPPING;
+
+	ctx_skip_nodeport_set(ctx);
+	ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);
+	return DROP_MISSED_TAIL_CALL;
 
 #if (defined(ENABLE_EGRESS_GATEWAY) || defined(TUNNEL_MODE))
 encap_redirect:

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -678,9 +678,13 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 
 	ctx_snat_done_set(ctx);
 
+#if !defined(ENABLE_DSR) || (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID))
 	ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_REVNAT);
+#else
+	ctx_skip_nodeport_set(ctx);
+	ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
+#endif
 	ret = DROP_MISSED_TAIL_CALL;
-	goto drop_err;
 
  drop_err:
 	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
@@ -1638,14 +1642,23 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 
 	/* At this point we know that a reverse SNAT mapping exists.
 	 * Otherwise, we would have tail-called back to
-	 * CALL_IPV4_FROM_NETDEV in the code above. The existence of the
-	 * mapping is an indicator that the packet might be a reply from
-	 * a remote backend. So handle the service reverse DNAT (if
-	 * needed)
+	 * CALL_IPV4_FROM_NETDEV in the code above.
+	 */
+#if !defined(ENABLE_DSR) || (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) ||	\
+    (defined(ENABLE_EGRESS_GATEWAY) && !defined(TUNNEL_MODE))
+	/* If we're not in full DSR mode, reply traffic from remote backends
+	 * might pass back through the LB node and requires revDNAT.
+	 *
+	 * Also let rev_nodeport_lb4() redirect EgressGW reply traffic into
+	 * tunnel (see there for details).
 	 */
 	ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_REVNAT);
+#else
+	/* There's no reason to continue in the RevDNAT path, just recircle back. */
+	ctx_skip_nodeport_set(ctx);
+	ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);
+#endif
 	ret = DROP_MISSED_TAIL_CALL;
-	goto drop_err;
 
  drop_err:
 	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -981,7 +981,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __u32 *ifind
 					    int *ext_err)
 {
 	const bool nat_46x64_fib = nat46x64_cb_route(ctx);
-	int ret, fib_ret, ret2, l3_off = ETH_HLEN, l4_off, hdrlen;
+	int ret, fib_ret, ret2, l4_off;
 	struct ipv6_ct_tuple tuple = {};
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -999,14 +999,16 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __u32 *ifind
 		goto skip_rev_dnat;
 #endif
 
-	tuple.nexthdr = ip6->nexthdr;
-	ipv6_addr_copy(&tuple.daddr, (union v6addr *) &ip6->daddr);
-	ipv6_addr_copy(&tuple.saddr, (union v6addr *) &ip6->saddr);
+	ret = lb6_extract_tuple(ctx, ip6, &l4_off, &tuple);
+	if (ret) {
+		if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
+			goto out;
+		return ret;
+	}
 
-	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
-	if (hdrlen < 0)
-		return hdrlen;
-	l4_off = l3_off + hdrlen;
+	if (!ct_has_nodeport_egress_entry6(get_ct_map6(&tuple), &tuple))
+		goto out;
+
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
 	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS, &ct_state,
@@ -1097,6 +1099,7 @@ skip_rev_dnat:
 		return CTX_ACT_REDIRECT;
 	}
 
+out:
 	if (bpf_skip_recirculation(ctx))
 		return DROP_NAT_NO_MAPPING;
 
@@ -1994,11 +1997,17 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 		goto encap_redirect;
 #endif /* ENABLE_EGRESS_GATEWAY */
 
-	tuple.nexthdr = ip4->protocol;
-	tuple.daddr = ip4->daddr;
-	tuple.saddr = ip4->saddr;
+	ret = lb4_extract_tuple(ctx, ip4, &l4_off, &tuple);
+	if (ret) {
+		/* If it's not a SVC protocol, we don't need to check for RevDNAT: */
+		if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
+			goto out;
+		return ret;
+	}
 
-	l4_off = l3_off + ipv4_hdrlen(ip4);
+	if (!ct_has_nodeport_egress_entry4(get_ct_map4(&tuple), &tuple))
+		goto out;
+
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
 	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_INGRESS, &ct_state,
@@ -2093,6 +2102,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 		return CTX_ACT_REDIRECT;
 	}
 
+out:
 	if (bpf_skip_recirculation(ctx))
 		return DROP_NAT_NO_MAPPING;
 


### PR DESCRIPTION
While working on https://github.com/cilium/cilium/issues/22659, I noticed that we mis-account RX traffic in the nodeport revDNAT path. Background is that we first do a CT lookup for a packet (and update the statistics while at it), but then decide that the matched CT entry doesn't fit the criteria for nodeport revDNAT.

```release-note
Fix double-accounted RX packets in CT statistics when Nodeport is in use.
```
