### PR TITLE
bgp: Replaced localNodeStore based nodespecer with resources

### DIFF
--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -26,7 +26,7 @@ var Cell = cell.Module(
 		// Signaler is used by all cells that observe resources to signal the controller to start reconciliation.
 		agent.NewSignaler,
 		// Local Node Store Specer provides the module with information about the current node.
-		agent.NewLocalNodeStoreSpecer,
+		agent.NewNodeSpecer,
 		// BGP Peering Policy resource provides the module with a stream of events for the BGPPeeringPolicy resource.
 		newBGPPeeringPolicyResource,
 		// goBGP is currently the only supported RouterManager, if more are

--- a/pkg/k8s/shared_resources.go
+++ b/pkg/k8s/shared_resources.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -31,6 +32,7 @@ var (
 		cell.Provide(
 			serviceResource,
 			localNodeResource,
+			localCiliumNodeResource,
 			namespaceResource,
 			lbIPPoolsResource,
 		),
@@ -39,10 +41,11 @@ var (
 
 type SharedResources struct {
 	cell.In
-	LocalNode  resource.Resource[*corev1.Node]
-	Services   resource.Resource[*slim_corev1.Service]
-	Namespaces resource.Resource[*slim_corev1.Namespace]
-	LBIPPools  resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]
+	LocalNode       *LocalNodeResource
+	LocalCiliumNode *LocalCiliumNodeResource
+	Services        resource.Resource[*slim_corev1.Service]
+	Namespaces      resource.Resource[*slim_corev1.Namespace]
+	LBIPPools       resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]
 }
 
 func serviceResource(lc hive.Lifecycle, cs client.Clientset) (resource.Resource[*slim_corev1.Service], error) {
@@ -58,13 +61,34 @@ func serviceResource(lc hive.Lifecycle, cs client.Clientset) (resource.Resource[
 	return resource.New[*slim_corev1.Service](lc, lw), nil
 }
 
-func localNodeResource(lc hive.Lifecycle, cs client.Clientset) (resource.Resource[*corev1.Node], error) {
+// LocalNodeResource is a resource.Resource[*corev1.Node] but one which will only stream updates for the node object
+// associated with the node we are currently running on.
+type LocalNodeResource struct {
+	resource.Resource[*corev1.Node]
+}
+
+func localNodeResource(lc hive.Lifecycle, cs client.Clientset) (*LocalNodeResource, error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherFromTyped[*corev1.NodeList](cs.CoreV1().Nodes())
 	lw = utils.ListerWatcherWithFields(lw, fields.ParseSelectorOrDie("metadata.name="+nodeTypes.GetName()))
-	return resource.New[*corev1.Node](lc, lw), nil
+	return &LocalNodeResource{Resource: resource.New[*corev1.Node](lc, lw)}, nil
+}
+
+// LocalCiliumNodeResource is a resource.Resource[*cilium_api_v2.Node] but one which will only stream updates for the
+// CiliumNode object associated with the node we are currently running on.
+type LocalCiliumNodeResource struct {
+	resource.Resource[*cilium_api_v2.CiliumNode]
+}
+
+func localCiliumNodeResource(lc hive.Lifecycle, cs client.Clientset) (*LocalCiliumNodeResource, error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes())
+	lw = utils.ListerWatcherWithFields(lw, fields.ParseSelectorOrDie("metadata.name="+nodeTypes.GetName()))
+	return &LocalCiliumNodeResource{Resource: resource.New[*cilium_api_v2.CiliumNode](lc, lw)}, nil
 }
 
 func namespaceResource(lc hive.Lifecycle, cs client.Clientset) (resource.Resource[*slim_corev1.Namespace], error) {


### PR DESCRIPTION
In PR #22397 the nodespecer implementation was turned into a cell. That implementation used the localNodeStore to get access to a generic node object that would contain annotations, labels and podCIDRs.

However, it turns out that the localNodeStore doesn't function as one might expect and didn't register updates properly.

This PR changes the implementation to use resources to subscribe to changes in the node objects of the API server directly. This is very much like the old pre-modularization implementation, but now using resources instead of informers.

Fixes: #23155

```release-note
Fixed bug where the BGP Control Plane would ignore annotations on the node objects
```
