### PR TITLE
ipam/crd: Add new flag for configuring custom resource update rate

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -181,6 +181,7 @@ cilium-agent [flags]
       --ip-allocation-timeout duration                          Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
       --ip-masq-agent-config-path string                        ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
       --ipam string                                             Backend to use for IPAM (default "cluster-pool")
+      --ipam-cilium-node-update-rate duration                   Maximum rate at which the CiliumNode custom resource is updated (default 15s)
       --ipsec-key-file string                                   Path to IPSec key file
       --iptables-lock-timeout duration                          Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                   Set iptables flag random-fully on masquerading rules

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1305,6 +1305,10 @@
      - Configure the eBPF-based ip-masq-agent
      - object
      - ``{"enabled":false}``
+   * - ipam.ciliumNodeUpdateRate
+     - Maximum rate at which the CiliumNode custom resource is updated.
+     - string
+     - ``"15s"``
    * - ipam.mode
      - Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -259,6 +259,8 @@ ci
 cidr
 cidrs
 ciliumAgent
+ciliumNodeUpdateRate
+ciliumnode
 classful
 classid
 cleanBpfState

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1082,6 +1082,9 @@ func initializeFlags() {
 	flags.MarkHidden(option.EnableStaleCiliumEndpointCleanup)
 	option.BindEnv(Vp, option.EnableStaleCiliumEndpointCleanup)
 
+	flags.Duration(option.IPAMCiliumNodeUpdateRate, 15*time.Second, "Maximum rate at which the CiliumNode custom resource is updated")
+	option.BindEnv(Vp, option.IPAMCiliumNodeUpdateRate)
+
 	if err := Vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -377,6 +377,7 @@ contributors across the globe, there is almost always someone available to help.
 | installIptablesRules | bool | `true` | Configure whether to install iptables rules to allow for TPROXY (L7 proxy injection), iptables-based masquerading and compatibility with kube-proxy. |
 | installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup. |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |
+| ipam.ciliumNodeUpdateRate | string | `"15s"` | Maximum rate at which the CiliumNode custom resource is updated. |
 | ipam.mode | string | `"cluster-pool"` | Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/ |
 | ipam.operator.clusterPoolIPv4MaskSize | int | `24` | IPv4 CIDR mask size to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv4PodCIDR | string | `"10.0.0.0/8"` | Deprecated in favor of ipam.operator.clusterPoolIPv4PodCIDRList. IPv4 CIDR range to delegate to individual nodes for IPAM. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -784,6 +784,10 @@ data:
   ipam: {{ $ipam | quote }}
 {{- end }}
 
+{{- if .Values.ipam.ciliumNodeUpdateRate }}
+  ipam-cilium-node-update-rate: {{ include "validateDuration" .Values.ipam.ciliumNodeUpdateRate | quote }}
+{{- end }}
+
 {{- if or (eq $ipam "cluster-pool") (eq $ipam "cluster-pool-v2beta") }}
 {{- if .Values.ipv4.enabled }}
   {{- if .Values.ipam.operator.clusterPoolIPv4PodCIDRList }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1305,6 +1305,8 @@ ipam:
   # -- Configure IP Address Management mode.
   # ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/
   mode: "cluster-pool"
+  # -- Maximum rate at which the CiliumNode custom resource is updated.
+  ciliumNodeUpdateRate: "15s"
   operator:
     # -- Deprecated in favor of ipam.operator.clusterPoolIPv4PodCIDRList.
     # IPv4 CIDR range to delegate to individual nodes for IPAM.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1302,6 +1302,8 @@ ipam:
   # -- Configure IP Address Management mode.
   # ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/
   mode: "cluster-pool"
+  # -- Maximum rate at which the CiliumNode custom resource is updated.
+  ciliumNodeUpdateRate: "15s"
   operator:
     # -- Deprecated in favor of ipam.operator.clusterPoolIPv4PodCIDRList.
     # IPv4 CIDR range to delegate to individual nodes for IPAM.

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -43,10 +43,6 @@ var (
 )
 
 const (
-	// customResourceUpdateRate is the maximum rate in which a custom
-	// resource is updated
-	customResourceUpdateRate = 15 * time.Second
-
 	fieldName = "name"
 )
 
@@ -96,7 +92,7 @@ func newNodeStore(nodeName string, conf Configuration, owner Owner, clientset cl
 
 	t, err := trigger.NewTrigger(trigger.Parameters{
 		Name:        "crd-allocator-node-refresher",
-		MinInterval: customResourceUpdateRate,
+		MinInterval: option.Config.IPAMCiliumNodeUpdateRate,
 		TriggerFunc: store.refreshNodeTrigger,
 	})
 	if err != nil {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1119,6 +1119,10 @@ const (
 	// EnableStaleCiliumEndpointCleanup sets whether Cilium should perform cleanup of
 	// stale CiliumEndpoints during init.
 	EnableStaleCiliumEndpointCleanup = "enable-stale-cilium-endpoint-cleanup"
+
+	// IPAMCiliumnodeUpdateRate is the maximum rate at which the CiliumNode custom
+	// resource is updated.
+	IPAMCiliumNodeUpdateRate = "ipam-cilium-node-update-rate"
 )
 
 // Default string arguments
@@ -2295,6 +2299,10 @@ type DaemonConfig struct {
 	// This will attempt to remove local CiliumEndpoints that are not managed by Cilium
 	// following Endpoint restoration.
 	EnableStaleCiliumEndpointCleanup bool
+
+	// IPAMCiliumNodeUpdateRate is the maximum rate at which the CiliumNode custom
+	// resource is updated.
+	IPAMCiliumNodeUpdateRate time.Duration
 }
 
 var (
@@ -3008,6 +3016,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.DeriveMasqIPAddrFromDevice = vp.GetString(DeriveMasqIPAddrFromDevice)
 	c.EnablePMTUDiscovery = vp.GetBool(EnablePMTUDiscovery)
 	c.IPv6NAT46x64CIDR = defaults.IPv6NAT46x64CIDR
+	c.IPAMCiliumNodeUpdateRate = vp.GetDuration(IPAMCiliumNodeUpdateRate)
 
 	c.populateLoadBalancerSettings(vp)
 	c.populateDevices(vp)


### PR DESCRIPTION
In crd ipam modes, the current agent side custom resource update rate is hardcoded as 15 seconds, which might be too big in burst pod creation cases. e.g. when a large number of pods are scheduled to a single node, let's say 25 pods and the `pre-allocate` is set to 5, a maximum of 5 IPs can be allocated every 15 seconds (update of used IPs are rate limited), which causes some pods to wait too long.

This commit adds a new agent flag `ipam-cilium-node-update-rate` to configure the ciliumnode custom resource update rate.

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

```release-note
ipam/crd: Add new flag for configuring CiliumNode update rate
```
