### PR TITLE
.github: Clean up RBAC artifacts for v1.13 CI

### DIFF
--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -270,6 +270,8 @@ jobs:
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
+          kubectl delete --all-namespaces rolebinding -l "app.kubernetes.io/part-of=cilium" --ignore-not-found=true
+          kubectl delete --all-namespaces role -l "app.kubernetes.io/part-of=cilium" --ignore-not-found=true
 
       - name: Create custom IPsec secret
         run: |

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -289,6 +289,8 @@ jobs:
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
+          kubectl delete --all-namespaces rolebinding -l "app.kubernetes.io/part-of=cilium" --ignore-not-found=true
+          kubectl delete --all-namespaces role -l "app.kubernetes.io/part-of=cilium" --ignore-not-found=true
 
       - name: Create custom IPsec secret
         run: |

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -269,6 +269,8 @@ jobs:
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
+          kubectl delete --all-namespaces rolebinding -l "app.kubernetes.io/part-of=cilium" --ignore-not-found=true
+          kubectl delete --all-namespaces role -l "app.kubernetes.io/part-of=cilium" --ignore-not-found=true
 
       - name: Install Cilium with tunnel datapath
         run: |
@@ -293,6 +295,8 @@ jobs:
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
+          kubectl delete --all-namespaces rolebinding -l "app.kubernetes.io/part-of=cilium" --ignore-not-found=true
+          kubectl delete --all-namespaces role -l "app.kubernetes.io/part-of=cilium" --ignore-not-found=true
 
       - name: Create custom IPsec secret
         run: |
@@ -321,6 +325,8 @@ jobs:
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
+          kubectl delete --all-namespaces rolebinding -l "app.kubernetes.io/part-of=cilium" --ignore-not-found=true
+          kubectl delete --all-namespaces role -l "app.kubernetes.io/part-of=cilium" --ignore-not-found=true
 
       - name: Install Cilium with encryption and tunnel datapath
         run: |


### PR DESCRIPTION
This commit is the v1.13 CI equivalent of git commit 43cb8e9124d0
(".github: manually clean up RBAC artifacts"), necessary until we
resolve https://github.com/cilium/cilium-cli/issues/1257 .

Related: https://github.com/cilium/cilium/pull/22822
