### PR TITLE
ci/multicluster: Re-enable WireGuard testing

### DIFF
--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -345,9 +345,7 @@ jobs:
         # on clustermesh) once https://github.com/cilium/cilium-cli/issues/600
         # is fixed.
 
-      # WireGuard testing is disabled due to https://github.com/cilium/cilium/issues/18699
       - name: Enable WireGuard
-        if: ${{ false }} # see comment above for details
         run: |
           for ctx in ${{ steps.contexts.outputs.context1 }} ${{ steps.contexts.outputs.context2 }} ; do
             kubectl config use-context "$ctx"
@@ -358,7 +356,6 @@ jobs:
           done
 
       - name: Run connectivity test with WireGuard
-        if: ${{ false }} # see comment above for details
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --context ${{ steps.contexts.outputs.context1 }} \

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -362,12 +362,9 @@ jobs:
             --multi-cluster ${{ steps.contexts.outputs.context2 }} \
             --collect-sysdump-on-failure \
             --test '!/pod-to-.*-nodeport' \
-            --test '!client-egress-l7,!echo-ingress-l7,!to-fqdns,!dns-only' \
             --test '!no-policies/pod-to-service'
             --test '!/pod-to-world' \
             --test '!/pod-to-cidr'
-        # TODO: Once WireGuard supports the L7 proxy, the L7 tests can be
-        # included here. See cilium/cilium#15462
         # TODO: Remove `no-policies/pod-to-service` test exception (unreliable
         # on clustermesh) once https://github.com/cilium/cilium-cli/issues/600
         # is fixed.


### PR DESCRIPTION
PR https://github.com/cilium/cilium/pull/21080 fixed WireGuard connectivity issues when using
kvstore mode. This likely also affected clustermesh, as WireGuard was
previously flaky in the clustermesh / multicluster conformance tests
workflow.

This commit re-enables the WireGuard-based connectivity test.

Fixes: https://github.com/cilium/cilium/issues/18699