### PR TITLE
 Parses the IP addr passed as CIDR from the delegated IPAM and then use the IP addr from the parsed prefix.

### DIFF
--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -288,9 +288,18 @@ func prepareIP(ipAddr string, state *CmdState, mtu int) (*cniTypesV1.IPConfig, [
 	var (
 		routes []route.Route
 		gw     string
+		ip     netip.Addr
 	)
 
-	ip, err := netip.ParseAddr(ipAddr)
+	// This handles both scenarios for handling IPaddress as CIDR as well as IPaddress
+	// from delegated Ipam and cilium-agent
+	ipPrefix, err := netip.ParsePrefix(ipAddr)
+	if err != nil {
+		ip, err = netip.ParseAddr(ipAddr)
+	} else {
+		ip = ipPrefix.Addr()
+	}
+
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
<!-- Description of change -->

Fixes: #22917 
Parses the ipaddress passed as CIDR from the delegated Ipam. And then use the ipaddress from the parsed prefix.

---

Fixes: https://github.com/cilium/cilium/pull/21421