### PR TITLE
ingress: Support NodePort for dedicated Ingress

### DIFF
--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -56,6 +56,15 @@ Supported Ingress Annotations
    * - ``io.cilium.ingress/loadbalancer-mode``
      - The loadbalancer mode for the ingress. Applicable values are ``dedicated`` and ``shared``.
      - Defaults to Helm option ``ingressController.loadbalancerMode`` value.
+   * - ``io.cilium.ingress/service-type``
+     - The Service type for dedicated Ingress. Applicable values are ``LoadBalancer`` and ``NodePort``.
+     - Defaults to ``LoadBalancer`` if unspecified.
+   * - ``io.cilium.ingress/insecure-node-port``
+     - The NodePort to use for the HTTP Ingress. Applicable only if ``io.cilium.ingress/service-type`` is ``NodePort``.
+     - If unspecified, a random NodePort will be allocated by kubernetes.
+   * - ``io.cilium.ingress/secure-node-port``
+     - The NodePort to use for the HTTPS Ingress. Applicable only if ``io.cilium.ingress/service-type`` is ``NodePort``.
+     - If unspecified, a random NodePort will be allocated by kubernetes.
    * - ``io.cilium/tcp-keep-alive``
      - Enable TCP keep-alive
      - 1 (enabled)

--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -6,13 +6,16 @@ package annotations
 import (
 	"strconv"
 
-	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
-
 	"github.com/cilium/cilium/pkg/annotation"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
 )
 
 const (
-	LBModeAnnotation = annotation.Prefix + ".ingress" + "/loadbalancer-mode"
+	LBModeAnnotation           = annotation.Prefix + ".ingress" + "/loadbalancer-mode"
+	ServiceTypeAnnotation      = annotation.Prefix + ".ingress" + "/service-type"
+	InsecureNodePortAnnotation = annotation.Prefix + ".ingress" + "/insecure-node-port"
+	SecureNodePortAnnotation   = annotation.Prefix + ".ingress" + "/secure-node-port"
 
 	TCPKeepAliveEnabledAnnotation          = annotation.Prefix + "/tcp-keep-alive"
 	TCPKeepAliveIdleAnnotation             = annotation.Prefix + "/tcp-keep-alive-idle"
@@ -33,6 +36,44 @@ const (
 // GetAnnotationIngressLoadbalancerMode returns the loadbalancer mode for the ingress if possible.
 func GetAnnotationIngressLoadbalancerMode(ingress *slim_networkingv1.Ingress) string {
 	return ingress.GetAnnotations()[LBModeAnnotation]
+}
+
+// GetAnnotationServiceType returns the service type for the ingress if possible.
+// Defaults to LoadBalancer
+func GetAnnotationServiceType(ingress *slim_networkingv1.Ingress) string {
+	val, exists := ingress.GetAnnotations()[ServiceTypeAnnotation]
+	if !exists {
+		return string(slim_corev1.ServiceTypeLoadBalancer)
+	}
+	return val
+}
+
+// GetAnnotationSecureNodePort returns the secure node port for the ingress if possible.
+func GetAnnotationSecureNodePort(ingress *slim_networkingv1.Ingress) (*uint32, error) {
+	val, exists := ingress.GetAnnotations()[SecureNodePortAnnotation]
+	if !exists {
+		return nil, nil
+	}
+	intVal, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	res := uint32(intVal)
+	return &res, nil
+}
+
+// GetAnnotationInsecureNodePort returns the insecure node port for the ingress if possible.
+func GetAnnotationInsecureNodePort(ingress *slim_networkingv1.Ingress) (*uint32, error) {
+	val, exists := ingress.GetAnnotations()[InsecureNodePortAnnotation]
+	if !exists {
+		return nil, nil
+	}
+	intVal, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	res := uint32(intVal)
+	return &res, nil
 }
 
 // GetAnnotationTCPKeepAliveEnabled returns 1 if enabled (default), 0 if disabled

--- a/operator/pkg/ingress/annotations/annotations_test.go
+++ b/operator/pkg/ingress/annotations/annotations_test.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package annotations
+
+import (
+	"reflect"
+	"testing"
+
+	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestGetAnnotationServiceType(t *testing.T) {
+	type args struct {
+		ingress *slim_networkingv1.Ingress
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "no service type annotation",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{},
+			},
+			want: "LoadBalancer",
+		},
+		{
+			name: "service type annotation as LoadBalancer",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/service-type": "LoadBalancer",
+						},
+					},
+				},
+			},
+			want: "LoadBalancer",
+		},
+		{
+			name: "service type annotation as NodePort",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/service-type": "NodePort",
+						},
+					},
+				},
+			},
+			want: "NodePort",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetAnnotationServiceType(tt.args.ingress); got != tt.want {
+				t.Errorf("GetAnnotationServiceType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAnnotationSecureNodePort(t *testing.T) {
+	type args struct {
+		ingress *slim_networkingv1.Ingress
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *uint32
+		wantErr bool
+	}{
+		{
+			name: "no secure node port annotation",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{},
+			},
+			want: nil,
+		},
+		{
+			name: "secure node port annotation with valid value",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/secure-node-port": "1000",
+						},
+					},
+				},
+			},
+			want: uint32p(1000),
+		},
+		{
+			name: "secure node port annotation with invalid value",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/secure-node-port": "invalid-numeric-value",
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetAnnotationSecureNodePort(tt.args.ingress)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAnnotationSecureNodePort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAnnotationInsecureNodePort(t *testing.T) {
+	type args struct {
+		ingress *slim_networkingv1.Ingress
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *uint32
+		wantErr bool
+	}{
+		{
+			name: "no insecure node port annotation",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{},
+			},
+			want: nil,
+		},
+		{
+			name: "insecure node port annotation with valid value",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/insecure-node-port": "1000",
+						},
+					},
+				},
+			},
+			want: uint32p(1000),
+		},
+		{
+			name: "insecure node port annotation with invalid value",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/insecure-node-port": "invalid-numeric-value",
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetAnnotationInsecureNodePort(tt.args.ingress)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAnnotationSecureNodePort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func uint32p(u uint32) *uint32 {
+	return &u
+}

--- a/operator/pkg/model/ingestion/doc.go
+++ b/operator/pkg/model/ingestion/doc.go
@@ -5,3 +5,10 @@
 // Kubernetes resources into Listener types for storage
 // in the model.
 package ingestion
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ingestion")

--- a/operator/pkg/model/ingestion/ingress_test.go
+++ b/operator/pkg/model/ingestion/ingress_test.go
@@ -862,7 +862,340 @@ var complexIngressListeners = []model.HTTPListener{
 	},
 }
 
+// complexNodePortIngress is same as complexIngress but with NodePort service
+var complexNodePortIngress = slim_networkingv1.Ingress{
+	ObjectMeta: slim_metav1.ObjectMeta{
+		Name:      "dummy-ingress",
+		Namespace: "dummy-namespace",
+		Annotations: map[string]string{
+			"io.cilium.ingress/service-type":       "NodePort",
+			"io.cilium.ingress/insecure-node-port": "30000",
+			"io.cilium.ingress/secure-node-port":   "30001",
+		},
+		UID: "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+	},
+	Spec: slim_networkingv1.IngressSpec{
+		IngressClassName: stringp("cilium"),
+		DefaultBackend: &slim_networkingv1.IngressBackend{
+			Service: &slim_networkingv1.IngressServiceBackend{
+				Name: "default-backend",
+				Port: slim_networkingv1.ServiceBackendPort{
+					Number: 8080,
+				},
+			},
+		},
+		TLS: []slim_networkingv1.IngressTLS{
+			{
+				Hosts:      []string{"very-secure.server.com"},
+				SecretName: "tls-very-secure-server-com",
+			},
+			{
+				Hosts: []string{
+					"another-very-secure.server.com",
+					"not-in-use.another-very-secure.server.com",
+				},
+				SecretName: "tls-another-very-secure-server-com",
+			},
+		},
+		Rules: []slim_networkingv1.IngressRule{
+			{
+				IngressRuleValue: slim_networkingv1.IngressRuleValue{
+					HTTP: &slim_networkingv1.HTTPIngressRuleValue{
+						Paths: []slim_networkingv1.HTTPIngressPath{
+							{
+								Path: "/dummy-path",
+								Backend: slim_networkingv1.IngressBackend{
+									Service: &slim_networkingv1.IngressServiceBackend{
+										Name: "dummy-backend",
+										Port: slim_networkingv1.ServiceBackendPort{
+											Number: 8080,
+										},
+									},
+								},
+								PathType: &exactPathType,
+							},
+							{
+								Path: "/another-dummy-path",
+								Backend: slim_networkingv1.IngressBackend{
+									Service: &slim_networkingv1.IngressServiceBackend{
+										Name: "another-dummy-backend",
+										Port: slim_networkingv1.ServiceBackendPort{
+											Number: 8081,
+										},
+									},
+								},
+								PathType: &prefixPathType,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var complexNodePortIngressListeners = []model.HTTPListener{
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     80,
+		Hostname: "*",
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     443,
+		Hostname: "another-very-secure.server.com",
+		TLS: []model.TLSSecret{
+			{
+				Name:      "tls-another-very-secure-server-com",
+				Namespace: "dummy-namespace",
+			},
+		},
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     443,
+		Hostname: "not-in-use.another-very-secure.server.com",
+		TLS: []model.TLSSecret{
+			{
+				Name:      "tls-another-very-secure-server-com",
+				Namespace: "dummy-namespace",
+			},
+		},
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     443,
+		Hostname: "very-secure.server.com",
+		TLS: []model.TLSSecret{
+			{
+				Name:      "tls-very-secure-server-com",
+				Namespace: "dummy-namespace",
+			},
+		},
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+}
+
 func stringp(in string) *string {
+	return &in
+}
+
+func uint32p(in uint32) *uint32 {
 	return &in
 }
 
@@ -889,6 +1222,10 @@ func TestIngress(t *testing.T) {
 		"cilium test ingress": {
 			ingress: complexIngress,
 			want:    complexIngressListeners,
+		},
+		"cilium test ingress with NodePort": {
+			ingress: complexNodePortIngress,
+			want:    complexNodePortIngressListeners,
 		},
 	}
 

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -42,6 +42,21 @@ type HTTPListener struct {
 	// Routes associated with HTTP traffic to the service.
 	// An empty list means that traffic will not be routed.
 	Routes []HTTPRoute `json:"routes,omitempty"`
+	// Service configuration
+	Service *Service `json:"service,omitempty"`
+}
+
+// Service holds the configuration for desired Service details
+type Service struct {
+	// Type is the type of service that is being used for Listener (e.g. Load Balancer or Node port)
+	// Defaults to Load Balancer type
+	Type string `json:"serviceType,omitempty"`
+	// InsecureNodePort is the back-end port of the service that is being used for HTTP Listener
+	// Applicable only if Type is Node NodePort
+	InsecureNodePort *uint32 `json:"insecureNodePort,omitempty"`
+	// SecureNodePort is the back-end port of the service that is being used for HTTPS Listener
+	// Applicable only if Type is Node NodePort
+	SecureNodePort *uint32 `json:"secureNodePort,omitempty"`
 }
 
 // FullyQualifiedResource stores the full details of a Kubernetes resource, including

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -14,44 +14,125 @@ import (
 )
 
 func Test_getService(t *testing.T) {
-	res := getService(model.FullyQualifiedResource{
+	resource := model.FullyQualifiedResource{
 		Name:      "dummy-ingress",
 		Namespace: "dummy-namespace",
 		Version:   "v1",
 		Kind:      "Ingress",
 		UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+	}
+
+	t.Run("Default LB service", func(t *testing.T) {
+		res := getService(resource, nil)
+		require.Equal(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cilium-ingress-dummy-ingress",
+				Namespace: "dummy-namespace",
+				Labels:    map[string]string{"cilium.io/ingress": "true"},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "networking.k8s.io/v1",
+						Kind:       "Ingress",
+						Name:       "dummy-ingress",
+						UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+					},
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Name:     "http",
+						Protocol: "TCP",
+						Port:     80,
+					},
+					{
+						Name:     "https",
+						Protocol: "TCP",
+						Port:     443,
+					},
+				},
+			},
+		}, res)
 	})
 
-	require.Equal(t, &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cilium-ingress-dummy-ingress",
-			Namespace: "dummy-namespace",
-			Labels:    map[string]string{"cilium.io/ingress": "true"},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "networking.k8s.io/v1",
-					Kind:       "Ingress",
-					Name:       "dummy-ingress",
-					UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+	t.Run("Invalid LB service annotation, defaults to LoadBalancer", func(t *testing.T) {
+		res := getService(resource, &model.Service{
+			Type: "InvalidServiceType",
+		})
+		require.Equal(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cilium-ingress-dummy-ingress",
+				Namespace: "dummy-namespace",
+				Labels:    map[string]string{"cilium.io/ingress": "true"},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "networking.k8s.io/v1",
+						Kind:       "Ingress",
+						Name:       "dummy-ingress",
+						UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+					},
 				},
 			},
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeLoadBalancer,
-			Ports: []corev1.ServicePort{
-				{
-					Name:     "http",
-					Protocol: "TCP",
-					Port:     80,
-				},
-				{
-					Name:     "https",
-					Protocol: "TCP",
-					Port:     443,
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Name:     "http",
+						Protocol: "TCP",
+						Port:     80,
+					},
+					{
+						Name:     "https",
+						Protocol: "TCP",
+						Port:     443,
+					},
 				},
 			},
-		},
-	}, res)
+		}, res)
+	})
+
+	t.Run("Node Port service", func(t *testing.T) {
+		var insecureNodePort uint32 = 3000
+		var secureNodePort uint32 = 3001
+		res := getService(resource, &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: &insecureNodePort,
+			SecureNodePort:   &secureNodePort,
+		})
+		require.Equal(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cilium-ingress-dummy-ingress",
+				Namespace: "dummy-namespace",
+				Labels:    map[string]string{"cilium.io/ingress": "true"},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "networking.k8s.io/v1",
+						Kind:       "Ingress",
+						Name:       "dummy-ingress",
+						UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+					},
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Name:     "http",
+						Protocol: "TCP",
+						Port:     80,
+						NodePort: 3000,
+					},
+					{
+						Name:     "https",
+						Protocol: "TCP",
+						Port:     443,
+						NodePort: 3001,
+					},
+				},
+			},
+		}, res)
+	})
 }
 
 func Test_getEndpointForIngress(t *testing.T) {

--- a/operator/pkg/model/translation/ingress/doc.go
+++ b/operator/pkg/model/translation/ingress/doc.go
@@ -4,3 +4,10 @@
 // Package ingress contains the translation logic from Ingress to CiliumEnvoyConfig
 // and related resources.
 package ingress
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ingress-controller")


### PR DESCRIPTION
## Description

This commit is to support NodePort service in dedicated mode. Shared service NodePort can be configured via helm as per #22583.

Relates: #22583
Signed-off-by: Tam Mach <tam.mach@cilium.io>

## Testing

Testing was done locally as per below

```yaml
# Basic ingress for istio bookinfo demo application, which can be found in below
# https://raw.githubusercontent.com/istio/istio/release-1.11/samples/bookinfo/platform/kube/bookinfo.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: basic-ingress
  namespace: default
  annotations:
    io.cilium.ingress/service-type: "NodePort"
    io.cilium.ingress/insecure-node-port: "30000"
    io.cilium.ingress/secure-node-port: "30001"
    io.cilium.ingress/loadbalancer-mode: "dedicated"
spec:
  ingressClassName: cilium
  rules:
  - http:
      paths:
      - backend:
          service:
            name: details
            port:
              number: 9080
        path: /details
        pathType: Prefix
      - backend:
          service:
            name: productpage
            port:
              number: 9080
        path: /
        pathType: Prefix
```

Sending traffic to NodePort service

```
$ kgsvc       
NAME                           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
cilium-ingress-basic-ingress   NodePort    10.106.157.226   <none>        80:30000/TCP,443:30001/TCP   3s
details                        ClusterIP   10.96.85.227     <none>        9080/TCP                     26m
kubernetes                     ClusterIP   10.96.0.1        <none>        443/TCP                      35m
productpage                    ClusterIP   10.104.152.26    <none>        9080/TCP                     26m
ratings                        ClusterIP   10.105.230.48    <none>        9080/TCP                     26m
reviews                        ClusterIP   10.102.73.248    <none>        9080/TCP                     26m

$ curl http://192.168.49.2:30000/details/1
{"id":1,"author":"William Shakespeare","year":1595,"type":"paperback","pages":200,"publisher":"PublisherA","language":"English","ISBN-10":"1234567890","ISBN-13":"123-1234567890"}
```
