### PR TITLE
contrib: Fix GitHub token check to allow fine-grained tokens

### DIFF
--- a/contrib/release/lib/gitlib.sh
+++ b/contrib/release/lib/gitlib.sh
@@ -20,7 +20,7 @@
 ###############################################################################
 # CONSTANTS
 ###############################################################################
-GHCURL="curl -s --fail --retry 10 -u ${GITHUB_TOKEN:-$FLAGS_github_token}:x-oauth-basic"
+GHCURL="curl -s --fail --retry 10 -u x-access-token:${GITHUB_TOKEN:-$FLAGS_github_token}"
 JCURL="curl -g -s --fail --retry 10"
 CILIUM_GITHUB_API='https://api.github.com/repos/cilium/cilium'
 CILIUM_GITHUB_RAW_ORG='https://raw.githubusercontent.com/cilium'


### PR DESCRIPTION
Classic GitHub tokens can be passed in the HTTP Authorization header in multiple ways, including as the username or as the password in Basic authentication. However, beta "Fine-grained personal access tokens" are not accepted as the username, which breaks the check in gitlib.sh.

For the purpose of that check, pass the token as the password, allowing both classic and beta tokens to pass the check.

Signed-off-by: Maxim Mikityanskiy <maxim@isovalent.com>
