### PR TITLE
per-node config improvements: testing, null selector, cleanups

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -472,6 +472,7 @@ This mode expects:
 - The current directory is ``cilium/test``
 
 - A test focus with ``--focus``. ``--focus="K8s"`` selects all kubernetes tests.
+  If not passing ``--focus=K8s`` then you must pass ``-cilium.testScope=K8s``.
 
 - Cilium images as full URLs specified with the ``--cilium.image`` and
   ``--cilium.operator-image`` options.
@@ -493,6 +494,14 @@ An example invocation is
 .. code-block:: shell-session
 
   CNI_INTEGRATION=eks K8S_VERSION=1.16 ginkgo --focus="K8s" --tags=integration_tests -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.passCLIEnvironment=true
+
+
+To run tests with Kind, try
+
+.. code-block:: shell-session
+
+  K8S_VERSION=1.25 ginkgo --focus=K8s -- -cilium.provision=false --cilium.image=localhost:5000/cilium/cilium-dev -cilium.tag=local  --cilium.operator-image=localhost:5000/cilium/operator -cilium.operator-tag=local -cilium.kubeconfig=`echo ~/.kube/config` -cilium.provision-k8s=false  -cilium.testScope=K8s -cilium.operator-suffix=
+
 
 Running in GKE
 ^^^^^^^^^^^^^^

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumnodeconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumnodeconfigs.yaml
@@ -52,7 +52,8 @@ spec:
                 type: object
               nodeSelector:
                 description: NodeSelector is a label selector that determines to which
-                  nodes this configuration applies.
+                  nodes this configuration applies. If not supplied, then this config
+                  applies to no nodes. If empty, then it applies to all nodes.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/pkg/k8s/apis/cilium.io/v2alpha1/cnc_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/cnc_types.go
@@ -38,7 +38,9 @@ type CiliumNodeConfigSpec struct {
 
 	// NodeSelector is a label selector that determines to which nodes
 	// this configuration applies.
-	NodeSelector metav1.LabelSelector `json:"nodeSelector"`
+	// If not supplied, then this config applies to no nodes. If
+	// empty, then it applies to all nodes.
+	NodeSelector *metav1.LabelSelector `json:"nodeSelector"`
 }
 
 //+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
@@ -408,7 +408,11 @@ func (in *CiliumNodeConfigSpec) DeepCopyInto(out *CiliumNodeConfigSpec) {
 			(*out)[key] = val
 		}
 	}
-	in.NodeSelector.DeepCopyInto(&out.NodeSelector)
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/option/resolver/resolver.go
+++ b/pkg/option/resolver/resolver.go
@@ -43,7 +43,7 @@ type ConfigSource struct {
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "option-resolver")
 
 func (cs *ConfigSource) String() string {
-	return fmt.Sprintf("%s namespace %s name %s", cs.Kind, cs.Namespace, cs.Name)
+	return fmt.Sprintf("%s:%s/%s", cs.Kind, cs.Namespace, cs.Name)
 }
 
 func ResolveConfigurations(ctx context.Context, client client.Clientset, nodeName string, sources []ConfigSource, allowConfigKeys, denyConfigKeys []string) (map[string]string, error) {
@@ -67,7 +67,7 @@ func ResolveConfigurations(ctx context.Context, client client.Clientset, nodeNam
 			return nil, fmt.Errorf("failed to read config source %s: %w", source.String(), err)
 		}
 		log.WithFields(logrus.Fields{
-			logfields.ConfigSource: source.String,
+			logfields.ConfigSource: source.String(),
 		}).Infof("Got %d config pairs from source", len(c))
 		if !first {
 			for k := range c {

--- a/pkg/option/resolver/resolver_test.go
+++ b/pkg/option/resolver/resolver_test.go
@@ -5,9 +5,18 @@ package resolver
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/onsi/gomega"
+
+	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 )
 
 func TestWriteConfigurations(t *testing.T) {
@@ -31,5 +40,299 @@ func TestWriteConfigurations(t *testing.T) {
 		if string(actual) != v {
 			t.Fatalf("Unexpected value, wanted %s got %s", v, actual)
 		}
+	}
+}
+
+// Test all of the various config sources
+// - configmap
+// - node annotations
+// - label selected CNC
+// - speific CNC name
+func TestResolveConfigurations(t *testing.T) {
+	testNS := "test-ns"
+	g := gomega.NewWithT(t)
+	clients, _ := k8sClient.NewFakeClientset()
+
+	fakeNode := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "nodename",
+			Labels: map[string]string{"a": "b"},
+			Annotations: map[string]string{
+				"io.cilium.config/anno-key": "anno-val",
+			},
+		},
+	}
+	_, err := clients.CoreV1().Nodes().Create(context.Background(), &fakeNode, metav1.CreateOptions{})
+	g.Expect(err).To(gomega.BeNil())
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "cm",
+		},
+		Data: map[string]string{
+			"cm-key": "cm-val",
+		},
+	}
+	_, err = clients.CoreV1().ConfigMaps(testNS).Create(context.Background(), &cm, metav1.CreateOptions{})
+	g.Expect(err).To(gomega.BeNil())
+
+	selCnc := ciliumv2alpha1.CiliumNodeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "test-1",
+		},
+		Spec: ciliumv2alpha1.CiliumNodeConfigSpec{
+			Defaults: map[string]string{
+				"cnc-key": "cnc-val",
+			},
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"a": "b"},
+			},
+		},
+	}
+	_, err = clients.CiliumV2alpha1().CiliumNodeConfigs(testNS).Create(context.Background(), &selCnc, metav1.CreateOptions{})
+	g.Expect(err).To(gomega.BeNil())
+
+	nameCnc := ciliumv2alpha1.CiliumNodeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "specific",
+		},
+		Spec: ciliumv2alpha1.CiliumNodeConfigSpec{
+			Defaults: map[string]string{
+				"cnc-key-2": "cnc-val-2",
+			},
+		},
+	}
+	_, err = clients.CiliumV2alpha1().CiliumNodeConfigs(testNS).Create(context.Background(), &nameCnc, metav1.CreateOptions{})
+	g.Expect(err).To(gomega.BeNil())
+
+	config, err := ResolveConfigurations(context.Background(), clients, "nodename",
+		[]ConfigSource{
+			{
+				Kind:      KindConfigMap,
+				Namespace: testNS,
+				Name:      "cm",
+			},
+			{
+				Kind:      KindNodeConfig,
+				Namespace: testNS,
+			},
+			{
+				Kind: KindNode,
+				Name: "nodename",
+			},
+			{
+				Kind:      KindNodeConfig,
+				Namespace: testNS,
+				Name:      "specific",
+			},
+		}, nil, nil)
+
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(config).To(gomega.Equal(map[string]string{
+		"cm-key":         "cm-val",
+		"anno-key":       "anno-val",
+		"cnc-key":        "cnc-val",
+		"cnc-key-2":      "cnc-val-2",
+		"config-sources": "config-map:test-ns/cm,cilium-node-config:test-ns/test-1,node:nodename,cilium-node-config:test-ns/specific",
+	}))
+}
+
+func TestWithBlockedFields(t *testing.T) {
+	testNS := "test-ns"
+	g := gomega.NewWithT(t)
+	clients, _ := k8sClient.NewFakeClientset()
+
+	fakeNode := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "nodename",
+			Labels: map[string]string{"a": "b"},
+			Annotations: map[string]string{
+				"io.cilium.config/anno-key": "anno-val",
+			},
+		},
+	}
+	_, err := clients.CoreV1().Nodes().Create(context.Background(), &fakeNode, metav1.CreateOptions{})
+	g.Expect(err).To(gomega.BeNil())
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "cm",
+		},
+		Data: map[string]string{
+			"cm-key": "cm-val",
+		},
+	}
+	_, err = clients.CoreV1().ConfigMaps(testNS).Create(context.Background(), &cm, metav1.CreateOptions{})
+	g.Expect(err).To(gomega.BeNil())
+
+	selCnc := ciliumv2alpha1.CiliumNodeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "test-1",
+		},
+		Spec: ciliumv2alpha1.CiliumNodeConfigSpec{
+			Defaults: map[string]string{
+				"allowed-key": "allowed-val",
+				"blocked-key": "blocked-val",
+			},
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"a": "b"},
+			},
+		},
+	}
+	_, err = clients.CiliumV2alpha1().CiliumNodeConfigs(testNS).Create(context.Background(), &selCnc, metav1.CreateOptions{})
+	g.Expect(err).To(gomega.BeNil())
+
+	sources := []ConfigSource{
+		{
+			Kind:      KindConfigMap,
+			Namespace: testNS,
+			Name:      "cm",
+		},
+		{
+			Kind:      KindNodeConfig,
+			Namespace: testNS,
+		},
+	}
+
+	// Test that only allowed-key is allowed
+	config, err := ResolveConfigurations(context.Background(), clients, "nodename",
+		sources, []string{"allowed-key"}, nil)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(config).To(gomega.Equal(map[string]string{
+		"cm-key":         "cm-val",
+		"allowed-key":    "allowed-val",
+		"config-sources": "config-map:test-ns/cm,cilium-node-config:test-ns/test-1",
+	}))
+
+	// Test that blocked-key is blocked
+	// but that the first source is privileged
+	config, err = ResolveConfigurations(context.Background(), clients, "nodename",
+		sources, nil, []string{"blocked-key", "cm-key"})
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(config).To(gomega.Equal(map[string]string{
+		"cm-key":         "cm-val",
+		"allowed-key":    "allowed-val",
+		"config-sources": "config-map:test-ns/cm,cilium-node-config:test-ns/test-1",
+	}))
+
+}
+
+func TestReadNodeConfigs(t *testing.T) {
+	testNS := "test-ns"
+
+	for _, tc := range []struct {
+		name       string
+		nodeLabels map[string]string
+
+		// can omit namespace + name, will be synthesized with an order
+		confs []ciliumv2alpha1.CiliumNodeConfigSpec
+
+		expected map[string]string
+	}{
+		{
+			name:       "one-matching",
+			nodeLabels: map[string]string{"a": "b"},
+			confs: []ciliumv2alpha1.CiliumNodeConfigSpec{
+				{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"a": "b",
+						},
+					},
+					Defaults: map[string]string{"key-1": "val-1"},
+				},
+			},
+			expected: map[string]string{
+				"key-1": "val-1",
+			},
+		},
+		{
+			name:       "none-matching",
+			nodeLabels: map[string]string{"a": "b"},
+			confs: []ciliumv2alpha1.CiliumNodeConfigSpec{
+				{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"a": "c",
+						},
+					},
+					Defaults: map[string]string{"key-1": "val-1"},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:       "two-matching",
+			nodeLabels: map[string]string{"a": "b"},
+			confs: []ciliumv2alpha1.CiliumNodeConfigSpec{
+				{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"a": "b",
+						},
+					},
+					Defaults: map[string]string{
+						"key-1": "val-1",
+						"key-2": "val-2",
+					},
+				},
+				{
+					NodeSelector: &metav1.LabelSelector{}, // empty selector, matches all
+					Defaults: map[string]string{
+						"key-1": "overridden",
+						"key-3": "val-3",
+					},
+				},
+				{
+					NodeSelector: nil, // selects nothing
+					Defaults: map[string]string{
+						"key-4": "val-4",
+					},
+				},
+			},
+			expected: map[string]string{
+				"key-1": "overridden",
+				"key-2": "val-2",
+				"key-3": "val-3",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			clients, _ := k8sClient.NewFakeClientset()
+
+			fakeNode := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   tc.name,
+					Labels: tc.nodeLabels,
+				},
+			}
+			_, err := clients.CoreV1().Nodes().Create(context.Background(), &fakeNode, metav1.CreateOptions{})
+			g.Expect(err).To(gomega.BeNil())
+
+			for i, conf := range tc.confs {
+				cnc := ciliumv2alpha1.CiliumNodeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("cco-%d", i),
+						Namespace: testNS,
+					},
+					Spec: conf,
+				}
+				_, err := clients.CiliumV2alpha1().CiliumNodeConfigs(testNS).Create(context.Background(), &cnc, metav1.CreateOptions{})
+				g.Expect(err).To(gomega.BeNil())
+			}
+
+			configs, _, err := readNodeConfigs(context.Background(), clients, tc.name, testNS, "")
+			g.Expect(err).To(gomega.BeNil())
+
+			g.Expect(configs).To(gomega.Equal(tc.expected))
+
+		})
 	}
 }

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -625,6 +625,10 @@ func DoesNotExistNodeWithoutCilium() bool {
 	return !ExistNodeWithoutCilium()
 }
 
+func RunsOnJenkins() bool {
+	return os.Getenv("JENKINS_HOME") != ""
+}
+
 // HasSocketLB returns true if the given Cilium pod has TCP and/or
 // UDP host reachable services are enabled.
 func (kub *Kubectl) HasSocketLB(pod string) bool {

--- a/test/k8s/config.go
+++ b/test/k8s/config.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8sTest
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+)
+
+// Some basic checks of the CiliumNodeConfig plumbing.
+//
+// This bit is an end-to-end test to ensure that the Helm
+// chart is working as intended. There is more complicated
+// tests of the logic in unit tests.
+//
+// It creates a CiliumNodeConfig, ensure it doesn't apply,
+// then labels one node and ensure that, yes, it did apply
+var _ = SkipDescribeIf(func() bool {
+	// right now, the 5.4 job is the fastest, so use only that
+	// but only if we're on jenkins
+	return helpers.DoesNotRunOn54Kernel() && helpers.RunsOnJenkins()
+}, "K8sAgentPerNodeConfigTest", func() {
+	var (
+		kubectl *helpers.Kubectl
+
+		ciliumFilename string
+	)
+	BeforeAll(func() {
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+
+		res := kubectl.ExecShort("kubectl label --overwrite --all node io.cilium.testing-")
+		Expect(res.GetErr("unlabel node")).To(BeNil())
+
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		RedeployCilium(kubectl, ciliumFilename, map[string]string{})
+	})
+
+	AfterAll(func() {
+		res := kubectl.ExecShort("kubectl label --overwrite --all node io.cilium.testing-")
+		Expect(res.GetErr("unlabel node")).To(BeNil())
+		UninstallCiliumFromManifest(kubectl, ciliumFilename)
+		kubectl.CloseSSHClient()
+	})
+
+	It("Correctly computes config overrides", func() {
+		pods, err := kubectl.GetPodsNodes(helpers.CiliumNamespace, helpers.CiliumSelector)
+		Expect(err).To(BeNil(), "error finding cilium pods")
+
+		// pick a node
+		var nodeName string
+		for _, v := range pods {
+			nodeName = v
+			break
+		}
+		if nodeName == "" {
+			Fail("No cilium pods were found")
+		}
+
+		recreatePods := func() {
+			By("Deleting all cilium pods")
+			kubectl.DeleteResource("-n kube-system pod", "-l "+helpers.CiliumAgentLabel)
+			// Wait for pods to be up and running
+			kubectl.WaitForCiliumReadiness(0, "not all cilium pods returned")
+		}
+
+		// returns a map of nodename -> config key
+		getNodeConfigKeys := func(key string) map[string]string {
+			podtonode, err := kubectl.GetPodsNodes(helpers.CiliumNamespace, helpers.CiliumSelector)
+			Expect(err).To(BeNil(), "error finding cilium pods")
+
+			ress, err := kubectl.ExecInPods(context.TODO(), helpers.CiliumNamespace, helpers.CiliumSelector,
+				fmt.Sprintf("/bin/sh -c 'cat /tmp/cilium/config-map/%s || true'", key))
+			Expect(err).NotTo(HaveOccurred())
+			out := map[string]string{}
+			for p, res := range ress {
+				Expect(res.GetErr(p)).NotTo((HaveOccurred()))
+				out[podtonode[p]] = res.Stdout()
+			}
+			return out
+		}
+
+		By("Creating a CiliumNodeConfig")
+		// Create a CiliumNodeConfig that does not apply to any nodes
+		cnc := `
+apiVersion: cilium.io/v2alpha1
+kind: CiliumNodeConfig
+metadata:
+  namespace: kube-system
+  name: testing
+spec:
+  nodeSelector:
+    matchLabels:
+      io.cilium.testing: foo
+  defaults:
+    test-key: foo
+`
+		f, err := os.CreateTemp("", "pernodeconfig-")
+		Expect(err).Should(BeNil())
+		defer os.Remove(f.Name())
+
+		_, err = f.WriteString(cnc)
+		Expect(err).Should(BeNil())
+
+		res := kubectl.Apply(helpers.ApplyOptions{
+			FilePath:  f.Name(),
+			Namespace: "kube-system",
+		})
+		Expect(res.GetErr("apply")).To(BeNil())
+
+		// ensure no pods have this key
+		recreatePods()
+		nodeConfigKeys := getNodeConfigKeys("test-key")
+		Expect(nodeConfigKeys).To(HaveKey(nodeName))
+		Expect(nodeConfigKeys).To(HaveEach("")) //ensure that all elements are ""
+
+		// Now, label 1 node and check the only it gets this config key
+		By("Labeling node %s with io.cilium.testing=foo", nodeName)
+		res = kubectl.ExecShort(fmt.Sprintf("kubectl label node %s io.cilium.testing=foo", nodeName))
+		Expect(res.GetErr("label node")).To(BeNil())
+		recreatePods()
+		By("Ensuring only node %s has the config override", nodeName)
+		nodeConfigKeys = getNodeConfigKeys("test-key")
+		// ensure it is zero
+		Expect(nodeConfigKeys).To(HaveKeyWithValue(nodeName, "foo"))
+		// If there are other nodes, make sure it doesn't have the config key
+		if len(nodeConfigKeys) > 1 {
+			delete(nodeConfigKeys, nodeName)
+			Expect(nodeConfigKeys).To(HaveEach(""))
+		}
+
+	})
+})


### PR DESCRIPTION
This PR includes lots of test coverage for per-node configs, both integration and unit tests.

It also fixes two minor nits:
- a null NodeSelector is now allowed
- Some log lines were broken

Fixes: #22507 
