### PR TITLE
.github/workflows: set right secret name

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -18,20 +18,20 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-        # Detect if the secret 'CHECK_TEAM_ORG' is set. If it's not set, don't
+        # Detect if the secret 'CHECK_TEAM_ORG_APP_ID' is set. If it's not set, don't
         # bother running this GH workflow.
-      - name: Check if CHECK_TEAM_ORG is set in github secrets
+      - name: Check if CHECK_TEAM_ORG_APP_ID is set in github secrets
         id: check_secret
         run: |
-          echo "is_CHECK_TEAM_ORG_set: ${{ secrets.CHECK_TEAM_ORG != '' }}"
-          echo is_CHECK_TEAM_ORG_set="${{ secrets.CHECK_TEAM_ORG != '' }}" >> $GITHUB_OUTPUT
+          echo "is_CHECK_TEAM_ORG_APP_ID_set: ${{ secrets.CHECK_TEAM_ORG_APP_ID != '' }}"
+          echo is_CHECK_TEAM_ORG_APP_ID_set="${{ secrets.CHECK_TEAM_ORG_APP_ID != '' }}" >> $GITHUB_OUTPUT
 
       - name: Get token
         # Get a token with the read:org permissions so that the GH action
         # can read the team membership for a user. We need to do this over a
         # GH app because GH actions don't have support for these type of
         # permissions.
-        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }}
         id: get_token
         uses: cilium/actions-app-token@350a14155dd9be79227f081310f4d77fdf792e76
         with:
@@ -39,7 +39,7 @@ jobs:
           APP_ID: ${{ secrets.CHECK_TEAM_ORG_APP_ID }}
 
       - name: Check author association
-        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }}
         uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975
         id: author_association
         # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
@@ -57,13 +57,13 @@ jobs:
             }
 
       - name: Print author association
-        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }}
         run: |
           echo author_association_from_event=${{ github.event.pull_request.author_association }}
           echo author_association_from_api=${{ steps.author_association.outputs.result }}
 
       - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975
-        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }} && \
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }} && \
             ${{ steps.author_association.outputs.result != 'true' }}
         with:
           script: |


### PR DESCRIPTION
The secret store in GH settings is CHECK_TEAM_ORG_APP_ID, and not the CHECK_TEAM_ORG which was used during development.

Fixes: a71374d83214 (".github/workflows: fix external contribution detection")
Signed-off-by: André Martins <andre@cilium.io>