### PR TITLE
docs: correct Prometheus port

### DIFF
--- a/Documentation/observability/grafana.rst
+++ b/Documentation/observability/grafana.rst
@@ -100,9 +100,9 @@ Expose the port on your local machine
 
 .. code-block:: shell-session
 
-    kubectl -n cilium-monitoring port-forward service/prometheus --address 0.0.0.0 --address :: 9962:9962
+    kubectl -n cilium-monitoring port-forward service/prometheus --address 0.0.0.0 --address :: 9090:9090
 
-Access it via your browser: http://localhost:9962
+Access it via your browser: http://localhost:9090
 
 Examples
 ========


### PR DESCRIPTION
The example monitoring deployment exposes Prometheus on port 9090, so that's what people should port-forward. Docs currently say 9962, but that's a port where prometheus can get metrics from Cilium.

Signed-off-by: Liz Rice <liz@lizrice.com>
