### PR TITLE
Docs: Add `policy_implementation_delay` to metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -335,7 +335,7 @@ Name                                       Labels                               
 ``policy_max_revision``                                                                       Enabled    Highest policy revision number in the agent
 ``policy_import_errors_total``                                                                Enabled    Number of times a policy import has failed
 ``policy_endpoint_enforcement_status``                                                        Enabled    Number of endpoints labeled by policy enforcement status
-``policy_implementation_delay`` ``source``                                                    Enabled    Time in seconds between a policy change and it being fully deployed into the datapath, labeled by the policy's source
+``policy_implementation_delay``            ``source``                                         Enabled    Time in seconds between a policy change and it being fully deployed into the datapath, labeled by the policy's source
 ========================================== ================================================== ========== ========================================================
 
 Policy L7 (HTTP/Kafka)

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -335,6 +335,7 @@ Name                                       Labels                               
 ``policy_max_revision``                                                                       Enabled    Highest policy revision number in the agent
 ``policy_import_errors_total``                                                                Enabled    Number of times a policy import has failed
 ``policy_endpoint_enforcement_status``                                                        Enabled    Number of endpoints labeled by policy enforcement status
+``policy_implementation_delay`` ``source``                                                    Enabled    Time in seconds between a policy change and it being fully deployed into the datapath, labeled by the policy's source
 ========================================== ================================================== ========== ========================================================
 
 Policy L7 (HTTP/Kafka)


### PR DESCRIPTION
This commit adds the `policy_implementation_delay` to the metrics page in Cilium's documentation. This metric has already been implemented, however it was missing in the documentation.

Needs the `release-note/misc` label.

I used the description provided here, adding in a note about units and the label: https://github.com/cilium/cilium/blob/master/pkg/metrics/metrics.go#L793

