### PR TITLE
v1.10: install: fix TerminationMessagePolicy for the Hubble Relay deployment

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay-deployment.yaml
@@ -51,7 +51,6 @@ spec:
         - name: hubble-relay
           image: "{{ if .Values.hubble.relay.image.override }}{{ .Values.hubble.relay.image.override }}{{ else }}{{ .Values.hubble.relay.image.repository }}:{{ .Values.hubble.relay.image.tag }}{{ if .Values.hubble.relay.image.useDigest }}@{{ .Values.hubble.relay.image.digest }}{{ end }}{{ end }}"
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
-          terminationMessagePolicy: FallbackToLogsOnError
           command:
             - hubble-relay
           args:
@@ -72,7 +71,6 @@ spec:
           resources:
             {{- toYaml . | trim | nindent 12 }}
 {{- end }}
-          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
           {{- if $mountSocket }}
           - mountPath: {{ dir .Values.hubble.socketPath }}
@@ -87,6 +85,7 @@ spec:
             name: tls
             readOnly: true
 {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
       restartPolicy: Always
       serviceAccount: {{ .Values.serviceAccounts.relay.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.relay.name | quote }}


### PR DESCRIPTION
Commit 7ababfea backported a change to add support for TerminationMessagePolicy. However, the patch wasn't cleanly applied and the directive got introduced twice in the Hubble Relay deployment, breaking the Helm chart for Relay. This patch addresses this issue by removing the duplicate line.

Fixes: 7ababfea