### PR TITLE
proxy: Fix deadlock in error path of CreateOrUpdateRedirect

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -501,6 +501,17 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 
 	var revertStack revert.RevertStack
 	revertFunc = revertStack.Revert
+	defer func() {
+		if err != nil {
+			// We ignore errors while reverting. This is best-effort.
+			// revertFunc must be called after p.mutex is unlocked, because
+			// some functions in the revert stack (like removeRevertFunc)
+			// require it
+			p.mutex.Unlock()
+			revertFunc()
+			p.mutex.Lock()
+		}
+	}()
 
 	if redir, ok := p.redirects[id]; ok {
 		redir.mutex.Lock()
@@ -544,7 +555,6 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 	ppName, pp := findProxyPortByType(ProxyType(l4.GetL7Parser()), l4.GetListener(), l4.GetIngress())
 	if pp == nil {
 		err = proxyTypeNotFoundError(ProxyType(l4.GetL7Parser()), l4.GetListener(), l4.GetIngress())
-		revertFunc()
 		return 0, err, nil, nil
 	}
 
@@ -566,7 +576,6 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 			// been already configured.
 			pp.proxyPort, err = allocatePort(pp.proxyPort, p.rangeMin, p.rangeMax)
 			if err != nil {
-				revertFunc() // Ignore errors while reverting. This is best-effort.
 				return 0, err, nil, nil
 			}
 		}
@@ -629,7 +638,6 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 
 	// an error occurred, and we have no more retries
 	scopedLog.WithError(err).Errorf("Unable to create %s proxy %s", l4.GetL7Parser(), l4.GetListener())
-	revertFunc() // Ignore errors while reverting. This is best-effort.
 	return 0, err, nil, nil
 }
 


### PR DESCRIPTION
When an error occurs during CreateOrUpdateRedirect, it tries to revert previous actions by invoking the `revertFunc` in some (but not all) error paths.

This can unfortunately lead to a deadlock, because one of the `RevertFunc`s in its `revertStack` is the one returned by `p.removeRedirect`, which states in its contract that the `p.mutex` must not be held when the revert func is called. This contract was violated in the previous code, as `revertFunc` was called on errors paths without unlocking `p.mutex` first.

By moving the `revertFunc` into a defer statement, we ensure it's executed for all error paths. This means that the new code now also calls `implUpdateRevertFunc` in the two error cases "unable to update existing redirect" and "unable to remove old redirect".
