### PR TITLE
bpf: lb: introduce an optimized CT lookup

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -617,25 +617,18 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx)
 		struct lb6_service *svc;
 		struct lb6_key key = {};
 		__u16 proxy_port = 0;
-		int l4_off, hdrlen;
+		int l4_off;
 
-		tuple.nexthdr = ip6->nexthdr;
-		ipv6_addr_copy(&tuple.daddr, (union v6addr *)&ip6->daddr);
-		ipv6_addr_copy(&tuple.saddr, (union v6addr *)&ip6->saddr);
-
-		hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
-		if (hdrlen < 0)
-			return hdrlen;
-
-		l4_off = ETH_HLEN + hdrlen;
-
-		ret = lb6_extract_key(ctx, &tuple, l4_off, &key, &csum_off);
+		ret = lb6_extract_tuple(ctx, ip6, &l4_off, &tuple);
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
 				goto skip_service_lookup;
 			else
 				return ret;
 		}
+
+		lb6_fill_key(&key, &tuple);
+		csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
 		/*
 		 * Check if the destination address is among the address that should

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1163,19 +1163,18 @@ static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx)
 		int l4_off;
 
 		has_l4_header = ipv4_has_l4_header(ip4);
-		tuple.nexthdr = ip4->protocol;
-		tuple.daddr = ip4->daddr;
-		tuple.saddr = ip4->saddr;
 
-		l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
-
-		ret = lb4_extract_key(ctx, ip4, l4_off, &key, &csum_off);
+		ret = lb4_extract_tuple(ctx, ip4, &l4_off, &tuple);
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
 				goto skip_service_lookup;
 			else
 				return ret;
 		}
+
+		lb4_fill_key(&key, &tuple);
+		if (has_l4_header)
+			csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
 		svc = lb4_lookup_service(&key, is_defined(ENABLE_NODEPORT), false);
 		if (svc) {

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -51,7 +51,7 @@ static __always_inline bool ct_entry_seen_both_syns(const struct ct_entry *entry
  * - Non-zero if this flow has not been monitored recently.
  */
 static __always_inline __u32 __ct_update_timeout(struct ct_entry *entry,
-						 __u32 lifetime, int dir,
+						 __u32 lifetime, enum ct_dir dir,
 						 union tcp_flags flags,
 						 __u8 report_mask)
 {
@@ -123,7 +123,7 @@ static __always_inline __u32 __ct_update_timeout(struct ct_entry *entry,
  * last_updated timestamp and returns true. Otherwise returns false.
  */
 static __always_inline __u32 ct_update_timeout(struct ct_entry *entry,
-					       bool tcp, int dir,
+					       bool tcp, enum ct_dir dir,
 					       union tcp_flags seen_flags)
 {
 	__u32 lifetime = dir == CT_SERVICE ?
@@ -174,7 +174,7 @@ ct_entry_expired_rebalance(const struct ct_entry *entry)
 }
 
 static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
-					const void *tuple, int action, int dir,
+					const void *tuple, int action, enum ct_dir dir,
 					struct ct_state *ct_state,
 					bool is_tcp, union tcp_flags seen_flags,
 					__u32 *monitor)
@@ -331,7 +331,7 @@ ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
 static __always_inline int ct_lookup6(const void *map,
 				      struct ipv6_ct_tuple *tuple,
 				      struct __ctx_buff *ctx, int l4_off,
-				      int dir, struct ct_state *ct_state,
+				      enum ct_dir dir, struct ct_state *ct_state,
 				      __u32 *monitor)
 {
 	int ret = CT_NEW, action = ACTION_UNSPEC;
@@ -806,7 +806,7 @@ ct_update6_dsr(const void *map, const struct ipv6_ct_tuple *tuple,
 /* Offset must point to IPv6 */
 static __always_inline int ct_create6(const void *map_main, const void *map_related,
 				      struct ipv6_ct_tuple *tuple,
-				      struct __ctx_buff *ctx, const int dir,
+				      struct __ctx_buff *ctx, const enum ct_dir dir,
 				      const struct ct_state *ct_state,
 				      bool proxy_redirect, bool from_l7lb,
 				      bool auth_required)
@@ -916,7 +916,7 @@ ct_update4_dsr(const void *map, const struct ipv4_ct_tuple *tuple,
 static __always_inline int ct_create4(const void *map_main,
 				      const void *map_related,
 				      struct ipv4_ct_tuple *tuple,
-				      struct __ctx_buff *ctx, const int dir,
+				      struct __ctx_buff *ctx, const enum ct_dir dir,
 				      const struct ct_state *ct_state,
 				      bool proxy_redirect, bool from_l7lb,
 				      bool auth_required)

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -327,6 +327,79 @@ ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
 	ct_flip_tuple_dir6(tuple);
 }
 
+static __always_inline int
+__ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ctx,
+	     int l4_off, int action, enum ct_dir dir, struct ct_state *ct_state,
+	     __u32 *monitor)
+{
+	bool is_tcp = tuple->nexthdr == IPPROTO_TCP;
+	union tcp_flags tcp_flags = { .value = 0 };
+	int ret;
+
+	if (is_tcp) {
+		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+			return DROP_CT_INVALID_HDR;
+
+		if (unlikely(tcp_flags.value & (TCP_FLAG_RST | TCP_FLAG_FIN)))
+			action = ACTION_CLOSE;
+	}
+
+	/* Lookup the reverse direction
+	 *
+	 * This will find an existing flow in the reverse direction.
+	 * The reverse direction is the one where reverse nat index is stored.
+	 */
+	cilium_dbg3(ctx, DBG_CT_LOOKUP6_1, (__u32)tuple->saddr.p4, (__u32)tuple->daddr.p4,
+		    (bpf_ntohs(tuple->sport) << 16) | bpf_ntohs(tuple->dport));
+	cilium_dbg3(ctx, DBG_CT_LOOKUP6_2, (tuple->nexthdr << 8) | tuple->flags, 0, 0);
+	ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state, is_tcp,
+			  tcp_flags, monitor);
+	if (ret != CT_NEW) {
+		if (likely(ret == CT_ESTABLISHED || ret == CT_REOPENED)) {
+			if (unlikely(tuple->flags & TUPLE_F_RELATED))
+				ret = CT_RELATED;
+			else
+				ret = CT_REPLY;
+		}
+		goto out;
+	}
+
+	/* Lookup entry in forward direction */
+	if (dir != CT_SERVICE) {
+		ipv6_ct_tuple_reverse(tuple);
+		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
+				  is_tcp, tcp_flags, monitor);
+	}
+out:
+	cilium_dbg(ctx, DBG_CT_VERDICT, ret < 0 ? -ret : ret, ct_state->rev_nat_index);
+	return ret;
+}
+
+static __always_inline int
+ct_lb_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
+	      struct __ctx_buff *ctx, int l4_off, enum ct_dir dir,
+	      struct ct_state *ct_state, __u32 *monitor)
+{
+	/* The tuple is created in reverse order initially to find a
+	 * potential reverse flow. This is required because the RELATED
+	 * or REPLY state takes precedence over ESTABLISHED due to
+	 * policy requirements.
+	 *
+	 * tuple->flags separates entries that could otherwise be overlapping.
+	 */
+	if (dir == CT_INGRESS)
+		tuple->flags = TUPLE_F_OUT;
+	else if (dir == CT_EGRESS)
+		tuple->flags = TUPLE_F_IN;
+	else if (dir == CT_SERVICE)
+		tuple->flags = TUPLE_F_SERVICE;
+	else
+		return DROP_CT_INVALID_HDR;
+
+	return __ct_lookup6(map, tuple, ctx, l4_off, ACTION_CREATE, dir,
+			    ct_state, monitor);
+}
+
 /* Offset must point to IPv6 */
 static __always_inline int ct_lookup6(const void *map,
 				      struct ipv6_ct_tuple *tuple,
@@ -334,9 +407,7 @@ static __always_inline int ct_lookup6(const void *map,
 				      enum ct_dir dir, struct ct_state *ct_state,
 				      __u32 *monitor)
 {
-	int ret = CT_NEW, action = ACTION_UNSPEC;
-	bool is_tcp = tuple->nexthdr == IPPROTO_TCP;
-	union tcp_flags tcp_flags = { .value = 0 };
+	int action = ACTION_UNSPEC;
 
 	/* The tuple is created in reverse order initially to find a
 	 * potential reverse flow. This is required because the RELATED
@@ -394,21 +465,6 @@ static __always_inline int ct_lookup6(const void *map,
 		break;
 
 	case IPPROTO_TCP:
-		if (1) {
-			if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-				return DROP_CT_INVALID_HDR;
-
-			if (unlikely(tcp_flags.value & (TCP_FLAG_RST|TCP_FLAG_FIN)))
-				action = ACTION_CLOSE;
-			else
-				action = ACTION_CREATE;
-		}
-
-		/* load sport + dport into tuple */
-		if (ctx_load_bytes(ctx, l4_off, &tuple->dport, 4) < 0)
-			return DROP_CT_INVALID_HDR;
-		break;
-
 	case IPPROTO_UDP:
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
@@ -425,35 +481,7 @@ static __always_inline int ct_lookup6(const void *map,
 		return DROP_CT_UNKNOWN_PROTO;
 	}
 
-	/* Lookup the reverse direction
-	 *
-	 * This will find an existing flow in the reverse direction.
-	 * The reverse direction is the one where reverse nat index is stored.
-	 */
-	cilium_dbg3(ctx, DBG_CT_LOOKUP6_1, (__u32) tuple->saddr.p4, (__u32) tuple->daddr.p4,
-		      (bpf_ntohs(tuple->sport) << 16) | bpf_ntohs(tuple->dport));
-	cilium_dbg3(ctx, DBG_CT_LOOKUP6_2, (tuple->nexthdr << 8) | tuple->flags, 0, 0);
-	ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state, is_tcp,
-			  tcp_flags, monitor);
-	if (ret != CT_NEW) {
-		if (likely(ret == CT_ESTABLISHED || ret == CT_REOPENED)) {
-			if (unlikely(tuple->flags & TUPLE_F_RELATED))
-				ret = CT_RELATED;
-			else
-				ret = CT_REPLY;
-		}
-		goto out;
-	}
-
-	/* Lookup entry in forward direction */
-	if (dir != CT_SERVICE) {
-		ipv6_ct_tuple_reverse(tuple);
-		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
-				  is_tcp, tcp_flags, monitor);
-	}
-out:
-	cilium_dbg(ctx, DBG_CT_VERDICT, ret < 0 ? -ret : ret, ct_state->rev_nat_index);
-	return ret;
+	return __ct_lookup6(map, tuple, ctx, action, l4_off, dir, ct_state, monitor);
 }
 
 static __always_inline int
@@ -635,16 +663,104 @@ ct_is_reply4(const void *map, struct __ctx_buff *ctx, int off,
 	return 0;
 }
 
+static __always_inline int
+__ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ctx,
+	     int l4_off, bool has_l4_header, int action, enum ct_dir dir,
+	     struct ct_state *ct_state, __u32 *monitor)
+{
+	bool is_tcp = tuple->nexthdr == IPPROTO_TCP;
+	union tcp_flags tcp_flags = { .value = 0 };
+	int ret;
+
+	if (is_tcp && has_l4_header) {
+		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+			return DROP_CT_INVALID_HDR;
+
+		if (unlikely(tcp_flags.value & (TCP_FLAG_RST | TCP_FLAG_FIN)))
+			action = ACTION_CLOSE;
+	}
+
+	/* Lookup the reverse direction
+	 *
+	 * This will find an existing flow in the reverse direction.
+	 */
+#ifndef QUIET_CT
+	cilium_dbg3(ctx, DBG_CT_LOOKUP4_1, tuple->saddr, tuple->daddr,
+		    (bpf_ntohs(tuple->sport) << 16) | bpf_ntohs(tuple->dport));
+	cilium_dbg3(ctx, DBG_CT_LOOKUP4_2, (tuple->nexthdr << 8) | tuple->flags, 0, 0);
+#endif
+	ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state, is_tcp,
+			  tcp_flags, monitor);
+	if (ret != CT_NEW) {
+		if (likely(ret == CT_ESTABLISHED || ret == CT_REOPENED)) {
+			if (unlikely(tuple->flags & TUPLE_F_RELATED))
+				ret = CT_RELATED;
+			else
+				ret = CT_REPLY;
+		}
+		goto out;
+	}
+
+	relax_verifier();
+
+	/* Lookup entry in forward direction */
+	if (dir != CT_SERVICE) {
+		ipv4_ct_tuple_reverse(tuple);
+		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
+				  is_tcp, tcp_flags, monitor);
+	}
+out:
+	cilium_dbg(ctx, DBG_CT_VERDICT, ret < 0 ? -ret : ret, ct_state->rev_nat_index);
+	return ret;
+}
+
+/** Lookup a CT entry for a fully populated CT tuple
+ * @arg map		CT map
+ * @arg tuple		CT tuple (with populated L4 ports)
+ * @arg ctx		packet
+ * @arg l4_off		offset to L4 header
+ * @arg has_l4_header	packet has L4 header
+ * @arg dir		lookup direction
+ * @arg ct_state	returned CT entry
+ * @arg monitor		monitor feedback for trace aggregation
+ *
+ * This differs from ct_lookup4(), as here we expect that
+ * - the CT tuple has its L4 ports populated,
+ * - the L4 protocol is a SVC protocol (ie SCTP / UDP / TCP)
+ */
+static __always_inline int
+ct_lb_lookup4(const void *map, struct ipv4_ct_tuple *tuple,
+	      struct __ctx_buff *ctx, int l4_off, bool has_l4_header,
+	      enum ct_dir dir, struct ct_state *ct_state, __u32 *monitor)
+{
+	/* The tuple is created in reverse order initially to find a
+	 * potential reverse flow. This is required because the RELATED
+	 * or REPLY state takes precedence over ESTABLISHED due to
+	 * policy requirements.
+	 *
+	 * tuple->flags separates entries that could otherwise be overlapping.
+	 */
+	if (dir == CT_INGRESS)
+		tuple->flags = TUPLE_F_OUT;
+	else if (dir == CT_EGRESS)
+		tuple->flags = TUPLE_F_IN;
+	else if (dir == CT_SERVICE)
+		tuple->flags = TUPLE_F_SERVICE;
+	else
+		return DROP_CT_INVALID_HDR;
+
+	return __ct_lookup4(map, tuple, ctx, l4_off, has_l4_header,
+			    ACTION_CREATE, dir, ct_state, monitor);
+}
+
 /* Offset must point to IPv4 header */
 static __always_inline int ct_lookup4(const void *map,
 				      struct ipv4_ct_tuple *tuple,
 				      struct __ctx_buff *ctx, int off, enum ct_dir dir,
 				      struct ct_state *ct_state, __u32 *monitor)
 {
-	int err, ret = CT_NEW, action = ACTION_UNSPEC;
-	bool is_tcp = tuple->nexthdr == IPPROTO_TCP,
-	     has_l4_header = true;
-	union tcp_flags tcp_flags = { .value = 0 };
+	int err, action = ACTION_UNSPEC;
+	bool has_l4_header = true;
 
 	/* The tuple is created in reverse order initially to find a
 	 * potential reverse flow. This is required because the RELATED
@@ -699,69 +815,23 @@ static __always_inline int ct_lookup4(const void *map,
 		break;
 
 	case IPPROTO_TCP:
+	case IPPROTO_UDP:
+#ifdef ENABLE_SCTP
+	case IPPROTO_SCTP:
+#endif  /* ENABLE_SCTP */
 		err = ipv4_ct_extract_l4_ports(ctx, off, dir, tuple, &has_l4_header);
 		if (err < 0)
 			return err;
 
 		action = ACTION_CREATE;
-
-		if (has_l4_header) {
-			if (l4_load_tcp_flags(ctx, off, &tcp_flags) < 0)
-				return DROP_CT_INVALID_HDR;
-
-			if (unlikely(tcp_flags.value & (TCP_FLAG_RST|TCP_FLAG_FIN)))
-				action = ACTION_CLOSE;
-		}
 		break;
-
-	case IPPROTO_UDP:
-#ifdef ENABLE_SCTP
-	case IPPROTO_SCTP:
-#endif  /* ENABLE_SCTP */
-		err = ipv4_ct_extract_l4_ports(ctx, off, dir, tuple, NULL);
-		if (err < 0)
-			return err;
-
-		action = ACTION_CREATE;
-		break;
-
 	default:
 		/* Can't handle extension headers yet */
 		return DROP_CT_UNKNOWN_PROTO;
 	}
 
-	/* Lookup the reverse direction
-	 *
-	 * This will find an existing flow in the reverse direction.
-	 */
-#ifndef QUIET_CT
-	cilium_dbg3(ctx, DBG_CT_LOOKUP4_1, tuple->saddr, tuple->daddr,
-		      (bpf_ntohs(tuple->sport) << 16) | bpf_ntohs(tuple->dport));
-	cilium_dbg3(ctx, DBG_CT_LOOKUP4_2, (tuple->nexthdr << 8) | tuple->flags, 0, 0);
-#endif
-	ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state, is_tcp,
-			  tcp_flags, monitor);
-	if (ret != CT_NEW) {
-		if (likely(ret == CT_ESTABLISHED || ret == CT_REOPENED)) {
-			if (unlikely(tuple->flags & TUPLE_F_RELATED))
-				ret = CT_RELATED;
-			else
-				ret = CT_REPLY;
-		}
-		goto out;
-	}
-
-	relax_verifier();
-
-	/* Lookup entry in forward direction */
-	if (dir != CT_SERVICE) {
-		ipv4_ct_tuple_reverse(tuple);
-		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
-				  is_tcp, tcp_flags, monitor);
-	}
-out:
-	cilium_dbg(ctx, DBG_CT_VERDICT, ret < 0 ? -ret : ret, ct_state->rev_nat_index);
-	return ret;
+	return __ct_lookup4(map, tuple, ctx, off, has_l4_header,
+			    action, dir, ct_state, monitor);
 }
 
 static __always_inline void

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -349,11 +349,10 @@ bool lb6_svc_is_l7loadbalancer(const struct lb6_service *svc __maybe_unused)
 #endif
 }
 
-static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
-					   int l4_off,
-					   enum ct_dir dir __maybe_unused,
-					   __be16 *port,
-					   __maybe_unused struct iphdr *ip4)
+static __always_inline int
+lb4_extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr, int l4_off,
+		    enum ct_dir dir __maybe_unused, __be16 *port,
+		    __maybe_unused struct iphdr *ip4)
 {
 	int ret;
 
@@ -364,7 +363,7 @@ static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
 #ifdef ENABLE_IPV4_FRAGMENTS
-		if (ip4) {
+		{
 			struct ipv4_frag_l4ports ports = { };
 
 			ret = ipv4_handle_fragmentation(ctx, ip4, l4_off,
@@ -381,7 +380,6 @@ static __always_inline int extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 			return ret;
 		break;
 
-	case IPPROTO_ICMPV6:
 	case IPPROTO_ICMP:
 		/* No need to perform a service lookup for ICMP packets */
 		return DROP_NO_SERVICE;
@@ -1185,7 +1183,7 @@ static __always_inline int lb4_extract_key(struct __ctx_buff *ctx __maybe_unused
 	if (ipv4_has_l4_header(ip4))
 		csum_l4_offset_and_flags(ip4->protocol, csum_off);
 
-	return extract_l4_port(ctx, ip4->protocol, l4_off, CT_EGRESS, &key->dport, ip4);
+	return lb4_extract_l4_port(ctx, ip4->protocol, l4_off, CT_EGRESS, &key->dport, ip4);
 }
 
 static __always_inline int

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -851,7 +851,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		return DROP_NO_SERVICE;
 
 	/* See lb4_local comments re svc endpoint lookup process */
-	ret = ct_lookup6(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
+	ret = ct_lb_lookup6(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 #ifdef ENABLE_SESSION_AFFINITY
@@ -1542,7 +1542,8 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 	if (unlikely(svc->count == 0))
 		return DROP_NO_SERVICE;
 
-	ret = ct_lookup4(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
+	ret = ct_lb_lookup4(map, tuple, ctx, l4_off, has_l4_header, CT_SERVICE,
+			    state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 #ifdef ENABLE_SESSION_AFFINITY

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1086,7 +1086,8 @@ static __always_inline int snat_v6_track_connection(struct __ctx_buff *ctx,
 	struct ipv6_ct_tuple tmp;
 	bool needs_ct = false;
 	__u32 monitor = 0;
-	int ret, where;
+	enum ct_dir where;
+	int ret;
 
 	if (state && state->common.host_local) {
 		needs_ct = true;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -926,8 +926,8 @@ skip_service_lookup:
 	if (backend_local || !nodeport_uses_dsr6(&tuple)) {
 		struct ct_state ct_state = {};
 
-		ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
-				 CT_EGRESS, &ct_state, &monitor);
+		ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
+				    CT_EGRESS, &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
 redo:
@@ -1015,8 +1015,8 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 	if (!ct_has_nodeport_egress_entry6(get_ct_map6(&tuple), &tuple))
 		return CTX_ACT_OK;
 
-	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
-			 &ct_state, &trace->monitor);
+	ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
+			    &ct_state, &trace->monitor);
 
 	if (ret == CT_REPLY && ct_state.node_port && ct_state.rev_nat_index) {
 		struct csum_offset csum_off = {};
@@ -1069,8 +1069,8 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __u32 *ifind
 
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
-	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS, &ct_state,
-			 &monitor);
+	ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
+			    &ct_state, &monitor);
 
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		ret2 = lb6_rev_nat(ctx, l4_off, &csum_off, ct_state.rev_nat_index,
@@ -2003,8 +2003,8 @@ skip_service_lookup:
 	if (backend_local || !nodeport_uses_dsr4(&tuple)) {
 		struct ct_state ct_state = {};
 
-		ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-				 CT_EGRESS, &ct_state, &monitor);
+		ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
+				    has_l4_header, CT_EGRESS, &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
 redo:
@@ -2064,10 +2064,13 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 	struct ipv4_ct_tuple tuple = {};
 	struct ct_state ct_state = {};
 	void *data, *data_end;
+	bool has_l4_header;
 	struct iphdr *ip4;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
+
+	has_l4_header = ipv4_has_l4_header(ip4);
 
 	ret = lb4_extract_tuple(ctx, ip4, &l4_off, &tuple);
 	if (ret < 0) {
@@ -2080,9 +2083,8 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 	if (!ct_has_nodeport_egress_entry4(get_ct_map4(&tuple), &tuple))
 		return CTX_ACT_OK;
 
-	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
-			 &ct_state, &trace->monitor);
-
+	ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
+			    has_l4_header, CT_INGRESS, &ct_state, &trace->monitor);
 	if (ret == CT_REPLY && ct_state.node_port && ct_state.rev_nat_index) {
 		struct csum_offset csum_off = {};
 
@@ -2091,7 +2093,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 
 		ret = lb4_rev_nat(ctx, l3_off, l4_off, &csum_off, &ct_state,
 				  &tuple, REV_NAT_F_TUPLE_SADDR,
-				  ipv4_has_l4_header(ip4));
+				  has_l4_header);
 		if (IS_ERR(ret))
 			return ret;
 
@@ -2126,6 +2128,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 	bool l2_hdr_required = true;
 	__u32 tunnel_endpoint __maybe_unused = 0;
 	__u32 dst_id __maybe_unused = 0;
+	bool has_l4_header;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -2138,6 +2141,8 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 	if (egress_gw_reply_needs_redirect(ip4, &tunnel_endpoint, &dst_id))
 		goto encap_redirect;
 #endif /* ENABLE_EGRESS_GATEWAY */
+
+	has_l4_header = ipv4_has_l4_header(ip4);
 
 	ret = lb4_extract_tuple(ctx, ip4, &l4_off, &tuple);
 	if (ret < 0) {
@@ -2152,14 +2157,14 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
-	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_INGRESS, &ct_state,
-			 &monitor);
+	ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
+			    has_l4_header, CT_INGRESS, &ct_state, &monitor);
 
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		reason = TRACE_REASON_CT_REPLY;
 		ret2 = lb4_rev_nat(ctx, l3_off, l4_off, &csum_off,
 				   &ct_state, &tuple,
-				   REV_NAT_F_TUPLE_SADDR, ipv4_has_l4_header(ip4));
+				   REV_NAT_F_TUPLE_SADDR, has_l4_header);
 		if (IS_ERR(ret2))
 			return ret2;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1880,6 +1880,7 @@ drop_err:
 static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 					__u32 src_identity)
 {
+	bool backend_local, l4_ports, has_l4_header;
 	struct ipv4_ct_tuple tuple = {};
 	void *data, *data_end;
 	struct iphdr *ip4;
@@ -1888,7 +1889,6 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	struct lb4_service *svc;
 	struct lb4_key key = {};
 	struct ct_state ct_state_new = {};
-	bool backend_local, l4_ports;
 	__u32 monitor = 0;
 
 	cilium_capture_in(ctx);
@@ -1896,13 +1896,9 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
-	tuple.nexthdr = ip4->protocol;
-	tuple.daddr = ip4->daddr;
-	tuple.saddr = ip4->saddr;
+	has_l4_header = ipv4_has_l4_header(ip4);
 
-	l4_off = l3_off + ipv4_hdrlen(ip4);
-
-	ret = lb4_extract_key(ctx, ip4, l4_off, &key, &csum_off);
+	ret = lb4_extract_tuple(ctx, ip4, &l4_off, &tuple);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_NO_SERVICE)
 			goto skip_service_lookup;
@@ -1912,6 +1908,10 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 		}
 		return ret;
 	}
+
+	lb4_fill_key(&key, &tuple);
+	if (has_l4_header)
+		csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
 	svc = lb4_lookup_service(&key, false, false);
 	if (svc) {
@@ -1942,7 +1942,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 		} else {
 			ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off,
 					&csum_off, &key, &tuple, svc, &ct_state_new,
-					ip4->saddr, ipv4_has_l4_header(ip4),
+					ip4->saddr, has_l4_header,
 					skip_l3_xlate);
 		}
 		if (IS_ERR(ret))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -836,7 +836,7 @@ drop_err:
 static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 					__u32 src_identity)
 {
-	int ret, l3_off = ETH_HLEN, l4_off, hdrlen;
+	int ret, l3_off = ETH_HLEN, l4_off;
 	struct ipv6_ct_tuple tuple = {};
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -852,17 +852,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	tuple.nexthdr = ip6->nexthdr;
-	ipv6_addr_copy(&tuple.daddr, (union v6addr *) &ip6->daddr);
-	ipv6_addr_copy(&tuple.saddr, (union v6addr *) &ip6->saddr);
-
-	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
-	if (hdrlen < 0)
-		return hdrlen;
-
-	l4_off = l3_off + hdrlen;
-
-	ret = lb6_extract_key(ctx, &tuple, l4_off, &key, &csum_off);
+	ret = lb6_extract_tuple(ctx, ip6, &l4_off, &tuple);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_NO_SERVICE)
 			goto skip_service_lookup;
@@ -872,6 +862,9 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 		}
 		return ret;
 	}
+
+	lb6_fill_key(&key, &tuple);
+	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
 	svc = lb6_lookup_service(&key, false, false);
 	if (svc) {


### PR DESCRIPTION
This splits off the CT improvements from https://github.com/cilium/cilium/pull/22978 for easier reviewing (ie no need to follow all the DSR changes in that PR). They are needed to slim down the instruction count in the nodeport path. 

The main idea is to extract a fully populated CT tuple in the service lookup path *once*, and thus avoid multiple L4 port extractions in the `ct_lookup()` calls. As we need to extract the `dest` port for the Service lookup anyway, we can also extract the `source` port at this time without extra cost.

I expect that we can use the new `ct_lb_lookup()` helpers in more locations over time, and presumably also rename it at that point.
