### PR TITLE
bpf: Fix LB loopback path with ingress policy

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -282,7 +282,7 @@ skip_host_firewall:
 			return CTX_ACT_OK;
 
 		return ipv6_local_delivery(ctx, l3_off, secctx, ep,
-					   METRIC_INGRESS, from_host);
+					   METRIC_INGRESS, from_host, false);
 	}
 
 	/* Below remainder is only relevant when traffic is pushed via cilium_host.
@@ -562,7 +562,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 			return CTX_ACT_OK;
 
 		return ipv4_local_delivery(ctx, ETH_HLEN, secctx, ip4, ep,
-					   METRIC_INGRESS, from_host);
+					   METRIC_INGRESS, from_host, false);
 	}
 
 	/* Below remainder is only relevant when traffic is pushed via cilium_host.

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -458,7 +458,7 @@ ct_recreate6:
 			policy_clear_mark(ctx);
 			/* If the packet is from L7 LB it is coming from the host */
 			return ipv6_local_delivery(ctx, ETH_HLEN, SECLABEL, ep,
-						   METRIC_EGRESS, from_l7lb);
+						   METRIC_EGRESS, from_l7lb, hairpin_flow);
 		}
 	}
 
@@ -985,7 +985,7 @@ ct_recreate4:
 			policy_clear_mark(ctx);
 			/* If the packet is from L7 LB it is coming from the host */
 			return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL, ip4,
-						   ep, METRIC_EGRESS, from_l7lb);
+						   ep, METRIC_EGRESS, from_l7lb, hairpin_flow);
 		}
 	}
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -154,7 +154,7 @@ not_esp:
 			return hdrlen;
 
 		return ipv6_local_delivery(ctx, l3_off, *identity, ep,
-					   METRIC_INGRESS, false);
+					   METRIC_INGRESS, false, false);
 	}
 
 	/* A packet entering the node from the tunnel and not going to a local
@@ -306,7 +306,7 @@ not_esp:
 			goto to_host;
 
 		return ipv4_local_delivery(ctx, ETH_HLEN, *identity, ip4, ep,
-					   METRIC_INGRESS, false);
+					   METRIC_INGRESS, false, false);
 	}
 
 	/* A packet entering the node from the tunnel and not going to a local

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -66,7 +66,8 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 					       __u32 seclabel,
 					       const struct endpoint_info *ep,
 					       __u8 direction,
-					       bool from_host __maybe_unused)
+					       bool from_host __maybe_unused,
+					       bool hairpin_flow __maybe_unused)
 {
 	mac_t router_mac = ep->node_mac;
 	mac_t lxc_mac = ep->mac;
@@ -87,6 +88,16 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 	 */
 	update_metrics(ctx_full_len(ctx), direction, REASON_FORWARDED);
 #endif
+
+#ifndef DISABLE_LOOPBACK_LB
+	/* Skip ingress policy enforcement for hairpin traffic. As the hairpin
+	 * traffic is destined to a local pod (more specifically, the same pod
+	 * the traffic originated from, we skip the tail call for ingress policy
+	 * enforcement, and directly redirect it to the endpoint).
+	 */
+	if (unlikely(hairpin_flow))
+		return redirect_ep(ctx, ep->ifindex, from_host);
+#endif /* DISABLE_LOOPBACK_LB */
 
 #if defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && \
 	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)
@@ -127,7 +138,8 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 					       __u32 seclabel, struct iphdr *ip4,
 					       const struct endpoint_info *ep,
 					       __u8 direction __maybe_unused,
-					       bool from_host __maybe_unused)
+					       bool from_host __maybe_unused,
+					       bool hairpin_flow __maybe_unused)
 {
 	mac_t router_mac = ep->node_mac;
 	mac_t lxc_mac = ep->mac;
@@ -147,6 +159,16 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 	 */
 	update_metrics(ctx_full_len(ctx), direction, REASON_FORWARDED);
 #endif
+
+#ifndef DISABLE_LOOPBACK_LB
+	/* Skip ingress policy enforcement for hairpin traffic.	As the hairpin
+	 * traffic is destined to a local pod (more specifically, the same pod the
+	 * traffic originated from, we skip the tail call for ingress policy
+	 * enforcement, and directly redirect it to the endpoint).
+	 */
+	if (unlikely(hairpin_flow))
+		return redirect_ep(ctx, ep->ifindex, from_host);
+#endif /* DISABLE_LOOPBACK_LB */
 
 #if defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && \
 	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)


### PR DESCRIPTION
This PR fixes the packet path when a service pod connects to itself via cluster IP, and selected by an ingress (L4) policy.

Background:
When a service backend endpoint connects to itself via its service cluster IP address, the traffic is hairpin'd using a loopback IP address. We skip policy enforcement on egress, as a pod is allowed to connect to itself, and users don't have to specify additional policies to allow the hairpin'd traffic. We have a similar expectation on the ingress side.

Problem:
The ingress side was broken because of a regression due to which replies were dropped on the ingress policy enforcement path. The patch that introduced the regression split per packet load-balancing logic into a separate tail call, where (limited) LB state is stored in packet context, and restored later while handling rest of the packet processing including conntrack, and policy enforcement.
When a service pod connects to itself via its clusterIP, post the forward service translation, conntrack state update is done on the conntrack entry with loopback address (the restored state). As a result, when a reply is reverse SNAT'd and DNAT'd, the policy verdict for the `CT_NEW` entry is denied, and the reply packet is dropped.  Prior to the regression, the original conntrack entry would have the updated state, and loopback flag set.

Fix: 
When hairpin'd traffic is reverse translated, and sent for a local delivery in case of bpf_lxc, we should directly redirect it to the endpoint, thereby skipping the tail call with ingress policy enforcement altogether.
(The PR doesn't change the CT accounting.)

Here is the packet flow -

Request path: podA -> clusterIP --> svc xlate (dAddr=podA) --> SNAT using loopback address (saddr=loopback IP) --> conntrack entry created (loopback IP, backend IP) with loopback flag state

Reply path: cluster IP -> podA --> svc rev-xlate (saddr=podA address) --> SNAT using loopback (daddr=loopback IP) --> CT_REPLY match --> local_delivery

Reported-by: https://github.com/cyvcloud
Fixes: #22107 
Fixes: 7575ba03cc ("datapath: Reduce from LXC complexity")
Signed-off-by: Aditi Ghag <aditi@cilium.io>

```release-note
Fix packet drops when service pod connects to itself via clusterIP, and selected by an ingress policy.
```
