### PR TITLE
bpf_test: use bpf.LoadCollection, print full verifier error logs

### DIFF
--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -60,8 +60,8 @@ SETUP("tc", "hairpin_sctp_flow_1_forward_v4")
 int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	__u8 src[ETH_ALEN] = mac_one;
-	__u8 dst[ETH_ALEN] = mac_two;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
 	struct ethhdr *l2;
 	struct iphdr *l3;
 	struct sctphdr *l4;
@@ -84,7 +84,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	if (!l2)
 		return TEST_ERROR;
 
-	ethhdr__set_macs(l2, src, dst);
+	ethhdr__set_macs(l2, (__u8 *)src, (__u8 *)dst);
 
 	/* Push IPv4 header */
 	l3 = pktgen__push_default_iphdr(&builder);
@@ -210,8 +210,8 @@ int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct ethhdr *l2;
-	__u8 src[ETH_ALEN] = mac_one;
-	__u8 dst[ETH_ALEN] = mac_two;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
 	struct iphdr *l3;
 	struct sctphdr *l4;
 
@@ -224,7 +224,7 @@ int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 	if (!l2)
 		return TEST_ERROR;
 
-	ethhdr__set_macs(l2, src, dst);
+	ethhdr__set_macs(l2, (__u8 *)src, (__u8 *)dst);
 
 	/* Push IPv4 header */
 	l3 = pktgen__push_default_iphdr(&builder);

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -18,15 +18,20 @@
 #include <linux/tcp.h>
 
 /* A collection of pre-defined Ethernet MAC addresses, so tests can reuse them
- *  without having to come up with custom addresses.
+ * without having to come up with custom addresses.
+ *
+ * These are declared as volatile const to make them end up in .rodata. Cilium
+ * inlines global data from .data into bytecode as immediate values for compat
+ * with kernels before 5.2 that lack read-only map support. This test suite
+ * doesn't make the same assumptions, so disable the static data inliner by
+ * putting variables in another section.
  */
-
-#define mac_one   {0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xEF}
-#define mac_two   {0x13, 0x37, 0x13, 0x37, 0x13, 0x37}
-#define mac_three {0x31, 0x41, 0x59, 0x26, 0x35, 0x89}
-#define mac_four  {0x0D, 0x1D, 0x22, 0x59, 0xA9, 0xC2}
-#define mac_five  {0x15, 0x21, 0x39, 0x45, 0x4D, 0x5D}
-#define mac_six   {0x08, 0x14, 0x1C, 0x32, 0x52, 0x7E}
+static volatile const __u8 mac_one[] =   {0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xEF};
+static volatile const __u8 mac_two[] =   {0x13, 0x37, 0x13, 0x37, 0x13, 0x37};
+static volatile const __u8 mac_three[] = {0x31, 0x41, 0x59, 0x26, 0x35, 0x89};
+static volatile const __u8 mac_four[] =  {0x0D, 0x1D, 0x22, 0x59, 0xA9, 0xC2};
+static volatile const __u8 mac_five[] =  {0x15, 0x21, 0x39, 0x45, 0x4D, 0x5D};
+static volatile const __u8 mac_six[] =   {0x08, 0x14, 0x1C, 0x32, 0x52, 0x7E};
 
 /* A collection of pre-defined IP addresses, so tests can reuse them without
  *  having to come up with custom ips.

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -55,8 +55,8 @@ struct {
 int build_packet(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	__u8 src[ETH_ALEN] = mac_one;
-	__u8 dst[ETH_ALEN] = mac_two;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
 	struct ethhdr *l2;
 	struct iphdr *l3;
 	struct tcphdr *l4;
@@ -71,7 +71,7 @@ int build_packet(struct __ctx_buff *ctx)
 	if (!l2)
 		return TEST_ERROR;
 
-	ethhdr__set_macs(l2, src, dst);
+	ethhdr__set_macs(l2, (__u8 *)src, (__u8 *)dst);
 
 	/* Push IPv4 header */
 	l3 = pktgen__push_default_iphdr(&builder);
@@ -223,8 +223,8 @@ int hairpin_flow_reverse_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct ethhdr *l2;
-	__u8 src[ETH_ALEN] = mac_one;
-	__u8 dst[ETH_ALEN] = mac_two;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
 	struct iphdr *l3;
 	struct tcphdr *l4;
 	void *data;
@@ -238,7 +238,7 @@ int hairpin_flow_reverse_pktgen(struct __ctx_buff *ctx)
 	if (!l2)
 		return TEST_ERROR;
 
-	ethhdr__set_macs(l2, src, dst);
+	ethhdr__set_macs(l2, (__u8 *)src, (__u8 *)dst);
 
 	/* Push IPv4 header */
 	l3 = pktgen__push_default_iphdr(&builder);

--- a/test/bpf_tests/bpf_test.go
+++ b/test/bpf_tests/bpf_test.go
@@ -18,9 +18,7 @@ import (
 	"path"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -34,10 +32,10 @@ import (
 	"golang.org/x/tools/cover"
 	"google.golang.org/protobuf/encoding/protowire"
 
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/monitor"
-	"github.com/cilium/cilium/pkg/safeio"
 )
 
 var (
@@ -133,35 +131,28 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cove
 		err  error
 	)
 
-	opts := ebpf.CollectionOptions{
-		Programs: ebpf.ProgramOptions{
-			LogSize: 64 << 20, // 64 MiB, not needed in most cases, except when running instrumented code.
-		},
+	if *testCoverageReport == "" {
+		coll, err = bpf.LoadCollection(spec, ebpf.CollectionOptions{})
+	} else {
+		coll, cfg, err = coverbee.InstrumentAndLoadCollection(spec, ebpf.CollectionOptions{
+			Programs: ebpf.ProgramOptions{
+				// 64 MiB, not needed in most cases, except when running instrumented code.
+				LogSize: 64 << 20,
+			},
+		}, instrLog)
 	}
 
-	if *testCoverageReport == "" {
-		coll, err = ebpf.NewCollectionWithOptions(spec, opts)
-	} else {
-		coll, cfg, err = coverbee.InstrumentAndLoadCollection(spec, opts, instrLog)
+	var ve *ebpf.VerifierError
+	if errors.As(err, &ve) {
+		if ve.Truncated {
+			t.Fatal("Verifier log exceeds 64MiB, increase LogSize passed to coverbee.InstrumentAndLoadCollection")
+		}
+		t.Fatalf("verifier error: %+v", ve)
 	}
 	if err != nil {
-		// Use this definition of ENOSPC instead of syscall.ENOSPC, since the stdlib constant is only
-		// available on linux. Even if this doesn't run, we still want it to compile on non-linux systems.
-		const ENOSPC = syscall.Errno(0x1c)
-		// ENOSPC usually means that the log size was to small, so increase and retry.
-		if errors.Is(err, ENOSPC) {
-			t.Fatal("Verifier logs larger than 64MiB, increase the log size passed to ebpf.NewCollectionWithOptions " +
-				"or decrease the size/complexity of the program")
-		}
-
-		t.Fatal("new coll:", err)
+		t.Fatal("loading collection:", err)
 	}
 	defer coll.Close()
-
-	err = loadCallsMap(spec, coll)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	testNameToPrograms := make(map[string]programSet)
 
@@ -266,88 +257,26 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cove
 }
 
 func loadAndPrepSpec(t *testing.T, elfPath string) *ebpf.CollectionSpec {
-	spec, err := ebpf.LoadCollectionSpec(elfPath)
+	spec, err := bpf.LoadCollectionSpec(elfPath)
 	if err != nil {
-		t.Fatal("load spec: ", elfPath, err)
+		t.Fatalf("load spec %s: %v", elfPath, err)
 	}
 
-	for _, mspec := range spec.Maps {
-		// Drain extra info from map specs, cilium/ebpf will complain if we don't
-		if mspec.Extra != nil {
-			_, err := safeio.ReadAllLimit(mspec.Extra, safeio.MB)
-			if err != nil {
-				t.Fatalf("error draining map specs: %v", err)
-			}
-		}
-
-		mspec.Pinning = ebpf.PinNone
+	for _, m := range spec.Maps {
+		m.Pinning = ebpf.PinNone
 	}
 
-	var progTestType ebpf.ProgramType
-	for progName, prog := range spec.Programs {
-		switch prog.Type {
+	for n, p := range spec.Programs {
+		switch p.Type {
 		case ebpf.XDP, ebpf.SchedACT, ebpf.SchedCLS:
-		case ebpf.UnspecifiedProgram:
-		default:
-			t.Logf(
-				"program '%s' has program type '%s' which doesn't have BPF_PROG_RUN support, not loading it",
-				prog.Name,
-				prog.Type,
-			)
-			delete(spec.Programs, progName)
 			continue
 		}
 
-		if progTestType != prog.Type {
-			if progTestType == ebpf.UnspecifiedProgram {
-				progTestType = prog.Type
-				continue
-			}
-			if prog.Type == ebpf.UnspecifiedProgram {
-				continue
-			}
-		}
-	}
-
-	if progTestType == ebpf.UnspecifiedProgram {
-		t.Fatalf("File '%s' only contains unspecified program types", elfPath)
-	}
-
-	// Give all untyped tail call programs the same program type as the test programs
-	for _, spec := range spec.Programs {
-		if spec.Type == ebpf.UnspecifiedProgram {
-			spec.Type = progTestType
-		}
+		t.Logf("Skipping program '%s' of type '%s': BPF_PROG_RUN not supported", p.Name, p.Type)
+		delete(spec.Programs, n)
 	}
 
 	return spec
-}
-
-// Fill the tail calls map with the tail calls based on the calls .id and names of the program sections.
-func loadCallsMap(spec *ebpf.CollectionSpec, coll *ebpf.Collection) error {
-	callMap, found := coll.Maps[callsMapName]
-	if !found {
-		// If we can't find the map, tailcalls aren't required for the current tests
-		return nil
-	}
-
-	for name, prog := range coll.Programs {
-		if strings.HasPrefix(spec.Programs[name].SectionName, callsMapID) {
-			indexStr := strings.TrimPrefix(spec.Programs[name].SectionName, callsMapID)
-			index, err := strconv.Atoi(indexStr)
-			if err != nil {
-				return fmt.Errorf("atoi tail call index: %w", err)
-			}
-
-			index32 := uint32(index)
-			err = callMap.Update(&index32, prog, ebpf.UpdateAny)
-			if err != nil {
-				return fmt.Errorf("update tailcall map: %w", err)
-			}
-		}
-	}
-
-	return nil
 }
 
 type programSet struct {
@@ -362,11 +291,6 @@ const (
 	ResultSuccess = 1
 
 	suiteResultMap = "suite_result_map"
-
-	callsMapName = "test_cilium_calls_65535"
-	// TODO we should read the .id field from the maps BTF, but the current cilium/ebpf version doesn't make the raw
-	// map BTF available.
-	callsMapID = "2/"
 )
 
 func subTest(progSet programSet, resultMap *ebpf.Map) func(t *testing.T) {

--- a/test/bpf_tests/bpf_test.go
+++ b/test/bpf_tests/bpf_test.go
@@ -88,12 +88,14 @@ func TestBPF(t *testing.T) {
 			continue
 		}
 
-		profiles := loadAndRunSpec(t, entry, instrLog)
-		for _, profile := range profiles {
-			if len(profile.Blocks) > 0 {
-				mergedProfiles = addProfile(mergedProfiles, profile)
+		t.Run(entry.Name(), func(t *testing.T) {
+			profiles := loadAndRunSpec(t, entry, instrLog)
+			for _, profile := range profiles {
+				if len(profile.Blocks) > 0 {
+					mergedProfiles = addProfile(mergedProfiles, profile)
+				}
 			}
-		}
+		})
 	}
 
 	if *testCoverageReport != "" {


### PR DESCRIPTION
This patch de-duplicates the logic around detecting ProgramType and hooking up tail calls into prog arrays. The Cilium agent itself has been on bpf.LoadCollection() for the majority of its prog loads for a few months now.

Print full verifier logs when a VerifierError is encountered.