### PR TITLE
option,helm: Add a flag enable-k8s-networkpolicy

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1385,6 +1385,10 @@
      - Configure Kubernetes specific configuration
      - object
      - ``{}``
+   * - k8sNetworkPolicy.enabled
+     - Enable support for K8s NetworkPolicy
+     - bool
+     - ``true``
    * - k8sServiceHost
      - Kubernetes service host
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -876,6 +876,7 @@ runPath
 runtime
 runtimes
 sEventHandover
+sNetworkPolicy
 sNode
 sNodes
 sService

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1087,6 +1087,10 @@ func initializeFlags() {
 	flags.Duration(option.IPAMCiliumNodeUpdateRate, 15*time.Second, "Maximum rate at which the CiliumNode custom resource is updated")
 	option.BindEnv(Vp, option.IPAMCiliumNodeUpdateRate)
 
+	flags.Bool(option.EnableK8sNetworkPolicy, defaults.EnableK8sNetworkPolicy, "Enable support for K8s NetworkPolicy")
+	flags.MarkHidden(option.EnableK8sNetworkPolicy)
+	option.BindEnv(Vp, option.EnableK8sNetworkPolicy)
+
 	if err := Vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -397,6 +397,7 @@ contributors across the globe, there is almost always someone available to help.
 | ipv6.enabled | bool | `false` | Enable IPv6 support. |
 | ipv6NativeRoutingCIDR | string | `""` | Allows to explicitly specify the IPv6 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag. |
 | k8s | object | `{}` | Configure Kubernetes specific configuration |
+| k8sNetworkPolicy.enabled | bool | `true` | Enable support for K8s NetworkPolicy |
 | k8sServiceHost | string | `""` | Kubernetes service host |
 | k8sServicePort | string | `""` | Kubernetes service port |
 | keepDeprecatedLabels | bool | `false` | Keep the deprecated selector labels when deploying Cilium DaemonSet. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -700,6 +700,9 @@ data:
 {{- if and .Values.endpointRoutes .Values.endpointRoutes.enabled }}
   enable-endpoint-routes: {{ .Values.endpointRoutes.enabled | quote }}
 {{- end }}
+{{- if and .Values.k8sNetworkPolicy .Values.k8sNetworkPolicy.enabled }}
+  enable-k8s-networkpolicy: {{ .Values.k8sNetworkPolicy.enabled | quote }}
+{{- end }}
 {{- if .Values.cni.configMap }}
   read-cni-conf: {{ .Values.cni.confFileMountPath }}/{{ .Values.cni.configMapKey }}
   write-cni-conf-when-ready: {{ .Values.cni.hostConfDirMountPath }}/05-cilium.conflist

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -717,6 +717,10 @@ endpointRoutes:
   # the cilium_host interface.
   enabled: false
 
+k8sNetworkPolicy:
+  # -- Enable support for K8s NetworkPolicy
+  enabled: true
+
 eni:
   # -- Enable Elastic Network Interface (ENI) integration.
   enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -714,6 +714,10 @@ endpointRoutes:
   # the cilium_host interface.
   enabled: false
 
+k8sNetworkPolicy:
+  # -- Enable support for K8s NetworkPolicy
+  enabled: true
+
 eni:
   # -- Enable Elastic Network Interface (ENI) integration.
   enabled: false

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -530,6 +530,9 @@ const (
 
 	// Enable BGP control plane features.
 	EnableBGPControlPlane = false
+
+	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
+	EnableK8sNetworkPolicy = true
 )
 
 var (

--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -78,6 +78,12 @@ type GatewayAPIConfiguration interface {
 	K8sGatewayAPIEnabled() bool
 }
 
+// PolicyConfiguration is the required configuration for K8s NetworkPolicy
+type PolicyConfiguration interface {
+	// K8sNetworkPolicyEnabled returns true if cilium agent needs to support K8s NetworkPolicy
+	K8sNetworkPolicyEnabled() bool
+}
+
 // GetServiceListOptionsModifier returns the options modifier for service object list.
 // This methods returns a ListOptions modifier which adds a label selector to only
 // select services that are in context of Cilium.

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -432,10 +432,6 @@ func (k *K8sWatcher) resourceGroups() (beforeNodeInitGroups, afterNodeInitGroups
 		// with the right service -> backend (k8s endpoints) translation.
 		K8sAPIGroupServiceV1Core,
 
-		// We need all network policies in place before restoring to
-		// make sure we are enforcing the correct policies for each
-		// endpoint before restarting.
-		k8sAPIGroupNetworkingV1Core,
 		// Namespaces can contain labels which are essential for
 		// endpoints being restored to have the right identity.
 		k8sAPIGroupNamespaceV1Core,
@@ -445,6 +441,14 @@ func (k *K8sWatcher) resourceGroups() (beforeNodeInitGroups, afterNodeInitGroups
 		// We need to know the node labels to populate the host
 		// endpoint labels.
 		k8sAPIGroupNodeV1Core,
+	}
+
+	if k.cfg.K8sNetworkPolicyEnabled() {
+		// When the flag is set,
+		// We need all network policies in place before restoring to
+		// make sure we are enforcing the correct policies for each
+		// endpoint before restarting.
+		k8sGroups = append(k8sGroups, k8sAPIGroupNetworkingV1Core)
 	}
 
 	if k.cfg.K8sIngressControllerEnabled() || k.cfg.K8sGatewayAPIEnabled() {
@@ -520,6 +524,7 @@ type WatcherConfiguration interface {
 	utils.ServiceConfiguration
 	utils.IngressConfiguration
 	utils.GatewayAPIConfiguration
+	utils.PolicyConfiguration
 }
 
 // enableK8sWatchers starts watchers for given resources.

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -49,6 +49,10 @@ func (f *fakeWatcherConfiguration) K8sGatewayAPIEnabled() bool {
 	return false
 }
 
+func (f *fakeWatcherConfiguration) K8sNetworkPolicyEnabled() bool {
+	return true
+}
+
 type fakePolicyManager struct {
 	OnTriggerPolicyUpdates func(force bool, reason string)
 	OnPolicyAdd            func(rules api.Rules, opts *policy.AddOptions) (newRev uint64, err error)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1130,6 +1130,9 @@ const (
 	// IPAMCiliumnodeUpdateRate is the maximum rate at which the CiliumNode custom
 	// resource is updated.
 	IPAMCiliumNodeUpdateRate = "ipam-cilium-node-update-rate"
+
+	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
+	EnableK8sNetworkPolicy = "enable-k8s-networkpolicy"
 )
 
 // Default string arguments
@@ -2311,6 +2314,9 @@ type DaemonConfig struct {
 	// IPAMCiliumNodeUpdateRate is the maximum rate at which the CiliumNode custom
 	// resource is updated.
 	IPAMCiliumNodeUpdateRate time.Duration
+
+	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
+	EnableK8sNetworkPolicy bool
 }
 
 var (
@@ -2357,9 +2363,10 @@ var (
 		K8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
 		APIRateLimit:                     make(map[string]string),
 
-		ExternalClusterIP:     defaults.ExternalClusterIP,
-		EnableVTEP:            defaults.EnableVTEP,
-		EnableBGPControlPlane: defaults.EnableBGPControlPlane,
+		ExternalClusterIP:      defaults.ExternalClusterIP,
+		EnableVTEP:             defaults.EnableVTEP,
+		EnableBGPControlPlane:  defaults.EnableBGPControlPlane,
+		EnableK8sNetworkPolicy: defaults.EnableK8sNetworkPolicy,
 	}
 )
 
@@ -2597,6 +2604,11 @@ func (c *DaemonConfig) AgentNotReadyNodeTaintValue() string {
 	} else {
 		return defaults.AgentNotReadyNodeTaint
 	}
+}
+
+// K8sNetworkPolicyEnabled returns true if cilium agent needs to support K8s NetworkPolicy, false otherwise.
+func (c *DaemonConfig) K8sNetworkPolicyEnabled() bool {
+	return c.EnableK8sNetworkPolicy
 }
 
 // K8sIngressControllerEnabled returns true if ingress controller feature is enabled in Cilium
@@ -3364,6 +3376,9 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 		}
 	}
 	c.EnvoySecretNamespaces = nsList
+
+	// To support K8s NetworkPolicy
+	c.EnableK8sNetworkPolicy = vp.GetBool(EnableK8sNetworkPolicy)
 }
 
 func (c *DaemonConfig) additionalMetrics() []string {


### PR DESCRIPTION
This flag is for cilium agent to watch K8s NetworkPolicy. By default the value is true. User can set "enable-k8s-networkpolicy = false" to disable it.

```release-note
option,helm: Add a flag to opt out from support for Kubernetes NetworkPolicy in Cilium
```