### PR TITLE
gh/workflows: Enable IPv6 in ci-datapath

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -128,6 +128,7 @@ jobs:
             tunnel: 'vxlan'
             encryption: 'ipsec'
             encryption-node: 'false'
+            ipv6: 'false' # until https://github.com/cilium/cilium/issues/23461 has been fixed
 
           - name: '2'
             kernel: '5.4-main'
@@ -229,6 +230,7 @@ jobs:
           TUNNEL="--helm-set-string=tunnel=vxlan"
           if [ "${{ matrix.tunnel }}" == "disabled" ]; then
             TUNNEL="--helm-set-string=tunnel=disabled --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16"
+            TUNNEL="${TUNNEL} --helm-set-string=ipv6NativeRoutingCIDR=fd00:10:244::/56"
           fi
           LB_MODE=""
           if [ "${{ matrix.lb-mode }}" != "" ]; then
@@ -238,8 +240,12 @@ jobs:
           if [ "${{ matrix.endpoint-routes }}" == "true" ]; then
             ENDPOINT_ROUTES="--helm-set-string=endpointRoutes.enabled=true"
           fi
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES}"
+          IPV6=""
+          if [ "${{ matrix.ipv6 }}" != "false" ]; then
+            IPV6="--helm-set=ipv6.enabled=true"
+          fi
 
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
       - name: Set commit status to pending
@@ -291,7 +297,7 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host/
-            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}"
+            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
             ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
 
             ./cilium-cli status --wait
@@ -308,7 +314,7 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host/
-            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}"
+            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
             ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }} \
               --encryption=${{ matrix.encryption }} --node-encryption=${{ matrix.encryption-node }}
 


### PR DESCRIPTION
Unfortunately, enabling drops the BPF masquerading. So, until #14350 has been fixed, disable the IPv6 in one job to test the BPF masq.

Successful run - https://github.com/cilium/cilium/actions/runs/4045546589/jobs/6957906352.