### PR TITLE
Pr/tp/backport cep error ci fix

### DIFF
--- a/daemon/cmd/ciliumendpoints.go
+++ b/daemon/cmd/ciliumendpoints.go
@@ -110,7 +110,13 @@ func (d *Daemon) deleteCiliumEndpoint(
 			UID: cepUID,
 		},
 	}); err != nil {
-		log.WithError(err).WithFields(logrus.Fields{logfields.CEPName: cepName, logfields.K8sNamespace: cepNamespace}).
-			Error("Could not delete stale CEP")
+		logger := log.WithError(err).WithFields(logrus.Fields{logfields.CEPName: cepName, logfields.K8sNamespace: cepNamespace})
+		if k8serrors.IsNotFound(err) {
+			// CEP not found, likely already deleted. Do not log as an error as that
+			// will fail CI runs.
+			logger.Debug("Could not delete stale CEP")
+		} else {
+			logger.Error("Could not delete stale CEP")
+		}
 	}
 }


### PR DESCRIPTION
* #22474 -- daemon: Do not fail CI runs for already deleted CEP (@jrajahalme)
```upstream-prs
$ for pr in 22474; do contrib/backporting/set-labels.py $pr done v1.12; done
```

Fixes: #23264