### PR TITLE
bpf: Relax constant check for dst_id for clang 14+

### DIFF
--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -105,12 +105,16 @@ _send_drop_notify(__u8 file, __u16 line, struct __ctx_buff *ctx,
 	    !__builtin_constant_p(line) || line > 0xffff)
 		__throw_build_bug();
 
-	/* These fields should be constants, and non-zero 'dst_id' is only to be
-	 * used for ingress.
-	 */
-	if (!__builtin_constant_p(dst_id) ||
-	    (dst_id != 0 &&
-	     (!__builtin_constant_p(direction) || direction != METRIC_INGRESS)))
+/* Clang 14 or higher fails for constant check, so skip it right now.
+ * Enable again once we have more understanding why.
+ */
+#if __clang_major__ < 14
+	if (!__builtin_constant_p(dst_id))
+		__throw_build_bug();
+#endif
+
+	/* Non-zero 'dst_id' is only to be used for ingress. */
+	if (dst_id != 0 && (!__builtin_constant_p(direction) || direction != METRIC_INGRESS))
 		__throw_build_bug();
 
 	ctx_store_meta(ctx, 0, src);


### PR DESCRIPTION
## Description

The constant validation by __builtin_constant_p() failed for clang 14, it's mainly due to LXC_ID evaluation. The actual value of LXC_ID is written by datapath header file (written by pkg/datapath/linux/config/config.go).

This commit is to drop constant check for dst_id, so that cilium can still be compiled with clang 14+ while still honours the original goal in a246aa0ce4f5879219069eb6055ce022f346d280.

Relates: a246aa0ce4f5879219069eb6055ce022f346d280
Relates: #22834
Signed-off-by: Tam Mach <tam.mach@cilium.io>

## Testing

Testing was done by just using clang 10 and clang 14 to compile cilium agent

<details>
<summary>Clang 14</summary>

```bash
$ clang --version
clang version 14.0.5 (Fedora 14.0.5-2.fc36)
Target: x86_64-redhat-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
$ make -j $(nproc) build
...
make[1]: Leaving directory '/home/tammach/go/src/github.com/cilium/cilium/proxylib'
llc -march=bpf -mcpu=v2 -filetype=obj -o bpf_overlay.o bpf_overlay.ll
llc -march=bpf -mcpu=v2 -filetype=obj -o bpf_xdp.o bpf_xdp.ll
llc -march=bpf -mcpu=v2 -filetype=obj -o bpf_lxc.o bpf_lxc.ll
make[1]: Leaving directory '/home/tammach/go/src/github.com/cilium/cilium/hubble-relay'
llc -march=bpf -mcpu=v2 -filetype=obj -o bpf_host.o bpf_host.ll
make[1]: Leaving directory '/home/tammach/go/src/github.com/cilium/cilium/bpf'
make[1]: Leaving directory '/home/tammach/go/src/github.com/cilium/cilium/operator'
```

</details>

<details>
<summary>Clang 10</summary>

```
$ clang --version
clang version 10.0.1 (https://github.com/llvm/llvm-project.git ef32c611aa214dea855364efd7ba451ec5ec3f74)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/tammach/go/src/github.com/llvm/llvm-project/build/bin

$ make -j $(nproc) build
...
llc -march=bpf -mcpu=v2 -filetype=obj -o bpf_xdp.o bpf_xdp.ll
llc -march=bpf -mcpu=v2 -filetype=obj -o bpf_host.o bpf_host.ll
make[1]: Leaving directory '/home/tammach/go/src/github.com/cilium/cilium/bpf'

$ echo $? 
0
```

</details>