### PR TITLE
gha: Improve coverage for Ingress/GatewayAPI

### DIFF
--- a/.github/workflows/conformance-ingress-shared.yaml
+++ b/.github/workflows/conformance-ingress-shared.yaml
@@ -120,7 +120,8 @@ jobs:
             --set operator.image.useDigest=false \
             --set securityContext.privileged=true \
             --set ingressController.enabled=true \
-            --set ingressController.loadbalancerMode=shared
+            --set ingressController.loadbalancerMode=shared \
+            --set extraConfig.bpf-lb-acceleration=native # This is to make sure we have the coverage for XDP.
 
           kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=${{ env.timeout }}
 


### PR DESCRIPTION
## Description

Ingress/GatewayAPI relies heavily on NodePort implementation, so we
should have coverage for XDP in L7 Ingress. This commit is to enable XDP
for one of existing Ingress GHA jobs (e.g. shared).

Relates: #22985
Signed-off-by: Tam Mach <tam.mach@cilium.io>
