### PR TITLE
Add pod-name hubble metrics context for pod name label without namespace

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -557,8 +557,9 @@ Option Value          Description
 ===================== ===================================================================================
 ``identity``          All Cilium security identity labels
 ``namespace``         Kubernetes namespace name
-``pod``               Kubernetes pod name
-``pod-short``         Deprecated, will be removed in Cilium 1.14 - use ``workload-name|pod`` instead. Short version of the Kubernetes pod name. Typically the deployment/replicaset name.
+``pod``               Kubernetes pod name and namespace name in the form of ``namespace/pod``.
+``pod-short``         Deprecated, will be removed in Cilium 1.14 - use ``workload-name|pod-name`` instead. Short version of the Kubernetes pod name. Typically the deployment/replicaset name.
+``pod-name``          Kubernetes pod name.
 ``dns``               All known DNS names of the source or destination (comma-separated)
 ``ip``                The IPv4 or IPv6 address
 ``reserved-identity`` Reserved identity label.

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -28,11 +28,13 @@ const (
 	ContextIdentity
 	// ContextNamespace uses the namespace name for identification purposes
 	ContextNamespace
-	// ContextPod uses the pod name for identification purposes
+	// ContextPod uses the namespace and pod name for identification purposes in the form of namespace/pod-name.
 	ContextPod
 	// ContextPodShort uses a short version of the pod name. It should
-	// typically map to the deployment/replicaset name
+	// typically map to the deployment/replicaset name. Deprecated.
 	ContextPodShort
+	// ContextPodName uses the pod name for identification purposes
+	ContextPodName
 	// ContextDNS uses the DNS name for identification purposes
 	ContextDNS
 	// ContextIP uses the IP address for identification purposes
@@ -56,7 +58,7 @@ const ContextOptionsHelp = `
  destinationEgressContext  ::= identifier , { "|", identifier }
  destinationIngressContext ::= identifier , { "|", identifier }
  labels                    ::= label , { ",", label }
- identifier                ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
+ identifier             ::= identity | namespace | pod | pod-short | pod-name | dns | ip | reserved-identity | workload-name | app
  label                     ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 
@@ -164,6 +166,8 @@ func parseContextIdentifier(s string) (ContextIdentifier, error) {
 		return ContextPod, nil
 	case "pod-short":
 		return ContextPodShort, nil
+	case "pod-name":
+		return ContextPodName, nil
 	case "dns":
 		return ContextDNS, nil
 	case "ip":
@@ -466,6 +470,8 @@ func getContextIDLabelValue(contextID ContextIdentifier, flow *pb.Flow, source b
 		if ep.GetNamespace() != "" {
 			labelValue = ep.GetNamespace() + "/" + labelValue
 		}
+	case ContextPodName:
+		labelValue = ep.GetPodName()
 	case ContextDNS:
 		if source {
 			labelValue = strings.Join(flow.GetSourceNames(), ",")

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -115,6 +115,14 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.Nil(t, err)
 	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar-bar-123-123"}}), []string{"foo/bar-bar"})
 
+	opts, err = ParseContextOptions(Options{"sourceContext": "pod-name"})
+	assert.Nil(t, err)
+	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123"}}), []string{"foo-123"})
+
+	opts, err = ParseContextOptions(Options{"destinationContext": "pod-name"})
+	assert.Nil(t, err)
+	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar-123"}}), []string{"bar-123"})
+
 	opts, err = ParseContextOptions(Options{"sourceContext": "dns"})
 	assert.Nil(t, err)
 	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{SourceNames: []string{"foo", "bar"}}), []string{"foo,bar"})

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -27,7 +27,7 @@ Options:
  destinationEgressContext  ::= identifier , { "|", identifier }
  destinationIngressContext ::= identifier , { "|", identifier }
  labels                    ::= label , { ",", label }
- identifier                ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
+ identifier             ::= identity | namespace | pod | pod-short | pod-name | dns | ip | reserved-identity | workload-name | app
  label                     ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 	assert.Equal(t, expected, plugin.HelpText())


### PR DESCRIPTION
This fixes an inconsistency in the source/destination metrics labels, where currently, `pod` and `pod-short` include the namespace in the label, where the `app` and `workload-name` do not. For consistency, this PR adds a `pod-name` option which doesn't include the namespace. 

Fixes: #23122 

I've marked this for 1.13 because `app` and `workload-name` were introduced for 1.13 and I believe it's important we have consistency for these metrics, otherwise dashboards and alerts may be inconsistent depending on the options your using.

```release-note
Add pod-name hubble metrics context for pod name label without namespace
```
