### PR TITLE
helm: Add SA automount configuration

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -156,11 +156,19 @@
    * - certgen
      - Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually.
      - object
-     - ``{"annotations":{"cronJob":{},"job":{}},"image":{"digest":"sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.8","useDigest":true},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}``
+     - ``{"annotations":{"cronJob":{},"job":{}},"extraVolumeMounts":[],"extraVolumes":[],"image":{"digest":"sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.8","useDigest":true},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}``
    * - certgen.annotations
      - Annotations to be added to the hubble-certgen initial Job and CronJob
      - object
      - ``{"cronJob":{},"job":{}}``
+   * - certgen.extraVolumeMounts
+     - Additional certgen volumeMounts.
+     - list
+     - ``[]``
+   * - certgen.extraVolumes
+     - Additional certgen volumes.
+     - list
+     - ``[]``
    * - certgen.podLabels
      - Labels to be added to hubble-certgen pods
      - object
@@ -223,6 +231,14 @@
      - ``{}``
    * - clustermesh.apiserver.extraEnv
      - Additional clustermesh-apiserver environment variables.
+     - list
+     - ``[]``
+   * - clustermesh.apiserver.extraVolumeMounts
+     - Additional clustermesh-apiserver volumeMounts.
+     - list
+     - ``[]``
+   * - clustermesh.apiserver.extraVolumes
+     - Additional clustermesh-apiserver volumes.
      - list
      - ``[]``
    * - clustermesh.apiserver.image
@@ -663,6 +679,14 @@
      - ``["https://CHANGE-ME:2379"]``
    * - etcd.extraArgs
      - Additional cilium-etcd-operator container arguments.
+     - list
+     - ``[]``
+   * - etcd.extraVolumeMounts
+     - Additional cilium-etcd-operator volumeMounts.
+     - list
+     - ``[]``
+   * - etcd.extraVolumes
+     - Additional cilium-etcd-operator volumes.
      - list
      - ``[]``
    * - etcd.image
@@ -1125,6 +1149,14 @@
      - Additional hubble-ui backend environment variables.
      - list
      - ``[]``
+   * - hubble.ui.backend.extraVolumeMounts
+     - Additional hubble-ui backend volumeMounts.
+     - list
+     - ``[]``
+   * - hubble.ui.backend.extraVolumes
+     - Additional hubble-ui backend volumes.
+     - list
+     - ``[]``
    * - hubble.ui.backend.image
      - Hubble-ui backend image.
      - object
@@ -1139,6 +1171,14 @@
      - ``false``
    * - hubble.ui.frontend.extraEnv
      - Additional hubble-ui frontend environment variables.
+     - list
+     - ``[]``
+   * - hubble.ui.frontend.extraVolumeMounts
+     - Additional hubble-ui frontend volumeMounts.
+     - list
+     - ``[]``
+   * - hubble.ui.frontend.extraVolumes
+     - Additional hubble-ui frontend volumes.
      - list
      - ``[]``
    * - hubble.ui.frontend.image
@@ -1769,6 +1809,14 @@
      - Additional preflight environment variables.
      - list
      - ``[]``
+   * - preflight.extraVolumeMounts
+     - Additional preflight volumeMounts.
+     - list
+     - ``[]``
+   * - preflight.extraVolumes
+     - Additional preflight volumes.
+     - list
+     - ``[]``
    * - preflight.image
      - Cilium pre-flight image.
      - object
@@ -1940,11 +1988,11 @@
    * - serviceAccounts.clustermeshcertgen
      - Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob
      - object
-     - ``{"annotations":{},"create":true,"name":"clustermesh-apiserver-generate-certs"}``
+     - ``{"annotations":{},"automount":true,"create":true,"name":"clustermesh-apiserver-generate-certs"}``
    * - serviceAccounts.hubblecertgen
      - Hubblecertgen is used if hubble.tls.auto.method=cronJob
      - object
-     - ``{"annotations":{},"create":true,"name":"hubble-generate-certs"}``
+     - ``{"annotations":{},"automount":true,"create":true,"name":"hubble-generate-certs"}``
    * - sleepAfterInit
      - Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node.
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -89,8 +89,10 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |
 | bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY to reduce reliance on iptables rules for implementing Layer 7 policy. |
 | bpf.vlanBypass | list | `[]` | Configure explicitly allowed VLAN id's for bpf logic bypass. [0] will allow all VLAN id's without any filtering. |
-| certgen | object | `{"annotations":{"cronJob":{},"job":{}},"image":{"digest":"sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.8","useDigest":true},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
+| certgen | object | `{"annotations":{"cronJob":{},"job":{}},"extraVolumeMounts":[],"extraVolumes":[],"image":{"digest":"sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.1.8","useDigest":true},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.annotations | object | `{"cronJob":{},"job":{}}` | Annotations to be added to the hubble-certgen initial Job and CronJob |
+| certgen.extraVolumeMounts | list | `[]` | Additional certgen volumeMounts. |
+| certgen.extraVolumes | list | `[]` | Additional certgen volumes. |
 | certgen.podLabels | object | `{}` | Labels to be added to hubble-certgen pods |
 | certgen.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | certgen.ttlSecondsAfterFinished | int | `1800` | Seconds after which the completed job pod will be deleted |
@@ -107,6 +109,8 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.etcd.init.resources | object | `{}` | Specifies the resources for etcd init container in the apiserver |
 | clustermesh.apiserver.etcd.resources | object | `{}` | Specifies the resources for etcd container in the apiserver |
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
+| clustermesh.apiserver.extraVolumeMounts | list | `[]` | Additional clustermesh-apiserver volumeMounts. |
+| clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |
 | clustermesh.apiserver.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver-ci","tag":"latest","useDigest":false}` | Clustermesh API server image. |
 | clustermesh.apiserver.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
@@ -217,6 +221,8 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |
 | etcd.endpoints | list | `["https://CHANGE-ME:2379"]` | List of etcd endpoints (not needed when using managed=true). |
 | etcd.extraArgs | list | `[]` | Additional cilium-etcd-operator container arguments. |
+| etcd.extraVolumeMounts | list | `[]` | Additional cilium-etcd-operator volumeMounts. |
+| etcd.extraVolumes | list | `[]` | Additional cilium-etcd-operator volumes. |
 | etcd.image | object | `{"digest":"sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-etcd-operator","tag":"v2.0.7","useDigest":true}` | cilium-etcd-operator image. |
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
 | etcd.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -332,10 +338,14 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.tls.server.extraIpAddresses | list | `[]` | Extra IP addresses added to certificate when it's auto generated |
 | hubble.ui.affinity | object | `{}` | Affinity for hubble-ui |
 | hubble.ui.backend.extraEnv | list | `[]` | Additional hubble-ui backend environment variables. |
+| hubble.ui.backend.extraVolumeMounts | list | `[]` | Additional hubble-ui backend volumeMounts. |
+| hubble.ui.backend.extraVolumes | list | `[]` | Additional hubble-ui backend volumes. |
 | hubble.ui.backend.image | object | `{"digest":"sha256:cc5e2730b3be6f117b22176e25875f2308834ced7c3aa34fb598aa87a2c0a6a4","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"v0.10.0","useDigest":true}` | Hubble-ui backend image. |
 | hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
 | hubble.ui.enabled | bool | `false` | Whether to enable the Hubble UI. |
 | hubble.ui.frontend.extraEnv | list | `[]` | Additional hubble-ui frontend environment variables. |
+| hubble.ui.frontend.extraVolumeMounts | list | `[]` | Additional hubble-ui frontend volumeMounts. |
+| hubble.ui.frontend.extraVolumes | list | `[]` | Additional hubble-ui frontend volumes. |
 | hubble.ui.frontend.image | object | `{"digest":"sha256:118ad2fcfd07fabcae4dde35ec88d33564c9ca7abe520aa45b1eb13ba36c6e0a","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui","tag":"v0.10.0","useDigest":true}` | Hubble-ui frontend image. |
 | hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |
@@ -493,6 +503,8 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-preflight |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
 | preflight.extraEnv | list | `[]` | Additional preflight environment variables. |
+| preflight.extraVolumeMounts | list | `[]` | Additional preflight volumeMounts. |
+| preflight.extraVolumes | list | `[]` | Additional preflight volumes. |
 | preflight.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-ci","tag":"latest","useDigest":false}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/  |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
@@ -535,8 +547,8 @@ contributors across the globe, there is almost always someone available to help.
 | securityContext.privileged | bool | `false` | Run the pod with elevated privileges |
 | securityContext.seLinuxOptions | object | `{"level":"s0","type":"spc_t"}` | SELinux options for the `cilium-agent` and init containers |
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
-| serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
-| serviceAccounts.hubblecertgen | object | `{"annotations":{},"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |
+| serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"automount":true,"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
+| serviceAccounts.hubblecertgen | object | `{"annotations":{},"automount":true,"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |
 | sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
 | socketLB | object | `{"enabled":false}` | Configure socket LB |
 | socketLB.enabled | bool | `false` | Enable socket LB |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -668,6 +668,7 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.cilium.name | quote }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.cilium.automount }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       hostNetwork: true
       {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -219,6 +219,7 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.operator.priorityClassName "system-cluster-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.operator.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.operator.name | quote }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.operator.automount }}
       {{- with .Values.operator.affinity }}
       # In HA mode, cilium-operator pods must not be scheduled on the same
       # node as they will clash with each other.

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -75,6 +75,9 @@ spec:
             readOnly: true
           {{- end }}
           {{- end }}
+          {{- with .Values.preflight.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- with .Values.preflight.resources }}
           resources:
             {{- toYaml . | trim | nindent 12 }}
@@ -131,6 +134,9 @@ spec:
             readOnly: true
           {{- end }}
           {{- end }}
+          {{- with .Values.preflight.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- with .Values.preflight.extraEnv }}
           {{- toYaml . | trim | nindent 10 }}
           {{- end }}
@@ -155,6 +161,7 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.preflight.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.preflight.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.preflight.name | quote }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.preflight.automount }}
       terminationGracePeriodSeconds: {{ .Values.preflight.terminationGracePeriodSeconds }}
       {{- with .Values.preflight.tolerations }}
       tolerations:
@@ -188,6 +195,9 @@ spec:
           # note: the leading zero means this number is in octal representation: do not remove it
           defaultMode: 0400
           optional: true
+      {{- end }}
+      {{- with .Values.preflight.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -160,6 +160,9 @@ spec:
         - name: etcd-admin-client
           mountPath: /var/lib/cilium/etcd-secrets
           readOnly: true
+        {{- with .Values.clustermesh.apiserver.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
       volumes:
       - name: etcd-server-secrets
@@ -174,10 +177,14 @@ spec:
           defaultMode: 0400
       - name: etcd-data-dir
         emptyDir: {}
+      {{- with .Values.clustermesh.apiserver.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.clustermesh.apiserver.priorityClassName "system-cluster-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.clustermeshApiserver.automount }}
       {{- with .Values.clustermesh.apiserver.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -41,13 +41,22 @@ spec:
             - "--clustermesh-apiserver-remote-cert-generate"
             - "--clustermesh-apiserver-remote-cert-validity-duration={{ $certValiditySecondsStr }}"
             {{- end }}
+          {{- with .Values.certgen.extraVolumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       hostNetwork: true
       serviceAccount: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.clustermeshcertgen.automount }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
+      {{- with .Values.certgen.extraVolumes }}
+      volumes:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
   ttlSecondsAfterFinished: {{ .Values.certgen.ttlSecondsAfterFinished }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -90,12 +90,17 @@ spec:
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
         terminationMessagePolicy: FallbackToLogsOnError
+        {{- with .Values.etcd.extraVolumeMounts }}
+        volumeMounts:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       dnsPolicy: ClusterFirst
       hostNetwork: true
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.clustermesh.apiserver.priorityClassName "system-cluster-critical") }}
       restartPolicy: Always
       serviceAccount: {{ .Values.serviceAccounts.etcd.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.etcd.name | quote }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.etcd.automount }}
 {{- with .Values.etcd.nodeSelector }}
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
@@ -104,4 +109,8 @@ spec:
       tolerations:
       {{- toYaml . | trim | nindent 6 }}
 {{- end }}
+      {{- with .Values.etcd.extraVolumes }}
+      volumes:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -100,7 +100,7 @@ spec:
       priorityClassName: {{ .Values.hubble.relay.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.relay.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.relay.name | quote }}
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ .Values.serviceAccounts.relay.automount }}
       terminationGracePeriodSeconds: {{ .Values.hubble.relay.terminationGracePeriodSeconds }}
       {{- with .Values.hubble.relay.affinity }}
       affinity:

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -40,6 +40,7 @@ spec:
       priorityClassName: {{ .Values.hubble.ui.priorityClassName }}
       serviceAccount: {{ .Values.serviceAccounts.ui.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.ui.name | quote }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.ui.automount }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -60,11 +61,14 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
         volumeMounts:
-          - name: hubble-ui-nginx-conf
-            mountPath: /etc/nginx/conf.d/default.conf
-            subPath: nginx.conf
-          - name: tmp-dir
-            mountPath: /tmp
+        - name: hubble-ui-nginx-conf
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: nginx.conf
+        - name: tmp-dir
+          mountPath: /tmp
+        {{- with .Values.hubble.ui.frontend.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
       - name: backend
         image: {{ include "cilium.image" .Values.hubble.ui.backend.image | quote }}
@@ -104,6 +108,9 @@ spec:
         - name: hubble-ui-client-certs
           mountPath: /var/lib/hubble-ui/certs
           readOnly: true
+        {{- end }}
+        {{- with .Values.hubble.ui.backend.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
       {{- with .Values.hubble.ui.affinity }}
@@ -155,5 +162,11 @@ spec:
                 - key: tls.key
                   path: client.key
       {{- end }}
+      {{- end }}
+      {{- with .Values.hubble.ui.frontend.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.hubble.ui.backend.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
@@ -43,6 +43,10 @@ spec:
             - "--hubble-relay-server-cert-generate"
             - "--hubble-relay-server-cert-validity-duration={{ $certValiditySecondsStr }}"
             {{- end }}
+          {{- with .Values.certgen.extraVolumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       hostNetwork: true
       {{- with .Values.certgen.tolerations }}
       tolerations:
@@ -50,10 +54,15 @@ spec:
       {{- end }}
       serviceAccount: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.hubblecertgen.automount }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
+      {{- with .Values.certgen.extraVolumes }}
+      volumes:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
   ttlSecondsAfterFinished: {{ .Values.certgen.ttlSecondsAfterFinished }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -53,40 +53,49 @@ serviceAccounts:
   cilium:
     create: true
     name: cilium
+    automount: true
     annotations: {}
   etcd:
     create: true
     name: cilium-etcd-operator
+    automount: true
     annotations: {}
   operator:
     create: true
     name: cilium-operator
+    automount: true
     annotations: {}
   preflight:
     create: true
     name: cilium-pre-flight
+    automount: true
     annotations: {}
   relay:
     create: true
     name: hubble-relay
+    automount: false
     annotations: {}
   ui:
     create: true
     name: hubble-ui
+    automount: true
     annotations: {}
   clustermeshApiserver:
     create: true
     name: clustermesh-apiserver
+    automount: true
     annotations: {}
   # -- Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob
   clustermeshcertgen:
     create: true
     name: clustermesh-apiserver-generate-certs
+    automount: true
     annotations: {}
   # -- Hubblecertgen is used if hubble.tls.auto.method=cronJob
   hubblecertgen:
     create: true
     name: hubble-generate-certs
+    automount: true
     annotations: {}
 
 # -- Configure termination grace period for cilium-agent DaemonSet.
@@ -814,6 +823,12 @@ certgen:
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations: []
 
+  # -- Additional certgen volumes.
+  extraVolumes: []
+
+  # -- Additional certgen volumeMounts.
+  extraVolumeMounts: []
+
 hubble:
   # -- Enable Hubble (true by default).
   enabled: true
@@ -1199,6 +1214,12 @@ hubble:
       # -- Additional hubble-ui backend environment variables.
       extraEnv: []
 
+      # -- Additional hubble-ui backend volumes.
+      extraVolumes: []
+
+      # -- Additional hubble-ui backend volumeMounts.
+      extraVolumeMounts: []
+
       # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
       resources: {}
       #   limits:
@@ -1220,6 +1241,12 @@ hubble:
 
       # -- Additional hubble-ui frontend environment variables.
       extraEnv: []
+
+      # -- Additional hubble-ui frontend volumes.
+      extraVolumes: []
+
+      # -- Additional hubble-ui frontend volumeMounts.
+      extraVolumeMounts: []
 
       # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
       resources: {}
@@ -1736,6 +1763,12 @@ etcd:
   # -- Additional cilium-etcd-operator container arguments.
   extraArgs: []
 
+  # -- Additional cilium-etcd-operator volumes.
+  extraVolumes: []
+
+  # -- Additional cilium-etcd-operator volumeMounts.
+  extraVolumeMounts: []
+
   # -- Node tolerations for cilium-etcd-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
@@ -2093,6 +2126,12 @@ preflight:
   # -- Additional preflight environment variables.
   extraEnv: []
 
+  # -- Additional preflight volumes.
+  extraVolumes: []
+
+  # -- Additional preflight volumeMounts.
+  extraVolumeMounts: []
+
   # -- Affinity for cilium-preflight
   affinity:
     podAffinity:
@@ -2269,6 +2308,12 @@ clustermesh:
 
     # -- Additional clustermesh-apiserver environment variables.
     extraEnv: []
+
+    # -- Additional clustermesh-apiserver volumes.
+    extraVolumes: []
+
+    # -- Additional clustermesh-apiserver volumeMounts.
+    extraVolumeMounts: []
 
     # -- Annotations to be added to clustermesh-apiserver pods
     podAnnotations: {}

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -50,40 +50,49 @@ serviceAccounts:
   cilium:
     create: true
     name: cilium
+    automount: true
     annotations: {}
   etcd:
     create: true
     name: cilium-etcd-operator
+    automount: true
     annotations: {}
   operator:
     create: true
     name: cilium-operator
+    automount: true
     annotations: {}
   preflight:
     create: true
     name: cilium-pre-flight
+    automount: true
     annotations: {}
   relay:
     create: true
     name: hubble-relay
+    automount: false
     annotations: {}
   ui:
     create: true
     name: hubble-ui
+    automount: true
     annotations: {}
   clustermeshApiserver:
     create: true
     name: clustermesh-apiserver
+    automount: true
     annotations: {}
   # -- Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob
   clustermeshcertgen:
     create: true
     name: clustermesh-apiserver-generate-certs
+    automount: true
     annotations: {}
   # -- Hubblecertgen is used if hubble.tls.auto.method=cronJob
   hubblecertgen:
     create: true
     name: hubble-generate-certs
+    automount: true
     annotations: {}
 
 # -- Configure termination grace period for cilium-agent DaemonSet.
@@ -811,6 +820,12 @@ certgen:
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations: []
 
+  # -- Additional certgen volumes.
+  extraVolumes: []
+
+  # -- Additional certgen volumeMounts.
+  extraVolumeMounts: []
+
 hubble:
   # -- Enable Hubble (true by default).
   enabled: true
@@ -1196,6 +1211,12 @@ hubble:
       # -- Additional hubble-ui backend environment variables.
       extraEnv: []
 
+      # -- Additional hubble-ui backend volumes.
+      extraVolumes: []
+
+      # -- Additional hubble-ui backend volumeMounts.
+      extraVolumeMounts: []
+
       # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
       resources: {}
       #   limits:
@@ -1217,6 +1238,12 @@ hubble:
 
       # -- Additional hubble-ui frontend environment variables.
       extraEnv: []
+
+      # -- Additional hubble-ui frontend volumes.
+      extraVolumes: []
+
+      # -- Additional hubble-ui frontend volumeMounts.
+      extraVolumeMounts: []
 
       # -- Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
       resources: {}
@@ -1733,6 +1760,12 @@ etcd:
   # -- Additional cilium-etcd-operator container arguments.
   extraArgs: []
 
+  # -- Additional cilium-etcd-operator volumes.
+  extraVolumes: []
+
+  # -- Additional cilium-etcd-operator volumeMounts.
+  extraVolumeMounts: []
+
   # -- Node tolerations for cilium-etcd-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations:
@@ -2090,6 +2123,12 @@ preflight:
   # -- Additional preflight environment variables.
   extraEnv: []
 
+  # -- Additional preflight volumes.
+  extraVolumes: []
+
+  # -- Additional preflight volumeMounts.
+  extraVolumeMounts: []
+
   # -- Affinity for cilium-preflight
   affinity:
     podAffinity:
@@ -2266,6 +2305,12 @@ clustermesh:
 
     # -- Additional clustermesh-apiserver environment variables.
     extraEnv: []
+
+    # -- Additional clustermesh-apiserver volumes.
+    extraVolumes: []
+
+    # -- Additional clustermesh-apiserver volumeMounts.
+    extraVolumeMounts: []
 
     # -- Annotations to be added to clustermesh-apiserver pods
     podAnnotations: {}


### PR DESCRIPTION
### Description

This commit is to make sure that users can enable/disable SA token auto mount, which is recommended in NSA security hardening guide. Kindly note that the default value hubble relay SA automount is false for consistency with current behavior.

https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF
Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

Testing was done mainly for extra volume mounts, as the `automountServiceAccountToken` syntax is already verified by GHA.

<details>
<summary>Values file for testing</summary>

```yaml
certgen:
  extraVolumes:
  - name: tmp
    emptyDir: {}
  extraVolumeMounts:
  - mountPath: /tmp/dir
    name: tmp
hubble:
  tls:
    auto:
      method: cronJob
  relay:
    enabled: true
  ui:
    enabled: true
    backend:
      extraVolumes:
      - name: tmp
        emptyDir: {}
      extraVolumeMounts:
      - mountPath: /tmp/dir
        name: tmp
    frontend:
      extraVolumes:
      - name: tmp
        emptyDir: {}
      extraVolumeMounts:
      - mountPath: /tmp/dir
        name: tmp
etcd:
  enabled: true
  extraVolumes:
  - name: tmp
    emptyDir: {}
  extraVolumeMounts:
  - mountPath: /tmp/dir
    name: tmp
clustermesh:
  useAPIServer: true
  apiserver:
    extraVolumes:
    - name: tmp
      emptyDir: {}
    extraVolumeMounts:
    - mountPath: /tmp/dir
      name: tmp
preflight:
  enabled: true
  extraVolumes:
  - name: tmp
    emptyDir: {}
  extraVolumeMounts:
  - mountPath: /tmp/dir
    name: tmp
```

</details>

<details>
<summary>Result</summary>

```
---
# Source: cilium/templates/cilium-operator/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "cilium-operator"
  namespace: default
---
# Source: cilium/templates/cilium-preflight/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "cilium-pre-flight"
  namespace: default
---
# Source: cilium/templates/clustermesh-apiserver/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "clustermesh-apiserver"
  namespace: default
---
# Source: cilium/templates/hubble-relay/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "hubble-relay"
  namespace: default
---
# Source: cilium/templates/hubble-ui/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "hubble-ui"
  namespace: default
---
# Source: cilium/templates/hubble/tls-cronjob/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "hubble-generate-certs"
  namespace: default
---
# Source: cilium/templates/cilium-ca-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: cilium-ca
  namespace: default
data:
  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRWUdLdmtkOHVWQm4rcHg2TytTaG5tREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URXlOVEU0V2hjTk1qWXdNVEk1TVRFeQpOVEU0V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzM0N3FKRXdURGh4R21IZW1ENFNWTnR6N2hqR1BDT0J0WXc1WFVGTUVRRzBRZk9ZSXUKYW1NZkdGZy9tOEpPOUZmZXJyVHRmZjljeWNnRkZEd3hCNnoyNkVlQWRMejJ2bkJCOVlpUDBWdG81YTllSFhpQQpoOTJzWDRUd2NQMUdxdFdQemJPb2JVcXg0b1Iza0lubC9MekJGbEZzUVd6Z3VPcEpJTnhsN2UrempXb0srWWt2Clh2aUN4ZUlQUzAxVFhHQVVuYmwvUGdHRXhDdmEvT3g0Uzl4ZDR3cC84NERqYjl1bm9WYzJrMndUQy9oa0VLSm0KMTcwUU4rZytqd0xIWXpiTnhtVVRLWmc0N1FmNUd4Q1ZkS1paamlqSXUzQXNjSUw5eExndDIwOFFkSndYVWRlVQpTRUZQS0lMUEpRUVVvdmFJTXlDY1dTWkpablovYkNLaVBxWTlBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVTbk1IaG16REpPT25LajVMRlFtOCswUWZIZWN3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFCeEJ5WmpST2g4OFlrNUVzeFhnK2xZa05RL1dwSDlnWnVoZ3Rpcm5Zc3poLzhHZ0pQMkpyem5NCkl4T2dtWDdXSXp3YWJTcHlmeGpuMzdWTEVPaTh4Vmg3RDNqeElXd0RnOXRBdHdkTXl1UXd0R2JTZkMyV0RFYUYKK2ZoM2R5VWJGRmVicFF4NnIxQWJSTThHRlJJK2p4R3JaQjJ2ZDVBMnZlaEVCQU1IajdKYWIrMStiVVZKWm91Rwptc3V5amMzNDB2aDR1SldnZW11VzdLcFZhZjJoa2U3YzJicWpnTkwrY2QrT2kvL0puaFJHM205NGFobFljcHd2ClFOeWRDME0vOVZZSGxMZGNLek5Gd0sxb3RMUUNWUkYrY3ZrTko2NWlxaVVrYkRWa1p6cEs0aE5qeXRmbEZBWEMKOTk2SmtEc0kxOHB1bmtLYTQ5T2htLzZ5cUsvOVhWbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  ca.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBdCtPNmlSTUV3NGNScGgzcGcrRWxUYmMrNFl4andqZ2JXTU9WMUJUQkVCdEVIem1DCkxtcGpIeGhZUDV2Q1R2UlgzcTYwN1gzL1hNbklCUlE4TVFlczl1aEhnSFM4OXI1d1FmV0lqOUZiYU9XdlhoMTQKZ0lmZHJGK0U4SEQ5UnFyVmo4MnpxRzFLc2VLRWQ1Q0o1Znk4d1JaUmJFRnM0TGpxU1NEY1plM3ZzNDFxQ3ZtSgpMMTc0Z3NYaUQwdE5VMXhnRkoyNWZ6NEJoTVFyMnZ6c2VFdmNYZU1LZi9PQTQyL2JwNkZYTnBOc0V3djRaQkNpClp0ZTlFRGZvUG84Q3gyTTJ6Y1psRXltWU9PMEgrUnNRbFhTbVdZNG95THR3TEhDQy9jUzRMZHRQRUhTY0YxSFgKbEVoQlR5aUN6eVVFRktMMmlETWduRmttU1daMmYyd2lvajZtUFFJREFRQUJBb0lCQUY4TDlCUjVvaEsyTTZjYQordUhSYzRpUjJJeVlGZEFEVkE4ek9MUWY3aEkzSmFUR0FzV2U4NURVOG5nZU4vYTdVTmVta1puWGNEQXprNUVjCmZtZ1JRWk4xUjgvYmh2ZzZRcWUxRTFyU3FWNjBxVW9LRFlqUnNRQXhkdk1ZVTdFOUI1bUdodi9kVGFoWUhvUDIKVDNCeWk5VjVoYWhnd0xmK25Bb2tWQWJUVHZ3TWtXWHVEYUlMUWhOVzlrNW9TT3BRMER3Q2pUc05lOTV6b1BPTQpkWXhHOUluS0xkL1ErV3UrOXdtUmJsQTdjUkpUdkFYcjFZOGwzeU9aNXg5NklzMlNzd1psdjIxemc4bHZnQ2Q5Ck9nK3JWM3Y1Yk1SeitNSW4vTUtXVlQ2RDd2SE1Ib2lETnZrT3h3NDdXcVFwaFRkYlI0dktNdllhdHdLL0F1ck0KcjNScklIa0NnWUVBNHlLbEdQTE1uVmlRREF4YkpPYUlrNTlxekxzVzgvRWlmbk9MbnAyV09CTHFKRUdKeXhQRwpOZDNuQlpUUGRtZ093RnVRNlUzNjFIMGxJTU9ycEZuZWkvVzcvYjBnNk9CaDJRdmZCdGNhWDNxQS9rRnZYb2tkCnFvUTZjT2J3UkR2Rkt5R3hyL2ZOb3d0Mk1qeC9vUzNJS3VqbkthZjdpZzNwUDRqaXVlaFdnbmNDZ1lFQXowSXQKTkIvSlRESlpieUVwejU3elA1eU5VVHpQRStVcUx4aDQxby8rTzIrRHQzTERxaE9kdDFFeTFKTUQ1cEhvVTlqYgpwOGlBYXl1eDhyYVJML2VNK2RzaUlxRk1kelBDY2oyZXNpMHh1dW0rOFBUK3UzUEVSb2xqS1ptbDJjVWpwRUVrCktCQUlwc2dWbFJlUWtCTEtMV2c4UFZPeWlEbHl6WmxUbVMwUDllc0NnWUJnY1E1dTZIRXZBakt2bXZOOFdKSjMKTkFKU0NjSjJNOVgwb1RVUVZWTTZYZldqRFZ6bnFHN0o0bjI4WmZJdEVZUHA4emMxaU5IUE5ZLzFPSUFCMmRMZgoxS2hNMWVoS1dUUFN4L0tiNGV1bHpNdEdxaHdTcE4rK3prUk9PaENjdUZCQXZ4N0dXODZwd3kwZHFZaDd0SWZBCmlJSFdzeWZmOTRZcFh3TDk4d1FBZ3dLQmdHTHNBd2RONUpZcHNlWUl2aHdLa2E5YTJWaGMzYmx4TjZFaTNRb0wKMEJ3dUxYL3hsdEltYXJDRVlPNTAvUGVmekhPNG5aNkhaRVBDcHp4aFJ3ck43TXVVZThacmxrT093TkFsK1FpeAo2WHA4OWxXcm1hbCtwNy9DODBGM3hHRWNadGFQQU9MZVJFTFdYUGE4T0pPTFpGUW4zQmlwU2gwYXptQ3pQZU51ClRwL2hBb0dBTkJXeDd2d2d6ZFJmVnU2Vzh2SnVqb240RlM2cHU0b1FLV1J6N3lxNkp3emtBTHNlNjFjWStHb1kKV3NLZlZwZ2gwM3ZCMnBiVGFBNmVkVUEyelRkWjl1cDRNa1ZwR0RSdG40SFh2eEpmc0hOT2lRWU1EMDVmNWlnRgo1ZGFMUVNyM1I3ekhYSHNZVHBNZEJ4KzlOMUZKNjZoUy8yWURaM1lFZ3VyRmRwSDJkZjQ9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
---
# Source: cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: clustermesh-apiserver-admin-cert
  namespace: default
type: kubernetes.io/tls
data:
  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRWUdLdmtkOHVWQm4rcHg2TytTaG5tREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URXlOVEU0V2hjTk1qWXdNVEk1TVRFeQpOVEU0V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzM0N3FKRXdURGh4R21IZW1ENFNWTnR6N2hqR1BDT0J0WXc1WFVGTUVRRzBRZk9ZSXUKYW1NZkdGZy9tOEpPOUZmZXJyVHRmZjljeWNnRkZEd3hCNnoyNkVlQWRMejJ2bkJCOVlpUDBWdG81YTllSFhpQQpoOTJzWDRUd2NQMUdxdFdQemJPb2JVcXg0b1Iza0lubC9MekJGbEZzUVd6Z3VPcEpJTnhsN2UrempXb0srWWt2Clh2aUN4ZUlQUzAxVFhHQVVuYmwvUGdHRXhDdmEvT3g0Uzl4ZDR3cC84NERqYjl1bm9WYzJrMndUQy9oa0VLSm0KMTcwUU4rZytqd0xIWXpiTnhtVVRLWmc0N1FmNUd4Q1ZkS1paamlqSXUzQXNjSUw5eExndDIwOFFkSndYVWRlVQpTRUZQS0lMUEpRUVVvdmFJTXlDY1dTWkpablovYkNLaVBxWTlBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVTbk1IaG16REpPT25LajVMRlFtOCswUWZIZWN3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFCeEJ5WmpST2g4OFlrNUVzeFhnK2xZa05RL1dwSDlnWnVoZ3Rpcm5Zc3poLzhHZ0pQMkpyem5NCkl4T2dtWDdXSXp3YWJTcHlmeGpuMzdWTEVPaTh4Vmg3RDNqeElXd0RnOXRBdHdkTXl1UXd0R2JTZkMyV0RFYUYKK2ZoM2R5VWJGRmVicFF4NnIxQWJSTThHRlJJK2p4R3JaQjJ2ZDVBMnZlaEVCQU1IajdKYWIrMStiVVZKWm91Rwptc3V5amMzNDB2aDR1SldnZW11VzdLcFZhZjJoa2U3YzJicWpnTkwrY2QrT2kvL0puaFJHM205NGFobFljcHd2ClFOeWRDME0vOVZZSGxMZGNLek5Gd0sxb3RMUUNWUkYrY3ZrTko2NWlxaVVrYkRWa1p6cEs0aE5qeXRmbEZBWEMKOTk2SmtEc0kxOHB1bmtLYTQ5T2htLzZ5cUsvOVhWbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKRENDQWd5Z0F3SUJBZ0lSQUkzeDRQMy9iY0o2VXhLNUZxZU1XcDh3RFFZSktvWklodmNOQVFFTEJRQXcKRkRFU01CQUdBMVVFQXhNSlEybHNhWFZ0SUVOQk1CNFhEVEl6TURFek1ERXhNalV4T1ZvWERUSTJNREV5T1RFeApNalV4T1Zvd0R6RU5NQXNHQTFVRUF4TUVjbTl2ZERDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1rTmZEUE16dTlZTktjRUFWQXozSkdJWDg5cUU2dlJDY3lQWUJ6QUl4QkNhR1dmSDExNS9wTTIKQk5yMkgxTkpjNDhTSThMeGZ5V1pQSUlKcStNa2dvTk4zYVdBWWhPaXJmaTQ3M0w1d3NJMy9veGJBbWloKzB4dQpLaXJneC9hLys3c0tmbUs3Z2RaaFRaTytlVkNzTEsyUE1uRzdmMW1PY3ZORXpwcmpERnZoU241amZQU3kvc0I0Cmt2ZWNHUWV0aHM4dTBWNWhVYVUvMXZ2aEcveEdOU3JpUHNRZ01qM0JXZjIwNHNOQWw5K2VQcVFtN1Y2bkJWbXoKbmtVZGlaeUlHSGJxVWZDa3dTc1FPUXJNRHA0ekdpSXFrV3pOWFN1anJ1dDV1ckUwMHZ3ZGZZT2tnb2VzaFU3QQpjRHJVczVFbWxsdFdyNUF4MFJFWi9tZUFoT1BLYzVzQ0F3RUFBYU4yTUhRd0RnWURWUjBQQVFIL0JBUURBZ1dnCk1CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFNQmdOVkhSTUJBZjhFQWpBQU1COEcKQTFVZEl3UVlNQmFBRkVwekI0WnN3eVRqcHlvK1N4VUp2UHRFSHgzbk1CUUdBMVVkRVFRTk1BdUNDV3h2WTJGcwphRzl6ZERBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUpKdnZJTnBoNGhZY294UkFHNEErWGhYQVBpVkhKaVI3CmNENkZaaFRPTlBiM0hjTmxBMmlCZjNXdWp2M2NiNHlmMEgxYTVvZTlYY3ROby9PY3J2OXBPOG9Odit6cVUwU3IKRTJMRWtSM1ovU2puNUN6emJkTm1MVGhJYStFWjhOcjRySzVOSDFpeDJ5cUVIZUtjdUFNUlp2TWFoQ3JvUFYyOQpsNlpXejRBc1YydEZrdE8yQ1ZGSk14UHdKTExaWENZeU95Qy9tdHY5cXg1dFhIYWluTEsvSnB6ZjB6c2ZaY25SCjFQMDZJWGgyV056NTlRQ1VEa2gxRHNSRXVvZURnRHdFanBUaUhwK085MFNXanhYT3VCTDhpamM5ejk5REZ0NmsKTlU5Z0RtRC9MNy9WWlQ5Mk5pSFZrQlBvUHp3bzRacEQ3cW1HOUZTR3lQVzE1cGg2MFgyMzNRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBeVExOE04ek83MWcwcHdRQlVEUGNrWWhmejJvVHE5RUp6STlnSE1BakVFSm9aWjhmClhYbitrellFMnZZZlUwbHpqeElqd3ZGL0paazhnZ21yNHlTQ2cwM2RwWUJpRTZLdCtManZjdm5Dd2pmK2pGc0MKYUtIN1RHNHFLdURIOXIvN3V3cCtZcnVCMW1GTms3NTVVS3dzclk4eWNidC9XWTV5ODBUT211TU1XK0ZLZm1OOAo5TEwrd0hpUzk1d1pCNjJHenk3UlhtRlJwVC9XKytFYi9FWTFLdUkreENBeVBjRlovYlRpdzBDWDM1NCtwQ2J0ClhxY0ZXYk9lUlIySm5JZ1lkdXBSOEtUQkt4QTVDc3dPbmpNYUlpcVJiTTFkSzZPdTYzbTZzVFRTL0IxOWc2U0MKaDZ5RlRzQndPdFN6a1NhV1cxYXZrREhSRVJuK1o0Q0U0OHB6bXdJREFRQUJBb0lCQUV4UVhoQ2JjUURRamt2Rwo3V2l3QnMwRzRyY3NJSU5iT1VqNE14YzJweGlJM0crV1VxVjhwUERqMUR2NHFETkk4aUFnVm9xc2VBS2hnNklvCllhSTZQWC94a213N3F2NmhCVUFma21RbUFaTVBCZ1BvbDZWM3RwZHdTWGsxRVRITDlaVXRpb09YZ05VSzRoTnUKZlVYdDFKZWNmeDFFZWpaWUo3SEhNRlVDVWJLZHlRZWh6bk1sMlBFcWJGRSt5bHI1UGNwY0hoVWFQcWVQSHJFOQoxcjNmYUtuOHBwNS9MWS9YeVE4bkZDd1grV09IQ1QwRzJNTGZOUWlBVmhaRXJxVFhwSkF2TmFRdFNPTWVURi9NCmplZHBRVERhOE1TN0FQZlJhaHNReGlIV201aCtrblREdjBWVW5pK3VYek1WK3hhN0xsaWM0TXo2S3N2SFdPWTEKd0NwbmNtRUNnWUVBNlpRVjFuVDJyNVNHOUNoSkpFVWkwcGpuTHd1YXhJN1poYkx1Q2pnSGZheU5iSjRJVjJTVApQNm5iQU9TeGNrMVB3T2o3N2VzYkIxa3pabHJ2UUZtdkRJNmJMcUtGT3I2NVhVdmE0enZra29HUDEveXVoTm1lCmVFUkhzTEJnT052UEVIZnpvRHBINkt5ZUdvaUlPRklUeXR6QjQ2aFV0aS9pK0dDMGlUVXpuYzBDZ1lFQTNGb2UKQUlQajNmcjNDZXdsN1RWdlozeHg4a0JwdW5rWDFkNzh5TWtVaWQ2RXV0Rkd5QXZoWjVxSFVGek81UktIVkxzZwpQRkREY1BuN21oc09LeklTQzEvRkdIdzg4azl6VHR4SVZuRXMrWXhQSVZiNHRhR1E4akV3ZG1jZHAxbGc5ZXhpCkxYK0lPVTBWVEJjWkFQdEFybzdqNWtYYUpMMDNJOXJEMlc2S3J3Y0NnWUJkUVA4YStPV0lJZjlqT1RaQ1ljdk8KVXJkeDQrc3RjRzdOM3lzRUwyeG1NMTdmTDVUYTkwK0dpbFRpWFd1dTI4anNsdGdHRytoVm5icFVzaGQxRkprNwpwUysxaGJNMVNmSU5tbnhRWHBnYUdkb0kvRnZjdEZsOVlKMVNvSWc2Q3gvM1RqeVpDc3VzekVYdkIvV0NydG95CkVzTGlGbEdEejBpSnEycElvVkh6UFFLQmdGdnh0bWNjb1c0MGsvUXQ5ejFkZUpqRDBuLzA1S2tNY2llcG5lemkKQ3BIa3FabVNUV2lYbkh3d2ZKbkp3QUxSa21xR2tsTFltRlNCMnJ4WTRiYWdjK3NQRVJ6QWFtWHBSUUg0NUs0OQpGemtobExzaW9UQ1lzL1I3RmUreDR5dTdIYncvNEU5LzBZV25abVdUbGJsVkhZNDR6VnQrZGlHeVdsbTVwTk1MClR3N3RBb0dBTUpqVWhUeFp0aGJydDB3TTVMTkZOdGY0TTE5ZS9ETGVaTXI1NFJQbEZkMkdNNUhqWmM1WmlLT0YKWDhraGNWRXBBZjhkY2lNN0xpREJheVZvSUhja2ZkTFhJUjAwUjlLekZ0bEVldFVBVVhCNmFhZTlxMDhiVSs5agpqbGs1WUVvaDVaQ2ZaOXN5aUtLN1JYRGdUZmxxWXdPaFNUMWhVZ1Jiam1OOXQ1aWYrVmc9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
---
# Source: cilium/templates/clustermesh-apiserver/tls-helm/ca-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: clustermesh-apiserver-ca-cert
  namespace: default
data:
  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRWUdLdmtkOHVWQm4rcHg2TytTaG5tREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URXlOVEU0V2hjTk1qWXdNVEk1TVRFeQpOVEU0V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzM0N3FKRXdURGh4R21IZW1ENFNWTnR6N2hqR1BDT0J0WXc1WFVGTUVRRzBRZk9ZSXUKYW1NZkdGZy9tOEpPOUZmZXJyVHRmZjljeWNnRkZEd3hCNnoyNkVlQWRMejJ2bkJCOVlpUDBWdG81YTllSFhpQQpoOTJzWDRUd2NQMUdxdFdQemJPb2JVcXg0b1Iza0lubC9MekJGbEZzUVd6Z3VPcEpJTnhsN2UrempXb0srWWt2Clh2aUN4ZUlQUzAxVFhHQVVuYmwvUGdHRXhDdmEvT3g0Uzl4ZDR3cC84NERqYjl1bm9WYzJrMndUQy9oa0VLSm0KMTcwUU4rZytqd0xIWXpiTnhtVVRLWmc0N1FmNUd4Q1ZkS1paamlqSXUzQXNjSUw5eExndDIwOFFkSndYVWRlVQpTRUZQS0lMUEpRUVVvdmFJTXlDY1dTWkpablovYkNLaVBxWTlBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVTbk1IaG16REpPT25LajVMRlFtOCswUWZIZWN3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFCeEJ5WmpST2g4OFlrNUVzeFhnK2xZa05RL1dwSDlnWnVoZ3Rpcm5Zc3poLzhHZ0pQMkpyem5NCkl4T2dtWDdXSXp3YWJTcHlmeGpuMzdWTEVPaTh4Vmg3RDNqeElXd0RnOXRBdHdkTXl1UXd0R2JTZkMyV0RFYUYKK2ZoM2R5VWJGRmVicFF4NnIxQWJSTThHRlJJK2p4R3JaQjJ2ZDVBMnZlaEVCQU1IajdKYWIrMStiVVZKWm91Rwptc3V5amMzNDB2aDR1SldnZW11VzdLcFZhZjJoa2U3YzJicWpnTkwrY2QrT2kvL0puaFJHM205NGFobFljcHd2ClFOeWRDME0vOVZZSGxMZGNLek5Gd0sxb3RMUUNWUkYrY3ZrTko2NWlxaVVrYkRWa1p6cEs0aE5qeXRmbEZBWEMKOTk2SmtEc0kxOHB1bmtLYTQ5T2htLzZ5cUsvOVhWbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  ca.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBdCtPNmlSTUV3NGNScGgzcGcrRWxUYmMrNFl4andqZ2JXTU9WMUJUQkVCdEVIem1DCkxtcGpIeGhZUDV2Q1R2UlgzcTYwN1gzL1hNbklCUlE4TVFlczl1aEhnSFM4OXI1d1FmV0lqOUZiYU9XdlhoMTQKZ0lmZHJGK0U4SEQ5UnFyVmo4MnpxRzFLc2VLRWQ1Q0o1Znk4d1JaUmJFRnM0TGpxU1NEY1plM3ZzNDFxQ3ZtSgpMMTc0Z3NYaUQwdE5VMXhnRkoyNWZ6NEJoTVFyMnZ6c2VFdmNYZU1LZi9PQTQyL2JwNkZYTnBOc0V3djRaQkNpClp0ZTlFRGZvUG84Q3gyTTJ6Y1psRXltWU9PMEgrUnNRbFhTbVdZNG95THR3TEhDQy9jUzRMZHRQRUhTY0YxSFgKbEVoQlR5aUN6eVVFRktMMmlETWduRmttU1daMmYyd2lvajZtUFFJREFRQUJBb0lCQUY4TDlCUjVvaEsyTTZjYQordUhSYzRpUjJJeVlGZEFEVkE4ek9MUWY3aEkzSmFUR0FzV2U4NURVOG5nZU4vYTdVTmVta1puWGNEQXprNUVjCmZtZ1JRWk4xUjgvYmh2ZzZRcWUxRTFyU3FWNjBxVW9LRFlqUnNRQXhkdk1ZVTdFOUI1bUdodi9kVGFoWUhvUDIKVDNCeWk5VjVoYWhnd0xmK25Bb2tWQWJUVHZ3TWtXWHVEYUlMUWhOVzlrNW9TT3BRMER3Q2pUc05lOTV6b1BPTQpkWXhHOUluS0xkL1ErV3UrOXdtUmJsQTdjUkpUdkFYcjFZOGwzeU9aNXg5NklzMlNzd1psdjIxemc4bHZnQ2Q5Ck9nK3JWM3Y1Yk1SeitNSW4vTUtXVlQ2RDd2SE1Ib2lETnZrT3h3NDdXcVFwaFRkYlI0dktNdllhdHdLL0F1ck0KcjNScklIa0NnWUVBNHlLbEdQTE1uVmlRREF4YkpPYUlrNTlxekxzVzgvRWlmbk9MbnAyV09CTHFKRUdKeXhQRwpOZDNuQlpUUGRtZ093RnVRNlUzNjFIMGxJTU9ycEZuZWkvVzcvYjBnNk9CaDJRdmZCdGNhWDNxQS9rRnZYb2tkCnFvUTZjT2J3UkR2Rkt5R3hyL2ZOb3d0Mk1qeC9vUzNJS3VqbkthZjdpZzNwUDRqaXVlaFdnbmNDZ1lFQXowSXQKTkIvSlRESlpieUVwejU3elA1eU5VVHpQRStVcUx4aDQxby8rTzIrRHQzTERxaE9kdDFFeTFKTUQ1cEhvVTlqYgpwOGlBYXl1eDhyYVJML2VNK2RzaUlxRk1kelBDY2oyZXNpMHh1dW0rOFBUK3UzUEVSb2xqS1ptbDJjVWpwRUVrCktCQUlwc2dWbFJlUWtCTEtMV2c4UFZPeWlEbHl6WmxUbVMwUDllc0NnWUJnY1E1dTZIRXZBakt2bXZOOFdKSjMKTkFKU0NjSjJNOVgwb1RVUVZWTTZYZldqRFZ6bnFHN0o0bjI4WmZJdEVZUHA4emMxaU5IUE5ZLzFPSUFCMmRMZgoxS2hNMWVoS1dUUFN4L0tiNGV1bHpNdEdxaHdTcE4rK3prUk9PaENjdUZCQXZ4N0dXODZwd3kwZHFZaDd0SWZBCmlJSFdzeWZmOTRZcFh3TDk4d1FBZ3dLQmdHTHNBd2RONUpZcHNlWUl2aHdLa2E5YTJWaGMzYmx4TjZFaTNRb0wKMEJ3dUxYL3hsdEltYXJDRVlPNTAvUGVmekhPNG5aNkhaRVBDcHp4aFJ3ck43TXVVZThacmxrT093TkFsK1FpeAo2WHA4OWxXcm1hbCtwNy9DODBGM3hHRWNadGFQQU9MZVJFTFdYUGE4T0pPTFpGUW4zQmlwU2gwYXptQ3pQZU51ClRwL2hBb0dBTkJXeDd2d2d6ZFJmVnU2Vzh2SnVqb240RlM2cHU0b1FLV1J6N3lxNkp3emtBTHNlNjFjWStHb1kKV3NLZlZwZ2gwM3ZCMnBiVGFBNmVkVUEyelRkWjl1cDRNa1ZwR0RSdG40SFh2eEpmc0hOT2lRWU1EMDVmNWlnRgo1ZGFMUVNyM1I3ekhYSHNZVHBNZEJ4KzlOMUZKNjZoUy8yWURaM1lFZ3VyRmRwSDJkZjQ9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
---
# Source: cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: clustermesh-apiserver-remote-cert
  namespace: default
type: kubernetes.io/tls
data:
  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRWUdLdmtkOHVWQm4rcHg2TytTaG5tREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URXlOVEU0V2hjTk1qWXdNVEk1TVRFeQpOVEU0V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzM0N3FKRXdURGh4R21IZW1ENFNWTnR6N2hqR1BDT0J0WXc1WFVGTUVRRzBRZk9ZSXUKYW1NZkdGZy9tOEpPOUZmZXJyVHRmZjljeWNnRkZEd3hCNnoyNkVlQWRMejJ2bkJCOVlpUDBWdG81YTllSFhpQQpoOTJzWDRUd2NQMUdxdFdQemJPb2JVcXg0b1Iza0lubC9MekJGbEZzUVd6Z3VPcEpJTnhsN2UrempXb0srWWt2Clh2aUN4ZUlQUzAxVFhHQVVuYmwvUGdHRXhDdmEvT3g0Uzl4ZDR3cC84NERqYjl1bm9WYzJrMndUQy9oa0VLSm0KMTcwUU4rZytqd0xIWXpiTnhtVVRLWmc0N1FmNUd4Q1ZkS1paamlqSXUzQXNjSUw5eExndDIwOFFkSndYVWRlVQpTRUZQS0lMUEpRUVVvdmFJTXlDY1dTWkpablovYkNLaVBxWTlBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVTbk1IaG16REpPT25LajVMRlFtOCswUWZIZWN3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFCeEJ5WmpST2g4OFlrNUVzeFhnK2xZa05RL1dwSDlnWnVoZ3Rpcm5Zc3poLzhHZ0pQMkpyem5NCkl4T2dtWDdXSXp3YWJTcHlmeGpuMzdWTEVPaTh4Vmg3RDNqeElXd0RnOXRBdHdkTXl1UXd0R2JTZkMyV0RFYUYKK2ZoM2R5VWJGRmVicFF4NnIxQWJSTThHRlJJK2p4R3JaQjJ2ZDVBMnZlaEVCQU1IajdKYWIrMStiVVZKWm91Rwptc3V5amMzNDB2aDR1SldnZW11VzdLcFZhZjJoa2U3YzJicWpnTkwrY2QrT2kvL0puaFJHM205NGFobFljcHd2ClFOeWRDME0vOVZZSGxMZGNLek5Gd0sxb3RMUUNWUkYrY3ZrTko2NWlxaVVrYkRWa1p6cEs0aE5qeXRmbEZBWEMKOTk2SmtEc0kxOHB1bmtLYTQ5T2htLzZ5cUsvOVhWbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lRQ1ExTG51QTRrT2tML0pIUGtZWVhwREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URXlOVEU1V2hjTk1qWXdNVEk1TVRFeQpOVEU1V2pBUk1ROHdEUVlEVlFRREV3WnlaVzF2ZEdVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3CmdnRUtBb0lCQVFDNzZqdTFjS3VWTjhNV0dVTFh2RmM1aWd3ZWltbDlaTzMxTlJvODd3dUd6cHpaaU4ycW1Qd28KOTY5Vm00UkhMKys2QjQ0YXhCLzNGRWNFZGRVeUVxSkkzV2FvQjNhYUtmMXMvR3diZ2pUcWFwdGZYYld2UFc3bQpKb2oxRGFJZ3FUMm5ucFlEMXRLbDM0MDVZVkRUWElUdkxmRHBublV6QzRmTnR2UjlicHUzZ1BmYlcyVSt3ZFZGCnlEb3hCUWV2L0I3a0IwMitZVTdscXVmWG4wSWc1U2lLZ244NzEyOHI1Mlo3V2tJMUI3RHZ6Vjg4bXJmTVgvaWcKOTlUVUdua09wRUVzVmxYYmlhelNqWkxXbVJiM1BON1hMajhaSWRaMGRoVkNlcFNiKzNUUHFHYWZTQUJHM0FzSwpDd2RtREkvNkF1ZHJDTGFCN0RMeGRnblhUSkF6VTI2VEFnTUJBQUdqWURCZU1BNEdBMVVkRHdFQi93UUVBd0lGCm9EQWRCZ05WSFNVRUZqQVVCZ2dyQmdFRkJRY0RBUVlJS3dZQkJRVUhBd0l3REFZRFZSMFRBUUgvQkFJd0FEQWYKQmdOVkhTTUVHREFXZ0JSS2N3ZUdiTU1rNDZjcVBrc1ZDYno3UkI4ZDV6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQwpBUUVBTG52UmdhK0xzKzlTcWFRZzlHd3liOWdlb2JWV2xtVHlqRmpTZzBBbks1TlFody9hVXJTWGl1WGVJVTFzClBlV0M1NzVONHFZQkg0R1lUN2tSVUVTRCtrL083bFhyL2xONGxlZHp2amJlVkhEZFhpVFVHTWphRHg3OURJc08KVDRTMm9GWG5TWENyY3NXc1ZMaEJXdXE5UjB2T0lkcWhicEVwUlJDOFpmK05RMDUvakNiNHd0c1RPT3F5N2RMRAp6TjM0eGloRXVnTVdUZ1JaRlVCRlZ5TDlRWUdJemRNempXOElIdHhtbGlQMUdycTdPN2p1MFVVa1AxQ2V1VHNuCkZ6NTl0NmVKSHl5MFgzdm1YbVcyVGJGNlRmNnl4UVQrYWFCcDBYeDkrL3ZIa3VVeHoxYXNqYUFrN08zNTdYM0gKaGZkVzVzR0NiNkVIVlI3V3BqZTdCNTQzRkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBdStvN3RYQ3JsVGZERmhsQzE3eFhPWW9NSG9wcGZXVHQ5VFVhUE84TGhzNmMyWWpkCnFwajhLUGV2Vlp1RVJ5L3Z1Z2VPR3NRZjl4UkhCSFhWTWhLaVNOMW1xQWQybWluOWJQeHNHNEkwNm1xYlgxMjEKcnoxdTVpYUk5UTJpSUtrOXA1NldBOWJTcGQrTk9XRlEwMXlFN3kzdzZaNTFNd3VIemJiMGZXNmJ0NEQzMjF0bApQc0hWUmNnNk1RVUhyL3dlNUFkTnZtRk81YXJuMTU5Q0lPVW9pb0ovTzlkdksrZG1lMXBDTlFldzc4MWZQSnEzCnpGLzRvUGZVMUJwNURxUkJMRlpWMjRtczBvMlMxcGtXOXp6ZTF5NC9HU0hXZEhZVlFucVVtL3QwejZobW4wZ0EKUnR3TENnc0haZ3lQK2dMbmF3aTJnZXd5OFhZSjEweVFNMU51a3dJREFRQUJBb0lCQVFDUXBiSUdiVTgya25EUgovdW5zQktjanZIYXR2NStLRFhuNktVRWtMR0cwQ0RER1prc3krWVlJeHZlcEx3ZTRnRmJJM08zdS9vOFljdnhqCm00eGJlZXAvcWlWT0xFaUlUTkF0NTNRVURMdE13bmtOQktaSTJVSVhXUXhOall3Q0ZpUkdkWlZHS1VPR3VUa04KTlRLeEwrT0g5TllnRG9CcXBYS0kwRThNaW1yRTZlaW9KakNQY0d3VXdkRFhxbEd3ZWl6UDFxbWF2VWRDOEg1WApzcVhGNERFTVpoMGpIQ3NPeXNmallENHpTNHhpMTh2UTdrTHdwdkFod0QvMkVEUXpRQU1DWkdHUGhIU3k1L2orClRqMEwxb1o0MThvaW9SajhjTEVBNENpVmNJc1JRVzlpbTU0aVBGdDBuaTdLVW95a0NFOHhWbnhSME8xanB0cVgKYVJiTUJBM1JBb0dCQU5kcXBWZGVuUmZxcnIrcG9tL3dpeTBGTFo1aTU5WEhtMXB2Wmdjb0p5aTJ5TVROYkVITwpCTHphZWlqZVdMRDIwVEhMNDFMcGdUeG5ZeTBWM2hpUTRlTHZLQ01nT216OTAzblBkL3VMdlNDK0UwaVdDMVhICks2MGpUVVA5a0VKOHBMeWpxQjRaaytkMFZ1NWlLYk50bEd5V1Foa2ozOFlrRk9COVA3QmdmUThyQW9HQkFOOVIKTldkUlhtcFJtR01YZlJpRWhUT0dxb0QrVWUvSUVvVUVqWUNjL2pXRGYvTnB5Zjd4dHlFRGNIYmJOWHF5RGxZVgpuSEdBajFBeW5jazFidHowVjVvQzAwVnBjMWxqMm9LTVlMc25XK2RvcGh3RzFaY0RRYTVoM0tnSUNwK3R0ZTYrCmRIVERjcVZNTHg2MklEZ1dQNnBKTEtCdzZpNHJENlF5ZHZhcCtpbzVBb0dBZnRFajRabXJ0Z2JOTmJ4eUNxQjcKN3RjYmtpRDhCeGpwMW9XNmRRQW9mWW1PREg0NiswcUQ4NEpUWkhmeGtzemJQd3VmR3BLcEtKeGRBSS9kSG0wOAo3bEtKT0pTaWtNT2xtaEtQdWlEOENLaWR4Wisvc0pIK25vRW4zWjBMTG5rZXFvZFdVOUlQQnJXdzc4b09icmxXCkpjOFh2cUVsL2dvRDJGMGovM3Z1WTkwQ2dZQkd0WUR5VU5wVFViaXRqNDlsaHZoaUl6NnpqMU5FV0JZOUZmN3oKL1VHa2tobWVhaDJ5WXJpNGRFMVU1UDNlOXFnQmErQllNL3VzeWdvWjNwaFd6K3M0OGJJUnBWMEhyYzFQVHNHRwpJT1ZCdFduN0w5TExlUlYvOEs2Y2FjZHJYZVpnVE4rMDVQblZDdlZVaFJoWWlmcm9vVGpIS0ZtTitzWitHQmlBCjY3c3hTUUtCZ0VkQjlKNWFPajBtZ003WU5wU3p6SzAzSlFnRmc5ZlA2T0x1MU5jR0dCOHhycWp6aFgzQTRMUk8KSW5JTlFmQk5qbDgvUjJhVEJDVmFxU09VK2V4UGpqU3g5ZmlMeXJUaWZ4dTQvSUFENmwvYnZNMHplTUZVWHFKRQpueHR1Uk84NFhCY1VTY2dJRzI0VkRkOW5tdHk5VTQ0bkJMSjQzUlJDdjMxc0EydEsvd2hHCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
---
# Source: cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: clustermesh-apiserver-server-cert
  namespace: default
type: kubernetes.io/tls
data:
  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRWUdLdmtkOHVWQm4rcHg2TytTaG5tREFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URXlOVEU0V2hjTk1qWXdNVEk1TVRFeQpOVEU0V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzM0N3FKRXdURGh4R21IZW1ENFNWTnR6N2hqR1BDT0J0WXc1WFVGTUVRRzBRZk9ZSXUKYW1NZkdGZy9tOEpPOUZmZXJyVHRmZjljeWNnRkZEd3hCNnoyNkVlQWRMejJ2bkJCOVlpUDBWdG81YTllSFhpQQpoOTJzWDRUd2NQMUdxdFdQemJPb2JVcXg0b1Iza0lubC9MekJGbEZzUVd6Z3VPcEpJTnhsN2UrempXb0srWWt2Clh2aUN4ZUlQUzAxVFhHQVVuYmwvUGdHRXhDdmEvT3g0Uzl4ZDR3cC84NERqYjl1bm9WYzJrMndUQy9oa0VLSm0KMTcwUU4rZytqd0xIWXpiTnhtVVRLWmc0N1FmNUd4Q1ZkS1paamlqSXUzQXNjSUw5eExndDIwOFFkSndYVWRlVQpTRUZQS0lMUEpRUVVvdmFJTXlDY1dTWkpablovYkNLaVBxWTlBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVTbk1IaG16REpPT25LajVMRlFtOCswUWZIZWN3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFCeEJ5WmpST2g4OFlrNUVzeFhnK2xZa05RL1dwSDlnWnVoZ3Rpcm5Zc3poLzhHZ0pQMkpyem5NCkl4T2dtWDdXSXp3YWJTcHlmeGpuMzdWTEVPaTh4Vmg3RDNqeElXd0RnOXRBdHdkTXl1UXd0R2JTZkMyV0RFYUYKK2ZoM2R5VWJGRmVicFF4NnIxQWJSTThHRlJJK2p4R3JaQjJ2ZDVBMnZlaEVCQU1IajdKYWIrMStiVVZKWm91Rwptc3V5amMzNDB2aDR1SldnZW11VzdLcFZhZjJoa2U3YzJicWpnTkwrY2QrT2kvL0puaFJHM205NGFobFljcHd2ClFOeWRDME0vOVZZSGxMZGNLek5Gd0sxb3RMUUNWUkYrY3ZrTko2NWlxaVVrYkRWa1p6cEs0aE5qeXRmbEZBWEMKOTk2SmtEc0kxOHB1bmtLYTQ5T2htLzZ5cUsvOVhWbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnVENDQW1tZ0F3SUJBZ0lSQUlDaldKWUdaV2lJc3dIWmtBeFdXYkF3RFFZSktvWklodmNOQVFFTEJRQXcKRkRFU01CQUdBMVVFQXhNSlEybHNhWFZ0SUVOQk1CNFhEVEl6TURFek1ERXhNalV4T1ZvWERUSTJNREV5T1RFeApNalV4T1Zvd0tqRW9NQ1lHQTFVRUF4TWZZMngxYzNSbGNtMWxjMmd0WVhCcGMyVnlkbVZ5TG1OcGJHbDFiUzVwCmJ6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUxYTkRRQXNaK0k1RWpWVjMwRGsKY3pza01NMERtK3ZvZ1oybFRUZ0REYnJvaUVYM2VmNUl1S3NIdk54OEM4MEtCd3BXZWh5NWVTeEs3akExVEJkRAp0ci90a0xBa280dnZmRys1MUloVUJHaEc2ZWlZWGFIcEhGRWVyWTZIWnVBYVQwK0tuZE1rbm15cUNXNyt1YTJiCjRoeHV4WGdBSklpdnNOb0VlSU5IcHp3N3BrL2R6cXNZSUd3YlhrV1A1RzNyc1FMRitSMlgzSS9KTHZMR0dqZlIKYThnM0JXOXFpUk14MGlTZTRTdjc3RUVoSnRIbEZqY0gxUlp5R0l0Kzl5ZFdvUW01N1hzTG1aSjFmT0d5N3VXYQoxMTdwM3A5MkNzUkl2MXhUbEplNXIrQ3htK3p3WlpzQWlXVXJab0FVd0MrbFh3azRGNzQ4d1lDdVREczN1c2NUCmpRRUNBd0VBQWFPQnR6Q0J0REFPQmdOVkhROEJBZjhFQkFNQ0JhQXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUgKQXdFR0NDc0dBUVVGQndNQ01Bd0dBMVVkRXdFQi93UUNNQUF3SHdZRFZSMGpCQmd3Rm9BVVNuTUhobXpESk9PbgpLajVMRlFtOCswUWZIZWN3VkFZRFZSMFJCRTB3UzRJZlkyeDFjM1JsY20xbGMyZ3RZWEJwYzJWeWRtVnlMbU5wCmJHbDFiUzVwYjRJUUtpNXRaWE5vTG1OcGJHbDFiUzVwYjRjRWZ3QUFBWWNRQUFBQUFBQUFBQUFBQUFBQUFBQUEKQVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQXJjcmRJODNJdkZqZkZMeFdFbkJBVER4bDlXVGlUbmdsYU0wcApNeXBWTlpXMWdvMzFyNVRmb1lMNnhKWENVSUtPYjBzbXg5dGRtamkzSU1ZbGltenRzbmx5RkZQbzFQREVkc1AwClFGbEkxSnVKMmJTN2RKelBnSkl4bkJxUmFUOHluVE16bXN5WDIxaThQSFJYSjdXK2JCeHdBTkNLSmFRMUNmZUsKdG5EOEJyaGdyVFhXK0lrWUlBUWRGSm83bWlST2dSQW9oZklsUE8zWUFQRFBmaStFSjV4OXl3d1hmVEFIT084egpEYlZGRWRRMFRzSTcrNFFKUzRQMGduODcvR1RnVjBIdFgxYWNPeEl2U2VFYXF2eFZRbjJXM0ZyNHBPcjM3cFE5CkxTK2haY1V1bnd2ZnBHRWlTd01FMjRvQ01LR0kydmtKaTBmTk90ZER4b0g5S0VzR2JnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBdGMwTkFDeG40amtTTlZYZlFPUnpPeVF3elFPYjYraUJuYVZOT0FNTnV1aUlSZmQ1Ci9raTRxd2U4M0h3THpRb0hDbFo2SExsNUxFcnVNRFZNRjBPMnYrMlFzQ1NqaSs5OGI3blVpRlFFYUVicDZKaGQKb2VrY1VSNnRqb2RtNEJwUFQ0cWQweVNlYktvSmJ2NjVyWnZpSEc3RmVBQWtpSyt3MmdSNGcwZW5QRHVtVDkzTwpxeGdnYkJ0ZVJZL2tiZXV4QXNYNUhaZmNqOGt1OHNZYU45RnJ5RGNGYjJxSkV6SFNKSjdoSy92c1FTRW0wZVVXCk53ZlZGbklZaTM3M0oxYWhDYm50ZXd1WmtuVjg0Ykx1NVpyWFh1bmVuM1lLeEVpL1hGT1VsN212NExHYjdQQmwKbXdDSlpTdG1nQlRBTDZWZkNUZ1h2anpCZ0s1TU96ZTZ4eE9OQVFJREFRQUJBb0lCQUVwN2dkSUtYMTA5aUlvMQpia3dGekhmMGNkSHNvcHJhSFJCYlF2R3B2cHhPM0ZYZCtDc0gzRENsOE9oY0lmR1ZKQ0ZHSUsxWUI1N3Y2L253ClBBWmtCYUZJVVRqNUtkQVJBK2c2T0NyS1VTdnZzYkZMaTBEa1ltZVJyQVZ5eitFTXBtV3VJczc0ZDdlSlNtZ2gKRUMxaWFoYkFBME1RdStjTUkrYU9ZbGxXcDl0eTI4bHBWdHU4ZFc2T1FrV1RUb0k2NmhKQTdmYTRhZ1hoMTJ6UApLbTExYXpBT2N2OGdUZGdxQ1ZjbGk4OWM5VTZCd3FKODNsaFVQQkhwaGVjUmd4SDYzMXdtRitvb2s0V1gyQjVRCld3dlN5OTBnL1BSS2RBcWUrY0R1a0wraFhvSGlPS2dnaVNURmQycXY5cFJvczJucW5rUWlqUUlkaFpsUld1UkIKNnVhQ2JHRUNnWUVBelZBakFsWjlDTUFQRWpiRDhjalVuQVRTR1lvVEs1TzRLQW5UaXU3YXBPblFzVjkvcCsrKwptdHB4U1hrS0wrdiswVlVqVkJsNy96ZTlBNWFjTStMUFZUdTVzTGVnbTV0TnBLdVE0ekNLajF2TCtCTUhkWWk4CncwWkdrdzZjblQweSt5cVBBZmlEOGk2VmtKVys4Q0E1L1czMWFOVUJWZWVJdmhCZFc0UVQxNDBDZ1lFQTRxN3gKYlpFZU12Z1VKVVh5clF3OVJpMjYwUzY4VHVrVFB0NzRCVXZtN0tZMUJuU3ZLbHZNdjhyeElwR3pLZ3FCNEplMAp1ZXhtY0FDaWdyRkY1cEd1aTlRTkRSSFRGNXlMMkRxZzlKTXk0QkY4azY2WEMwSkV1SHplQmZVdENEdnhqUk90CnlVSnVTWVpwNDRicXRGUUNqc3JuNTRVeERLOHVacnlSNFZPZFJFVUNnWUFJM05XMkN4KzRtZm5Na25xZzNFZDUKT0tnTkhDMjVxdFcvUExWYUFQZUZPT2FlVVg0RU5OQW9oUmR3MFgzRUZjN1pJSEMyOTZhbm5MTlhEVkJPMlJLVQpIbERrdFBpRTN3NVo5bUg1dktXdWpJcmdlWW5QNUFncDhjV29JWEJYUlVZSEc0NHl5cFIvaHMxRUFZTE5nTWFnCkR2Z1IvMmZnV205SHJSTXFtU2YySFFLQmdFemo5blNwNHNwN0o2bzAvY29BK3MvUk55czVaUnFIS01ZTXI2aHMKUkpwRkRudHdIUEtMVFBwSmhsMnBlbEpxV2YrcXRkelMrVFJJb3RjZDlvM3RJSDNCb2VPckJpVmVMbmxiK2JpOApMV2VmeHRmNVFyYkk5YkoyZUlFZzF2T1NFYTgrMjVZRytJM3NFQUxqZ3IxRU9kSGh0YVBzbytTZmoyZTkwdVhSCmpPalpBb0dBZkRZVjRqdHY4a0ZqSTVlTVdRQnVzVi80Ly9CYTUzbzhVZGN6WEExNG9adWRrSFVLL1BuL25TUkkKTDNpMjZpRFR1UitMOG1vRUpqeUlIMVNLVDBkMm9NalJMVWRMVlBncHpaT2RMRkc5bEtXYVhlcEM5bWJKVllLSApZQ1BvK3hZM2FrUkl4Mi9SWDdUaElzelBFVWtZZG9hZUU3VGZKeHRSYjBpNnJBNDNobXM9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
---
# Source: cilium/templates/hubble-relay/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: hubble-relay-config
  namespace: default
data:
  config.yaml: |
    cluster-name: default
    peer-service: "hubble-peer.default.svc.cluster.local:443"
    listen-address: :4245
    dial-timeout: 
    retry-timeout: 
    sort-buffer-len-max: 
    sort-buffer-drain-timeout: 
    tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
    tls-client-key-file: /var/lib/hubble-relay/tls/client.key
    tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
    disable-server-tls: true
---
# Source: cilium/templates/hubble-ui/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: hubble-ui-nginx
  namespace: default
data:
  nginx.conf: "server {\n    listen       8081;\n    listen       [::]:8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if ($request_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n\n        location / {\n            try_files $uri $uri/ /index.html;\n        }\n    }\n}"
---
# Source: cilium/templates/cilium-operator/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: cilium-operator
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - get
  - list
  - watch
  # to automatically delete [core|kube]dns pods so that are starting to being
  # managed by Cilium
  - delete
- apiGroups:
  - ""
  resources:
  - nodes
  verbs:
  - list
  - watch
- apiGroups:
  - ""
  resources:
  # To remove node taints
  - nodes
  # To set NetworkUnavailable false on startup
  - nodes/status
  verbs:
  - patch
- apiGroups:
  - discovery.k8s.io
  resources:
  - endpointslices
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  # to perform LB IP allocation for BGP
  - services/status
  verbs:
  - update
  - patch
- apiGroups:
  - ""
  resources:
  # to check apiserver connectivity
  - namespaces
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
  - services
  - endpoints
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - ciliumnetworkpolicies
  - ciliumclusterwidenetworkpolicies
  verbs:
  # Create auto-generated CNPs and CCNPs from Policies that have 'toGroups'
  - create
  - update
  - deletecollection
  # To update the status of the CNPs and CCNPs
  - patch
  - get
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - ciliumnetworkpolicies/status
  - ciliumclusterwidenetworkpolicies/status
  verbs:
  # Update the auto-generated CNPs and CCNPs status.
  - patch
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumendpoints
  - ciliumidentities
  verbs:
  # To perform garbage collection of such resources
  - delete
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - ciliumidentities
  verbs:
  # To synchronize garbage collection of such resources
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumnodes
  verbs:
  - create
  - update
  - get
  - list
  - watch
    # To perform CiliumNode garbage collector
  - delete
- apiGroups:
  - cilium.io
  resources:
  - ciliumnodes/status
  verbs:
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumendpointslices
  - ciliumenvoyconfigs
  verbs:
  - create
  - update
  - get
  - list
  - watch
  - delete
  - patch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - create
  - get
  - list
  - watch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - update
  resourceNames:
  - ciliumloadbalancerippools.cilium.io
  - ciliumbgppeeringpolicies.cilium.io
  - ciliumclusterwideenvoyconfigs.cilium.io
  - ciliumclusterwidenetworkpolicies.cilium.io
  - ciliumegressgatewaypolicies.cilium.io
  - ciliumendpoints.cilium.io
  - ciliumendpointslices.cilium.io
  - ciliumenvoyconfigs.cilium.io
  - ciliumexternalworkloads.cilium.io
  - ciliumidentities.cilium.io
  - ciliumlocalredirectpolicies.cilium.io
  - ciliumnetworkpolicies.cilium.io
  - ciliumnodes.cilium.io
  - ciliumnodeconfigs.cilium.io
- apiGroups:
  - cilium.io
  resources:
  - ciliumloadbalancerippools
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - ciliumloadbalancerippools/status
  verbs:
  - patch
# For cilium-operator running in HA mode.
#
# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
# between multiple running instances.
# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
# common and fewer objects in the cluster watch "all Leases".
- apiGroups:
  - coordination.k8s.io
  resources:
  - leases
  verbs:
  - create
  - get
  - update
---
# Source: cilium/templates/cilium-preflight/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: cilium-pre-flight
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - networking.k8s.io
  resources:
  - networkpolicies
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - discovery.k8s.io
  resources:
  - endpointslices
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - namespaces
  - services
  - pods
  - endpoints
  - nodes
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - list
  - watch
  # This is used when validating policies in preflight. This will need to stay
  # until we figure out how to avoid "get" inside the preflight, and then
  # should be removed ideally.
  - get
- apiGroups:
  - cilium.io
  resources:
  - ciliumloadbalancerippools
  - ciliumbgppeeringpolicies
  - ciliumclusterwideenvoyconfigs
  - ciliumclusterwidenetworkpolicies
  - ciliumegressgatewaypolicies
  - ciliumendpoints
  - ciliumendpointslices
  - ciliumenvoyconfigs
  - ciliumidentities
  - ciliumlocalredirectpolicies
  - ciliumnetworkpolicies
  - ciliumnodes
  - ciliumnodeconfigs
  verbs:
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - ciliumidentities
  - ciliumendpoints
  - ciliumnodes
  verbs:
  - create
- apiGroups:
  - cilium.io
  # To synchronize garbage collection of such resources
  resources:
  - ciliumidentities
  verbs:
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumendpoints
  verbs:
  - delete
  - get
- apiGroups:
  - cilium.io
  resources:
  - ciliumnodes
  - ciliumnodes/status
  verbs:
  - get
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumnetworkpolicies/status
  - ciliumclusterwidenetworkpolicies/status
  - ciliumendpoints/status
  - ciliumendpoints
  verbs:
  - patch
---
# Source: cilium/templates/clustermesh-apiserver/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: clustermesh-apiserver
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - cilium.io
  resources:
  - ciliumnodes
  - ciliumendpoints
  - ciliumidentities
  verbs:
  - create
- apiGroups:
  - cilium.io
  resources:
  - ciliumexternalworkloads/status
  - ciliumnodes
  - ciliumidentities
  verbs:
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumendpoints
  - ciliumendpoints/status
  verbs:
  - patch
- apiGroups:
  - cilium.io
  resources:
  - ciliumidentities
  - ciliumexternalworkloads
  - ciliumendpoints
  - ciliumnodes
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - endpoints
  - namespaces
  - services
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - discovery.k8s.io
  resources:
  - endpointslices
  verbs:
  - get
  - list
  - watch
---
# Source: cilium/templates/hubble-ui/clusterrole.yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: hubble-ui
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - networking.k8s.io
  resources:
  - networkpolicies
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - componentstatuses
  - endpoints
  - namespaces
  - nodes
  - pods
  - services
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - "*"
  verbs:
  - get
  - list
  - watch
---
# Source: cilium/templates/hubble/tls-cronjob/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: hubble-generate-certs
  labels:
    app.kubernetes.io/part-of: cilium
rules:
  - apiGroups:
      - ""
    resources:
      - secrets
    verbs:
      - create
  - apiGroups:
      - ""
    resources:
      - secrets
    resourceNames:
      - hubble-server-certs
      - hubble-relay-client-certs
      - hubble-relay-server-certs
    verbs:
      - update
  - apiGroups:
      - ""
    resources:
      - secrets
    resourceNames:
      - cilium-ca
      - hubble-ca-secret
    verbs:
      - get
      - update
---
# Source: cilium/templates/cilium-operator/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: cilium-operator
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cilium-operator
subjects:
- kind: ServiceAccount
  name: "cilium-operator"
  namespace: default
---
# Source: cilium/templates/cilium-preflight/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: cilium-pre-flight
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cilium-pre-flight
subjects:
- kind: ServiceAccount
  name: "cilium-pre-flight" 
  namespace: default
---
# Source: cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: clustermesh-apiserver
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: clustermesh-apiserver
subjects:
- kind: ServiceAccount
  name: "clustermesh-apiserver"
  namespace: default
---
# Source: cilium/templates/hubble-ui/clusterrolebinding.yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: hubble-ui
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: hubble-ui
subjects:
- kind: ServiceAccount
  name: "hubble-ui"
  namespace: default
---
# Source: cilium/templates/hubble/tls-cronjob/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: hubble-generate-certs
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: hubble-generate-certs
subjects:
- kind: ServiceAccount
  name: "hubble-generate-certs"
  namespace: default
---
# Source: cilium/templates/cilium-agent/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: cilium-config-agent
  namespace: default
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - ""
  resources:
  - configmaps
  verbs:
  - get
  - list
  - watch
---
# Source: cilium/templates/cilium-agent/rolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: cilium-config-agent
  namespace: default
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: cilium-config-agent
subjects:
  - kind: ServiceAccount
    name: "cilium"
    namespace: default
---
# Source: cilium/templates/clustermesh-apiserver/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: clustermesh-apiserver
  namespace: default
  labels:
    k8s-app: clustermesh-apiserver
    app.kubernetes.io/part-of: cilium
    app.kubernetes.io/name: clustermesh-apiserver
spec:
  type: NodePort
  selector:
    k8s-app: clustermesh-apiserver
  ports:
  - port: 2379
    nodePort: 32379
---
# Source: cilium/templates/hubble-relay/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: hubble-relay
  namespace: default
  labels:
    k8s-app: hubble-relay
    app.kubernetes.io/name: hubble-relay
    app.kubernetes.io/part-of: cilium
spec:
  type: "ClusterIP"
  selector:
    k8s-app: hubble-relay
  ports:
  - protocol: TCP
    port: 80
    targetPort: 4245
---
# Source: cilium/templates/hubble-ui/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: hubble-ui
  namespace: default
  labels:
    k8s-app: hubble-ui
    app.kubernetes.io/name: hubble-ui
    app.kubernetes.io/part-of: cilium
spec:
  type: "ClusterIP"
  selector:
    k8s-app: hubble-ui
  ports:
    - name: http
      port: 80
      targetPort: 8081
---
# Source: cilium/templates/hubble/peer-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: hubble-peer
  namespace: default
  labels:
    k8s-app: cilium
    app.kubernetes.io/part-of: cilium
    app.kubernetes.io/name: hubble-peer
spec:
  selector:
    k8s-app: cilium
  ports:
  - name: peer-service
    port: 443
    protocol: TCP
    targetPort: 4244
  internalTrafficPolicy: Local
---
# Source: cilium/templates/cilium-preflight/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: cilium-pre-flight-check
  namespace: default
spec:
  selector:
    matchLabels:
      k8s-app: cilium-pre-flight-check
      kubernetes.io/cluster-service: "true"
  template:
    metadata:
      labels:
        app.kubernetes.io/part-of: cilium
        k8s-app: cilium-pre-flight-check
        app.kubernetes.io/name: cilium-pre-flight-check
        kubernetes.io/cluster-service: "true"
    spec:
      initContainers:
        - name: clean-cilium-state
          image: "quay.io/cilium/cilium-ci:latest"
          imagePullPolicy: Always
          command: ["/bin/echo"]
          args:
          - "hello"
          terminationMessagePolicy: FallbackToLogsOnError
      containers:
        - name: cilium-pre-flight-check
          image: "quay.io/cilium/cilium-ci:latest"
          imagePullPolicy: Always
          command: ["/bin/sh"]
          args:
          - -c
          - "touch /tmp/ready; sleep 1h"
          livenessProbe:
            exec:
              command:
              - cat
              - /tmp/ready
            initialDelaySeconds: 5
            periodSeconds: 5
          readinessProbe:
            exec:
              command:
              - cat
              - /tmp/ready
            initialDelaySeconds: 5
            periodSeconds: 5
          volumeMounts:
          - name: cilium-run
            mountPath: /var/run/cilium
          - name: etcd-config-path
            mountPath: /var/lib/etcd-config
            readOnly: true
          - mountPath: /tmp/dir
            name: tmp
          terminationMessagePolicy: FallbackToLogsOnError
      hostNetwork: true
      # This is here to seamlessly allow migrate-identity to work with
      # etcd-operator setups. The assumption is that other cases would also
      # work since the cluster DNS would forward the request on.
      # This differs from the cilium-agent daemonset, where this is only
      # enabled when etcd.managed=true
      dnsPolicy: ClusterFirstWithHostNet
      restartPolicy: Always
      priorityClassName: system-node-critical
      serviceAccount: "cilium-pre-flight"
      serviceAccountName: "cilium-pre-flight"
      automountServiceAccountToken: true
      terminationGracePeriodSeconds: 1
      tolerations:
        - effect: NoSchedule
          key: node.kubernetes.io/not-ready
        - effect: NoSchedule
          key: node-role.kubernetes.io/master
        - effect: NoSchedule
          key: node-role.kubernetes.io/control-plane
        - effect: NoSchedule
          key: node.cloudprovider.kubernetes.io/uninitialized
          value: "true"
        - key: CriticalAddonsOnly
          operator: Exists
      volumes:
        # To keep state between restarts / upgrades
      - name: cilium-run
        hostPath:
          path: /var/run/cilium
          type: DirectoryOrCreate
      - name: bpf-maps
        hostPath:
          path: /sys/fs/bpf
          type: DirectoryOrCreate
        # To read the etcd config stored in config maps
      - name: etcd-config-path
        configMap:
          name: cilium-config
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          items:
          - key: etcd-config
            path: etcd.config
        # To read the k8s etcd secrets in case the user might want to use TLS
      - emptyDir: {}
        name: tmp
---
# Source: cilium/templates/cilium-operator/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cilium-operator
  namespace: default
  labels:
    io.cilium/app: operator
    name: cilium-operator
    app.kubernetes.io/part-of: cilium
    app.kubernetes.io/name: cilium-operator
spec:
  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
  # for more details.
  replicas: 2
  selector:
    matchLabels:
      io.cilium/app: operator
      name: cilium-operator
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      annotations:
      labels:
        io.cilium/app: operator
        name: cilium-operator
        app.kubernetes.io/part-of: cilium
        app.kubernetes.io/name: cilium-operator
    spec:
      containers:
      - name: cilium-operator
        image: "quay.io/cilium/operator-generic-ci:latest"
        imagePullPolicy: Always
        command:
        - cilium-operator-generic
        args:
        - --config-dir=/tmp/cilium/config-map
        - --debug=$(CILIUM_DEBUG)
        env:
        - name: K8S_NODE_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: spec.nodeName
        - name: CILIUM_K8S_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: CILIUM_DEBUG
          valueFrom:
            configMapKeyRef:
              key: debug
              name: cilium-config
              optional: true
        livenessProbe:
          httpGet:
            host: "127.0.0.1"
            path: /healthz
            port: 9234
            scheme: HTTP
          initialDelaySeconds: 60
          periodSeconds: 10
          timeoutSeconds: 3
        volumeMounts:
        - name: cilium-config-path
          mountPath: /tmp/cilium/config-map
          readOnly: true
        - name: etcd-config-path
          mountPath: /var/lib/etcd-config
          readOnly: true
        terminationMessagePolicy: FallbackToLogsOnError
      hostNetwork: true
      restartPolicy: Always
      priorityClassName: system-cluster-critical
      serviceAccount: "cilium-operator"
      serviceAccountName: "cilium-operator"
      automountServiceAccountToken: true
      # In HA mode, cilium-operator pods must not be scheduled on the same
      # node as they will clash with each other.
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                io.cilium/app: operator
            topologyKey: kubernetes.io/hostname
      nodeSelector:
        kubernetes.io/os: linux
      tolerations:
        - operator: Exists
      volumes:
        # To read the configuration from the config map
      - name: cilium-config-path
        configMap:
          name: cilium-config
      # To read the etcd config stored in config maps
      - name: etcd-config-path
        configMap:
          name: cilium-config
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          items:
          - key: etcd-config
            path: etcd.config
---
# Source: cilium/templates/cilium-preflight/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cilium-pre-flight-check
  namespace: default
  labels:
    app.kubernetes.io/part-of: cilium
    app.kubernetes.io/name: cilium-pre-flight-check
spec:
  selector:
    matchLabels:
      k8s-app: cilium-pre-flight-check-deployment
      kubernetes.io/cluster-service: "true"
  template:
    metadata:
      labels:
        app.kubernetes.io/part-of: cilium
        k8s-app: cilium-pre-flight-check-deployment
        kubernetes.io/cluster-service: "true"
        app.kubernetes.io/name: cilium-pre-flight-check
    spec:
      containers:
        - name: cnp-validator
          image: "quay.io/cilium/cilium-ci:latest"
          imagePullPolicy: Always
          command: ["/bin/sh"]
          args:
          - -ec
          - |
            cilium preflight validate-cnp;
            touch /tmp/ready-validate-cnp;
            sleep 1h;
          livenessProbe:
            exec:
              command:
              - cat
              - /tmp/ready-validate-cnp
            initialDelaySeconds: 5
            periodSeconds: 5
          readinessProbe:
            exec:
              command:
              - cat
              - /tmp/ready-validate-cnp
            initialDelaySeconds: 5
            periodSeconds: 5
          env:
          terminationMessagePolicy: FallbackToLogsOnError
      hostNetwork: true
      restartPolicy: Always
      priorityClassName: system-cluster-critical
      serviceAccount: "cilium-pre-flight"
      serviceAccountName: "cilium-pre-flight"
      terminationGracePeriodSeconds: 1
      affinity:
        podAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                k8s-app: cilium
            topologyKey: kubernetes.io/hostname
      nodeSelector:
        kubernetes.io/os: linux
      tolerations:
        - effect: NoSchedule
          key: node.kubernetes.io/not-ready
        - effect: NoSchedule
          key: node-role.kubernetes.io/master
        - effect: NoSchedule
          key: node-role.kubernetes.io/control-plane
        - effect: NoSchedule
          key: node.cloudprovider.kubernetes.io/uninitialized
          value: "true"
        - key: CriticalAddonsOnly
          operator: Exists
---
# Source: cilium/templates/clustermesh-apiserver/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: clustermesh-apiserver
  namespace: default
  labels:
    k8s-app: clustermesh-apiserver
    app.kubernetes.io/part-of: cilium
    app.kubernetes.io/name: clustermesh-apiserver
spec:
  replicas: 1
  selector:
    matchLabels:
      k8s-app: clustermesh-apiserver
  strategy:
    rollingUpdate:
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      annotations:
      labels:
        app.kubernetes.io/part-of: cilium
        app.kubernetes.io/name: clustermesh-apiserver
        k8s-app: clustermesh-apiserver
    spec:
      initContainers:
      - name: etcd-init
        image: "quay.io/coreos/etcd:v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"
        imagePullPolicy: Always
        command: ["/bin/sh", "-c"]
        args:
        - |
          rm -rf /var/run/etcd/*;
          /usr/local/bin/etcd --data-dir=/var/run/etcd --name=clustermesh-apiserver --listen-client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster-token=clustermesh-apiserver --initial-cluster-state=new --auto-compaction-retention=1 &
          export rootpw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
          echo $rootpw | etcdctl --interactive=false user add root;
          etcdctl user grant-role root root;
          export vmpw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
          echo $vmpw | etcdctl --interactive=false user add externalworkload;
          etcdctl role add externalworkload;
          etcdctl role grant-permission externalworkload --from-key read '';
          etcdctl role grant-permission externalworkload readwrite --prefix cilium/state/noderegister/v1/;
          etcdctl role grant-permission externalworkload readwrite --prefix cilium/.initlock/;
          etcdctl user grant-role externalworkload externalworkload;
          export remotepw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
          echo $remotepw | etcdctl --interactive=false user add remote;
          etcdctl role add remote;
          etcdctl role grant-permission remote --from-key read '';
          etcdctl user grant-role remote remote;
          etcdctl auth enable;
          exit
        env:
        - name: ETCDCTL_API
          value: "3"
        - name: HOSTNAME_IP
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
        volumeMounts:
        - name: etcd-data-dir
          mountPath: /var/run/etcd
        terminationMessagePolicy: FallbackToLogsOnError
      containers:
      - name: etcd
        image: "quay.io/coreos/etcd:v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"
        imagePullPolicy: Always
        command:
        - /usr/local/bin/etcd
        args:
        - --data-dir=/var/run/etcd
        - --name=clustermesh-apiserver
        - --client-cert-auth
        - --trusted-ca-file=/var/lib/etcd-secrets/ca.crt
        - --cert-file=/var/lib/etcd-secrets/tls.crt
        - --key-file=/var/lib/etcd-secrets/tls.key
        # Surrounding the IPv4 address with brackets works in this case, since etcd
        # uses net.SplitHostPort() internally and it accepts the that format.
        - --listen-client-urls=https://127.0.0.1:2379,https://[$(HOSTNAME_IP)]:2379
        - --advertise-client-urls=https://[$(HOSTNAME_IP)]:2379
        - --initial-cluster-token=clustermesh-apiserver
        - --auto-compaction-retention=1
        env:
        - name: ETCDCTL_API
          value: "3"
        - name: HOSTNAME_IP
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
        volumeMounts:
        - name: etcd-server-secrets
          mountPath: /var/lib/etcd-secrets
          readOnly: true
        - name: etcd-data-dir
          mountPath: /var/run/etcd
        terminationMessagePolicy: FallbackToLogsOnError
      - name: apiserver
        image: "quay.io/cilium/clustermesh-apiserver-ci:latest"
        imagePullPolicy: Always
        command:
        - /usr/bin/clustermesh-apiserver
        args:
        - --cluster-name=$(CLUSTER_NAME)
        - --cluster-id=$(CLUSTER_ID)
        - --kvstore-opt
        - etcd.config=/var/lib/cilium/etcd-config.yaml
        env:
        - name: CLUSTER_NAME
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: cluster-name
        - name: CLUSTER_ID
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: cluster-id
              optional: true
        - name: IDENTITY_ALLOCATION_MODE
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: identity-allocation-mode
        - name: ENABLE_K8S_ENDPOINT_SLICE
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: enable-k8s-endpoint-slice
              optional: true
        volumeMounts:
        - name: etcd-admin-client
          mountPath: /var/lib/cilium/etcd-secrets
          readOnly: true
        - mountPath: /tmp/dir
          name: tmp
        terminationMessagePolicy: FallbackToLogsOnError
      volumes:
      - name: etcd-server-secrets
        secret:
          secretName: clustermesh-apiserver-server-cert
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
      - name: etcd-admin-client
        secret:
          secretName: clustermesh-apiserver-admin-cert
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
      - name: etcd-data-dir
        emptyDir: {}
      - emptyDir: {}
        name: tmp
      restartPolicy: Always
      priorityClassName: system-cluster-critical
      serviceAccount: "clustermesh-apiserver"
      serviceAccountName: "clustermesh-apiserver"
      automountServiceAccountToken: true
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                k8s-app: clustermesh-apiserver
            topologyKey: kubernetes.io/hostname
      nodeSelector:
        kubernetes.io/os: linux
---
# Source: cilium/templates/hubble-relay/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hubble-relay
  namespace: default
  labels:
    k8s-app: hubble-relay
    app.kubernetes.io/name: hubble-relay
    app.kubernetes.io/part-of: cilium
spec:
  replicas: 1
  selector:
    matchLabels:
      k8s-app: hubble-relay
  strategy:
    rollingUpdate:
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      annotations:
      labels:
        k8s-app: hubble-relay
        app.kubernetes.io/name: hubble-relay
        app.kubernetes.io/part-of: cilium
    spec:
      securityContext:
        fsGroup: 65532
      containers:
        - name: hubble-relay
          securityContext:
            capabilities:
              drop:
              - ALL
            runAsGroup: 65532
            runAsNonRoot: true
            runAsUser: 65532
          image: "quay.io/cilium/hubble-relay-ci:latest"
          imagePullPolicy: Always
          command:
            - hubble-relay
          args:
            - serve
          ports:
            - name: grpc
              containerPort: 4245
          readinessProbe:
            tcpSocket:
              port: grpc
          livenessProbe:
            tcpSocket:
              port: grpc
          volumeMounts:
          - name: config
            mountPath: /etc/hubble-relay
            readOnly: true
          - name: tls
            mountPath: /var/lib/hubble-relay/tls
            readOnly: true
          terminationMessagePolicy: FallbackToLogsOnError
      restartPolicy: Always
      priorityClassName: 
      serviceAccount: "hubble-relay"
      serviceAccountName: "hubble-relay"
      automountServiceAccountToken: false
      terminationGracePeriodSeconds: 1
      affinity:
        podAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                k8s-app: cilium
            topologyKey: kubernetes.io/hostname
      nodeSelector:
        kubernetes.io/os: linux
      volumes:
      - name: config
        configMap:
          name: hubble-relay-config
          items:
          - key: config.yaml
            path: config.yaml
      - name: tls
        projected:
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          sources:
          - secret:
              name: hubble-relay-client-certs
              items:
                - key: ca.crt
                  path: hubble-server-ca.crt
                - key: tls.crt
                  path: client.crt
                - key: tls.key
                  path: client.key
---
# Source: cilium/templates/hubble-ui/deployment.yaml
kind: Deployment
apiVersion: apps/v1
metadata:
  name: hubble-ui
  namespace: default
  labels:
    k8s-app: hubble-ui
    app.kubernetes.io/name: hubble-ui
    app.kubernetes.io/part-of: cilium
spec:
  replicas: 1
  selector:
    matchLabels:
      k8s-app: hubble-ui
  template:
    metadata:
      annotations:
      labels:
        k8s-app: hubble-ui
        app.kubernetes.io/name: hubble-ui
        app.kubernetes.io/part-of: cilium
    spec:
      securityContext:
        fsGroup: 1001
        runAsGroup: 1001
        runAsUser: 1001
      priorityClassName: 
      serviceAccount: "hubble-ui"
      serviceAccountName: "hubble-ui"
      automountServiceAccountToken: true
      containers:
      - name: frontend
        image: "quay.io/cilium/hubble-ui:v0.10.0@sha256:118ad2fcfd07fabcae4dde35ec88d33564c9ca7abe520aa45b1eb13ba36c6e0a"
        imagePullPolicy: Always
        ports:
        - name: http
          containerPort: 8081
        volumeMounts:
        - name: hubble-ui-nginx-conf
          mountPath: /etc/nginx/conf.d/default.conf
          subPath: nginx.conf
        - name: tmp-dir
          mountPath: /tmp
        - mountPath: /tmp/dir
          name: tmp
        terminationMessagePolicy: FallbackToLogsOnError
      - name: backend
        image: "quay.io/cilium/hubble-ui-backend:v0.10.0@sha256:cc5e2730b3be6f117b22176e25875f2308834ced7c3aa34fb598aa87a2c0a6a4"
        imagePullPolicy: Always
        env:
        - name: EVENTS_SERVER_PORT
          value: "8090"
        - name: FLOWS_API_ADDR
          value: "hubble-relay:80"
        ports:
        - name: grpc
          containerPort: 8090
        volumeMounts:
        - mountPath: /tmp/dir
          name: tmp
        terminationMessagePolicy: FallbackToLogsOnError
      nodeSelector:
        kubernetes.io/os: linux
      volumes:
      - configMap:
          defaultMode: 420
          name: hubble-ui-nginx
        name: hubble-ui-nginx-conf
      - emptyDir: {}
        name: tmp-dir
      - emptyDir: {}
        name: tmp
      - emptyDir: {}
        name: tmp
---
# Source: cilium/templates/hubble/tls-cronjob/job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: hubble-generate-certs-25ea79c042
  namespace: default
  labels:
    k8s-app: hubble-generate-certs
    app.kubernetes.io/name: hubble-generate-certs
    app.kubernetes.io/part-of: cilium
  annotations:
spec:
  template:
    metadata:
      labels:
        k8s-app: hubble-generate-certs
    spec:
      containers:
        - name: certgen
          image: "quay.io/cilium/certgen:v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"
          imagePullPolicy: Always
          command:
            - "/usr/bin/cilium-certgen"
          # Because this is executed as a job, we pass the values as command
          # line args instead of via config map. This allows users to inspect
          # the values used in past runs by inspecting the completed pod.
          args:
            - "--cilium-namespace=default"
            - "--ca-generate"
            - "--ca-reuse-secret"
            - "--hubble-server-cert-generate"
            - "--hubble-server-cert-common-name=*.default.hubble-grpc.cilium.io"
            - "--hubble-server-cert-validity-duration=94608000s"
            - "--hubble-relay-client-cert-generate"
            - "--hubble-relay-client-cert-validity-duration=94608000s"
          volumeMounts:
          - mountPath: /tmp/dir
            name: tmp
      hostNetwork: true
      serviceAccount: "hubble-generate-certs"
      serviceAccountName: "hubble-generate-certs"
      automountServiceAccountToken: true
      restartPolicy: OnFailure
      volumes:
      - emptyDir: {}
        name: tmp
  ttlSecondsAfterFinished: 1800
---
# Source: cilium/templates/hubble/tls-cronjob/cronjob.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: hubble-generate-certs
  namespace: default
  labels:
    k8s-app: hubble-generate-certs
    app.kubernetes.io/name: hubble-generate-certs
    app.kubernetes.io/part-of: cilium
  annotations:
spec:
  schedule: "0 0 1 */4 *"
  concurrencyPolicy: Forbid
  jobTemplate:
    spec:
      template:
        metadata:
          labels:
            k8s-app: hubble-generate-certs
        spec:
          containers:
            - name: certgen
              image: "quay.io/cilium/certgen:v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"
              imagePullPolicy: Always
              command:
                - "/usr/bin/cilium-certgen"
              # Because this is executed as a job, we pass the values as command
              # line args instead of via config map. This allows users to inspect
              # the values used in past runs by inspecting the completed pod.
              args:
                - "--cilium-namespace=default"
                - "--ca-generate"
                - "--ca-reuse-secret"
                - "--hubble-server-cert-generate"
                - "--hubble-server-cert-common-name=*.default.hubble-grpc.cilium.io"
                - "--hubble-server-cert-validity-duration=94608000s"
                - "--hubble-relay-client-cert-generate"
                - "--hubble-relay-client-cert-validity-duration=94608000s"
              volumeMounts:
              - mountPath: /tmp/dir
                name: tmp
          hostNetwork: true
          serviceAccount: "hubble-generate-certs"
          serviceAccountName: "hubble-generate-certs"
          automountServiceAccountToken: true
          restartPolicy: OnFailure
          volumes:
          - emptyDir: {}
            name: tmp
      ttlSecondsAfterFinished: 1800
---
# Source: cilium/templates/cilium-secrets-namespace.yaml
# Only create the namespace if it's different from Ingress secret namespace or Ingress is not enabled.

```

</details>