### PR TITLE
docs: Disable exclusive lock when chaining with aws-cni

### DIFF
--- a/Documentation/installation/cni-chaining-aws-cni.rst
+++ b/Documentation/installation/cni-chaining-aws-cni.rst
@@ -66,6 +66,7 @@ Deploy Cilium via Helm:
    helm install cilium |CHART_RELEASE| \\
      --namespace kube-system \\
      --set cni.chainingMode=aws-cni \\
+     --set cni.exclusive=false \\
      --set enableIPv4Masquerade=false \\
      --set tunnel=disabled \\
      --set endpointRoutes.enabled=true


### PR DESCRIPTION
When Cilium is installed via Helm with `cni.exclusive=true`, AWS CNI functionality is not restored when Cilium is uninstalled resulting in EKS nodes to be in NotReady state due to

```
container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
```

This is because original CNI config file `10-aws.conflist` was renamed to `10-aws.conflist.cilium_bak` as a result of exclusive locking mechanism.

Setting `cni.exclusive=false` prevents this issue.

Signed-off-by: Martin Odstrcilik <martin.odstrcilik@gmail.com>