### PR TITLE
CODEOWNERS: assign images/hubble-relay to SIG Hubble

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -350,6 +350,7 @@ Makefile* @cilium/build
 /images/builder/install-protoc.sh @cilium/sig-hubble-api
 /images/builder/install-protoplugins.sh @cilium/sig-hubble-api
 /images/builder/update-cilium-builder-image.sh @cilium/github-sec
+/images/hubble-relay @cilium/sig-hubble
 /images/runtime/update-cilium-runtime-image.sh @cilium/github-sec
 /install/kubernetes/ @cilium/sig-k8s @cilium/helm
 /install/kubernetes/cilium/templates/hubble* @cilium/sig-k8s @cilium/helm @cilium/sig-hubble


### PR DESCRIPTION
I was surprised no one from SIG Hubble was pulled in to review #23259. Let's make sure that changes to the Hubble Relay image are checked by SIG Hubble.