### PR TITLE
test: Exclude per-endpoint object files from artifacts

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -811,7 +811,7 @@ func (s *SSHMeta) DumpCiliumCommandOutput() {
 	// No need to create file for bugtool because it creates an archive of files
 	// for us.
 	res := s.ExecWithSudo(
-		fmt.Sprintf("%s -t %q", CiliumBugtool, filepath.Join(s.basePath, testPath)),
+		fmt.Sprintf("%s %s -t %q", CiliumBugtool, CiliumBugtoolArgs, filepath.Join(s.basePath, testPath)),
 		ExecOptions{SkipLog: true})
 	if !res.WasSuccessful() {
 		s.logger.Errorf("Error running bugtool: %s", res.CombineOutput())

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -162,6 +162,7 @@ const (
 
 	DaemonName             = "cilium"
 	CiliumBugtool          = "cilium-bugtool"
+	CiliumBugtoolArgs      = "--exclude-object-files"
 	CiliumDockerDaemonName = "cilium-docker"
 	AgentDaemon            = "cilium-agent"
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3604,8 +3604,8 @@ func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace strin
 
 		// Get bugtool output. Since bugtool output is dumped in the pod's filesystem,
 		// copy it over with `kubectl cp`.
-		bugtoolCmd := fmt.Sprintf("%s exec -n %s %s -- %s",
-			KubectlCmd, namespace, pod, CiliumBugtool)
+		bugtoolCmd := fmt.Sprintf("%s exec -n %s %s -- %s %s",
+			KubectlCmd, namespace, pod, CiliumBugtool, CiliumBugtoolArgs)
 		res := kub.ExecContext(ctx, bugtoolCmd, ExecOptions{SkipLog: true})
 		if !res.WasSuccessful() {
 			logger.Errorf("%s failed: %s", bugtoolCmd, res.CombineOutput().String())


### PR DESCRIPTION
Our Jenkins artifacts are regularly over 25MB and for that reason can't be attached to GitHub issues. We can reduce the size with the cilium-bugtool `--exclude-object-files` flag. That flag excludes per-endpoint object files from the bugtool reports (template object files are kept).

I'm tired of recompressing with 7z then zip just to be able to upload...