### PR TITLE
ctmap: fix-up host_local flag in the DSR NAT entry for GC test

### DIFF
--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -397,10 +397,9 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		},
 	}
 	natVal = &nat.NatEntry4{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv4{10, 0, 2, 20},
-		Port:      0x409c,
+		Created: 37400,
+		Addr:    types.IPv4{10, 0, 2, 20},
+		Port:    0x409c,
 	}
 	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
 		unsafe.Pointer(natVal), 0)


### PR DESCRIPTION
DSR NAT entries don't have the .host_local flag set, see eg. snat_v4_create_dsr().

This was presumably just copy&pasted from the other NAT entries in the file. It currently doesn't make a difference for the test, but let's still fix it.

Fixes: 790465042b91 ("ctmap: add support for GC of DSR orphaned entries")