### PR TITLE
bpf: nodeport: fix-up error check in rev_nodeport_lb*() for XDP

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1001,7 +1001,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __u32 *ifind
 #endif
 
 	ret = lb6_extract_tuple(ctx, ip6, &l4_off, &tuple);
-	if (ret) {
+	if (ret < 0) {
 		if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
 			goto out;
 		return ret;
@@ -2006,7 +2006,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 #endif /* ENABLE_EGRESS_GATEWAY */
 
 	ret = lb4_extract_tuple(ctx, ip4, &l4_off, &tuple);
-	if (ret) {
+	if (ret < 0) {
 		/* If it's not a SVC protocol, we don't need to check for RevDNAT: */
 		if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
 			goto out;


### PR DESCRIPTION
lb4_extract_tuple() calls ipv4_ct_extract_l4_ports(), which returns CTX_ACT_OK on success. This is 0 in TC, but 2 in XDP. This caused us to erronously bail out from the RevDNAT check in the XDP NAT reply path.

Fix up the error check accordingly. Also adjust lb6_extract_tuple() for consistency.

Fixes: fd52b2fb1382 ("bpf: nodeport: skip CT lookup for non-NodePort replies in RevDNAT path")