### PR TITLE
ci, l4lb: Remove leftover args after DinD conversion

### DIFF
--- a/.github/workflows/tests-l4lb-v1.13.yaml
+++ b/.github/workflows/tests-l4lb-v1.13.yaml
@@ -188,11 +188,11 @@ jobs:
 
       - name: Run LoadBalancing test
         run: |
-          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request/install/kubernetes/cilium
+          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }}
 
       - name: Run NAT46x64 test
         run: |
-          cd ${{ github.workspace }}/test/nat46x64 && sudo ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request/install/kubernetes/cilium
+          cd ${{ github.workspace }}/test/nat46x64 && sudo ./test.sh ${{ github.repository_owner}} ${{ steps.vars.outputs.sha }}
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}


### PR DESCRIPTION
Partial backport of ...

  - b4767f9eec61 ("test/l4lb: Use DinD instead of Kind/Helm")
  - ed94b2405e0b ("test/nat46x64: Use DinD instead of Helm/Kind")

... for the 1.13 test suite. The last arg becomes noop with conversion of the test suite via #23242.

After that, the tests-l4lb.yaml vs tests-l4lb-v1.13.yaml are fully equivalent.

Reported-by: Martynas Pumputis <m@lambda.lt>
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>