### PR TITLE
chore: use errors.Is to check for a specific error

### DIFF
--- a/cilium/cmd/map_event_list.go
+++ b/cilium/cmd/map_event_list.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -63,7 +64,7 @@ var mapEventListCmd = &cobra.Command{
 			for {
 				event := &models.MapEvent{}
 				err := dec.Decode(&event)
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					return
 				}
 				if err != nil {

--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -257,7 +257,7 @@ func runMonitor(args []string) {
 		case err == nil:
 		// no-op
 
-		case err == io.EOF, errors.Is(err, io.ErrUnexpectedEOF):
+		case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
 			log.WithError(err).Warn("connection closed")
 			continue
 

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -7,6 +7,7 @@ package bpf
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -295,7 +296,7 @@ func GetNextKeyFromPointers(fd int, structPtr unsafe.Pointer, sizeOfStruct uintp
 
 	// BPF_MAP_GET_NEXT_KEY returns ENOENT when all keys have been iterated
 	// translate that to io.EOF to signify there are no next keys
-	if err == unix.ENOENT {
+	if errors.Is(err, unix.ENOENT) {
 		return io.EOF
 	}
 

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -642,7 +642,7 @@ func (m *Map) DumpWithCallback(cb DumpCallback) error {
 	value := make([]byte, m.ReadValueSize)
 
 	if err := GetFirstKey(m.fd, unsafe.Pointer(&nextKey[0])); err != nil {
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		return err
@@ -686,7 +686,7 @@ func (m *Map) DumpWithCallback(cb DumpCallback) error {
 		copy(key, nextKey)
 
 		if err := GetNextKeyFromPointers(m.fd, bpfCurrentKeyPtr, bpfCurrentKeySize); err != nil {
-			if err == io.EOF { // end of map, we're done iterating
+			if errors.Is(err, io.EOF) { // end of map, we're done iterating
 				return nil
 			}
 			return err
@@ -736,7 +736,7 @@ func (m *Map) DumpReliablyWithCallback(cb DumpCallback, stats *DumpStats) error 
 
 	if err := GetFirstKey(m.fd, unsafe.Pointer(&currentKey[0])); err != nil {
 		stats.Lookup = 1
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// map is empty, nothing to clean up.
 			stats.Completed = true
 			return nil
@@ -813,7 +813,7 @@ func (m *Map) DumpReliablyWithCallback(cb DumpCallback, stats *DumpStats) error 
 		}
 
 		if nextKeyErr != nil {
-			if nextKeyErr == io.EOF {
+			if errors.Is(nextKeyErr, io.EOF) {
 				stats.Completed = true
 				return nil // end of map, we're done iterating
 			}
@@ -1061,7 +1061,7 @@ func (m *Map) DeleteAll() error {
 	defer m.deleteAllMapEvent(err)
 	for {
 		if err := GetFirstKey(m.fd, unsafe.Pointer(&nextKey[0])); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return err

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/netip"
@@ -45,7 +46,7 @@ func getCiliumVersionString(epCHeaderFilePath string) ([]byte, error) {
 	defer f.Close()
 	for {
 		b, err := br.ReadBytes('\n')
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return []byte{}, nil
 		}
 		if err != nil {

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -138,7 +138,7 @@ func (s *Server) HandleRequestStream(ctx context.Context, stream Stream, default
 		for {
 			req, err := stream.Recv()
 			if err != nil {
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					streamLog.Debug("xDS stream closed")
 				} else if strings.HasPrefix(err.Error(), grpcCanceled) {
 					streamLog.WithError(err).Debug("xDS stream canceled")

--- a/proxylib/npds/client.go
+++ b/proxylib/npds/client.go
@@ -176,7 +176,7 @@ func (c *Client) Run(connected func()) (err error) {
 		// Receive next policy configuration. This will block until the
 		// server has a new version to send, which may take a long time.
 		resp, err := stream.Recv()
-		if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			logrus.Debugf("NPDS: Client %s stream on %s closed.", c.nodeId, c.path)
 			break
 		}


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

Comparing with `==` will fail on wrapped errors, use errors.Is to check for a specific error，select the unmodified part in the following way
```sh
➜  cilium git:(master) ✗ git grep 'err ==' | grep -v ^vendor | sed 's/.*err == \([^ :),;.]\+\).*/\1/g' | grep -i Err | grep -v "err == 0" | grep -v "err == nil" | sort -u
bpf/bpf_sock.c: if (err == -EHOSTUNREACH || err == -ENOMEM) {
pkg/checker/checker_test.go:            c.Assert(equal, check.Equals, err == "")
```
