### PR TITLE
bpf: test: fix xdp_lb4_forward_to_other_node test

### DIFF
--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -74,7 +74,7 @@ static int build_packet(struct __ctx_buff *ctx)
 		.ihl = 5,
 		.tot_len = 40, /* 20 bytes l3 + 20 bytes l4 + 20 bytes data */
 		.id = 0x5438,
-		.frag_off = 0x4000,
+		.frag_off = bpf_htons(IP_DF),
 		.ttl = 64,
 		.protocol = IPPROTO_TCP,
 		.saddr = 0x0F00000A, /* 10.0.0.15 */
@@ -209,8 +209,8 @@ int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	data += sizeof(struct tcphdr);
 
-	if (l4->dest != 80)
-		test_fatal("dst port changed");
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port != backend port");
 
 	char msg[20] = "Should not change!!";
 


### PR DESCRIPTION
The test is meant to check that a TCPv4 packet addressed to FRONTEND_IP:FRONTEND_PORT gets DNATed to BACKEND_IP:BACKEND_PORT and TXed back out.

But right now we actually assert that the destination port *doesn't* get DNATed, and the test still works! The reason is that the .frag_off field in the IPv4 header isn't built correctly (it has the wrong endianness), so the LB code in lb4_xlate() believes that the packet doesn't have a L4 header and consequently also doesn't apply L4 DNAT on the packet.

Fix both aspects.
