### PR TITLE
.github: fix renovate's config file

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,7 +33,7 @@
       "matchPackageNames": [
         "docker.io/library/ubuntu"
       ],
-      "allowedVersions": "<22.05",
+      "allowedVersions": "22.04",
       "matchBaseBranches": [
         "master",
         "v1.13"
@@ -43,7 +43,7 @@
       "matchPackageNames": [
         "docker.io/library/ubuntu"
       ],
-      "allowedVersions": "<20.05",
+      "allowedVersions": "20.04",
       "matchBaseBranches": [
         "v1.12",
         "v1.11",


### PR DESCRIPTION
allowedVersions is a field that has its value validated at runtime because it depends on the versioning scheme. In ubuntu's case, this value doesn't need to be a "range" since we are only interested in a specific tag.

Fixes: d9ab2a85be42 (".github: fix renovate docker image update")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/23230