### PR TITLE
gha: Pin minikube version used in CI

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -22,8 +22,9 @@ concurrency:
 
 env:
   cilium_cli_version: v0.12.12
-  timeout: 5m
+  minikube_version: 1.28.0
   gateway_api_version: v0.5.1
+  timeout: 5m
 
 jobs:
   gateway-api-conformance-test:
@@ -63,11 +64,13 @@ jobs:
           persist-credentials: false
 
       - name: Create minikube cluster with multiple nodes
-        run: |
-          # Use at least 3 nodes, so that at least 2 worker nodes are available for scheduling
-          minikube start --network-plugin=cni --cni=false \
-            --docker-opt="default-ulimit=nofile=102400:102400" \
-            --nodes 3
+        uses: medyagh/setup-minikube@ab221dee176f8eabd8deddf849b5bf1d6244a6e8
+        with:
+          minikube-version: ${{ env.minikube_version }}
+          network-plugin: cni
+          cni: false
+          wait: false
+          start-args: --nodes 3 --docker-opt "default-ulimit=nofile=102400:102400"
 
       # Start minikube tunnel
       - name: Setup minikube

--- a/.github/workflows/conformance-ingress-shared.yaml
+++ b/.github/workflows/conformance-ingress-shared.yaml
@@ -22,6 +22,7 @@ concurrency:
 
 env:
   cilium_cli_version: v0.12.12
+  minikube_version: 1.28.0
   timeout: 5m
 
 jobs:
@@ -62,11 +63,13 @@ jobs:
           persist-credentials: false
 
       - name: Create minikube cluster with multiple nodes
-        run: |
-          # Use at least 3 nodes, so that at least 2 worker nodes are available for scheduling
-          minikube start --network-plugin=cni --cni=false \
-            --docker-opt="default-ulimit=nofile=102400:102400" \
-            --nodes 3
+          uses: medyagh/setup-minikube@ab221dee176f8eabd8deddf849b5bf1d6244a6e8
+        with:
+          minikube-version: ${{ env.minikube_version }}
+          network-plugin: cni
+          cni: false
+          wait: false
+          start-args: --nodes 3 --docker-opt "default-ulimit=nofile=102400:102400"
 
       # Start minikube tunnel
       - name: Setup minikube

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -22,6 +22,7 @@ concurrency:
 
 env:
   cilium_cli_version: v0.12.12
+  minikube_version: 1.28.0
   timeout: 5m
 
 jobs:
@@ -62,11 +63,13 @@ jobs:
           persist-credentials: false
 
       - name: Create minikube cluster with multiple nodes
-        run: |
-          # Use at least 3 nodes, so that at least 2 worker nodes are available for scheduling
-          minikube start --network-plugin=cni --cni=false \
-            --docker-opt="default-ulimit=nofile=102400:102400" \
-            --nodes 3
+          uses: medyagh/setup-minikube@ab221dee176f8eabd8deddf849b5bf1d6244a6e8
+        with:
+          minikube-version: ${{ env.minikube_version }}
+          network-plugin: cni
+          cni: false
+          wait: false
+          start-args: --nodes 3 --docker-opt "default-ulimit=nofile=102400:102400"
 
       # Start minikube tunnel
       - name: Setup minikube


### PR DESCRIPTION
### Description

This is to avoid any potential version drift in CI. The setup action (e.g. medyagh/setup-minikube) is maintained by Minikube maintainers.

Relates: https://github.com/cilium/cilium/pull/21386#discussion_r982562385
Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Notes
I have marked this PR to be backported in 1.12, just a note that only conforamance-ingress.yaml is required in 1.12.

Full CI is not required, related jobs are successfully ran.

- [Ingress Conformance](https://github.com/cilium/cilium/actions/runs/3926394737)
- [Ingress Conformance (Shared)](https://github.com/cilium/cilium/actions/runs/3926394736)
- [Gateway API](https://github.com/cilium/cilium/actions/runs/3938626203/jobs/6737540865)