### PR TITLE
Make api/v1/model/BackendAddressState const string , not manual define.

### DIFF
--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -474,13 +474,13 @@ func IsValidStateTransition(old, new BackendState) bool {
 
 func GetBackendState(state string) (BackendState, error) {
 	switch strings.ToLower(state) {
-	case "active", "":
+	case models.BackendAddressStateActive, "":
 		return BackendStateActive, nil
-	case "terminating":
+	case models.BackendAddressStateTerminating:
 		return BackendStateTerminating, nil
-	case "quarantined":
+	case models.BackendAddressStateQuarantined:
 		return BackendStateQuarantined, nil
-	case "maintenance":
+	case models.BackendAddressStateMaintenance:
 		return BackendStateMaintenance, nil
 	default:
 		return BackendStateInvalid, fmt.Errorf("invalid backend state %s", state)
@@ -490,13 +490,13 @@ func GetBackendState(state string) (BackendState, error) {
 func (state BackendState) String() (string, error) {
 	switch state {
 	case BackendStateActive:
-		return "active", nil
+		return models.BackendAddressStateActive, nil
 	case BackendStateTerminating:
-		return "terminating", nil
+		return models.BackendAddressStateTerminating, nil
 	case BackendStateQuarantined:
-		return "quarantined", nil
+		return models.BackendAddressStateQuarantined, nil
 	case BackendStateMaintenance:
-		return "maintenance", nil
+		return models.BackendAddressStateMaintenance, nil
 	default:
 		return "", fmt.Errorf("invalid backend state %d", state)
 	}

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -141,8 +141,8 @@ var _ = Describe("RuntimeDatapathLB", func() {
 		frontend2 := "2.2.2.3:8080"
 		backend1 := "1.1.1.2:8080"
 		backend2 := "1.1.1.3:8080"
-		activeState := "active"
-		quarantineState := "quarantined"
+		activeState := models.BackendAddressStateActive
+		quarantineState := models.BackendAddressStateQuarantined
 		type backendCheckTest struct {
 			frontend string
 			backend  string


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

Reused the const string for BackendAddressState status, not manual it again.
