### PR TITLE
test: egressgw: also test with XDP and tunnel mode

### DIFF
--- a/test/k8s/egress.go
+++ b/test/k8s/egress.go
@@ -374,6 +374,32 @@ var _ = SkipDescribeIf(func() bool {
 			"loadBalancer.acceleration": "testing-only",
 		},
 	)
+
+	doContext("tunnel vxlan with endpointRoutes enabled and XDP",
+		map[string]string{
+			"egressGateway.enabled":     "true",
+			"bpf.masquerade":            "true",
+			"tunnel":                    "vxlan",
+			"autoDirectNodeRoutes":      "false",
+			"endpointRoutes.enabled":    "true",
+			"enableCiliumEndpointSlice": "false",
+			"l7Proxy":                   "false",
+			"loadBalancer.acceleration": "testing-only",
+		},
+	)
+
+	doContext("tunnel vxlan with endpointRoutes disabled and XDP",
+		map[string]string{
+			"egressGateway.enabled":     "true",
+			"bpf.masquerade":            "true",
+			"tunnel":                    "vxlan",
+			"autoDirectNodeRoutes":      "false",
+			"endpointRoutes.enabled":    "false",
+			"enableCiliumEndpointSlice": "false",
+			"l7Proxy":                   "false",
+			"loadBalancer.acceleration": "testing-only",
+		},
+	)
 })
 
 // Use x.x.x.100 as the egress IP


### PR DESCRIPTION
The XDP Nodeport acceleration code now also supports tunnel mode [0]. EgressGW takes different code paths in rev_nodeport_lb4(), depending on whether Tunnel is enabled or not. So add test coverage for this scenario.

[0] see commit ed6fe90b1e35 ("datapath, test: allow to combine XDP Nodeport Acceleration with Tunneling")