### PR TITLE
CODEOWNERS: Cover the egress gateway guide

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -314,6 +314,7 @@ Makefile* @cilium/build
 /Documentation/network/concepts/ipam/azure* @cilium/sig-ipam @cilium/azure @cilium/docs-structure
 /Documentation/network/concepts/ipam/eni* @cilium/sig-ipam @cilium/aws @cilium/docs-structure
 /Documentation/network/ebpf/ @cilium/sig-datapath @cilium/docs-structure
+/Documentation/network/egress-gateway.rst @cilium/sig-datapath @cilium/docs-structure
 /Documentation/network/kubernetes/ @cilium/sig-k8s @cilium/docs-structure
 /Documentation/network/kubernetes/bandwidth-manager.rst @cilium/sig-datapath @cilium/docs-structure
 /Documentation/network/kubernetes/ipam* @cilium/sig-ipam @cilium/docs-structure


### PR DESCRIPTION
The egress gateway guide is currently not assigned to any team besides the generic cilium/docs-structure one. This pull request assigns it to the datapath team.