### PR TITLE
bpf,test: Fixed bugs when running BPF tests on older kernels

### DIFF
--- a/test/bpf_tests/bpf_test.go
+++ b/test/bpf_tests/bpf_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/coverbee"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/perf"
+	"github.com/cilium/ebpf/rlimit"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/protobuf/proto"
 	"github.com/vishvananda/netlink/nl"
@@ -51,6 +52,10 @@ var (
 func TestBPF(t *testing.T) {
 	if testPath == nil || *testPath == "" {
 		t.Skip("Set -bpf-test-path to run BPF tests")
+	}
+
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Log(err)
 	}
 
 	entries, err := os.ReadDir(*testPath)
@@ -269,9 +274,21 @@ func loadAndPrepSpec(t *testing.T, elfPath string) *ebpf.CollectionSpec {
 		mspec.Pinning = ebpf.PinNone
 	}
 
-	// Detect program type mismatches
 	var progTestType ebpf.ProgramType
-	for _, prog := range spec.Programs {
+	for progName, prog := range spec.Programs {
+		switch prog.Type {
+		case ebpf.XDP, ebpf.SchedACT, ebpf.SchedCLS:
+		case ebpf.UnspecifiedProgram:
+		default:
+			t.Logf(
+				"program '%s' has program type '%s' which doesn't have BPF_PROG_RUN support, not loading it",
+				prog.Name,
+				prog.Type,
+			)
+			delete(spec.Programs, progName)
+			continue
+		}
+
 		if progTestType != prog.Type {
 			if progTestType == ebpf.UnspecifiedProgram {
 				progTestType = prog.Type


### PR DESCRIPTION
The BPF unit/integration tests had some trouble running on older kernels (<=5.8). That is because the test runner always attempted to load all programs in the ELF. This fix makes it so we only attempt to load XDP and TC programs, both of which have `BPF_PROG_RUN` support.

This PR also removes the rlimit memory lock which is required on pre-5.11 kernels.

Fixes: #22779
Fixes: #22780

```release-note
Fixed BPF tests which would fail on older kernels (<=5.8) due to unsupported program loading
```
