### PR TITLE
@raybejjani is no longer an active committer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -54,7 +54,6 @@ by the "janitor role" which is rotated between all committers.
  * [Nirmoy Das] (AMD)
  * [Paul Chaignon] (Isovalent)
  * [Quentin Monnet] (Isovalent)
- * [Ray Bejjani]
  * [Robin Hahling] (Isovalent)
  * [Tam Mach] (Isovalent)
  * [Thomas Graf] (Isovalent)
@@ -72,6 +71,7 @@ by the "janitor role" which is rotated between all committers.
 We would like to acknowledge previous committers and their huge contributions to our collective success:
 
  * [Ilya Dmitrichenko] (Docker)
+ * [Ray Bejjani]
 
 Please see the AUTHORS file for the full list of contributors to the Cilium
 project.


### PR DESCRIPTION
Moved @raybejjani to Emeritus Committers.

cc @xmulligan 

```release-note
Moved @raybejjani to Emeritus Committers
```
