### PR TITLE
v1.12 backports 2023-01-09

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -4,16 +4,15 @@ on:
   pull_request_target:
     types:
       - opened
-      - synchronize
       - reopened
 
 jobs:
   labeler:
     if: |
       (
-        (github.event.issue.author_association != 'OWNER') &&
-        (github.event.issue.author_association != 'COLLABORATOR') &&
-        (github.event.issue.author_association != 'MEMBER')
+        (github.event.pull_request.author_association != 'OWNER') &&
+        (github.event.pull_request.author_association != 'COLLABORATOR') &&
+        (github.event.pull_request.author_association != 'MEMBER')
       )
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -1,0 +1,30 @@
+name: PR from External Contribution Detector
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  labeler:
+    if: |
+      (
+        (github.event.issue.author_association != 'OWNER') &&
+        (github.event.issue.author_association != 'COLLABORATOR') &&
+        (github.event.issue.author_association != 'MEMBER')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["kind/community-contribution"]
+            })

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -73,8 +73,9 @@ jobs:
 
       - name: Enable IPv6 in docker
         run: |
-          # Keep existing cgroup-parent in github action
-          sudo sh -c "echo '{ \"cgroup-parent\": \"/actions_job\", \"ipv6\": true, \"fixed-cidr-v6\": \"2001:db8:1::/64\" }' > /etc/docker/daemon.json"
+          sudo cat /etc/docker/daemon.json || true
+          # Keep existing config like cgroup-parent in github action
+          sudo sh -c "echo '{ \"exec-opts\": [\"native.cgroupdriver=cgroupfs\"], \"cgroup-parent\": \"/actions_job\", \"ipv6\": true, \"fixed-cidr-v6\": \"2001:db8:1::/64\" }' > /etc/docker/daemon.json"
           sudo cat /etc/docker/daemon.json
           sudo ip -6 route add 2001:db8:1::/64 dev docker0
           sudo sysctl net.ipv6.conf.default.forwarding=1

--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -34,6 +34,7 @@ cilium-bugtool [OPTIONS] [flags]
       --dry-run                   Create configuration file of all commands that would have been executed
       --enable-markdown           Dump output of commands in markdown format
       --envoy-dump                When set, dump envoy configuration from unix socket (default true)
+      --exclude-object-files      Exclude per-endpoint object files. Template object files will be kept
       --exec-timeout duration     The default timeout for any cmd execution in seconds (default 30s)
       --get-pprof                 When set, only gets the pprof traces from the cilium-agent binary
   -h, --help                      help for cilium-bugtool

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -110,7 +110,7 @@ archive_filename = archive_name + '.tar.gz'
 archive_link = github_repo + 'archive/' + archive_filename
 archive_name = 'cilium-' + archive_name.strip('v')
 project_link = github_repo + 'projects?query=is:open+' + next_release
-backport_format = github_repo + 'pulls?q=is:open+is:pr+label:%s/' + current_release
+backport_format = github_repo + 'pulls?q=is:open+is:pr+-label:backport/author+label:%s/' + current_release
 
 # Store variables in the epilogue so they are globally available.
 rst_epilog = """

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -59,6 +59,14 @@ maintainers when the PR is reviewed. When proposing PRs that have already been
 merged, also add a comment to the PR to ensure that the backporters are
 notified.
 
+Marking PRs to be backported by the author
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For PRs which need to be backported, but are likely to run into conflicts or
+other difficulties, the author has the option of adding the ``backport/author``
+label. This will exclude the PR from backporting automation, and the author is
+expected to perform the backport themselves.
+
 Backporting Guide for the Backporter
 ------------------------------------
 
@@ -349,7 +357,9 @@ Original Committers and Reviewers
 Committers should mark PRs needing backport as ``needs-backport/X.Y``, based on
 the `backport criteria <backport_criteria_>`_. It is up to the reviewers to
 confirm that the backport request is reasonable and, if not, raise concerns on
-the PR as comments.
+the PR as comments. In addition, if conflicts are foreseen or significant
+changes to the PR are necessary for older branches, consider adding the
+``backport/author`` label to mark the PR to be backported by the author.
 
 At some point, changes will be picked up on a backport PR and the committer will
 be notified and asked to approve the backport commits. Confirm that:

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1027,7 +1027,8 @@ int to_netdev(struct __ctx_buff *ctx __maybe_unused)
 
 			ctx->mark = 0;
 			tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);
-			return DROP_MISSED_TAIL_CALL;
+			return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL,
+						      CTX_ACT_DROP, METRIC_EGRESS);
 		}
 	}
 #endif

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1008,8 +1008,11 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 	ret = rev_nodeport_lb6(ctx, &ifindex, &ext_err);
 	if (IS_ERR(ret))
 		goto drop;
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
+		ret = DROP_INVALID;
 		goto drop;
+	}
+
 	if (is_v4_in_v6((union v6addr *)&ip6->saddr)) {
 		ret = lb6_to_lb4(ctx, ip6);
 		if (ret)

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -185,7 +185,8 @@ gitlib::github_api_token
 
 echo "Checking for backports on branch '${STABLE_BRANCH}'"
 
-stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport-done/${STABLE_BRANCH}"))
+# Don't consider PRs with `backport/author`, which the author will backport themselves.
+stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport/author" ))
 echo -e "v$STABLE_BRANCH backports $(date +%Y-%m-%d)\n" | tee $SUMMARY_LOG
 echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1821,16 +1821,18 @@ func runDaemon() {
 		log.WithError(err).Warn("Failed to send agent start monitor message")
 	}
 
-	if !d.datapath.Node().NodeNeighDiscoveryEnabled() {
-		// Remove all non-GC'ed neighbor entries that might have previously set
-		// by a Cilium instance.
-		d.datapath.Node().NodeCleanNeighbors(false)
-	} else {
-		// If we came from an agent upgrade, migrate entries.
-		d.datapath.Node().NodeCleanNeighbors(true)
-		// Start periodical refresh of the neighbor table from the agent if needed.
-		if option.Config.ARPPingRefreshPeriod != 0 && !option.Config.ARPPingKernelManaged {
-			d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.Node())
+	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
+		if !d.datapath.Node().NodeNeighDiscoveryEnabled() {
+			// Remove all non-GC'ed neighbor entries that might have previously set
+			// by a Cilium instance.
+			d.datapath.Node().NodeCleanNeighbors(false)
+		} else {
+			// If we came from an agent upgrade, migrate entries.
+			d.datapath.Node().NodeCleanNeighbors(true)
+			// Start periodical refresh of the neighbor table from the agent if needed.
+			if option.Config.ARPPingRefreshPeriod != 0 && !option.Config.ARPPingKernelManaged {
+				d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.Node())
+			}
 		}
 	}
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -96,14 +96,6 @@ type DNSProxy struct {
 	// parsing etc. for us.
 	UDPServer, TCPServer *dns.Server
 
-	// UDPClient, TCPClient are the miekg/dns client instances. Forwarded
-	// requests are made with these clients but are sent to the originally
-	// intended DNS server.
-	// Note: The DNS request ID is randomized but when seeing a lot of traffic we
-	// may still exhaust the 16-bit ID space for our (source IP, source Port) and
-	// this may cause DNS disruption. A client pool may be better.
-	UDPClient, TCPClient *dns.Client
-
 	// EnableDNSCompression allows the DNS proxy to compress responses to
 	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
 	EnableDNSCompression bool
@@ -458,12 +450,6 @@ func StartDNSProxy(address string, port uint16, enableDNSCompression bool, maxRe
 		EnableIPv4, EnableIPv6 = option.Config.EnableIPv4, option.Config.EnableIPv6
 	)
 
-	// Bind the DNS forwarding clients on UDP and TCP
-	// Note: SingleInFlight should remain disabled. When enabled it folds DNS
-	// retries into the previous lookup, suppressing them.
-	p.UDPClient = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: false}
-	p.TCPClient = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: false}
-
 	start := time.Now()
 	for time.Since(start) < ProxyBindTimeout {
 		UDPConn, TCPListener, err = bindToAddr(address, port, EnableIPv4, EnableIPv6)
@@ -705,9 +691,9 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	var client *dns.Client
 	switch protocol {
 	case "udp":
-		client = p.UDPClient
+		client = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: false}
 	case "tcp":
-		client = p.TCPClient
+		client = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: false}
 	default:
 		scopedLog.Error("Cannot parse DNS proxy client network to select forward client")
 		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %w", err)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3000,17 +3000,17 @@ func (kub *Kubectl) CiliumPolicyRevision(pod string) (int, error) {
 	defer cancel()
 	res := kub.CiliumExecContext(ctx, pod, "cilium policy get -o json")
 	if !res.WasSuccessful() {
-		return -1, fmt.Errorf("cannot get the revision %s", res.Stdout())
+		return -1, fmt.Errorf("cannot get policy revision: %q", res.Stdout())
 	}
 
 	revision, err := res.Filter("{.revision}")
 	if err != nil {
-		return -1, fmt.Errorf("cannot get revision from json output '%s': %s", res.CombineOutput(), err)
+		return -1, fmt.Errorf("unable to find revision from json output %q: %s", res.CombineOutput(), err)
 	}
 
 	revi, err := strconv.Atoi(strings.Trim(revision.String(), "\n"))
 	if err != nil {
-		kub.Logger().Errorf("revision on pod '%s' is not valid '%s'", pod, res.CombineOutput())
+		kub.Logger().Errorf("Found invalid policy revision on pod %q: %q", pod, res.CombineOutput())
 		return -1, err
 	}
 	return revi, nil
@@ -3032,7 +3032,7 @@ func (kub *Kubectl) getPodRevisions() (map[string]int, error) {
 		revision, err := kub.CiliumPolicyRevision(pod)
 		if err != nil {
 			kub.Logger().WithError(err).Error("cannot retrieve cilium pod policy revision")
-			return nil, fmt.Errorf("Cannot retrieve cilium pod %s policy revision: %s", pod, err)
+			return nil, fmt.Errorf("Cannot retrieve %q's policy revision: %s", pod, err)
 		}
 		revisions[pod] = revision
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2832,15 +2832,18 @@ func (kub *Kubectl) CiliumExecContext(ctx context.Context, pod string, cmd strin
 	// changes did not fix the isse, and we need to make this workaround to
 	// avoid Kubectl issue.
 	// https://github.com/openshift/origin/issues/16246
-	// Sometimes kubectl returns 137 exit code, when the command has been
-	// killed with the stderr "signal: killed", where the same command
-	// succeeds in a forthcoming sysdump. Keep trying also in this case
-	// until the 'limitTimes' retries has been exhausted.
+	//
+	// Sometimes kubectl returns -1 exit code, when the command has been killed
+	// with the stderr "signal: killed" (or generically when a process has been
+	// killed by a signal [1]), where the same command succeeds in a
+	// forthcoming sysdump. Keep trying also in this case until the
+	// 'limitTimes' retries has been exhausted.
 	// https://github.com/cilium/cilium/issues/22476
+	// [1]: https://github.com/golang/go/blob/go1.20rc1/src/os/exec_posix.go#L128-L130
 	for i := 0; i < limitTimes; i++ {
 		res = execute()
 		switch res.GetExitCode() {
-		case 126, 137:
+		case -1, 126:
 			// Retry.
 		default:
 			kub.Logger().Warningf("command terminated with exit code %d on try %d", res.GetExitCode(), i)

--- a/test/helpers/local_node.go
+++ b/test/helpers/local_node.go
@@ -162,7 +162,7 @@ func (s *LocalExecutor) ExecContext(ctx context.Context, cmd string, options ...
 		ops = options[0]
 	}
 
-	log.Debugf("running command: %s", cmd)
+	log.Debugf("running local command: %s", cmd)
 	fmt.Fprintln(SSHMetaLogs, cmd)
 	stdout := new(Buffer)
 	stderr := new(Buffer)
@@ -184,7 +184,7 @@ func (s *LocalExecutor) ExecContext(ctx context.Context, cmd string, options ...
 		}
 		res.success = false
 
-		log.WithError(err).Errorf("Error executing command '%s'", cmd)
+		log.WithError(err).Errorf("Error executing local command '%s'", cmd)
 		res.err = err
 	}
 
@@ -233,7 +233,7 @@ func (s *LocalExecutor) ExecInBackground(ctx context.Context, cmd string, option
 			}
 			res.success = false
 
-			log.WithError(err).Errorf("Error executing command '%s'", strings.Join(append([]string{cmd.Path}, cmd.Args...), " "))
+			log.WithError(err).Errorf("Error executing local background command '%s'", strings.Join(append([]string{cmd.Path}, cmd.Args...), " "))
 			res.err = err
 		}
 

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -196,7 +196,7 @@ func (s *SSHMeta) ExecContext(ctx context.Context, cmd string, options ...ExecOp
 		ops = options[0]
 	}
 
-	log.Debugf("running command: %s", cmd)
+	log.Debugf("running command via SSH: %s", cmd)
 	stdout := new(Buffer)
 	stderr := new(Buffer)
 	start := time.Now()
@@ -222,7 +222,7 @@ func (s *SSHMeta) ExecContext(ctx context.Context, cmd string, options ...ExecOp
 			res.exitcode = exiterr.Waitmsg.ExitStatus()
 		} else {
 			// Log other error types. They are likely from SSH or the network
-			log.WithError(err).Errorf("Error executing command '%s'", cmd)
+			log.WithError(err).Errorf("Error executing command from SSH '%s'", cmd)
 		}
 		res.err = err
 	}

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -375,7 +375,7 @@ func doFragmentedRequest(kubectl *helpers.Kubectl, srcPod string, srcPort, dstPo
 	ExpectWithOffset(2, []int{fragmentedPacketsAfterK8s1, fragmentedPacketsAfterK8s2}).To(SatisfyAny(
 		Equal([]int{fragmentedPacketsBeforeK8s1, fragmentedPacketsBeforeK8s2 + delta}),
 		Equal([]int{fragmentedPacketsBeforeK8s1 + delta, fragmentedPacketsBeforeK8s2}),
-	), "Failed to account for INGRESS IPv4 fragments in BPF metrics", dstIP)
+	), "Failed to account for INGRESS IPv4 fragments to %s in BPF metrics", dstIP)
 }
 
 func testNodePort(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, bpfNodePort, testFromOutside bool, fails int) {


### PR DESCRIPTION
* #22461 -- .github: add PR labeler for external contributions (@aanm)
 * #22508 -- .github/workflows: use right event type for auto labeler (@aanm)
 * #22370 -- Bugtool: add flag to exclude object for endpoints (@tbalthazar) (⚠️ Resolved conflicts)
 * #22543 -- bpf: nodeport: fix drop notification in IPv6 revNAT (@julianwiedmann)
 * #22676 -- daemon: Do not remove PERM L2 entries in L4LB (@brb)
 * #22726 -- test/helpers: Fix retry condition for CiliumExecContext (@christarazi) (⚠️ Resolved conflicts)
 * #22679 -- bpf: add drop notification for missed L7 LB tailcall in to-netdev (@julianwiedmann)
 * #22774 -- ci, github: Fix IPv6 conformance test (@borkmann)
 * #22654 -- backporting: leave `backport/author` PRs alone (@bimmlerd)
 * #22619 -- fqdn: dnsproxy: fix data race in dns proxy implementation (@aspsk)
 * #22772 -- test: service: fix formatting of error msg in doFragmentedRequest() (@julianwiedmann)

Skipped due to author-driven backports/non-trivial backports/non-applicable:

 *  test/k8s: remove l7_demos test (@tklauser) -- https://github.com/cilium/cilium/pull/20619
 *  Fix behavior where packets leave node if there are no backends (v2) 
 *  Adding/fixing DNSProxy metrics (@rahulkjoshi) -- https://github.com/cilium/cilium/pull/21267
 * https://github.com/cilium/cilium/pull/22721 -- install/kubernetes: make securityContext SELinux options configurable (@tklauser)
 * Add sphinxcontrib-googleanalytics to doc requirements (@chalin) -- https://github.com/cilium/cilium/pull/22821
 * daemon/cmd: improve stale cilium endpoint error handling. (@tommyp1ckles) 

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 22461 22508 22370 22543 22676 22726 22679 22774 22654 22619 22772; do contrib/backporting/set-labels.py $pr done 1.12; done