### PR TITLE
datapath: Fix L7 ingress with XDP

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -858,6 +858,9 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 
 #if defined(ENABLE_L7_LB)
 		if (lb6_svc_is_l7loadbalancer(svc) && svc->l7_lb_proxy_port > 0) {
+#if __ctx_is == __ctx_xdp
+			return CTX_ACT_OK;
+#endif
 			send_trace_notify(ctx, TRACE_TO_PROXY, src_identity, 0,
 					  bpf_ntohs((__u16)svc->l7_lb_proxy_port), 0,
 					  TRACE_REASON_POLICY, monitor);
@@ -1813,6 +1816,13 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 			return DROP_NOT_IN_SRC_RANGE;
 #if defined(ENABLE_L7_LB)
 		if (lb4_svc_is_l7loadbalancer(svc) && svc->l7_lb_proxy_port > 0) {
+#if __ctx_is == __ctx_xdp
+			/* We cannot redirect from the XDP layer to cilium_host.
+			 * Therefore, let the bpf_host to handle the L7 ingress
+			 * request.
+			 */
+			return CTX_ACT_OK;
+#endif
 			send_trace_notify(ctx, TRACE_TO_PROXY, src_identity, 0,
 					  bpf_ntohs((__u16)svc->l7_lb_proxy_port), 0,
 					  TRACE_REASON_POLICY, monitor);


### PR DESCRIPTION
Fredrik Björkman has reported that the BPF L7 Ingress (and thus Gateway API) does not work when the Cilium's XDP is enabled.

A quick glimps into the `nodeport_lb4/6` revealed that in the case of an L7 service the `ctx_redirect_to_proxy_hairpin_ipv4/6()` is called. The latter invokes the `ctx_redirect()` to the cilium_host. Unfortunately, the redirect does not work when called from the bpf_xdp, as the cilium_host doesn't have any XDP prog attached.

Fix this by offloading the L7 handling to the bpf_host at the TC BPF ingress.

Reported-by: Fredrik Björkman <fredrik.bjorkman1@ingka.ikea.com>
Signed-off-by: Martynas Pumputis <m@lambda.lt>
