### PR TITLE
IPsec: Refactor `ipSecReplaceState{In,Out}` functions

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -138,15 +138,15 @@ func ipSecJoinState(state *netlink.XfrmState, keys *ipSecKey) {
 	state.Reqid = keys.ReqID
 }
 
-func ipSecReplaceStateIn(remoteIP, localIP net.IP, zeroMark bool) (uint8, error) {
-	key := getIPSecKeys(localIP)
+func ipSecReplaceStateIn(localIP, remoteIP net.IP, zeroMark bool) (uint8, error) {
+	key := getIPSecKeys(remoteIP)
 	if key == nil {
 		return 0, fmt.Errorf("IPSec key missing")
 	}
 	state := ipSecNewState()
 	ipSecJoinState(state, key)
-	state.Src = localIP
-	state.Dst = remoteIP
+	state.Src = remoteIP
+	state.Dst = localIP
 	state.Mark = &netlink.XfrmMark{
 		Value: linux_defaults.RouteMarkDecrypt,
 		Mask:  linux_defaults.IPsecMarkMaskIn,

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -166,7 +166,7 @@ func ipSecReplaceStateIn(localIP, remoteIP net.IP, zeroMark bool) (uint8, error)
 	return key.Spi, netlink.XfrmStateAdd(state)
 }
 
-func ipSecReplaceStateOut(remoteIP, localIP net.IP) (uint8, error) {
+func ipSecReplaceStateOut(localIP, remoteIP net.IP) (uint8, error) {
 	key := getIPSecKeys(localIP)
 	if key == nil {
 		return 0, fmt.Errorf("IPSec key missing")
@@ -398,7 +398,7 @@ func UpsertIPsecEndpoint(local, remote *net.IPNet, outerLocal, outerRemote net.I
 		}
 
 		if dir == IPSecDirOut || dir == IPSecDirOutNode || dir == IPSecDirBoth {
-			if spi, err = ipSecReplaceStateOut(outerRemote, outerLocal); err != nil {
+			if spi, err = ipSecReplaceStateOut(outerLocal, outerRemote); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace remote state: %s", err)
 				}


### PR DESCRIPTION
This pull request simply tries to make the variable names a bit clearer and more consistent. See commits for details.