### PR TITLE
docs: Update Minikube ver. requirement and manual BPFFS mount instructions  

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -180,7 +180,7 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
     .. group-tab:: minikube
 
-       Install minikube >= v1.12 as per minikube documentation:
+       Install minikube ≥ v1.28.0 as per minikube documentation:
        `Install Minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
        The following command will bring up a single node minikube cluster prepared for installing cilium.
 

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -194,6 +194,10 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
           ``--cni=cilium`` parameter in ``minikube start`` command. However, this may not
           install the latest version of cilium.
 
+          MacOS M1 users using a Minikube version < v1.28.0 with ``--cni=false`` will also need to run
+          ``minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf`` in order to mount the BPF filesystem
+          ``bpffs`` to ``/sys/fs/bpf``.
+
     .. group-tab:: Rancher Desktop
 
        Install Rancher Desktop >= v1.1.0 as per Rancher Desktop documentation:


### PR DESCRIPTION
This PR contains changes updating the **[Cilium | Getting Started | Create the Cluster | Minikube](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#create-the-cluster)** docs. It bumps the minimum version requirement for installing Minikube from **v1.12** to **v1.28.0**. It also adds a note for MacOS users on older Minikube versions (**< v1.28.0**) with instructions on manually mounting the BPF filesystem `bpffs` to `/sys/fs/bpf`. 

MacOS users who create a Minikube cluster with `--cni=false` must manually mount the BPF filesystem `bpffs` to `/sys/fs/bpf` on Minikube **< v1.28.0** with `minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf`. 

Local testing reveals that MacOS M1 users using Minikube **v1.28.0** and `minikube start --network-plugin=cni --cni=false` don't require a manual mount. @sayboras discovered that on M1 Macs with Minikube **v1.27.1**, the BPFFS is not mounted by default. Although I wasn't able to find the exact fix in Minikube's [release notes](https://github.com/kubernetes/minikube/releases), the automatic mount appears to occur on the latest version - despite this [related PR](https://github.com/kubernetes/minikube/pull/15164) which hasn't yet been merged upstream. 

Minikube will automatically mount the BPFFS if the user passes the `--cni=cilium` flag. See [here](https://github.com/kubernetes/minikube/blob/9c2840b93c959768a0ed19efcf89f27961e58382/pkg/minikube/cni/cilium.go#L854). 

References:
* [Minikube Releases](https://github.com/kubernetes/minikube/releases)
* https://github.com/kubernetes/minikube/pull/15164

Signed-off-by: Stacy Kim [stacy.kim@ucla.edu](mailto:stacy.kim@ucla.edu)