### PR TITLE
egressgw: ensure stale IP routes/rules are deleted

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -680,7 +680,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	d.cgroupManager = manager.NewCgroupManager()
 
 	if option.Config.EnableIPv4EgressGateway {
-		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(&d, d.identityAllocator)
+		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(&d, d.identityAllocator, option.Config.InstallEgressGatewayRoutes)
 	}
 
 	d.k8sWatcher = watchers.NewK8sWatcher(

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -205,6 +205,22 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 		{ep1IP, destCIDR, egressCIDR1, testInterface1Idx},
 	})
 
+	// Test if disabling the --install-egress-gateway-routes agent option
+	// will result in stale IP routes/rules getting removed
+	egressGatewayManager.installRoutes = false
+	egressGatewayManager.reconcile()
+
+	assertIPRules(c, []ipRule{})
+
+	// Enabling it back should result in the routes/rules being in place
+	// again
+	egressGatewayManager.installRoutes = true
+	egressGatewayManager.reconcile()
+
+	assertIPRules(c, []ipRule{
+		{ep1IP, destCIDR, egressCIDR1, testInterface1Idx},
+	})
+
 	// Update the endpoint labels in order for it to not be a match
 	_ = updateEndpointAndIdentity(&ep1, id1, map[string]string{})
 	egressGatewayManager.OnUpdateEndpoint(&ep1)

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -134,7 +134,7 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 
 	k8sCacheSyncedChecker := &k8sCacheSyncedCheckerMock{}
 
-	egressGatewayManager := NewEgressGatewayManager(k8sCacheSyncedChecker, identityAllocator)
+	egressGatewayManager := NewEgressGatewayManager(k8sCacheSyncedChecker, identityAllocator, option.Config.InstallEgressGatewayRoutes)
 	c.Assert(egressGatewayManager, NotNil)
 	assertIPRules(c, []ipRule{})
 


### PR DESCRIPTION
when the --install-egres-gateway-routes agent option is set to false

Fixes: #23255
