### PR TITLE
ipmasq: Add support for ip-masq-agent with IPv6

### DIFF
--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -65,7 +65,7 @@ to determine which devices the program is running on:
 From the output above, the program is running on the ``eth0`` and ``eth1`` devices.
 
 
-The eBPF-based masquerading can masquerade packets of the following IPv4 L4 protocols:
+The eBPF-based masquerading can masquerade packets of the following L4 protocols:
 
 - TCP
 - UDP
@@ -79,8 +79,9 @@ The eBPF-based masquerading can masquerade packets of the following IPv4 L4 prot
 
 By default, all packets from a pod destined to an IP address outside of the
 ``ipv4-native-routing-cidr`` range are masqueraded, except for packets destined
-to other cluster nodes. The exclusion CIDR is shown in the above output of
-``cilium status`` (``10.0.0.0/16``).
+to other cluster nodes (as with ``ipv6-native-routing-cidr`` for IPv6). The
+preceding output shows the exclusion CIDR of ``cilium status``
+(``10.0.0.0/16``).
 
 .. note::
 
@@ -93,8 +94,8 @@ To allow more fine-grained control, Cilium implements `ip-masq-agent
 <https://github.com/kubernetes-sigs/ip-masq-agent>`_ in eBPF which can be
 enabled with the ``ipMasqAgent.enabled=true`` helm option.
 
-The eBPF-based ip-masq-agent supports the ``nonMasqueradeCIDRs`` and
-``masqLinkLocal`` options set in a configuration file. A packet sent from a pod to
+The eBPF-based ip-masq-agent supports the ``nonMasqueradeCIDRs``, ``masqLinkLocal``, and
+``masqLinkLocalIPv6`` options set in a configuration file. A packet sent from a pod to
 a destination which belongs to any CIDR from the ``nonMasqueradeCIDRs`` is not
 going to be masqueraded. If the configuration file is empty, the agent will provision
 the following non-masquerade CIDRs:
@@ -112,7 +113,9 @@ the following non-masquerade CIDRs:
 - ``240.0.0.0/4``
 
 In addition, if the ``masqLinkLocal`` is not set or set to false, then
-``169.254.0.0/16`` is appended to the non-masquerade CIDRs list.
+``169.254.0.0/16`` is appended to the non-masquerade CIDRs list. For IPv6, if
+``masqLinkLocalIPv6`` is not set or set to false, ``fe80::/10`` is appended.
+
 
 The agent uses Fsnotify to track updates to the configuration file, so the original
 ``resyncInterval`` option is unnecessary.
@@ -134,13 +137,13 @@ The example below shows how to configure the agent via :term:`ConfigMap` and to 
     192.168.0.0/16
 
 Alternatively, you can pass ``--set ipMasqAgent.config.nonMasqueradeCIDRs='{10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}'``
-and ``--set ipMasqAgent.config.masqLinkLocal=false`` when installing Cilium via Helm to
+and ``--set ipMasqAgent.config.masqLinkLocal=false`` (or with the corresponding
+option, for IPv6) when installing Cilium via Helm to
 configure the ``ip-masq-agent`` as above.
 
 .. note::
 
-    - The eBPF-based ip-masq-agent is not supported for IPv6 traffic.
-    - eBPF-based masquerading for IPv6 is not compatible with the host firewall.
+    eBPF-based masquerading for IPv6 is not compatible with the host firewall.
 
 iptables-based
 **************

--- a/Documentation/network/ebpf/maps.rst
+++ b/Documentation/network/ebpf/maps.rst
@@ -29,7 +29,8 @@ Proxy Map                node             512k            Max 512k concurrent re
 Tunnel                   node             64k             Max 32k nodes (IPv4+IPv6) or 64k nodes (IPv4 or IPv6) across all clusters
 IPv4 Fragmentation       node             8k              Max 8k fragmented datagrams in flight simultaneously on the node
 Session Affinity         node             64k             Max 64k affinities from different clients
-IP Masq                  node             16k             Max 16k IPv4 cidrs used by BPF-based ip-masq-agent
+IPv4 Masq                node             16k             Max 16k IPv4 cidrs used by BPF-based ip-masq-agent
+IPv6 Masq                node             16k             Max 16k IPv6 cidrs used by BPF-based ip-masq-agent
 Service Source Ranges    node             64k             Max 64k cumulative LB source ranges across all services
 Egress Policy            endpoint         16k             Max 16k endpoints across all destination CIDRs across all clusters 
 ======================== ================ =============== =====================================================

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -721,6 +721,7 @@ makefile
 mapDynamicSizeRatio
 masq
 masqLinkLocal
+masqLinkLocalIPv
 masterDevice
 matchLabels
 matchPattern

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -144,7 +144,7 @@ struct {
 #endif
 #endif
 
-#ifdef ENABLE_IP_MASQ_AGENT
+#ifdef ENABLE_IP_MASQ_AGENT_IPV4
 struct {
 	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
 	__type(key, struct lpm_v4_key);
@@ -842,7 +842,7 @@ skip_egress_gateway:
 		return false;
 
 	if (remote_ep) {
-#ifdef ENABLE_IP_MASQ_AGENT
+#ifdef ENABLE_IP_MASQ_AGENT_IPV4
 		/* Do not SNAT if dst belongs to any ip-masq-agent
 		 * subnet.
 		 */

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1005,8 +1005,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			return nil, nil, fmt.Errorf("failed to determine BPF masquerade addrs: %w", err)
 		}
 	} else if option.Config.EnableIPMasqAgent {
-		log.WithError(err).Errorf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
-		return nil, nil, fmt.Errorf("BPF ip-masq-agent requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
+		log.WithError(err).Errorf("BPF ip-masq-agent requires (--%s=\"true\" or --%s=\"true\") and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableIPv6Masquerade, option.EnableBPFMasquerade)
+		return nil, nil, fmt.Errorf("BPF ip-masq-agent requires (--%s=\"true\" or --%s=\"true\") and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableIPv6Masquerade, option.EnableBPFMasquerade)
 	} else if option.Config.EnableIPv4EgressGateway {
 		log.WithError(err).Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
 		return nil, nil, fmt.Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
@@ -1014,12 +1014,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		log.Infof("Auto-disabling %q feature since IPv4 and IPv6 masquerading are disabled",
 			option.EnableBPFMasquerade)
 		option.Config.EnableBPFMasquerade = false
-	}
-	if option.Config.EnableIPMasqAgent {
-		if !option.Config.EnableIPv4 {
-			log.WithError(err).Errorf("BPF ip-masq-agent requires IPv4 support (--%s=\"true\")", option.EnableIPv4Name)
-			return nil, nil, fmt.Errorf("BPF ip-masq-agent requires IPv4 support (--%s=\"true\")", option.EnableIPv4Name)
-		}
 	}
 	if len(option.Config.GetDevices()) == 0 {
 		if option.Config.EnableHostFirewall {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -416,7 +416,12 @@ func (d *Daemon) initMaps() error {
 
 	if option.Config.EnableIPv4 && option.Config.EnableIPMasqAgent {
 		if err := ipmasq.IPMasq4Map().OpenOrCreate(); err != nil {
-			return fmt.Errorf("initializing masquerading map: %w", err)
+			return fmt.Errorf("initializing IPv4 masquerading map: %w", err)
+		}
+	}
+	if option.Config.EnableIPv6 && option.Config.EnableIPMasqAgent {
+		if err := ipmasq.IPMasq6Map().OpenOrCreate(); err != nil {
+			return fmt.Errorf("initializing IPv6 masquerading map: %w", err)
 		}
 	}
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -336,6 +336,10 @@ func (d *Daemon) getBPFMapStatus() *models.BPFMapStatus {
 				Size: int64(ipmasqmap.MaxEntriesIPv4),
 			},
 			{
+				Name: "IPv6 masquerading agent",
+				Size: int64(ipmasqmap.MaxEntriesIPv6),
+			},
+			{
 				Name: "IPv4 fragmentation",
 				Size: int64(option.Config.FragmentsMapEntries),
 			},

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -332,8 +332,8 @@ func (d *Daemon) getBPFMapStatus() *models.BPFMapStatus {
 				Size: int64(ipcachemap.MaxEntries),
 			},
 			{
-				Name: "IP masquerading agent",
-				Size: int64(ipmasqmap.MaxEntries),
+				Name: "IPv4 masquerading agent",
+				Size: int64(ipmasqmap.MaxEntriesIPv4),
 			},
 			{
 				Name: "IPv4 fragmentation",

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1487,6 +1487,7 @@ ipMasqAgent:
 # config:
   # nonMasqueradeCIDRs: []
   # masqLinkLocal: false
+  # masqLinkLocalIPv6: false
 
 # iptablesLockTimeout defines the iptables "--wait" option when invoked from Cilium.
 # iptablesLockTimeout: "5s"

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1484,6 +1484,7 @@ ipMasqAgent:
 # config:
   # nonMasqueradeCIDRs: []
   # masqLinkLocal: false
+  # masqLinkLocalIPv6: false
 
 # iptablesLockTimeout defines the iptables "--wait" option when invoked from Cilium.
 # iptablesLockTimeout: "5s"

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -609,7 +609,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				// ip-masq-agent depends on bpf-masq
 				if option.Config.EnableIPMasqAgent {
 					cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV4"] = "1"
-					cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapName
+					cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapNameIPv4
 				}
 			}
 			if option.Config.EnableIPv6Masquerade {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -608,7 +608,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 				// ip-masq-agent depends on bpf-masq
 				if option.Config.EnableIPMasqAgent {
-					cDefinesMap["ENABLE_IP_MASQ_AGENT"] = "1"
+					cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV4"] = "1"
 					cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapName
 				}
 			}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -608,8 +608,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 				// ip-masq-agent depends on bpf-masq
 				if option.Config.EnableIPMasqAgent {
-					cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV4"] = "1"
-					cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapNameIPv4
+					if option.Config.EnableIPv4 {
+						cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV4"] = "1"
+						cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapNameIPv4
+					}
+					if option.Config.EnableIPv6 {
+						cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV6"] = "1"
+						cDefinesMap["IP_MASQ_AGENT_IPV6"] = ipmasq.MapNameIPv6
+					}
 				}
 			}
 			if option.Config.EnableIPv6Masquerade {

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -164,7 +164,7 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 			lbmap.Affinity4MapName,
 			lbmap.SourceRange4MapName,
 			lbmap.HealthProbe4MapName,
-			ipmasq.MapName,
+			ipmasq.MapNameIPv4,
 			cidrmap.MapName + "v4_dyn",
 			cidrmap.MapName + "v4_fix",
 		}...)
@@ -204,7 +204,7 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 	}
 
 	if !option.Config.EnableIPMasqAgent {
-		maps = append(maps, ipmasq.MapName)
+		maps = append(maps, ipmasq.MapNameIPv4)
 	}
 
 	if !option.Config.EnableXDPPrefilter {

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -141,6 +141,7 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 			lbmap.Affinity6MapName,
 			lbmap.SourceRange6MapName,
 			lbmap.HealthProbe6MapName,
+			ipmasq.MapNameIPv6,
 			cidrmap.MapName + "v6_dyn",
 			cidrmap.MapName + "v6_fix",
 		}...)
@@ -204,7 +205,12 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 	}
 
 	if !option.Config.EnableIPMasqAgent {
-		maps = append(maps, ipmasq.MapNameIPv4)
+		if option.Config.EnableIPv4 {
+			maps = append(maps, ipmasq.MapNameIPv4)
+		}
+		if option.Config.EnableIPv6 {
+			maps = append(maps, ipmasq.MapNameIPv6)
+		}
 	}
 
 	if !option.Config.EnableXDPPrefilter {

--- a/pkg/ipmasq/ipmasq.go
+++ b/pkg/ipmasq/ipmasq.go
@@ -63,12 +63,9 @@ func (c *Ipnet) UnmarshalJSON(json []byte) error {
 }
 
 func parseCIDR(c string) (*net.IPNet, error) {
-	ip, n, err := net.ParseCIDR(c)
+	_, n, err := net.ParseCIDR(c)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid CIDR %s: %s", c, err)
-	}
-	if ip.To4() == nil {
-		return nil, fmt.Errorf("Invalid CIDR %s: only IPv4 is supported", c)
 	}
 	return n, nil
 }

--- a/pkg/ipmasq/ipmasq_test.go
+++ b/pkg/ipmasq/ipmasq_test.go
@@ -22,8 +22,10 @@ func Test(t *testing.T) {
 
 type ipMasqMapMock struct {
 	lock.RWMutex
-	cidrsIPv4 map[string]net.IPNet
-	cidrsIPv6 map[string]net.IPNet
+	ipv4Enabled bool
+	ipv6Enabled bool
+	cidrsIPv4   map[string]net.IPNet
+	cidrsIPv6   map[string]net.IPNet
 }
 
 func (m *ipMasqMapMock) Update(cidr net.IPNet) error {
@@ -32,15 +34,23 @@ func (m *ipMasqMapMock) Update(cidr net.IPNet) error {
 
 	cidrStr := cidr.String()
 	if ip.IsIPv4(cidr.IP) {
-		if _, ok := m.cidrsIPv4[cidrStr]; ok {
-			return fmt.Errorf("CIDR already exists: %s", cidrStr)
+		if m.ipv4Enabled {
+			if _, ok := m.cidrsIPv4[cidrStr]; ok {
+				return fmt.Errorf("CIDR already exists: %s", cidrStr)
+			}
+			m.cidrsIPv4[cidrStr] = cidr
+		} else {
+			return fmt.Errorf("IPv4 disabled, but required for this CIDR: %s", cidrStr)
 		}
-		m.cidrsIPv4[cidrStr] = cidr
 	} else {
-		if _, ok := m.cidrsIPv6[cidrStr]; ok {
-			return fmt.Errorf("CIDR already exists: %s", cidrStr)
+		if m.ipv6Enabled {
+			if _, ok := m.cidrsIPv6[cidrStr]; ok {
+				return fmt.Errorf("CIDR already exists: %s", cidrStr)
+			}
+			m.cidrsIPv6[cidrStr] = cidr
+		} else {
+			return fmt.Errorf("IPv6 disabled, but required for this CIDR: %s", cidrStr)
 		}
-		m.cidrsIPv6[cidrStr] = cidr
 	}
 
 	return nil
@@ -52,15 +62,23 @@ func (m *ipMasqMapMock) Delete(cidr net.IPNet) error {
 
 	cidrStr := cidr.String()
 	if ip.IsIPv4(cidr.IP) {
-		if _, ok := m.cidrsIPv4[cidrStr]; !ok {
-			return fmt.Errorf("CIDR not found: %s", cidrStr)
+		if m.ipv4Enabled {
+			if _, ok := m.cidrsIPv4[cidrStr]; !ok {
+				return fmt.Errorf("CIDR not found: %s", cidrStr)
+			}
+			delete(m.cidrsIPv4, cidrStr)
+		} else {
+			return fmt.Errorf("IPv4 disabled, but required for this CIDR: %s", cidrStr)
 		}
-		delete(m.cidrsIPv4, cidrStr)
 	} else {
-		if _, ok := m.cidrsIPv6[cidrStr]; !ok {
-			return fmt.Errorf("CIDR not found: %s", cidrStr)
+		if m.ipv6Enabled {
+			if _, ok := m.cidrsIPv6[cidrStr]; !ok {
+				return fmt.Errorf("CIDR not found: %s", cidrStr)
+			}
+			delete(m.cidrsIPv6, cidrStr)
+		} else {
+			return fmt.Errorf("IPv6 disabled, but required for this CIDR: %s", cidrStr)
 		}
-		delete(m.cidrsIPv6, cidrStr)
 	}
 
 	return nil
@@ -71,11 +89,15 @@ func (m *ipMasqMapMock) Dump() ([]net.IPNet, error) {
 	defer m.RUnlock()
 
 	cidrs := make([]net.IPNet, 0, len(m.cidrsIPv4)+len(m.cidrsIPv6))
-	for _, cidr := range m.cidrsIPv4 {
-		cidrs = append(cidrs, cidr)
+	if m.ipv4Enabled {
+		for _, cidr := range m.cidrsIPv4 {
+			cidrs = append(cidrs, cidr)
+		}
 	}
-	for _, cidr := range m.cidrsIPv6 {
-		cidrs = append(cidrs, cidr)
+	if m.ipv6Enabled {
+		for _, cidr := range m.cidrsIPv6 {
+			cidrs = append(cidrs, cidr)
+		}
 	}
 
 	return cidrs, nil
@@ -85,12 +107,24 @@ func (m *ipMasqMapMock) dumpToSet() map[string]struct{} {
 	m.RLock()
 	defer m.RUnlock()
 
-	cidrs := make(map[string]struct{}, len(m.cidrsIPv4)+len(m.cidrsIPv6))
-	for cidrStr := range m.cidrsIPv4 {
-		cidrs[cidrStr] = struct{}{}
+	length := 0
+	if m.ipv4Enabled {
+		length += len(m.cidrsIPv4)
 	}
-	for cidrStr := range m.cidrsIPv6 {
-		cidrs[cidrStr] = struct{}{}
+	if m.ipv6Enabled {
+		length += len(m.cidrsIPv6)
+	}
+
+	cidrs := make(map[string]struct{}, length)
+	if m.ipv4Enabled {
+		for cidrStr := range m.cidrsIPv4 {
+			cidrs[cidrStr] = struct{}{}
+		}
+	}
+	if m.ipv6Enabled {
+		for cidrStr := range m.cidrsIPv6 {
+			cidrs[cidrStr] = struct{}{}
+		}
 	}
 
 	return cidrs
@@ -105,7 +139,10 @@ type IPMasqTestSuite struct {
 var _ = check.Suite(&IPMasqTestSuite{})
 
 func (i *IPMasqTestSuite) SetUpTest(c *check.C) {
-	i.ipMasqMap = &ipMasqMapMock{cidrsIPv4: map[string]net.IPNet{}}
+	i.ipMasqMap = &ipMasqMapMock{
+		cidrsIPv4: map[string]net.IPNet{},
+		cidrsIPv6: map[string]net.IPNet{},
+	}
 
 	configFile, err := os.CreateTemp("", "ipmasq-test")
 	c.Assert(err, check.IsNil)
@@ -114,7 +151,6 @@ func (i *IPMasqTestSuite) SetUpTest(c *check.C) {
 	agent, err := newIPMasqAgent(i.configFilePath, i.ipMasqMap)
 	c.Assert(err, check.IsNil)
 	i.ipMasqAgent = agent
-	i.ipMasqAgent.Start()
 }
 
 func (i *IPMasqTestSuite) TearDownTest(c *check.C) {
@@ -127,7 +163,10 @@ func (i *IPMasqTestSuite) writeConfig(cfg string, c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (i *IPMasqTestSuite) TestUpdate(c *check.C) {
+func (i *IPMasqTestSuite) TestUpdateIPv4(c *check.C) {
+	i.ipMasqMap.ipv4Enabled = true
+	i.ipMasqMap.ipv6Enabled = false
+	i.ipMasqAgent.Start()
 	i.writeConfig("nonMasqueradeCIDRs:\n- 1.1.1.1/32\n- 2.2.2.2/16", c)
 	time.Sleep(300 * time.Millisecond)
 
@@ -187,9 +226,140 @@ func (i *IPMasqTestSuite) TestUpdate(c *check.C) {
 	c.Assert(ok, check.Equals, true)
 }
 
-func (i *IPMasqTestSuite) TestRestore(c *check.C) {
+func (i *IPMasqTestSuite) TestUpdateIPv6(c *check.C) {
+	i.ipMasqMap.ipv4Enabled = false
+	i.ipMasqMap.ipv6Enabled = true
+	i.ipMasqAgent.Start()
+	i.writeConfig("nonMasqueradeCIDRs:\n- 1:1:1:1::/64\n- 2:2::/32", c)
+	time.Sleep(300 * time.Millisecond)
+
+	ipnets := i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 3)
+	_, ok := ipnets["1:1:1:1::/64"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets["2:2::/32"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv6Str]
+	c.Assert(ok, check.Equals, true)
+
+	// Write new config
+	i.writeConfig("nonMasqueradeCIDRs:\n- 8:8:8:8::/64\n- 2:2::/32", c)
+	time.Sleep(300 * time.Millisecond)
+
+	ipnets = i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 3)
+	_, ok = ipnets["8:8:8:8::/64"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets["2:2::/32"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv6Str]
+	c.Assert(ok, check.Equals, true)
+
+	// Write config with no CIDRs
+	i.writeConfig("nonMasqueradeCIDRs:\n", c)
+	time.Sleep(300 * time.Millisecond)
+
+	ipnets = i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 1)
+	_, ok = ipnets[linkLocalCIDRIPv6Str]
+	c.Assert(ok, check.Equals, true)
+
+	// Write new config in JSON
+	i.writeConfig(`{"nonMasqueradeCIDRs": ["8:8:8:8::/64", "1:2:3:4::/64"], "masqLinkLocalIPv6": true}`, c)
+	time.Sleep(300 * time.Millisecond)
+
+	ipnets = i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 2)
+	_, ok = ipnets["8:8:8:8::/64"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets["1:2:3:4::/64"]
+	c.Assert(ok, check.Equals, true)
+
+	// Delete file, should remove the CIDRs and add default nonMasq CIDRs
+	err := os.Remove(i.configFilePath)
+	c.Assert(err, check.IsNil)
+	time.Sleep(300 * time.Millisecond)
+	ipnets = i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 1)
+	_, ok = ipnets[linkLocalCIDRIPv6Str]
+	c.Assert(ok, check.Equals, true)
+}
+
+func (i *IPMasqTestSuite) TestUpdate(c *check.C) {
+	i.ipMasqMap.ipv4Enabled = true
+	i.ipMasqMap.ipv6Enabled = true
+	i.ipMasqAgent.Start()
+	i.writeConfig("nonMasqueradeCIDRs:\n- 1.1.1.1/32\n- 2:2::/32", c)
+	time.Sleep(300 * time.Millisecond)
+
+	ipnets := i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 4)
+	_, ok := ipnets["1.1.1.1/32"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets["2:2::/32"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv4Str]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv6Str]
+	c.Assert(ok, check.Equals, true)
+
+	// Write new config
+	i.writeConfig("nonMasqueradeCIDRs:\n- 8:8:8:8::/64\n- 2.2.0.0/16", c)
+	time.Sleep(300 * time.Millisecond)
+
+	ipnets = i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 4)
+	_, ok = ipnets["8:8:8:8::/64"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets["2.2.0.0/16"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv4Str]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv6Str]
+	c.Assert(ok, check.Equals, true)
+
+	// Write config with no CIDRs
+	i.writeConfig("nonMasqueradeCIDRs:\n", c)
+	time.Sleep(300 * time.Millisecond)
+
+	ipnets = i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 2)
+	_, ok = ipnets[linkLocalCIDRIPv4Str]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv6Str]
+	c.Assert(ok, check.Equals, true)
+
+	// Write new config in JSON
+	i.writeConfig(`{"nonMasqueradeCIDRs": ["1.2.3.4/32", "1:2:3:4::/64"], "masqLinkLocalIPv6": true}`, c)
+	time.Sleep(300 * time.Millisecond)
+
+	ipnets = i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 3)
+	_, ok = ipnets["1.2.3.4/32"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets["1:2:3:4::/64"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv4Str]
+	c.Assert(ok, check.Equals, true)
+
+	// Delete file, should remove the CIDRs and add default nonMasq CIDRs
+	err := os.Remove(i.configFilePath)
+	c.Assert(err, check.IsNil)
+	time.Sleep(300 * time.Millisecond)
+	ipnets = i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, len(defaultNonMasqCIDRs)+1+1)
+	_, ok = ipnets[linkLocalCIDRIPv4Str]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv6Str]
+	c.Assert(ok, check.Equals, true)
+}
+
+func (i *IPMasqTestSuite) TestRestoreIPv4(c *check.C) {
 	var err error
 
+	i.ipMasqMap.ipv4Enabled = true
+	i.ipMasqMap.ipv6Enabled = false
+	i.ipMasqAgent.Start()
 	// Check that stale entry is removed from the map after restore
 	i.ipMasqAgent.Stop()
 
@@ -214,7 +384,11 @@ func (i *IPMasqTestSuite) TestRestore(c *check.C) {
 	// Now stop the goroutine, and also remove the maps. It should bootstrap from
 	// the config
 	i.ipMasqAgent.Stop()
-	i.ipMasqMap = &ipMasqMapMock{cidrsIPv4: map[string]net.IPNet{}}
+	i.ipMasqMap = &ipMasqMapMock{
+		cidrsIPv4:   map[string]net.IPNet{},
+		ipv4Enabled: true,
+		ipv6Enabled: false,
+	}
 	i.ipMasqAgent.ipMasqMap = i.ipMasqMap
 	i.writeConfig("nonMasqueradeCIDRs:\n- 3.3.0.0/16\nmasqLinkLocal: true", c)
 	i.ipMasqAgent, err = newIPMasqAgent(i.configFilePath, i.ipMasqMap)
@@ -224,5 +398,110 @@ func (i *IPMasqTestSuite) TestRestore(c *check.C) {
 	ipnets = i.ipMasqMap.dumpToSet()
 	c.Assert(len(ipnets), check.Equals, 1)
 	_, ok = ipnets["3.3.0.0/16"]
+	c.Assert(ok, check.Equals, true)
+}
+
+func (i *IPMasqTestSuite) TestRestoreIPv6(c *check.C) {
+	var err error
+
+	i.ipMasqMap.ipv4Enabled = false
+	i.ipMasqMap.ipv6Enabled = true
+	i.ipMasqAgent.Start()
+	// Check that stale entry is removed from the map after restore
+	i.ipMasqAgent.Stop()
+
+	_, cidr, _ := net.ParseCIDR("3:3:3:3::/64")
+	i.ipMasqMap.cidrsIPv6[cidr.String()] = *cidr
+	_, cidr, _ = net.ParseCIDR("4:4::/32")
+	i.ipMasqMap.cidrsIPv6[cidr.String()] = *cidr
+	i.writeConfig("nonMasqueradeCIDRs:\n- 4:4::/32", c)
+
+	i.ipMasqAgent, err = newIPMasqAgent(i.configFilePath, i.ipMasqMap)
+	c.Assert(err, check.IsNil)
+	i.ipMasqAgent.Start()
+	time.Sleep(300 * time.Millisecond)
+
+	ipnets := i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 2)
+	_, ok := ipnets["4:4::/32"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv6Str]
+	c.Assert(ok, check.Equals, true)
+
+	// Now stop the goroutine, and also remove the maps. It should bootstrap from
+	// the config
+	i.ipMasqAgent.Stop()
+	i.ipMasqMap = &ipMasqMapMock{
+		cidrsIPv6:   map[string]net.IPNet{},
+		ipv4Enabled: false,
+		ipv6Enabled: true,
+	}
+	i.ipMasqAgent.ipMasqMap = i.ipMasqMap
+	i.writeConfig("nonMasqueradeCIDRs:\n- 3:3::/96\nmasqLinkLocalIPv6: true", c)
+	i.ipMasqAgent, err = newIPMasqAgent(i.configFilePath, i.ipMasqMap)
+	c.Assert(err, check.IsNil)
+	i.ipMasqAgent.Start()
+
+	ipnets = i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 1)
+	_, ok = ipnets["3:3::/96"]
+	c.Assert(ok, check.Equals, true)
+}
+
+func (i *IPMasqTestSuite) TestRestore(c *check.C) {
+	var err error
+
+	i.ipMasqMap.ipv4Enabled = true
+	i.ipMasqMap.ipv6Enabled = true
+	i.ipMasqAgent.Start()
+	// Check that stale entry is removed from the map after restore
+	i.ipMasqAgent.Stop()
+
+	_, cidr, _ := net.ParseCIDR("3:3:3:3::/64")
+	i.ipMasqMap.cidrsIPv6[cidr.String()] = *cidr
+	_, cidr, _ = net.ParseCIDR("4:4::/32")
+	i.ipMasqMap.cidrsIPv6[cidr.String()] = *cidr
+	_, cidr, _ = net.ParseCIDR("3.3.3.0/24")
+	i.ipMasqMap.cidrsIPv4[cidr.String()] = *cidr
+	_, cidr, _ = net.ParseCIDR("4.4.0.0/16")
+	i.ipMasqMap.cidrsIPv4[cidr.String()] = *cidr
+	i.writeConfig("nonMasqueradeCIDRs:\n- 4.4.0.0/16\n- 4:4::/32", c)
+
+	i.ipMasqAgent, err = newIPMasqAgent(i.configFilePath, i.ipMasqMap)
+	c.Assert(err, check.IsNil)
+	i.ipMasqAgent.Start()
+	time.Sleep(300 * time.Millisecond)
+
+	ipnets := i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 4)
+	_, ok := ipnets["4.4.0.0/16"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets["4:4::/32"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv4Str]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets[linkLocalCIDRIPv6Str]
+	c.Assert(ok, check.Equals, true)
+
+	// Now stop the goroutine, and also remove the maps. It should bootstrap from
+	// the config
+	i.ipMasqAgent.Stop()
+	i.ipMasqMap = &ipMasqMapMock{
+		cidrsIPv4:   map[string]net.IPNet{},
+		cidrsIPv6:   map[string]net.IPNet{},
+		ipv4Enabled: true,
+		ipv6Enabled: true,
+	}
+	i.ipMasqAgent.ipMasqMap = i.ipMasqMap
+	i.writeConfig("nonMasqueradeCIDRs:\n- 3.3.0.0/16\n- 3:3:3:3::/96\nmasqLinkLocal: true\nmasqLinkLocalIPv6: true", c)
+	i.ipMasqAgent, err = newIPMasqAgent(i.configFilePath, i.ipMasqMap)
+	c.Assert(err, check.IsNil)
+	i.ipMasqAgent.Start()
+
+	ipnets = i.ipMasqMap.dumpToSet()
+	c.Assert(len(ipnets), check.Equals, 2)
+	_, ok = ipnets["3.3.0.0/16"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = ipnets["3:3:3:3::/96"]
 	c.Assert(ok, check.Equals, true)
 }

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -333,7 +333,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 		testIPMasqAgent := func() {
 			Expect(testPodHTTPToOutside(kubectl,
 				fmt.Sprintf("http://%s:80", nodeIP), false, true, false)).Should(BeTrue(),
-				"Connectivity test to http://%s failed", nodeIP)
+				"IPv4 Connectivity test to http://%s failed", nodeIP)
 
 			// remove nonMasqueradeCIDRs from the ConfigMap
 			kubectl.Patch(helpers.CiliumNamespace, "configMap", "ip-masq-agent", `{"data":{"config":"{\"nonMasqueradeCIDRs\":[]}"}}`)
@@ -343,7 +343,11 @@ var _ = Describe("K8sDatapathConfig", func() {
 			// Check that requests to the echoserver from client pods are masqueraded.
 			Expect(testPodHTTPToOutside(kubectl,
 				fmt.Sprintf("http://%s:80", nodeIP), true, false, false)).Should(BeTrue(),
-				"Connectivity test to http://%s failed", nodeIP)
+				"IPv4 Connectivity test to http://%s failed", nodeIP)
+
+			Expect(testPodHTTPToOutside(kubectl,
+				fmt.Sprintf("http://%s:80", nodeIP), true, false, true)).Should(BeTrue(),
+				"IPv6 Connectivity test to http://%s failed", nodeIP)
 		}
 
 		It("DirectRouting", func() {


### PR DESCRIPTION
Follow-up to https://github.com/cilium/cilium/pull/23165

- bpf: nat: Rename ENABLE_IP_MASQ_AGENT to [...]_IPV4
- ipmasq: Rename ipmasq-related variables to [...]IPv4
- bpf: nat: Plumb IPv6 ip-masq-agent in datapath
- ipmasq: Implement ip-masq-agent support for IPv6
- ipmasq: Enable IPv6 support for ip-masq-agent
- ipmasq: Add integration tests for IPv6 with ip-masq-agent
- test: Add datapath configuration tests for the ip-masq-agent with IPv6
