### PR TITLE
contrib: Update PR template for backport

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -202,7 +202,7 @@ if [[ ${#stable_prs[@]} > 0 ]]; then
     title=$(extract_pr_title "$pr")
     echo " * PR: $pr -- $title -- https://github.com/cilium/cilium/pull/$pr"
     if [[ ! -z $SUMMARY_LOG ]]; then
-      echo " * #$pr -- $title" >> $SUMMARY_LOG
+      echo " - [ ] #$pr -- $title" >> $SUMMARY_LOG
     fi
     generate_commit_list_for_pr $pr $merged_at
     echo ""


### PR DESCRIPTION
This is just to use check box so that individual reviewer can just tick after review. IMO, this is helpful for a few cases:

- Backport with long list of commits, e.g. #23001. Tophat can quickly check which one is pending.
- Backport with commits from external contributor. Tophat can easily and quickly focus on these commits and review again if required.

Signed-off-by: Tam Mach <tam.mach@cilium.io>
