### PR TITLE
workflow: Cover VXLAN + IPsec + endpoint routes in datapath tests

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -184,6 +184,15 @@ jobs:
             encryption-node: 'true'
             lb-mode: 'snat'
 
+          - name: '8'
+            kernel: 'bpf-next-main'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'vxlan'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+            endpoint-routes: 'true'
+
     timeout-minutes: 60
     steps:
       - name: Set up job variables


### PR DESCRIPTION
Commit https://github.com/cilium/cilium/commit/92a3e31428f60b91a1db6f7a2a658fa3e11fc2ad ("bpf: Remove link scope of cilium_host's IPv4 address") fixed connectivity via a NodePort service with tunneling and endpoint routes. Commit https://github.com/cilium/cilium/commit/d39ca10f849060ca90f4a1ddc54734d0e05ba80a ("ipsec: Don't match on packet mark for FWD XFRM policy") then fixed cross-node pod connectivity with tunneling, endpoint routes, and IPsec.

We can therefore start test this specific setup in the datapath tests. bpf-next is picked as the kernel to have some coverage of IPsec on the latest kernel. We currently rely on [some assumption on kernel internals](https://github.com/cilium/cilium/blob/v1.13.0-rc5/bpf/lib/encap.h#L24-L25).

Passing run with the test commit: https://github.com/cilium/cilium/actions/runs/4018394161.