### PR TITLE
hubble-relay: use distroless as the base image and run as non-root

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -929,6 +929,10 @@
      - Labels to be added to hubble-relay pods
      - object
      - ``{}``
+   * - hubble.relay.podSecurityContext
+     - hubble-relay pod security context
+     - object
+     - ``{"fsGroup":65532}``
    * - hubble.relay.pprof.address
      - Configure pprof listen address for hubble-relay
      - string
@@ -990,9 +994,9 @@
      - bool
      - ``false``
    * - hubble.relay.securityContext
-     - hubble-relay security context
+     - hubble-relay container security context
      - object
-     - ``{}``
+     - ``{"capabilities":{"drop":["ALL"]},"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}``
    * - hubble.relay.service
      - hubble-relay service configuration.
      - object

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -286,16 +286,16 @@ The table below lists suggested upgrade transitions, from a specified current
 version running in a cluster to a specified target version. If a specific
 combination is not listed in the table below, then it may not be safe. In that
 case, consider performing incremental upgrades between versions (e.g. upgrade
-from ``1.10.x`` to ``1.11.y`` first, and to ``1.12.z`` only afterwards).
+from ``1.11.x`` to ``1.12.y`` first, and to ``1.13.z`` only afterwards).
 
 +-----------------------+-----------------------+-------------------------+---------------------------+
 | Current version       | Target version        | L3/L4 impact            | L7 impact                 |
 +=======================+=======================+=========================+===========================+
+| ``1.12.x``            | ``1.13.y``            | Minimal to None         | Clients must reconnect[1] |
++-----------------------+-----------------------+-------------------------+---------------------------+
 | ``1.11.x``            | ``1.12.y``            | Minimal to None         | Clients must reconnect[1] |
 +-----------------------+-----------------------+-------------------------+---------------------------+
 | ``1.10.x``            | ``1.11.y``            | Minimal to None         | Clients must reconnect[1] |
-+-----------------------+-----------------------+-------------------------+---------------------------+
-| ``1.9.x``             | ``1.10.y``            | Minimal to None         | Clients must reconnect[1] |
 +-----------------------+-----------------------+-------------------------+---------------------------+
 
 Annotations:
@@ -306,115 +306,6 @@ Annotations:
    connections.
 
 .. _current_release_required_changes:
-
-.. _1.13_upgrade_notes:
-
-1.13 Upgrade Notes
-------------------
-* The code for the deprecated ``spec.eni.min-allocate``, ``spec.eni.pre-allocate``
-  ``spec.eni.max-above-watermark`` fields has been removed, those fields are
-  no longer functional. Please use their semantically equivalent ``spec.ipam``
-  replacements instead.
-
-* The kube-proxy replacement in DSR or Hybrid mode with tunneling causes failure upon cilium-agent start.
-  In previous versions, cilium-agent automatically used SNAT mode when we set tunneling.
-
-* In the ENI IPAM mode, the default subnet in which ENIs are created has changed
-  from the subnet (in the same VPC and AZ) with the most addresses available to
-  the subnet in which the primary ENI of the node is attached. Note that this
-  default only matters if no explicit selection of the subnet occurs, i.e.
-  specifying subnet IDs or tags still takes precedence.
-
-* NodeExternalIP of the local node is now correctly included into the ``host``
-  :ref:`entity <Entities based>` (it used to belong to the world entity).
-
-* The scope of the ``policy_implementation_delay`` Prometheus metric has been expanded to cover the
-  full interval from when a policy is first received from a cilium-agent, to when the policy has been
-  applied to endpoints. In previous versions, ``policy_implementation_delay`` only covered the work
-  done by the daemon subsystem to implement the policy. As a result, users may notice an expected
-  increase in ``policy_implementation_delay`` after upgrading.
-
-Removed Options
-~~~~~~~~~~~~~~~
-
-* The ineffective ``disable-conntrack``, ``endpoint-interface-name-prefix`` options deprecated in
-  version 1.12 have been removed.
-* The ``host-reachable-services-protos`` option deprecated in version v1.12 has
-  been removed.
-* The ``probe`` option of ``kube-proxy-replacement`` deprecated in version v1.12
-  has been removed. Users of the ``probe`` option are advised either to use
-  ``strict`` or ``partial`` with individual options configured. Please refer to
-  :ref:`kubeproxy-free` for more info.
-* The ``CiliumEgressNATPolicy`` CRD deprecated in version 1.12 has been removed. It is superseded
-  by the ``CiliumEgressGatewayPolicy`` CRD.
-* The ``pprof``, ``pprof-port`` flags for cilium-operator have been renamed
-  to ``operator-pprof`` and ``operator-pprof-port`` respectively.
-
-Deprecated Options
-~~~~~~~~~~~~~~~~~~
-
-* The ``force-local-policy-eval-at-source`` option is deprecated and will be
-  removed in 1.14.
-
-Added Metrics
-~~~~~~~~~~~~~
-
-* ``cilium_operator_allocation_duration_seconds``
-* ``cilium_operator_release_duration_seconds``
-* ``httpV2``, an updated version of the existing ``http`` metrics.
-* ``cilium_operator_ipam_interface_candidates``
-* ``cilium_operator_ipam_empty_interface_slots``
-
-Modified Metrics
-~~~~~~~~~~~~~~~~~~
-
-* ``hubble_policy_verdicts_total`` now lists L7 flows. The match label has value ``l7/<l7_proto>``
-  after the detected L7 protocol of the flow (for example: ``l7/http``).
-* Values for the ``reason`` label have been updated in  ``hubble_drop_total`` metric.
-  Please see `the API documentation <https://github.com/cilium/cilium/tree/master/api/v1/flow#flow-DropReason>`_
-  for the complete list of drop reasons.
-
-Deprecated Metrics
-~~~~~~~~~~~~~~~~~~
-
-* ``http`` is deprecated. Please use ``httpV2`` instead.
-* ``cilium_operator_ipam_available_interfaces`` is deprecated. Please use ``cilium_operator_ipam_interface_candidates`` and ``cilium_operator_ipam_empty_interface_slots`` instead.
-
-Removed Metrics/Labels
-~~~~~~~~~~~~~~~~~~~~~~
-
-* ``cilium_operator_ipam_available`` is removed. Please use ``cilium_operator_ipam_interface_candidates`` and ``cilium_operator_ipam_empty_interface_slots`` instead.
-* ``cilium_operator_ipam_allocation_ops`` is removed. Please use ``cilium_operator_ipam_ip_allocation_ops`` instead.
-* ``cilium_operator_ipam_release_ops`` is removed. Please use ``cilium_operator_ipam_ip_release_ops`` instead.
-* The label of ``status`` in ``cilium_operator_ipam_interface_creation_ops`` is removed.
-* ``cilium_node_neigh_arping_requests_total`` is removed. The counter was ineffective since the v1.11.0.
-
-Helm Options
-~~~~~~~~~~~~
-
-* The way Linux capabilities are configured has been revamped in this release.
-  All capabilities of every container in the ``cilium-agent`` DaemonSet is
-  configured from Helm's values, defaulting to the old behavior. If you have not
-  been using ``securityContext.extraCapabilities`` you do not need to do anything.
-  If you were leveraging ``securityContext.extraCapabilities``, you need to review
-  ``securityContext.capabilities.cilium_agent``.
-* ``bpf.hostLegacyRouting`` will be set to true automatically if ``cni.chainingMode`` is set to any other value than ``none`` (default)
-* The top-level ``pprof`` section now only configures pprof for cilium agent.
-  The cilium-operator pprof configuration is now managed via the ``operator.pprof`` section.
-  Additionally, a``hubble.relay.pprof`` section has been added.
-* All pprof configuration now support configuring the pprof listen address, defaulting to localhost.
-
-CRD Changes
-~~~~~~~~~~~
-
-* ``CiliumBGPLoadBalancerIPPool`` CRD has been renamed to ``CiliumLoadBalancerIPPool``.
-
-Deprecated API Fields
-~~~~~~~~~~~~~~~~~~~~~
-
-* ``trafficPolicy`` has been renamed to ``extTrafficPolicy`` in ``ServiceSpec.flags`` and
-  ``ServiceUpsertNotification``, in order to emphasize the distinction between the external and
-  internal traffic policies. The old name remains for backward compatibility.
 
 .. _earlier_upgrade_notes:
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -307,6 +307,20 @@ Annotations:
 
 .. _current_release_required_changes:
 
+.. _1.14_upgrade_notes:
+
+1.14 Upgrade Notes
+------------------
+
+Helm Options
+~~~~~~~~~~~~
+
+* The ``securityContext`` for Hubble Relay now applies to the container, not
+  the pod. To update the security context of the pod, use
+  ``podSecurityContext``.
+* The ``securityContext`` for Hubble Relay now defaults to drop all
+  capabilities and run as non-root user.
+
 .. _earlier_upgrade_notes:
 
 Earlier Upgrade Notes

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -776,6 +776,7 @@ podAnnotations
 podCIDR
 podDisruptionBudget
 podLabels
+podSecurityContext
 podcasts
 policyAuditMode
 policyEnforcementMode

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -1,9 +1,17 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE=scratch
+# distroless images are signed by cosign. You should verify the image with the following public key:
+# $ cat cosign.pub
+# -----BEGIN PUBLIC KEY-----
+# MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q
+# OqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==
+# -----END PUBLIC KEY-----
+# $ cosign verify --key cosign.pub $BASE_IMAGE
+# The key may be found at the following address:
+# https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub
+ARG BASE_IMAGE=gcr.io/distroless/static-debian11:nonroot@sha256:1fa522fe6cfe020d50341f1ca561c099487bd44f8eb98d25d1920b07e05e40be
 ARG GOLANG_IMAGE=docker.io/library/golang:1.19.5@sha256:bb9811fad43a7d6fd2173248d8331b2dcf5ac9af20976b1937ecd214c5b8c383
-ARG ALPINE_IMAGE=docker.io/library/alpine:3.17.1@sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
@@ -33,12 +41,6 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
-FROM --platform=${BUILDPLATFORM} ${ALPINE_IMAGE} as certs
-RUN apk --update add ca-certificates
-
-# BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
-# Represents the plataform where the build is happening, do not mix with
-# TARGETARCH
 FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} as gops
 
 # build-gops.sh will build both archs at the same time
@@ -53,11 +55,10 @@ ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETARCH
 LABEL maintainer="maintainer@cilium.io"
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /out/${TARGETOS}/${TARGETARCH}/bin/gops /bin/gops
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/hubble-relay /usr/bin/hubble-relay
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
-WORKDIR /
-ENV GOPS_CONFIG_DIR=/
+# use uid:gid for the nonroot user for compatibility with runAsNonRoot
+USER 65532:65532
 ENTRYPOINT ["/usr/bin/hubble-relay"]
 CMD ["serve"]

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -283,6 +283,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | hubble.relay.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | hubble.relay.podLabels | object | `{}` | Labels to be added to hubble-relay pods |
+| hubble.relay.podSecurityContext | object | `{"fsGroup":65532}` | hubble-relay pod security context |
 | hubble.relay.pprof.address | string | `"localhost"` | Configure pprof listen address for hubble-relay |
 | hubble.relay.pprof.enabled | bool | `false` | Enable pprof for hubble-relay |
 | hubble.relay.pprof.port | int | `6062` | Configure pprof listen port for hubble-relay |
@@ -298,7 +299,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.resources | object | `{}` | Specifies the resources for the hubble-relay pods |
 | hubble.relay.retryTimeout | string | `nil` | Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s"). |
 | hubble.relay.rollOutPods | bool | `false` | Roll out Hubble Relay pods automatically when configmap is updated. |
-| hubble.relay.securityContext | object | `{}` | hubble-relay security context |
+| hubble.relay.securityContext | object | `{"capabilities":{"drop":["ALL"]},"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | hubble-relay container security context |
 | hubble.relay.service | object | `{"nodePort":31234,"type":"ClusterIP"}` | hubble-relay service configuration. |
 | hubble.relay.service.nodePort | int | `31234` | - The port to use when the service type is set to NodePort. |
 | hubble.relay.service.type | string | `"ClusterIP"` | - The type of service used for Hubble Relay access, either ClusterIP or NodePort. |

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.hubble.relay.securityContext }}
+      {{- with .Values.hubble.relay.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -46,6 +46,10 @@ spec:
       {{- end }}
       containers:
         - name: hubble-relay
+          {{- with .Values.hubble.relay.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: {{ include "cilium.image" .Values.hubble.relay.image | quote }}
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
           command:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1047,8 +1047,19 @@ hubble:
       rollingUpdate:
         maxUnavailable: 1
 
-    # -- hubble-relay security context
-    securityContext: {}
+    # -- hubble-relay pod security context
+    podSecurityContext:
+      fsGroup: 65532
+
+    # -- hubble-relay container security context
+    securityContext:
+      # readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65532
+      runAsGroup: 65532
+      capabilities:
+        drop:
+        - ALL
 
     # -- hubble-relay service configuration.
     service:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1044,8 +1044,19 @@ hubble:
       rollingUpdate:
         maxUnavailable: 1
 
-    # -- hubble-relay security context
-    securityContext: {}
+    # -- hubble-relay pod security context
+    podSecurityContext:
+      fsGroup: 65532
+
+    # -- hubble-relay container security context
+    securityContext:
+      # readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65532
+      runAsGroup: 65532
+      capabilities:
+        drop:
+        - ALL
 
     # -- hubble-relay service configuration.
     service:


### PR DESCRIPTION
In order to improve the security posture of Hubble Relay, this patch updates the base image for Hubble Relay from scratch to distroless. Distroless images come in different variants and the one being used here is the most basic one that only contains the following:

  - ca-certificates
  - A /etc/passwd entry for a root, nonroot and nobody users
  - A /tmp directory
  - tzdata

Given that this new base image comes with CA certificates, we no longer need to import CA certificates from the Alpine image. Moreover, the hack for running gops, namely setting `ENV GOPS_CONFIG_DIR=/` is no longer required. Finally, the patch sets the image user to the nonroot user with UID 65532.

At last, to run as non-root, the securityContext for the Hubble Relay container is updated to drop all capabilities and run as the user:group 65532:65532.


```release-note
Run Hubble Relay as non-root user by default.
```
