### PR TITLE
Fix missing node neigh metric for counting arping requests

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1409,7 +1409,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 			collectors = append(collectors, APILimiterProcessedRequests)
 			c.APILimiterProcessedRequests = true
 
-		case Namespace + "_arping_requests_total":
+		case Namespace + "_" + SubsystemNodeNeigh + "_arping_requests_total":
 			ArpingRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 				Namespace: Namespace,
 				Subsystem: SubsystemNodeNeigh,


### PR DESCRIPTION
The metric was never enabled due to the missing subsystem from the
switch case.

Fixes: 42eb1edafda ("node-neigh: add metric to count arping requests")

Signed-off-by: Chris Tarazi <chris@isovalent.com>

---

Fixes: https://github.com/cilium/cilium/pull/14816
Related: https://github.com/cilium/cilium/pull/22888
