### PR TITLE
hubble-relay: set WORKDIR to nonroot home

### DIFF
--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -60,5 +60,6 @@ COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/hubble-relay /usr/bin
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 # use uid:gid for the nonroot user for compatibility with runAsNonRoot
 USER 65532:65532
+WORKDIR /home/nonroot
 ENTRYPOINT ["/usr/bin/hubble-relay"]
 CMD ["serve"]


### PR DESCRIPTION
Before this patch, when deployed with k8s v1.16 the Hubble Relay Pod would be in a CrashLoopBackOff state with the following error:

    Error: failed to start gops agent: open /1: permission denied

Fix https://github.com/cilium/cilium/issues/23374