### PR TITLE
tests: add exception for etcd error

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -232,13 +232,14 @@ const (
 	routerIPMismatch    = "Mismatch of router IPs found during restoration"
 
 	// ...and their exceptions.
-	opCantBeFulfilled        = "Operation cannot be fulfilled on leases.coordination.k8s.io"        // cf. https://github.com/cilium/cilium/issues/16402
-	initLeaderElection       = "error initially creating leader election record: leases."           // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-861544964
-	globalDataSupport        = "kernel doesn't support global data"                                 // cf. https://github.com/cilium/cilium/issues/16418
-	removeInexistentID       = "removing identity not added to the identity manager!"               // cf. https://github.com/cilium/cilium/issues/16419
-	failedToListCRDs         = "the server could not find the requested resource"                   // cf. https://github.com/cilium/cilium/issues/16425
-	retrieveResLock          = "retrieving resource lock kube-system/cilium-operator-resource-lock" // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-871155492
-	failedToRelLockEmptyName = "Failed to release lock: resource name may not be empty"             // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-985819560
+	opCantBeFulfilled            = "Operation cannot be fulfilled on leases.coordination.k8s.io"        // cf. https://github.com/cilium/cilium/issues/16402
+	initLeaderElection           = "error initially creating leader election record: leases."           // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-861544964
+	globalDataSupport            = "kernel doesn't support global data"                                 // cf. https://github.com/cilium/cilium/issues/16418
+	removeInexistentID           = "removing identity not added to the identity manager!"               // cf. https://github.com/cilium/cilium/issues/16419
+	failedToListCRDs             = "the server could not find the requested resource"                   // cf. https://github.com/cilium/cilium/issues/16425
+	retrieveResLock              = "retrieving resource lock kube-system/cilium-operator-resource-lock" // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-871155492
+	failedToRelLockEmptyName     = "Failed to release lock: resource name may not be empty"             // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-985819560
+	failedToUpdateLockReqTimeout = "Failed to update lock: etcdserver: request timed out"
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -300,7 +301,7 @@ var badLogMessages = map[string][]string{
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
-	"level=error": {opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName},
+	"level=error": {opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLockReqTimeout},
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
The etcd error 'Failed to update lock: etcdserver: request timed out' does not seem to be related with Cilium. Thus, we will add it to the list of exceptions and not fail the CI because of this error. This seems to be a consequence of etcd's errors such as:
 - 'Server.processUnaryRPC failed to write status: connection error: desc = "transport is closing"'
 - 'Failed to update lock: etcdserver: request timed out'

Those issues are referred in the etcd repository:
 - https://github.com/etcd-io/etcd/issues/14071
 - https://github.com/etcd-io/etcd/issues/14027#issuecomment-1293725491

Signed-off-by: André Martins <andre@cilium.io>

Close https://github.com/cilium/cilium/issues/16402
Close https://github.com/cilium/cilium/issues/23047
Close https://github.com/cilium/cilium/issues/21175