### PR TITLE
bpf: Consistent usage of `MARK_MAGIC_` constants

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -567,14 +567,10 @@ enum metric_dir {
 #define MARK_MAGIC_ENCRYPT		0x0E00
 #define MARK_MAGIC_IDENTITY		0x0F00 /* mark carries identity */
 #define MARK_MAGIC_TO_PROXY		0x0200
+#define MARK_MAGIC_SNAT_DONE		0x0300
 
-#define MARK_MAGIC_KEY_ID		0xF000
 #define MARK_MAGIC_KEY_MASK		0xFF00
 
-/* IPSec cannot be configured with NodePort BPF today, hence non-conflicting
- * overlap with MARK_MAGIC_KEY_ID.
- */
-#define MARK_MAGIC_SNAT_DONE		0x1500
 
 /* MARK_MAGIC_HEALTH_IPIP_DONE can overlap with MARK_MAGIC_SNAT_DONE with both
  * being mutual exclusive given former is only under DSR. Used to push health

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -167,12 +167,13 @@ ctx_change_head(struct __sk_buff *ctx, __u32 head_room, __u64 flags)
 
 static __always_inline void ctx_snat_done_set(struct __sk_buff *ctx)
 {
+	ctx->mark &= ~MARK_MAGIC_HOST_MASK;
 	ctx->mark |= MARK_MAGIC_SNAT_DONE;
 }
 
 static __always_inline bool ctx_snat_done(struct __sk_buff *ctx)
 {
-	return (ctx->mark & MARK_MAGIC_SNAT_DONE) == MARK_MAGIC_SNAT_DONE;
+	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_SNAT_DONE;
 }
 
 #ifdef HAVE_ENCAP


### PR DESCRIPTION
We currently use 8 bits of the packet mark to indicate that SNAT was already performed. That is more than necessary and inconsistent with other users of the packet mark for similar purposes.

This pull request changes that to only use 4 bits under the reserved `MARK_MAGIC_HOST_MASK` mask.

Also worth noting that the IPsec comment here is incorrect: `MARK_MAGIC_KEY_ID` is currently unused so it wasn't conflicting with the SNAT mark.