### PR TITLE
.github/workflows: fix typo in organization parameter

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -48,7 +48,7 @@ jobs:
           script: |
             try {
               const result = await github.rest.orgs.checkMembershipForUser({
-                org: "${{ github.repository_owner }},"
+                org: "${{ github.repository_owner }}",
                 username: "${{github.event.pull_request.user.login}}",
               })
               return result.status == 204;


### PR DESCRIPTION
The comma should not be part of the organization name.

Fixes: a71374d83214 (".github/workflows: fix external contribution detection")
Signed-off-by: André Martins <andre@cilium.io>