### PR TITLE
node: Use new asynchronous IPCache API for Manager (v2)

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -309,7 +309,7 @@ func (d *Daemon) syncHostIPs() error {
 
 func (d *Daemon) sourceByIP(ip net.IP, defaultSrc source.Source) source.Source {
 	if addr, ok := ippkg.AddrFromIP(ip); ok {
-		lbls := d.ipcache.GetIDMetadataByIP(addr)
+		lbls := d.ipcache.GetMetadataLabelsByIP(addr)
 		if lbls.Has(labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer]) {
 			return source.KubeAPIServer
 		}

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -225,6 +225,12 @@ func (ipc *IPCache) GetHostIP(ip string) net.IP {
 	return hostIP
 }
 
+func (ipc *IPCache) GetHostIPCache(ip string) (net.IP, uint8) {
+	ipc.mutex.RLock()
+	defer ipc.mutex.RUnlock()
+	return ipc.getHostIPCache(ip)
+}
+
 func (ipc *IPCache) getHostIPCache(ip string) (net.IP, uint8) {
 	ipKeyPair := ipc.ipToHostIPCache[ip]
 	return ipKeyPair.IP, ipKeyPair.Key

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -125,10 +125,10 @@ func (m *metadata) upsertLocked(prefix netip.Prefix, src source.Source, resource
 	m.m[prefix].logConflicts(log.WithField(logfields.CIDR, prefix))
 }
 
-// GetIDMetadataByIP returns the associated labels with an IP. The caller must
+// GetMetadataLabelsByIP returns the associated labels with an IP. The caller must
 // not modifying the returned object as it's a live reference to the underlying
 // map.
-func (ipc *IPCache) GetIDMetadataByIP(addr netip.Addr) labels.Labels {
+func (ipc *IPCache) GetMetadataLabelsByIP(addr netip.Addr) labels.Labels {
 	prefix := netip.PrefixFrom(addr, addr.BitLen())
 	ipc.metadata.RLock()
 	defer ipc.metadata.RUnlock()

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -425,7 +425,8 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 	// we allow more arbitrary labels to be associated with these IPs that
 	// correspond to remote nodes.
 	if !lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) &&
-		!lbls.Has(labels.LabelHealth[labels.IDNameHealth]) {
+		!lbls.Has(labels.LabelHealth[labels.IDNameHealth]) &&
+		!lbls.Has(labels.LabelIngress[labels.IDNameIngress]) {
 		cidrLabels := cidrlabels.GetCIDRLabels(prefix)
 		lbls.MergeLabels(cidrLabels)
 	}

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -22,6 +22,9 @@ import (
 // independently based on the ResourceID of the origin of that information, and
 // provides convenient accessors to consistently merge the stored information
 // to generate ipcache output based on a range of inputs.
+//
+// Note that when making a copy of this object, resourceInfo is pointer which
+// means it needs to be deep-copied via (*resourceInfo).DeepCopy().
 type prefixInfo map[ipcachetypes.ResourceID]*resourceInfo
 
 // IdentityOverride can be used to override the identity of a given prefix.
@@ -111,6 +114,16 @@ func (m *resourceInfo) isValid() bool {
 		return true
 	}
 	return false
+}
+
+func (m *resourceInfo) DeepCopy() *resourceInfo {
+	n := new(resourceInfo)
+	n.labels = labels.NewFrom(m.labels)
+	n.source = m.source
+	n.identityOverride = m.identityOverride
+	n.tunnelPeer = m.tunnelPeer
+	n.encryptKey = m.encryptKey
+	return n
 }
 
 func (s prefixInfo) isValid() bool {

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -6,6 +6,8 @@ package types
 import (
 	"context"
 	"net"
+	"net/netip"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -63,4 +65,31 @@ func NewResourceID(kind ResourceKind, namespace, name string) ResourceID {
 // NodeHandler is responsible for the management of node identities.
 type NodeHandler interface {
 	AllocateNodeID(net.IP) uint16
+}
+
+// TunnelPeer is the IP address of the host associated with this prefix. This is
+// typically used to establish a tunnel, e.g. in tunnel mode or for encryption.
+// This type implements ipcache.IPMetadata
+type TunnelPeer struct{ netip.Addr }
+
+func (t TunnelPeer) IP() net.IP {
+	return t.AsSlice()
+}
+
+// EncryptKey is the identity of the encryption key.
+// This type implements ipcache.IPMetadata
+type EncryptKey uint8
+
+const EncryptKeyEmpty = EncryptKey(0)
+
+func (e EncryptKey) IsValid() bool {
+	return e != EncryptKeyEmpty
+}
+
+func (e EncryptKey) Uint8() uint8 {
+	return uint8(e)
+}
+
+func (e EncryptKey) String() string {
+	return strconv.Itoa(int(e))
 }

--- a/pkg/ipcache/types_test.go
+++ b/pkg/ipcache/types_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_sortedByResourceIDsAndSource(t *testing.T) {
-	pi := make(prefixInfo, 1)
+	pi := make(PrefixInfo, 1)
 	pi["a-restored-uid"] = &resourceInfo{
 		source: source.Restored,
 	}

--- a/pkg/ipcache/types_test.go
+++ b/pkg/ipcache/types_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+func Test_sortedByResourceIDsAndSource(t *testing.T) {
+	pi := make(prefixInfo, 1)
+	pi["a-restored-uid"] = &resourceInfo{
+		source: source.Restored,
+	}
+	pi["b-restored-uid"] = &resourceInfo{
+		source: source.Restored,
+	}
+	pi["node-uid"] = &resourceInfo{
+		source: source.CustomResource,
+	}
+	pi["node2-uid"] = &resourceInfo{
+		source: source.Local,
+	}
+	pi["daemon-uid"] = &resourceInfo{
+		source: source.Local,
+	}
+	pi["endpoints-uid"] = &resourceInfo{
+		source: source.KubeAPIServer,
+	}
+	pi["2-identity-uid"] = &resourceInfo{
+		source: source.Kubernetes,
+	}
+	pi["1-identity-uid"] = &resourceInfo{
+		source: source.Kubernetes,
+	}
+	pi["generated-uid"] = &resourceInfo{
+		source: source.Generated,
+	}
+	pi["kvstore-uid"] = &resourceInfo{
+		source: source.KVStore,
+	}
+
+	expected := []types.ResourceID{
+		"endpoints-uid",
+		"daemon-uid",
+		"node2-uid",
+		"kvstore-uid",
+		"node-uid",
+		"1-identity-uid",
+		"2-identity-uid",
+		"generated-uid",
+		"a-restored-uid",
+		"b-restored-uid",
+	}
+	assert.Equal(t, expected, pi.sortedBySourceThenResourceID())
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -47,6 +47,9 @@ const (
 	// Labels are any label, they may not be relevant to the security identity.
 	Labels = "labels"
 
+	// Source is the label or node information source
+	Source = "source"
+
 	// Controller is the name of the controller to log it.
 	Controller = "controller"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -362,6 +362,13 @@ const (
 	// Tunnel is the tunnel name
 	Tunnel = "tunnel"
 
+	// TunnelPeer is the tunnel peer address
+	TunnelPeer = "tunnelPeer"
+
+	// ConflictingTunnelPeer is the address of a tunnel peer which conflicts
+	// with TunnelPeer
+	ConflictingTunnelPeer = "conflictingTunnelPeer"
+
 	// Selector is a selector of any sort: endpoint, CIDR, toFQDNs
 	Selector = "Selector"
 
@@ -541,6 +548,10 @@ const (
 
 	// Key is the identity of the encryption key
 	Key = "key"
+
+	// ConflictingKey is the identity of the encryption key which conflicts with
+	// Key
+	ConflictingKey = "conflictingKey"
 
 	// URL represents a Uniform Resource Locator.
 	URL = "url"

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -403,12 +403,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 			key = n.EncryptionKey
 		}
 
-		var prefix netip.Prefix
-		if v4 := address.IP.To4(); v4 != nil {
-			prefix = ip.IPToNetPrefix(v4)
-		} else {
-			prefix = ip.IPToNetPrefix(address.IP.To16())
-		}
+		prefix := ip.IPToNetPrefix(address.IP)
 		ipAddrStr := prefix.String()
 		_, err := m.ipcache.Upsert(ipAddrStr, tunnelIP, key, nil, ipcache.Identity{
 			ID:     remoteHostIdentity,

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -59,8 +60,8 @@ func (c *configMock) EncryptionEnabled() bool {
 }
 
 type nodeEvent struct {
-	event string
-	ip    net.IP
+	event  string
+	prefix netip.Prefix
 }
 
 type ipcacheMock struct {
@@ -73,17 +74,17 @@ func newIPcacheMock() *ipcacheMock {
 	}
 }
 
-func AddrOrPrefixToIP(ip string) (net.IP, error) {
-	var err error
-
-	addr := net.ParseIP(ip)
-	if addr == nil {
-		addr, _, err = net.ParseCIDR(ip)
+func AddrOrPrefixToIP(ip string) (netip.Prefix, error) {
+	prefix, err := netip.ParsePrefix(ip)
+	if err != nil {
+		addr, err := netip.ParseAddr(ip)
 		if err != nil {
-			return nil, err
+			return netip.Prefix{}, err
 		}
+		return addr.Prefix(prefix.Bits())
 	}
-	return addr, nil
+
+	return prefix, err
 }
 
 func (i *ipcacheMock) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error) {
@@ -106,7 +107,22 @@ func (i *ipcacheMock) Delete(ip string, source source.Source) bool {
 	return false
 }
 
-func (i *ipcacheMock) UpsertLabels(netip.Prefix, labels.Labels, source.Source, ipcacheTypes.ResourceID) {
+func (i *ipcacheMock) GetMetadataByPrefix(prefix netip.Prefix) ipcache.PrefixInfo {
+	return ipcache.PrefixInfo{}
+}
+func (i *ipcacheMock) UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
+	i.Upsert(prefix.String(), nil, 0, nil, ipcache.Identity{})
+}
+func (i *ipcacheMock) OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
+	i.UpsertMetadata(prefix, src, resource)
+}
+
+func (i *ipcacheMock) RemoveMetadata(prefix netip.Prefix, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
+	i.Delete(prefix.String(), source.CustomResource)
+}
+
+func (i *ipcacheMock) RemoveIdentityOverride(prefix netip.Prefix, identityLabels labels.Labels, resource ipcacheTypes.ResourceID) {
+	i.Delete(prefix.String(), source.CustomResource)
 }
 
 type signalNodeHandler struct {
@@ -198,7 +214,12 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	mngr.Subscribe(dp)
 	c.Assert(err, check.IsNil)
 
-	n1 := nodeTypes.Node{Name: "node1", Cluster: "c1"}
+	n1 := nodeTypes.Node{Name: "node1", Cluster: "c1", IPAddresses: []nodeTypes.Address{
+		{
+			Type: addressing.NodeInternalIP,
+			IP:   net.ParseIP("10.0.0.1"),
+		},
+	}}
 	mngr.NodeUpdated(n1)
 
 	select {
@@ -212,7 +233,12 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 		c.Errorf("timeout while waiting for NodeAdd() event for node1")
 	}
 
-	n2 := nodeTypes.Node{Name: "node2", Cluster: "c1"}
+	n2 := nodeTypes.Node{Name: "node2", Cluster: "c1", IPAddresses: []nodeTypes.Address{
+		{
+			Type: addressing.NodeInternalIP,
+			IP:   net.ParseIP("10.0.0.2"),
+		},
+	}}
 	mngr.NodeUpdated(n2)
 
 	select {
@@ -261,7 +287,12 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 
-	n1k8s := nodeTypes.Node{Name: "node1", Cluster: "c1", Source: source.Kubernetes}
+	n1k8s := nodeTypes.Node{Name: "node1", Cluster: "c1", Source: source.Kubernetes, IPAddresses: []nodeTypes.Address{
+		{
+			Type: addressing.NodeInternalIP,
+			IP:   net.ParseIP("10.0.0.1"),
+		},
+	}}
 	mngr.NodeUpdated(n1k8s)
 	select {
 	case nodeEvent := <-dp.NodeAddEvent:
@@ -275,7 +306,12 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	}
 
 	// agent can overwrite kubernetes
-	n1agent := nodeTypes.Node{Name: "node1", Cluster: "c1", Source: source.Local}
+	n1agent := nodeTypes.Node{Name: "node1", Cluster: "c1", Source: source.Local, IPAddresses: []nodeTypes.Address{
+		{
+			Type: addressing.NodeInternalIP,
+			IP:   net.ParseIP("10.0.0.1"),
+		},
+	}}
 	mngr.NodeUpdated(n1agent)
 	select {
 	case nodeEvent := <-dp.NodeUpdateEvent:
@@ -357,7 +393,12 @@ func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
 	prevInterval := time.Nanosecond
 
 	for i := 0; i < 1000; i++ {
-		n := nodeTypes.Node{Name: fmt.Sprintf("%d", i), Source: source.Local}
+		n := nodeTypes.Node{Name: fmt.Sprintf("%d", i), Source: source.Local, IPAddresses: []nodeTypes.Address{
+			{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("10.0.0.1"),
+			},
+		}}
 		mngr.NodeUpdated(n)
 		newInterval := mngr.ClusterSizeDependantInterval(time.Minute)
 		c.Assert(newInterval > prevInterval, check.Equals, true)
@@ -405,7 +446,12 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 	}()
 
 	for i := 0; i < numNodes; i++ {
-		n := nodeTypes.Node{Name: fmt.Sprintf("%d", i), Source: source.Kubernetes}
+		n := nodeTypes.Node{Name: fmt.Sprintf("%d", i), Source: source.Kubernetes, IPAddresses: []nodeTypes.Address{
+			{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("10.0.0.1"),
+			},
+		}}
 		mngr.NodeUpdated(n)
 	}
 
@@ -433,7 +479,7 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("1.1.1.1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
 	}
@@ -448,7 +494,7 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("1.1.1.1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
 	}
@@ -472,7 +518,7 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 		Name:    "node1",
 		Cluster: "c1",
 		IPAddresses: []nodeTypes.Address{
-			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1")},
+			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1").To4()},
 		},
 		IPv4HealthIP: net.ParseIP("10.0.0.4"),
 		IPv6HealthIP: net.ParseIP("f00d::4"),
@@ -481,21 +527,21 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("1.1.1.1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("10.0.0.4")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("10.0.0.4"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache upsert for IP 10.0.0.4")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("f00d::4")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("f00d::4"), 128)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache upsert for IP f00d::4")
 	}
@@ -510,21 +556,21 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("1.1.1.1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("10.0.0.4")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("10.0.0.4"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP 10.0.0.4")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("f00d::4")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("f00d::4"), 128)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP f00d::4")
 	}
@@ -557,21 +603,21 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("1.1.1.1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("10.0.0.2")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache upsert for IP 10.0.0.2")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("f00d::1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache upsert for IP f00d::1")
 	}
@@ -586,21 +632,21 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("1.1.1.1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("10.0.0.2")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP 10.0.0.2")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("f00d::1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP f00d::1")
 	}
@@ -633,21 +679,21 @@ func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("1.1.1.1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("10.0.0.2")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache upsert for IP 10.0.0.2")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("f00d::1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache upsert for IP f00d::1")
 	}
@@ -662,21 +708,21 @@ func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("1.1.1.1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("10.0.0.2")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP 10.0.0.2")
 	}
 
 	select {
 	case event := <-ipcacheMock.events:
-		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("f00d::1")})
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP f00d::1")
 	}
@@ -693,7 +739,11 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	ipcacheExpect := func(eventType, ipStr string) {
 		select {
 		case event := <-ipcacheMock.events:
-			if !c.Check(event, checker.DeepEquals, nodeEvent{event: eventType, ip: net.ParseIP(ipStr)}) {
+			b := 32
+			if strings.Contains(ipStr, ":") {
+				b = 128
+			}
+			if !c.Check(event, checker.DeepEquals, nodeEvent{event: eventType, prefix: netip.PrefixFrom(netip.MustParseAddr(ipStr), b)}) {
 				// Panic just to get a stack trace so you can find the source of the problem
 				panic("assertion failed")
 			}


### PR DESCRIPTION
On top of https://github.com/cilium/cilium/pull/22086 with additional fixes.

Related: https://github.com/cilium/cilium/issues/21142