### PR TITLE
tooling: remove depedency on GOPATH for k8s api generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,12 +326,7 @@ generate-hubble-api: api/v1/flow/flow.proto api/v1/peer/peer.proto api/v1/observ
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C api/v1
 
 generate-k8s-api: ## Generate Cilium k8s API client, deepcopy and deepequal Go sources.
-	@if [ -z "$(GOPATH)" ] || [ ! -d "$(GOPATH)/src/github.com/cilium/cilium" ] || \
-		[ "$(PWD)" != "$(GOPATH)/src/github.com/cilium/cilium" ]; then \
-		echo "Set \$$GOPATH to a directory containing the Cilium repository at \$$GOPATH/src/github.com/cilium/cilium."; \
-		echo "The current working directory must be the repository root for code generation to work correctly."; \
-		exit 1; \
-	fi
+	$(ASSERT_CILIUM_MODULE)
 
 	$(call generate_k8s_protobuf,$\
 	github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1$(comma)$\

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -217,3 +217,10 @@ endef
 define print_help_from_makefile
   @awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9][a-zA-Z0-9 _-]*:.*?##/ { split($$1, targets, " "); for (i in targets) { printf "  \033[36m%-28s\033[0m %s\n", targets[i], $$2 } } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 endef
+
+# Use to ensure the CWD, or any child of it, belongs to Cilium's go module.
+CILIUM_GO_MODULE = github.com/cilium/cilium
+CURRENT_GO_MODULE = $(shell go list -m)
+define ASSERT_CILIUM_MODULE
+	$(if $(filter $(CILIUM_GO_MODULE), $(CURRENT_GO_MODULE)) ,, $(error "Could not locate Cilium's go.mod file, are you in Cilium's repository?"))
+endef


### PR DESCRIPTION
this commit removes the hard-coded pathing required for `make generate-k8s-api`.

it is now possible to generate k8s API inside a git worktree.

the only requirement is that `go list -m` returns Cilium's module name when ran in the root, or any child of it, directory.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>

```release-note
Remove dependency on $GOPATH for `make generate-k8s-api`
```
