### PR TITLE
bpf: Fix broken remote-node identity classification

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -170,8 +170,7 @@ resolve_srcid_ipv6(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	if (from_host)
 		src_id = srcid_from_ipcache;
 	else if (src_id == WORLD_ID &&
-		 identity_from_ipcache_ok() &&
-		 !identity_is_reserved(srcid_from_ipcache))
+		 identity_from_ipcache_ok())
 		src_id = srcid_from_ipcache;
 	return src_id;
 }
@@ -448,8 +447,7 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	/* If we could not derive the secctx from the packet itself but
 	 * from the ipcache instead, then use the ipcache identity.
 	 */
-	else if (identity_from_ipcache_ok() &&
-		 !identity_is_reserved(srcid_from_ipcache))
+	else if (identity_from_ipcache_ok())
 		src_id = srcid_from_ipcache;
 	return src_id;
 }


### PR DESCRIPTION
When Cilium resolves a src ID from ipcache with a remote node IP, the resolved ID is ignored and returns the world ID. This is because the resolve_srcid_ipv[4,6] function checks if the resolved src ID is a reserved ID, which includes the remote node ID, and if it's true, then returns the world ID. This PR fixes this problem by removing !identity_is_reserved check.

This issue occurs if BPF host routing is in use because Cilium stores the src ID resolved by resolve_srcid_ipv[4,6] in ipv[4,6]_local_delivery and enforces the policy using the stored src id. 
https://github.com/cilium/cilium/blob/2c9c8c17aeebcd2e295ecd29fd99305000bc7790/bpf/lib/l3.h#L137

On the other hand, Cilium uses the src ID resolved in bpx_lxc tail_ipv4_to_endpoint if the legacy routing mode is enabled. There's no corresponding !identity_is_reserved check in bpf_lxc side. Therefore it works with the legacy routing mode.
https://github.com/cilium/cilium/blob/b3747c8a1bf0a0ee750385f23cc382bd92f0653c/bpf/bpf_lxc.c#L1942

According to #4874 #6703, this check was added when those introduced the fallback to use the ipcache data if the packet info does not contain any useful information. As far as I look it into those PR, there's no solid reason to keep the !identity_is_reserved check, because resolve_srcid_ipv[4,6] works as follows without the check which is the same as bpx_lxc tail_ipv4_to_endpoint side.

1. the packet info, ctx->mark, cotaints the identity, then return it (from host)
2. the packet info does not contain any useful information, then resolved from ipcache and return it (from netdev)
3. the identity is not resolved from both the packet info and ipcache then return the world ID

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #18042

