### PR TITLE
Docs: Fix kubernetes version which isn't emphasized

### DIFF
--- a/Documentation/network/kubernetes/configuration.rst
+++ b/Documentation/network/kubernetes/configuration.rst
@@ -129,7 +129,7 @@ CNI
 delegate networking configuration. You can find additional information on the
 :term:`CNI` project website.
 
-.. note:: Kubernetes `` >= 1.3.5`` requires the ``loopback`` :term:`CNI` plugin to be
+.. note:: Kubernetes ``>= 1.3.5`` requires the ``loopback`` :term:`CNI` plugin to be
           installed on all worker nodes. The binary is typically provided by
           most Kubernetes distributions. See section :ref:`install_cni` for
           instructions on how to install :term:`CNI` in case the ``loopback`` binary


### PR DESCRIPTION
The version is intended to be emphasized, but there is a mistake to emphasize it.

The current one is:
![Screenshot from 2023-01-09 18-21-49](https://user-images.githubusercontent.com/25903627/211275732-ca02f55e-264b-443b-ba2d-56d25fd7ffc3.png)


Modified to:
![Screenshot from 2023-01-09 18-21-10](https://user-images.githubusercontent.com/25903627/211275674-d365bf50-58d9-4fda-8ff6-3c9adb588e26.png)


Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!


```release-note
docs: Fix markup to properly emphasize Kubernetes version in a note
```
