### PR TITLE
bpf_tests: Always RemoveMemlock()

### DIFF
--- a/test/bpf_tests/bpf_test.go
+++ b/test/bpf_tests/bpf_test.go
@@ -51,6 +51,10 @@ var (
 )
 
 func TestBPF(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Fatal("rlimit.RemoveMemlock: ", err)
+	}
+
 	if testPath == nil || *testPath == "" {
 		t.Skip("Set -bpf-test-path to run BPF tests")
 	}


### PR DESCRIPTION
Use RemoveMemlock() to avoid error seen on a local run of the bpf tests:

--- FAIL: TestBPF (0.02s)
    bpf_test.go:149: new coll: map test_cilium_signals: map create: operation not permitted (MEMLOCK may be too low, consider rlimit.RemoveMemlock)
FAIL

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
