### PR TITLE
envoy: Fix passing SNI option to upstream TLS connections

### DIFF
--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -921,6 +921,18 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 		}),
 	}
 
+	useDownstreamProtocolAutoSNI := map[string]*any.Any{
+		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": toAny(&envoy_config_upstream.HttpProtocolOptions{
+			UpstreamHttpProtocolOptions: &envoy_config_core.UpstreamHttpProtocolOptions{
+				AutoSni:           true,
+				AutoSanValidation: true,
+			},
+			UpstreamProtocolOptions: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamProtocolConfig{
+				UseDownstreamProtocolConfig: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamHttpConfig{},
+			},
+		}),
+	}
+
 	http2ProtocolOptions := map[string]*any.Any{
 		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": toAny(&envoy_config_upstream.HttpProtocolOptions{
 			UpstreamProtocolOptions: &envoy_config_upstream.HttpProtocolOptions_ExplicitHttpConfig_{
@@ -949,7 +961,7 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 					ConnectTimeout:                &duration.Duration{Seconds: connectTimeout, Nanos: 0},
 					CleanupInterval:               &duration.Duration{Seconds: connectTimeout, Nanos: 500000000},
 					LbPolicy:                      envoy_config_cluster.Cluster_CLUSTER_PROVIDED,
-					TypedExtensionProtocolOptions: useDownstreamProtocol,
+					TypedExtensionProtocolOptions: useDownstreamProtocolAutoSNI,
 					TransportSocket:               &envoy_config_core.TransportSocket{Name: "cilium.tls_wrapper"},
 				},
 				{
@@ -966,7 +978,7 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 					ConnectTimeout:                &duration.Duration{Seconds: connectTimeout, Nanos: 0},
 					CleanupInterval:               &duration.Duration{Seconds: connectTimeout, Nanos: 500000000},
 					LbPolicy:                      envoy_config_cluster.Cluster_CLUSTER_PROVIDED,
-					TypedExtensionProtocolOptions: useDownstreamProtocol,
+					TypedExtensionProtocolOptions: useDownstreamProtocolAutoSNI,
 					TransportSocket:               &envoy_config_core.TransportSocket{Name: "cilium.tls_wrapper"},
 				},
 				{


### PR DESCRIPTION
Backport commit db0dd4bc1212e7be367b88b0d3a46b5a211a25f3:

    envoy: Configure Auto SNI for TLS clusters
    
    Cilium L7 policy filter no longer sets up auto SNI and auto SAN
    validation metadata. Configure TLS clusters to do it instead.

```release-note
envoy: Fix regression on passing TLS SNI option to upstream TLS connections
```
