### PR TITLE
Egress gateway modularization

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -10,6 +10,8 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/node"
@@ -68,6 +70,14 @@ var (
 
 		// Certificate manager provides an API for retrieving secrets and certificate in the form of TLS contexts.
 		certificatemanager.Cell,
+
+		// Endpoint manager and IPCache have an import cycle, so we provide an interface to sidestep that issue
+		cell.Provide(func(epMgr endpointmanager.EndpointManager) ipcacheTypes.DatapathHandler {
+			return epMgr
+		}),
+
+		// IPCache maps endpoint IPs or CIDRs to associated information like security identities
+		ipcache.Cell,
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -78,6 +79,10 @@ var (
 
 		// IPCache maps endpoint IPs or CIDRs to associated information like security identities
 		ipcache.Cell,
+
+		// The egressgateway allows outbound connections to be routed via a specific node and IP address so
+		// static configuration can be made on that IP address (for example firewalls).
+		egressgateway.Cell,
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"github.com/cilium/cilium/pkg/bgpv1"
+	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/gops"
@@ -64,6 +65,9 @@ var (
 
 		// NodeManager maintains a collection of other nodes in the cluster.
 		nodeManager.Cell,
+
+		// Certificate manager provides an API for retrieving secrets and certificate in the form of TLS contexts.
+		certificatemanager.Cell,
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/counter"
+	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
@@ -407,6 +408,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	wgAgent *wg.Agent,
 	clientset k8sClient.Clientset,
 	sharedResources k8s.SharedResources,
+	certManager certificatemanager.CertificateManager,
+	secretManager certificatemanager.SecretManager,
 ) (*Daemon, *endpointRestoreState, error) {
 
 	var (
@@ -603,7 +606,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	// TODO: convert these package level variables to types for easier unit
 	// testing in the future.
 	d.identityAllocator = NewCachingIdentityAllocator(&d)
-	if err := d.initPolicy(epMgr); err != nil {
+	if err := d.initPolicy(epMgr, certManager, secretManager); err != nil {
 		return nil, nil, fmt.Errorf("error while initializing policy subsystem: %w", err)
 	}
 	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -41,7 +41,11 @@ import (
 )
 
 // initPolicy initializes the core policy components of the daemon.
-func (d *Daemon) initPolicy(epMgr endpointmanager.EndpointManager) error {
+func (d *Daemon) initPolicy(
+	epMgr endpointmanager.EndpointManager,
+	certManager certificatemanager.CertificateManager,
+	secretManager certificatemanager.SecretManager,
+) error {
 	// Reuse policy.TriggerMetrics and PolicyTriggerInterval here since
 	// this is only triggered by agent configuration changes for now and
 	// should be counted in pol.TriggerMetrics.
@@ -58,7 +62,9 @@ func (d *Daemon) initPolicy(epMgr endpointmanager.EndpointManager) error {
 
 	d.policy = policy.NewPolicyRepository(d.identityAllocator,
 		d.identityAllocator.GetIdentityCache(),
-		certificatemanager.NewManager(option.Config.CertDirectory, d.clientset))
+		certManager,
+		secretManager,
+	)
 	d.policy.SetEnvoyRulesFunc(envoy.GetEnvoyHTTPRules)
 	d.policyUpdater, err = policy.NewUpdater(d.policy, epMgr)
 	if err != nil {

--- a/pkg/crypto/certificatemanager/certificate_manager.go
+++ b/pkg/crypto/certificatemanager/certificate_manager.go
@@ -9,37 +9,65 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/policy/api"
+
+	"github.com/spf13/pflag"
 )
 
-const (
-	caDefaultName      = "ca.crt"
-	publicDefaultName  = "tls.crt"
-	privateDefaultName = "tls.key"
+var Cell = cell.Module(
+	"certificate-manager",
+	"Provides TLS certificates and secrets",
+
+	cell.Provide(NewManager),
+
+	cell.Config(defaultManagerConfig),
 )
 
-type k8sClient interface {
-	GetSecrets(ctx context.Context, ns, name string) (map[string][]byte, error)
+type CertificateManager interface {
+	GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, err error)
+}
+
+type SecretManager interface {
+	GetSecrets(ctx context.Context, secret *api.Secret, ns string) (string, map[string][]byte, error)
+	GetSecretString(ctx context.Context, secret *api.Secret, ns string) (string, error)
+}
+
+var defaultManagerConfig = managerConfig{
+	CertDirectory: "/var/run/cilium/certs",
+}
+
+type managerConfig struct {
+	// CertsDirectory is the root directory to be used by cilium to find
+	// certificates locally.
+	CertDirectory string `mapstructure:"certificates-directory"`
+}
+
+func (mc managerConfig) Flags(flags *pflag.FlagSet) {
+	flags.String("certificates-directory", mc.CertDirectory, "Root directory to find certificates specified in L7 TLS policy enforcement")
 }
 
 // Manager will manage the way certificates are retrieved based in the given
 // k8sClient and rootPath.
-type Manager struct {
+type manager struct {
 	rootPath  string
-	k8sClient k8sClient
+	k8sClient k8sClient.Clientset
 }
 
 // NewManager returns a new manager.
-func NewManager(certsRootPath string, k8sClient k8sClient) *Manager {
-	return &Manager{
-		rootPath:  certsRootPath,
-		k8sClient: k8sClient,
+func NewManager(cfg managerConfig, clientset k8sClient.Clientset) (CertificateManager, SecretManager) {
+	m := &manager{
+		rootPath:  cfg.CertDirectory,
+		k8sClient: clientset,
 	}
+
+	return m, m
 }
 
 // GetSecrets returns either local or k8s secrets, giving precedence for local secrets if configured.
 // The 'ns' parameter is used as the secret namespace if 'secret.Namespace' is an empty string.
-func (m *Manager) GetSecrets(ctx context.Context, secret *api.Secret, ns string) (string, map[string][]byte, error) {
+func (m *manager) GetSecrets(ctx context.Context, secret *api.Secret, ns string) (string, map[string][]byte, error) {
 	if secret == nil {
 		return "", nil, fmt.Errorf("Secret must not be nil")
 	}
@@ -78,9 +106,15 @@ func (m *Manager) GetSecrets(ctx context.Context, secret *api.Secret, ns string)
 	return nsName, secrets, err
 }
 
+const (
+	caDefaultName      = "ca.crt"
+	publicDefaultName  = "tls.crt"
+	privateDefaultName = "tls.key"
+)
+
 // GetTLSContext returns a new ca, public and private certificates found based
 // in the given api.TLSContext.
-func (m *Manager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, err error) {
+func (m *manager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, err error) {
 	name, secrets, err := m.GetSecrets(ctx, tlsCtx.Secret, ns)
 	if err != nil {
 		return "", "", "", err
@@ -127,7 +161,7 @@ func (m *Manager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns 
 }
 
 // GetSecretString returns a secret string stored in a k8s secret
-func (m *Manager) GetSecretString(ctx context.Context, secret *api.Secret, ns string) (string, error) {
+func (m *manager) GetSecretString(ctx context.Context, secret *api.Secret, ns string) (string, error) {
 	name, secrets, err := m.GetSecrets(ctx, secret, ns)
 	if err != nil {
 		return "", err

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -84,7 +84,7 @@ func (config *policyGatewayConfig) selectsNodeAsGateway(node nodeTypes.Node) boo
 	return config.nodeSelector.Matches(k8sLabels.Set(node.Labels))
 }
 
-func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
+func (config *PolicyConfig) regenerateGatewayConfig(manager *manager) {
 	gwc := gatewayConfig{
 		egressIP: net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 0)},
 	}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&EndpointManagerSuite{})
 
 func (s *EndpointManagerSuite) SetUpSuite(c *C) {
 	idAllocator := testidentity.NewMockIdentityAllocator(nil)
-	s.repo = policy.NewPolicyRepository(idAllocator, nil, nil)
+	s.repo = policy.NewPolicyRepository(idAllocator, nil, nil, nil)
 }
 
 func (s *EndpointManagerSuite) GetPolicyRepository() *policy.Repository {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -189,7 +189,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 	}, nil, wg)
 	wg.Wait()
 
-	s.repo = policy.NewPolicyRepository(nil, nil, nil)
+	s.repo = policy.NewPolicyRepository(nil, nil, nil, nil)
 	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: time.Second, SingleInflight: true}
 	s.dnsServer = setupServer(c)
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))

--- a/pkg/ipcache/cell.go
+++ b/pkg/ipcache/cell.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import "github.com/cilium/cilium/pkg/hive/cell"
+
+var Cell = cell.Module(
+	"ipcache",
+	"IPCache maps IPs to identities",
+
+	cell.Provide(NewIPCache),
+)

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -98,7 +99,7 @@ type IPCache struct {
 
 	// k8sSyncedChecker knows how to check for whether the K8s watcher cache
 	// has been fully synced.
-	k8sSyncedChecker k8sSyncedChecker
+	k8sSyncedChecker *k8s.CacheSyncedChecker
 
 	// Configuration provides pointers towards other agent components that
 	// the IPCache relies upon at runtime.
@@ -758,7 +759,7 @@ func (ipc *IPCache) LookupByHostRLocked(hostIPv4, hostIPv6 net.IP) (cidrs []net.
 
 // RegisterK8sWaiter registers the object that checks for wehther the K8s cache
 // has been fully synced.
-func (ipc *IPCache) RegisterK8sSyncedChecker(c k8sSyncedChecker) {
+func (ipc *IPCache) RegisterK8sSyncedChecker(c *k8s.CacheSyncedChecker) {
 	ipc.k8sSyncedChecker = c
 }
 
@@ -779,10 +780,4 @@ func (m *K8sMetadata) Equal(o *K8sMetadata) bool {
 		}
 	}
 	return m.Namespace == o.Namespace && m.PodName == o.PodName
-}
-
-// k8sCacheIsSynced is an interface for checking if the K8s watcher cache has
-// been fully synced.
-type k8sSyncedChecker interface {
-	K8sCacheIsSynced() bool
 }

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -38,7 +38,7 @@ func Test(t *testing.T) {
 func (s *IPCacheTestSuite) SetUpTest(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	allocator := testidentity.NewMockIdentityAllocator(nil)
-	IPIdentityCache = NewIPCache(&Configuration{
+	IPIdentityCache = newIPCache(&Configuration{
 		Context:           ctx,
 		IdentityAllocator: allocator,
 		PolicyHandler:     &mockUpdater{},

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -160,7 +160,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 		return modifiedPrefixes, ErrLocalIdentityAllocatorUninitialized
 	}
 
-	if ipc.k8sSyncedChecker == nil || !ipc.k8sSyncedChecker.K8sCacheIsSynced() {
+	if ipc.k8sSyncedChecker == nil || !ipc.k8sSyncedChecker.IsSynced() {
 		return modifiedPrefixes, errors.New("k8s cache not fully synced")
 	}
 

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -130,7 +131,8 @@ func setupTest(t *testing.T) (cleanup func()) {
 		PolicyHandler:     &mockUpdater{},
 		DatapathHandler:   &mockTriggerer{},
 	})
-	IPIdentityCache.k8sSyncedChecker = &mockK8sSyncedChecker{}
+	IPIdentityCache.k8sSyncedChecker = k8s.NewCacheSyncedChecker()
+	IPIdentityCache.k8sSyncedChecker.Synced()
 
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.CustomResource, "kube-uid", labels.LabelKubeAPIServer)
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.Local, "host-uid", labels.LabelHost)
@@ -140,10 +142,6 @@ func setupTest(t *testing.T) (cleanup func()) {
 		IPIdentityCache.Shutdown()
 	}
 }
-
-type mockK8sSyncedChecker struct{}
-
-func (m *mockK8sSyncedChecker) K8sCacheIsSynced() bool { return true }
 
 type mockUpdater struct{}
 

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -124,7 +124,7 @@ func setupTest(t *testing.T) (cleanup func()) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	allocator := testidentity.NewMockIdentityAllocator(nil)
-	IPIdentityCache = NewIPCache(&Configuration{
+	IPIdentityCache = newIPCache(&Configuration{
 		Context:           ctx,
 		IdentityAllocator: allocator,
 		PolicyHandler:     &mockUpdater{},

--- a/pkg/k8s/cache_sync_checker.go
+++ b/pkg/k8s/cache_sync_checker.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+type CacheSyncedChecker struct {
+	c chan struct{}
+}
+
+func NewCacheSyncedChecker() *CacheSyncedChecker {
+	return &CacheSyncedChecker{
+		c: make(chan struct{}),
+	}
+}
+
+// Wait blocks until the kubernetes cache has been synced
+func (sc *CacheSyncedChecker) Wait() {
+	<-sc.c
+}
+
+func (sc *CacheSyncedChecker) IsSynced() bool {
+	select {
+	case <-sc.c:
+		return true
+	default:
+		return false
+	}
+}
+
+func (sc *CacheSyncedChecker) Synced() {
+	close(sc.c)
+}

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -90,7 +90,7 @@ type DummySelectorCacheUser struct{}
 
 func testNewPolicyRepository() *policy.Repository {
 	idAllocator := testidentity.NewMockIdentityAllocator(nil)
-	repo := policy.NewPolicyRepository(idAllocator, nil, nil)
+	repo := policy.NewPolicyRepository(idAllocator, nil, nil, nil)
 	repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return repo
 }

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -21,7 +21,7 @@ import (
 
 func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	idAllocator := testidentity.NewMockIdentityAllocator(nil)
-	repo := policy.NewPolicyRepository(idAllocator, nil, nil)
+	repo := policy.NewPolicyRepository(idAllocator, nil, nil, nil)
 
 	tag1 := labels.LabelArray{labels.ParseLabel("tag1")}
 	serviceInfo := ServiceID{
@@ -125,7 +125,7 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 
 func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	idAllocator := testidentity.NewMockIdentityAllocator(nil)
-	repo := policy.NewPolicyRepository(idAllocator, nil, nil)
+	repo := policy.NewPolicyRepository(idAllocator, nil, nil, nil)
 	svcLabels := map[string]string{
 		"app": "tested-service",
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -92,10 +92,6 @@ const (
 	// BPFRoot is the Path to BPF filesystem
 	BPFRoot = "bpf-root"
 
-	// CertsDirectory is the root directory used to find out certificates used
-	// in L7 HTTPs policy enforcement.
-	CertsDirectory = "certificates-directory"
-
 	// CGroupRoot is the path to Cgroup2 filesystem
 	CGroupRoot = "cgroup-root"
 
@@ -2047,10 +2043,6 @@ type DaemonConfig struct {
 	// control plane, e.g. when using the managed etcd feature
 	EnableWellKnownIdentities bool
 
-	// CertsDirectory is the root directory to be used by cilium to find
-	// certificates locally.
-	CertDirectory string
-
 	// EnableRemoteNodeIdentity enables use of the remote-node identity
 	EnableRemoteNodeIdentity bool
 
@@ -2829,7 +2821,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableL2NeighDiscovery = vp.GetBool(EnableL2NeighDiscovery)
 	c.AutoCreateCiliumNodeResource = vp.GetBool(AutoCreateCiliumNodeResource)
 	c.BPFRoot = vp.GetString(BPFRoot)
-	c.CertDirectory = vp.GetString(CertsDirectory)
 	c.CGroupRoot = vp.GetString(CGroupRoot)
 	c.ClusterID = vp.GetUint32(ClusterIDName)
 	c.ClusterName = vp.GetString(ClusterName)

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -37,7 +37,7 @@ var (
 )
 
 func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	cache := repo.policyCache
 	identity := ep1.GetSecurityIdentity()
 	c.Assert(ep2.GetSecurityIdentity(), Equals, identity)
@@ -73,7 +73,7 @@ func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
 }
 
 func (s *DistilleryTestSuite) TestCachePopulation(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.revision = 42
 	cache := repo.policyCache
 
@@ -347,7 +347,7 @@ type policyDistillery struct {
 func newPolicyDistillery(selectorCache *SelectorCache) *policyDistillery {
 	identityAllocator := testidentity.NewMockIdentityAllocator(nil)
 	ret := &policyDistillery{
-		Repository: NewPolicyRepository(identityAllocator, nil, nil),
+		Repository: NewPolicyRepository(identityAllocator, nil, nil, nil),
 	}
 	ret.selectorCache = selectorCache
 	return ret

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -27,7 +27,7 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooSelectLabel := labels.ParseSelectLabel("foo")
@@ -248,7 +248,7 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestGetRulesMatching(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -316,7 +316,7 @@ func (ds *PolicyTestSuite) TestGetRulesMatching(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestDeniesIngress(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -415,7 +415,7 @@ func (ds *PolicyTestSuite) TestDeniesIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestDeniesEgress(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -523,7 +523,7 @@ func (ds *PolicyTestSuite) TestDeniesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
@@ -570,7 +570,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDeny(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -658,7 +658,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3DependentL4IngressDenyFromRequires(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -727,7 +727,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressDenyFromRequires(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3DependentL4EgressDenyFromRequires(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -818,7 +818,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressDenyFromRequires(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -942,7 +942,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1036,7 +1036,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
@@ -1134,7 +1134,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1189,7 +1189,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1246,7 +1246,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	app2Selector := labels.ParseSelectLabelArray("id=app2")
@@ -1377,7 +1377,7 @@ func buildDenyRule(from, to, port string) api.Rule {
 }
 
 func (ds *PolicyTestSuite) TestPolicyDenyTrace(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	// Add rules to allow foo=>bar

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -31,7 +31,7 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooSelectLabel := labels.ParseSelectLabel("foo")
@@ -237,7 +237,7 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	// cannot add empty rule
@@ -323,7 +323,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 }
 
 func BenchmarkParseLabel(b *testing.B) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	b.ResetTimer()
@@ -362,7 +362,7 @@ func BenchmarkParseLabel(b *testing.B) {
 }
 
 func (ds *PolicyTestSuite) TestAllowsIngress(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -461,7 +461,7 @@ func (ds *PolicyTestSuite) TestAllowsIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestAllowsEgress(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -569,7 +569,7 @@ func (ds *PolicyTestSuite) TestAllowsEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
@@ -801,7 +801,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -953,7 +953,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1022,7 +1022,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1113,7 +1113,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1316,7 +1316,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1474,7 +1474,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgress(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
@@ -1591,7 +1591,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1731,7 +1731,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1871,7 +1871,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	app2Selector := labels.ParseSelectLabelArray("id=app2")
@@ -2059,7 +2059,7 @@ func (repo *Repository) checkTrace(c *C, ctx *SearchContext, trace string,
 }
 
 func (ds *PolicyTestSuite) TestPolicyTrace(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	// Add rules to allow foo=>bar
@@ -2254,7 +2254,7 @@ func (ds *PolicyTestSuite) TestremoveIdentityFromRuleCaches(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestIterate(c *C) {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	numWithEgress := 0

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -193,7 +193,7 @@ func bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, c *C) *Reposit
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	ids := mgr.GetIdentityCache()
 	fakeAllocator := testidentity.NewMockIdentityAllocator(ids)
-	testRepo := NewPolicyRepository(fakeAllocator, ids, nil)
+	testRepo := NewPolicyRepository(fakeAllocator, ids, nil, nil)
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 	GenerateNumIdentities(3000)

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1618,7 +1618,7 @@ func checkEgress(c *C, repo *Repository, ctx *SearchContext, verdict api.Decisio
 }
 
 func parseAndAddRules(c *C, rules api.Rules) *Repository {
-	repo := NewPolicyRepository(nil, nil, nil)
+	repo := NewPolicyRepository(nil, nil, nil, nil)
 	repo.selectorCache = testSelectorCache
 
 	_, _ = repo.AddList(rules)

--- a/pkg/promise/promise.go
+++ b/pkg/promise/promise.go
@@ -121,12 +121,12 @@ func (await wrappedPromise[T]) Await(ctx context.Context) (T, error) {
 }
 
 // Map transforms the value of a promise with the provided function.
-func Map[A, B any](p Promise[A], transform func(A) B) Promise[B] {
+func Map[A, B any](p Promise[A], transform func(A) (B, error)) Promise[B] {
 	return wrappedPromise[B](func(ctx context.Context) (out B, err error) {
 		v, err := p.Await(ctx)
 		if err != nil {
 			return out, err
 		}
-		return transform(v), nil
+		return transform(v)
 	})
 }

--- a/pkg/promise/promise_test.go
+++ b/pkg/promise/promise_test.go
@@ -12,7 +12,7 @@ import (
 func TestPromiseResolve(t *testing.T) {
 	resolver, promiseI := New[int]()
 
-	promiseU := Map(promiseI, func(n int) uint64 { return uint64(n) * 2 })
+	promiseU := Map(promiseI, func(n int) (uint64, error) { return uint64(n) * 2, nil })
 
 	go func() {
 		resolver.Resolve(123)


### PR DESCRIPTION
This PR converts the egress gateway into a Hive cell. To facilitate this change the `ipcache.IPCache`, `daemon.CachingIdentityAllocator`, `policy.Repository`, and `certificatemanager` have been modularized as well. 
