### PR TITLE
labels, ipcache: Introduce convenience NewFrom()

### DIFF
--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -40,9 +40,7 @@ type IPMetadata any
 func (m *resourceInfo) merge(info IPMetadata, src source.Source) {
 	switch info := info.(type) {
 	case labels.Labels:
-		l := labels.NewLabelsFromModel(nil)
-		l.MergeLabels(info)
-		m.labels = l
+		m.labels = labels.NewFrom(info)
 	default:
 		log.Errorf("BUG: Invalid IPMetadata passed to ipinfo.merge(): %+v", info)
 		return

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -411,6 +411,13 @@ func NewSelectLabelArrayFromModel(base []string) LabelArray {
 	return lbls.Sort()
 }
 
+// NewFrom creates a new Labels from the given labels by creating a copy.
+func NewFrom(l Labels) Labels {
+	nl := NewLabelsFromModel(nil)
+	nl.MergeLabels(l)
+	return nl
+}
+
 // GetModel returns model with all the values of the labels.
 func (l Labels) GetModel() []string {
 	res := make([]string, 0, len(l))


### PR DESCRIPTION
This new function is a convenience and safe wrapper for creating a copy
of a Labels object from another.

This is especially useful going forward with the IPcache rework
(https://github.com/cilium/cilium/issues/21142), where many call sites
are being converted from using raw identities over to labels. Being able
to create copies of labels without accidentally copying the reference to
the backing slice is crucial to avoid very subtle and hard to find bugs.

For example:

```
// Node 1 comes online.
node1Labels := labels.LabelRemoteNote
// Detect that node1 also has the kube-apiserver deployed on it, so add
// its label.
node1Labels.MergeLabels(labels.LabelKubeAPIServer)
...

// Node 2 comes onlne.
node2Labels := labels.LabelRemoteNote
// Now node2Labels contains the kube-apiserver label as well because
// node1Labels was set to the reference of labels.LabelRemoteNote.
```

Signed-off-by: Chris Tarazi <chris@isovalent.com>
