### PR TITLE
bpf: nodeport: reset EDT aggregate ID for XDP-to-TC tunnel punt

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1054,6 +1054,8 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 		ctx_snat_done_set(ctx);
 
 	if (flags & XFER_PKT_ENCAP) {
+		edt_set_aggregate(ctx, 0);
+
 		return __encap_and_redirect_with_nodeid(ctx, ctx_get_xfer(ctx, XFER_ENCAP_NODEID),
 							ctx_get_xfer(ctx, XFER_ENCAP_SECLABEL),
 							ctx_get_xfer(ctx, XFER_ENCAP_DSTID),


### PR DESCRIPTION
If a punted skb enters from-netdev on TC-Ingress with an RX queue mapping,
this can collide with an aggregate in the THROTTLE_MAP when to-overlay
calls edt_sched_departure().

So reset the aggregate ID before redirecting into the tunnel, same as we
would do in the pure TC nodeport path.

Fixes: https://github.com/cilium/cilium/commit/5af76a0b6a73b6c047d3998cfde8e0a2cc3a3ec4 ("bpf: xdp: enable tunnel encap for EgressGW reply traffic")