### PR TITLE
test: print log messages that need to be investigated

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -465,8 +465,8 @@ func failIfContainsBadLogMsg(logs, label string, blacklist map[string][]string) 
 					}
 				}
 				if !ok {
-					count, _ := uniqueFailures[fail]
-					uniqueFailures[fail] = count + 1
+					count, _ := uniqueFailures[msg]
+					uniqueFailures[msg] = count + 1
 				}
 			}
 		}


### PR DESCRIPTION
There is more value in printing the log messages than the exception so we should add in the test jenkins output the message that cause the test to fail.

Signed-off-by: André Martins <andre@cilium.io>