### PR TITLE
clustermesh: Add missing brackets of etcd option

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -89,8 +89,10 @@ spec:
         - --trusted-ca-file=/var/lib/etcd-secrets/ca.crt
         - --cert-file=/var/lib/etcd-secrets/tls.crt
         - --key-file=/var/lib/etcd-secrets/tls.key
-        - --listen-client-urls=https://127.0.0.1:2379,https://$(HOSTNAME_IP):2379
-        - --advertise-client-urls=https://$(HOSTNAME_IP):2379
+        # Surrounding the IPv4 address with brackets works in this case, since etcd
+        # uses net.SplitHostPort() internally and it accepts the that format.
+        - --listen-client-urls=https://127.0.0.1:2379,https://[$(HOSTNAME_IP)]:2379
+        - --advertise-client-urls=https://[$(HOSTNAME_IP)]:2379
         - --initial-cluster-token=clustermesh-apiserver
         - --auto-compaction-retention=1
         env:


### PR DESCRIPTION
Please take a look at the commit message for more details. I think this needs to be backported to all stable versions because, without this fix, ClusterMesh with IPv6 single stack deployment is not functional at all. That meets the criteria `Major bugfixes relevant to the correct operation of Cilium`.

Fixes: #22952

```release-note
clustermesh: Add missing brackets of IPv6 address for etcd option
```
