### PR TITLE
test: Unquarantine working FQDN test

### DIFF
--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -94,7 +94,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 		_ = kubectl.Exec(fmt.Sprintf("%s delete --all cnp", helpers.KubectlCmd))
 	})
 
-	SkipItIf(helpers.SkipQuarantined, "Restart Cilium validate that FQDN is still working", func() {
+	It("Restart Cilium validate that FQDN is still working", func() {
 		// Test functionality:
 		// - When Cilium is running) Connectivity from App2 application can
 		// connect to DNS because dns-proxy filter the DNS request. If the

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -594,10 +594,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 
 		// Run on net-next and 4.19 but not on old versions, because of
 		// LRU requirement.
-		SkipItIf(func() bool {
-			return helpers.DoesNotRunOn419OrLaterKernel() ||
-				(helpers.SkipQuarantined() && helpers.RunsOnGKE())
-		}, "Supports IPv4 fragments", func() {
+		SkipItIf(helpers.DoesNotRunOn419OrLaterKernel, "Supports IPv4 fragments", func() {
 			options := map[string]string{}
 			// On GKE we need to disable endpoint routes as fragment tracking
 			// isn't compatible with that options. See #15958.


### PR DESCRIPTION
The first commit unquarantines an FQDN test that appears to have been quarantined by mistake (?). The second commit removes some dead code. See commits for details.