### PR TITLE
docs: Update hostfw tuto with ICMP policy rule

### DIFF
--- a/Documentation/security/host-firewall.rst
+++ b/Documentation/security/host-firewall.rst
@@ -83,8 +83,8 @@ Apply a Host Network Policy
 
 `HostPolicies` match on node labels using a :ref:`NodeSelector` to identify the
 nodes to which the policy applies. The following policy applies to all nodes.
-It allows communications from outside the cluster only on port TCP/22. All
-communications from the cluster to the hosts are allowed.
+It allows communications from outside the cluster only for TCP/22 and for ICMP
+echo requests. All communications from the cluster to the hosts are allowed.
 
 Host policies don't apply to communications between pods or between pods and
 the outside of the cluster, except if those pods are host-networking pods.

--- a/examples/policies/host/demo-host-policy.yaml
+++ b/examples/policies/host/demo-host-policy.yaml
@@ -14,3 +14,7 @@ spec:
     - ports:
       - port: "22"
         protocol: TCP
+  - icmps:
+    - fields:
+      - type: 8
+        family: IPv4


### PR DESCRIPTION
This pull request updates the host firewall getting started guide to also allow ICMP echo requests as part of the initial policy.

Suggested-by: Rob Landers <landers.robert@gmail.com>
Signed-off-by: Paul Chaignon <paul@cilium.io>
