### PR TITLE
proxylib: Downgrade noisy log msg to debug level

### DIFF
--- a/proxylib/proxylib/instance.go
+++ b/proxylib/proxylib/instance.go
@@ -183,7 +183,7 @@ func (ins *Instance) PolicyUpdate(resp *envoy_service_discovery.DiscoveryRespons
 			return fmt.Errorf("NPDS: Policy has no endpoint_ips")
 		}
 		for _, ip := range ips {
-			logrus.Infof("NPDS: Endpoint IP: %s", ip)
+			logrus.Debugf("NPDS: Endpoint IP: %s", ip)
 		}
 		// Locate the old version, if any
 		oldPolicy, found := oldMap[ips[0]]


### PR DESCRIPTION
The log msg doesn't provide any useful / actionable information anyway,
presumably unless you're debugging.

Fixes: 69518a1e2be ("envoy: API update")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
