### PR TITLE
build: Avoid re-building when building docs from the main Makefile

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -33,7 +33,11 @@ builder-image: Dockerfile $(REQUIREMENTS) ## Build the docs-builder image for re
 # cilium must have all build artifacts present for
 # documentation to be generated correctly.
 cilium-build:
+ifndef SKIP_BUILD
 	make -C ../ build
+else
+	echo "SKIP_BUILD set, assuming all build artifacts are already present."
+endif
 
 READTHEDOCS_VERSION:=$(READTHEDOCS_VERSION)
 DOCKER_CTR_ROOT_DIR := /src

--- a/Makefile
+++ b/Makefile
@@ -619,7 +619,7 @@ install-manpages: ## Install manpages the Cilium CLI.
 	mandb
 
 postcheck: build ## Run Cilium build postcheck (update-cmdref, build documentation etc.).
-	$(QUIET)$(MAKE) $(SUBMAKEOPTS) -C Documentation check
+	$(QUIET) SKIP_BUILD=true $(MAKE) $(SUBMAKEOPTS) -C Documentation check
 
 licenses-all: ## Generate file with all the License from dependencies.
 	@$(GO) run ./tools/licensegen > LICENSE.all || ( rm -f LICENSE.all ; false )


### PR DESCRIPTION
Plain `make` builds twice as Documentation/Makefile also builds in the main directory. Avoid this by passing `SKIP_BUILD` from the main Makefile to make in Documentation.
