### PR TITLE
docs: add label and name to scrape job

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -87,11 +87,6 @@ option is set in the ``scrape_configs`` section:
           regex: (.+):(?:\d+);(\d+)
           replacement: ${1}:${2}
           target_label: __address__
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
-        - source_labels: [__meta_kubernetes_pod_name]
-          action: replace
-          target_label: pod
 
 Hubble Metrics
 ==============

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -87,6 +87,11 @@ option is set in the ``scrape_configs`` section:
           regex: (.+):(?:\d+);(\d+)
           replacement: ${1}:${2}
           target_label: __address__
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: pod
 
 Hubble Metrics
 ==============


### PR DESCRIPTION
### Description

The current [cilium agent grafana dashboard](https://grafana.com/grafana/dashboards/16611-cilium-metrics/) uses labels and pod name in the prometheus queries, e.g:
```
avg(irate(cilium_process_cpu_seconds_total{k8s_app="cilium", pod=~"cilium.*"}[1m])) by (pod) * 100
```
The [cilium metrics documentation](https://docs.cilium.io/en/v1.12/operations/metrics/#installation) has an example scrape job which doesn't collect either, meaning the dashboard won't work out of the box.   

Signed-off-by: Kai Hanssen [kai.hanssen@tromso.serit.no](mailto:kai.hanssen@tromso.serit.no)