### PR TITLE
test: Unquarantine tests for iptables-based masquerading

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -233,7 +233,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test with IPsec between nodes failed")
 		}, 600)
 
-		SkipItIf(helpers.SkipQuarantined, "Check iptables masquerading with random-fully", func() {
+		It("Check iptables masquerading with random-fully", func() {
 			options := map[string]string{
 				"bpf.masquerade":       "false",
 				"enableIPv6Masquerade": "true",
@@ -250,7 +250,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				Should(BeTrue(), "IPv6 connectivity test to http://google.com failed")
 		})
 
-		SkipItIf(helpers.SkipQuarantined, "Check iptables masquerading without random-fully", func() {
+		It("Check iptables masquerading without random-fully", func() {
 			options := map[string]string{
 				"bpf.masquerade":       "false",
 				"enableIPv6Masquerade": "true",


### PR DESCRIPTION
Commit 1732c218b ("test, jenkinsfile: Clean up natnetworks in CI after test run") added some clean up for VirtualBox state in an effort to fix the flakes affecting the iptables-based masquerading tests.

DataStudio [1] now shows that this effort was fruitful: those tests didn't fail in the quarantined runs. The few failures observed on the dashboard are actually cases where all tests failed because of a failure to retrieve Cilium container images (so unrelated).

This commit unquarantines the two tests. They had been quarantined by 0fc1188532 ("test/DatapathConfiguration: Quarantine 'Encapsulation'") more than a year ago...

1 - https://datastudio.google.com/s/rhLunJ7r1Dw
Fixes: https://github.com/cilium/cilium/issues/17353.