### PR TITLE
Modify helm chart: delete validations for certManagerIssuerRef

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -22,18 +22,6 @@
   {{- end }}
 {{- end }}
 
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") }}
-  {{- if not .Values.hubble.tls.auto.certManagerIssuerRef }}
-    {{ fail "Hubble TLS certgen method=certmanager requires user specify .Values.hubble.tls.auto.certManagerIssuerRef" }}
-  {{- end }}  
-{{- end }}
-
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
-  {{- if not .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef }}
-    {{ fail "ClusterMesh TLS certgen method=certmanager requires user specify .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef" }}
-  {{- end }}  
-{{- end }}
-
 {{/* validate hubble-ui specific config */}}
 {{- if and .Values.hubble.ui.enabled
   (ne .Values.hubble.ui.backend.image.tag "latest")


### PR DESCRIPTION
Because the helm chart generates cert manager issuers and attaches them to certificates, we have to remove validations which fail if we don't specify certManagerIssuerRef.

I investigated that in #17238, 
- [firstly](https://github.com/cilium/cilium/pull/17238/commits/7d7aaac27cc6539ff1a88ce171f7748e0e46f6b1) we set the validations to restrict users to set their certManagerIssuer.
- But [finally](https://github.com/cilium/cilium/commit/e21d1b2a14d6dd75ef6bd5fd9c6dc4f75e9e930e), we added template files which generates issuers if users don't specify certManagerIssuer.

I think that we have to delete these validations, otherwise helm can't generate manifest files without specifying certManagerIssuerRef.

Here is the trial on my local:

1. Prepare `test-values.yaml`:
<details>
<summary>test-values.yaml</summary>

```yaml
rollOutCiliumPods: true

cni:
  exclusive: false
  debug:
    enabled: true

prometheus:
  enabled: true

operator:
  rollOutPods: true
  prometheus:
    enabled: true

kubeProxyReplacement: "strict"

k8sServiceHost: "172.16.102.137"
k8sServicePort: "6443"

bpf:
  masquerade: true

bgp:
  enabled: false
  announce:
    loadbalancerIP: true

ipam:
  mode: "kubernetes"

bgpControlPlane:
  enabled: true

ingressController:
  enabled: true

hubble:
  relay:
    rollOutPods: true
    enabled: true
  ui:
    rollOutPods: true
    enabled: true

bandwidthManager:
  enabled: true

cluster:
  name: "cluster2"
  id: 2

clustermesh:
  name: "cluster2"
  config:
    enable: true
  clusters: ["cluster1", "cluster2"]
  useAPIServer: true
  apiserver:
    tls:
      auto:
        method: "certmanager"

```

</details>

2. Using this `test-values.yaml`, I ran helm template:
```console
cd install/kubernetes/cilium
helm template test ./ --values=test-values.yaml > generated_manifests.yaml
```

3. Check the output. the following is the part of the output:
<details>
<summary>generated_manifests.yaml</summary>

```yaml
# Source: cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: clustermesh-apiserver-admin-cert
  namespace: default
spec:
  issuerRef:
    
      group: cert-manager.io
      kind: Issuer
      name: clustermesh-apiserver-issuer
  secretName: clustermesh-apiserver-admin-cert
  commonName: root
  dnsNames:
  - localhost
  duration: 26280h0m0s
---
# Source: cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: clustermesh-apiserver-remote-cert
  namespace: default
spec:
  issuerRef:
    
      group: cert-manager.io
      kind: Issuer
      name: clustermesh-apiserver-issuer
  secretName: clustermesh-apiserver-remote-cert
  commonName: remote
  duration: 26280h0m0s
---
# Source: cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: clustermesh-apiserver-server-cert
  namespace: default
spec:
  issuerRef:
    
      group: cert-manager.io
      kind: Issuer
      name: clustermesh-apiserver-issuer
  secretName: clustermesh-apiserver-server-cert
  commonName: clustermesh-apiserver.cilium.io
  dnsNames:
  - clustermesh-apiserver.cilium.io
  - "*.mesh.cilium.io"
  ipAddresses:
  - "127.0.0.1"
  - "::1"
  duration: 26280h0m0s
---
# Source: cilium/templates/cilium-ingress-service.yaml
apiVersion: v1
kind: Endpoints
metadata:
  name: cilium-ingress
  namespace: default
subsets:
- addresses:
  - ip: "192.192.192.192"
  ports:
  - port: 9999
---
# Source: cilium/templates/clustermesh-apiserver/tls-certmanager/clustermesh-apiserver-issuer.yaml
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: clustermesh-apiserver-issuer
  namespace: default
spec:
  ca:
    secretName: clustermesh-apiserver-ca-cert

```
</details>




Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #22784

```release-note
helm: Delete validations for certManagerIssuerRef
```
