### PR TITLE
v1.10 Backports 2023-01-27

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -18,7 +18,53 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+        # Detect if the secret 'CHECK_TEAM_ORG' is set. If it's not set, don't
+        # bother running this GH workflow.
+      - name: Check if CHECK_TEAM_ORG is set in github secrets
+        id: check_secret
+        run: |
+          echo "is_CHECK_TEAM_ORG_set: ${{ secrets.CHECK_TEAM_ORG != '' }}"
+          echo is_CHECK_TEAM_ORG_set="${{ secrets.CHECK_TEAM_ORG != '' }}" >> $GITHUB_OUTPUT
+
+      - name: Get token
+        # Get a token with the read:org permissions so that the GH action
+        # can read the team membership for a user. We need to do this over a
+        # GH app because GH actions don't have support for these type of
+        # permissions.
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        id: get_token
+        uses: cilium/actions-app-token@350a14155dd9be79227f081310f4d77fdf792e76
+        with:
+          APP_PEM: ${{ secrets.CHECK_TEAM_ORG_PEM }}
+          APP_ID: ${{ secrets.CHECK_TEAM_ORG_APP_ID }}
+
+      - name: Check author association
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        id: author_association
+        # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+        with:
+          github-token: ${{ steps.get_token.outputs.app_token }}
+          script: |
+            try {
+              const result = await github.rest.orgs.checkMembershipForUser({
+                org: "${{ github.repository_owner }},"
+                username: "${{github.event.pull_request.user.login}}",
+              })
+              return result.status == 204;
+            } catch {
+              return false;
+            }
+
+      - name: Print author association
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        run: |
+          echo author_association_from_event=${{ github.event.pull_request.author_association }}
+          echo author_association_from_api=${{ steps.author_association.outputs.result }}
+
       - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }} && \
+            ${{ steps.author_association.outputs.result != 'true' }}
         with:
           script: |
             github.rest.issues.addLabels({

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -110,7 +110,7 @@ archive_filename = archive_name + '.tar.gz'
 archive_link = github_repo + 'archive/' + archive_filename
 archive_name = 'cilium-' + archive_name.strip('v')
 project_link = github_repo + 'projects?query=is:open+' + next_release
-backport_format = github_repo + 'pulls?q=is:open+is:pr+label:%s/' + current_release
+backport_format = github_repo + 'pulls?q=is:open+is:pr+-label:backport/author+label:%s/' + current_release
 
 # Store variables in the epilogue so they are globally available.
 rst_epilog = """

--- a/Documentation/contributing/governance/commit_access.rst
+++ b/Documentation/contributing/governance/commit_access.rst
@@ -54,14 +54,15 @@ Expectations for Developers with commit access
 Pre-requisites
 ~~~~~~~~~~~~~~
 
-Be familiar with the :ref:`dev_guide`.
+Be familiar with the :ref:`dev_guide` and have `2-Factor Authentication
+<https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication>`__ 
+enabled on your Github account.
 
 Review
 ~~~~~~
 
 Code (yours or others') must be reviewed publicly (by you or others)
-before you push it to the repository. With one exception (see below),
-every change needs at least one review.
+before you push it to the repository. Every change needs at least one review.
 
 If one or more people know an area of code particularly well, code that
 affects that area should ordinarily get a review from one of them.
@@ -76,11 +77,6 @@ good," then this is probably not a quality review.
 review, but it is not strictly tied to it. A search and replace across
 many files may not need much review, but one-line optimization changes
 can have widespread implications.)
-
-Your own small changes to fix a recently broken build ("make") or tests
-("make check"), that you believe to be visible to a large number of
-developers, may be checked in without review. If you are not sure, ask
-for review.
 
 Regularly review submitted code in areas where you have expertise.
 Consider reviewing other code as well.

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -59,6 +59,14 @@ maintainers when the PR is reviewed. When proposing PRs that have already been
 merged, also add a comment to the PR to ensure that the backporters are
 notified.
 
+Marking PRs to be backported by the author
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For PRs which need to be backported, but are likely to run into conflicts or
+other difficulties, the author has the option of adding the ``backport/author``
+label. This will exclude the PR from backporting automation, and the author is
+expected to perform the backport themselves.
+
 Backporting Guide for the Backporter
 ------------------------------------
 
@@ -314,7 +322,9 @@ Original Committers and Reviewers
 Committers should mark PRs needing backport as ``needs-backport/X.Y``, based on
 the `backport criteria <backport_criteria_>`_. It is up to the reviewers to
 confirm that the backport request is reasonable and, if not, raise concerns on
-the PR as comments.
+the PR as comments. In addition, if conflicts are foreseen or significant
+changes to the PR are necessary for older branches, consider adding the
+``backport/author`` label to mark the PR to be backported by the author.
 
 At some point, changes will be picked up on a backport PR and the committer will
 be notified and asked to approve the backport commits. Confirm that:

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -266,6 +266,14 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
            cilium install
            cilium status --wait
 
+       .. note::
+
+           If you have to uninstall Cilium and later install it again, that could cause
+           connectivity issues due to ``aws-node`` DaemonSet flushing Linux routing tables.
+           The issues can be fixed by restarting all pods, alternatively to avoid such issues
+           you can delete ``aws-node`` DaemonSet prior to installing Cilium.
+
+
     .. group-tab:: OpenShift
 
        .. include:: requirements-openshift.rst

--- a/Documentation/gettingstarted/k8s-install-helm.rst
+++ b/Documentation/gettingstarted/k8s-install-helm.rst
@@ -153,14 +153,14 @@ Install Cilium
 
        .. include:: requirements-eks.rst
 
-       **Delete VPC CNI (``aws-node`` DaemonSet)**
+       **Patch VPC CNI (aws-node DaemonSet)**
 
        Cilium will manage ENIs instead of VPC CNI, so the ``aws-node``
-       DaemonSet has to be deleted to prevent conflict behavior.
+       DaemonSet has to be patched to prevent conflict behavior.
 
        .. code-block:: shell-session
 
-          kubectl -n kube-system delete daemonset aws-node
+          kubectl -n kube-system patch daemonset aws-node --type='strategic' -p='{"spec":{"template":{"spec":{"nodeSelector":{"io.cilium/aws-node-enabled":"true"}}}}}'
 
        **Install Cilium:**
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1189,7 +1189,10 @@ domain name.
 Limitations and known issues
 ----------------------------
 
-The current known limitation is a deny policy with ``toEntities`` "world" for
+Deny policies for peers outside the cluster may be ineffectual due to
+:gh-issue:`15198`.
+
+One example of this would be a deny policy with ``toEntities`` "world" for
 which a ``toFQDNs`` can cause traffic to be allowed if such traffic is
 considered external to the cluster.
 

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -185,7 +185,8 @@ gitlib::github_api_token
 
 echo "Checking for backports on branch '${STABLE_BRANCH}'"
 
-stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport-done/${STABLE_BRANCH}"))
+# Don't consider PRs with `backport/author`, which the author will backport themselves.
+stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport/author" ))
 echo -e "v$STABLE_BRANCH backports $(date +%Y-%m-%d)\n" | tee $SUMMARY_LOG
 echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -163,7 +163,7 @@ func ipSecReplaceStateIn(localIP, remoteIP net.IP, zeroMark bool) (uint8, error)
 	return key.Spi, netlink.XfrmStateAdd(state)
 }
 
-func ipSecReplaceStateOut(remoteIP, localIP net.IP) (uint8, error) {
+func ipSecReplaceStateOut(localIP, remoteIP net.IP) (uint8, error) {
 	key := getIPSecKeys(localIP)
 	if key == nil {
 		return 0, fmt.Errorf("IPSec key missing")
@@ -395,7 +395,7 @@ func UpsertIPsecEndpoint(local, remote *net.IPNet, outerLocal, outerRemote net.I
 		}
 
 		if dir == IPSecDirOut || dir == IPSecDirOutNode || dir == IPSecDirBoth {
-			if spi, err = ipSecReplaceStateOut(outerRemote, outerLocal); err != nil {
+			if spi, err = ipSecReplaceStateOut(outerLocal, outerRemote); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace remote state: %s", err)
 				}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -135,15 +135,15 @@ func ipSecJoinState(state *netlink.XfrmState, keys *ipSecKey) {
 	state.Reqid = keys.ReqID
 }
 
-func ipSecReplaceStateIn(remoteIP, localIP net.IP, zeroMark bool) (uint8, error) {
-	key := getIPSecKeys(localIP)
+func ipSecReplaceStateIn(localIP, remoteIP net.IP, zeroMark bool) (uint8, error) {
+	key := getIPSecKeys(remoteIP)
 	if key == nil {
 		return 0, fmt.Errorf("IPSec key missing")
 	}
 	state := ipSecNewState()
 	ipSecJoinState(state, key)
-	state.Src = localIP
-	state.Dst = remoteIP
+	state.Src = remoteIP
+	state.Dst = localIP
 	state.Mark = &netlink.XfrmMark{
 		Value: linux_defaults.RouteMarkDecrypt,
 		Mask:  linux_defaults.IPsecMarkMaskIn,


### PR DESCRIPTION
 * [x] #22620 (@NikAleksandrov)
   * Minor conflict due to docs reorganisation
 * [x] #22654 (@bimmlerd)
 * [x] #22619 (@aspsk)
 * [x] #23095 (@joestringer)
 * [x] #23134 (@xmulligan)
   * Minor conflict due to docs reorganisation
 * [x] #23158 (@pchaigno)
 * [x] #23406 (@aanm)
   * Minor conflict due to Dependabot having updated an image digest on v1.10.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 22620 22654 22619 23095 23134 23158 23406; do contrib/backporting/set-labels.py $pr done 1.10; done
```
or with
```
$ make add-label BRANCH=v1.10 ISSUES=22620,22726,22654,22619,23095,23134,23158,23406
```

Left aside:

* #20350 - Conflicts due to source file missing. I think this is because https://github.com/cilium/cilium/pull/20350 has not been marked for backports to v1.10 (see for example https://github.com/cilium/cilium/pull/23097). Cc @tommyp1ckles 