### PR TITLE
Make cilium pprof listen address configurable

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -227,8 +227,9 @@ cilium-agent [flags]
       --node-port-range strings                                 Set the min/max NodePort port range (default [30000,32767])
       --policy-audit-mode                                       Enable policy audit (non-drop) mode
       --policy-queue-size int                                   size of queues for policy-related events (default 100)
-      --pprof                                                   Enable serving the pprof debugging API
-      --pprof-port int                                          Port that the pprof listens on (default 6060)
+      --pprof                                                   Enable serving pprof debugging API
+      --pprof-address string                                    Address that pprof listens on (default "localhost")
+      --pprof-port int                                          Port that pprof listens on (default 6060)
       --preallocate-bpf-maps                                    Enable BPF map pre-allocation (default true)
       --prepend-iptables-chains                                 Prepend custom iptables chains instead of appending (default true)
       --procfs string                                           Root's proc filesystem path (default "/proc")

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -65,10 +65,10 @@ cilium-operator-alibabacloud [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-pprof                            Enable pprof debugging endpoint
+      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
-      --pprof                                     Enable pprof debugging endpoint
-      --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -71,10 +71,10 @@ cilium-operator-aws [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-pprof                            Enable pprof debugging endpoint
+      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
-      --pprof                                     Enable pprof debugging endpoint
-      --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -68,10 +68,10 @@ cilium-operator-azure [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-pprof                            Enable pprof debugging endpoint
+      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
-      --pprof                                     Enable pprof debugging endpoint
-      --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -64,10 +64,10 @@ cilium-operator-generic [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-pprof                            Enable pprof debugging endpoint
+      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
-      --pprof                                     Enable pprof debugging endpoint
-      --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -76,10 +76,10 @@ cilium-operator [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
+      --operator-pprof                            Enable pprof debugging endpoint
+      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
-      --pprof                                     Enable pprof debugging endpoint
-      --pprof-port int                            Port that the pprof listens on (default 6061)
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -797,6 +797,18 @@
      - Labels to be added to hubble-relay pods
      - object
      - ``{}``
+   * - hubble.relay.pprof.address
+     - Configure pprof listen address for hubble-relay
+     - string
+     - ``"localhost"``
+   * - hubble.relay.pprof.enabled
+     - Enable pprof for hubble-relay
+     - bool
+     - ``false``
+   * - hubble.relay.pprof.port
+     - Configure pprof listen port for hubble-relay
+     - int
+     - ``6062``
    * - hubble.relay.priorityClassName
      - The priority class to use for hubble-relay
      - string
@@ -1377,6 +1389,18 @@
      - Labels to be added to cilium-operator pods
      - object
      - ``{}``
+   * - operator.pprof.address
+     - Configure pprof listen address for cilium-operator
+     - string
+     - ``"localhost"``
+   * - operator.pprof.enabled
+     - Enable pprof for cilium-operator
+     - bool
+     - ``false``
+   * - operator.pprof.port
+     - Configure pprof listen port for cilium-operator
+     - int
+     - ``6061``
    * - operator.priorityClassName
      - The priority class to use for cilium-operator
      - string
@@ -1465,10 +1489,18 @@
      - The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes
      - string
      - ``"default"``
+   * - pprof.address
+     - Configure pprof listen address for cilium-agent
+     - string
+     - ``"localhost"``
    * - pprof.enabled
-     - Enable Go pprof debugging
+     - Enable pprof for cilium-agent
      - bool
      - ``false``
+   * - pprof.port
+     - Configure pprof listen port for cilium-agent
+     - int
+     - ``6060``
    * - preflight.affinity
      - Affinity for cilium-preflight
      - object

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -384,6 +384,8 @@ Removed Options
   ``ipv4-native-routing-cidr`` has been removed.
 * The ``prefilter-device`` and ``prefilter-mode`` options deprecated in 1.11 in
   favor of ``enable-xdp-prefilter`` and ``bpf-lb-acceleration`` have been removed.
+* The ``pprof``, ``pprof-port`` flags for cilium-operator have been renamed
+  to ``operator-pprof`` and ``operator-pprof-port`` respectively.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~
@@ -425,6 +427,10 @@ Helm Options
   container images are not scheduled on non-Linux nodes.
 * ``cluster.id`` cannot be empty and a value must be specified.
   Use the ``0`` value to leave Cluster Mesh disabled.
+* The top-level ``pprof`` section now only configures pprof for cilium agent.
+  The cilium-operator pprof configuration is now managed via the ``operator.pprof`` section.
+  Additionally, a``hubble.relay.pprof`` section has been added.
+* All pprof configuration now support configuring the pprof listen address, defaulting to localhost.
 
 .. _1.11_upgrade_notes:
 

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -53,6 +53,7 @@ import (
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/pprof"
 )
 
 type configuration struct {
@@ -236,6 +237,15 @@ func runApiserver() error {
 
 	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enable support of Kubernetes EndpointSlice")
 	option.BindEnv(option.K8sEnableEndpointSlice)
+
+	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
+	option.BindEnv(option.PProf)
+
+	flags.String(option.PProfAddress, defaults.PprofAddressAPIServer, "Address that pprof listens on")
+	option.BindEnv(option.PProfAddress)
+
+	flags.Int(option.PProfPort, defaults.PprofPortAPIServer, "Port that pprof listens on")
+	option.BindEnv(option.PProfPort)
 
 	viper.BindPFlags(flags)
 
@@ -641,6 +651,10 @@ func runServer(cmd *cobra.Command) {
 			<-timer.After(kvstore.HeartbeatWriteInterval)
 		}
 	}()
+
+	if option.Config.PProf {
+		pprof.Enable(option.Config.PProfAddress, option.Config.PProfPort)
+	}
 
 	log.Info("Initialization complete")
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -818,10 +818,13 @@ func initializeFlags() {
 	flags.Bool(option.Version, false, "Print version information")
 	option.BindEnv(option.Version)
 
-	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
+	flags.Bool(option.PProf, false, "Enable serving pprof debugging API")
 	option.BindEnv(option.PProf)
 
-	flags.Int(option.PProfPort, defaults.PprofPortAgent, "Port that the pprof listens on")
+	flags.String(option.PProfAddress, defaults.PprofAddressAgent, "Address that pprof listens on")
+	option.BindEnv(option.PProfAddress)
+
+	flags.Int(option.PProfPort, defaults.PprofPortAgent, "Port that pprof listens on")
 	option.BindEnv(option.PProfPort)
 
 	flags.Bool(option.EnableXDPPrefilter, false, "Enable XDP prefiltering")
@@ -1257,7 +1260,7 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if option.Config.PProf {
-		pprof.Enable(option.Config.PProfPort)
+		pprof.Enable(option.Config.PProfAddress, option.Config.PProfPort)
 	}
 
 	if option.Config.PreAllocateMaps {

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -25,6 +25,7 @@ import (
 const (
 	keyClusterName            = "cluster-name"
 	keyPprof                  = "pprof"
+	keyPprofAddress           = "pprof-address"
 	keyPprofPort              = "pprof-port"
 	keyGops                   = "gops"
 	keyGopsPort               = "gops-port"
@@ -62,8 +63,11 @@ func New(vp *viper.Viper) *cobra.Command {
 	flags.Bool(
 		keyPprof, false, "Enable serving the pprof debugging API",
 	)
+	flags.String(
+		keyPprofAddress, defaults.PprofAddress, "Address that pprof listens on",
+	)
 	flags.Int(
-		keyPprofPort, defaults.PprofPort, "Port that the pprof listens on",
+		keyPprofPort, defaults.PprofPort, "Port that pprof listens on",
 	)
 	flags.Bool(
 		keyGops, true, "Run gops agent",
@@ -204,7 +208,7 @@ func runServe(vp *viper.Viper) error {
 	}
 
 	if vp.GetBool(keyPprof) {
-		pprof.Enable(vp.GetInt(keyPprofPort))
+		pprof.Enable(vp.GetString(keyPprofAddress), vp.GetInt(keyPprofPort))
 	}
 	gopsEnabled := vp.GetBool(keyGops)
 	if gopsEnabled {

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -250,6 +250,9 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | hubble.relay.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | hubble.relay.podLabels | object | `{}` | Labels to be added to hubble-relay pods |
+| hubble.relay.pprof.address | string | `"localhost"` | Configure pprof listen address for hubble-relay |
+| hubble.relay.pprof.enabled | bool | `false` | Enable pprof for hubble-relay |
+| hubble.relay.pprof.port | int | `6062` | Configure pprof listen port for hubble-relay |
 | hubble.relay.priorityClassName | string | `""` | The priority class to use for hubble-relay |
 | hubble.relay.prometheus | object | `{"enabled":false,"port":9966,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for hubble-relay on the configured port at /metrics |
 | hubble.relay.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble-relay |
@@ -395,6 +398,9 @@ contributors across the globe, there is almost always someone available to help.
 | operator.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | operator.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | operator.podLabels | object | `{}` | Labels to be added to cilium-operator pods |
+| operator.pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-operator |
+| operator.pprof.enabled | bool | `false` | Enable pprof for cilium-operator |
+| operator.pprof.port | int | `6061` | Configure pprof listen port for cilium-operator |
 | operator.priorityClassName | string | `""` | The priority class to use for cilium-operator |
 | operator.prometheus | object | `{"enabled":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
 | operator.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-operator |
@@ -417,7 +423,9 @@ contributors across the globe, there is almost always someone available to help.
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes |
-| pprof.enabled | bool | `false` | Enable Go pprof debugging |
+| pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-agent |
+| pprof.enabled | bool | `false` | Enable pprof for cilium-agent |
+| pprof.port | int | `6060` | Configure pprof listen port for cilium-agent |
 | preflight.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-preflight |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
 | preflight.extraEnv | list | `[]` | Additional preflight environment variables. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -655,9 +655,18 @@ data:
 {{- end }}
 {{- end }}
 
-{{- if and .Values.pprof .Values.pprof.enabled }}
+{{- if .Values.pprof.enabled }}
   pprof: {{ .Values.pprof.enabled | quote }}
+  pprof-address: {{ .Values.pprof.address | quote }}
+  pprof-port: {{ .Values.pprof.port | quote }}
 {{- end }}
+
+{{- if .Values.operator.pprof.enabled }}
+  operator-pprof: {{ .Values.operator.pprof.enabled | quote }}
+  operator-pprof-address: {{ .Values.operator.pprof.address | quote }}
+  operator-pprof-port: {{ .Values.operator.pprof.port | quote }}
+{{- end }}
+
 {{- if .Values.logSystemLoad }}
   log-system-load: {{ .Values.logSystemLoad | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -18,6 +18,11 @@ data:
     peer-service: unix://{{ .Values.hubble.socketPath }}
     {{- end }}
     listen-address: {{ .Values.hubble.relay.listenHost }}:{{ .Values.hubble.relay.listenPort }}
+    {{- if .Values.hubble.relay.pprof.enabled }}
+    pprof: {{ .Values.hubble.relay.pprof.enabled | quote }}
+    pprof-address: {{ .Values.hubble.relay.pprof.address | quote }}
+    pprof-port: {{ .Values.hubble.relay.pprof.port | quote }}
+    {{- end }}
     {{- if .Values.hubble.relay.prometheus.enabled }}
     metrics-listen-address: ":{{ .Values.hubble.relay.prometheus.port }}"
     {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -944,6 +944,14 @@ hubble:
         # -- Metrics relabeling configs for the ServiceMonitor hubble-relay
         metricRelabelings: ~
 
+    pprof:
+      # -- Enable pprof for hubble-relay
+      enabled: false
+      # -- Configure pprof listen address for hubble-relay
+      address: localhost
+      # -- Configure pprof listen port for hubble-relay
+      port: 6062
+
   ui:
     # -- Whether to enable the Hubble UI.
     enabled: false
@@ -1345,8 +1353,12 @@ nodePort:
 policyEnforcementMode: "default"
 
 pprof:
-  # -- Enable Go pprof debugging
+  # -- Enable pprof for cilium-agent
   enabled: false
+  # -- Configure pprof listen address for cilium-agent
+  address: localhost
+  # -- Configure pprof listen port for cilium-agent
+  port: 6060
 
 # -- Configure prometheus metrics on the configured port at /metrics
 prometheus:
@@ -1671,6 +1683,14 @@ operator:
 
   # -- Timeout for identity heartbeats.
   identityHeartbeatTimeout: "30m0s"
+
+  pprof:
+    # -- Enable pprof for cilium-operator
+    enabled: false
+    # -- Configure pprof listen address for cilium-operator
+    address: localhost
+    # -- Configure pprof listen port for cilium-operator
+    port: 6061
 
   # -- Enable prometheus metrics for cilium-operator on the configured port at
   # /metrics

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -941,6 +941,14 @@ hubble:
         # -- Metrics relabeling configs for the ServiceMonitor hubble-relay
         metricRelabelings: ~
 
+    pprof:
+      # -- Enable pprof for hubble-relay
+      enabled: false
+      # -- Configure pprof listen address for hubble-relay
+      address: localhost
+      # -- Configure pprof listen port for hubble-relay
+      port: 6062
+
   ui:
     # -- Whether to enable the Hubble UI.
     enabled: false
@@ -1342,8 +1350,12 @@ nodePort:
 policyEnforcementMode: "default"
 
 pprof:
-  # -- Enable Go pprof debugging
+  # -- Enable pprof for cilium-agent
   enabled: false
+  # -- Configure pprof listen address for cilium-agent
+  address: localhost
+  # -- Configure pprof listen port for cilium-agent
+  port: 6060
 
 # -- Configure prometheus metrics on the configured port at /metrics
 prometheus:
@@ -1668,6 +1680,14 @@ operator:
 
   # -- Timeout for identity heartbeats.
   identityHeartbeatTimeout: "30m0s"
+
+  pprof:
+    # -- Enable pprof for cilium-operator
+    enabled: false
+    # -- Configure pprof listen address for cilium-operator
+    address: localhost
+    # -- Configure pprof listen port for cilium-operator
+    port: 6061
 
   # -- Enable prometheus metrics for cilium-operator on the configured port at
   # /metrics

--- a/operator/main.go
+++ b/operator/main.go
@@ -255,7 +255,7 @@ func runOperator() {
 	}
 
 	if operatorOption.Config.PProf {
-		pprof.Enable(operatorOption.Config.PProfPort)
+		pprof.Enable(operatorOption.Config.PProfAddress, operatorOption.Config.PProfPort)
 	}
 
 	initK8s(k8sInitDone)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -109,10 +109,13 @@ const (
 	OperatorPrometheusServeAddr = "operator-prometheus-serve-addr"
 
 	// PProf enabled pprof debugging endpoint
-	PProf = "pprof"
+	PProf = "operator-pprof"
+
+	// PProfAddress is the port that the pprof listens on
+	PProfAddress = "operator-pprof-address"
 
 	// PProfPort is the port that the pprof listens on
-	PProfPort = "pprof-port"
+	PProfPort = "operator-pprof-port"
 
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices = "synchronize-k8s-services"
@@ -334,6 +337,9 @@ type OperatorConfig struct {
 	// PProf enables pprof debugging endpoint
 	PProf bool
 
+	// PProfAddress is the address that the pprof listens on
+	PProfAddress string
+
 	// PProfPort is the port that the pprof listens on
 	PProfPort int
 
@@ -527,6 +533,7 @@ func (c *OperatorConfig) Populate() {
 	c.OperatorAPIServeAddr = viper.GetString(OperatorAPIServeAddr)
 	c.OperatorPrometheusServeAddr = viper.GetString(OperatorPrometheusServeAddr)
 	c.PProf = viper.GetBool(PProf)
+	c.PProfAddress = viper.GetString(PProfAddress)
 	c.PProfPort = viper.GetInt(PProfPort)
 	c.SyncK8sServices = viper.GetBool(SyncK8sServices)
 	c.SyncK8sNodes = viper.GetBool(SyncK8sNodes)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -17,11 +17,20 @@ const (
 	// ClusterMeshHealthPort is the default value for option.ClusterMeshHealthPort
 	ClusterMeshHealthPort = 80
 
+	// PprofAddressAgent is the default value for pprof in the agent
+	PprofAddressAgent = "localhost"
+
+	// PprofAddressAPIServer is the default value for pprof in the clustermesh-apiserver
+	PprofAddressAPIServer = "localhost"
+
 	// PprofPortAgent is the default value for pprof in the agent
 	PprofPortAgent = 6060
 
 	// PprofPortAgent is the default value for pprof in the operator
 	PprofPortOperator = 6061
+
+	// PprofPortAPIServer is the default value for pprof in the clustermesh-apiserver
+	PprofPortAPIServer = 6063
 
 	// GopsPortAgent is the default value for option.GopsPort in the agent
 	GopsPortAgent = 9890

--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -19,6 +19,8 @@ const (
 	DialTimeout = 5 * time.Second
 	// GopsPort is the default port for gops to listen on.
 	GopsPort = 9893
+	// PprofAddress is the default port for pprof to listen on.
+	PprofAddress = "localhost"
 	// PprofPort is the default port for pprof to listen on.
 	PprofPort = 6062
 	// RetryTimeout is the duration to wait between reconnection attempts.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -420,6 +420,9 @@ const (
 	// PProf enables serving the pprof debugging API
 	PProf = "pprof"
 
+	// PProfAddress is the port that the pprof listens on
+	PProfAddress = "pprof-address"
+
 	// PProfPort is the port that the pprof listens on
 	PProfPort = "pprof-port"
 
@@ -1633,6 +1636,7 @@ type DaemonConfig struct {
 	TracePayloadlen            int
 	Version                    string
 	PProf                      bool
+	PProfAddress               string
 	PProfPort                  int
 	PrometheusServeAddr        string
 	ToFQDNsMinTTL              int
@@ -2894,6 +2898,7 @@ func (c *DaemonConfig) Populate() {
 	c.MonitorQueueSize = viper.GetInt(MonitorQueueSizeName)
 	c.MTU = viper.GetInt(MTUName)
 	c.PProf = viper.GetBool(PProf)
+	c.PProfAddress = viper.GetString(PProfAddress)
 	c.PProfPort = viper.GetInt(PProfPort)
 	c.PreAllocateMaps = viper.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
@@ -2939,7 +2944,6 @@ func (c *DaemonConfig) Populate() {
 	c.BGPConfigPath = viper.GetString(BGPConfigPath)
 	c.ExternalClusterIP = viper.GetBool(ExternalClusterIPName)
 	c.TCFilterPriority = viper.GetInt(TCFilterPriority)
-
 	c.EnableIPv4Masquerade = viper.GetBool(EnableIPv4Masquerade) && c.EnableIPv4
 	c.EnableIPv6Masquerade = viper.GetBool(EnableIPv6Masquerade) && c.EnableIPv6
 	c.EnableBPFMasquerade = viper.GetBool(EnableBPFMasquerade)

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -17,8 +17,8 @@ import (
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "pprof")
 
 // Enable runs an HTTP server to serve the pprof API
-func Enable(port int) {
-	var apiAddress = net.JoinHostPort("localhost", strconv.Itoa(port))
+func Enable(host string, port int) {
+	var apiAddress = net.JoinHostPort(host, strconv.Itoa(port))
 	go func() {
 		if err := http.ListenAndServe(apiAddress, nil); err != nil {
 			log.WithError(err).Warn("Unable to serve pprof API")


### PR DESCRIPTION
 * #22768 -- Make cilium pprof listen address configurable (@chancez)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 22768 ; do contrib/backporting/set-labels.py $pr done 1.12; done
```