### PR TITLE
feature: Flag to change size of egress gateway policy map

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -78,6 +78,7 @@ cilium-agent [flags]
       --dns-policy-unload-on-shutdown                           Unload DNS policy rules on graceful shutdown
       --dnsproxy-concurrency-limit int                          Limit concurrency of DNS message processing
       --dnsproxy-concurrency-processing-grace-period duration   Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing
+      --egress-gateway-policy-map-max int                       Maximum number of entries in egress gateway policy map (default 16384)
       --egress-masquerade-interfaces string                     Limit egress masquerading to interface selector
       --egress-multi-home-ip-rule-compat                        Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
       --enable-auto-protect-node-port-range                     Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -64,6 +64,7 @@ import (
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap/gc"
+	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
@@ -666,6 +667,9 @@ func initializeFlags() {
 
 	flags.Bool(option.InstallEgressGatewayRoutes, false, "Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface")
 	option.BindEnv(Vp, option.InstallEgressGatewayRoutes)
+
+	flags.Int(option.EgressGatewayPolicyMapEntriesName, egressmap.MaxPolicyEntries, "Maximum number of entries in egress gateway policy map")
+	option.BindEnv(Vp, option.EgressGatewayPolicyMapEntriesName)
 
 	flags.Bool(option.EnableEnvoyConfig, false, "Enable Envoy Config CRDs")
 	option.BindEnv(Vp, option.EnableEnvoyConfig)

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -345,7 +345,7 @@ func (d *Daemon) initMaps() error {
 	}
 
 	if option.Config.EnableIPv4EgressGateway {
-		if err := egressmap.InitEgressMaps(); err != nil {
+		if err := egressmap.InitEgressMaps(option.Config.EgressGatewayPolicyMapEntries); err != nil {
 			return err
 		}
 	}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -834,6 +834,9 @@ data:
 {{- if .Values.egressGateway.installRoutes }}
   install-egress-gateway-routes: "true"
 {{- end }}
+{{- if .Values.egressGateway.maxPolicyEntries }}
+  egress-gateway-policy-map-max: {{ .Values.egressGateway.maxPolicyEntries }}
+{{- end }}
 
 {{- if hasKey .Values "vtep" }}
   enable-vtep: {{ .Values.vtep.enabled | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1502,6 +1502,8 @@ egressGateway:
   # -- Install egress gateway IP rules and routes in order to properly steer
   # egress gateway traffic to the correct ENI interface
   installRoutes: false
+  # -- Maximum number of entries in egress gateway policy map
+  # maxPolicyEntries: 16384
 
 vtep:
 # -- Enables VXLAN Tunnel Endpoint (VTEP) Integration (beta) to allow

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1499,6 +1499,8 @@ egressGateway:
   # -- Install egress gateway IP rules and routes in order to properly steer
   # egress gateway traffic to the correct ENI interface
   installRoutes: false
+  # -- Maximum number of entries in egress gateway policy map
+  # maxPolicyEntries: 16384
 
 vtep:
 # -- Enables VXLAN Tunnel Endpoint (VTEP) Integration (beta) to allow

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -150,7 +150,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["IPCACHE_MAP"] = ipcachemap.Name
 	cDefinesMap["IPCACHE_MAP_SIZE"] = fmt.Sprintf("%d", ipcachemap.MaxEntries)
 	cDefinesMap["EGRESS_POLICY_MAP"] = egressmap.PolicyMapName
-	cDefinesMap["EGRESS_POLICY_MAP_SIZE"] = fmt.Sprintf("%d", egressmap.MaxPolicyEntries)
+	cDefinesMap["EGRESS_POLICY_MAP_SIZE"] = fmt.Sprintf("%d", option.Config.EgressGatewayPolicyMapEntries)
 	cDefinesMap["SRV6_VRF_MAP4"] = srv6map.VRFMapName4
 	cDefinesMap["SRV6_VRF_MAP6"] = srv6map.VRFMapName6
 	cDefinesMap["SRV6_POLICY_MAP4"] = srv6map.PolicyMapName4

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -120,7 +120,7 @@ func (k *EgressGatewayTestSuite) SetUpSuite(c *C) {
 	option.Config.EnableIPv4EgressGateway = true
 	option.Config.InstallEgressGatewayRoutes = true
 
-	egressmap.InitEgressMaps()
+	egressmap.InitEgressMaps(egressmap.MaxPolicyEntries)
 
 	nodeTypes.SetName(node1)
 }

--- a/pkg/maps/egressmap/egress.go
+++ b/pkg/maps/egressmap/egress.go
@@ -14,11 +14,11 @@ var (
 )
 
 // InitEgressMaps initializes the egress policy map.
-func InitEgressMaps() error {
-	return initEgressPolicyMap(PolicyMapName, true)
+func InitEgressMaps(maxPolicyEntries int) error {
+	return initEgressPolicyMap(PolicyMapName, maxPolicyEntries, true)
 }
 
 // OpenEgressMaps initializes the egress policy map.
 func OpenEgressMaps() error {
-	return initEgressPolicyMap(PolicyMapName, false)
+	return initEgressPolicyMap(PolicyMapName, 0, false)
 }

--- a/pkg/maps/egressmap/egress_privileged_test.go
+++ b/pkg/maps/egressmap/egress_privileged_test.go
@@ -35,7 +35,7 @@ func (k *EgressMapTestSuite) SetUpSuite(c *C) {
 }
 
 func (k *EgressMapTestSuite) TestEgressMap(c *C) {
-	err := initEgressPolicyMap(PolicyMapName, true)
+	err := initEgressPolicyMap(PolicyMapName, MaxPolicyEntries, true)
 	c.Assert(err, IsNil)
 	defer EgressPolicyMap.Unpin()
 

--- a/pkg/maps/egressmap/policy.go
+++ b/pkg/maps/egressmap/policy.go
@@ -39,7 +39,7 @@ type egressPolicyMap struct {
 }
 
 // initEgressPolicyMap initializes the egress policy map.
-func initEgressPolicyMap(policyMapName string, create bool) error {
+func initEgressPolicyMap(policyMapName string, maxPolicyEntries int, create bool) error {
 	var m *ebpf.Map
 
 	if create {
@@ -48,7 +48,7 @@ func initEgressPolicyMap(policyMapName string, create bool) error {
 			Type:       ebpf.LPMTrie,
 			KeySize:    uint32(unsafe.Sizeof(EgressPolicyKey4{})),
 			ValueSize:  uint32(unsafe.Sizeof(EgressPolicyVal4{})),
-			MaxEntries: uint32(MaxPolicyEntries),
+			MaxEntries: uint32(maxPolicyEntries),
 			Pinning:    ebpf.PinByName,
 		})
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -636,6 +636,10 @@ const (
 	// entries.
 	SockRevNatEntriesName = "bpf-sock-rev-map-max"
 
+	// EgressGatewayPolicyMapEntriesName configures max entries for egress gateway's policy
+	// map.
+	EgressGatewayPolicyMapEntriesName = "egress-gateway-policy-map-max"
+
 	// LogSystemLoadConfigName is the name of the option to enable system
 	// load loggging
 	LogSystemLoadConfigName = "log-system-load"
@@ -1477,6 +1481,10 @@ type DaemonConfig struct {
 	// SockRevNatEntries is the maximum number of sock rev nat mappings
 	// allowed in the BPF rev nat table
 	SockRevNatEntries int
+
+	// EgressGatewayPolicyMapEntries is the maximum number of entries
+	// allowed in the BPF egress gateway policy map.
+	EgressGatewayPolicyMapEntries int
 
 	// DisableCiliumEndpointCRD disables the use of CiliumEndpoint CRD
 	DisableCiliumEndpointCRD bool
@@ -2956,6 +2964,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableIPMasqAgent = vp.GetBool(EnableIPMasqAgent)
 	c.EnableIPv4EgressGateway = vp.GetBool(EnableIPv4EgressGateway)
 	c.InstallEgressGatewayRoutes = vp.GetBool(InstallEgressGatewayRoutes)
+	c.EgressGatewayPolicyMapEntries = vp.GetInt(EgressGatewayPolicyMapEntriesName)
 	c.EnableEnvoyConfig = vp.GetBool(EnableEnvoyConfig)
 	c.EnableIngressController = vp.GetBool(EnableIngressController)
 	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)


### PR DESCRIPTION
Signed-off-by: cyclinder <qifeng.guo@daocloud.io>

<!-- Description of change -->

Flag to change size of egress gateway policy map

Fixes: 

[#issue-22929](https://github.com/cilium/cilium/issues/22929)
[#issue-22805](https://github.com/cilium/cilium/issues/22805)

Fixes #22929
Fixes #22805

```release-note
Add flag to configure the size of the egress gateway policy map
```
