### PR TITLE
Optimize `PrefixString()`

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -4,8 +4,8 @@
 package identity
 
 import (
-	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/cilium/cilium/pkg/labels"
 )
@@ -143,21 +143,14 @@ func (pair *IPIdentityPair) IsHost() bool {
 // format w.x.y.z if 'host' is true, or as a prefix in the format the w.x.y.z/N
 // if 'host' is false.
 func (pair *IPIdentityPair) PrefixString() string {
-	var suffix string
-	if !pair.IsHost() {
-		var ones int
-		if pair.Mask == nil {
-			if pair.IP.To4() != nil {
-				ones = net.IPv4len
-			} else {
-				ones = net.IPv6len
-			}
-		} else {
-			ones, _ = pair.Mask.Size()
-		}
-		suffix = fmt.Sprintf("/%d", ones)
+	ipstr := pair.IP.String()
+
+	if pair.IsHost() {
+		return ipstr
 	}
-	return fmt.Sprintf("%s%s", pair.IP.String(), suffix)
+
+	ones, _ := pair.Mask.Size()
+	return ipstr + "/" + strconv.Itoa(ones)
 }
 
 // RequiresGlobalIdentity returns true if the label combination requires a

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -356,3 +356,53 @@ func TestIPIdentityPair_PrefixString(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkIPIdentityPair_PrefixString(b *testing.B) {
+	cases := []struct {
+		name     string
+		expected string
+		pair     *IPIdentityPair
+	}{
+		{
+			name:     "host",
+			expected: "10.1.128.15/32",
+			pair: &IPIdentityPair{
+				IP:           net.ParseIP("10.1.128.15"),
+				Mask:         net.IPv4Mask(255, 255, 255, 255),
+				HostIP:       net.ParseIP("10.1.128.15"),
+				ID:           1,
+				Key:          3,
+				Metadata:     "metadata",
+				K8sNamespace: "kube-system",
+				K8sPodName:   "pod-name",
+				NamedPorts: []NamedPort{
+					{Name: "port", Port: 8080, Protocol: "TCP"},
+				},
+			},
+		},
+		{
+			name: "not host",
+			pair: &IPIdentityPair{
+				IP:           net.ParseIP("10.1.128.15"),
+				HostIP:       net.ParseIP("10.1.128.15"),
+				ID:           1,
+				Key:          3,
+				Metadata:     "metadata",
+				K8sNamespace: "kube-system",
+				K8sPodName:   "pod-name",
+				NamedPorts: []NamedPort{
+					{Name: "port", Port: 8080, Protocol: "TCP"},
+				},
+			},
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for _, tt := range cases {
+		b.Run(tt.name, func(bb *testing.B) {
+			for i := 0; i < bb.N; i++ {
+				_ = tt.pair.PrefixString()
+			}
+		})
+	}
+}


### PR DESCRIPTION
- pkg/identity: Add PrefixString() tests
- pkg/identity: Add benchmark for PrefixString()
- pkg/identity: Optimize PrefixString()

Co-contributed by @schlosna.

---

Main commit pasted here for ease of viewing:

> Remove the use of fmt.Sprintf() which is known to be inefficient and
> simplify the function by reducing allocations and computations
> generating prefix string.
>
> Results:
>
> ```
> $ go test -v ./pkg/identity -run '^$' -count 10 -bench BenchmarkIPIdentityPair_PrefixString -benchmem > old.txt
> $ go test -v ./pkg/identity -run '^$' -count 10 -bench BenchmarkIPIdentityPair_PrefixString -benchmem > new.txt
> $ benchstat old.txt new.txt
> name                                     old time/op    new time/op    delta
> IPIdentityPair_PrefixString/host-16         438ns ± 6%     126ns ± 6%  -71.12%  (p=0.000 n=10+10)
> IPIdentityPair_PrefixString/not_host-16     248ns ± 8%      61ns ± 3%  -75.55%  (p=0.000 n=10+9)
> 
> name                                     old alloc/op   new alloc/op   delta
> IPIdentityPair_PrefixString/host-16         64.0B ± 0%     32.0B ± 0%  -50.00%  (p=0.000 n=10+10)
> IPIdentityPair_PrefixString/not_host-16     48.0B ± 0%     16.0B ± 0%  -66.67%  (p=0.000 n=10+10)
> 
> name                                     old allocs/op  new allocs/op  delta
> IPIdentityPair_PrefixString/host-16          5.00 ± 0%      2.00 ± 0%  -60.00%  (p=0.000 n=10+10)
> IPIdentityPair_PrefixString/not_host-16      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
> ```

---

Related: #19571
