### PR TITLE
clustermesh: Make IPCache CPlane aware of the ClusterID

### DIFF
--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/api"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/ipcache"
 )
 
@@ -47,8 +48,10 @@ type ipCacheDumpListener struct {
 
 // OnIPIdentityCacheChange is called by DumpToListenerLocked
 func (ipc *ipCacheDumpListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
-	cidr net.IPNet, oldHostIP, newHostIP net.IP, oldID *ipcache.Identity,
+	cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *ipcache.Identity,
 	newID ipcache.Identity, encryptKey uint8, _ uint16, k8sMeta *ipcache.K8sMetadata) {
+	cidr := cidrCluster.AsIPNet()
+
 	// only capture entries which are a subnet of cidrFilter
 	if ipc.cidrFilter != nil && !containsSubnet(*ipc.cidrFilter, cidr) {
 		return

--- a/pkg/clustermesh/types/addressing.go
+++ b/pkg/clustermesh/types/addressing.go
@@ -347,3 +347,16 @@ func (pc PrefixCluster) AsIPNet() net.IPNet {
 		Mask: net.CIDRMask(pc.prefix.Bits(), addr.BitLen()),
 	}
 }
+
+// This function is solely exists for annotating IPCache's key string with ClusterID.
+// IPCache's key string is IP address or Prefix string (10.0.0.1 and 10.0.0.0/32 are
+// different entry). This function assumes given string is one of those format and
+// just put @<ClusterID> suffix and there's no format check for performance reason.
+// User must make sure the input is a valid IP or Prefix string.
+//
+// We should eventually remove this function once we finish refactoring IPCache and
+// stop using string as a key. At that point, we should consider using PrefixCluster
+// type for IPCache's key.
+func AnnotateIPCacheKeyWithClusterID(key string, clusterID uint32) string {
+	return key + "@" + strconv.FormatUint(uint64(clusterID), 10)
+}

--- a/pkg/clustermesh/types/addressing.go
+++ b/pkg/clustermesh/types/addressing.go
@@ -220,6 +220,10 @@ func (ac AddrCluster) AsNetIP() net.IP {
 	return ac.addr.AsSlice()
 }
 
+func (ac AddrCluster) AsPrefixCluster() PrefixCluster {
+	return PrefixClusterFrom(ac.addr, ac.addr.BitLen(), ac.clusterID)
+}
+
 // PrefixCluster is a type that holds a pair of prefix and ClusterID.
 // We should use this type as much as possible when we implement
 // prefix + Cluster addressing. We should avoid managing prefix and
@@ -228,6 +232,64 @@ func (ac AddrCluster) AsNetIP() net.IP {
 type PrefixCluster struct {
 	prefix    netip.Prefix
 	clusterID uint32
+}
+
+// ParsePrefixCluster parses s as an Prefix + ClusterID and returns PrefixCluster.
+// The string s can be a bare IP prefix string (any prefix format allowed in
+// netip.ParsePrefix()) or prefix string + @ + ClusterID with decimal. Bare prefix
+// string is considered as prefix string + @ + ClusterID = 0.
+func ParsePrefixCluster(s string) (PrefixCluster, error) {
+	atIndex := strings.LastIndex(s, "@")
+
+	var (
+		prefixStr    string
+		clusterIDStr string
+	)
+
+	if atIndex == -1 {
+		// s may be a bare IP prefix string, still valid
+		prefixStr = s
+		clusterIDStr = ""
+	} else {
+		// s may be a prefix + ClusterID string
+		prefixStr = s[:atIndex]
+		clusterIDStr = s[atIndex+1:]
+	}
+
+	prefix, err := netip.ParsePrefix(prefixStr)
+	if err != nil {
+		return PrefixCluster{}, err
+	}
+
+	if clusterIDStr == "" {
+		if atIndex != len(s)-1 {
+			return PrefixCluster{prefix: prefix, clusterID: 0}, nil
+		} else {
+			// handle the invalid case like "10.0.0.0/24@"
+			return PrefixCluster{}, fmt.Errorf("empty cluster ID")
+		}
+	}
+
+	clusterID64, err := strconv.ParseUint(clusterIDStr, 10, 32)
+	if err != nil {
+		return PrefixCluster{}, err
+	}
+
+	return PrefixCluster{prefix: prefix, clusterID: uint32(clusterID64)}, nil
+}
+
+// MustParsePrefixCluster calls ParsePrefixCluster(s) and panics on error.
+// It is intended for use in tests with hard-coded strings.
+func MustParsePrefixCluster(s string) PrefixCluster {
+	prefixCluster, err := ParsePrefixCluster(s)
+	if err != nil {
+		panic(err)
+	}
+	return prefixCluster
+}
+
+func (pc PrefixCluster) IsSingleIP() bool {
+	return pc.prefix.IsSingleIP()
 }
 
 func PrefixClusterFrom(addr netip.Addr, bits int, clusterID uint32) PrefixCluster {
@@ -271,4 +333,17 @@ func (pc PrefixCluster) String() string {
 		return pc.prefix.String()
 	}
 	return pc.prefix.String() + "@" + strconv.FormatUint(uint64(pc.clusterID), 10)
+}
+
+// AsIPNet returns the IP prefix part of PrefixCluster as a net.IPNet type. This
+// function exists for keeping backward compatibility between the existing
+// components which are not aware of the cluster-aware addressing. Calling
+// this function against the PrefixCluster which has non-zero clusterID will
+// lose the ClusterID information. It should be used with an extra care.
+func (pc PrefixCluster) AsIPNet() net.IPNet {
+	addr := pc.prefix.Addr()
+	return net.IPNet{
+		IP:   addr.AsSlice(),
+		Mask: net.CIDRMask(pc.prefix.Bits(), addr.BitLen()),
+	}
 }

--- a/pkg/clustermesh/types/addressing_test.go
+++ b/pkg/clustermesh/types/addressing_test.go
@@ -190,3 +190,43 @@ func TestAddrCluster_String(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePrefixCluster(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		wantErr bool
+	}{
+		{"valid bare IPv4 prefix", "10.0.0.0/24", false},
+		{"invalid bare IPv4 prefix 1", "10.0.0.0", true},
+		{"invalid bare IPv4 prefix 2", "257.0.0.0/24", true},
+
+		{"valid IPv4 prefix and valid cluster-id", "10.0.0.0/24@1", false},
+		{"invalid IPv4 prefix and valid cluster-id", "257.0.0.0/24@1", true},
+		{"valid IPv4 prefix and invalid cluster-id", "10.0.0.0/24@foo", true},
+		{"valid IPv4 prefix and empty cluster-id", "10.0.0.0/24@", true},
+
+		{"valid bare IPv6 prefix", "a::/64", false},
+		{"invalid bare IPv6 prefix", "g::/64", true},
+
+		{"valid IPv6 prefix and valid cluster-id", "a::/64@1", false},
+		{"invalid IPv6 prefix and valid cluster-id", "g::/64@1", true},
+		{"valid IPv6 prefix and invalid cluster-id", "a::/64@foo", true},
+		{"valid IPv6 prefix and empty cluster-id", "a::/64@", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePrefixCluster(tt.arg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParsePrefixCluster() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+
+	// Ensure bare IP address equals to ClusterID = 0
+	if MustParsePrefixCluster("10.0.0.0/24") != MustParsePrefixCluster("10.0.0.0/24@0") {
+		t.Errorf("ParsePrefixCluster() returns different results for bare IP prefix and IP prefix with zero ClusterID")
+		return
+	}
+}

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging"
@@ -115,9 +116,10 @@ func (l *BPFListener) notifyMonitor(modType ipcache.CacheModification,
 // 'oldIPIDPair' is ignored here, because in the BPF maps an update for the
 // IP->ID mapping will replace any existing contents; knowledge of the old pair
 // is not required to upsert the new pair.
-func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet,
+func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster,
 	oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity,
 	encryptKey uint8, nodeID uint16, k8sMeta *ipcache.K8sMetadata) {
+	cidr := cidrCluster.AsIPNet()
 
 	scopedLog := log
 	if option.Config.Debug {

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -13,6 +13,7 @@ import (
 	envoyAPI "github.com/cilium/proxy/go/cilium/api"
 	"github.com/sirupsen/logrus"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -94,11 +95,14 @@ func (cache *NPHDSCache) OnIPIdentityCacheGC() {
 // OnIPIdentityCacheChange pushes modifications to the IP<->Identity mapping
 // into the Network Policy Host Discovery Service (NPHDS).
 //
-// Note that the caller is responsible for passing 'oldID' when 'cidr' has been associated with a
-// different ID before, as this function does not search for conflicting IP/ID mappings.
-func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet,
+// Note that the caller is responsible for passing 'oldID' when 'cidrCluster' has been
+// associated with a different ID before, as this function does not search for conflicting
+// IP/ID mappings.
+func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster,
 	oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity,
 	encryptKey uint8, nodeID uint16, k8sMeta *ipcache.K8sMetadata) {
+	cidr := cidrCluster.AsIPNet()
+
 	cidrStr := cidr.String()
 	resourceName := newID.ID.StringID()
 
@@ -126,7 +130,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModificati
 		// but only if the old ID is different.
 		if oldID != nil && oldID.ID != newID.ID {
 			// Recursive call to delete the 'cidr' from the 'oldID'
-			cache.OnIPIdentityCacheChange(ipcache.Delete, cidr, nil, nil, nil, *oldID, encryptKey, nodeID, k8sMeta)
+			cache.OnIPIdentityCacheChange(ipcache.Delete, cidrCluster, nil, nil, nil, *oldID, encryptKey, nodeID, k8sMeta)
 		}
 		err := cache.handleIPUpsert(npHost, resourceName, cidrStr, newID.ID)
 		if err != nil {

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -14,6 +14,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/checker"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -564,12 +565,12 @@ func newDummyListener(ipc *IPCache) *dummyListener {
 }
 
 func (dl *dummyListener) OnIPIdentityCacheChange(modType CacheModification,
-	cidr net.IPNet, oldHostIP, newHostIP net.IP, oldID *Identity,
+	cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *Identity,
 	newID Identity, encryptKey uint8, _ uint16, k8sMeta *K8sMetadata) {
 
 	switch modType {
 	case Upsert:
-		dl.entries[cidr.String()] = newID.ID
+		dl.entries[cidrCluster.String()] = newID.ID
 	default:
 		// Ignore, for simplicity we just clear the cache every time
 	}

--- a/pkg/ipcache/listener.go
+++ b/pkg/ipcache/listener.go
@@ -5,6 +5,8 @@ package ipcache
 
 import (
 	"net"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 )
 
 // CacheModification represents the type of operation performed upon IPCache.
@@ -28,7 +30,7 @@ type IPIdentityMappingListener interface {
 	// hostIP is optional and may only be non-nil for an Upsert modification.
 	// k8sMeta contains the Kubernetes pod namespace and name behind the IP
 	// and may be nil.
-	OnIPIdentityCacheChange(modType CacheModification, cidr net.IPNet, oldHostIP, newHostIP net.IP,
+	OnIPIdentityCacheChange(modType CacheModification, cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP,
 		oldID *Identity, newID Identity, encryptKey uint8, nodeID uint16, k8sMeta *K8sMetadata)
 
 	// OnIPIdentityCacheGC will be called to sync other components which are

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -248,6 +248,9 @@ const (
 	// ClusterName is the name of the cluster
 	ClusterName = "clusterName"
 
+	// AddrCluster is a pair of IP address and ClusterID
+	AddrCluster = "addrCluster"
+
 	// ServiceID is the orchestration unique ID of a service
 	ServiceID = "serviceID"
 

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/cidr"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -491,8 +492,9 @@ func loadOrGeneratePrivKey(filePath string) (key wgtypes.Key, err error) {
 }
 
 // OnIPIdentityCacheChange implements ipcache.IPIdentityMappingListener
-func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, ipnet net.IPNet, oldHostIP, newHostIP net.IP,
+func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP,
 	_ *ipcache.Identity, _ ipcache.Identity, _ uint8, _ uint16, _ *ipcache.K8sMetadata) {
+	ipnet := cidrCluster.AsIPNet()
 
 	// This function is invoked from the IPCache with the
 	// ipcache.IPIdentityCache lock held. We therefore need to be careful when


### PR DESCRIPTION
This is a part of the Cluster Mesh with overlapping PodCIDR support. This PR extends IPCache CPlane (specifically, IPIdentityWatcher) to take ClusterID. Please see the commit messages for more details. Note that this PR only adds infrastructure for taking ClusterID and no one actually uses it yet.

```release-note
clustermesh: Make IPCache CPlane aware of the ClusterID
```
