### PR TITLE
stateId: delete redundant type conversion

### DIFF
--- a/pkg/datapath/linux/ipsec/probe_linux.go
+++ b/pkg/datapath/linux/ipsec/probe_linux.go
@@ -31,7 +31,7 @@ func initDummyXfrmState() *netlink.XfrmState {
 		Key:    k,
 		ICVLen: 128,
 	}
-	state.Spi = int(stateId)
+	state.Spi = stateId
 	state.Reqid = stateId
 
 	state.Src = net.ParseIP(dummyIP)


### PR DESCRIPTION
stateId is a int, and does not need to be forced to int type.

Signed-off-by: XiaozhiD-web <chuanzhi.dai@daocloud.io>
