### PR TITLE
operator: Fix use of Resource.Events() in CEC controller

### DIFF
--- a/operator/watchers/cec.go
+++ b/operator/watchers/cec.go
@@ -27,24 +27,16 @@ func StartCECController(ctx context.Context, clientset k8sClient.Clientset, serv
 			log.WithError(err).Fatal("Error creating CiliumEnvoyConfiguration manager")
 		}
 		go m.Run(ctx)
-
-		services.Observe(
-			ctx,
-			func(ev resource.Event[*slim_corev1.Service]) {
-				ev.Handle(
-					func() error {
-						m.MarkSynced()
-						return nil
-					},
-					func(_ resource.Key, svc *slim_corev1.Service) error {
-						return m.OnUpdateService(nil, svc)
-					},
-					func(_ resource.Key, svc *slim_corev1.Service) error {
-						return m.OnDeleteService(svc)
-					},
-				)
-			},
-			func(error) { /* only completes when stopping */ },
-		)
+		for ev := range services.Events(ctx) {
+			switch ev.Kind {
+			case resource.Sync:
+				m.MarkSynced()
+				ev.Done(nil)
+			case resource.Upsert:
+				ev.Done(m.OnUpdateService(nil, ev.Object))
+			case resource.Delete:
+				ev.Done(m.OnDeleteService(ev.Object))
+			}
+		}
 	}()
 }


### PR DESCRIPTION
The commit "resource: Refactor the API for simplified usage" was tested against older master, before the commit "cli: Add configuration flag for service LB" which used the older API, causing the build to fail.

This updates StartCECController() to use the new Resource.Events method.

Fixes: f3a9b0ac7181 ("resource: Refactor the API for simplified usage")
