### PR TITLE
[Backport v1.12] Stale CEP cleanup backports

### DIFF
--- a/daemon/cmd/ciliumendpoints.go
+++ b/daemon/cmd/ciliumendpoints.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiTypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+type localEndpointCache interface {
+	LookupPodName(name string) *endpoint.Endpoint
+}
+
+// This must only be run after K8s Pod and CES/CEP caches are synced and local endpoint restoration is complete.
+func (d *Daemon) cleanStaleCEPs(ctx context.Context, eps localEndpointCache, ciliumClient ciliumv2.CiliumV2Interface, enableCiliumEndpointSlice bool) error {
+	crdType := "ciliumendpoint"
+	if enableCiliumEndpointSlice {
+		crdType = "ciliumendpointslice"
+	}
+	indexer := d.k8sWatcher.GetIndexer(crdType)
+	objs, err := indexer.ByIndex("localNode", node.GetCiliumEndpointNodeIP())
+	if err != nil {
+		return fmt.Errorf("could not get %s objects from localNode indexer: %w", crdType, err)
+	}
+	if enableCiliumEndpointSlice {
+		for _, cesObj := range objs {
+			ces, ok := cesObj.(*cilium_v2a1.CiliumEndpointSlice)
+			if !ok {
+				return fmt.Errorf("unexpected object type returned from ciliumendpointslice store: %T", cesObj)
+			}
+			for _, cep := range ces.Endpoints {
+				if cep.Networking.NodeIP == node.GetCiliumEndpointNodeIP() && eps.LookupPodName(ces.Namespace+"/"+cep.Name) == nil {
+					d.deleteCiliumEndpoint(ctx, ces.Namespace, cep.Name, nil, ciliumClient, eps)
+				}
+			}
+		}
+	} else {
+		for _, cepObj := range objs {
+			cep, ok := cepObj.(*types.CiliumEndpoint)
+			if !ok {
+				return fmt.Errorf("unexpected object type returned from ciliumendpoint store: %T", cepObj)
+			}
+
+			if cep.Networking.NodeIP == node.GetCiliumEndpointNodeIP() && eps.LookupPodName(cep.Namespace+"/"+cep.Name) == nil {
+				d.deleteCiliumEndpoint(ctx, cep.Namespace, cep.Name, &cep.ObjectMeta.UID, ciliumClient, eps)
+			}
+		}
+	}
+	return nil
+}
+
+// deleteCiliumEndpoint safely deletes a CEP by name, if no UID is passed this will reverify that
+// the CEP is still local before doing a delete.
+func (d *Daemon) deleteCiliumEndpoint(
+	ctx context.Context,
+	cepNamespace,
+	cepName string,
+	cepUID *apiTypes.UID,
+	ciliumClient ciliumv2.CiliumV2Interface,
+	eps localEndpointCache) {
+	// To avoid having to store CEP UIDs in CES Endpoints array, we have to get the latest
+	// referenced CEP from apiserver to verify that it still references this node.
+	// To avoid excessive api calls, we only do this if CES is enabled and the CEP
+	// appears to be stale.
+	if cepUID == nil {
+		cep, err := ciliumClient.CiliumEndpoints(cepNamespace).Get(ctx, cepName, metav1.GetOptions{})
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{logfields.CEPName: cepName, logfields.K8sNamespace: cepNamespace}).
+				Error("Failed to get possibly stale ciliumendpoints from apiserver, skipping.")
+			return
+		}
+		if cep.Status.Networking.NodeIP != node.GetCiliumEndpointNodeIP() {
+			log.WithError(err).WithFields(logrus.Fields{logfields.CEPName: cepName, logfields.K8sNamespace: cepNamespace}).
+				Debug("Stale CEP fetched apiserver no longer references this Node, skipping.")
+			return
+		}
+		cepUID = &cep.ObjectMeta.UID
+	}
+	// There exists a local CiliumEndpoint that is not in the endpoint manager.
+	// This function is run after completing endpoint restoration from local state and K8s cache sync.
+	// Therefore, we can delete the CiliumEndpoint as it is not referencing a Pod that is being managed.
+	// This may occur for various reasons:
+	// * Pod was restarted while Cilium was not running (likely prior to CNI conf being installed).
+	// * Local endpoint was deleted (i.e. due to reboot + temporary filesystem) and Cilium or the Pod where restarted.
+	log.WithFields(logrus.Fields{logfields.CEPName: cepName, logfields.K8sNamespace: cepNamespace}).
+		Info("Found stale ciliumendpoint for local pod that is not being managed, deleting.")
+	if err := ciliumClient.CiliumEndpoints(cepNamespace).Delete(ctx, cepName, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID: cepUID,
+		},
+	}); err != nil {
+		log.WithError(err).WithFields(logrus.Fields{logfields.CEPName: cepName, logfields.K8sNamespace: cepNamespace}).
+			Error("Could not delete stale CEP")
+	}
+}

--- a/daemon/cmd/ciliumendpoints_test.go
+++ b/daemon/cmd/ciliumendpoints_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
+	slimmetav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+var (
+	testCESs = []cilium_v2a1.CiliumEndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ciliumEndpointSlices-000",
+			},
+			Namespace: "x",
+			Endpoints: []cilium_v2a1.CoreCiliumEndpoint{
+				{
+					Name: "foo",
+					Networking: &ciliumv2.EndpointNetworking{
+						Addressing: ciliumv2.AddressPairList{},
+						NodeIP:     "<nil>",
+					},
+				},
+			},
+		},
+	}
+)
+
+func Test_cleanStaleCEP(t *testing.T) {
+	tests := map[string]struct {
+		ciliumEndpoints []types.CiliumEndpoint
+		// should only be used if disableCEPCRD is true.
+		ciliumEndpointSlices []cilium_v2a1.CiliumEndpointSlice
+		// if true, simulates running CiliumEndpointSlice watcher instead of CEP.
+		enableCES bool
+		// endpoints in endpointManaged.
+		managedEndpoints map[string]*endpoint.Endpoint
+		// expectedDeletedSet contains CiliumEndpoints that are expected to be deleted
+		// during test, in the form '<namespace>/<cilium_endpoint>'.
+		expectedDeletedSet []string
+		// apiserverCEPs is used to mock apiserver get requests when running with CES enabled.
+		apiserverCEPs map[string]*ciliumv2.CiliumEndpoint
+	}{
+		"CEPs with local pods without endpoints should be GCd": {
+			ciliumEndpoints:    []types.CiliumEndpoint{cep("foo", "x", "<nil>"), cep("foo", "y", "<nil>")},
+			managedEndpoints:   map[string]*endpoint.Endpoint{"y/foo": {}},
+			expectedDeletedSet: []string{"x/foo"},
+		},
+		"CEPs with local pods with endpoints should not be GCd": {
+			ciliumEndpoints:    []types.CiliumEndpoint{cep("foo", "x", "")},
+			managedEndpoints:   map[string]*endpoint.Endpoint{"x/foo": {}},
+			expectedDeletedSet: []string{},
+		},
+		"Non local CEPs should not be GCd": {
+			ciliumEndpoints:    []types.CiliumEndpoint{cep("foo", "x", "1.2.3.4")},
+			managedEndpoints:   map[string]*endpoint.Endpoint{},
+			expectedDeletedSet: []string{},
+		},
+		"Nothing should be deleted if fields are missing": {
+			ciliumEndpoints:    []types.CiliumEndpoint{cep("", "", "")},
+			managedEndpoints:   map[string]*endpoint.Endpoint{},
+			expectedDeletedSet: []string{},
+		},
+		"CES: local CEPs without endpoints should be GCd": {
+			ciliumEndpointSlices: testCESs,
+			ciliumEndpoints: []types.CiliumEndpoint{
+				cep("bar", "x", "<nil>"),
+				cep("foo", "x", "<nil>"),
+				cep("notlocal", "x", "1.2.3.4"),
+			},
+			enableCES:          true,
+			managedEndpoints:   map[string]*endpoint.Endpoint{"x/bar": {}},
+			expectedDeletedSet: []string{"x/foo"},
+			apiserverCEPs: map[string]*ciliumv2.CiliumEndpoint{
+				"x/foo": {
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "00001",
+					},
+					Status: ciliumv2.EndpointStatus{
+						Networking: &ciliumv2.EndpointNetworking{
+							NodeIP: "<nil>",
+						},
+					},
+				},
+			},
+		},
+		"CES: Test case where IP in apiserver changes and delete should be skipped": {
+			ciliumEndpointSlices: testCESs,
+			ciliumEndpoints: []types.CiliumEndpoint{
+				cep("foo", "x", "<nil>"),
+			},
+			enableCES:          true,
+			managedEndpoints:   map[string]*endpoint.Endpoint{"x/bar": {}},
+			expectedDeletedSet: []string{},
+			apiserverCEPs: map[string]*ciliumv2.CiliumEndpoint{
+				"x/foo": {
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "00001",
+					},
+					Status: ciliumv2.EndpointStatus{
+						Networking: &ciliumv2.EndpointNetworking{
+							NodeIP: "1.2.3.4",
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			d := Daemon{
+				k8sWatcher: &watchers.K8sWatcher{},
+			}
+
+			fakeClient := fake.NewSimpleClientset()
+			fakeClient.PrependReactor("create", "ciliumendpoints", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
+				cep := action.(k8stesting.CreateAction).GetObject().(*ciliumv2.CiliumEndpoint)
+				return true, cep, nil
+			}))
+			fakeClient.PrependReactor("get", "ciliumendpoints", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if !test.enableCES {
+					assert.Fail("unexpected get on ciliumendpoints in CEP mode, expected only in CES mode")
+				}
+				name := action.(k8stesting.GetAction).GetName()
+				ns := action.(k8stesting.GetActionImpl).Namespace
+				cep, ok := test.apiserverCEPs[ns+"/"+name]
+				if !ok {
+					return true, nil, fmt.Errorf("not found")
+				}
+				return true, cep, nil
+			}))
+			cepStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{
+				"localNode": watchers.CreateCiliumEndpointLocalPodIndexFunc(), // empty nodeIP means this will index all nodes.
+			})
+			ciliumEndpointSlicesStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{
+				"localNode": watchers.CreateCiliumEndpointSliceLocalPodIndexFunc(), // empty nodeIP means this will index all nodes.
+			})
+
+			for _, ces := range test.ciliumEndpointSlices {
+				ciliumEndpointSlicesStore.Add(ces.DeepCopy())
+			}
+			for _, cep := range test.ciliumEndpoints {
+				_, err := fakeClient.CiliumV2().CiliumEndpoints(cep.Namespace).Create(context.Background(), &ciliumv2.CiliumEndpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cep.Name,
+						Namespace: cep.Namespace,
+					},
+				}, metav1.CreateOptions{})
+				assert.NoError(err)
+				cepStore.Add(cep.DeepCopy())
+			}
+			d.k8sWatcher.SetIndexer("ciliumendpoint", cepStore)
+			d.k8sWatcher.SetIndexer("ciliumendpointslice", ciliumEndpointSlicesStore)
+			l := &lock.Mutex{}
+			var deletedSet []string
+			fakeClient.PrependReactor("delete", "ciliumendpoints", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
+				l.Lock()
+				defer l.Unlock()
+				a := action.(k8stesting.DeleteAction)
+				deletedSet = append(deletedSet, fmt.Sprintf("%s/%s", a.GetNamespace(), a.GetName()))
+				return true, nil, nil
+			}))
+
+			epm := &fakeEPManager{test.managedEndpoints}
+
+			err := d.cleanStaleCEPs(context.Background(), epm, fakeClient.CiliumV2(), test.enableCES)
+
+			assert.NoError(err)
+			assert.ElementsMatch(test.expectedDeletedSet, deletedSet)
+		})
+	}
+}
+
+type fakeEPManager struct {
+	byPodName map[string]*endpoint.Endpoint
+}
+
+func (epm *fakeEPManager) LookupPodName(name string) *endpoint.Endpoint {
+	ep, ok := epm.byPodName[name]
+	if !ok {
+		return nil
+	}
+	return ep
+}
+
+func cep(name, ns, nodeIP string) types.CiliumEndpoint {
+	return types.CiliumEndpoint{
+		ObjectMeta: slimmetav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Networking: &ciliumv2.EndpointNetworking{
+			NodeIP: nodeIP,
+		},
+	}
+}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -664,6 +664,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 		d.ipcache,
 	)
 	nd.RegisterK8sGetters(d.k8sWatcher)
+
 	d.ipcache.RegisterK8sSyncedChecker(&d)
 
 	d.k8sWatcher.RegisterNodeSubscriber(d.endpointManager)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1137,6 +1137,10 @@ func initializeFlags() {
 	flags.Bool(option.EnableBGPControlPlane, false, "Enable the BGP control plane.")
 	option.BindEnv(option.EnableBGPControlPlane)
 
+	flags.Bool(option.EnableStaleCiliumEndpointCleanup, true, "Enable running cleanup init procedure of local CiliumEndpoints which are not being managed.")
+	flags.MarkHidden(option.EnableStaleCiliumEndpointCleanup)
+	option.BindEnv(option.EnableStaleCiliumEndpointCleanup)
+
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1822,7 +1822,7 @@ func runDaemon() {
 	d.startAgentHealthHTTPService()
 	if option.Config.KubeProxyReplacementHealthzBindAddr != "" {
 		if option.Config.KubeProxyReplacement != option.KubeProxyReplacementDisabled {
-			d.startKubeProxyHealthzHTTPService(fmt.Sprintf("%s", option.Config.KubeProxyReplacementHealthzBindAddr))
+			d.startKubeProxyHealthzHTTPService(option.Config.KubeProxyReplacementHealthzBindAddr)
 		}
 	}
 

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -690,12 +690,18 @@ func (d *Daemon) DeleteEndpoint(id string) (int, error) {
 		switch containerID := ep.GetShortContainerID(); containerID {
 		case "":
 			log.WithFields(logrus.Fields{
-				logfields.IPv4: ep.GetIPv4Address(),
-				logfields.IPv6: ep.GetIPv6Address(),
+				logfields.IPv4:         ep.GetIPv4Address(),
+				logfields.IPv6:         ep.GetIPv6Address(),
+				logfields.EndpointID:   ep.ID,
+				logfields.K8sPodName:   ep.GetK8sPodName(),
+				logfields.K8sNamespace: ep.GetK8sPodName(),
 			}).Info(msg)
 		default:
 			log.WithFields(logrus.Fields{
-				logfields.ContainerID: containerID,
+				logfields.ContainerID:  containerID,
+				logfields.EndpointID:   ep.ID,
+				logfields.K8sPodName:   ep.GetK8sPodName(),
+				logfields.K8sNamespace: ep.GetK8sPodName(),
 			}).Info(msg)
 		}
 		return d.deleteEndpoint(ep), nil

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -127,11 +127,7 @@ func getEndpointNetworking(mdlNetworking *models.EndpointNetworking) (networking
 		Addressing: make(cilium_v2.AddressPairList, len(mdlNetworking.Addressing)),
 	}
 
-	if option.Config.EnableIPv4 {
-		networking.NodeIP = node.GetIPv4().String()
-	} else {
-		networking.NodeIP = node.GetIPv6().String()
-	}
+	networking.NodeIP = node.GetCiliumEndpointNodeIP()
 
 	for i, pair := range mdlNetworking.Addressing {
 		networking.Addressing[i] = &cilium_v2.AddressPair{

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/addressing"
@@ -398,6 +399,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		K8sPodName:            e.K8sPodName,
 		K8sNamespace:          e.K8sNamespace,
 		DatapathConfiguration: e.DatapathConfiguration,
+		CiliumEndpointUID:     e.ciliumEndpointUID,
 	}
 }
 
@@ -486,6 +488,12 @@ type serializableEndpoint struct {
 	// plugin which performed the plumbing will enable certain datapath
 	// features according to the mode selected.
 	DatapathConfiguration models.EndpointDatapathConfiguration
+
+	// CiliumEndpointUID contains the unique identifier ref for the CiliumEndpoint
+	// that this Endpoint was managing.
+	// This is used to avoid overwriting/deleting ciliumendpoints that are managed
+	// by other endpoints.
+	CiliumEndpointUID types.UID
 }
 
 // UnmarshalJSON expects that the contents of `raw` are a serializableEndpoint,
@@ -533,4 +541,5 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.K8sNamespace = r.K8sNamespace
 	ep.DatapathConfiguration = r.DatapathConfiguration
 	ep.Options = r.Options
+	ep.ciliumEndpointUID = r.CiliumEndpointUID
 }

--- a/pkg/k8s/informer/informer.go
+++ b/pkg/k8s/informer/informer.go
@@ -54,6 +54,21 @@ func NewInformer(
 	return clientState, NewInformerWithStore(lw, objType, resyncPeriod, h, convertFunc, clientState)
 }
 
+// NewIndexerInformer is a copy of k8s.io/client-go/tools/cache/NewIndexerInformer with a new
+// argument which converts an object into another object that can be stored in
+// the local cache.
+func NewIndexerInformer(
+	lw cache.ListerWatcher,
+	objType k8sRuntime.Object,
+	resyncPeriod time.Duration,
+	h cache.ResourceEventHandler,
+	convertFunc ConvertFunc,
+	indexers cache.Indexers,
+) (cache.Indexer, cache.Controller) {
+	clientState := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, indexers)
+	return clientState, NewInformerWithStore(lw, objType, resyncPeriod, h, convertFunc, clientState)
+}
+
 // NewInformerWithStore uses the same arguments as NewInformer for which a
 // caller can also set a cache.Store.
 func NewInformerWithStore(

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -252,6 +252,11 @@ func CreateCiliumEndpointLocalPodIndexFunc() cache.IndexFunc {
 			return nil, fmt.Errorf("unexpected object type: %T", obj)
 		}
 		indices := []string{}
+		if cep.Networking == nil {
+			log.WithField("ciliumendpoint", cep.GetNamespace()+"/"+cep.GetName()).
+				Debug("cannot index CiliumEndpoint by node without network status")
+			return nil, nil
+		}
 		if cep.Networking.NodeIP == nodeIP {
 			indices = append(indices, cep.Networking.NodeIP)
 		}

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -4,6 +4,7 @@
 package watchers
 
 import (
+	"fmt"
 	"net"
 	"sync"
 
@@ -32,7 +33,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, as
 	var once sync.Once
 	apiGroup := k8sAPIGroupCiliumEndpointV2
 	for {
-		_, ciliumEndpointInformer := informer.NewInformer(
+		cepIndexer, ciliumEndpointInformer := informer.NewIndexerInformer(
 			cache.NewListWatchFromClient(ciliumNPClient.CiliumV2().RESTClient(),
 				cilium_v2.CEPPluralName, v1.NamespaceAll, fields.Everything()),
 			&cilium_v2.CiliumEndpoint{},
@@ -76,7 +77,13 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, as
 				},
 			},
 			k8s.ConvertToCiliumEndpoint,
+			cache.Indexers{
+				"localNode": CreateCiliumEndpointLocalPodIndexFunc(),
+			},
 		)
+		k.ciliumEndpointIndexerMU.Lock()
+		k.ciliumEndpointIndexer = cepIndexer
+		k.ciliumEndpointIndexerMU.Unlock()
 		isConnected := make(chan struct{})
 		// once isConnected is closed, it will stop waiting on caches to be
 		// synchronized.
@@ -112,7 +119,6 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 			k.policyManager.TriggerPolicyUpdates(true, "Named ports added or updated")
 		}
 	}()
-
 	var ipsAdded []string
 	if oldEndpoint != nil && oldEndpoint.Networking != nil {
 		// Delete the old IP addresses from the IP cache
@@ -233,5 +239,22 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 	}
 	if option.Config.EnableIPv4EgressGateway {
 		k.egressGatewayManager.OnDeleteEndpoint(endpoint)
+	}
+}
+
+// CreateCiliumEndpointLocalPodIndexFunc returns an IndexFunc that indexes only local
+// CiliumEndpoints, by their local Node IP.
+func CreateCiliumEndpointLocalPodIndexFunc() cache.IndexFunc {
+	nodeIP := node.GetCiliumEndpointNodeIP()
+	return func(obj interface{}) ([]string, error) {
+		cep, ok := obj.(*types.CiliumEndpoint)
+		if !ok {
+			return nil, fmt.Errorf("unexpected object type: %T", obj)
+		}
+		indices := []string{}
+		if cep.Networking.NodeIP == nodeIP {
+			indices = append(indices, cep.Networking.NodeIP)
+		}
+		return indices, nil
 	}
 }

--- a/pkg/k8s/watchers/cilium_endpoint_slice.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice.go
@@ -4,6 +4,7 @@
 package watchers
 
 import (
+	"fmt"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
@@ -11,10 +12,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
 	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/node"
 )
 
 var (
@@ -22,6 +25,26 @@ var (
 	// cepMap maps CEPName to CEBName.
 	cepMap = newCEPToCESMap()
 )
+
+// CreateCiliumEndpointSliceLocalPodIndexFunc returns an IndexFunc that indexes CiliumEndpointSlices
+// by their corresponding Pod, which are running locally on this Node.
+func CreateCiliumEndpointSliceLocalPodIndexFunc() cache.IndexFunc {
+	nodeIP := node.GetCiliumEndpointNodeIP()
+	return func(obj interface{}) ([]string, error) {
+		ces, ok := obj.(*v2alpha1.CiliumEndpointSlice)
+		if !ok {
+			return nil, fmt.Errorf("unexpected object type: %T", obj)
+		}
+		indices := []string{}
+		for _, ep := range ces.Endpoints {
+			if ep.Networking.NodeIP == nodeIP {
+				indices = append(indices, ep.Networking.NodeIP)
+				break
+			}
+		}
+		return indices, nil
+	}
+}
 
 func (k *K8sWatcher) ciliumEndpointSliceInit(client *k8s.K8sCiliumClient, asyncControllers *sync.WaitGroup) {
 	log.Info("Initializing CES controller")
@@ -31,7 +54,7 @@ func (k *K8sWatcher) ciliumEndpointSliceInit(client *k8s.K8sCiliumClient, asyncC
 	cesNotify.Register(newCESSubscriber(k))
 
 	for {
-		_, cesInformer := informer.NewInformer(
+		cesIndexer, cesInformer := informer.NewIndexerInformer(
 			cache.NewListWatchFromClient(client.CiliumV2alpha1().RESTClient(),
 				cilium_v2a1.CESPluralName, v1.NamespaceAll, fields.Everything()),
 			&cilium_v2a1.CiliumEndpointSlice{},
@@ -59,7 +82,13 @@ func (k *K8sWatcher) ciliumEndpointSliceInit(client *k8s.K8sCiliumClient, asyncC
 				},
 			},
 			nil,
+			cache.Indexers{
+				"localNode": CreateCiliumEndpointSliceLocalPodIndexFunc(),
+			},
 		)
+		k.ciliumEndpointSliceIndexerMU.Lock()
+		k.ciliumEndpointSliceIndexer = cesIndexer
+		k.ciliumEndpointSliceIndexerMU.Unlock()
 		isConnected := make(chan struct{})
 		// once isConnected is closed, it will stop waiting on caches to be
 		// synchronized.

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -24,6 +24,7 @@ import (
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	pkgLabels "github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -146,7 +147,10 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 						// Backfill the CEP UID as we need to do if the CEP was
 						// created on an agent version that did not yet store the
 						// UID at CEP create time.
-						updateCEPUIDIfNeeded(scopedLog, e, localCEP)
+						if err := updateCEPUID(scopedLog, e, localCEP); err != nil {
+							scopedLog.WithError(err).Warn("could not take ownership of existing ciliumendpoint")
+							return err
+						}
 					case k8serrors.IsNotFound(err):
 						pod := e.GetPod()
 						if pod == nil {
@@ -216,7 +220,10 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 						// Backfill the CEP UID as we need to do if the CEP was
 						// created on an agent version that did not yet store the
 						// UID at CEP create time.
-						updateCEPUIDIfNeeded(scopedLog, e, localCEP)
+						if err := updateCEPUID(scopedLog, e, localCEP); err != nil {
+							scopedLog.WithError(err).Warn("could not take ownership of existing ciliumendpoint")
+							return err
+						}
 
 					// The CEP doesn't exist in k8s. This is unexpetected but may occur
 					// if the endpoint was removed from k8s but not yet within the agent.
@@ -271,11 +278,6 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					k8stypes.JSONPatchType,
 					createStatusPatch,
 					meta_v1.PatchOptions{})
-				if err != nil {
-					scopedLog.WithError(err).Error("failed to update ciliumendpoint status")
-					return err
-				}
-				scopedLog.Info("patched ciliumendpoint status with local mdl")
 
 				// Handle Update errors or return successfully
 				switch {
@@ -311,18 +313,44 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 		})
 }
 
-// updateCEPUIDIfNeeded updates the endpoint's CEP UID from the local CEP if the
-// CEP UID is different (i.e., has never been set on the endpoint or has
-// changed).
-func updateCEPUIDIfNeeded(scopedLog *logrus.Entry, e *endpoint.Endpoint, localCEP *cilium_v2.CiliumEndpoint) {
-	if cepUID := e.GetCiliumEndpointUID(); cepUID != localCEP.UID {
+// updateCEPUID attempts to update the endpoints UID to be that of localCEP.
+// This in effect takes ownership of the referenced CEP, thus we can only
+// do this if it is safe to do so. Otherwise an error is returned.
+//
+// One caveat is that, although endpoints are now restored to reference their
+// previous CEP, this has to handle cases where agent was upgraded from a version
+// that did not store CEP UIDs in the restore state header.
+// It is only safe to do so if the CEP is local.
+func updateCEPUID(scopedLog *logrus.Entry, e *endpoint.Endpoint, localCEP *cilium_v2.CiliumEndpoint) error {
+	var nodeIP string
+	if netStatus := localCEP.Status.Networking; netStatus == nil {
+		return fmt.Errorf("endpoint sync cannot take ownership of CEP that has no nodeIP status")
+	} else {
+		nodeIP = netStatus.NodeIP
+	}
+
+	// We do not want to take ownership of CEPs created on other Nodes.
+	if nodeIP != node.GetCiliumEndpointNodeIP() {
+		return fmt.Errorf("endpoint sync cannot take ownership of CEP that is not local (%q)", nodeIP)
+	}
+
+	// If the endpoint has a CEP UID, which does not match the current CEP, we cannot take
+	// ownership.
+	if epUID := e.GetCiliumEndpointUID(); epUID != "" && epUID != localCEP.GetUID() {
+		return fmt.Errorf("endpoint sync could not take ownership of CEP %q, endpoint UID (%q) did not match CEP UID: %q",
+			localCEP.GetNamespace()+"/"+localCEP.GetName(), epUID, localCEP.GetUID())
+	}
+
+	if cepUID := e.GetCiliumEndpointUID(); cepUID == "" {
 		scopedLog.WithFields(logrus.Fields{
 			logfields.Node:           types.GetName(),
 			"old" + logfields.CEPUID: cepUID,
 			logfields.CEPUID:         localCEP.UID,
-		}).Debug("updating CEP UID")
+		}).Debug("updating CEP UID and syncing endpoint header file")
 		e.SetCiliumEndpointUID(localCEP.UID)
+		e.SyncEndpointHeaderFile()
 	}
+	return nil
 }
 
 // DeleteK8sCiliumEndpointSync replaces the endpoint controller to remove the

--- a/pkg/k8s/watchers/endpointsynchronizer_test.go
+++ b/pkg/k8s/watchers/endpointsynchronizer_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+
+package watchers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+func Test_updateCEPUID(t *testing.T) {
+	for name, test := range map[string]struct {
+		err           error
+		cep           *v2.CiliumEndpoint
+		ep            *endpoint.Endpoint
+		expectedEPUID types.UID
+	}{
+		"no net status": {
+			ep:  &endpoint.Endpoint{},
+			err: fmt.Errorf("no nodeIP"),
+			cep: &v2.CiliumEndpoint{Status: v2.EndpointStatus{}},
+		},
+		"non local": {
+			ep:  &endpoint.Endpoint{},
+			err: fmt.Errorf("is not local"),
+			cep: &v2.CiliumEndpoint{
+				Status: v2.EndpointStatus{
+					Networking: &v2.EndpointNetworking{
+						NodeIP: "1.2.3.4", // in testing, the node ip is returned as "<nil>"
+					},
+				},
+			},
+		},
+		"ciliumendpoint already exists": {
+			err:           fmt.Errorf("did not match CEP UID"),
+			expectedEPUID: "b",
+			ep: func() *endpoint.Endpoint {
+				ep := &endpoint.Endpoint{}
+				ep.SetCiliumEndpointUID("b")
+				return ep
+			}(),
+			cep: &v2.CiliumEndpoint{
+				ObjectMeta: v1.ObjectMeta{UID: types.UID("a")},
+				Status: v2.EndpointStatus{
+					Networking: &v2.EndpointNetworking{
+						NodeIP: "<nil>", // in testing, the node ip is returned as "<nil>"
+					},
+				},
+			},
+		},
+		"take ownership of cep": {
+			ep:            &endpoint.Endpoint{},
+			expectedEPUID: "a",
+			cep: &v2.CiliumEndpoint{
+				ObjectMeta: v1.ObjectMeta{UID: types.UID("a")},
+				Status: v2.EndpointStatus{
+					Networking: &v2.EndpointNetworking{
+						NodeIP: "<nil>", // in testing, the node ip is returned as "<nil>"
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			err := updateCEPUID(logrus.StandardLogger().WithFields(logrus.Fields{}), test.ep, test.cep)
+			if test.err == nil {
+				assert.NoError(err)
+			} else {
+				assert.ErrorContains(err, test.err.Error())
+			}
+			assert.Equal(test.expectedEPUID, test.ep.GetCiliumEndpointUID())
+		})
+
+	}
+}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -236,6 +236,13 @@ type K8sWatcher struct {
 	ciliumNodeStoreMU lock.RWMutex
 	ciliumNodeStore   cache.Store
 
+	ciliumEndpointIndexerMU lock.RWMutex
+	ciliumEndpointIndexer   cache.Indexer
+
+	ciliumEndpointSliceIndexerMU lock.RWMutex
+	// note: this store only contains endpointslices referencing local endpoints.
+	ciliumEndpointSliceIndexer cache.Indexer
+
 	namespaceStore cache.Store
 	datapath       datapath.Datapath
 
@@ -931,7 +938,45 @@ func (k *K8sWatcher) K8sEventReceived(apiResourceName, scope, action string, val
 	k.k8sResourceSynced.SetEventTimestamp(apiResourceName)
 }
 
+// GetIndexer returns an index to a k8s cache store for the given resource name.
+// Objects gotten using returned stores should *not* be mutated as they
+// are references to internal k8s watcher store state.
+func (k *K8sWatcher) GetIndexer(name string) cache.Indexer {
+	switch name {
+	case "ciliumendpointslice":
+		k.ciliumEndpointSliceIndexerMU.RLock()
+		defer k.ciliumEndpointSliceIndexerMU.RUnlock()
+		return k.ciliumEndpointSliceIndexer
+	case "ciliumendpoint":
+		k.ciliumEndpointIndexerMU.RLock()
+		defer k.ciliumEndpointIndexerMU.RUnlock()
+		return k.ciliumEndpointIndexer
+	default:
+		panic("no such indexer: " + name)
+	}
+}
+
+// SetIndexer lets you set a named cache store, only used for testing.
+func (k *K8sWatcher) SetIndexer(name string, indexer cache.Indexer) {
+	switch name {
+	case "ciliumendpointslice":
+		k.ciliumEndpointSliceIndexerMU.Lock()
+		defer k.ciliumEndpointSliceIndexerMU.Unlock()
+		k.ciliumEndpointSliceIndexer = indexer
+	case "ciliumendpoint":
+		k.ciliumEndpointIndexerMU.Lock()
+		defer k.ciliumEndpointIndexerMU.Unlock()
+		k.ciliumEndpointIndexer = indexer
+	default:
+		panic("no such indexer: " + name)
+	}
+}
+
 // GetStore returns the k8s cache store for the given resource name.
+// It's possible for valid resource names to return nil stores if that
+// watcher is not in use.
+// Objects gotten using returned stores should *not* be mutated as they
+// are references to internal k8s watcher store state.
 func (k *K8sWatcher) GetStore(name string) cache.Store {
 	switch name {
 	case "networkpolicy":
@@ -945,8 +990,16 @@ func (k *K8sWatcher) GetStore(name string) cache.Store {
 		k.podStoreMU.RLock()
 		defer k.podStoreMU.RUnlock()
 		return k.podStore
+	case "ciliumendpoint":
+		k.ciliumEndpointIndexerMU.RLock()
+		defer k.ciliumEndpointIndexerMU.RUnlock()
+		return k.ciliumEndpointIndexer
+	case "ciliumendpointslice":
+		k.ciliumEndpointSliceIndexerMU.RLock()
+		defer k.ciliumEndpointSliceIndexerMU.RUnlock()
+		return k.ciliumEndpointSliceIndexer
 	default:
-		return nil
+		panic("no such store: " + name)
 	}
 }
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -302,6 +302,15 @@ func GetIPv4() net.IP {
 	return clone(addrs.ipv4Address)
 }
 
+// GetCiliumEndpointNodeIP is the node IP that will be referenced by CiliumEndpoints with endpoints
+// running on this node.
+func GetCiliumEndpointNodeIP() string {
+	if option.Config.EnableIPv4 {
+		return GetIPv4().String()
+	}
+	return GetIPv6().String()
+}
+
 // SetInternalIPv4Router sets the cilium internal IPv4 node address, it is allocated from the node prefix.
 // This must not be conflated with k8s internal IP as this IP address is only relevant within the
 // Cilium-managed network (this means within the node for direct routing mode and on the overlay

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1086,6 +1086,18 @@ const (
 	// EnableRuntimeDeviceDetection is the name of the option to enable detection
 	// of new and removed datapath devices during the agent runtime.
 	EnableRuntimeDeviceDetection = "enable-runtime-device-detection"
+
+	// EnablePMTUDiscovery enables path MTU discovery to send ICMP
+	// fragmentation-needed replies to the client (when needed).
+	EnablePMTUDiscovery = "enable-pmtu-discovery"
+
+	// BPFMapEventBuffers specifies what maps should have event buffers enabled,
+	// and the max size and TTL of events in the buffers should be.
+	BPFMapEventBuffers = "bpf-map-event-buffers"
+
+	// EnableStaleCiliumEndpointCleanup sets whether Cilium should perform cleanup of
+	// stale CiliumEndpoints during init.
+	EnableStaleCiliumEndpointCleanup = "enable-stale-cilium-endpoint-cleanup"
 )
 
 // Default string arguments
@@ -2235,6 +2247,11 @@ type DaemonConfig struct {
 
 	// EnvoySecretNamespace for TLS secrets. Used by CiliumEnvoyConfig via SDS.
 	EnvoySecretNamespace string
+
+	// EnableStaleCiliumEndpointCleanup enables cleanup routine during Cilium init.
+	// This will attempt to remove local CiliumEndpoints that are not managed by Cilium
+	// following Endpoint restoration.
+	EnableStaleCiliumEndpointCleanup bool
 }
 
 var (
@@ -3225,6 +3242,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableICMPRules = viper.GetBool(EnableICMPRules)
 	c.BypassIPAvailabilityUponRestore = viper.GetBool(BypassIPAvailabilityUponRestore)
 	c.EnableK8sTerminatingEndpoint = viper.GetBool(EnableK8sTerminatingEndpoint)
+	c.EnableStaleCiliumEndpointCleanup = viper.GetBool(EnableStaleCiliumEndpointCleanup)
 
 	// Disable Envoy version check if L7 proxy is disabled.
 	c.DisableEnvoyVersionCheck = viper.GetBool(DisableEnvoyVersionCheck)


### PR DESCRIPTION
* #21768 -- Endpoint/CEP Ownership Fix (@tommyp1ckles )
* #20350 -- daemon: add cleanup for stale local ciliumendpoints that aren't being managed. (@tommyp1ckles)
* #22600 -- daemon/cmd: improve stale cilium endpoint error handling. (@tommyp1ckles)
```upstream-prs
$ for pr in 21768 20350 22600; do contrib/backporting/set-labels.py $pr done v1.12; done
```