### PR TITLE
lint: enable gosec G402 (minimum TLS version)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,6 +60,9 @@ linters-settings:
     template: |-
       SPDX-License-Identifier: Apache-2.0
       Copyright Authors of {{ PROJECT }}
+  gosec:
+    includes:
+      - G402
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
@@ -89,6 +92,7 @@ linters:
     - unused
     - varcheck
     - goheader
+    - gosec
 
 # To enable later if makes sense
 #    - deadcode

--- a/pkg/crypto/certloader/server.go
+++ b/pkg/crypto/certloader/server.go
@@ -116,8 +116,12 @@ func (c *WatchedServerConfig) ServerConfig(base *tls.Config) *tls.Config {
 				}
 			}
 			c.log.WithField("keypair-sn", keypairId(keypair)).
-				Debugf("Server tls handshake")
+				Debug("Server tls handshake")
 			return tlsConfig, nil
 		},
+		// NOTE: this MinVersion is not used as this tls.Config will be
+		// overridden by the one returned by GetConfigForClient. The effective
+		// MinVersion must be set by the provided base TLS configuration.
+		MinVersion: tls.VersionTLS13,
 	}
 }

--- a/pkg/hubble/peer/types/client.go
+++ b/pkg/hubble/peer/types/client.go
@@ -74,7 +74,9 @@ func (b RemoteClientBuilder) Client(target string) (Client, error) {
 	if b.TLSConfig == nil {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
-		tlsConfig := b.TLSConfig.ClientConfig(&tls.Config{
+		// NOTE: gosec is unable to resolve the constant and warns about "TLS
+		// MinVersion too low".
+		tlsConfig := b.TLSConfig.ClientConfig(&tls.Config{ //nolint:gosec
 			ServerName: b.TLSServerName,
 			MinVersion: hubbleopts.MinTLSVersion,
 		})

--- a/pkg/hubble/relay/pool/client.go
+++ b/pkg/hubble/relay/pool/client.go
@@ -52,7 +52,9 @@ func (b GRPCClientConnBuilder) ClientConn(target, hostname string) (poolTypes.Cl
 	if b.TLSConfig == nil {
 		opts = append(opts, grpc.WithInsecure())
 	} else {
-		tlsConfig := b.TLSConfig.ClientConfig(&tls.Config{
+		// NOTE: gosec is unable to resolve the constant and warns about "TLS
+		// MinVersion too low".
+		tlsConfig := b.TLSConfig.ClientConfig(&tls.Config{ //nolint:gosec
 			ServerName: hostname,
 			MinVersion: hubbleopts.MinTLSVersion,
 		})

--- a/pkg/hubble/server/server.go
+++ b/pkg/hubble/server/server.go
@@ -63,7 +63,9 @@ func (s *Server) newGRPCServer() (*grpc.Server, error) {
 		opts = append(opts, grpc.StreamInterceptor(interceptor))
 	}
 	if s.opts.ServerTLSConfig != nil {
-		tlsConfig := s.opts.ServerTLSConfig.ServerConfig(&tls.Config{
+		// NOTE: gosec is unable to resolve the constant and warns about "TLS
+		// MinVersion too low".
+		tlsConfig := s.opts.ServerTLSConfig.ServerConfig(&tls.Config{ //nolint:gosec
 			MinVersion: serveroption.MinTLSVersion,
 		})
 		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsConfig)))


### PR DESCRIPTION
Enable gosec, starting with G402 "Look for bad TLS connection settings" only.
