### PR TITLE
ipsec: Fix packet mark for FWD XFRM policy

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -196,11 +196,11 @@ func _ipSecReplacePolicyInFwd(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, prox
 	policy := ipSecNewPolicy()
 	policy.Dir = dir
 	policy.Dst = dst
-	policy.Mark = &netlink.XfrmMark{
-		Mask: linux_defaults.IPsecMarkMaskIn,
-	}
 	if dir == netlink.XFRM_DIR_IN {
 		policy.Src = src
+		policy.Mark = &netlink.XfrmMark{
+			Mask: linux_defaults.IPsecMarkMaskIn,
+		}
 		if proxyMark {
 			// We require a policy to match on packets going to the proxy which are
 			// therefore carrying the proxy mark. We however don't need a policy

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -216,6 +216,23 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}
 		})
 
+		SkipItIf(func() bool {
+			// IPsec + encapsulation requires Linux 4.19.
+			// We also can't disable KPR on GKE at the moment (cf. #16597).
+			return helpers.RunsWithoutKubeProxy() || helpers.DoesNotRunOn419OrLaterKernel() || helpers.RunsOnGKE() || helpers.RunsOnAKS()
+		}, "Check connectivity with transparent encryption, VXLAN, and endpoint routes", func() {
+			deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
+			options := map[string]string{
+				"kubeProxyReplacement":   "disabled",
+				"encryption.enabled":     "true",
+				"endpointRoutes.enabled": "true",
+			}
+			enableVXLANTunneling(options)
+			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
+			validateBPFTunnelMap()
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test with IPsec between nodes failed")
+		}, 600)
+
 		SkipItIf(helpers.SkipQuarantined, "Check iptables masquerading with random-fully", func() {
 			options := map[string]string{
 				"bpf.masquerade":       "false",


### PR DESCRIPTION
First commit fixes https://github.com/cilium/cilium/issues/23090; second extends the existing test. See commits for details.