### PR TITLE
[v1.12] ci: update cilium-cli to v0.12.12 in v1.12 workflows

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   minikube_version: 1.25.2
-  cilium_cli_version: v0.12.0
+  cilium_cli_version: v0.12.12
   timeout: 5m
 
 jobs:

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -23,7 +23,7 @@ concurrency:
 env:
   kind_version: v0.17.0
   kind_config: .github/kind-config.yaml
-  cilium_cli_version: v0.12.0
+  cilium_cli_version: v0.12.12
 
 jobs:
   installation-and-connectivity:

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_version: v0.12.0
+  cilium_cli_version: v0.12.12
   KIND_VERSION: v0.17.0
   KIND_CONFIG: .github/kind-config-ipv6.yaml
   # Skip external traffic (e.g. 1.1.1.1 and www.google.com) due to no support for IPv6 in github action

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cilium_cli_version: v0.12.0
+  cilium_cli_version: v0.12.12
   KIND_VERSION: v0.17.0
   KIND_CONFIG: .github/kind-config.yaml
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check.yaml


### PR DESCRIPTION
Update the workflows that are checked out from v1.12 branch. Most of the 1.12 workflows are checked out from master branch and were updated in commit 48ddc9a ("ci: update cilium-cli to v0.12.12")

cilium-cli v0.12.12 release notes:
https://github.com/cilium/cilium-cli/releases/tag/v0.12.12
