### PR TITLE
Local CI VM: Add comments for NFS's IP ranges

### DIFF
--- a/test/vagrant-local-start-runtime.sh
+++ b/test/vagrant-local-start-runtime.sh
@@ -15,5 +15,11 @@ else
     unset SERVER_VERSION
 fi
 
+if [[ "$NFS" != "0" ]]; then
+    echo "# NFS enabled. don't forget to enable these ports on your host"
+    echo "# before starting the VMs in order to have nfs working"
+    echo "# iptables -I INPUT -s 192.168.58.0/24 -j ACCEPT"
+fi
+
 echo "starting runtime vm"
 vagrant up runtime --provision

--- a/test/vagrant-local-start.sh
+++ b/test/vagrant-local-start.sh
@@ -20,6 +20,12 @@ else
     unset SERVER_VERSION
 fi
 
+if [[ "$NFS" != "0" ]]; then
+    echo "# NFS enabled. don't forget to enable these ports on your host"
+    echo "# before starting the VMs in order to have nfs working"
+    echo "# iptables -I INPUT -s 192.168.58.0/24 -j ACCEPT"
+fi
+
 echo "starting vms"
 for i in $( seq 1 ${K8S_NODES} )
 do


### PR DESCRIPTION
Like [contrib/vagrant/start.sh](https://github.com/cilium/cilium/blob/master/contrib/vagrant/start.sh#L448-L450), we should add comments about NFS's ip ranges on scripts for Local CI VMs.


Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #22901

```release-note
test: add comments for NFS's IP ranges on local CI VM scripts
```
