### PR TITLE
v1.12: k8s: Remove spammy deprecation warning for CENP

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumegressnatpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumegressnatpolicies.yaml
@@ -25,9 +25,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    deprecated: true
-    deprecationWarning: CiliumEgressNATPolicy is deprecated and will be removed in
-      version 1.13. Use CiliumEgressGatewayPolicy instead.
     name: v2alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/k8s/apis/cilium.io/v2alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/types.go
@@ -17,7 +17,6 @@ import (
 // +kubebuilder:resource:categories={cilium,ciliumpolicy},singular="ciliumegressnatpolicy",path="ciliumegressnatpolicies",scope="Cluster",shortName={cenp}
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
 // +kubebuilder:storageversion
-// +kubebuilder:deprecatedversion:warning="CiliumEgressNATPolicy is deprecated and will be removed in version 1.13. Use CiliumEgressGatewayPolicy instead."
 
 type CiliumEgressNATPolicy struct {
 	// +k8s:openapi-gen=false


### PR DESCRIPTION
Commit b7d6dcb85 ("egressgw: deprecate the CENP CRD") introduced a warning for the new deprecated CiliumEgressNATPolicy CR. However, the CRD's deprecation warning is regularly emitted even when simply watching for CENPs without loading any. Thus, anyone who enables the egress gateway on v1.12 will see this warning regardless of how they use the feature.

We still want to watch for CENPs during the deprecation period, so we should remove that warning message to avoid spamming logs. Users will still be warned if they actually use a CENP because there is a second warning message during CENP parsing.

Note that removing the deprecationWarning field in the CRD isn't enough, as simply having the deprecated field results in the following recurrent error message:

    level=warning msg="cilium.io/v2alpha1 CiliumEgressNATPolicy is deprecated" subsys=klog

Also note that users upgrading from a previous patch v1.12 release will need to manually reload the CRD to see the warning disappear.

Fixes: https://github.com/cilium/cilium/pull/19561.

```release-note
Avoid deprecation warnings for CiliumEgressNATPolicy when the resource isn't used.
```