### PR TITLE
.github/workflows: fix external contribution detection

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -18,10 +18,53 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Install Cilium CLI
+        # Detect if the secret 'CHECK_TEAM_ORG' is set. If it's not set, don't
+        # bother running this GH workflow.
+      - name: Check if CHECK_TEAM_ORG is set in github secrets
+        id: check_secret
         run: |
-          echo author_association=${{ github.event.pull_request.author_association }}
+          echo "is_CHECK_TEAM_ORG_set: ${{ secrets.CHECK_TEAM_ORG != '' }}"
+          echo is_CHECK_TEAM_ORG_set="${{ secrets.CHECK_TEAM_ORG != '' }}" >> $GITHUB_OUTPUT
+
+      - name: Get token
+        # Get a token with the read:org permissions so that the GH action
+        # can read the team membership for a user. We need to do this over a
+        # GH app because GH actions don't have support for these type of
+        # permissions.
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        id: get_token
+        uses: cilium/actions-app-token@350a14155dd9be79227f081310f4d77fdf792e76
+        with:
+          APP_PEM: ${{ secrets.CHECK_TEAM_ORG_PEM }}
+          APP_ID: ${{ secrets.CHECK_TEAM_ORG_APP_ID }}
+
+      - name: Check author association
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        id: author_association
+        # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+        with:
+          github-token: ${{ steps.get_token.outputs.app_token }}
+          script: |
+            try {
+              const result = await github.rest.orgs.checkMembershipForUser({
+                org: "${{ github.repository_owner }},"
+                username: "${{github.event.pull_request.user.login}}",
+              })
+              return result.status == 204;
+            } catch {
+              return false;
+            }
+
+      - name: Print author association
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        run: |
+          echo author_association_from_event=${{ github.event.pull_request.author_association }}
+          echo author_association_from_api=${{ steps.author_association.outputs.result }}
+
       - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }} && \
+            ${{ steps.author_association.outputs.result != 'true' }}
         with:
           script: |
             github.rest.issues.addLabels({


### PR DESCRIPTION
GH is unable to detect if an user belongs to an organization unless that user has that membership visible in their GH profile.

In order to fix this detection, this commit adds a script to perform the membership request from with a GH token that has permissions to read the all members that belong to the Cilium organization.

Fixes: d4aedd9c592f (".github/workflows: print author association")
Signed-off-by: André Martins <andre@cilium.io>
