### PR TITLE
v1.12 backports 2023-01-25

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -455,6 +455,11 @@ snat_v4_can_skip(const struct ipv4_nat_target *target,
 {
 	__u16 dport = bpf_ntohs(tuple->dport), sport = bpf_ntohs(tuple->sport);
 
+#if defined(ENABLE_EGRESS_GATEWAY)
+	if (target->egress_gateway)
+		return false;
+#endif
+
 	if (dir == NAT_DIR_EGRESS &&
 	    ((!target->from_local_endpoint && !target->src_from_world &&
 	      sport < NAT_MIN_EGRESS) ||


### PR DESCRIPTION
- [ ] #23274 -- bpf: nat: fix snat_v4_can_skip() for egress gateway (@jibi)
  * had to drop the bpf unit test commit as v1.12 doesn't have all the necessary infrastructure

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 23274; do contrib/backporting/set-labels.py $pr done 1.12; done
```