### PR TITLE
pkg/policy: Add benchmark for ForEachGo

### DIFF
--- a/pkg/policy/identifier_test.go
+++ b/pkg/policy/identifier_test.go
@@ -41,7 +41,7 @@ func (ds *PolicyTestSuite) TestNewEndpointSet(c *C) {
 	c.Assert(epSet.Len(), Equals, 0)
 }
 
-func (ds *PolicyTestSuite) TestForEach(c *C) {
+func (ds *PolicyTestSuite) TestForEachGo(c *C) {
 	var wg sync.WaitGroup
 
 	d0 := &DummyEndpoint{}
@@ -59,4 +59,20 @@ func (ds *PolicyTestSuite) TestForEach(c *C) {
 
 	c.Assert(d0.rev, Equals, uint64(100))
 	c.Assert(d1.rev, Equals, uint64(100))
+}
+
+func (ds *PolicyTestSuite) BenchmarkForEachGo(c *C) {
+	m := make(map[Endpoint]struct{}, c.N)
+	for i := uint64(0); i < uint64(c.N); i++ {
+		m[&DummyEndpoint{rev: i}] = struct{}{}
+	}
+	epSet := NewEndpointSet(m)
+
+	c.StartTimer()
+	var wg sync.WaitGroup
+	epSet.ForEachGo(&wg, func(e Endpoint) {
+		e.PolicyRevisionBumpEvent(100)
+	})
+	wg.Wait()
+	c.StopTimer()
 }


### PR DESCRIPTION
I added this benchmark code in order to evaluate whether ForEachGo could
be switched to a model where the number of goroutines are limited to the
number of CPUs. The performance difference was quite drastic. For a
benchmark run that took about ~10s prior to the change, it took about
~8m after the change.

One of the callers of ForEachGo bumps the policy revision of each
endpoint, which is a relatively cheap operation (incrementing an atomic
int), it doesn't seem worth optimizing ForEachGo.

The other caller of ForEachGo is for regenerating the endpoints. Under
the hood, regenerating endpoints is already limited by a semaphore,
bounded by number of CPUs, so there's no need to limit ForEachGo itself.

One could argue that launching as many goroutines as endpoints on a node
is a concern, especially to the Go scheduler. However, given the
performance impact of bounding ForEachGo, it seems that it may not be
worth pre-optimizing now until we have more evidence that ForEachGo can
cause issues.

For now, I'll submit this benchmark-adding commit so that we may
evaluate this code in the future.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
