### PR TITLE
gha: Run integration tests in GHA

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,67 @@
+name: IntegrationTests
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request:
+    paths-ignore:
+    - 'Documentation/**'
+    - 'test/**'
+  push:
+    branches:
+    - master
+    - ft/master/**
+    paths-ignore:
+    - 'Documentation/**'
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 45
+    steps:
+    - name: Checkout master branch to access local actions
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        persist-credentials: false
+    - name: Set Environment Variables
+      uses: ./.github/actions/set-env-variables
+
+    - name: Set image tag
+      id: vars
+      run: |
+        if [ ${{ github.event.pull_request }} ]; then
+          SHA=${{ github.event.pull_request.head.sha }}
+        else
+          SHA=${{ github.sha }}
+        fi
+        echo ::set-output name=sha::${SHA}
+
+    - name: Checkout
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      with:
+        ref: ${{ steps.vars.outputs.sha }}
+        persist-credentials: false
+
+    - name: Install Go
+      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+      with:
+        go-version: 1.19.4
+
+    - name: Prepare environment
+      timeout-minutes: 15
+      run: |
+        ./.travis/prepare.sh
+
+    - name: Run integration tests
+      timeout-minutes: 30
+      run: |
+        export PATH=/usr/local/clang/bin:$PATH
+        export V=0
+        export DOCKER_BUILD_FLAGS=--quiet
+        ./.travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ go: "1.19.5"
 
 jobs:
   include:
-    - arch: amd64
     - arch: arm64-graviton2
       virt: vm
       group: edge

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -7,6 +7,4 @@ export CFLAGS="-Werror"
 make -j 2 --quiet
 make integration-tests --quiet
 
-$HOME/gopath/bin/goveralls -coverprofile=coverage-all.out -service=travis-ci || true
-
 exit 0


### PR DESCRIPTION
## Description

Current travis CI is used to run integration-tests target only, however, this can be achieved with GitHub action easily (at least for amd64).

Signed-off-by: Tam Mach <tam.mach@cilium.io>

## Testing

Both jobs are taking around 20 mins to complete, GHA job is having a shorter bootstrap time compared to Travis, hence from UX point of view, GHA provides a faster feedback, not to mention that Cilium contributors are already familiar with GHA ops such as re-run, checking logs, etc.

- Github Action run https://github.com/cilium/cilium/actions/runs/3966354144/jobs/6797060899
- Travis run https://app.travis-ci.com/github/cilium/cilium/builds/259287088

## Note

Not sure if arm64 run in travis provides any added value, if not, we can just remove travis completely and refactor the scripts a little bit.
