### PR TITLE
docs: Fix inconsistent node label in egress gateway guide

### DIFF
--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -392,7 +392,7 @@ This way, the agent will use the first IPv4 assigned to the interface for the
 default route.
 
 To let the policy select the node designated to be the Egress Gateway, apply the
-label ``egress-node: test`` to it:
+label ``egress-node: true`` to it:
 
 .. code-block:: shell-session
 

--- a/examples/kubernetes-egress-gateway/egress-gateway-policy.yaml
+++ b/examples/kubernetes-egress-gateway/egress-gateway-policy.yaml
@@ -21,7 +21,7 @@ spec:
       matchLabels:
         # The following label selects which node will act as egress gateway for
         # this policy
-        egress-node: test
+        egress-node: true
     # IP used to masquerade traffic leaving the cluster
     egressIP: "192.168.60.100"
     # Alternatively it is possible to:


### PR DESCRIPTION
The label used to identify the gateway node isn't the same in the guide and in the example policy, leading to an unapplied egress policy. This pull request fixes it.