### PR TITLE
helm: use Helm hooks instead of Job unique name

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
@@ -1,21 +1,14 @@
 {{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") }}
-{{/*
-Because Kubernetes job specs are immutable, Helm will fail patch this job if
-the spec changes between releases. To avoid breaking the upgrade path, we
-generate a name for the job here which is based on the checksum of the spec.
-This will cause the name of the job to change if its content changes,
-and in turn cause Helm to do delete the old job and replace it with a new one.
-*/}}
-{{- $jobSpec := include "clustermesh-apiserver-generate-certs.job.spec" . -}}
-{{- $checkSum := $jobSpec | sha256sum | trunc 10 -}}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: clustermesh-apiserver-generate-certs-{{$checkSum}}
+  name: clustermesh-apiserver-generate-certs
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: clustermesh-apiserver-generate-certs
     app.kubernetes.io/part-of: cilium
-{{ $jobSpec }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+{{ include "clustermesh-apiserver-generate-certs.job.spec" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
@@ -10,5 +10,8 @@ metadata:
     app.kubernetes.io/part-of: cilium
   annotations:
     "helm.sh/hook": post-install,post-upgrade
+    {{- with .Values.certgen.annotations.job }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{ include "clustermesh-apiserver-generate-certs.job.spec" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
@@ -1,26 +1,18 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") }}
-{{/*
-Because Kubernetes job specs are immutable, Helm will fail patch this job if
-the spec changes between releases. To avoid breaking the upgrade path, we
-generate a name for the job here which is based on the checksum of the spec.
-This will cause the name of the job to change if its content changes,
-and in turn cause Helm to do delete the old job and replace it with a new one.
-*/}}
-{{- $jobSpec := include "hubble-generate-certs.job.spec" . -}}
-{{- $checkSum := $jobSpec | sha256sum | trunc 10 -}}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hubble-generate-certs-{{$checkSum}}
+  name: hubble-generate-certs
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: hubble-generate-certs
     app.kubernetes.io/name: hubble-generate-certs
     app.kubernetes.io/part-of: cilium
   annotations:
+    "helm.sh/hook": post-install,post-upgrade
     {{- with .Values.certgen.annotations.job }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{ $jobSpec }}
+{{ include "hubble-generate-certs.job.spec" . }}
 {{- end }}


### PR DESCRIPTION
Without this, ArgoCD (and other Gitops tools) thinks there is a diff.

See https://helm.sh/docs/topics/charts_hooks/.

<!--

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

-->

<!-- Description of change -->

<!--
Fixes: #issue-number
-->

```release-note
helm: use Helm hooks instead of Job unique name
```
