### PR TITLE
CODEOWNERS: Cover test/bpf_tests by sig-datapath

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -459,6 +459,7 @@ jenkinsfiles @cilium/ci-structure
 /test/bpf/ @cilium/sig-datapath
 /test/bpf/check-complexity.sh @cilium/loader
 /test/bpf/verifier-test.sh @cilium/loader
+/test/bpf_tests/ @cilium/sig-datapath
 /test/k8s/bandwidth.go @cilium/sig-datapath @cilium/ci-structure
 /test/k8s/chaos.go @cilium/sig-datapath @cilium/ci-structure
 /test/k8s/datapath_configuration.go @cilium/sig-datapath @cilium/ci-structure


### PR DESCRIPTION
Fixes: 2ba0b4fd4b ("bpf: Add `BPF_PROG_TEST_RUN` based testing
framework")

Signed-off-by: Chris Tarazi <chris@isovalent.com>

---

Fixes: https://github.com/cilium/cilium/pull/20017
