### PR TITLE
fix：make fsnotify event more readable

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -668,7 +668,7 @@ func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath
 	for {
 		select {
 		case event := <-watcher.Events:
-			if event.Op&(fsnotify.Create|fsnotify.Write) == 0 {
+			if !event.Op.Has(fsnotify.Create) || !event.Op.Has(fsnotify.Write) {
 				continue
 			}
 


### PR DESCRIPTION
Signed-off-by: yulng <wei.yang@daocloud.io>

https://github.com/fsnotify/fsnotify/pull/477 and [fsnotify release](https://github.com/fsnotify/fsnotify/releases/tag/v1.6.0) .
so to make fsnotify event more readable

Thanks