### PR TITLE
ci: Disable WireGuard in ci-multicluster again

### DIFF
--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -346,6 +346,7 @@ jobs:
         # is fixed.
 
       - name: Enable WireGuard
+        if: ${{ false }} # Tracking issue: https://github.com/cilium/cilium/issues/23044
         run: |
           for ctx in ${{ steps.contexts.outputs.context1 }} ${{ steps.contexts.outputs.context2 }} ; do
             kubectl config use-context "$ctx"
@@ -356,6 +357,7 @@ jobs:
           done
 
       - name: Run connectivity test with WireGuard
+        if: ${{ false }} # Tracking issue: https://github.com/cilium/cilium/issues/23044
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --context ${{ steps.contexts.outputs.context1 }} \


### PR DESCRIPTION
Seems to be failing pretty consistently since we reenabled it in #22815. Let's disable it again and investigate.