### PR TITLE
iptables: skip reverse IP lookup

### DIFF
--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -97,7 +97,7 @@ var ciliumChains = []customChain{
 }
 
 func (c *customChain) exists(prog iptablesInterface) (bool, error) {
-	args := []string{"-t", c.table, "-L", c.name}
+	args := []string{"-t", c.table, "-S", c.name}
 
 	output, err := prog.runProgOutput(args)
 	if err != nil {

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -102,7 +102,7 @@ func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {
 	mockIp4tables := &mockIptables{c: c, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
-			args: "-t mangle -L CILIUM_PRE_mangle",
+			args: "-t mangle -S CILIUM_PRE_mangle",
 		},
 		{
 			args: "-t mangle -E CILIUM_PRE_mangle OLD_CILIUM_PRE_mangle",


### PR DESCRIPTION
When listing a table or chain with '-L', iptables will by default try to perform a reverse IP lookup for each IP referenced in the ruleset that is being listed.

This adds a useless dependency on DNS, which can lead to an increased initialization time for the agent in case the DNS server is slow to respond.

As the reverse lookup is not needed, switch to the '-S' command, which does not perform any reverse lookup.