### PR TITLE
test: Get rid of 4.9 pipeline

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2474,7 +2474,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 			opts["k8sServicePort"] = "6443"
 		}
 
-		if RunsOn419OrLaterKernel() {
+		if RunsOn54OrLaterKernel() {
 			opts["bpf.masquerade"] = "true"
 			opts["enableIPv6Masquerade"] = "false"
 		}
@@ -2484,19 +2484,17 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		}
 	}
 
-	if RunsOn419OrLaterKernel() {
+	if RunsOn54OrLaterKernel() {
 		// To enable SA for both cases when KPR is enabled and disabled
 		addIfNotOverwritten(options, "sessionAffinity", "true")
 	}
 
 	// Disable unsupported features that will just generated unnecessary
 	// warnings otherwise.
-	if DoesNotRunOn419OrLaterKernel() {
+	if DoesNotRunOnNetNextKernel() {
 		addIfNotOverwritten(options, "kubeProxyReplacement", "disabled")
 		addIfNotOverwritten(options, "bpf.masquerade", "false")
 		addIfNotOverwritten(options, "sessionAffinity", "false")
-	}
-	if DoesNotRunOnNetNextKernel() {
 		addIfNotOverwritten(options, "bandwidthManager.enabled", "false")
 	}
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -578,7 +578,7 @@ func DoesNotRunOnEKS() bool {
 // kube-proxy replacement. Note that kube-proxy may still be running
 // alongside Cilium.
 func RunsWithKubeProxyReplacement() bool {
-	return RunsOnGKE() || RunsOn419OrLaterKernel()
+	return RunsOnGKE() || RunsOn54OrLaterKernel()
 }
 
 // DoesNotRunWithKubeProxyReplacement is the complement function of

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -25,9 +25,9 @@ import (
 var _ = Describe("K8sAgentHubbleTest", func() {
 	// We want to run Hubble tests both with and without our kube-proxy
 	// replacement, as the trace events depend on it. We thus run the tests
-	// on GKE and our 4.9 pipeline.
+	// on GKE and our 4.19 pipeline.
 	SkipContextIf(func() bool {
-		return helpers.RunsOn419OrLaterKernel() || helpers.RunsOnAKS()
+		return helpers.RunsOnNetNextKernel() || helpers.RunsOnAKS()
 	}, "Hubble Observe", func() {
 		var (
 			kubectl        *helpers.Kubectl

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -24,12 +24,12 @@ import (
 )
 
 var _ = SkipDescribeIf(func() bool {
-	// We only need to run on 4.9 with kube-proxy and net-next with KPR
+	// We only need to run on 4.19 with kube-proxy and net-next with KPR
 	// and the third node. Other CI jobs are not expected to increase
 	// code coverage.
 	//
 	// For GKE coverage, see the K8sPolicyTestExtended Describe block below.
-	return helpers.RunsOnGKE() || helpers.RunsOn419Kernel() || helpers.RunsOn54Kernel() || helpers.RunsOnAKS()
+	return helpers.RunsOnGKE() || helpers.RunsOn54Kernel() || helpers.RunsOnAKS()
 }, "K8sAgentPolicyTest", func() {
 
 	var (

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -796,15 +796,17 @@ func testSessionAffinity(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, fromOu
 	}
 }
 
-func testExternalTrafficPolicyLocal(kubectl *helpers.Kubectl, ni *helpers.NodesInfo) {
+func testExternalTrafficPolicyLocal(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, ipsec bool) {
 	var (
 		data    v1.Service
 		httpURL string
 		tftpURL string
 
+		// Service backends on both nodes
 		localNodePortSvcIPv4 = "test-nodeport-local"
 		localNodePortSvcIPv6 = "test-nodeport-local-ipv6"
 
+		// Service backend only on k8s2 node
 		localNodePortK8s2SvcIpv4 = "test-nodeport-local-k8s2"
 		localNodePortK8s2SvcIpv6 = "test-nodeport-local-k8s2-ipv6"
 	)
@@ -865,13 +867,17 @@ func testExternalTrafficPolicyLocal(kubectl *helpers.Kubectl, ni *helpers.NodesI
 			testCurlFromOutside(kubectl, ni, tftpURL, count, true)
 		}
 
-		// Local requests should be load-balanced on kube-proxy 1.15+.
-		// See kubernetes/kubernetes#77523 for the PR which introduced this
-		// behavior on the iptables-backend for kube-proxy.
 		httpURL = getHTTPLink(node.node1IP, data.Spec.Ports[0].NodePort)
 		tftpURL = getTFTPLink(node.node1IP, data.Spec.Ports[1].NodePort)
-		testCurlFromPodInHostNetNS(kubectl, httpURL, count, 0, ni.K8s1NodeName)
-		testCurlFromPodInHostNetNS(kubectl, tftpURL, count, 0, ni.K8s1NodeName)
+
+		// Until https://github.com/cilium/cilium/issues/23481 has been fixed
+		if !ipsec {
+			// Local requests should be load-balanced on kube-proxy 1.15+.
+			// See kubernetes/kubernetes#77523 for the PR which introduced this
+			// behavior on the iptables-backend for kube-proxy.
+			testCurlFromPodInHostNetNS(kubectl, httpURL, count, 0, ni.K8s1NodeName)
+			testCurlFromPodInHostNetNS(kubectl, tftpURL, count, 0, ni.K8s1NodeName)
+		}
 		// In-cluster connectivity from k8s2 to k8s1 IP will still work with
 		// SocketLB (regardless of if we are running with or
 		// without kube-proxy) since we'll hit the wildcard rule in bpf_sock

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -196,6 +196,9 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 				deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
 				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 					"encryption.enabled": "true",
+					// Until https://github.com/cilium/cilium/issues/23461
+					// has been fixed, we need to disable IPv6 masq
+					"enableIPv6Masquerade": "false",
 				})
 				testExternalTrafficPolicyLocal(kubectl, ni)
 				deploymentManager.DeleteAll()

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -200,7 +200,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 					// has been fixed, we need to disable IPv6 masq
 					"enableIPv6Masquerade": "false",
 				})
-				testExternalTrafficPolicyLocal(kubectl, ni)
+				testExternalTrafficPolicyLocal(kubectl, ni, true)
 				deploymentManager.DeleteAll()
 				deploymentManager.DeleteCilium()
 			})
@@ -209,12 +209,12 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 					"hostFirewall.enabled": "true",
 				})
-				testExternalTrafficPolicyLocal(kubectl, ni)
+				testExternalTrafficPolicyLocal(kubectl, ni, false)
 			})
 
 			It("with externalTrafficPolicy=Local", func() {
 				DeployCiliumAndDNS(kubectl, ciliumFilename)
-				testExternalTrafficPolicyLocal(kubectl, ni)
+				testExternalTrafficPolicyLocal(kubectl, ni, false)
 			})
 
 			It("", func() {


### PR DESCRIPTION
In v1.13 we stopped supporting the 4.9 kernel \[1\]. Therefore, we can remove the 4.9 CI pipeline for the main and v1.13 branches.

Previously, the 4.9 CI used to run with kube-proxy and KPR=disabled, while the 4.19 CI with kube-proxy and KPR=strict (aka mixed mode). This commit sets KPR=disabled in the 4.19 CI. The mixed mode is tested in the new ci-datapath GHA (minus the IPv6 until \[2\] has been resolved; this is fine).

\[1\]: https://github.com/cilium/cilium/issues/22116
\[2\]: https://github.com/cilium/cilium-cli/issues/1139
