### PR TITLE
v1.12 backports 2023-01-12

### DIFF
--- a/.github/kind-config-ipv6.yaml
+++ b/.github/kind-config-ipv6.yaml
@@ -2,19 +2,19 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.24.7
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
       - |
-        apiVersion: kubeadm.k8s.io/v1beta2
+        apiVersion: kubeadm.k8s.io/v1beta3
         kind: InitConfiguration
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.24.7
 networking:
   ipFamily: ipv6
   disableDefaultCNI: true
-  podSubnet: "fd00:10:244::/64"
+  podSubnet: "fd00:10:244::/48"
   serviceSubnet: "fd00:10:96::/112"

--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -2,17 +2,17 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.24.7
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
       - |
-        apiVersion: kubeadm.k8s.io/v1beta2
+        apiVersion: kubeadm.k8s.io/v1beta3
         kind: InitConfiguration
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:v1.19.1
+    image: kindest/node:v1.24.7
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  kind_version: v0.11.1
+  kind_version: v0.17.0
   kind_config: .github/kind-config.yaml
   cilium_cli_version: v0.12.0
 

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   cilium_cli_version: v0.12.0
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.17.0
   KIND_CONFIG: .github/kind-config-ipv6.yaml
   # Skip external traffic (e.g. 1.1.1.1 and www.google.com) due to no support for IPv6 in github action
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check-internal.yaml

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   cilium_cli_version: v0.12.0
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.17.0
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml
   TIMEOUT: 2m


### PR DESCRIPTION
Manual backport this changes due to different kubernetes versions between releases.

- [x] #22325 -- gha: Bump k8s version in kind conformance tests (@sayboras)


Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 22325; do contrib/backporting/set-labels.py $pr done 1.12; done
```