### PR TITLE
cleanup: Replace deprecated failure-domain.beta.kubernetes.io label

### DIFF
--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -56,8 +56,10 @@ var nodeSampleJSON = `{
             "cloud.google.com/gke-nodepool": "default-pool",
             "cloud.google.com/gke-os-distribution": "cos",
             "disktype": "ssd",
-            "failure-domain.beta.kubernetes.io/region": "earth",
-            "failure-domain.beta.kubernetes.io/zone": "earth",
+            "failure-domain.beta.kubernetes.io/region": "earth", // Remove after support for 1.17 is dropped
+            "failure-domain.beta.kubernetes.io/zone": "earth", // Remove after support for 1.17 is dropped
+            "topology.kubernetes.io/region": "earth",
+            "topology.kubernetes.io/zone": "earth",
             "kubernetes.io/hostname": "super-node"
         },
         "name": "super-node",


### PR DESCRIPTION
`failure-domain.beta.kubernetes` labels has been deprecated from k8s 1.17, and replaced by `topology.kubernetes.io`: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md

It is better for us to add label `topology.kubernetes.io` now.
And  remove `failure-domain.beta.kubernetes` label  when cilium is not supported by k8s 1.17.

```release-note
pkg/k8s: Replace label failure-domain.beta.kunerbetes.io deprecated in K8s 1.17 (with topology.kubernetes.io)
```