### PR TITLE
clustermesh: uniform global and shared service annotations behavior

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -44,14 +44,25 @@ func getAnnotationIncludeExternal(svc *slim_corev1.Service) bool {
 }
 
 func getAnnotationShared(svc *slim_corev1.Service) bool {
+	// The SharedService annotation is ignored if the service is not declared as global.
+	if !getAnnotationIncludeExternal(svc) {
+		return false
+	}
+
 	if value, ok := svc.ObjectMeta.Annotations[annotation.SharedService]; ok {
 		return strings.ToLower(value) == "true"
 	}
 
-	return getAnnotationIncludeExternal(svc)
+	// A global service is marked as shared by default.
+	return true
 }
 
 func getAnnotationServiceAffinity(svc *slim_corev1.Service) string {
+	// The ServiceAffinity annotation is ignored if the service is not declared as global.
+	if !getAnnotationIncludeExternal(svc) {
+		return serviceAffinityNone
+	}
+
 	if value, ok := svc.ObjectMeta.Annotations[annotation.ServiceAffinity]; ok {
 		return strings.ToLower(value)
 	}

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -553,9 +553,10 @@ func (s *ServiceCache) mergeServiceUpdateLocked(service *serviceStore.ClusterSer
 		s.externalEndpoints[id] = externalEndpoints
 	}
 
-	// we don't need to check if the current cluster is remote or local,
-	// as externalEndpoints should not have any local cluster endpoints anyway.
-	if service.IncludeExternal && !service.Shared {
+	// The cluster the service belongs to will match the current one when dealing with external
+	// workloads (and in that case all endpoints shall be always present), and not match in the
+	// cluster-mesh case (where remote endpoints shall be used only if it is global and shared).
+	if service.Cluster != option.Config.ClusterName && !(service.IncludeExternal && service.Shared) {
 		delete(externalEndpoints.endpoints, service.Cluster)
 	} else {
 		scopedLog.Debugf("Updating backends to %+v", service.Backends)

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -54,7 +54,12 @@ func (s *K8sSuite) TestGetAnnotationShared(c *check.C) {
 	c.Assert(getAnnotationShared(svc), check.Equals, true)
 
 	svc = &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
-		Annotations: map[string]string{"io.cilium/shared-service": "True"},
+		Annotations: map[string]string{"io.cilium/shared-service": "true"},
+	}}
+	c.Assert(getAnnotationShared(svc), check.Equals, false)
+
+	svc = &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/global-service": "true", "io.cilium/shared-service": "True"},
 	}}
 	c.Assert(getAnnotationShared(svc), check.Equals, true)
 
@@ -66,14 +71,19 @@ func (s *K8sSuite) TestGetAnnotationShared(c *check.C) {
 
 func (s *K8sSuite) TestGetAnnotationServiceAffinity(c *check.C) {
 	svc := &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
-		Annotations: map[string]string{"io.cilium/service-affinity": "local"},
+		Annotations: map[string]string{"io.cilium/global-service": "true", "io.cilium/service-affinity": "local"},
 	}}
 	c.Assert(getAnnotationServiceAffinity(svc), check.Equals, serviceAffinityLocal)
 
 	svc = &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
-		Annotations: map[string]string{"io.cilium/service-affinity": "remote"},
+		Annotations: map[string]string{"io.cilium/global-service": "true", "io.cilium/service-affinity": "remote"},
 	}}
 	c.Assert(getAnnotationServiceAffinity(svc), check.Equals, serviceAffinityRemote)
+
+	svc = &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/service-affinity": "remote"},
+	}}
+	c.Assert(getAnnotationServiceAffinity(svc), check.Equals, serviceAffinityNone)
 
 	svc = &slim_corev1.Service{ObjectMeta: slim_metav1.ObjectMeta{
 		Annotations: map[string]string{},


### PR DESCRIPTION
Currently, marking a service as *global* through the dedicated annotation in the local cluster only leads to the usage of both local and remote endpoints in that cluster, and in that case the *shared* service annotation possibly specified in the remote cluster(s) is not respected.

This PR adapts the behavior such that:
* the backends of a given service are shared only in case that service has the global-service annotation set to true, and the shared-service annotation is either not present, or set to true;
* the shared-service and service-affinity annotations take effect only if the global-service one is also present, otherwise they are silently ignored.

The full list of possibilities, in case of two clusters, is exemplified in the following:
1. the local svc is not marked as global: => local svc backends include local endpoints only;
2. the local svc is marked as global, the remote one has no annotations: => local svc backends include local endpoints only;
3. the local svc is marked as global, the remote one is marked as global (thus, implicitly as shared): => local svc backends include local and remote endpoints;
4. ~~the local svc is marked as global, the remote one is marked as shared: => local svc backends include local and remote endpoints;~~
    the local svc is marked as global, the remote one is marked as shared (but not global): => local svc backends include local endpoints only;
6. the local svc is marked as global, the remote one is marked as global and not shared: => local svc backends include local endpoints only.

~~The second commit adds a section to the cluster-mesh load-balancing and service discovery documentation, including a reference table describing the behavior considering different combinations of the global-service and shared-service annotation values.~~ Moved to #23408

Edit: I've updated the description to reflect the modified behavior for case 4.

Fixes: 25f058b1cd3d ("clustermesh: Correct shared service annotation behaviour")

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>

```release-note
clustermesh: make global and shared service annotations behavior uniform
```