### PR TITLE
bpf: nodeport: minor DSR improvements

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1438,7 +1438,10 @@ skip_policy_enforcement:
 # ifdef ENABLE_DSR
 		int ret2;
 
-		ret2 = handle_dsr_v6(ctx, &dsr);
+		if (!revalidate_data(ctx, &data, &data_end, &ip6))
+			return DROP_INVALID;
+
+		ret2 = handle_dsr_v6(ctx, ip6, &dsr);
 		if (ret2 != 0)
 			return ret2;
 
@@ -1772,7 +1775,10 @@ skip_policy_enforcement:
 # ifdef ENABLE_DSR
 		int ret2;
 
-		ret2 = handle_dsr_v4(ctx, &dsr);
+		if (!revalidate_data(ctx, &data, &data_end, &ip4))
+			return DROP_INVALID;
+
+		ret2 = handle_dsr_v4(ctx, ip4, &dsr);
 		if (ret2 != 0)
 			return ret2;
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -594,8 +594,7 @@ enum metric_dir {
  */
 #define MARK_MAGIC_HEALTH		MARK_MAGIC_DECRYPT
 
-/* IPv4 option used to carry service addr and port for DSR. Lower 16bits set to
- * zero so that they can be OR'd with service port.
+/* IPv4 option used to carry service addr and port for DSR.
  *
  * Copy = 1 (option is copied to each fragment)
  * Class = 0 (control option)
@@ -604,9 +603,7 @@ enum metric_dir {
  *
  * [1]: https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml
  */
-#define DSR_IPV4_OPT_32		0x9a080000
-#define DSR_IPV4_OPT_MASK	0xffff0000
-#define DSR_IPV4_DPORT_MASK	0x0000ffff
+#define DSR_IPV4_OPT_TYPE	(IPOPT_COPY | 0x1a)
 
 /* IPv6 option type of Destination Option used to carry service IPv6 addr and
  * port for DSR.

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -545,7 +545,7 @@ static __always_inline __maybe_unused int snat_v4_create_dsr(struct __ctx_buff *
 	tuple.saddr = ip4->daddr;
 	tuple.flags = NAT_DIR_EGRESS;
 
-	off = ((void *)ip4 - data) + ipv4_hdrlen(ip4);
+	off = ETH_HLEN + ipv4_hdrlen(ip4);
 
 	switch (tuple.nexthdr) {
 	case IPPROTO_TCP:
@@ -1313,7 +1313,7 @@ static __always_inline __maybe_unused int snat_v6_create_dsr(struct __ctx_buff *
 	ipv6_addr_copy(&tuple.saddr, (union v6addr *)&ip6->daddr);
 	tuple.flags = NAT_DIR_EGRESS;
 
-	off = ((void *)ip6 - data) + hdrlen;
+	off = ETH_HLEN + hdrlen;
 
 	switch (tuple.nexthdr) {
 	case IPPROTO_TCP:

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -532,10 +532,6 @@ static __always_inline __maybe_unused int snat_v4_create_dsr(struct __ctx_buff *
 	struct ipv4_ct_tuple tuple = {};
 	struct ipv4_nat_entry state = {};
 	struct iphdr *ip4;
-	struct {
-		__be16 sport;
-		__be16 dport;
-	} l4hdr;
 	__u32 off;
 	int ret;
 
@@ -557,10 +553,8 @@ static __always_inline __maybe_unused int snat_v4_create_dsr(struct __ctx_buff *
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		if (ctx_load_bytes(ctx, off, &l4hdr, sizeof(l4hdr)) < 0)
+		if (l4_load_ports(ctx, off, &tuple.dport) < 0)
 			return DROP_INVALID;
-		tuple.dport = l4hdr.sport;
-		tuple.sport = l4hdr.dport;
 		break;
 	default:
 		/* NodePort svc can be reached only via TCP or UDP, so
@@ -1302,10 +1296,6 @@ static __always_inline __maybe_unused int snat_v6_create_dsr(struct __ctx_buff *
 	struct ipv6_ct_tuple tuple = {};
 	struct ipv6_nat_entry state = {};
 	struct ipv6hdr *ip6;
-	struct {
-		__be16 sport;
-		__be16 dport;
-	} l4hdr;
 	int ret, hdrlen;
 	__u32 off;
 
@@ -1331,10 +1321,8 @@ static __always_inline __maybe_unused int snat_v6_create_dsr(struct __ctx_buff *
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		if (ctx_load_bytes(ctx, off, &l4hdr, sizeof(l4hdr)) < 0)
+		if (l4_load_ports(ctx, off, &tuple.dport) < 0)
 			return DROP_INVALID;
-		tuple.dport = l4hdr.sport;
-		tuple.sport = l4hdr.dport;
 		break;
 	default:
 		/* NodePort svc can be reached only via TCP or UDP, so

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -524,21 +524,16 @@ snat_v4_rev_nat_can_skip(const struct ipv4_nat_target *target, const struct ipv4
 	return dport < target->min_port || dport > target->max_port;
 }
 
-static __always_inline __maybe_unused int snat_v4_create_dsr(struct __ctx_buff *ctx,
-							     __be32 to_saddr,
-							     __be16 to_sport)
+static __always_inline __maybe_unused int
+snat_v4_create_dsr(struct __ctx_buff *ctx, struct iphdr *ip4,
+		   __be32 to_saddr, __be16 to_sport)
 {
-	void *data, *data_end;
 	struct ipv4_ct_tuple tuple = {};
 	struct ipv4_nat_entry state = {};
-	struct iphdr *ip4;
 	__u32 off;
 	int ret;
 
 	build_bug_on(sizeof(struct ipv4_nat_entry) > 64);
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
 
 	tuple.nexthdr = ip4->protocol;
 	tuple.daddr = ip4->saddr;
@@ -1288,21 +1283,16 @@ snat_v6_rev_nat_can_skip(const struct ipv6_nat_target *target, const struct ipv6
 	return dport < target->min_port || dport > target->max_port;
 }
 
-static __always_inline __maybe_unused int snat_v6_create_dsr(struct __ctx_buff *ctx,
-							     const union v6addr *to_saddr,
-							     __be16 to_sport)
+static __always_inline __maybe_unused int
+snat_v6_create_dsr(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
+		   const union v6addr *to_saddr, __be16 to_sport)
 {
-	void *data, *data_end;
 	struct ipv6_ct_tuple tuple = {};
 	struct ipv6_nat_entry state = {};
-	struct ipv6hdr *ip6;
 	int ret, hdrlen;
 	__u32 off;
 
 	build_bug_on(sizeof(struct ipv6_nat_entry) > 64);
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
 
 	tuple.nexthdr = ip6->nexthdr;
 	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -318,22 +318,18 @@ static __always_inline int find_dsr_v6(struct __ctx_buff *ctx, __u8 nexthdr,
 	return DROP_INVALID_EXTHDR;
 }
 
-static __always_inline int handle_dsr_v6(struct __ctx_buff *ctx, bool *dsr)
+static __always_inline int
+handle_dsr_v6(struct __ctx_buff *ctx, struct ipv6hdr *ip6, bool *dsr)
 {
 	struct dsr_opt_v6 opt __align_stack_8 = {};
-	void *data, *data_end;
-	struct ipv6hdr *ip6;
 	int ret;
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
 
 	ret = find_dsr_v6(ctx, ip6->nexthdr, &opt, dsr);
 	if (ret != 0)
 		return ret;
 
 	if (*dsr) {
-		if (snat_v6_create_dsr(ctx, &opt.addr, opt.port) < 0)
+		if (snat_v6_create_dsr(ctx, ip6, &opt.addr, opt.port) < 0)
 			return DROP_INVALID;
 	}
 
@@ -1463,14 +1459,9 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 }
 #endif /* DSR_ENCAP_MODE */
 
-static __always_inline int handle_dsr_v4(struct __ctx_buff *ctx, bool *dsr)
+static __always_inline int
+handle_dsr_v4(struct __ctx_buff *ctx, struct iphdr *ip4, bool *dsr)
 {
-	void *data, *data_end;
-	struct iphdr *ip4;
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
-
 	/* Check whether IPv4 header contains a 64-bit option (IPv4 header
 	 * w/o option (5 x 32-bit words) + the DSR option (2 x 32-bit words)).
 	 */
@@ -1496,7 +1487,7 @@ static __always_inline int handle_dsr_v4(struct __ctx_buff *ctx, bool *dsr)
 			address = opt2;
 			*dsr = true;
 
-			if (snat_v4_create_dsr(ctx, address, dport) < 0)
+			if (snat_v4_create_dsr(ctx, ip4, address, dport) < 0)
 				return DROP_INVALID;
 		}
 	}

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -37,7 +37,7 @@ static volatile const __u8 mac_six[] =   {0x08, 0x14, 0x1C, 0x32, 0x52, 0x7E};
  *  having to come up with custom ips.
  */
 
-#define IPV4(a, b, c, d) (((d) << 24) + ((c) << 16) + ((b) << 8) + (a))
+#define IPV4(a, b, c, d) __bpf_htonl(((d) << 24) + ((c) << 16) + ((b) << 8) + (a))
 
 /* IPv4 addresses for hosts, external to the cluster */
 #define v4_ext_one	IPV4(110, 0, 11, 1)

--- a/bpf/tests/tc_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_lb.c
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
+#define ETH_HLEN 14
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_DSR
+
+#define DISABLE_LOOPBACK_LB
+
+/* Skip ingress policy checks, not needed to validate hairpin flow */
+#define USE_BPF_PROG_FOR_INGRESS_POLICY
+#undef FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define FRONTEND_IP		v4_svc_two
+#define FRONTEND_PORT		tcp_svc_one
+
+#define LB_IP			v4_node_one
+#define IPV4_DIRECT_ROUTING	LB_IP
+
+#define BACKEND_IP		v4_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define fib_lookup mock_fib_lookup
+
+static volatile const __u8 *client_mac = mac_one;
+/* this matches the default node_config.h: */
+static volatile const __u8 lb_mac[ETH_ALEN] = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
+static volatile const __u8 *remote_backend_mac = mac_five;
+
+long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	params->ifindex = 0;
+
+	if (params->ipv4_dst == BACKEND_IP) {
+		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
+		__bpf_memcpy_builtin(params->dmac, (__u8 *)remote_backend_mac, ETH_ALEN);
+	} else {
+		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
+		__bpf_memcpy_builtin(params->dmac, (__u8 *)client_mac, ETH_ALEN);
+	}
+
+	return 0;
+}
+
+#define SECCTX_FROM_IPCACHE 1
+
+#include <bpf_host.c>
+
+#define FROM_NETDEV	0
+#define TO_NETDEV	1
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Test that a SVC request that is LBed to a DSR remote backend
+ * - gets DNATed,
+ * - has IP Option inserted,
+ * - gets redirected back out by TC
+ */
+PKTGEN("tc", "tc_nodeport_dsr_fwd")
+int nodeport_dsr_fwd_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = FRONTEND_IP;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = FRONTEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_dsr_fwd")
+int nodeport_dsr_fwd_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+
+	/* Register a fake LB backend matching our packet. */
+	struct lb4_key lb_svc_key = {
+		.address = FRONTEND_IP,
+		.dport = FRONTEND_PORT,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	/* Create a service with only one backend */
+	struct lb4_service lb_svc_value = {
+		.count = 1,
+		.flags = SVC_FLAG_ROUTABLE,
+		.rev_nat_index = revnat_id,
+	};
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+	/* We need to register both in the external and internal scopes for the
+	 * packet to be redirected to a neighboring node
+	 */
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_INT;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* A backend between 1 and .count is chosen, since we have only one backend
+	 * it is always backend_slot 1. Point it to backend_id 124.
+	 */
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_EXT;
+	lb_svc_key.backend_slot = 1;
+	lb_svc_value.backend_id = 124;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* Insert a reverse NAT entry for the above service */
+	struct lb4_reverse_nat revnat_value = {
+		.address = FRONTEND_IP,
+		.port = FRONTEND_PORT,
+	};
+	map_update_elem(&LB4_REVERSE_NAT_MAP, &revnat_id, &revnat_value, BPF_ANY);
+
+	/* Create backend id 124 which contains the IP and port to send the
+	 * packet to.
+	 */
+	struct lb4_backend backend = {
+		.address = BACKEND_IP,
+		.port = BACKEND_PORT,
+		.proto = IPPROTO_TCP,
+		.flags = BE_STATE_ACTIVE,
+	};
+	map_update_elem(&LB4_BACKEND_MAP, &lb_svc_value.backend_id, &backend, BPF_ANY);
+
+	struct ipcache_key cache_key = {
+		.lpm_key.prefixlen = 32,
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = BACKEND_IP,
+	};
+	struct remote_endpoint_info cache_value = {
+		.sec_label = 112233,
+	};
+	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_dsr_fwd")
+int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	struct dsr_opt_v4 *opt;
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	opt = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)opt + 2 * sizeof(__u32) > data_end)
+		test_fatal("l3 DSR option out of bounds");
+
+	l4 = (void *)opt + sizeof(*opt);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the LB MAC")
+	if (memcmp(l2->h_dest, (__u8 *)remote_backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the backend MAC")
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP)
+		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (opt->type != DSR_IPV4_OPT_TYPE)
+		test_fatal("type in DSR IP option is bad")
+	if (opt->len != 8)
+		test_fatal("length in DSR IP option is bad")
+	if (opt->port != __bpf_ntohs(FRONTEND_PORT))
+		test_fatal("port in DSR IP option is bad")
+	if (opt->addr != __bpf_ntohl(FRONTEND_IP))
+		test_fatal("addr in DSR IP option is bad")
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
+
+	test_finish();
+}

--- a/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/xdp.h>
+#include "pktgen.h"
+
+/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
+#define ETH_HLEN 14
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_NODEPORT_ACCELERATION
+#define ENABLE_DSR
+
+#define DISABLE_LOOPBACK_LB
+
+/* Skip ingress policy checks, not needed to validate hairpin flow */
+#define USE_BPF_PROG_FOR_INGRESS_POLICY
+#undef FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define FRONTEND_IP		v4_svc_two
+#define FRONTEND_PORT		tcp_svc_one
+
+#define LB_IP			v4_node_one
+#define IPV4_DIRECT_ROUTING	LB_IP
+
+#define BACKEND_IP		v4_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define fib_lookup mock_fib_lookup
+
+static volatile const __u8 *client_mac = mac_one;
+/* this matches the default node_config.h: */
+static volatile const __u8 lb_mac[ETH_ALEN] = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
+static volatile const __u8 *remote_backend_mac = mac_five;
+
+long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	params->ifindex = 0;
+
+	if (params->ipv4_dst == BACKEND_IP) {
+		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
+		__bpf_memcpy_builtin(params->dmac, (__u8 *)remote_backend_mac, ETH_ALEN);
+	} else {
+		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
+		__bpf_memcpy_builtin(params->dmac, (__u8 *)client_mac, ETH_ALEN);
+	}
+
+	return 0;
+}
+
+#include <bpf_xdp.c>
+
+#define FROM_NETDEV	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_xdp_entry,
+	},
+};
+
+/* Test that a SVC request that is LBed to a DSR remote backend
+ * - gets DNATed,
+ * - has IP Option inserted,
+ * - gets redirected back out by XDP
+ */
+PKTGEN("xdp", "xdp_nodeport_dsr_fwd")
+int nodeport_dsr_fwd_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = FRONTEND_IP;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = FRONTEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("xdp", "xdp_nodeport_dsr_fwd")
+int nodeport_dsr_fwd_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+
+	/* Register a fake LB backend matching our packet. */
+	struct lb4_key lb_svc_key = {
+		.address = FRONTEND_IP,
+		.dport = FRONTEND_PORT,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	/* Create a service with only one backend */
+	struct lb4_service lb_svc_value = {
+		.count = 1,
+		.flags = SVC_FLAG_ROUTABLE,
+		.rev_nat_index = revnat_id,
+	};
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+	/* We need to register both in the external and internal scopes for the
+	 * packet to be redirected to a neighboring node
+	 */
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_INT;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* A backend between 1 and .count is chosen, since we have only one backend
+	 * it is always backend_slot 1. Point it to backend_id 124.
+	 */
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_EXT;
+	lb_svc_key.backend_slot = 1;
+	lb_svc_value.backend_id = 124;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* Insert a reverse NAT entry for the above service */
+	struct lb4_reverse_nat revnat_value = {
+		.address = FRONTEND_IP,
+		.port = FRONTEND_PORT,
+	};
+	map_update_elem(&LB4_REVERSE_NAT_MAP, &revnat_id, &revnat_value, BPF_ANY);
+
+	/* Create backend id 124 which contains the IP and port to send the
+	 * packet to.
+	 */
+	struct lb4_backend backend = {
+		.address = BACKEND_IP,
+		.port = BACKEND_PORT,
+		.proto = IPPROTO_TCP,
+		.flags = BE_STATE_ACTIVE,
+	};
+	map_update_elem(&LB4_BACKEND_MAP, &lb_svc_value.backend_id, &backend, BPF_ANY);
+
+	struct ipcache_key cache_key = {
+		.lpm_key.prefixlen = 32,
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = BACKEND_IP,
+	};
+	struct remote_endpoint_info cache_value = {
+		.sec_label = 112233,
+	};
+	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("xdp", "xdp_nodeport_dsr_fwd")
+int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	struct dsr_opt_v4 *opt;
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	opt = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)opt + 2 * sizeof(__u32) > data_end)
+		test_fatal("l3 DSR option out of bounds");
+
+	l4 = (void *)opt + sizeof(*opt);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the LB MAC")
+	if (memcmp(l2->h_dest, (__u8 *)remote_backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the backend MAC")
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP)
+		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (opt->type != DSR_IPV4_OPT_TYPE)
+		test_fatal("type in DSR IP option is bad")
+	if (opt->len != 8)
+		test_fatal("length in DSR IP option is bad")
+	if (opt->port != __bpf_ntohs(FRONTEND_PORT))
+		test_fatal("port in DSR IP option is bad")
+	if (opt->addr != __bpf_ntohl(FRONTEND_IP))
+		test_fatal("addr in DSR IP option is bad")
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
+
+	test_finish();
+}


### PR DESCRIPTION
Looks like https://github.com/cilium/cilium/pull/22978 needs some more cycles. So let's split off some non-controversial cleanups & tests to reduce the review later on. I'll tag this PR for backports once https://github.com/cilium/cilium/pull/22978 is ready and needs it.

Best reviewed patch-by-patch - https://github.com/cilium/cilium/pull/23262 has some more context on the IPv4 option endianness.