### PR TITLE
k8s: Add node-role.kubernetes.io/control-plane taint

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -129,6 +129,7 @@ done
 
 set +e
 kubectl taint nodes --all node-role.kubernetes.io/master-
+kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 set -e
 
 echo

--- a/test/k8s/manifests/demo_ds.yaml
+++ b/test/k8s/manifests/demo_ds.yaml
@@ -33,6 +33,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
 ---

--- a/test/k8s/manifests/demo_ds_local.yaml
+++ b/test/k8s/manifests/demo_ds_local.yaml
@@ -33,6 +33,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
 ---

--- a/test/k8s/manifests/demo_hostfw.yaml
+++ b/test/k8s/manifests/demo_hostfw.yaml
@@ -35,6 +35,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
 ---
@@ -96,6 +98,8 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"

--- a/test/vtep/README.rst
+++ b/test/vtep/README.rst
@@ -62,6 +62,7 @@ VTEP integration test steps, You can also run install.sh for following steps
    # deploy busybox on kind control plaine node
    kubectl label node kind-control-plane  dedicated=master
    kubectl taint nodes --all node-role.kubernetes.io/master-
+   kubectl taint nodes --all node-role.kubernetes.io/control-plane-
    kubectl apply -f busybox-master.yaml
    # Deploy vxlan-responder.py in systemd service
    cp vxlan-responder.service /etc/systemd/system/


### PR DESCRIPTION
This new node-role.kubernetes.io/control-plane taint replaced old one node-role.kubernetes.io/master, mainly for promoting inclusive language. From k8s 1.26+ onward, the old taint is no longer working.

Related docs: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#removed

Relates: #22893

Signed-off-by: Tam Mach <tam.mach@cilium.io>
