### PR TITLE
WIP bpf: nodeport: remove revDNAT for local backends in bpf_lxc

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -646,7 +646,7 @@ static __always_inline __u32 or_encrypt_key(__u8 key)
 #define TC_INDEX_F_SKIP_INGRESS_PROXY	1
 #define TC_INDEX_F_SKIP_EGRESS_PROXY	2
 #define TC_INDEX_F_SKIP_NODEPORT	4
-#define TC_INDEX_F_SKIP_RECIRCULATION	8
+#define TC_INDEX_F_UNUSED		8
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16
 
 /*

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1059,16 +1059,4 @@ ct_has_nodeport_egress_entry6(const void *map,
 
 	return 0;
 }
-
-static __always_inline void
-ct_update_nodeport(const void *map, const void *tuple, const bool node_port)
-{
-	struct ct_entry *entry;
-
-	entry = map_lookup_elem(map, tuple);
-	if (!entry)
-		return;
-
-	entry->node_port = node_port;
-}
 #endif /* __LIB_CONNTRACK_H_ */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -52,19 +52,6 @@ static __always_inline bool nodeport_uses_dsr(__u8 nexthdr __maybe_unused)
 # endif
 }
 
-static __always_inline bool
-bpf_skip_recirculation(const struct __ctx_buff *ctx __maybe_unused)
-{
-	/* From XDP layer, we do not go through an egress hook from
-	 * here, hence nothing to be skipped.
-	 */
-#if __ctx_is == __ctx_skb
-	return ctx->tc_index & TC_INDEX_F_SKIP_RECIRCULATION;
-#else
-	return false;
-#endif
-}
-
 static __always_inline __u64 ctx_adjust_hroom_dsr_flags(void)
 {
 #ifdef HAVE_CSUM_LEVEL
@@ -1162,9 +1149,6 @@ skip_rev_dnat:
 	}
 
 out:
-	if (bpf_skip_recirculation(ctx))
-		return DROP_NAT_NO_MAPPING;
-
 	ctx_skip_nodeport_set(ctx);
 	ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
 	return DROP_MISSED_TAIL_CALL;
@@ -2261,9 +2245,6 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 	}
 
 out:
-	if (bpf_skip_recirculation(ctx))
-		return DROP_NAT_NO_MAPPING;
-
 	ctx_skip_nodeport_set(ctx);
 	ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);
 	return DROP_MISSED_TAIL_CALL;


### PR DESCRIPTION
Just let to-overlay/to-netdev handle it.

This fixes a netfilter asymmetry, and the EDT issue.

TODO: can the stale .node_port flag cause us any issue? should we clear it?

Signed-off-by: Julian Wiedmann <jwi@isovalent.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
