### PR TITLE
gh/workflow: Remove specific GKE 1.24.5 version

### DIFF
--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -63,7 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
-  k8s_version: 1.24.5
+  k8s_version: 1.24
   cilium_cli_version: v0.12.12
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -63,7 +63,7 @@ concurrency:
 env:
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   zone: us-west2-a
-  k8s_version: 1.24.5
+  k8s_version: 1.24
   cilium_cli_version: v0.12.12
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -69,7 +69,7 @@ env:
   cilium_cli_version: v0.12.12
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
-  k8s_version: 1.24.5
+  k8s_version: 1.24
 
 jobs:
   check_changes:


### PR DESCRIPTION
This commit removes specific GKE versions from 3 workflows. Version 1.24.5 is no longer available and makes tests fail. Instead, we use 1.24 which will use the default version of GKE.

Resolves: #23153 

Signed-off-by: Birol Bilgin <birol@cilium.io>
