### PR TITLE
fqdn/dnsproxy: move init LRU cache call out of StartDNSProxy.

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
+	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
 	secIDCache "github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ip"
@@ -348,6 +349,9 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	} else if port == 0 {
 		// Try locate old DNS proxy port number from the datapath
 		port = d.datapath.GetProxyPort(proxy.DNSProxyName)
+	}
+	if err := re.InitRegexCompileLRU(option.Config.FQDNRegexCompileLRUSize); err != nil {
+		return fmt.Errorf("could not initialize regex LRU cache: %w", err)
 	}
 	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
 		option.Config.DNSMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -569,10 +569,6 @@ func StartDNSProxy(
 	notifyFunc NotifyOnDNSMsgFunc,
 	concurrencyLimit int, concurrencyGracePeriod time.Duration,
 ) (*DNSProxy, error) {
-	if err := re.InitRegexCompileLRU(option.Config.FQDNRegexCompileLRUSize); err != nil {
-		return nil, fmt.Errorf("failed to start DNS proxy: %w", err)
-	}
-
 	if port == 0 {
 		log.Debug("DNS Proxy port is configured to 0. A random port will be assigned by the OS.")
 	}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -195,6 +195,8 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))
 
 	option.Config.FQDNRegexCompileLRUSize = 1024
+	err := re.InitRegexCompileLRU(option.Config.FQDNRegexCompileLRUSize)
+	c.Assert(err, IsNil)
 	proxy, err := StartDNSProxy("", 0, true, 1000, // any address, any port, enable compression, max 1000 restore IPs
 		// LookupEPByIP
 		func(ip net.IP) (*endpoint.Endpoint, error) {


### PR DESCRIPTION
LRU init does global init and doesn't need to be part of starting the FQDN proxy.

Signed-off-by: Tom Hadlaw <tom.hadlaw@isovalent.com>


```release-note
fqdn/dnsproxy: move init LRU cache call out of StartDNSProxy. 
```