### PR TITLE
Optimize identity allocation with CRD backend.

### DIFF
--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
+	cacheKey "github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -180,7 +181,7 @@ func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 	watcher.watch(events)
 
 	lbls := labels.NewLabelsFromSortedList("id=foo")
-	key := GlobalIdentity{lbls.LabelArray()}
+	key := &cacheKey.GlobalIdentity{lbls.LabelArray()}
 
 	for i := 1024; i < 1034; i++ {
 		events <- allocator.AllocatorEvent{

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/key"
 	identitymodel "github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -54,7 +55,7 @@ func (m *CachingIdentityAllocator) GetIdentityCache() IdentityCache {
 	if m.isGlobalIdentityAllocatorInitialized() {
 		m.IdentityAllocator.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
 			if val != nil {
-				if gi, ok := val.(GlobalIdentity); ok {
+				if gi, ok := val.(*key.GlobalIdentity); ok {
 					cache[identity.NumericIdentity(id)] = gi.LabelArray
 				} else {
 					log.Warningf("Ignoring unknown identity type '%s': %+v",
@@ -81,7 +82,7 @@ func (m *CachingIdentityAllocator) GetIdentities() IdentitiesModel {
 
 	if m.isGlobalIdentityAllocatorInitialized() {
 		m.IdentityAllocator.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
-			if gi, ok := val.(GlobalIdentity); ok {
+			if gi, ok := val.(*key.GlobalIdentity); ok {
 				identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(id), gi.LabelArray)
 				identities = append(identities, identitymodel.CreateModel(identity))
 			}
@@ -110,7 +111,7 @@ func collectEvent(event allocator.AllocatorEvent, added, deleted IdentityCache) 
 	id := identity.NumericIdentity(event.ID)
 	// Only create events have the key
 	if event.Typ == kvstore.EventTypeCreate {
-		if gi, ok := event.Key.(GlobalIdentity); ok {
+		if gi, ok := event.Key.(*key.GlobalIdentity); ok {
 			// Un-delete the added ID if previously
 			// 'deleted' so that collected events can be
 			// processed in any order.
@@ -219,7 +220,7 @@ func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labe
 	}
 
 	lblArray := lbls.LabelArray()
-	id, err := m.IdentityAllocator.GetIncludeRemoteCaches(ctx, GlobalIdentity{lblArray})
+	id, err := m.IdentityAllocator.GetIncludeRemoteCaches(ctx, &key.GlobalIdentity{LabelArray: lblArray})
 	if err != nil {
 		return nil
 	}
@@ -262,7 +263,7 @@ func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id id
 		return nil
 	}
 
-	if gi, ok := allocatorKey.(GlobalIdentity); ok {
+	if gi, ok := allocatorKey.(*key.GlobalIdentity); ok {
 		return identity.NewIdentityFromLabelArray(id, gi.LabelArray)
 	}
 

--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -108,7 +109,7 @@ func (l *localIdentityCache) lookupOrCreate(lbls labels.Labels, oldNID identity.
 		l.events <- allocator.AllocatorEvent{
 			Typ: kvstore.EventTypeCreate,
 			ID:  idpool.ID(id.ID),
-			Key: GlobalIdentity{id.LabelArray},
+			Key: &key.GlobalIdentity{LabelArray: id.LabelArray},
 		}
 	}
 

--- a/pkg/identity/key/global_identity.go
+++ b/pkg/identity/key/global_identity.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package key
+
+import (
+	"strings"
+
+	"github.com/cilium/cilium/pkg/allocator"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+// GlobalIdentity is the structure used to store an identity
+type GlobalIdentity struct {
+	labels.LabelArray
+}
+
+// GetKey encodes an Identity as string
+func (gi *GlobalIdentity) GetKey() string {
+	var str strings.Builder
+	for _, l := range gi.LabelArray {
+		str.Write(l.FormatForKVStore())
+	}
+	return str.String()
+}
+
+// GetAsMap encodes a GlobalIdentity a map of keys to values. The keys will
+// include a source delimted by a ':'. This output is pareable by PutKeyFromMap.
+func (gi *GlobalIdentity) GetAsMap() map[string]string {
+	return gi.StringMap()
+}
+
+// PutKey decodes an Identity from its string representation
+func (gi *GlobalIdentity) PutKey(v string) allocator.AllocatorKey {
+	return &GlobalIdentity{labels.NewLabelArrayFromSortedList(v)}
+}
+
+// PutKeyFromMap decodes an Identity from a map of key to value. Output
+// from GetAsMap can be parsed.
+// Note: NewLabelArrayFromMap will parse the ':' separated label source from
+// the keys because the source parameter is ""
+func (gi *GlobalIdentity) PutKeyFromMap(v map[string]string) allocator.AllocatorKey {
+	return &GlobalIdentity{labels.Map2Labels(v, "").LabelArray()}
+}

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -39,6 +39,9 @@ const (
 
 	k8sPrefix               = labels.LabelSourceK8s + ":"
 	k8sNamespaceLabelPrefix = labels.LabelSourceK8s + ":" + k8sConst.PodNamespaceMetaLabels + labels.PathDelimiter
+
+	// byKeyIndex is the name of the index of the identities by key.
+	byKeyIndex = "by-key-index"
 )
 
 func NewCRDBackend(c CRDBackendConfiguration) (allocator.Backend, error) {
@@ -47,9 +50,9 @@ func NewCRDBackend(c CRDBackendConfiguration) (allocator.Backend, error) {
 
 type CRDBackendConfiguration struct {
 	NodeName string
-	Store    cache.Store
+	Store    cache.Indexer
 	Client   clientset.Interface
-	KeyType  allocator.AllocatorKey
+	KeyFunc  func(map[string]string) allocator.AllocatorKey
 }
 
 type crdBackend struct {
@@ -220,7 +223,12 @@ func (c *crdBackend) get(ctx context.Context, key allocator.AllocatorKey) *v2.Ci
 		return nil
 	}
 
-	for _, identityObject := range c.Store.List() {
+	identities, err := c.Store.ByIndex(byKeyIndex, key.GetKey())
+	if err != nil || len(identities) == 0 {
+		return nil
+	}
+
+	for _, identityObject := range identities {
 		identity, ok := identityObject.(*v2.CiliumIdentity)
 		if !ok {
 			return nil
@@ -230,7 +238,6 @@ func (c *crdBackend) get(ctx context.Context, key allocator.AllocatorKey) *v2.Ci
 			return identity
 		}
 	}
-
 	return nil
 }
 
@@ -295,7 +302,7 @@ func (c *crdBackend) GetByID(ctx context.Context, id idpool.ID) (allocator.Alloc
 		return nil, nil
 	}
 
-	return c.KeyType.PutKeyFromMap(identity.SecurityLabels), nil
+	return c.KeyFunc(identity.SecurityLabels), nil
 }
 
 // Release dissociates this node from using the identity bound to the given ID.
@@ -308,8 +315,19 @@ func (c *crdBackend) Release(ctx context.Context, id idpool.ID, key allocator.Al
 	return nil
 }
 
+func getIdentitiesByKeyFunc(keyFunc func(map[string]string) allocator.AllocatorKey) func(obj interface{}) ([]string, error) {
+	return func(obj interface{}) ([]string, error) {
+		if identity, ok := obj.(*v2.CiliumIdentity); ok {
+			return []string{keyFunc(identity.SecurityLabels).GetKey()}, nil
+		}
+		return []string{}, fmt.Errorf("object other than CiliumIdentity was pushed to the store")
+	}
+}
+
 func (c *crdBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMutations, stopChan chan struct{}) {
-	c.Store = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+	c.Store = cache.NewIndexer(
+		cache.DeletionHandlingMetaNamespaceKeyFunc,
+		cache.Indexers{byKeyIndex: getIdentitiesByKeyFunc(c.KeyFunc)})
 	identityInformer := informer.NewInformerWithStore(
 		k8sUtils.ListerWatcherFromTyped[*v2.CiliumIdentityList](c.Client.CiliumV2().CiliumIdentities()),
 		&v2.CiliumIdentity{},
@@ -318,7 +336,7 @@ func (c *crdBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMu
 			AddFunc: func(obj interface{}) {
 				if identity, ok := obj.(*v2.CiliumIdentity); ok {
 					if id, err := strconv.ParseUint(identity.Name, 10, 64); err == nil {
-						handler.OnAdd(idpool.ID(id), c.KeyType.PutKeyFromMap(identity.SecurityLabels))
+						handler.OnAdd(idpool.ID(id), c.KeyFunc(identity.SecurityLabels))
 					}
 				}
 			},
@@ -329,7 +347,7 @@ func (c *crdBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMu
 							return
 						}
 						if id, err := strconv.ParseUint(newIdentity.Name, 10, 64); err == nil {
-							handler.OnModify(idpool.ID(id), c.KeyType.PutKeyFromMap(newIdentity.SecurityLabels))
+							handler.OnModify(idpool.ID(id), c.KeyFunc(newIdentity.SecurityLabels))
 						}
 					}
 				}
@@ -343,7 +361,7 @@ func (c *crdBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMu
 
 				if identity, ok := obj.(*v2.CiliumIdentity); ok {
 					if id, err := strconv.ParseUint(identity.Name, 10, 64); err == nil {
-						handler.OnDelete(idpool.ID(id), c.KeyType.PutKeyFromMap(identity.SecurityLabels))
+						handler.OnDelete(idpool.ID(id), c.KeyFunc(identity.SecurityLabels))
 					}
 				} else {
 					log.Debugf("Ignoring unknown delete event %#v", obj)

--- a/pkg/k8s/identitybackend/identity_test.go
+++ b/pkg/k8s/identitybackend/identity_test.go
@@ -4,13 +4,23 @@
 package identitybackend
 
 import (
+	"strconv"
 	"testing"
+	"time"
 
+	"golang.org/x/net/context"
 	. "gopkg.in/check.v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/identity/key"
+	"github.com/cilium/cilium/pkg/idpool"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1/validation"
+	"github.com/cilium/cilium/pkg/labels"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -80,5 +90,139 @@ func (s *K8sIdentityBackendSuite) TestSanitizeK8sLabels(c *C) {
 		c.Assert(selected, checker.DeepEquals, test.selected)
 		c.Assert(skipped, checker.DeepEquals, test.skipped)
 		c.Assert(validation.ValidateLabels(selected, path), checker.DeepEquals, test.validationErrors)
+	}
+}
+
+type FakeHandler struct{}
+
+func (f FakeHandler) OnListDone()                                       {}
+func (f FakeHandler) OnAdd(id idpool.ID, key allocator.AllocatorKey)    {}
+func (f FakeHandler) OnModify(id idpool.ID, key allocator.AllocatorKey) {}
+func (f FakeHandler) OnDelete(id idpool.ID, key allocator.AllocatorKey) {}
+
+func getLabelsKey(rawMap map[string]string) allocator.AllocatorKey {
+	return &key.GlobalIdentity{LabelArray: labels.Map2Labels(rawMap, labels.LabelSourceK8s).LabelArray()}
+}
+func getLabelsMap(rawMap map[string]string) map[string]string {
+	return getLabelsKey(rawMap).GetAsMap()
+}
+func createCiliumIdentity(id int, labels map[string]string) v2.CiliumIdentity {
+	return v2.CiliumIdentity{
+		ObjectMeta: v1.ObjectMeta{
+			Name: strconv.Itoa(id),
+		},
+		SecurityLabels: getLabelsMap(labels),
+	}
+}
+
+func TestGetIdentity(t *testing.T) {
+	simpleMap := map[string]string{"key": "value"}
+	simpleMap2 := map[string]string{"ke2": "value2"}
+	simpleMap3 := map[string]string{"key3": "value3"}
+	duplicateMap1 := map[string]string{"key": "foo=value"}
+	duplicateMap2 := map[string]string{"key=foo": "value"}
+
+	testCases := []struct {
+		desc         string
+		identities   []v2.CiliumIdentity
+		requestedKey allocator.AllocatorKey
+		expectedId   string
+	}{
+		{
+			desc:         "Simple case",
+			identities:   []v2.CiliumIdentity{createCiliumIdentity(10, simpleMap)},
+			requestedKey: getLabelsKey(simpleMap),
+			expectedId:   "10",
+		},
+		{
+			desc: "Multiple identities",
+			identities: []v2.CiliumIdentity{
+				createCiliumIdentity(10, simpleMap),
+				createCiliumIdentity(11, simpleMap2),
+				createCiliumIdentity(12, simpleMap3),
+			},
+			requestedKey: getLabelsKey(simpleMap2),
+			expectedId:   "11",
+		},
+		{
+			desc: "Duplicated identity",
+			identities: []v2.CiliumIdentity{
+				createCiliumIdentity(10, duplicateMap1),
+				createCiliumIdentity(11, duplicateMap1),
+			},
+			requestedKey: getLabelsKey(duplicateMap1),
+			expectedId:   "10",
+		},
+		{
+			desc: "Duplicated key",
+			identities: []v2.CiliumIdentity{
+				createCiliumIdentity(10, duplicateMap1),
+				createCiliumIdentity(11, duplicateMap2),
+			},
+			requestedKey: getLabelsKey(duplicateMap2),
+			expectedId:   "11",
+		},
+		{
+			desc:         "No identities",
+			identities:   []v2.CiliumIdentity{},
+			requestedKey: getLabelsKey(simpleMap),
+			expectedId:   idpool.NoID.String(),
+		},
+		{
+			desc: "Identity not found",
+			identities: []v2.CiliumIdentity{
+				createCiliumIdentity(10, simpleMap),
+				createCiliumIdentity(11, simpleMap2),
+			},
+			requestedKey: getLabelsKey(simpleMap3),
+			expectedId:   idpool.NoID.String(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, client := k8sClient.NewFakeClientset()
+			backend, err := NewCRDBackend(CRDBackendConfiguration{
+				NodeName: "some-node",
+				Store:    nil,
+				Client:   client,
+				KeyFunc:  (&key.GlobalIdentity{}).PutKeyFromMap,
+			})
+			ctx := context.Background()
+			stopChan := make(chan struct{}, 1)
+			defer func() {
+				stopChan <- struct{}{}
+			}()
+			go backend.ListAndWatch(ctx, FakeHandler{}, stopChan)
+			if err != nil {
+				t.Fatalf("Can't create CRD Backedn: %s", err)
+			}
+
+			for _, identity := range tc.identities {
+				_, err = client.CiliumV2().CiliumIdentities().Create(ctx, &identity, v1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Can't create identity %s: %s", identity.Name, err)
+				}
+			}
+			// Wait for watcher to process the identities in the background
+			for i := 0; i < 10; i++ {
+				id, err := backend.Get(ctx, tc.requestedKey)
+				if err != nil {
+					t.Fatalf("Can't get identity by key %s: %s", tc.requestedKey.GetKey(), err)
+				}
+				if id == idpool.NoID {
+					time.Sleep(25 * time.Millisecond)
+					continue
+				}
+				if id.String() != tc.expectedId {
+					t.Errorf("Expected key %s, got %s", tc.expectedId, id.String())
+				} else {
+					return
+				}
+			}
+			if tc.expectedId != idpool.NoID.String() {
+				t.Errorf("Identity not found in the store")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Introduce by key indexer to prevent going through all the identities all the time.
GlobalIdentity is moved to a separate packet so it can be imported without cyclic dependency.

Signed-off-by: Alan Kutniewski <kutniewski@google.com>
Fixes: #22984 

```release-note
Optimize getting identity by key with CRD Backend by introducing indexer.
```
