### PR TITLE
bpf: nodeport: fix up endianness of IPv4 DSR option content

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -597,9 +597,7 @@ enum metric_dir {
  *
  * [1]: https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml
  */
-#define DSR_IPV4_OPT_32		0x9a080000
-#define DSR_IPV4_OPT_MASK	0xffff0000
-#define DSR_IPV4_DPORT_MASK	0x0000ffff
+#define DSR_IPV4_OPT_16		0x9a08
 
 /* IPv6 option type of Destination Option used to carry service IPv6 addr and
  * port for DSR.

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -39,6 +39,12 @@ struct dsr_opt_v6 {
 	__u16 pad;
 };
 
+struct dsr_opt_v4 {
+	__be16 id;
+	__be16 port;
+	__be32 addr;
+};
+
 static __always_inline bool nodeport_uses_dsr(__u8 nexthdr __maybe_unused)
 {
 # if defined(ENABLE_DSR) && !defined(ENABLE_DSR_HYBRID)
@@ -1394,9 +1400,10 @@ static __always_inline int dsr_set_ipip4(struct __ctx_buff *ctx,
 #elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
 static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 					struct iphdr *ip4, __be32 svc_addr,
-					__be32 svc_port, __be16 *ohead)
+					__be16 svc_port, __be16 *ohead)
 {
-	__u32 iph_old, iph_new, opt[2];
+	__u32 iph_old, iph_new;
+	struct dsr_opt_v4 opt;
 	__u16 tot_len = bpf_ntohs(ip4->tot_len) + sizeof(opt);
 	__be32 sum;
 
@@ -1426,8 +1433,9 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 	ip4->tot_len = bpf_htons(tot_len);
 	iph_new = *(__u32 *)ip4;
 
-	opt[0] = bpf_htonl(DSR_IPV4_OPT_32 | svc_port);
-	opt[1] = bpf_htonl(svc_addr);
+	opt.id = bpf_htons(DSR_IPV4_OPT_16);
+	opt.port = svc_port;
+	opt.addr = svc_addr;
 
 	sum = csum_diff(&iph_old, 4, &iph_new, 4, 0);
 	sum = csum_diff(NULL, 0, &opt, sizeof(opt), sum);
@@ -1459,28 +1467,16 @@ static __always_inline int handle_dsr_v4(struct __ctx_buff *ctx, bool *dsr)
 	 * w/o option (5 x 32-bit words) + the DSR option (2 x 32-bit words)).
 	 */
 	if (ip4->ihl == 0x7) {
-		__u32 opt1 = 0, opt2 = 0;
-		__be32 address;
-		__be16 dport;
+		struct dsr_opt_v4 opt;
 
 		if (ctx_load_bytes(ctx, ETH_HLEN + sizeof(struct iphdr),
-				   &opt1, sizeof(opt1)) < 0)
+				   &opt, sizeof(opt)) < 0)
 			return DROP_INVALID;
 
-		opt1 = bpf_ntohl(opt1);
-		if ((opt1 & DSR_IPV4_OPT_MASK) == DSR_IPV4_OPT_32) {
-			if (ctx_load_bytes(ctx, ETH_HLEN +
-					   sizeof(struct iphdr) +
-					   sizeof(opt1),
-					   &opt2, sizeof(opt2)) < 0)
-				return DROP_INVALID;
-
-			opt2 = bpf_ntohl(opt2);
-			dport = opt1 & DSR_IPV4_DPORT_MASK;
-			address = opt2;
+		if (opt.id == bpf_htons(DSR_IPV4_OPT_16)) {
 			*dsr = true;
 
-			if (snat_v4_create_dsr(ctx, address, dport) < 0)
+			if (snat_v4_create_dsr(ctx, opt.addr, opt.port) < 0)
 				return DROP_INVALID;
 		}
 	}


### PR DESCRIPTION
The IPv4 DSR information (daddr, dport) is extracted from the packet header in big-endian format, and sent to tail_nodeport_ipv4_dsr() via the ctx metadata.

dsr_set_opt4() then erroneously applies a bpf_htonl() to them, converting back to host-endianness. The result is stored into the IPv4 DSR option. On the receiver side there is a matching erroneous bpf_ntohl() in handle_dsr_v4(), "fixing" things up (assuming that both sides have a matching host-endianness).

Clean up the whole thing for good, and agree on a wire format in network byte-order (as IPv6 already uses). There is a small risk of breaking connections that are in the process of being established (during upgrade, the datapath on different nodes might momentarily disagree on the expected endianness). That's an acceptable pain, when we gain a robust on-wire format.

```release-note
Change the byte-format of the IPv4 DSR Option to big-endian. This change can cause momentary disruption for DSR connections that are being established while Cilium is upgraded.
```
