### PR TITLE
Align IP selection behavior with kernel

### DIFF
--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -6,7 +6,6 @@
 package node
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"sort"
@@ -47,8 +46,8 @@ retryInterface:
 	}
 
 retryScope:
-	ipsPublic := []net.IP{}
-	ipsPrivate := []net.IP{}
+	ipsPublic := []netlink.Addr{}
+	ipsPrivate := []netlink.Addr{}
 	hasPreferred := false
 
 	for _, a := range addr {
@@ -58,9 +57,9 @@ retryScope:
 			}
 			if len(a.IP) >= ipLen {
 				if ip.IsPublicAddr(a.IP) {
-					ipsPublic = append(ipsPublic, a.IP)
+					ipsPublic = append(ipsPublic, a)
 				} else {
-					ipsPrivate = append(ipsPrivate, a.IP)
+					ipsPrivate = append(ipsPrivate, a)
 				}
 				// If the IP is the same as the preferredIP, that
 				// means that maybe it is restored from node_config.h,
@@ -83,11 +82,11 @@ retryScope:
 
 		// Just make sure that we always return the same one and not a
 		// random one. More info in the issue GH-7637.
-		sort.Slice(ipsPublic, func(i, j int) bool {
-			return bytes.Compare(ipsPublic[i], ipsPublic[j]) < 0
+		sort.SliceStable(ipsPublic, func(i, j int) bool {
+			return ipsPublic[i].LinkIndex < ipsPublic[j].LinkIndex
 		})
 
-		return ipsPublic[0], nil
+		return ipsPublic[0].IP, nil
 	}
 
 	if len(ipsPrivate) != 0 {
@@ -96,11 +95,11 @@ retryScope:
 		}
 
 		// Same stable order, see above ipsPublic.
-		sort.Slice(ipsPrivate, func(i, j int) bool {
-			return bytes.Compare(ipsPrivate[i], ipsPrivate[j]) < 0
+		sort.SliceStable(ipsPrivate, func(i, j int) bool {
+			return ipsPrivate[i].LinkIndex < ipsPrivate[j].LinkIndex
 		})
 
-		return ipsPrivate[0], nil
+		return ipsPrivate[0].IP, nil
 	}
 
 	// First, if a device is specified, fall back to anything wider
@@ -123,7 +122,7 @@ retryScope:
 }
 
 // firstGlobalV4Addr returns the first IPv4 global IP of an interface,
-// where the IPs are sorted in ascending order.
+// where the IPs are sorted in creation order (oldest to newest).
 //
 // Public IPs are preferred over private ones. When intf is defined only
 // IPs belonging to that interface are considered.

--- a/pkg/node/address_linux_test.go
+++ b/pkg/node/address_linux_test.go
@@ -55,6 +55,11 @@ func (s *NodePrivilegedSuite) Test_firstGlobalV4Addr(c *C) {
 			preferredIP:    "192.168.0.1",
 			want:           "21.0.0.1",
 		},
+		{
+			name:           "primary IP preferred by default",
+			ipsOnInterface: []string{"192.168.0.2", "192.168.0.1"},
+			want:           "192.168.0.2",
+		},
 	}
 	const ifName = "dummy_iface"
 	for _, tc := range testCases {


### PR DESCRIPTION
Sorting IPs by `bytes.Compare` gets rid of creation order, which can
lead to secondary IPs being chosed for masquerading and NodePort SNAT
purposes. Instead, stably sort by ifindex to preserve creation order and
give preference to primary IPs. Also, filter out secondary IPs.

This also more closely aligns with the Linux kernel's IP selection
behavior.

Fixes: #22853

```release-note
Align selection of IP addresses used for masquerading and NodePort SNAT with Linux kernel behavior, by preferring addresses assigned to the interface earlier and filtering out secondary addresses.
```
