### PR TITLE
bpf: Return better error codes from hooked syscalls

### DIFF
--- a/bpf/include/bpf/errno.h
+++ b/bpf/include/bpf/errno.h
@@ -33,8 +33,14 @@
 #ifndef ECONNRESET
 # define ECONNRESET	104
 #endif
+#ifndef ENOBUFS
+# define ENOBUFS	105
+#endif
 #ifndef ENOTCONN
 # define ENOTCONN	107
+#endif
+#ifndef ECONNREFUSED
+# define ECONNREFUSED	111
 #endif
 #ifndef EHOSTUNREACH
 # define EHOSTUNREACH	113


### PR DESCRIPTION
When a syscall is rejected in BPF, by default the error code returned is -EPERM. Set more appropriate codes explicitly in the remaining places.

Signed-off-by: Maxim Mikityanskiy <maxim@isovalent.com>

```release-note
Return better error codes from hooked syscalls, such as connect() and bind().
```
