### PR TITLE
bpf: nodeport: NAT64 cleanups

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -990,6 +990,11 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __u32 *ifind
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
+#ifdef ENABLE_NAT_46X64_GATEWAY
+	if (nat_46x64_fib)
+		goto skip_rev_dnat;
+#endif
+
 	tuple.nexthdr = ip6->nexthdr;
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *) &ip6->daddr);
 	ipv6_addr_copy(&tuple.saddr, (union v6addr *) &ip6->saddr);
@@ -997,10 +1002,6 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __u32 *ifind
 	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
-#ifdef ENABLE_NAT_46X64_GATEWAY
-	if (nat_46x64_fib)
-		goto skip_rev_dnat;
-#endif
 	l4_off = l3_off + hdrlen;
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1040,8 +1040,10 @@ skip_rev_dnat:
 		fib_params.family = AF_INET6;
 		fib_params.ifindex = ctx_get_ifindex(ctx);
 
-		ipv6_addr_copy((union v6addr *)&fib_params.ipv6_src, &tuple.saddr);
-		ipv6_addr_copy((union v6addr *)&fib_params.ipv6_dst, &tuple.daddr);
+		ipv6_addr_copy((union v6addr *)&fib_params.ipv6_src,
+			       (union v6addr *)&ip6->saddr);
+		ipv6_addr_copy((union v6addr *)&fib_params.ipv6_dst,
+			       (union v6addr *)&ip6->daddr);
 
 		fib_ret = fib_lookup(ctx, &fib_params, sizeof(fib_params), 0);
 		/* See comment in rev_nodeport_lb4() on why we only set ifindex
@@ -1071,7 +1073,7 @@ skip_rev_dnat:
 			}
 
 			/* See comment in rev_nodeport_lb4(). */
-			dmac = neigh_lookup_ip6(&tuple.daddr);
+			dmac = neigh_lookup_ip6((union v6addr *)&fib_params.ipv6_dst);
 			if (unlikely(!dmac)) {
 				*ext_err = fib_ret;
 				return DROP_NO_FIB;
@@ -2057,7 +2059,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 			 * table instead where we recorded the client
 			 * address in nodeport_lb4().
 			 */
-			dmac = neigh_lookup_ip4(&tuple.daddr);
+			dmac = neigh_lookup_ip4(&fib_params.ipv4_dst);
 			if (unlikely(!dmac)) {
 				*ext_err = fib_ret;
 				return DROP_NO_FIB;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -655,18 +655,13 @@ drop_err:
 declare_tailcall_if(__not(is_defined(IS_BPF_LXC)), CILIUM_CALL_IPV6_NODEPORT_NAT_INGRESS)
 int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 {
-	const bool nat_46x64 = nat46x64_cb_xlate(ctx);
-	union v6addr tmp = IPV6_DIRECT_ROUTING;
 	struct ipv6_nat_target target = {
+		.addr = IPV6_DIRECT_ROUTING,
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
 		.src_from_world = true,
 	};
 	int ret;
-
-	if (nat_46x64)
-		build_v4_in_v6(&tmp, IPV4_DIRECT_ROUTING);
-	target.addr = tmp;
 
 	ret = snat_v6_rev_nat(ctx, &target);
 	if (IS_ERR(ret)) {

--- a/test/bpf/check-complexity.sh
+++ b/test/bpf/check-complexity.sh
@@ -21,6 +21,8 @@ function annotate_section_names {
 	    -e "s/\(section '2\/5'\)/\1 (tail_call SEND_ICMP6_TIME_EXCEEDED)/" \
 	    -e "s/\(section '2\/6'\)/\1 (tail_call ARP)/" \
 	    -e "s/\(section '2\/7'\)/\1 (tail_call IPV4_FROM_LXC)/" \
+	    -e "s/\(section '2\/8'\)/\1 (tail_call IPV46_RFC8215)/" \
+	    -e "s/\(section '2\/9'\)/\1 (tail_call IPV64_RFC8215)/" \
 	    -e "s/\(section '2\/10'\)/\1 (tail_call IPV6_FROM_LXC)/" \
 	    -e "s/\(section '2\/11'\)/\1 (tail_call IPV4_TO_LXC_POLICY_ONLY)/" \
 	    -e "s/\(section '2\/12'\)/\1 (tail_call IPV6_TO_LXC_POLICY_ONLY)/" \


### PR DESCRIPTION
Clean up a few pieces of the NAT64 nodeport code that were introduced late in the v1.13 cycle, so that we don't have to maintain them further.