### PR TITLE
operator: Add RBAC permission for CiliumNodeConfigs resource

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -194,6 +194,7 @@ rules:
   - ciliumlocalredirectpolicies.cilium.io
   - ciliumnetworkpolicies.cilium.io
   - ciliumnodes.cilium.io
+  - ciliumnodeconfigs.cilium.io
 - apiGroups:
   - cilium.io
   resources:


### PR DESCRIPTION
This is to make sure that cilium operator is having update permission for the newly added CiliumNodeConfigs CRD, otherwise, we will have the below issue:

```
2022-12-21T05:29:34.477230831Z level=fatal msg="Unable to register CRDs" error="Unable to create custom resource definition: customresourcedefinitions.apiextensions.k8s.io \"ciliumnodeconfigs.cilium.io\" is forbidden: User \"system:serviceaccount:kube-system:cilium-operator\" cannot update resource \"customresourcedefinitions\" in API group \"apiextensions.k8s.io\" at the cluster scope" subsys=cilium-operator-generic
```

Relates: #22656
Signed-off-by: Tam Mach <tam.mach@cilium.io>
