### PR TITLE
bpf: nodeport: only add DSR Extension to TCPv6 SYN packet

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -31,15 +31,6 @@ static __always_inline bool ct_entry_seen_both_syns(const struct ct_entry *entry
 	return rx_syn && tx_syn;
 }
 
-union tcp_flags {
-	struct {
-		__u8 upper_bits;
-		__u8 lower_bits;
-		__u16 pad;
-	};
-	__u32 value;
-};
-
 /**
  * Update the CT timeout and TCP flags for the specified entry.
  *
@@ -404,7 +395,7 @@ static __always_inline int ct_lookup6(const void *map,
 
 	case IPPROTO_TCP:
 		if (1) {
-			if (ctx_load_bytes(ctx, l4_off + 12, &tcp_flags, 2) < 0)
+			if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
 				return DROP_CT_INVALID_HDR;
 
 			if (unlikely(tcp_flags.value & (TCP_FLAG_RST|TCP_FLAG_FIN)))
@@ -715,7 +706,7 @@ static __always_inline int ct_lookup4(const void *map,
 		action = ACTION_CREATE;
 
 		if (has_l4_header) {
-			if (ctx_load_bytes(ctx, off + 12, &tcp_flags, 2) < 0)
+			if (l4_load_tcp_flags(ctx, off, &tcp_flags) < 0)
 				return DROP_CT_INVALID_HDR;
 
 			if (unlikely(tcp_flags.value & (TCP_FLAG_RST|TCP_FLAG_FIN)))

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -15,6 +15,14 @@
 #define UDP_DPORT_OFF (offsetof(struct udphdr, dest))
 #define UDP_SPORT_OFF (offsetof(struct udphdr, source))
 
+union tcp_flags {
+	struct {
+		__u8 upper_bits;
+		__u8 lower_bits;
+		__u16 pad;
+	};
+	__u32 value;
+};
 
 /**
  * Modify L4 port and correct checksum
@@ -56,5 +64,11 @@ static __always_inline int l4_load_ports(struct __ctx_buff *ctx, int off,
 					 __be16 *ports)
 {
 	return ctx_load_bytes(ctx, off, ports, 2 * sizeof(__be16));
+}
+
+static __always_inline int l4_load_tcp_flags(struct __ctx_buff *ctx, int l4_off,
+					     union tcp_flags *flags)
+{
+	return ctx_load_bytes(ctx, l4_off + 12, flags, 2);
 }
 #endif

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1403,8 +1403,7 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 	if (ip4->protocol == IPPROTO_TCP) {
 		union tcp_flags tcp_flags = { .value = 0 };
 
-		if (ctx_load_bytes(ctx, ETH_HLEN + sizeof(*ip4) + 12,
-				   &tcp_flags, 2) < 0)
+		if (l4_load_tcp_flags(ctx, ETH_HLEN + sizeof(*ip4), &tcp_flags) < 0)
 			return DROP_CT_INVALID_HDR;
 
 		/* Setting the option is required only for the first packet

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -213,7 +213,7 @@ func testCurlFromPodInHostNetNSExpectingHTTPCode(kubectl *helpers.Kubectl, url s
 func testCurlFromOutsideWithLocalPort(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, url string, count int, checkSourceIP bool, fromPort int) {
 	var cmd string
 
-	By("Making %d HTTP requests from outside cluster to %q", count, url)
+	By("Making %d HTTP requests from outside cluster (using port %d) to %q", count, fromPort, url)
 	for i := 1; i <= count; i++ {
 		if fromPort == 0 {
 			cmd = helpers.CurlFail(url)
@@ -1002,7 +1002,7 @@ func testMaglev(kubectl *helpers.Kubectl, ni *helpers.NodesInfo) {
 	}
 }
 
-func testDSR(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, sourcePortForCTGCtest int) {
+func testDSR(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, k8s1IP string, k8s2SvcName string, sourcePortForCTGCtest int) {
 	var data v1.Service
 	err := kubectl.Get(helpers.DefaultNamespace, "service test-nodeport").Unmarshal(&data)
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot retrieve service")
@@ -1015,13 +1015,13 @@ func testDSR(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, sourcePortForCTGCt
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot determine cilium pod name")
 	// "test-nodeport-k8s2" because we want to trigger SNAT with a single request:
 	// client -> k8s1 -> endpoint @ k8s2.
-	err = kubectl.Get(helpers.DefaultNamespace, "service test-nodeport-k8s2").Unmarshal(&data)
+	err = kubectl.Get(helpers.DefaultNamespace, k8s2SvcName).Unmarshal(&data)
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot retrieve service")
-	url = getHTTPLink(ni.K8s1IP, data.Spec.Ports[0].NodePort)
+	url = getHTTPLink(k8s1IP, data.Spec.Ports[0].NodePort)
 
 	testCurlFromOutsideWithLocalPort(kubectl, ni, url, 1, true, sourcePortForCTGCtest)
 	res := kubectl.CiliumExecContext(context.TODO(), pod, fmt.Sprintf("cilium bpf nat list | grep %d", sourcePortForCTGCtest))
-	ExpectWithOffset(1, res.Stdout()).ShouldNot(BeEmpty(), "NAT entry was not evicted")
+	ExpectWithOffset(1, res.Stdout()).ShouldNot(BeEmpty(), "NAT entry was not found")
 	// Flush CT maps to trigger eviction of the NAT entries (simulates CT GC)
 	_ = kubectl.CiliumExecMustSucceed(context.TODO(), pod, "cilium bpf ct flush global", "Unable to flush CT maps")
 	res = kubectl.CiliumExecContext(context.TODO(), pod, fmt.Sprintf("cilium bpf nat list | grep %d", sourcePortForCTGCtest))

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -476,7 +476,10 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"autoDirectNodeRoutes": "true",
 			})
 
-			testDSR(kubectl, ni, 64000)
+			testDSR(kubectl, ni, ni.K8s1IP, "service test-nodeport-k8s2", 64000)
+			if helpers.DualStackSupported() {
+				testDSR(kubectl, ni, ni.PrimaryK8s1IPv6, "service test-nodeport-k8s2-ipv6", 64001)
+			}
 			testNodePortExternal(kubectl, ni, false, true, true)
 		})
 


### PR DESCRIPTION
For DSR on TCP connections, we only want to insert the DSR information into
the SYN packet. This is an obvious optimization, and allows us to avoid any
risk of exceeding the MTU.

The support for this functionality currently only exists in the IPv4 path.
Also add it to the IPv6 path.

Fixes: https://github.com/cilium/cilium/issues/21991

```release-note
Reduce the risk of packet fragmentation on IPv6 when using KPR with DSR mode.
```
