### PR TITLE
docs: Correct `PRELOAD_VM` environment variable

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -230,7 +230,7 @@ This will first destroy any CI VMs you may have running on the current
 ``K8S_VERSION``, and then create a local Vagrant box if not already
 created. This can take some time.
 
-VM preloading can be turned off by exporting ``VM_PRELOAD=false``. You
+VM preloading can be turned off by exporting ``PRELOAD_VM=false``. You
 can run ``make clean`` in ``test`` to delete the cached vagrant box.
 
 To start the CI runtime VM locally, run:


### PR DESCRIPTION
[Document says](https://docs.cilium.io/en/v1.12/contributing/development/dev_setup/#launch-ci-vms) `VM_PRELOAD` is the environment variable which controls VM preloading for Local CI VM. However, the actual environment variable is `PRELOAD_VM` (Please see [here](https://github.com/cilium/cilium/blob/master/test/vagrant-local-start.sh#L15)).

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!


```release-note
docs: modify `PRELOAD_VM` for local CI VM
```
