### PR TITLE
remove export from shell session to avoid the inconsistency

### DIFF
--- a/Documentation/gettingstarted/hubble-install.rst
+++ b/Documentation/gettingstarted/hubble-install.rst
@@ -6,7 +6,7 @@
 
       .. code-block:: shell-session
 
-         export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
+         HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
          HUBBLE_ARCH=amd64
          if [ "$(uname -m)" = "aarch64" ]; then HUBBLE_ARCH=arm64; fi
          curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
@@ -20,7 +20,7 @@
 
       .. code-block:: shell-session
 
-         export HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
+         HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
          HUBBLE_ARCH=amd64
          if [ "$(uname -m)" = "arm64" ]; then HUBBLE_ARCH=arm64; fi
          curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-${HUBBLE_ARCH}.tar.gz{,.sha256sum}


### PR DESCRIPTION
### Description

adding `export` to be environmental variable would be better for user-friendly installation doc, because that user would be likely to copy and paste the command described in this shell session to the terminal to process the installation.

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!