### PR TITLE
bpf: lb: fix check for L3 pseudo-hdr csum update in lb6_xlate()

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -697,7 +697,7 @@ static __always_inline int lb6_xlate(struct __ctx_buff *ctx,
 		goto l4_xlate;
 
 	ipv6_store_daddr(ctx, new_dst->addr, l3_off);
-	if (csum_off) {
+	if (csum_off->offset) {
 		__be32 sum = csum_diff(key->address.addr, 16, new_dst->addr,
 				       16, 0);
 


### PR DESCRIPTION
We never pass NULL for the csum_off pointer, so right now this check just always succeeds. But comparing to lb4_xlate(), we actually want to test csum_off->offset before updating the L3 pseudo-hdr csum in the L4 header.

Looking at csum_l4_offset_and_flags(), this change fixes an issue for SCTP over IPv6. There we intentionally set csum->offset as 0 to opt out from the pseudo-header csum update.