### PR TITLE
clustermesh/types: don't panic on invalid IP in PrefixClusterFromCIDR

### DIFF
--- a/pkg/clustermesh/types/addressing.go
+++ b/pkg/clustermesh/types/addressing.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/pkg/cidr"
-	"github.com/cilium/cilium/pkg/ip"
 	ippkg "github.com/cilium/cilium/pkg/ip"
 )
 
@@ -243,7 +242,10 @@ func PrefixClusterFromCIDR(c *cidr.CIDR, clusterID uint32) PrefixCluster {
 		return PrefixCluster{}
 	}
 
-	addr := ip.MustAddrFromIP(c.IP)
+	addr, ok := ippkg.AddrFromIP(c.IP)
+	if !ok {
+		return PrefixCluster{}
+	}
 	ones, _ := c.Mask.Size()
 
 	return PrefixCluster{


### PR DESCRIPTION
ip.MustAddrFromIP will panic in case of an invalid address. These types of conversion functions should usually only be used in test code. Return an empty PrefixCluster in this case instead, like in other error cases.

Fixes: b4e75da9419f ("clustermesh: Add some helper functions to PrefixCluster")
