### PR TITLE
contrib: Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "Cilium",
+  "image": "quay.io/cilium/cilium-builder:1b8f97cf70e2a4e7b0609f259d9540523c50cc9f@sha256:0b18c799b88ec039cb0d6d6338ddf539f530319960f9dbc22b69ec6167d3c2ec",
+  "workspaceFolder": "/go/src/github.com/cilium/cilium",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker": {}
+  },
+  "postCreateCommand": "git config --global --add safe.directory /go/src/github.com/cilium/cilium"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Cilium",
-  "image": "quay.io/cilium/cilium-builder:1b8f97cf70e2a4e7b0609f259d9540523c50cc9f@sha256:0b18c799b88ec039cb0d6d6338ddf539f530319960f9dbc22b69ec6167d3c2ec",
+  "image": "quay.io/cilium/cilium-builder:2460ae43ce9ab3ab0ff3a8b6e3bc434e6b58e9c0@sha256:97a6aa77af7f8fd5b2cff11ce2049a57e7debec4684652bd368f5911279da4bc",
   "workspaceFolder": "/go/src/github.com/cilium/cilium",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
   "features": {

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -216,6 +216,7 @@
 /CONTRIBUTING.md @cilium/contributing
 /.authors.aux @cilium/tophat
 /.clomonitor.yml @cilium/tophat
+/.devcontainer @cilium/contributing
 /.gitattributes @cilium/tophat
 /.github/ @cilium/contributing
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -9,6 +9,20 @@
 Development Setup
 =================
 
+Dev Container
+~~~~~~~~~~~~~
+
+Cilium provides `Dev Container <https://code.visualstudio.com/docs/devcontainers/containers>`_ configuration for Visual Studio Code Remote Containers
+and `Github Codespaces <https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers>`_.
+This allows you to use a preconfigured development environment in the cloud or locally.
+The container is based on the official Cilium builder image and provides all the dependencies
+required to build Cilium.
+
+.. note::
+
+    The current Dev Container is running as root. Non-root user support requires non-root
+    user in Cilium builder image, which is related to :gh-issue:`23217`.
+
 Verifying Your Development Setup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -656,15 +670,15 @@ These options enable logging functions in the datapath: ``cilium_dbg()``,
    monitor``.  In this case, ``bpftool prog tracelog`` can be used to retrieve
    debugging information from the eBPF based datapath. Both ``cilium_dbg()`` and
    ``printk()`` functions are available from the ``bpf/lib/dbg.h`` header file.
-   
+
 The image below shows the options that could be used as startup options by
 ``cilium-agent`` (see upper blue box) or could be changed at runtime by running
 ``cilium config <option(s)>`` for an already running agent (see lower blue box).
 Along with each option, there is one or more logging function associated with it:
 ``cilium_dbg()`` and ``printk()``, for ``DEBUG`` and ``cilium_dbg_lb()`` for
-``DEBUG_LB``. 
+``DEBUG_LB``.
 
-.. image:: _static/cilium-debug-datapath-options.svg 
+.. image:: _static/cilium-debug-datapath-options.svg
   :align: center
   :alt: Cilium debug datapath options
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -24,6 +24,7 @@ Cheng
 Chewbacca
 Chun
 Cloudflare
+Codespaces
 ConnectX
 Corefile
 CronJob

--- a/README.rst
+++ b/README.rst
@@ -5,18 +5,18 @@
       <img src="https://cdn.jsdelivr.net/gh/cilium/cilium@master/Documentation/images/logo-dark.png" width="350" alt="Cilium Logo">
    </picture>
 
-|cii| |go-report| |clomonitor| |artifacthub| |slack| |go-doc| |rtd| |apache| |bsd| |gpl| |fossa|
+|cii| |go-report| |clomonitor| |artifacthub| |slack| |go-doc| |rtd| |apache| |bsd| |gpl| |fossa| |codespaces|
 
 Cilium is a networking, observability, and security solution with an eBPF-based
-dataplane. It provides a simple flat Layer 3 network with the ability to span 
-multiple clusters in either a native routing or overlay mode. It is L7-protocol 
-aware and can enforce network policies on L3-L7 using an identity based security 
+dataplane. It provides a simple flat Layer 3 network with the ability to span
+multiple clusters in either a native routing or overlay mode. It is L7-protocol
+aware and can enforce network policies on L3-L7 using an identity based security
 model that is decoupled from network addressing.
 
-Cilium implements distributed load balancing for traffic between pods and to 
-external services, and is able to fully replace kube-proxy, using efficient 
-hash tables in eBPF allowing for almost unlimited scale. It also supports 
-advanced functionality like integrated ingress and egress gateway, bandwidth 
+Cilium implements distributed load balancing for traffic between pods and to
+external services, and is able to fully replace kube-proxy, using efficient
+hash tables in eBPF allowing for almost unlimited scale. It also supports
+advanced functionality like integrated ingress and egress gateway, bandwidth
 management and service mesh, and provides deep network and security visibility and monitoring.
 
 A new Linux kernel technology called eBPF_ is at the foundation of Cilium. It
@@ -356,3 +356,7 @@ and the `2-Clause BSD License <bsd-license_>`__
 .. |fossa| image:: https://app.fossa.com/api/projects/custom%2B162%2Fgit%40github.com%3Acilium%2Fcilium.git.svg?type=shield
     :alt: FOSSA Status
     :target: https://app.fossa.com/projects/custom%2B162%2Fgit%40github.com%3Acilium%2Fcilium.git?ref=badge_shield
+
+.. |codespaces| image:: https://github.com/codespaces/badge.svg
+    :alt: Github Codespaces
+    :target: https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=48109239&machine=standardLinux32gb&location=WestEurope

--- a/api/v1/Makefile
+++ b/api/v1/Makefile
@@ -3,7 +3,7 @@
 include ../../Makefile.defs
 
 # Update this via images/scripts/update-cilium-builder-image.sh
-CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:ed2947b8ba3ec68e56e3cd1818aa58f284592d7e@sha256:c6672a633834b8a253e763eee13f4cc3e84dce9d4c2929beb68215894e5ef69b
+CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:2460ae43ce9ab3ab0ff3a8b6e3bc434e6b58e9c0@sha256:97a6aa77af7f8fd5b2cff11ce2049a57e7debec4684652bd368f5911279da4bc
 
 .PHONY: proto
 proto:

--- a/images/builder/update-cilium-builder-image.sh
+++ b/images/builder/update-cilium-builder-image.sh
@@ -22,6 +22,12 @@ for i in "${used_by[@]}" ; do
   sed -E "s#(CILIUM_BUILDER_IMAGE=|image: )${image}:.*\$#\1${image_full}#" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
 done
 
+used_by=(".devcontainer/devcontainer.json")
+
+for i in "${used_by[@]}" ; do
+  sed -E "s#(\"image\": \")${image}:.*\",\$#\1${image_full}\",#" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
+done
+
 do_check="${CHECK:-false}"
 if [ "${do_check}" = "true" ] ; then
     git diff --exit-code "${used_by[@]}"

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:ed2947b8ba3ec68e56e3cd1818aa58f284592d7e@sha256:c6672a633834b8a253e763eee13f4cc3e84dce9d4c2929beb68215894e5ef69b
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:2460ae43ce9ab3ab0ff3a8b6e3bc434e6b58e9c0@sha256:97a6aa77af7f8fd5b2cff11ce2049a57e7debec4684652bd368f5911279da4bc
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:ae79224411f92933918659b6bebd0f4a318351f1@sha256:9338b471e9df4427b049d79b7889fe35a89e013eb7ddabfba2a5577122ead450
 
 # cilium-envoy from github.com/cilium/proxy

--- a/test/k8s/manifests/demo-customcalls.yaml
+++ b/test/k8s/manifests/demo-customcalls.yaml
@@ -99,7 +99,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:ed2947b8ba3ec68e56e3cd1818aa58f284592d7e@sha256:c6672a633834b8a253e763eee13f4cc3e84dce9d4c2929beb68215894e5ef69b
+    image: quay.io/cilium/cilium-builder:2460ae43ce9ab3ab0ff3a8b6e3bc434e6b58e9c0@sha256:97a6aa77af7f8fd5b2cff11ce2049a57e7debec4684652bd368f5911279da4bc
     workingDir: /cilium
     command: ["sleep"]
     args:


### PR DESCRIPTION
## Description

This is to provide the quick way for new contributors to bootstrap
development environment with [devcontainer], which is
widely used in vscode as well as github [codespaces]. The
docker image is completely re-used from cilium builder image.

Minimum set of features (e.g. docker-in-docker) is enabled by default.
While enabling more features is handy, it will increase the bootstrap
time. Hence, only docker is enabled as required by Makefile targets (e.g
helm-docs).

[devcontainer]: https://code.visualstudio.com/docs/devcontainers/containers
[codespaces]: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers

Signed-off-by: Tam Mach <tam.mach@cilium.io>

## Testing

Please find below the snippet of local devcontainer with vscode

```bash
root@1a0f5e8517c5:/go/src/github.com/cilium/cilium# make dev-doctor
go version 2>/dev/null || ( echo "go not found, see https://golang.org/doc/install" ; false )
go version go1.19.3 linux/amd64
go run ./tools/dev-doctor
RESULT    CHECK           MESSAGE
ok        os/arch         linux/amd64
ok        uname           Linux 1a0f5e8517c5 6.0.12-200.fc36.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Dec 8 17:15:53 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
ok        root-dir        found /go/src/github.com/cilium/cilium
ok        make            found /usr/bin/make, version 4.3
ok        go              found /usr/local/go/bin/go, version 1.19.3
warning   tparse          tparse not found in $PATH
ok        clang           found /usr/local/bin/clang, version 10.0.0
ok        docker-server   found /usr/bin/docker, version 20.10.22
ok        docker-client   found /usr/bin/docker, version 20.10.22
ok        docker-buildx   found /usr/bin/docker, version 0.9.1
warning   ginkgo          ginkgo not found in $PATH
warning   golangci-lint   golangci-lint not found in $PATH
ok        docker          found /usr/bin/docker, version 20.10.22
warning   helm            helm not found in $PATH
ok        llc             found /usr/local/bin/llc, version 10.0.0
info      vagrant         vagrant not found in $PATH
info      virtualbox      virtualbox not found in $PATH
info      vboxheadless    vboxheadless not found in $PATH
warning   pip3            pip3 not found in $PATH
warning   cfssl           cfssl not found in $PATH
warning   cfssljson       cfssljson not found in $PATH
ok        docker-group    user root in docker group

CHECK           HINT
tparse          Run "go install github.com/mfridman/tparse@latest"
ginkgo          Run "go install github.com/onsi/ginkgo/ginkgo@latest".
golangci-lint   See https://golangci-lint.run/usage/install/#local-installation.
vboxheadless    run "VBoxHeadless --help" to diagnose why vboxheadless failed to execute
cfssl           See https://github.com/cloudflare/cfssl#installation.
cfssljson       See https://github.com/cloudflare/cfssl#installation.

See https://docs.cilium.io/en/latest/contributing/development/dev_setup/.
root@1a0f5e8517c5:/go/src/github.com/cilium/cilium# 
```
