### PR TITLE
golangci-lint-action: Remove skip-go-installation option

### DIFF
--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -48,7 +48,6 @@ jobs:
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376
         with:
           version: v1.37.1
-          skip-go-installation: true
 
   precheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's been removed.

Ref: https://github.com/golangci/golangci-lint-action#compatibility

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>