### PR TITLE
.github: Pin docker buildx version to v0.9.1 (v2)

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          version: v0.9.1
 
       - name: Set up QEMU
         id: qemu

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -91,7 +91,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}
-          version: v0.9.1
 
       - name: Sign Container Image Runtime
         if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
@@ -158,7 +157,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}
-          version: v0.9.1
 
       - name: Sign Container Image Builder
         if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -102,7 +102,6 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
-          version: v0.9.1
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          version: v0.9.1
 
       - name: Login to quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -73,6 +73,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          version: v0.9.1
 
       - name: Login to quay.io for CI
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -123,7 +123,6 @@ jobs:
           push: false
           platforms: linux/amd64
           target: import-cache
-          version: v0.9.1
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
@@ -147,7 +146,6 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
-          version: v0.9.1
 
       - name: CI race detection Build ${{ matrix.name }}
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -170,7 +168,6 @@ jobs:
             LOCKDEBUG=1
             RACE=1
             OPERATOR_VARIANT=${{ matrix.name }}
-          version: v0.9.1
 
       - name: CI Unstripped Binaries Build ${{ matrix.name }}
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -191,7 +188,6 @@ jobs:
           build-args: |
             NOSTRIP=1
             OPERATOR_VARIANT=${{ matrix.name }}
-          version: v0.9.1
 
       - name: Sign Container Images
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -229,7 +225,6 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
-          version: v0.9.1
 
       - name: CI race detection Build ${{ matrix.name }}
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -248,7 +243,6 @@ jobs:
             LOCKDEBUG=1
             RACE=1
             OPERATOR_VARIANT=${{ matrix.name }}
-          version: v0.9.1
 
       - name: CI Unstripped Binaries Build ${{ matrix.name }}
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -265,7 +259,6 @@ jobs:
           build-args: |
             NOSTRIP=1
             OPERATOR_VARIANT=${{ matrix.name }}
-          version: v0.9.1
 
       - name: Sign Container Images
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -304,7 +297,6 @@ jobs:
           outputs: type=local,dest=/tmp/docker-cache-${{ matrix.name }}
           platforms: linux/amd64
           target: export-cache
-          version: v0.9.1
 
       # Store docker's golang's cache build locally only on the main branch
       - name: Store ${{ matrix.name }} Golang cache in GitHub cache path

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          version: v0.9.1
 
       - name: Login to quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -97,7 +97,6 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
-          version: v0.9.1
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          version: v0.9.1
 
       - name: Login to DockerHub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -95,7 +95,6 @@ jobs:
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
-          version: v0.9.1
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b


### PR DESCRIPTION
GitHub recently rolled out Docker buildx version v0.10.0 on their
builders, which transparently changed the MediaType of docker images to
OCI v1 and added provenance attestations.

Unfortunately, various tools we use in CI like SBOM tooling and docker
manifest inspect do not properly support some aspect of the new image
formats. This resulted in breaking CI, with some messages like this:

    level=fatal msg="generating doc: creating SPDX document: generating
    SPDX package from image ref quay.io/cilium/docker-plugin-ci:XXX:
    generating image package"

This could also lead CI to fail while waiting for image builds to
complete, because the command we use to test whether the image is
available did not support the image types.

This commit attempts to revert buildx back to v0.9.1 to prevent it from
generating the images in a format that other tooling doesn't expect.
Over time we can work on migrating to buildx v0.10, testing various
parts of our CI as we do so.

This is a quick-and-dirty hack to stabilize CI for the short term, then
we can figure out over time how to properly resolve the conflict between
these systems.

Reverts https://github.com/cilium/cilium/pull/23206
