### PR TITLE
.github: only run external-contribution-label from cilium/cilium

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -10,6 +10,7 @@ jobs:
   labeler:
     if: |
       (
+        (github.repository == 'cilium/cilium') &&
         (github.event.pull_request.author_association != 'OWNER') &&
         (github.event.pull_request.author_association != 'COLLABORATOR') &&
         (github.event.pull_request.author_association != 'MEMBER')


### PR DESCRIPTION
The upstream PR contributions are the only ones that might need help from Cilium maintainers. Thus we should only run this GH workflow from cilium/cilium.

Suggested-by: Joe Stringer <joe@cilium.io>
Signed-off-by: André Martins <andre@cilium.io>