### PR TITLE
gateway-api: Expose metric port setting

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -765,6 +765,10 @@
      - Enable support for Gateway API in cilium This will automatically set enable-envoy-config as well.
      - bool
      - ``false``
+   * - gatewayAPI.metricsPort
+     - Metrics port for Gateway API controller If set to 0, metrics will be disabled
+     - int
+     - ``9965``
    * - gatewayAPI.secretsNamespace
      - SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
      - object

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -427,6 +427,7 @@ Port Range / Protocol    Description
 9962/tcp                 cilium-agent Prometheus metrics
 9963/tcp                 cilium-operator Prometheus metrics
 9964/tcp                 cilium-proxy Prometheus metrics
+9965/tcp                 cilium-operator Gateway API controller metrics
 51871/udp                WireGuard encryption tunnel endpoint
 ======================== ==================================================================
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -678,6 +678,7 @@ memcd
 mentees
 metadata
 metricRelabelings
+metricsPort
 metricsServer
 microk
 microservice

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -242,6 +242,7 @@ contributors across the globe, there is almost always someone available to help.
 | extraVolumeMounts | list | `[]` | Additional agent volumeMounts. |
 | extraVolumes | list | `[]` | Additional agent volumes. |
 | gatewayAPI.enabled | bool | `false` | Enable support for Gateway API in cilium This will automatically set enable-envoy-config as well. |
+| gatewayAPI.metricsPort | int | `9965` | Metrics port for Gateway API controller. If set to 0, metrics will be disabled. |
 | gatewayAPI.secretsNamespace | object | `{"create":true,"name":"cilium-secrets","sync":true}` | SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from. |
 | gatewayAPI.secretsNamespace.create | bool | `true` | Create secrets namespace for Gateway API. |
 | gatewayAPI.secretsNamespace.name | string | `"cilium-secrets"` | Name of Gateway API secret namespace. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -217,6 +217,7 @@ data:
   enable-envoy-config: "true"
   enable-gateway-api-secrets-sync: {{ .Values.gatewayAPI.secretsNamespace.sync | quote }}
   gateway-api-secrets-namespace: {{ .Values.gatewayAPI.secretsNamespace.name | quote }}
+  gateway-api-metrics-addr: ":{{ .Values.gatewayAPI.metricsPort }}"
 {{- end }}
 
 {{- if hasKey .Values "loadBalancer" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -625,6 +625,10 @@ gatewayAPI:
   # This will automatically set enable-envoy-config as well.
   enabled: false
 
+  # -- Metrics port for Gateway API controller.
+  # If set to 0, metrics will be disabled.
+  metricsPort: 9965
+
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
     # -- Create secrets namespace for Gateway API.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -622,6 +622,10 @@ gatewayAPI:
   # This will automatically set enable-envoy-config as well.
   enabled: false
 
+  # -- Metrics port for Gateway API controller.
+  # If set to 0, metrics will be disabled.
+  metricsPort: 9965
+
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
     # -- Create secrets namespace for Gateway API.

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -693,6 +693,7 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 
 	if operatorOption.Config.EnableGatewayAPI {
 		gatewayController, err := gatewayapi.NewController(
+			operatorOption.Config.GatewayAPIMetricsAddr,
 			operatorOption.Config.EnableGatewayAPISecretsSync,
 			operatorOption.Config.GatewayAPISecretsNamespace,
 		)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -289,6 +289,9 @@ const (
 	// This must be enabled along with enable-envoy-config in cilium agent.
 	EnableGatewayAPI = "enable-gateway-api"
 
+	// GatewayAPIMetricsAddr is the address to serve Gateway API metrics on.
+	GatewayAPIMetricsAddr = "gateway-api-metrics-addr"
+
 	// CiliumK8sNamespace is the namespace where Cilium pods are running.
 	CiliumK8sNamespace = "cilium-pod-namespace"
 
@@ -553,6 +556,9 @@ type OperatorConfig struct {
 	// EnableGatewayAPI enables support of Gateway API
 	EnableGatewayAPI bool
 
+	// GatewayAPIMetricsAddr is the address the metric endpoint binds to.
+	GatewayAPIMetricsAddr string
+
 	// EnforceIngressHTTPS enforces https if required
 	EnforceIngressHTTPS bool
 
@@ -640,6 +646,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.LoadBalancerL7Algorithm = vp.GetString(LoadBalancerL7Algorithm)
 	c.EnableIngressController = vp.GetBool(EnableIngressController)
 	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)
+	c.GatewayAPIMetricsAddr = vp.GetString(GatewayAPIMetricsAddr)
 	c.EnforceIngressHTTPS = vp.GetBool(EnforceIngressHttps)
 	c.IngressSecretsNamespace = vp.GetString(IngressSecretsNamespace)
 	c.GatewayAPISecretsNamespace = vp.GetString(GatewayAPISecretsNamespace)

--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -54,9 +54,10 @@ type Controller struct {
 
 // NewController returns a new gateway controller, which is implemented
 // using the controller-runtime library.
-func NewController(enableSecretSync bool, secretsNamespace string) (*Controller, error) {
+func NewController(metricsAddr string, enableSecretSync bool, secretsNamespace string) (*Controller, error) {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme: scheme,
+		Scheme:             scheme,
+		MetricsBindAddress: metricsAddr,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description

This is to make sure that users can disable and set port number for Gateway API controller accordingly.

Fixes: #23082
Reported-by: Karsten Nielsen <karsten.nielsen@ingka.ikea.com>
Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Tasks

- [x] Provide the way to configure metric port
   - [x] sensible default number
   - [x] disable metric server by convention (e.g. using value as 0)
- [x] Update related docs https://docs.cilium.io/en/latest/operations/system_requirements/

### Testing

Testing was done locally as per below

Installation with default value
```
docker@minikube:~$ sudo lsof -i :9965   
COMMAND      PID USER   FD   TYPE  DEVICE SIZE/OFF NODE NAME
cilium-op 206673 root   10u  IPv6 2432329      0t0  TCP *:9965 (LISTEN)
```

Installation with metric port disabled
```
docker@minikube:~$ sudo lsof -i TCP | grep cilium-op
cilium-op 213975   root    3u  IPv4 2457566      0t0  TCP localhost:9891 (LISTEN)
cilium-op 213975   root    7u  IPv4 2457570      0t0  TCP minikube:44918->minikube:8443 (ESTABLISHED)
cilium-op 213975   root    8u  IPv4 2466675      0t0  TCP localhost:9234 (LISTEN)
cilium-op 213975   root    9u  IPv4 2474711      0t0  TCP minikube:51888->minikube:8443 (ESTABLISHED)
cilium-op 213975   root   10u  IPv6 2477908      0t0  TCP *:37571 (LISTEN)
```
