### PR TITLE
hubble: Fix panic if IP address cannot be parsed

### DIFF
--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/server"
 	"github.com/cilium/cilium/pkg/hubble/server/serveroption"
 	"github.com/cilium/cilium/pkg/identity"
+	ippkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging"
@@ -340,7 +341,12 @@ func (d *Daemon) GetNamesOf(sourceEpID uint32, ip net.IP) []string {
 	if ep == nil {
 		return nil
 	}
-	names := ep.DNSHistory.LookupIP(ip)
+
+	addr, ok := ippkg.AddrFromIP(ip)
+	if !ok {
+		return nil
+	}
+	names := ep.DNSHistory.LookupIP(addr)
 
 	for i := range names {
 		names[i] = strings.TrimSuffix(names[i], ".")

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -443,11 +443,11 @@ func (c *DNSCache) lookupByRegexpByTime(now time.Time, re *regexp.Regexp) (match
 // maintains the latest-expiring entry per-name per-IP. This means that multiple
 // names referrring to the same IP will expire from the cache at different times,
 // and only 1 entry for each name-IP pair is internally retained.
-func (c *DNSCache) LookupIP(ip net.IP) (names []string) {
+func (c *DNSCache) LookupIP(ip netip.Addr) (names []string) {
 	c.RLock()
 	defer c.RUnlock()
 
-	return c.lookupIPByTime(c.lastCleanup, ippkg.MustAddrFromIP(ip))
+	return c.lookupIPByTime(c.lastCleanup, ip)
 }
 
 // lookupIPByTime takes a timestamp for expiration comparisons, and is

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -560,7 +560,7 @@ func (ds *DNSCacheTestSuite) TestOverlimitEntriesWithValidLimit(c *C) {
 	c.Assert(affectedNames, checker.DeepEquals, []string{"test.com"})
 
 	c.Assert(cache.Lookup("test.com"), HasLen, limit)
-	c.Assert(cache.LookupIP(net.ParseIP("1.1.1.1")), checker.DeepEquals, []string{"foo.bar"})
+	c.Assert(cache.LookupIP(netip.MustParseAddr("1.1.1.1")), checker.DeepEquals, []string{"foo.bar"})
 	c.Assert(cache.forward["test.com"][netip.MustParseAddr("1.1.1.1")], IsNil)
 	c.Assert(cache.Lookup("foo.bar"), HasLen, 1)
 	c.Assert(cache.Lookup("bar.foo"), HasLen, 1)


### PR DESCRIPTION
The Hubble code internally still uses the old `net.IP` type. Because of this, when performing an IP lookup in the FQDN cache, we converted Hubble's `net.IP` to `netip.Addr` using `ippkg.MustAddrFromIP` which panics if the `net.IP` is nil.

It's not yet clear why `net.IP` would be nil for L7 flows (see linked issue) - but we should avoid a panic if the IP is malformed. This commit fixes this by moving the translation from `net.IP` to `netip.Addr` to the Hubble code. This is a stopgap till we have ported the Hubble subsystem to also use `netip.Addr` internally. This commit is intentionally kept small to ease backporting.

Fixes: #22949