### PR TITLE
build: Bump base image build time for SBOM

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment: release-base-images
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
SBOM build and sign is too slow to fit safely within a 30m window, so
bump the timeout in the hopes we can generate all artifacts in this
workflow.
