### PR TITLE
.github: Pin docker buildx version to v0.9.1

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -91,6 +91,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}
+          version: v0.9.1
 
       - name: Sign Container Image Runtime
         if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
@@ -187,6 +188,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}
+          version: v0.9.1
 
       - name: Sign Container Image Builder
         if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -103,6 +103,7 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
+          version: v0.9.1
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -124,6 +124,7 @@ jobs:
           push: false
           platforms: linux/amd64
           target: import-cache
+          version: v0.9.1
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
@@ -154,6 +155,7 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
+          version: v0.9.1
 
       - name: CI race detection Build ${{ matrix.name }}
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -176,6 +178,7 @@ jobs:
             LOCKDEBUG=1
             RACE=1
             OPERATOR_VARIANT=${{ matrix.name }}
+          version: v0.9.1
 
       - name: CI Unstripped Binaries Build ${{ matrix.name }}
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -196,6 +199,7 @@ jobs:
           build-args: |
             NOSTRIP=1
             OPERATOR_VARIANT=${{ matrix.name }}
+          version: v0.9.1
 
       - name: Sign Container Images
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -273,6 +277,7 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
+          version: v0.9.1
 
       - name: CI race detection Build ${{ matrix.name }}
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -291,6 +296,7 @@ jobs:
             LOCKDEBUG=1
             RACE=1
             OPERATOR_VARIANT=${{ matrix.name }}
+          version: v0.9.1
 
       - name: CI Unstripped Binaries Build ${{ matrix.name }}
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -307,6 +313,7 @@ jobs:
           build-args: |
             NOSTRIP=1
             OPERATOR_VARIANT=${{ matrix.name }}
+          version: v0.9.1
 
       - name: Sign Container Images
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -385,6 +392,7 @@ jobs:
           outputs: type=local,dest=/tmp/docker-cache-${{ matrix.name }}
           platforms: linux/amd64
           target: export-cache
+          version: v0.9.1
 
       # Store docker's golang's cache build locally only on the main branch
       - name: Store ${{ matrix.name }} Golang cache in GitHub cache path

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -98,6 +98,7 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
+          version: v0.9.1
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -96,6 +96,7 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
+          version: v0.9.1
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b


### PR DESCRIPTION
Somewhere between the combination of GitHub action                                                                                                                                                                                                                                         
docker/build-push-action v3.3.0 and Docker buildx version v0.10.0,                                                                                                                                                                                                                         
provenance attestation was transparently added into the build process                                                                                                                                                                                                                      
for new images. Unfortunately, since we already have SBOM generation                                                                                                                                                                                                                       
steps in our workflows, this would break the workflows. The existing                                                                                                                                                                                                                       
workflows would attempt to pull the images with provenance and then                                                                                                                                                                                                                        
generate an SBOM from that existing attestation. This would lead to a                                                                                                                                                                                                                      
message like the following in CI image builds:                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                           
    level=fatal msg="generating doc: creating SPDX document: generating                                                                                                                                                                                                                    
    SPDX package from image ref quay.io/cilium/docker-plugin-ci:XXX:                                                                                                                                                                                                                       
    generating image package"                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                           
I tried disabling provenance in the docker/build-push-action, but                                                                                                                                                                                                                          
apparently it just ignored such requests and pushed the attestation into                                                                                                                                                                                                                   
the image anyway. So, this commit attempts to revert buildx back to                                                                                                                                                                                                                        
v0.9.1 to prevent it from generating those artifacts.                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                           
This is a quick-and-dirty hack to stabilize CI for the short term, then                                                                                                                                                                                                                    
we can figure out over time how to properly resolve the conflict between                                                                                                                                                                                                                   
these systems.