### PR TITLE
test/runtime: Set NO_COLOR for privileged tests

### DIFF
--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -42,7 +42,7 @@ var _ = Describe("RuntimeDatapathPrivilegedUnitTests", func() {
 		path, _ := filepath.Split(vm.BasePath())
 		ctx, cancel := context.WithTimeout(context.Background(), privilegedUnitTestTimeout)
 		defer cancel()
-		res := vm.ExecContext(ctx, fmt.Sprintf("bash -c 'sudo make -C %s tests-privileged | ts \"[%%H:%%M:%%S]\"; exit \"${PIPESTATUS[0]}\"'", path))
+		res := vm.ExecContext(ctx, fmt.Sprintf("bash -c 'sudo make -C %s tests-privileged NO_COLOR=1 | ts \"[%%H:%%M:%%S]\"; exit \"${PIPESTATUS[0]}\"'", path))
 		res.ExpectSuccess("Failed to run privileged unit tests")
 	})
 })


### PR DESCRIPTION
When the privileged tests send output to Jenkins with colour, the output
logger doesn't recognize or even skip drawing the terminal signals for
the colours, so as a result we see output like:

    [01:26:48] │  �[92mPASS�[0m

In order to make this more readable, set NO_COLOR=1 in the CLI.
