### PR TITLE
Prometheus metric add highest IPsec output sequence number

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -291,6 +291,7 @@ IPSec
 Name                                          Labels                                             Default    Description
 ============================================= ================================================== ========== ========================================================
 ``ipsec_xfrm_error``                          ``error``, ``type``                                Enabled    Total number of xfrm errors.
+``xfrm_highest_sequence_number``                                                                 Enabled    Highest XFRM anti-replay sequence number on the node
 ============================================= ================================================== ========== ========================================================
 
 eBPF


### PR DESCRIPTION
add metric: cilium_ipsec_xfrm_max_sequence_number to output highest IPsec

Signed-off-by: tanberBro <pengfei.song@daocloud.io>

Fixes: #22924

metric is like this output
<img width="671" alt="image" src="https://user-images.githubusercontent.com/53817917/212243976-4bd9d0f0-bd6b-42a0-a94b-6d07e07acea1.png">
and cilium encrypt status:
<img width="382" alt="image" src="https://user-images.githubusercontent.com/53817917/212244424-bcf92309-35db-46bb-98c9-9f9dc23c6f1e.png">

0x89ec=35308



