### PR TITLE
.github: set do not use provenance from docker buildx

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -38,8 +38,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Set up QEMU
         id: qemu
@@ -87,6 +85,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_release_runtime
         with:
+          provenance: false
           context: ./images/runtime
           file: ./images/runtime/Dockerfile
           push: true
@@ -184,6 +183,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_release_builder
         with:
+          provenance: false
           context: ./images/builder
           file: ./images/builder/Dockerfile
           push: true

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -63,8 +63,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -96,6 +94,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_release
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -74,8 +74,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to quay.io for CI
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -121,6 +119,7 @@ jobs:
       - name: Copy ${{ matrix.name }} Golang cache to docker cache
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         with:
+          provenance: false
           context: /tmp/.cache/${{ matrix.name }}
           file: ./images/cache/Dockerfile
           push: false
@@ -143,6 +142,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_master
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           # Only push when the event name was a GitHub push, this is to avoid
@@ -162,6 +162,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_master_detect_race_condition
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           # Only push when the event name was a GitHub push, this is to avoid
@@ -184,6 +185,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_master_unstripped
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           # Only push when the event name was a GitHub push, this is to avoid
@@ -266,6 +268,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_pr
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
@@ -281,6 +284,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_pr_detect_race_condition
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
@@ -299,6 +303,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_pr_unstripped
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
@@ -381,6 +386,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request_target' && steps.cache.outputs.cache-hit != 'true' }}
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         with:
+          provenance: false
           context: .
           file: ./images/cache/Dockerfile
           push: false

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -57,8 +57,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -90,6 +88,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_release
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -58,8 +58,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to DockerHub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -88,6 +86,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_release
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true


### PR DESCRIPTION
.github: set do not use provenance from docker buildx

This reverts commit 9ab03d05ef3d347a305456f66cb3901a7b389e31.

GitHub recently rolled out Docker buildx version v0.10.0 on their
builders, which transparently changed the MediaType of docker images to
OCI v1 and added provenance attestations.

Unfortunately, various tools we use in CI like SBOM tooling and docker
manifest inspect do not properly support some aspect of the new image
formats. This resulted in breaking CI, with some messages like this:

    level=fatal msg="generating doc: creating SPDX document: generating
    SPDX package from image ref quay.io/cilium/docker-plugin-ci:XXX:
    generating image package"

This could also lead CI to fail while waiting for image builds to
complete, because the command we use to test whether the image is
available did not support the image types.

The commit 9ab03d05ef3d347a305456f66cb3901a7b389e31 attempted to fix
this problem by pinning the buildx version to v0.9.1 but unfortunately
that didn't work since that version became unavailable. This commit
reverts those changes and adds the "provenance: false", which is a
flag available in docker buildx >= v0.10.0, to disable the provenance
attestation.