### PR TITLE
bpf: lb: fix L3 pseudo-hdr csum update for SCTP in __lb6_rev_nat()

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -477,7 +477,8 @@ static __always_inline int __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 		return DROP_WRITE_ERROR;
 
 	sum = csum_diff(old_saddr.addr, 16, new_saddr, 16, 0);
-	if (csum_l4_replace(ctx, l4_off, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+	if (csum_off->offset &&
+	    csum_l4_replace(ctx, l4_off, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 		return DROP_CSUM_L4;
 
 	return 0;


### PR DESCRIPTION
Same as in commit 9f27973a1052 ("bpf: lb: fix check for L3 pseudo-hdr csum update in lb6_xlate()"), only update the L3 pseudo-hdr component in the L4 csum when the L4 protocol requires it (ie. for TCP/UDP, but not for SCTP).