### PR TITLE
resource: Add FakeResource for testing

### DIFF
--- a/pkg/k8s/resource/fake.go
+++ b/pkg/k8s/resource/fake.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/stream"
+
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+type FakeResource[T k8sRuntime.Object] struct {
+	// The lock protects against a race with replaying history and subscribing
+	// to new events.
+	lock.Mutex
+
+	src      stream.Observable[Event[T]]
+	emit     func(Event[T])
+	complete func(error)
+
+	// history emulates the behavior to emit all latest objects followed by a
+	// sync event in resource.
+	history []Event[T]
+}
+
+func NewFakeResource[T k8sRuntime.Object]() (*FakeResource[T], Resource[T]) {
+	m := &FakeResource[T]{}
+	m.src, m.emit, m.complete = stream.Multicast[Event[T]]()
+	return m, m
+}
+
+func (m *FakeResource[T]) EmitSync() {
+	m.Lock()
+	defer m.Unlock()
+
+	ev := Event[T]{Kind: Sync, Done: func(error) {}}
+	m.history = append(m.history, ev)
+	m.emit(ev)
+}
+
+func (m *FakeResource[T]) EmitUpsert(obj T) {
+	m.Lock()
+	defer m.Unlock()
+
+	ev := Event[T]{
+		Kind:   Upsert,
+		Key:    NewKey(obj),
+		Object: obj,
+		Done:   func(error) {},
+	}
+	m.history = append(m.history, ev)
+	m.emit(ev)
+}
+
+func (m *FakeResource[T]) EmitDelete(obj T) {
+	m.Lock()
+	defer m.Unlock()
+
+	ev := Event[T]{
+		Kind:   Delete,
+		Key:    NewKey(obj),
+		Object: obj,
+	}
+	m.history = append(m.history, ev)
+	m.emit(ev)
+}
+
+func (r *FakeResource[T]) Events(ctx context.Context, opts ...EventsOpt) <-chan Event[T] {
+	events := make(chan Event[T])
+	next := func(ev Event[T]) {
+		events <- ev
+	}
+	go func() {
+		r.Lock()
+		defer r.Unlock()
+
+		// Replay the history first.
+		for _, ev := range r.history {
+			next(ev)
+		}
+
+		// And then subscribe for new events.
+		r.src.Observe(ctx, next, func(error) { close(events) })
+	}()
+	return events
+}
+
+func (m *FakeResource[T]) Store(context.Context) (Store[T], error) {
+	panic("FakeResource does not implement Store(). Use a fake client with real resource instead.")
+}
+
+var _ Resource[*k8sRuntime.Unknown] = &FakeResource[*k8sRuntime.Unknown]{}

--- a/pkg/k8s/resource/fake_test.go
+++ b/pkg/k8s/resource/fake_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFakeResource(t *testing.T) {
+	type testObject = v1.PartialObjectMetadata
+	var (
+		objA = &testObject{ObjectMeta: v1.ObjectMeta{Name: "a", Namespace: "X"}}
+		objB = &testObject{ObjectMeta: v1.ObjectMeta{Name: "b", Namespace: "X"}}
+		objC = &testObject{ObjectMeta: v1.ObjectMeta{Name: "c", Namespace: "X"}}
+	)
+
+	f, _ := NewFakeResource[*testObject]()
+	ctx, cancel := context.WithCancel(context.Background())
+	events := f.Events(ctx)
+
+	seq := []struct {
+		kind EventKind
+		obj  *testObject
+	}{
+		{Upsert, objA},
+		{Upsert, objB},
+		{Upsert, objC},
+		{Sync, nil},
+		{Delete, objC},
+		{Delete, objA},
+		{Delete, objB},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for _, s := range seq {
+			switch s.kind {
+			case Upsert:
+				f.EmitUpsert(s.obj)
+			case Sync:
+				f.EmitSync()
+			case Delete:
+				f.EmitDelete(s.obj)
+			}
+		}
+	}()
+
+	// Test events from empty state
+	for _, s := range seq {
+		ev := <-events
+		assert.Equal(t, s.kind, ev.Kind)
+		if s.obj != nil {
+			assert.Equal(t, s.obj.Name, ev.Object.Name)
+		}
+	}
+	wg.Wait()
+	cancel()
+	_, ok := <-events
+	assert.False(t, ok)
+
+	// Test replay of history
+	ctx, cancel = context.WithCancel(context.Background())
+	events = f.Events(ctx)
+	for _, s := range seq {
+		ev := <-events
+		assert.Equal(t, s.kind, ev.Kind)
+		if s.obj != nil {
+			assert.Equal(t, s.obj.Name, ev.Object.Name)
+		}
+	}
+	cancel()
+	_, ok = <-events
+	assert.False(t, ok)
+}


### PR DESCRIPTION
Add a fake implementation of Resource[T] for use in tests where we want to synchronously emit events.

Example use:
```go
  var fakeNodes *resource.FakeResource[*corev1.Node]
  testHive := hive.New(
    cell.Provide(resource.NewFakeResource[*corev1.Node]),
    cell.Invoke(func(f *resource.FakeResource[*corev1.Node]) {
      fakeNodes := f
    }),
    theTestTarget,
  )
  testHive.Start(ctx)
  fakeNodes.EmitUpsert(&corev1.Node{...})
  // (validate test target state)
```