### PR TITLE
v1.13 backports 2023-01-24

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -208,7 +208,8 @@ jobs:
             --rollback=false \
             --config monitor-aggregation=none \
             --nodes-without-cilium=kind-worker3 \
-            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
+            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }} \
+            --helm-set=bpf.masquerade=false"
           TUNNEL="--helm-set-string=tunnel=vxlan"
           if [ "${{ matrix.tunnel }}" == "disabled" ]; then
             TUNNEL="--helm-set-string=tunnel=disabled --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16"

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -441,6 +441,10 @@
      - Enable debug logging
      - bool
      - ``false``
+   * - debug.verbose
+     - Configure verbosity levels for debug logging This option is used to enable debug messages for operations related to such sub-system such as (e.g. kvstore, envoy, datapath or policy), and flow is for enabling debug messages emitted per request, message and connection.  Applicable values: - flow - kvstore - envoy - datapath - policy
+     - string
+     - ``nil``
    * - disableEndpointCRD
      - Disable the usage of CiliumEndpoint CRD.
      - string

--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -56,6 +56,15 @@ Supported Ingress Annotations
    * - ``io.cilium.ingress/loadbalancer-mode``
      - The loadbalancer mode for the ingress. Applicable values are ``dedicated`` and ``shared``.
      - Defaults to Helm option ``ingressController.loadbalancerMode`` value.
+   * - ``io.cilium.ingress/service-type``
+     - The Service type for dedicated Ingress. Applicable values are ``LoadBalancer`` and ``NodePort``.
+     - Defaults to ``LoadBalancer`` if unspecified.
+   * - ``io.cilium.ingress/insecure-node-port``
+     - The NodePort to use for the HTTP Ingress. Applicable only if ``io.cilium.ingress/service-type`` is ``NodePort``.
+     - If unspecified, a random NodePort will be allocated by kubernetes.
+   * - ``io.cilium.ingress/secure-node-port``
+     - The NodePort to use for the HTTPS Ingress. Applicable only if ``io.cilium.ingress/service-type`` is ``NodePort``.
+     - If unspecified, a random NodePort will be allocated by kubernetes.
    * - ``io.cilium/tcp-keep-alive``
      - Enable TCP keep-alive
      - 1 (enabled)

--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -70,7 +70,7 @@ Supported Ingress Annotations
      - 10
    * - ``io.cilium/websocket``
      - Enable websocket
-     - 0 (disabled)
+     - disabled
 
 Additionally, cloud-provider specific annotations for the LoadBalancer service
 are supported. Please refer to the `Kubernetes documentation <https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer>`_

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -387,6 +387,7 @@ Removed Metrics/Labels
 * ``cilium_operator_ipam_allocation_ops`` is removed. Please use ``cilium_operator_ipam_ip_allocation_ops`` instead.
 * ``cilium_operator_ipam_release_ops`` is removed. Please use ``cilium_operator_ipam_ip_release_ops`` instead.
 * The label of ``status`` in ``cilium_operator_ipam_interface_creation_ops`` is removed.
+* ``cilium_node_neigh_arping_requests_total`` is removed. The counter was ineffective since the v1.11.0.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -202,7 +202,7 @@ if [[ ${#stable_prs[@]} > 0 ]]; then
     title=$(extract_pr_title "$pr")
     echo " * PR: $pr -- $title -- https://github.com/cilium/cilium/pull/$pr"
     if [[ ! -z $SUMMARY_LOG ]]; then
-      echo " * #$pr -- $title" >> $SUMMARY_LOG
+      echo " - [ ] #$pr -- $title" >> $SUMMARY_LOG
     fi
     generate_commit_list_for_pr $pr $merged_at
     echo ""

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -161,6 +161,7 @@ contributors across the globe, there is almost always someone available to help.
 | daemon.configSources | string | `nil` | Configure a custom list of possible configuration override sources The default is "config-map:cilium-config,cilium-node-config". For supported values, see the help text for the build-config subcommand. Note that this value should be a comma-separated string. |
 | daemon.runPath | string | `"/var/run/cilium"` | Configure where Cilium runtime state should be stored. |
 | debug.enabled | bool | `false` | Enable debug logging |
+| debug.verbose | string | `nil` | Configure verbosity levels for debug logging This option is used to enable debug messages for operations related to such sub-system such as (e.g. kvstore, envoy, datapath or policy), and flow is for enabling debug messages emitted per request, message and connection.  Applicable values: - flow - kvstore - envoy - datapath - policy |
 | disableEndpointCRD | string | `"false"` | Disable the usage of CiliumEndpoint CRD. |
 | dnsPolicy | string | `""` | DNS policy for Cilium agent pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | dnsProxy.dnsRejectResponseCode | string | `"refused"` | DNS response code for rejecting DNS requests, available options are '[nameError refused]'. |

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -22,18 +22,6 @@
   {{- end }}
 {{- end }}
 
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") }}
-  {{- if not .Values.hubble.tls.auto.certManagerIssuerRef }}
-    {{ fail "Hubble TLS certgen method=certmanager requires user specify .Values.hubble.tls.auto.certManagerIssuerRef" }}
-  {{- end }}  
-{{- end }}
-
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
-  {{- if not .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef }}
-    {{ fail "ClusterMesh TLS certgen method=certmanager requires user specify .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef" }}
-  {{- end }}  
-{{- end }}
-
 {{/* validate hubble-ui specific config */}}
 {{- if and .Values.hubble.ui.enabled
   (ne .Values.hubble.ui.backend.image.tag "latest")

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -10,7 +10,18 @@
 debug:
   # -- Enable debug logging
   enabled: false
-  # verbose:
+  # -- Configure verbosity levels for debug logging
+  # This option is used to enable debug messages for operations related to such
+  # sub-system such as (e.g. kvstore, envoy, datapath or policy), and flow is
+  # for enabling debug messages emitted per request, message and connection.
+  #
+  # Applicable values:
+  # - flow
+  # - kvstore
+  # - envoy
+  # - datapath
+  # - policy
+  verbose: ~
 
 rbac:
   # -- Enable creation of Resource-Based Access Control configuration.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -7,7 +7,18 @@
 debug:
   # -- Enable debug logging
   enabled: false
-  # verbose:
+  # -- Configure verbosity levels for debug logging
+  # This option is used to enable debug messages for operations related to such
+  # sub-system such as (e.g. kvstore, envoy, datapath or policy), and flow is
+  # for enabling debug messages emitted per request, message and connection.
+  #
+  # Applicable values:
+  # - flow
+  # - kvstore
+  # - envoy
+  # - datapath
+  # - policy
+  verbose: ~
 
 rbac:
   # -- Enable creation of Resource-Based Access Control configuration.

--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -6,13 +6,16 @@ package annotations
 import (
 	"strconv"
 
-	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
-
 	"github.com/cilium/cilium/pkg/annotation"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
 )
 
 const (
-	LBModeAnnotation = annotation.Prefix + ".ingress" + "/loadbalancer-mode"
+	LBModeAnnotation           = annotation.Prefix + ".ingress" + "/loadbalancer-mode"
+	ServiceTypeAnnotation      = annotation.Prefix + ".ingress" + "/service-type"
+	InsecureNodePortAnnotation = annotation.Prefix + ".ingress" + "/insecure-node-port"
+	SecureNodePortAnnotation   = annotation.Prefix + ".ingress" + "/secure-node-port"
 
 	TCPKeepAliveEnabledAnnotation          = annotation.Prefix + "/tcp-keep-alive"
 	TCPKeepAliveIdleAnnotation             = annotation.Prefix + "/tcp-keep-alive-idle"
@@ -33,6 +36,44 @@ const (
 // GetAnnotationIngressLoadbalancerMode returns the loadbalancer mode for the ingress if possible.
 func GetAnnotationIngressLoadbalancerMode(ingress *slim_networkingv1.Ingress) string {
 	return ingress.GetAnnotations()[LBModeAnnotation]
+}
+
+// GetAnnotationServiceType returns the service type for the ingress if possible.
+// Defaults to LoadBalancer
+func GetAnnotationServiceType(ingress *slim_networkingv1.Ingress) string {
+	val, exists := ingress.GetAnnotations()[ServiceTypeAnnotation]
+	if !exists {
+		return string(slim_corev1.ServiceTypeLoadBalancer)
+	}
+	return val
+}
+
+// GetAnnotationSecureNodePort returns the secure node port for the ingress if possible.
+func GetAnnotationSecureNodePort(ingress *slim_networkingv1.Ingress) (*uint32, error) {
+	val, exists := ingress.GetAnnotations()[SecureNodePortAnnotation]
+	if !exists {
+		return nil, nil
+	}
+	intVal, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	res := uint32(intVal)
+	return &res, nil
+}
+
+// GetAnnotationInsecureNodePort returns the insecure node port for the ingress if possible.
+func GetAnnotationInsecureNodePort(ingress *slim_networkingv1.Ingress) (*uint32, error) {
+	val, exists := ingress.GetAnnotations()[InsecureNodePortAnnotation]
+	if !exists {
+		return nil, nil
+	}
+	intVal, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	res := uint32(intVal)
+	return &res, nil
 }
 
 // GetAnnotationTCPKeepAliveEnabled returns 1 if enabled (default), 0 if disabled

--- a/operator/pkg/ingress/annotations/annotations_test.go
+++ b/operator/pkg/ingress/annotations/annotations_test.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package annotations
+
+import (
+	"reflect"
+	"testing"
+
+	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestGetAnnotationServiceType(t *testing.T) {
+	type args struct {
+		ingress *slim_networkingv1.Ingress
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "no service type annotation",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{},
+			},
+			want: "LoadBalancer",
+		},
+		{
+			name: "service type annotation as LoadBalancer",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/service-type": "LoadBalancer",
+						},
+					},
+				},
+			},
+			want: "LoadBalancer",
+		},
+		{
+			name: "service type annotation as NodePort",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/service-type": "NodePort",
+						},
+					},
+				},
+			},
+			want: "NodePort",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetAnnotationServiceType(tt.args.ingress); got != tt.want {
+				t.Errorf("GetAnnotationServiceType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAnnotationSecureNodePort(t *testing.T) {
+	type args struct {
+		ingress *slim_networkingv1.Ingress
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *uint32
+		wantErr bool
+	}{
+		{
+			name: "no secure node port annotation",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{},
+			},
+			want: nil,
+		},
+		{
+			name: "secure node port annotation with valid value",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/secure-node-port": "1000",
+						},
+					},
+				},
+			},
+			want: uint32p(1000),
+		},
+		{
+			name: "secure node port annotation with invalid value",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/secure-node-port": "invalid-numeric-value",
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetAnnotationSecureNodePort(tt.args.ingress)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAnnotationSecureNodePort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAnnotationInsecureNodePort(t *testing.T) {
+	type args struct {
+		ingress *slim_networkingv1.Ingress
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *uint32
+		wantErr bool
+	}{
+		{
+			name: "no insecure node port annotation",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{},
+			},
+			want: nil,
+		},
+		{
+			name: "insecure node port annotation with valid value",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/insecure-node-port": "1000",
+						},
+					},
+				},
+			},
+			want: uint32p(1000),
+		},
+		{
+			name: "insecure node port annotation with invalid value",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium.ingress/insecure-node-port": "invalid-numeric-value",
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetAnnotationInsecureNodePort(tt.args.ingress)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAnnotationSecureNodePort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func uint32p(u uint32) *uint32 {
+	return &u
+}

--- a/operator/pkg/model/ingestion/doc.go
+++ b/operator/pkg/model/ingestion/doc.go
@@ -5,3 +5,10 @@
 // Kubernetes resources into Listener types for storage
 // in the model.
 package ingestion
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ingestion")

--- a/operator/pkg/model/ingestion/ingress_test.go
+++ b/operator/pkg/model/ingestion/ingress_test.go
@@ -862,7 +862,340 @@ var complexIngressListeners = []model.HTTPListener{
 	},
 }
 
+// complexNodePortIngress is same as complexIngress but with NodePort service
+var complexNodePortIngress = slim_networkingv1.Ingress{
+	ObjectMeta: slim_metav1.ObjectMeta{
+		Name:      "dummy-ingress",
+		Namespace: "dummy-namespace",
+		Annotations: map[string]string{
+			"io.cilium.ingress/service-type":       "NodePort",
+			"io.cilium.ingress/insecure-node-port": "30000",
+			"io.cilium.ingress/secure-node-port":   "30001",
+		},
+		UID: "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+	},
+	Spec: slim_networkingv1.IngressSpec{
+		IngressClassName: stringp("cilium"),
+		DefaultBackend: &slim_networkingv1.IngressBackend{
+			Service: &slim_networkingv1.IngressServiceBackend{
+				Name: "default-backend",
+				Port: slim_networkingv1.ServiceBackendPort{
+					Number: 8080,
+				},
+			},
+		},
+		TLS: []slim_networkingv1.IngressTLS{
+			{
+				Hosts:      []string{"very-secure.server.com"},
+				SecretName: "tls-very-secure-server-com",
+			},
+			{
+				Hosts: []string{
+					"another-very-secure.server.com",
+					"not-in-use.another-very-secure.server.com",
+				},
+				SecretName: "tls-another-very-secure-server-com",
+			},
+		},
+		Rules: []slim_networkingv1.IngressRule{
+			{
+				IngressRuleValue: slim_networkingv1.IngressRuleValue{
+					HTTP: &slim_networkingv1.HTTPIngressRuleValue{
+						Paths: []slim_networkingv1.HTTPIngressPath{
+							{
+								Path: "/dummy-path",
+								Backend: slim_networkingv1.IngressBackend{
+									Service: &slim_networkingv1.IngressServiceBackend{
+										Name: "dummy-backend",
+										Port: slim_networkingv1.ServiceBackendPort{
+											Number: 8080,
+										},
+									},
+								},
+								PathType: &exactPathType,
+							},
+							{
+								Path: "/another-dummy-path",
+								Backend: slim_networkingv1.IngressBackend{
+									Service: &slim_networkingv1.IngressServiceBackend{
+										Name: "another-dummy-backend",
+										Port: slim_networkingv1.ServiceBackendPort{
+											Number: 8081,
+										},
+									},
+								},
+								PathType: &prefixPathType,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var complexNodePortIngressListeners = []model.HTTPListener{
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     80,
+		Hostname: "*",
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     443,
+		Hostname: "another-very-secure.server.com",
+		TLS: []model.TLSSecret{
+			{
+				Name:      "tls-another-very-secure-server-com",
+				Namespace: "dummy-namespace",
+			},
+		},
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     443,
+		Hostname: "not-in-use.another-very-secure.server.com",
+		TLS: []model.TLSSecret{
+			{
+				Name:      "tls-another-very-secure-server-com",
+				Namespace: "dummy-namespace",
+			},
+		},
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+	{
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "dummy-ingress",
+				Namespace: "dummy-namespace",
+				Version:   "v1",
+				Kind:      "Ingress",
+				UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+			},
+		},
+		Port:     443,
+		Hostname: "very-secure.server.com",
+		TLS: []model.TLSSecret{
+			{
+				Name:      "tls-very-secure-server-com",
+				Namespace: "dummy-namespace",
+			},
+		},
+		Routes: []model.HTTPRoute{
+			{
+				Backends: []model.Backend{
+					{
+						Name:      "default-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Exact: "/dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			{
+				PathMatch: model.StringMatch{
+					Prefix: "/another-dummy-path",
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "another-dummy-backend",
+						Namespace: "dummy-namespace",
+						Port: &model.BackendPort{
+							Port: 8081,
+						},
+					},
+				},
+			},
+		},
+		Service: &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: uint32p(30000),
+			SecureNodePort:   uint32p(30001),
+		},
+	},
+}
+
 func stringp(in string) *string {
+	return &in
+}
+
+func uint32p(in uint32) *uint32 {
 	return &in
 }
 
@@ -889,6 +1222,10 @@ func TestIngress(t *testing.T) {
 		"cilium test ingress": {
 			ingress: complexIngress,
 			want:    complexIngressListeners,
+		},
+		"cilium test ingress with NodePort": {
+			ingress: complexNodePortIngress,
+			want:    complexNodePortIngressListeners,
 		},
 	}
 

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -42,6 +42,21 @@ type HTTPListener struct {
 	// Routes associated with HTTP traffic to the service.
 	// An empty list means that traffic will not be routed.
 	Routes []HTTPRoute `json:"routes,omitempty"`
+	// Service configuration
+	Service *Service `json:"service,omitempty"`
+}
+
+// Service holds the configuration for desired Service details
+type Service struct {
+	// Type is the type of service that is being used for Listener (e.g. Load Balancer or Node port)
+	// Defaults to Load Balancer type
+	Type string `json:"serviceType,omitempty"`
+	// InsecureNodePort is the back-end port of the service that is being used for HTTP Listener
+	// Applicable only if Type is Node NodePort
+	InsecureNodePort *uint32 `json:"insecureNodePort,omitempty"`
+	// SecureNodePort is the back-end port of the service that is being used for HTTPS Listener
+	// Applicable only if Type is Node NodePort
+	SecureNodePort *uint32 `json:"secureNodePort,omitempty"`
 }
 
 // FullyQualifiedResource stores the full details of a Kubernetes resource, including

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -14,44 +14,125 @@ import (
 )
 
 func Test_getService(t *testing.T) {
-	res := getService(model.FullyQualifiedResource{
+	resource := model.FullyQualifiedResource{
 		Name:      "dummy-ingress",
 		Namespace: "dummy-namespace",
 		Version:   "v1",
 		Kind:      "Ingress",
 		UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+	}
+
+	t.Run("Default LB service", func(t *testing.T) {
+		res := getService(resource, nil)
+		require.Equal(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cilium-ingress-dummy-ingress",
+				Namespace: "dummy-namespace",
+				Labels:    map[string]string{"cilium.io/ingress": "true"},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "networking.k8s.io/v1",
+						Kind:       "Ingress",
+						Name:       "dummy-ingress",
+						UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+					},
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Name:     "http",
+						Protocol: "TCP",
+						Port:     80,
+					},
+					{
+						Name:     "https",
+						Protocol: "TCP",
+						Port:     443,
+					},
+				},
+			},
+		}, res)
 	})
 
-	require.Equal(t, &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cilium-ingress-dummy-ingress",
-			Namespace: "dummy-namespace",
-			Labels:    map[string]string{"cilium.io/ingress": "true"},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "networking.k8s.io/v1",
-					Kind:       "Ingress",
-					Name:       "dummy-ingress",
-					UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+	t.Run("Invalid LB service annotation, defaults to LoadBalancer", func(t *testing.T) {
+		res := getService(resource, &model.Service{
+			Type: "InvalidServiceType",
+		})
+		require.Equal(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cilium-ingress-dummy-ingress",
+				Namespace: "dummy-namespace",
+				Labels:    map[string]string{"cilium.io/ingress": "true"},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "networking.k8s.io/v1",
+						Kind:       "Ingress",
+						Name:       "dummy-ingress",
+						UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+					},
 				},
 			},
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeLoadBalancer,
-			Ports: []corev1.ServicePort{
-				{
-					Name:     "http",
-					Protocol: "TCP",
-					Port:     80,
-				},
-				{
-					Name:     "https",
-					Protocol: "TCP",
-					Port:     443,
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Name:     "http",
+						Protocol: "TCP",
+						Port:     80,
+					},
+					{
+						Name:     "https",
+						Protocol: "TCP",
+						Port:     443,
+					},
 				},
 			},
-		},
-	}, res)
+		}, res)
+	})
+
+	t.Run("Node Port service", func(t *testing.T) {
+		var insecureNodePort uint32 = 3000
+		var secureNodePort uint32 = 3001
+		res := getService(resource, &model.Service{
+			Type:             "NodePort",
+			InsecureNodePort: &insecureNodePort,
+			SecureNodePort:   &secureNodePort,
+		})
+		require.Equal(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cilium-ingress-dummy-ingress",
+				Namespace: "dummy-namespace",
+				Labels:    map[string]string{"cilium.io/ingress": "true"},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "networking.k8s.io/v1",
+						Kind:       "Ingress",
+						Name:       "dummy-ingress",
+						UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+					},
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Name:     "http",
+						Protocol: "TCP",
+						Port:     80,
+						NodePort: 3000,
+					},
+					{
+						Name:     "https",
+						Protocol: "TCP",
+						Port:     443,
+						NodePort: 3001,
+					},
+				},
+			},
+		}, res)
+	})
 }
 
 func Test_getEndpointForIngress(t *testing.T) {

--- a/operator/pkg/model/translation/ingress/doc.go
+++ b/operator/pkg/model/translation/ingress/doc.go
@@ -4,3 +4,10 @@
 // Package ingress contains the translation logic from Ingress to CiliumEnvoyConfig
 // and related resources.
 package ingress
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ingress-controller")

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -67,9 +67,6 @@ const (
 	// SubsystemAPILimiter is the subsystem to scope metrics related to the API limiter package.
 	SubsystemAPILimiter = "api_limiter"
 
-	// SubsystemNodeNeigh is the subsystem to scope metrics related to management of node neighbor.
-	SubsystemNodeNeigh = "node_neigh"
-
 	// Namespace is used to scope metrics from cilium. It is prepended to metric
 	// names and separated with a '_'
 	Namespace = "cilium"
@@ -524,10 +521,6 @@ var (
 	// APILimiterProcessedRequests is the counter of the number of
 	// processed (successful and failed) requests
 	APILimiterProcessedRequests = NoOpCounterVec
-
-	// ArpingRequestsTotal is the counter of the number of sent
-	// (successful and failed) arping requests
-	ArpingRequestsTotal = NoOpCounterVec
 )
 
 type Configuration struct {
@@ -605,7 +598,6 @@ type Configuration struct {
 	APILimiterRateLimit                     bool
 	APILimiterAdjustmentFactor              bool
 	APILimiterProcessedRequests             bool
-	ArpingRequestsTotalEnabled              bool
 }
 
 func DefaultMetrics() map[string]struct{} {
@@ -671,7 +663,6 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemAPILimiter + "_rate_limit":                        {},
 		Namespace + "_" + SubsystemAPILimiter + "_adjustment_factor":                 {},
 		Namespace + "_" + SubsystemAPILimiter + "_processed_requests_total":          {},
-		Namespace + "_" + SubsystemNodeNeigh + "_arping_requests_total":              {},
 	}
 }
 
@@ -1415,17 +1406,6 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, APILimiterProcessedRequests)
 			c.APILimiterProcessedRequests = true
-
-		case Namespace + "_" + SubsystemNodeNeigh + "_arping_requests_total":
-			ArpingRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemNodeNeigh,
-				Name:      "arping_requests_total",
-				Help:      "Number of arping requests sent labeled by status",
-			}, []string{LabelStatus})
-
-			collectors = append(collectors, ArpingRequestsTotal)
-			c.ArpingRequestsTotalEnabled = true
 
 		case Namespace + "_endpoint_propagation_delay_seconds":
 			EndpointPropagationDelay = prometheus.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
- [x] #22864 -- hubble: Rate limit "hubble events queue is full" logs (@lambdanis)
- [x] #23058 -- contrib: Update PR template for backport (@sayboras)
- [ ] #23171 -- gh/workflows: Disable BPF masq in ci-datapath (@brb)
- [x] #23178 -- helm: Document debug.verbose option (@sayboras)
- [ ] #23167 -- docs: add egress troubleshooting (@lizrice)
- [ ] #23057 -- metrics: Remove unused ARP ping metrics (@brb)
- [x] #22921 -- Modify helm chart: delete validations for certManagerIssuerRef (@Shunpoco)
- [x] #22662 -- fix(docs): fix websocket annotation value (@24601).
- [x] #22974 -- ingress: Support NodePort for dedicated Ingress (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 22864 23058 23171 23178 23167 23057 22921 22662 22974; do contrib/backporting/set-labels.py $pr done 1.13; done
```