### PR TITLE
k8s: Fix unnecessary update with MetalLB

### DIFF
--- a/pkg/bgp/mock/gen.go
+++ b/pkg/bgp/mock/gen.go
@@ -158,7 +158,7 @@ func GenTestServicePairs() (slim_corev1.Service, v1.Service, metallbspr.Service,
 				Ingress: []v1.LoadBalancerIngress{
 					{
 						IP:    IP,
-						Ports: []v1.PortStatus{},
+						Ports: nil,
 					},
 				},
 			},

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -383,7 +383,7 @@ func ConvertToK8sV1LoadBalancerIngress(slimLBIngs []slim_corev1.LoadBalancerIngr
 
 	lbIngs := make([]v1.LoadBalancerIngress, 0, len(slimLBIngs))
 	for _, lbIng := range slimLBIngs {
-		ports := make([]v1.PortStatus, 0, len(lbIng.Ports))
+		var ports []v1.PortStatus
 		for _, port := range lbIng.Ports {
 			ports = append(ports, v1.PortStatus{
 				Port:     port.Port,

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -1066,7 +1066,7 @@ func (s *K8sSuite) Test_ConvertToK8sV1LoadBalancerIngress(c *C) {
 			want: []v1.LoadBalancerIngress{
 				{
 					IP:    "1.1.1.1",
-					Ports: []v1.PortStatus{},
+					Ports: nil,
 				},
 			},
 		},


### PR DESCRIPTION
ConvertToK8sV1LoadBalancerIngress sets an empty ports array even if the correspoinding ports field is nil. Because of this, MetalLB updates svc.Status.LoadBalancer.Ingres even though it has already allocated an external IP.

Metal detects a diff as follows, and updates the lb svc unnecessarily.

```
v1.ServiceStatus{
   LoadBalancer: v1.LoadBalancerStatus{
      Ingress: []v1.LoadBalancerIngress{
         {
            IP:       "10.72.32.4",
            Hostname: "",
            - Ports:    []v1.PortStatus{},
            + Ports:    nil,
         },},},Conditions: nil,}
```

Fixes: #23107

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

```release-note
Removed unnecessary updates to service status by MetalLB
```