### PR TITLE
[cilium-cmd bpf-metrics-list] return first when []*metricsRow is nil.

### DIFF
--- a/cilium/cmd/bpf_metrics_list.go
+++ b/cilium/cmd/bpf_metrics_list.go
@@ -76,6 +76,11 @@ func listMetrics(m metricsmap.MetricsMap) {
 }
 
 func listJSONMetrics(bpfMetricsList []*metricsRow) {
+	if len(bpfMetricsList) == 0 {
+		fmt.Fprintf(os.Stderr, "No entries found.\n")
+		return
+	}
+
 	metricsByReason := map[int]jsonMetric{}
 
 	for _, row := range bpfMetricsList {


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

Just return and alert error message when []*metricsRow is return nil.
