### PR TITLE
docs,daemon: Added discouragement warnings for MetalLB to docs and agent

### DIFF
--- a/Documentation/network/bgp.rst
+++ b/Documentation/network/bgp.rst
@@ -10,6 +10,11 @@
 BGP (beta)
 **********
 
+.. warning::
+  This feature will only receive security updates and bug fixes. It is recommended
+  to use the :ref:`BGP Control Plane <bgp_control_plane>` feature instead whenever
+  possible. More details are available at :gh-issue:`22246`.
+
 BGP provides a way to advertise routes using traditional networking protocols
 to allow Cilium-managed services to be accessible outside the cluster.
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -668,6 +668,10 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 
 	d.redirectPolicyManager = redirectpolicy.NewRedirectPolicyManager(d.svc)
 	if option.Config.BGPAnnounceLBIP || option.Config.BGPAnnouncePodCIDR {
+		log.WithField("url", "https://github.com/cilium/cilium/issues/22246").
+			Warn("You are using the legacy BGP feature, which will only receive security updates and bugfixes. " +
+				"It is recommended to migrate to the BGP Control Plane feature if possible, which has better support.")
+
 		d.bgpSpeaker, err = speaker.New(ctx, clientset, speaker.Opts{
 			LoadBalancerIP: option.Config.BGPAnnounceLBIP,
 			PodCIDR:        option.Config.BGPAnnouncePodCIDR,


### PR DESCRIPTION
Added warnings explaining that development on the MetalLB based BGP feature has stopped. The feature will not be deprecated in 1.13, so noted that security updates and bugfixes will still be applied.

Even though we can't officially deprecate yet, we would like to highly discourage adoption of the old feature unless absolutely necessary.

Fixes: #22246

Signed-off-by: Dylan Reimerink <dylan.reimerink@isovalent.com>

```release-note
 Added discouragement warnings for MetalLB to docs and agent
```
