### PR TITLE
clustermesh, kvstore: consistently pass controller context to kvstore operations

### DIFF
--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -91,7 +91,7 @@ func (o *testObserver) OnDelete(k store.NamedKey) {
 
 func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	kvstore.SetupDummy("etcd")
-	defer kvstore.Client().Close()
+	defer kvstore.Client().Close(context.TODO())
 
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -152,7 +152,7 @@ func (rc *remoteCluster) releaseOldConnection() {
 			remoteServices.Close(context.TODO())
 		}
 		if backend != nil {
-			backend.Close()
+			backend.Close(context.TODO())
 		}
 	}()
 }
@@ -176,7 +176,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				err, isErr := <-errChan
 				if isErr {
 					if backend != nil {
-						backend.Close()
+						backend.Close(ctx)
 					}
 					rc.getLogger().WithError(err).Warning("Unable to establish etcd connection to remote cluster")
 					return err
@@ -208,7 +208,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 					Observer:                rc.mesh.conf.NodeObserver(),
 				})
 				if err != nil {
-					backend.Close()
+					backend.Close(ctx)
 					return err
 				}
 
@@ -228,7 +228,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				})
 				if err != nil {
 					remoteNodes.Close(ctx)
-					backend.Close()
+					backend.Close(ctx)
 					return err
 				}
 				rc.swg.Stop()
@@ -237,7 +237,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				if err != nil {
 					remoteServices.Close(ctx)
 					remoteNodes.Close(ctx)
-					backend.Close()
+					backend.Close(ctx)
 					return err
 				}
 

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -163,7 +163,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 			DoFunc: func(ctx context.Context) error {
 				rc.releaseOldConnection()
 
-				backend, errChan := kvstore.NewClient(context.TODO(), kvstore.EtcdBackendName,
+				backend, errChan := kvstore.NewClient(ctx, kvstore.EtcdBackendName,
 					map[string]string{
 						kvstore.EtcdOptionConfig: rc.configPath,
 					},
@@ -227,7 +227,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 					},
 				})
 				if err != nil {
-					remoteNodes.Close(context.TODO())
+					remoteNodes.Close(ctx)
 					backend.Close()
 					return err
 				}
@@ -235,8 +235,8 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 
 				remoteIdentityCache, err := allocator.WatchRemoteIdentities(backend)
 				if err != nil {
-					remoteServices.Close(context.TODO())
-					remoteNodes.Close(context.TODO())
+					remoteServices.Close(ctx)
+					remoteNodes.Close(ctx)
 					backend.Close()
 					return err
 				}

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -120,7 +120,7 @@ func (s *ClusterMeshServicesTestSuite) TearDownTest(c *C) {
 
 	os.RemoveAll(s.testDir)
 	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 func (s *ClusterMeshServicesTestSuite) expectEvent(c *C, action k8s.CacheAction, id k8s.ServiceID, fn func(event k8s.ServiceEvent) bool) {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -157,7 +157,7 @@ func (s *EndpointSuite) SetUpTest(c *C) {
 
 func (s *EndpointSuite) TearDownTest(c *C) {
 	s.mgr.Close()
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 func (s *EndpointSuite) TestEndpointStatus(c *C) {

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -133,7 +133,7 @@ func (d *DummyOwner) UpdateIdentities(added, deleted cache.IdentityCache) {}
 func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	// Setup dependencies for endpoint.
 	kvstore.SetupDummy("etcd")
-	defer kvstore.Client().Close()
+	defer kvstore.Client().Close(context.TODO())
 
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -91,7 +91,7 @@ func (e *IdentityAllocatorEtcdSuite) SetUpTest(c *C) {
 }
 
 func (e *IdentityAllocatorEtcdSuite) TearDownTest(c *C) {
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type IdentityAllocatorConsulSuite struct {
@@ -105,7 +105,7 @@ func (e *IdentityAllocatorConsulSuite) SetUpTest(c *C) {
 }
 
 func (e *IdentityAllocatorConsulSuite) TearDownTest(c *C) {
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type dummyOwner struct {

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -48,7 +48,7 @@ func (e *AllocatorEtcdSuite) SetUpTest(c *C) {
 
 func (e *AllocatorEtcdSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type AllocatorConsulSuite struct {
@@ -64,7 +64,7 @@ func (e *AllocatorConsulSuite) SetUpTest(c *C) {
 
 func (e *AllocatorConsulSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 // FIXME: this should be named better, it implements pkg/allocator.Backend

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -193,7 +193,7 @@ type BackendOperations interface {
 	Watch(ctx context.Context, w *Watcher)
 
 	// Close closes the kvstore client
-	Close()
+	Close(ctx context.Context)
 
 	// GetCapabilities returns the capabilities of the backend
 	GetCapabilities() Capabilities

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -726,7 +726,7 @@ func (c *consulClient) listPrefix(ctx context.Context, prefix string) (KeyValueP
 }
 
 // Close closes the consul session
-func (c *consulClient) Close() {
+func (c *consulClient) Close(ctx context.Context) {
 	close(c.statusCheckErrors)
 	if c.controllers != nil {
 		c.controllers.RemoveAll()

--- a/pkg/kvstore/consul_test.go
+++ b/pkg/kvstore/consul_test.go
@@ -28,7 +28,7 @@ func (e *ConsulSuite) SetUpTest(c *C) {
 }
 
 func (e *ConsulSuite) TearDownTest(c *C) {
-	Client().Close()
+	Client().Close(context.TODO())
 }
 
 var handler http.HandlerFunc

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1633,9 +1633,9 @@ func (e *etcdClient) ListPrefix(ctx context.Context, prefix string) (v KeyValueP
 }
 
 // Close closes the etcd session
-func (e *etcdClient) Close() {
+func (e *etcdClient) Close(ctx context.Context) {
 	close(e.stopStatusChecker)
-	sessionErr := e.waitForInitialSession(context.Background())
+	sessionErr := e.waitForInitialSession(ctx)
 	if e.controllers != nil {
 		e.controllers.RemoveAll()
 	}

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -32,7 +32,7 @@ func (e *EtcdSuite) SetUpTest(c *C) {
 }
 
 func (e *EtcdSuite) TearDownTest(c *C) {
-	Client().Close()
+	Client().Close(context.TODO())
 }
 
 type MaintenanceMocker struct {
@@ -351,7 +351,7 @@ func (e *EtcdLockedSuite) SetUpSuite(c *C) {
 func (e *EtcdLockedSuite) TearDownSuite(c *C) {
 	err := e.etcdClient.Close()
 	c.Assert(err, IsNil)
-	Client().Close()
+	Client().Close(context.TODO())
 }
 
 func (e *EtcdLockedSuite) TestGetIfLocked(c *C) {
@@ -1958,7 +1958,7 @@ func (e *EtcdRateLimiterSuite) TestRateLimiter(c *C) {
 			err = kvlocker.Unlock(context.TODO())
 			c.Assert(err, IsNil)
 		}
-		Client().Close()
+		Client().Close(context.TODO())
 
 		// Clean created KV Pairs if populateKVPairs is disabled and cleanKVPairs is enabled.
 		if !op.populateKVPairs && op.cleanKVPairs {
@@ -1993,7 +1993,7 @@ func (e *EtcdRateLimiterSuite) TestRateLimiter(c *C) {
 			err = kvlocker.Unlock(context.TODO())
 			c.Assert(err, IsNil)
 		}
-		Client().Close()
+		Client().Close(context.TODO())
 
 		if op.needCondKey {
 			_, err = e.etcdClient.Delete(context.Background(), condKey)

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -43,7 +43,7 @@ func (e *StoreEtcdSuite) SetUpTest(c *C) {
 
 func (e *StoreEtcdSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 }
 
 type StoreConsulSuite struct {
@@ -58,7 +58,7 @@ func (e *StoreConsulSuite) SetUpTest(c *C) {
 
 func (e *StoreConsulSuite) TearDownTest(c *C) {
 	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close()
+	kvstore.Client().Close(context.TODO())
 	time.Sleep(sharedKeyDeleteDelay + 5*time.Second)
 }
 


### PR DESCRIPTION
See commits for details.
