### PR TITLE
gha: Replace deprecated set-output commands

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -46,16 +46,16 @@ jobs:
       - name: Generating image tag for Cilium-Runtime
         id: runtime-tag
         run: |
-          echo ::set-output name=tag::"$(git ls-tree --full-tree HEAD -- ./images/runtime | awk '{ print $3 }')"
+          echo tag="$(git ls-tree --full-tree HEAD -- ./images/runtime | awk '{ print $3 }')" >> $GITHUB_OUTPUT
 
       - name: Checking if tag for Cilium-Runtime already exists
         id: cilium-runtime-tag-in-repositories
         shell: bash
         run: |
           if docker buildx imagetools inspect quay.io/${{ github.repository_owner }}/cilium-runtime:${{  steps.runtime-tag.outputs.tag }} &>/dev/null; then
-            echo ::set-output name=exists::"true"
+            echo exists="true" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=exists::"false"
+            echo exists="false" >> $GITHUB_OUTPUT
           fi
 
       - name: Login to quay.io
@@ -105,16 +105,16 @@ jobs:
       - name: Generating image tag for Cilium-Builder
         id: builder-tag
         run: |
-          echo ::set-output name=tag::"$(git ls-tree --full-tree HEAD -- ./images/builder | awk '{ print $3 }')"
+          echo tag="$(git ls-tree --full-tree HEAD -- ./images/builder | awk '{ print $3 }')" >> $GITHUB_OUTPUT
 
       - name: Checking if tag for Cilium-Builder already exists
         id: cilium-builder-tag-in-repositories
         shell: bash
         run: |
           if docker buildx imagetools inspect quay.io/${{ github.repository_owner }}/cilium-builder:${{  steps.builder-tag.outputs.tag }} &>/dev/null; then
-            echo ::set-output name=exists::"true"
+            echo exists="true" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=exists::"false"
+            echo exists="false" >> $GITHUB_OUTPUT
           fi
 
       - name: Login to quay.io

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          echo ::set-output name=tag::${GITHUB_REF##*/}
+          echo tag=${GITHUB_REF##*/} >> $GITHUB_OUTPUT
 
       - name: Checking if tag already exists
         id: tag-in-repositories

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -65,9 +65,9 @@ jobs:
         id: tag
         run: |
           if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
-            echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
+            echo tag=${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=tag::${{ github.sha }}
+            echo tag=${{ github.sha }} >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout Source Code

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          echo ::set-output name=tag::${GITHUB_REF##*/}
+          echo tag=${GITHUB_REF##*/} >> $GITHUB_OUTPUT
 
       - name: Checking if tag already exists
         id: tag-in-repositories

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          echo ::set-output name=tag::${GITHUB_REF##*/}
+          echo tag=${GITHUB_REF##*/} >> $GITHUB_OUTPUT
 
       - name: Checkout Source Code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -121,7 +121,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          echo ::set-output name=tag::${GITHUB_REF##*/}
+          echo tag=${GITHUB_REF##*/} >> $GITHUB_OUTPUT
       - name: Downloading Image Digests
         shell: bash
         run: |

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -47,7 +47,7 @@ jobs:
           else
             SHA=${{ github.sha }}
           fi
-          echo ::set-output name=sha::${SHA}
+          echo sha=${SHA} >> $GITHUB_OUTPUT
 
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -61,10 +61,10 @@ jobs:
             --relay-image=quay.io/${{ github.repository_owner }}/hubble-relay-ci:${SHA} \
             --relay-version=${SHA}"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled"
-          echo ::set-output name=cilium_install_defaults::${CILIUM_INSTALL_DEFAULTS}
-          echo ::set-output name=hubble_enable_defaults::${HUBBLE_ENABLE_DEFAULTS}
-          echo ::set-output name=connectivity_test_defaults::${CONNECTIVITY_TEST_DEFAULTS}
-          echo ::set-output name=sha::${SHA}
+          echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
+          echo hubble_enable_defaults=${HUBBLE_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
+          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
+          echo sha=${SHA} >> $GITHUB_OUTPUT
 
       - name: Install Cilium CLI
         run: |

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -60,9 +60,9 @@ jobs:
         id: vars
         run: |
           if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
-            echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
+            echo tag=${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=tag::${{ github.sha }}
+            echo tag=${{ github.sha }} >> $GITHUB_OUTPUT
           fi
 
       - name: Precheck generated connectivity manifest files

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -91,9 +91,9 @@ jobs:
         id: vars
         run: |
           if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
-            echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
+            echo tag=${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=tag::${{ github.sha }}
+            echo tag=${{ github.sha }} >> $GITHUB_OUTPUT
           fi
 
       - name: Precheck generated connectivity manifest files


### PR DESCRIPTION
The changes are done by below command, thanks to @tklauser in cilium/cilium-cli#1296

```bash
sed -i \
  '/::set-output/ {
    s/::set-output name=//;
    s/::/=/;
    s/$/ >> $GITHUB_OUTPUT/;
  }' \
.github/workflows/*.yaml
```

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Relates: #22890
Signed-off-by: Tam Mach <tam.mach@cilium.io>