### PR TITLE
bgp: Replaced localNodeStore based nodespecer with resources

### DIFF
--- a/pkg/bgpv1/agent/nodespecer.go
+++ b/pkg/bgpv1/agent/nodespecer.go
@@ -5,12 +5,24 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
-	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/node/types"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/stream"
 
 	"github.com/cilium/workerpool"
 )
@@ -25,45 +37,57 @@ type nodeSpecer interface {
 type localNodeStoreSpecerParams struct {
 	cell.In
 
-	Lifecycle      hive.Lifecycle
-	Config         *option.DaemonConfig
-	LocalNodeStore node.LocalNodeStore
-	Signaler       Signaler
-	Shutdowner     hive.Shutdowner
+	Lifecycle          hive.Lifecycle
+	Config             *option.DaemonConfig
+	NodeResource       *LocalNodeResource
+	CiliumNodeResource *LocalCiliumNodeResource
+	Signaler           Signaler
 }
 
-// NewLocalNodeStoreSpecer constructs a new nodeSpecer and registers it in the hive lifecycle
-func NewLocalNodeStoreSpecer(params localNodeStoreSpecerParams) (nodeSpecer, error) {
-	specer := &localNodeStoreSpecer{
-		LocalNodeStore: params.LocalNodeStore,
-		Signaler:       params.Signaler,
-		Shutdowner:     params.Shutdowner,
-		workerpool:     workerpool.New(1),
+// NewNodeSpecer constructs a new nodeSpecer and registers it in the hive lifecycle
+func NewNodeSpecer(params localNodeStoreSpecerParams) (nodeSpecer, error) {
+	if !params.Config.BGPControlPlaneEnabled() {
+		return nil, nil
 	}
-	params.Lifecycle.Append(specer)
-	return specer, nil
+
+	switch params.Config.IPAM {
+	case ipamOption.IPAMClusterPoolV2, ipamOption.IPAMClusterPool:
+		cns := &ciliumNodeSpecer{
+			nodeResource: params.CiliumNodeResource,
+			signaler:     params.Signaler,
+		}
+		params.Lifecycle.Append(cns)
+		return cns, nil
+
+	case ipamOption.IPAMKubernetes:
+		kns := &kubernetesNodeSpecer{
+			nodeResource: params.NodeResource,
+			signaler:     params.Signaler,
+		}
+		params.Lifecycle.Append(kns)
+		return kns, nil
+
+	default:
+		return nil, fmt.Errorf("BGP Control Plane doesn't support current IPAM-mode: '%s'", params.Config.IPAM)
+	}
 }
 
-// localNodeStoreSpecer abstracts the underlying mechanism to list information about the
-// Node resource Cilium is running on.
-//
-// The localNodeStoreSpecer observes changes to the local node info and signals the Signaler
-// when it changes.
-type localNodeStoreSpecer struct {
-	LocalNodeStore node.LocalNodeStore
-	Signaler       Signaler
-	Shutdowner     hive.Shutdowner
+type kubernetesNodeSpecer struct {
+	nodeResource *LocalNodeResource
 
-	workerpool *workerpool.WorkerPool
+	currentNode *corev1.Node
+	workerpool  *workerpool.WorkerPool
+	signaler    Signaler
 }
 
-func (s *localNodeStoreSpecer) Start(_ hive.HookContext) error {
-	s.workerpool.Submit("local-node-store-run", s.run)
+func (s *kubernetesNodeSpecer) Start(_ hive.HookContext) error {
+	s.workerpool = workerpool.New(1)
+	s.workerpool.Submit("kubernetes-node-specer-run", s.run)
 
 	return nil
 }
 
-func (s *localNodeStoreSpecer) Stop(ctx hive.HookContext) error {
+func (s *kubernetesNodeSpecer) Stop(ctx hive.HookContext) error {
 	doneChan := make(chan struct{})
 
 	go func() {
@@ -80,53 +104,158 @@ func (s *localNodeStoreSpecer) Stop(ctx hive.HookContext) error {
 	return nil
 }
 
-// run observes the local node store for changes and triggers the signaller when the local node has been updated.
-func (s *localNodeStoreSpecer) run(ctx context.Context) error {
-	doneChan := make(chan struct{})
-
-	next := func(_ types.Node) {
-		s.Signaler.Event(nil)
+func (s *kubernetesNodeSpecer) run(ctx context.Context) error {
+	errChan := make(chan error, 2)
+	nodeChan := stream.ToChannel[resource.Event[*corev1.Node]](ctx, errChan, s.nodeResource)
+	for event := range nodeChan {
+		event.Handle(
+			nil,
+			func(k resource.Key, n *corev1.Node) error {
+				s.currentNode = n
+				s.signaler.Event(struct{}{})
+				return nil
+			},
+			nil,
+		)
 	}
 
-	complete := func(err error) {
-		if err != nil {
-			s.Shutdowner.Shutdown(hive.ShutdownWithError(err))
-		}
+	return <-errChan
+}
 
-		close(doneChan)
+func (s *kubernetesNodeSpecer) Annotations() (map[string]string, error) {
+	if s.currentNode == nil {
+		return nil, errors.New("annotations of current node not yet available")
 	}
 
-	s.LocalNodeStore.Observe(ctx, next, complete)
+	return s.currentNode.Annotations, nil
+}
 
-	<-doneChan
+func (s *kubernetesNodeSpecer) Labels() (map[string]string, error) {
+	if s.currentNode == nil {
+		return nil, errors.New("labels of current node not yet available")
+	}
+
+	return s.currentNode.Labels, nil
+}
+
+func (s *kubernetesNodeSpecer) PodCIDRs() ([]string, error) {
+	if s.currentNode == nil {
+		return nil, errors.New("pod ciders of current node not yet available")
+	}
+
+	if s.currentNode.Spec.PodCIDRs != nil {
+		return s.currentNode.Spec.PodCIDRs, nil
+	}
+	if s.currentNode.Spec.PodCIDR != "" {
+		return []string{s.currentNode.Spec.PodCIDR}, nil
+	}
+	return []string{}, nil
+}
+
+type ciliumNodeSpecer struct {
+	nodeResource *LocalCiliumNodeResource
+
+	currentNode *ciliumv2.CiliumNode
+	workerpool  *workerpool.WorkerPool
+	signaler    Signaler
+}
+
+func (s *ciliumNodeSpecer) Start(_ hive.HookContext) error {
+	s.workerpool = workerpool.New(1)
+	s.workerpool.Submit("cilium-node-specer-run", s.run)
+
 	return nil
 }
 
-func (s *localNodeStoreSpecer) Annotations() (map[string]string, error) {
-	return s.LocalNodeStore.Get().Annotations, nil
-}
+func (s *ciliumNodeSpecer) Stop(ctx hive.HookContext) error {
+	doneChan := make(chan struct{})
 
-func (s *localNodeStoreSpecer) Labels() (map[string]string, error) {
-	return s.LocalNodeStore.Get().Labels, nil
-}
+	go func() {
+		s.workerpool.Close()
+		close(doneChan)
+	}()
 
-func (s *localNodeStoreSpecer) PodCIDRs() ([]string, error) {
-	n := s.LocalNodeStore.Get()
-
-	var podCIDRs []string
-	if n.IPv4AllocCIDR != nil {
-		podCIDRs = append(podCIDRs, n.IPv4AllocCIDR.String())
-		for _, secCidr := range n.IPv4SecondaryAllocCIDRs {
-			podCIDRs = append(podCIDRs, secCidr.String())
-		}
+	select {
+	case <-doneChan:
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
-	if n.IPv6AllocCIDR != nil {
-		podCIDRs = append(podCIDRs, n.IPv6AllocCIDR.String())
-		for _, secCidr := range n.IPv6SecondaryAllocCIDRs {
-			podCIDRs = append(podCIDRs, secCidr.String())
-		}
+	return nil
+}
+
+func (s *ciliumNodeSpecer) run(ctx context.Context) error {
+	errChan := make(chan error, 2)
+	nodeChan := stream.ToChannel[resource.Event[*cilium_api_v2.CiliumNode]](ctx, errChan, s.nodeResource)
+	for event := range nodeChan {
+		event.Handle(
+			nil,
+			func(k resource.Key, cn *ciliumv2.CiliumNode) error {
+				s.currentNode = cn
+				s.signaler.Event(struct{}{})
+				return nil
+			},
+			nil,
+		)
 	}
 
-	return podCIDRs, nil
+	return <-errChan
+}
+
+func (s *ciliumNodeSpecer) Annotations() (map[string]string, error) {
+	if s.currentNode == nil {
+		return nil, errors.New("annotations of current node not yet available")
+	}
+
+	return s.currentNode.Annotations, nil
+}
+
+func (s *ciliumNodeSpecer) Labels() (map[string]string, error) {
+	if s.currentNode == nil {
+		return nil, errors.New("labels of current node not yet available")
+	}
+
+	return s.currentNode.Labels, nil
+}
+
+func (s *ciliumNodeSpecer) PodCIDRs() ([]string, error) {
+	if s.currentNode == nil {
+		return nil, errors.New("pod ciders of current node not yet available")
+	}
+
+	if s.currentNode.Spec.IPAM.PodCIDRs != nil {
+		return s.currentNode.Spec.IPAM.PodCIDRs, nil
+	}
+
+	return []string{}, nil
+}
+
+// LocalNodeResource is a resource.Resource[*corev1.Node] but one which will only stream updates for the node object
+// associated with the node we are currently running on.
+type LocalNodeResource struct {
+	resource.Resource[*v1.Node]
+}
+
+func NewLocalNodeResource(lc hive.Lifecycle, cs client.Clientset) (*LocalNodeResource, error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherFromTyped[*corev1.NodeList](cs.CoreV1().Nodes())
+	lw = utils.ListerWatcherWithFields(lw, fields.ParseSelectorOrDie("metadata.name="+nodeTypes.GetName()))
+	return &LocalNodeResource{Resource: resource.New[*corev1.Node](lc, lw)}, nil
+}
+
+// LocalCiliumNodeResource is a resource.Resource[*cilium_api_v2.Node] but one which will only stream updates for the
+// CiliumNode object associated with the node we are currently running on.
+type LocalCiliumNodeResource struct {
+	resource.Resource[*cilium_api_v2.CiliumNode]
+}
+
+func NewLocalCiliumNodeResource(lc hive.Lifecycle, cs client.Clientset) (*LocalCiliumNodeResource, error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes())
+	lw = utils.ListerWatcherWithFields(lw, fields.ParseSelectorOrDie("metadata.name="+nodeTypes.GetName()))
+	return &LocalCiliumNodeResource{Resource: resource.New[*cilium_api_v2.CiliumNode](lc, lw)}, nil
 }

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -32,7 +32,9 @@ var Cell = cell.Module(
 		// Signaler is used by all cells that observe resources to signal the controller to start reconciliation.
 		agent.NewSignaler,
 		// Local Node Store Specer provides the module with information about the current node.
-		agent.NewLocalNodeStoreSpecer,
+		agent.NewNodeSpecer,
+		agent.NewLocalNodeResource,
+		agent.NewLocalCiliumNodeResource,
 		// BGP Peering Policy resource provides the module with a stream of events for the BGPPeeringPolicy resource.
 		newBGPPeeringPolicyResource,
 		// goBGP is currently the only supported RouterManager, if more are


### PR DESCRIPTION
In PR #22397 the nodespecer implementation was turned into a cell. That implementation used the localNodeStore to get access to a generic node object that would contain annotations, labels and podCIDRs.

However, it turns out that the localNodeStore doesn't function as one might expect and didn't register updates properly.

This PR changes the implementation to use resources to subscribe to changes in the node objects of the API server directly. This is very much like the old pre-modularization implementation, but now using resources instead of informers.

Fixes: #23155

```release-note
Fixed bug where the BGP Control Plane would ignore annotations on the node objects
```
