### PR TITLE
MAINTAINERS: Add missing link to GitHub account

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -116,6 +116,7 @@ project.
 [Thomas Graf]: https://github.com/tgraf
 [Timo Beckers]: https://github.com/ti-mo
 [Tobias Klauser]: https://github.com/tklauser
+[Tom Hadlaw]: https://github.com/tommyp1ckles
 [Tom Payne]: https://github.com/twpayne
 [Vlad Ungureanu]: https://github.com/ungureanuvladvictor
 [Weilong Cui]: https://github.com/Weil0ng


### PR DESCRIPTION
Fixes: 78146e5202 ("Update MAINTAINERS.md to include Tom Hadlaw")

Signed-off-by: Chris Tarazi <chris@isovalent.com>

Fixes: https://github.com/cilium/cilium/pull/22769