### PR TITLE
gh/workflows: Extend ci-datapath config to include lb-mode and endpoint-routes

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -138,24 +138,28 @@ jobs:
             kpr: 'strict'
             tunnel: 'vxlan'
             encryption: 'wireguard'
+            lb-mode: 'snat'
 
           - kernel: '5.15-main'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'
             encryption: 'wireguard'
+            lb-mode: 'dsr'
 
           - kernel: '6.0-main'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'vxlan'
             encryption: 'wireguard'
+            lb-mode: 'snat'
 
           - kernel: 'bpf-next-main'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'disabled'
             encryption: 'wireguard'
+            lb-mode: 'dsr'
 
     timeout-minutes: 60
     steps:
@@ -187,12 +191,17 @@ jobs:
             --helm-set=hubble.relay.image.tag=${SHA} \
             --rollback=false \
             --config monitor-aggregation=none \
-            --nodes-without-cilium=kind-worker3"
+            --nodes-without-cilium=kind-worker3 \
+            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
           TUNNEL="--helm-set-string=tunnel=vxlan"
           if [ "${{ matrix.tunnel }}" == "disabled" ]; then
             TUNNEL="--helm-set-string=tunnel=disabled --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16"
           fi
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL}"
+          LB_MODE=""
+          if [ "${{ matrix.lb-mode }}" != "" ]; then
+            LB_MODE="--helm-set-string=loadBalancer.mode=${{ matrix.lb-mode }}"
+          fi
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE}"
 
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
@@ -246,8 +255,7 @@ jobs:
           cmd: |
             cd /host/
             ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}"
-            ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }} \
-              --helm-set-string="kubeProxyReplacement=${{ matrix.kpr }}"
+            ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
 
             ./cilium-cli status --wait
             ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
@@ -265,7 +273,6 @@ jobs:
             cd /host/
             ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}"
             ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }} \
-              --helm-set-string="kubeProxyReplacement=${{ matrix.kpr }}" \
               --encryption=${{ matrix.encryption }}
 
             ./cilium-cli status --wait

--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -121,40 +121,56 @@ jobs:
       matrix:
         include:
           # See https://github.com/cilium/cilium/issues/20606 for configuration table
-          - kernel: '4.19-main'
+          - name: '1'
+            kernel: '4.19-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'vxlan'
             encryption: 'ipsec'
 
-          - kernel: '5.4-main'
+          - name: '2'
+            kernel: '5.4-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
             encryption: 'ipsec'
 
-          - kernel: '5.10-main'
+          - name: '3'
+            kernel: '5.10-main'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'disabled'
+            encryption: 'ipsec'
+            endpoint-routes: 'true'
+
+          - name: '4'
+            kernel: '5.10-main'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'vxlan'
             encryption: 'wireguard'
             lb-mode: 'snat'
+            endpoint-routes: 'true'
 
-          - kernel: '5.15-main'
+          - name: '5'
+            kernel: '5.15-main'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'
             encryption: 'wireguard'
             lb-mode: 'dsr'
+            endpoint-routes: 'true'
 
-          - kernel: '6.0-main'
+          - name: '6'
+            kernel: '6.0-main'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'vxlan'
             encryption: 'wireguard'
             lb-mode: 'snat'
 
-          - kernel: 'bpf-next-main'
+          - name: '7'
+            kernel: 'bpf-next-main'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'disabled'
@@ -201,7 +217,11 @@ jobs:
           if [ "${{ matrix.lb-mode }}" != "" ]; then
             LB_MODE="--helm-set-string=loadBalancer.mode=${{ matrix.lb-mode }}"
           fi
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE}"
+          ENDPOINT_ROUTES=""
+          if [ "${{ matrix.endpoint-routes }}" == "true" ]; then
+            ENDPOINT_ROUTES="--helm-set-string=endpointRoutes.enabled=true"
+          fi
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES}"
 
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
@@ -259,9 +279,9 @@ jobs:
 
             ./cilium-cli status --wait
             ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.kernel }}-<ts>"
+              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./cilium-cli connectivity test --collect-sysdump-on-failure \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.kernel }}-<ts>"
+              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             kind delete cluster
 
       - name: Run encryption tests
@@ -277,9 +297,9 @@ jobs:
 
             ./cilium-cli status --wait
             ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.kernel }}-<ts>"
+              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./cilium-cli connectivity test --collect-sysdump-on-failure \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.kernel }}-<ts>"
+              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
 
       - name: Fetch artifacts
         if: ${{ !success() }}
@@ -291,7 +311,7 @@ jobs:
             kubectl get pods --all-namespaces -o wide
             ./cilium-cli status
             mkdir -p cilium-sysdumps
-            ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.kernel }}-final
+            ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
 
       - name: Upload artifacts
         if: ${{ !success() }}


### PR DESCRIPTION
Current view - https://github.com/cilium/cilium/issues/20606

Successful run - https://github.com/cilium/cilium/actions/runs/3748817845/jobs/6366600342.