### PR TITLE
metrics: Remove unused ARP ping metrics

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -383,6 +383,7 @@ Removed Metrics/Labels
 * ``cilium_operator_ipam_allocation_ops`` is removed. Please use ``cilium_operator_ipam_ip_allocation_ops`` instead.
 * ``cilium_operator_ipam_release_ops`` is removed. Please use ``cilium_operator_ipam_ip_release_ops`` instead.
 * The label of ``status`` in ``cilium_operator_ipam_interface_creation_ops`` is removed.
+* ``cilium_node_neigh_arping_requests_total`` is removed. The counter was ineffective since the v1.11.0.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -67,9 +67,6 @@ const (
 	// SubsystemAPILimiter is the subsystem to scope metrics related to the API limiter package.
 	SubsystemAPILimiter = "api_limiter"
 
-	// SubsystemNodeNeigh is the subsystem to scope metrics related to management of node neighbor.
-	SubsystemNodeNeigh = "node_neigh"
-
 	// Namespace is used to scope metrics from cilium. It is prepended to metric
 	// names and separated with a '_'
 	Namespace = "cilium"
@@ -518,10 +515,6 @@ var (
 	// APILimiterProcessedRequests is the counter of the number of
 	// processed (successful and failed) requests
 	APILimiterProcessedRequests = NoOpCounterVec
-
-	// ArpingRequestsTotal is the counter of the number of sent
-	// (successful and failed) arping requests
-	ArpingRequestsTotal = NoOpCounterVec
 )
 
 type Configuration struct {
@@ -599,7 +592,6 @@ type Configuration struct {
 	APILimiterRateLimit                     bool
 	APILimiterAdjustmentFactor              bool
 	APILimiterProcessedRequests             bool
-	ArpingRequestsTotalEnabled              bool
 }
 
 func DefaultMetrics() map[string]struct{} {
@@ -665,7 +657,6 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemAPILimiter + "_rate_limit":                        {},
 		Namespace + "_" + SubsystemAPILimiter + "_adjustment_factor":                 {},
 		Namespace + "_" + SubsystemAPILimiter + "_processed_requests_total":          {},
-		Namespace + "_" + SubsystemNodeNeigh + "_arping_requests_total":              {},
 	}
 }
 
@@ -1411,17 +1402,6 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, APILimiterProcessedRequests)
 			c.APILimiterProcessedRequests = true
-
-		case Namespace + "_" + SubsystemNodeNeigh + "_arping_requests_total":
-			ArpingRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemNodeNeigh,
-				Name:      "arping_requests_total",
-				Help:      "Number of arping requests sent labeled by status",
-			}, []string{LabelStatus})
-
-			collectors = append(collectors, ArpingRequestsTotal)
-			c.ArpingRequestsTotalEnabled = true
 
 		case Namespace + "_endpoint_propagation_delay_seconds":
 			EndpointPropagationDelay = prometheus.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
794ce347d1e ("neigh: Rework ARP handling to let the kernel do the resolution") removed the manual arpings which made the metrics obsolete.
