### PR TITLE
[v1.13] hubble-relay: deprecate peer svc through local unix domain socket

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -862,11 +862,11 @@
      - string
      - ``"cluster.local"``
    * - hubble.peerService.enabled
-     - Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client
+     - Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client. This configuration option is deprecated, the peer service will be non-optional starting Cilium v1.14.
      - bool
      - ``true``
    * - hubble.peerService.targetPort
-     - Target Port for the Peer service.
+     - Target Port for the Peer service, must match the hubble.listenAddress' port.
      - int
      - ``4244``
    * - hubble.preferIpv6

--- a/Documentation/internals/hubble.rst
+++ b/Documentation/internals/hubble.rst
@@ -32,9 +32,6 @@ respective gRPC APIs. This capability is usually referred to as multi-node.
 Hubble Relay's main goal is to offer a rich API that can be safely exposed and
 consumed by the Hubble UI and CLI.
 
-.. note:: This guide does not cover Hubble in standalone mode, which is
-          deprecated with the release of Cilium v1.8.
-
 Hubble Architecture
 ===================
 
@@ -59,7 +56,7 @@ other information related to the running instance(s)), ``GetFlows`` is far more
 sophisticated and the more important one.
 
 Using ``GetFlows``, callers get a stream of payloads. Request parameters allow
-callers to specify filters in the form of blacklists and whitelists to allow
+callers to specify filters in the form of allow lists and deny lists to allow
 for fine-grained filtering of data.
 
 In order to answer ``GetFlows`` requests, Hubble stores monitoring events from
@@ -68,6 +65,11 @@ events are obtained by registering a new listener on Cilium monitor. The
 ring buffer is capable of storing a configurable amount of events in memory.
 Events are continuously consumed, overriding older ones once the ring buffer is
 full.
+
+Additionally, the Observer service also provides the ``GetAgentEvents`` and
+``GetDebugEvents`` RPC endpoints to expose data about the Cilium agent events
+and Cilium datapath debug events, respectively. Both are similar to ``GetFlows``
+except they do not implement filtering capabilities.
 
 .. image:: ./../images/hubble_getflows.png
 
@@ -92,7 +94,7 @@ The Peer service
 The Peer service sends information about Hubble peers in the cluster in a
 stream. When the ``Notify`` method is called, it reports information about all
 the peers in the cluster and subsequently sends information about peers that
-are updated, added or removed from the cluster. Thus, it allows the caller to
+are updated, added, or removed from the cluster. Thus, it allows the caller to
 keep track of all Hubble instances and query their respective gRPC services.
 
 This service is typically only exposed on a local Unix domain socket and a
@@ -115,7 +117,7 @@ from across the entire cluster (or even multiple clusters in a ClusterMesh
 scenario).
 
 Hubble Relay was first introduced as a technology preview with the release of
-Cilium v1.8. It is declared stable with the release of Cilium v1.9.
+Cilium v1.8 and was declared stable with the release of Cilium v1.9.
 
 Hubble Relay implements the Observer service for multi-node. To that end, it
 maintains a persistent connection with every Hubble peer in a cluster with a

--- a/Documentation/internals/hubble.rst
+++ b/Documentation/internals/hubble.rst
@@ -43,8 +43,8 @@ Hubble server
 
 The Hubble server component implements two gRPC services. The **Observer
 service** which may optionally be exposed via a TCP socket in addition to a
-local Unix domain socket and the  **Peer service**, which is served on both
-as well as a Kubernetes Service.
+local Unix domain socket and the **Peer service**, which is served on both
+as well as being exposed as a Kubernetes Service when enabled via TCP.
 
 The Observer service
 ^^^^^^^^^^^^^^^^^^^^
@@ -97,9 +97,8 @@ the peers in the cluster and subsequently sends information about peers that
 are updated, added, or removed from the cluster. Thus, it allows the caller to
 keep track of all Hubble instances and query their respective gRPC services.
 
-This service is typically only exposed on a local Unix domain socket and a
-Kubernetes Service and is primarily used by Hubble Relay in order to have
-a cluster-wide view of all Hubble instances.
+This service is exposed as a Kubernetes Service and is primarily used by Hubble
+Relay in order to have a cluster-wide view of all Hubble instances.
 
 The Peer service obtains peer change notifications by subscribing to Cilium's
 node manager. To this end, it internally defines a handler that implements

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -403,6 +403,12 @@ Helm Options
   The cilium-operator pprof configuration is now managed via the ``operator.pprof`` section.
   Additionally, a``hubble.relay.pprof`` section has been added.
 * All pprof configuration now support configuring the pprof listen address, defaulting to localhost.
+* The ``hubble.peerService.enabled`` value is deprecated. Currently ``true`` by
+  default, Cilium v1.14 will remove the option to set it to ``false`` as support
+  for Hubble Relay to query the Peer Service through the Hubble local UNIX
+  domain socket will be removed and the Kubernetes peer-svc mandatory when
+  Hubble Relay is enabled. Users overriding ``hubble.peerService.enabled`` to
+  ``false`` are encouraged to migrate to ``true`` with the Cilium v1.13 release.
 
 CRD Changes
 ~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -266,8 +266,8 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor hubble |
 | hubble.metrics.serviceMonitor.relabelings | list | `[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]` | Relabeling configs for the ServiceMonitor hubble |
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
-| hubble.peerService.enabled | bool | `true` | Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client |
-| hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service. |
+| hubble.peerService.enabled | bool | `true` | Enable a K8s Service for the Peer service, so that it can be accessed by a non-local client. This configuration option is deprecated, the peer service will be non-optional starting Cilium v1.14. |
+| hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service, must match the hubble.listenAddress' port. |
 | hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -890,13 +890,15 @@ hubble:
 
   peerService:
     # -- Enable a K8s Service for the Peer service, so that it can be accessed
-    # by a non-local client
+    # by a non-local client. This configuration option is deprecated, the peer
+    # service will be non-optional starting Cilium v1.14.
     enabled: true
     # -- Service Port for the Peer service.
     # If not set, it is dynamically assigned to port 443 if TLS is enabled and to
     # port 80 if not.
     # servicePort: 80
-    # -- Target Port for the Peer service.
+    # -- Target Port for the Peer service, must match the hubble.listenAddress'
+    # port.
     targetPort: 4244
     # -- The cluster domain to use to query the Hubble Peer service. It should
     # be the local cluster.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -887,13 +887,15 @@ hubble:
 
   peerService:
     # -- Enable a K8s Service for the Peer service, so that it can be accessed
-    # by a non-local client
+    # by a non-local client. This configuration option is deprecated, the peer
+    # service will be non-optional starting Cilium v1.14.
     enabled: true
     # -- Service Port for the Peer service.
     # If not set, it is dynamically assigned to port 443 if TLS is enabled and to
     # port 80 if not.
     # servicePort: 80
-    # -- Target Port for the Peer service.
+    # -- Target Port for the Peer service, must match the hubble.listenAddress'
+    # port.
     targetPort: 4244
     # -- The cluster domain to use to query the Hubble Peer service. It should
     # be the local cluster.


### PR DESCRIPTION
v1.13 backport PR of https://github.com/cilium/cilium/pull/23407