### PR TITLE
Doc:fix networking.k8s.io/v1beta1 for ingress

### DIFF
--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -84,7 +84,7 @@ of all nodes in the cluster:
    KVStore:                Ok   Etcd: http://127.0.0.1:2379 - (Leader) 3.1.10
    ContainerRuntime:       Ok
    Kubernetes:             Ok   OK
-   Kubernetes APIs:        ["extensions/v1beta1::Ingress", "core/v1::Node", "CustomResourceDefinition", "cilium/v2::CiliumNetworkPolicy", "networking.k8s.io/v1::NetworkPolicy", "core/v1::Service", "core/v1::Endpoint"]
+   Kubernetes APIs:        ["networking.k8s.io/v1beta1::Ingress", "core/v1::Node", "CustomResourceDefinition", "cilium/v2::CiliumNetworkPolicy", "networking.k8s.io/v1::NetworkPolicy", "core/v1::Service", "core/v1::Endpoint"]
    Cilium:                 Ok   OK
    NodeMonitor:            Listening for events on 2 CPUs with 64x4096 of shared memory
    Cilium health daemon:   Ok
@@ -129,7 +129,7 @@ e.g.:
    KVStore:                Ok   etcd: 1/1 connected: https://192.168.60.11:2379 - 3.2.7 (Leader)
    ContainerRuntime:       Ok
    Kubernetes:             Ok   OK
-   Kubernetes APIs:        ["core/v1::Endpoint", "extensions/v1beta1::Ingress", "core/v1::Node", "CustomResourceDefinition", "cilium/v2::CiliumNetworkPolicy", "networking.k8s.io/v1::NetworkPolicy", "core/v1::Service"]
+   Kubernetes APIs:        ["core/v1::Endpoint", "networking.k8s.io/v1beta1::Ingress", "core/v1::Node", "CustomResourceDefinition", "cilium/v2::CiliumNetworkPolicy", "networking.k8s.io/v1::NetworkPolicy", "core/v1::Service"]
    Cilium:                 Ok   OK
    NodeMonitor:            Listening for events on 2 CPUs with 64x4096 of shared memory
    Cilium health daemon:   Ok


### PR DESCRIPTION
Signed-off-by: yulng <wei.yang@daocloud.io>

Update document Ingress to networking.k8s.io/v1beta1 
According to the following document:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

![image](https://user-images.githubusercontent.com/31728060/211479103-e1fd6899-359e-4d4a-8d33-96ad565f177a.png)





```release-note
docs: Update output for "cilium status" when troubleshooting (extensions/v1beta1::Ingress now deprecated in favor of networking.k8s.io/v1beta1::Ingress)
```