### PR TITLE
Add sphinxcontrib-googleanalytics to doc requirements

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -52,6 +52,7 @@ snowballstemmer==2.2.0
 sphinx_mdinclude==0.5.1
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-googleanalytics==0.3
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-httpdomain==1.8.0
 sphinxcontrib-jsmath==1.0.1


### PR DESCRIPTION
Adds sphinxcontrib-googleanalytics to doc requirements so that the docs can be published with a GA4 ID.

- Prerequisite to #22220.
  For details, see https://github.com/cilium/cilium/pull/22220#issuecomment-1360400381.
- Contributes to #22007

/cc @joestringer 
