### PR TITLE
helm: Add pod and container security context

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -229,6 +229,10 @@
      - Specifies the resources for etcd container in the apiserver
      - object
      - ``{}``
+   * - clustermesh.apiserver.etcd.securityContext
+     - Security context to be added to clustermesh-apiserver etcd containers
+     - object
+     - ``{}``
    * - clustermesh.apiserver.extraEnv
      - Additional clustermesh-apiserver environment variables.
      - list
@@ -269,6 +273,10 @@
      - Labels to be added to clustermesh-apiserver pods
      - object
      - ``{}``
+   * - clustermesh.apiserver.podSecurityContext
+     - Security context to be added to clustermesh-apiserver pods
+     - object
+     - ``{}``
    * - clustermesh.apiserver.priorityClassName
      - The priority class to use for clustermesh-apiserver
      - string
@@ -279,6 +287,10 @@
      - ``1``
    * - clustermesh.apiserver.resources
      - Resource requests and limits for the clustermesh-apiserver
+     - object
+     - ``{}``
+   * - clustermesh.apiserver.securityContext
+     - Security context to be added to clustermesh-apiserver containers
      - object
      - ``{}``
    * - clustermesh.apiserver.service.annotations
@@ -719,6 +731,10 @@
      - ``nil``
    * - etcd.podLabels
      - Labels to be added to cilium-etcd-operator pods
+     - object
+     - ``{}``
+   * - etcd.podSecurityContext
+     - Security context to be added to cilium-etcd-operator pods
      - object
      - ``{}``
    * - etcd.priorityClassName
@@ -1173,6 +1189,10 @@
      - Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
      - object
      - ``{}``
+   * - hubble.ui.backend.securityContext
+     - Hubble-ui backend security context.
+     - object
+     - ``{}``
    * - hubble.ui.enabled
      - Whether to enable the Hubble UI.
      - bool
@@ -1195,6 +1215,10 @@
      - ``{"digest":"sha256:118ad2fcfd07fabcae4dde35ec88d33564c9ca7abe520aa45b1eb13ba36c6e0a","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui","tag":"v0.10.0","useDigest":true}``
    * - hubble.ui.frontend.resources
      - Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment.
+     - object
+     - ``{}``
+   * - hubble.ui.frontend.securityContext
+     - Hubble-ui frontend security context.
      - object
      - ``{}``
    * - hubble.ui.frontend.server.ipv6
@@ -1701,6 +1725,10 @@
      - Labels to be added to cilium-operator pods
      - object
      - ``{}``
+   * - operator.podSecurityContext
+     - Security context to be added to cilium-operator pods
+     - object
+     - ``{}``
    * - operator.pprof.address
      - Configure pprof listen address for cilium-operator
      - string
@@ -1809,6 +1837,10 @@
      - Labels to be added to agent pods
      - object
      - ``{}``
+   * - podSecurityContext
+     - Security Context for cilium-agent pods.
+     - object
+     - ``{}``
    * - policyEnforcementMode
      - The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes
      - string
@@ -1871,6 +1903,10 @@
      - ``nil``
    * - preflight.podLabels
      - Labels to be added to the preflight pod.
+     - object
+     - ``{}``
+   * - preflight.podSecurityContext
+     - Security context to be added to preflight pods.
      - object
      - ``{}``
    * - preflight.priorityClassName

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -108,6 +108,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.etcd.image | object | `{"digest":"sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3","override":null,"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.5.4","useDigest":true}` | Clustermesh API server etcd image. |
 | clustermesh.apiserver.etcd.init.resources | object | `{}` | Specifies the resources for etcd init container in the apiserver |
 | clustermesh.apiserver.etcd.resources | object | `{}` | Specifies the resources for etcd container in the apiserver |
+| clustermesh.apiserver.etcd.securityContext | object | `{}` | Security context to be added to clustermesh-apiserver etcd containers |
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
 | clustermesh.apiserver.extraVolumeMounts | list | `[]` | Additional clustermesh-apiserver volumeMounts. |
 | clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |
@@ -118,9 +119,11 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | clustermesh.apiserver.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | clustermesh.apiserver.podLabels | object | `{}` | Labels to be added to clustermesh-apiserver pods |
+| clustermesh.apiserver.podSecurityContext | object | `{}` | Security context to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.priorityClassName | string | `""` | The priority class to use for clustermesh-apiserver |
 | clustermesh.apiserver.replicas | int | `1` | Number of replicas run for the clustermesh-apiserver deployment. |
 | clustermesh.apiserver.resources | object | `{}` | Resource requests and limits for the clustermesh-apiserver |
+| clustermesh.apiserver.securityContext | object | `{}` | Security context to be added to clustermesh-apiserver containers |
 | clustermesh.apiserver.service.annotations | object | `{}` | Annotations for the clustermesh-apiserver For GKE LoadBalancer, use annotation cloud.google.com/load-balancer-type: "Internal" For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0 |
 | clustermesh.apiserver.service.nodePort | int | `32379` | Optional port to use as the node port for apiserver access. |
 | clustermesh.apiserver.service.type | string | `"NodePort"` | The type of service used for apiserver access. |
@@ -231,6 +234,7 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | etcd.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | etcd.podLabels | object | `{}` | Labels to be added to cilium-etcd-operator pods |
+| etcd.podSecurityContext | object | `{}` | Security context to be added to cilium-etcd-operator pods |
 | etcd.priorityClassName | string | `""` | The priority class to use for cilium-etcd-operator |
 | etcd.resources | object | `{}` | cilium-etcd-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | etcd.securityContext | object | `{}` | Security context to be added to cilium-etcd-operator pods |
@@ -344,12 +348,14 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.backend.extraVolumes | list | `[]` | Additional hubble-ui backend volumes. |
 | hubble.ui.backend.image | object | `{"digest":"sha256:cc5e2730b3be6f117b22176e25875f2308834ced7c3aa34fb598aa87a2c0a6a4","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"v0.10.0","useDigest":true}` | Hubble-ui backend image. |
 | hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
+| hubble.ui.backend.securityContext | object | `{}` | Hubble-ui backend security context. |
 | hubble.ui.enabled | bool | `false` | Whether to enable the Hubble UI. |
 | hubble.ui.frontend.extraEnv | list | `[]` | Additional hubble-ui frontend environment variables. |
 | hubble.ui.frontend.extraVolumeMounts | list | `[]` | Additional hubble-ui frontend volumeMounts. |
 | hubble.ui.frontend.extraVolumes | list | `[]` | Additional hubble-ui frontend volumes. |
 | hubble.ui.frontend.image | object | `{"digest":"sha256:118ad2fcfd07fabcae4dde35ec88d33564c9ca7abe520aa45b1eb13ba36c6e0a","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui","tag":"v0.10.0","useDigest":true}` | Hubble-ui frontend image. |
 | hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
+| hubble.ui.frontend.securityContext | object | `{}` | Hubble-ui frontend security context. |
 | hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
@@ -476,6 +482,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | operator.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | operator.podLabels | object | `{}` | Labels to be added to cilium-operator pods |
+| operator.podSecurityContext | object | `{}` | Security context to be added to cilium-operator pods |
 | operator.pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-operator |
 | operator.pprof.enabled | bool | `false` | Enable pprof for cilium-operator |
 | operator.pprof.port | int | `6061` | Configure pprof listen port for cilium-operator |
@@ -503,6 +510,7 @@ contributors across the globe, there is almost always someone available to help.
 | pmtuDiscovery.enabled | bool | `false` | Enable path MTU discovery to send ICMP fragmentation-needed replies to the client. |
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |
+| podSecurityContext | object | `{}` | Security Context for cilium-agent pods. |
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes |
 | pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-agent |
 | pprof.enabled | bool | `false` | Enable pprof for cilium-agent |
@@ -519,6 +527,7 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | preflight.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | preflight.podLabels | object | `{}` | Labels to be added to the preflight pod. |
+| preflight.podSecurityContext | object | `{}` | Security context to be added to preflight pods. |
 | preflight.priorityClassName | string | `""` | The priority class to use for the preflight pod. |
 | preflight.resources | object | `{}` | preflight resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | preflight.securityContext | object | `{}` | Security context to be added to preflight pods |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -77,6 +77,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: cilium-agent
         image: {{ include "cilium.image" .Values.image | quote }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -61,6 +61,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.operator.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: cilium-operator
         image: {{ include "cilium.operator.image" . | quote }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -28,6 +28,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- with .Values.preflight.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: clean-cilium-state
           image: {{ include "cilium.image" .Values.preflight.image | quote }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -35,6 +35,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.clustermesh.apiserver.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: etcd-init
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
@@ -113,6 +117,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.clustermesh.apiserver.etcd.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       - name: apiserver
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
@@ -164,6 +172,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
+        {{- with .Values.clustermesh.apiserver.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: etcd-server-secrets
         secret:

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -54,6 +54,10 @@ spec:
       imagePullSecrets:
         {{ toYaml .Values.imagePullSecrets | indent 8 }}
 {{- end }}
+{{- with .Values.etcd.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
       containers:
       - args:
 {{- with .Values.etcd.extraArgs }}
@@ -90,6 +94,10 @@ spec:
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
         terminationMessagePolicy: FallbackToLogsOnError
+        {{- with .Values.etcd.securityContext }}
+        securityContext:
+          {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
         {{- with .Values.etcd.extraVolumeMounts }}
         volumeMounts:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -74,6 +74,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
+        {{- with .Values.hubble.ui.frontend.securityContext }}
+        securityContext:
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
       - name: backend
         image: {{ include "cilium.image" .Values.hubble.ui.backend.image | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
@@ -117,6 +121,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
+        {{- with .Values.hubble.ui.backend.securityContext }}
+        securityContext:
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
       {{- with .Values.hubble.ui.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -182,6 +182,9 @@ extraConfig: {}
 #    test 2
 #    test 3
 
+# -- Security Context for cilium-agent pods.
+podSecurityContext: {}
+
 # -- Annotations to be added to agent pods
 podAnnotations: {}
 
@@ -1230,6 +1233,9 @@ hubble:
         useDigest: true
         pullPolicy: "Always"
 
+      # -- Hubble-ui backend security context.
+      securityContext: {}
+
       # -- Additional hubble-ui backend environment variables.
       extraEnv: []
 
@@ -1257,6 +1263,9 @@ hubble:
         digest: "sha256:118ad2fcfd07fabcae4dde35ec88d33564c9ca7abe520aa45b1eb13ba36c6e0a"
         useDigest: true
         pullPolicy: "Always"
+
+      # -- Hubble-ui frontend security context.
+      securityContext: {}
 
       # -- Additional hubble-ui frontend environment variables.
       extraEnv: []
@@ -1811,6 +1820,9 @@ etcd:
   nodeSelector:
     kubernetes.io/os: linux
 
+  # -- Security context to be added to cilium-etcd-operator pods
+  podSecurityContext: {}
+
   # -- Annotations to be added to cilium-etcd-operator pods
   podAnnotations: {}
 
@@ -1955,6 +1967,9 @@ operator:
 
   # -- Additional cilium-operator volumeMounts.
   extraVolumeMounts: []
+
+  # -- Security context to be added to cilium-operator pods
+  podSecurityContext: {}
 
   # -- Annotations to be added to cilium-operator pods
   podAnnotations: {}
@@ -2185,6 +2200,9 @@ preflight:
     #   value: "value"
     #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+  # -- Security context to be added to preflight pods.
+  podSecurityContext: {}
+
   # -- Annotations to be added to preflight pods
   podAnnotations: {}
 
@@ -2299,6 +2317,9 @@ clustermesh:
       #     cpu: 1000m
       #     memory: 256Mi
 
+      # -- Security context to be added to clustermesh-apiserver etcd containers
+      securityContext: {}
+
       init:
         # -- Specifies the resources for etcd init container in the apiserver
         resources: {}
@@ -2333,6 +2354,12 @@ clustermesh:
 
     # -- Additional clustermesh-apiserver volumeMounts.
     extraVolumeMounts: []
+
+    # -- Security context to be added to clustermesh-apiserver containers
+    securityContext: {}
+
+    # -- Security context to be added to clustermesh-apiserver pods
+    podSecurityContext: {}
 
     # -- Annotations to be added to clustermesh-apiserver pods
     podAnnotations: {}

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -179,6 +179,9 @@ extraConfig: {}
 #    test 2
 #    test 3
 
+# -- Security Context for cilium-agent pods.
+podSecurityContext: {}
+
 # -- Annotations to be added to agent pods
 podAnnotations: {}
 
@@ -1227,6 +1230,9 @@ hubble:
         useDigest: true
         pullPolicy: "${PULL_POLICY}"
 
+      # -- Hubble-ui backend security context.
+      securityContext: {}
+
       # -- Additional hubble-ui backend environment variables.
       extraEnv: []
 
@@ -1254,6 +1260,9 @@ hubble:
         digest: "${HUBBLE_UI_FRONTEND_DIGEST}"
         useDigest: true
         pullPolicy: "${PULL_POLICY}"
+
+      # -- Hubble-ui frontend security context.
+      securityContext: {}
 
       # -- Additional hubble-ui frontend environment variables.
       extraEnv: []
@@ -1808,6 +1817,9 @@ etcd:
   nodeSelector:
     kubernetes.io/os: linux
 
+  # -- Security context to be added to cilium-etcd-operator pods
+  podSecurityContext: {}
+
   # -- Annotations to be added to cilium-etcd-operator pods
   podAnnotations: {}
 
@@ -1952,6 +1964,9 @@ operator:
 
   # -- Additional cilium-operator volumeMounts.
   extraVolumeMounts: []
+
+  # -- Security context to be added to cilium-operator pods
+  podSecurityContext: {}
 
   # -- Annotations to be added to cilium-operator pods
   podAnnotations: {}
@@ -2182,6 +2197,9 @@ preflight:
     #   value: "value"
     #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+  # -- Security context to be added to preflight pods.
+  podSecurityContext: {}
+
   # -- Annotations to be added to preflight pods
   podAnnotations: {}
 
@@ -2296,6 +2314,9 @@ clustermesh:
       #     cpu: 1000m
       #     memory: 256Mi
 
+      # -- Security context to be added to clustermesh-apiserver etcd containers
+      securityContext: {}
+
       init:
         # -- Specifies the resources for etcd init container in the apiserver
         resources: {}
@@ -2330,6 +2351,12 @@ clustermesh:
 
     # -- Additional clustermesh-apiserver volumeMounts.
     extraVolumeMounts: []
+
+    # -- Security context to be added to clustermesh-apiserver containers
+    securityContext: {}
+
+    # -- Security context to be added to clustermesh-apiserver pods
+    podSecurityContext: {}
 
     # -- Annotations to be added to clustermesh-apiserver pods
     podAnnotations: {}


### PR DESCRIPTION
### Description

This commit is to make sure that users can have options to configure security contexts in pod and container levels for all cilium related workload.

Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

Testing was done locally with below values file.

```yaml
podSecurityContext:
  runAsUser: 9999

hubble:
  relay:
    enabled: true
  ui:
    enabled: true
    backend:
      securityContext:
        allowPrivilegeEscalation: false
    frontend:
      securityContext:
        allowPrivilegeEscalation: false
etcd:
  managed: true
  enabled: true
  podSecurityContext:
    runAsUser: 1000

operator:
  podSecurityContext:
    runAsUser: 1001

preflight:
  enabled: false # Toggle this value to check for preflight
  podSecurityContext:
    runAsUser: 1002

clustermesh:
  useAPIServer: true
  apiserver:
    etcd:
      securityContext:
        runAsUser: 1003
```

<details>
<summary>Result template</summary>

```
---
# Source: cilium/templates/cilium-agent/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "cilium"
  namespace: default
---
# Source: cilium/templates/cilium-operator/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "cilium-operator"
  namespace: default
---
# Source: cilium/templates/clustermesh-apiserver/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "clustermesh-apiserver"
  namespace: default
---
# Source: cilium/templates/etcd-operator/cilium-etcd-operator-serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "cilium-etcd-operator"
  namespace: default
---
# Source: cilium/templates/etcd-operator/etcd-operator-serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: cilium-etcd-sa
  namespace: default
---
# Source: cilium/templates/hubble-relay/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "hubble-relay"
  namespace: default
---
# Source: cilium/templates/hubble-ui/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "hubble-ui"
  namespace: default
---
# Source: cilium/templates/cilium-ca-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: cilium-ca
  namespace: default
data:
  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRZXMwanVQWDFQQ2YrVGRUbkJzODJwVEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREFKNWlNR01ZSXovRko2YkxSQTFSRmIvNW5XUWRid2oyMmRnTU9kK050V0QxWEFZaTcKekRXK2ZuVzQ4emdIVHZQWEUrQlQyVmhjS1l0TkNoNnU1WlNNekNEbTJXbnRackRjZ3I3NUN5UTI4VGp1V2FZdQpXVnFxWndmR2ozVnBKUHVWemtCdXV5VThoV0hCNGhVdUZJc3AyVit4QmJBeVVHK0Q5VlFrbGVBaitNMkFZczJ5CnR4R3JXcTBGQVF3QWJndWhOVG43ZXVPRzNVeGc2ZERyVTNCcU95RkJZdm9SLzhKbFhhWDZFd2x4dHZrdDErbDYKNE1jQVE4bDRsRVIvUHQ5eE5PaXQ0UUJJWnJRbGlrR2ZXZkpZSE1qNElEVi9JVDJ6REIya0xLQVh0TEp5R3p0SQp3Y25oOWNtUFNrSzVhU2NuS21YS2hpd1lrNWVlNUdXVVpuZjFBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVoajl0cWszcDNDaWdEeU5naXZ3WWIvTEdUVzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFHa0twTnJRYk82b2NOLzc0ZWNKcERxeVJCQWt3cElVVTk2K0xpNGExcGlFTUR3dTZWTXVLTmhzCkRMQk5jODc2WWtoSzNGY1JiU0UveFU4cnByV3VqWjkyOFFieXhuVDRIMjloM1pmajJOR3lxU3NtL040VTNwUTkKcENJNjVLU3Q5NnN1bVdlKzVONmFHV085MVBNWWNJaGIvTW9wRmxCV2JVTTlXOTUzY3BFd1ZadWxoRElGQjlPKwp6MDZzd2NEaFl6cFBsTmVlRlJtTUsxL3h4aDFta2dlN1lEN1NvR3drbFFERVp4a0NmRWUwVkRkQ1NDNC9uWW4xCkI0Z2R6Q2pLNFV1TUN4SzdkUDFreWpoM2NTWG5KQ1h5akRKcUE3NzdmOGhVQ1JLYjFxZm50c3pncG1EWnQxVysKNlRaYW1tbzAzb1lRRWRnQVB0SmVXWm9YVnBoNWFGbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  ca.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBd0NlWWpCakdDTS94U2VteTBRTlVSVy8rWjFrSFc4STl0bllERG5mamJWZzlWd0dJCnU4dzF2bjUxdVBNNEIwN3oxeFBnVTlsWVhDbUxUUW9lcnVXVWpNd2c1dGxwN1dhdzNJSysrUXNrTnZFNDdsbW0KTGxsYXFtY0h4bzkxYVNUN2xjNUFicnNsUElWaHdlSVZMaFNMS2RsZnNRV3dNbEJ2Zy9WVUpKWGdJL2pOZ0dMTgpzcmNScTFxdEJRRU1BRzRMb1RVNSszcmpodDFNWU9uUTYxTndhanNoUVdMNkVmL0NaVjJsK2hNSmNiYjVMZGZwCmV1REhBRVBKZUpSRWZ6N2ZjVFRvcmVFQVNHYTBKWXBCbjFueVdCekkrQ0ExZnlFOXN3d2RwQ3lnRjdTeWNoczcKU01ISjRmWEpqMHBDdVdrbkp5cGx5b1lzR0pPWG51UmxsR1ozOVFJREFRQUJBb0lCQVFDaGNxTmhVbzlSYUNXNwpqSGVKMWRwQVhWRExWS295Rm9uemZFUWxLK1lTUVVtSWlPbHhvS3FuVzJsZDlEem5KeGNKWnRIY29ZajBKcE84Ckx2eUl4cXlCZ0NGRTFQZURWL3pSeWFqYlp0a09zSzY4MU9Zam16L3FYSmJUNWtVb0NzSzNvNHZQZmI1VGsxNEgKb1FWYXFqZ2krVmpGUzVvM0xBNEdPV0p4T3R3UVc4N1phMkFxaDJJdmt2M0hiM3JXNDNZS0lMeFRBdFlsNmdPeApCTkFyWCtGeTgxcStZSVQrbWU3a2lSNkg3TlpmRHdPelhzMlo3TUw4SGdnTnpsNThER1BpMVFYVW14OVc0QnM3CjJXQ3k1N0tGd3c2a2gvd0JXWk5GTytBR21OUnpCOTcwbTh6U2ZFaFRrd0dXUllwSlZDUTloVGkrakl3MmdUb04KWkFzbkpENEJBb0dCQU42MC9RaTEwTThWRTFYY1RGM0FZVERmV1J6N0FWUDhLckR2bGxJTW8xQW1GaGJiblZvTgoza1haMkthYmZ6WGVDckx4cUZ0WFpxTXA0WElxTTErZVAwdjgzS0RTOTZDTGdyZWFPV0ZCQjFJcWlNV01zVFgvClFlTVlYSWxqN0ZNcTF0OXE4K1ZPcTVYZ3AvSlZQd2dPNnNNUUZsWng1RU1raTl5MysvaHRsRFBSQW9HQkFOemgKWGtsTEhselFJSVh2eHFKa3AvYkdYYW43d1ZhRmMrUm13czhZTURKVU1KVEk4MlRpR3FlVm9zL24vWC84WWpYSQo0Q1M2NFJGUHFvTnZ2MzVLQkt2MzVIN2JLdVBORy8xT2p1U3pPNVAwRFQ0SnNsQ21DemhrWTA4UGN5cWRnM2tjCmh1RFRuN3Juc3lGMVMrZkVrc2k2RnI3MFZkWlhycS92dTBWOUw3N2xBb0dCQU5Nc2JRNllVSEk3K3NTY2l2RU8KM1ZuWlB3ZWkzdVNESlB2M2d1TTBScHRXTWZYa3NyVFVsNkpHYWcrNVBJdVlpeTZZeE5vdjZ3dm1SM2JZbXpRYwp1c3BUNytTemhzajk0S28ySEJpaTc4MHl0ZFFVajJpekxRZW9idjU3K0hmNEZCMXZyZXNPaU5jcVdqWUlMU2QzCjlaV1hLSWM1b1ljbEhWWGlRNU9TWEVneEFvR0FkUkZodHJrQW83S1B1azFHV3lXOFBEZ1F4cG92YzVzUnZKbVcKWU1yeUtJcWtvUWNNc1lpQkZoZGlEbzFudDJEZDhLSEI0dFhGbWpZK0txR2N2ZU9mTEVJYnNmeVpjOWx2SDBkMgp4dElVSHF1NEpReGduUXdVWUZRY3FuZUcwNnhlVlYrQVFVTUlvcmhSSWNlWWJvT3FSSWNVclNxMUlBQ2pEbzZpCkZBZHd1ZDBDZ1lCUUo5aUlMZCtNOFFYeE1RK1BhMVhGc2pkbmYvSGVvWUxIQ2JaQVkwRkw0RmhBenh5Y2lhbzQKRTJrd3RJZGN1anpwZ2xNa0U3d2JSL1RkU3BTeU9PY2ZoYU5yOWw3d3FwdlM2RGlyL0JaUlJKaWEzWmJLQlBGTQo1enVWa2pnelI4YnlPRkRvOWlhMjlPeVQwK05tTjZlY0xQZWFvaS92YmdIejc5NWt1d1pZR2c9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
---
# Source: cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: clustermesh-apiserver-admin-cert
  namespace: default
type: kubernetes.io/tls
data:
  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRZXMwanVQWDFQQ2YrVGRUbkJzODJwVEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREFKNWlNR01ZSXovRko2YkxSQTFSRmIvNW5XUWRid2oyMmRnTU9kK050V0QxWEFZaTcKekRXK2ZuVzQ4emdIVHZQWEUrQlQyVmhjS1l0TkNoNnU1WlNNekNEbTJXbnRackRjZ3I3NUN5UTI4VGp1V2FZdQpXVnFxWndmR2ozVnBKUHVWemtCdXV5VThoV0hCNGhVdUZJc3AyVit4QmJBeVVHK0Q5VlFrbGVBaitNMkFZczJ5CnR4R3JXcTBGQVF3QWJndWhOVG43ZXVPRzNVeGc2ZERyVTNCcU95RkJZdm9SLzhKbFhhWDZFd2x4dHZrdDErbDYKNE1jQVE4bDRsRVIvUHQ5eE5PaXQ0UUJJWnJRbGlrR2ZXZkpZSE1qNElEVi9JVDJ6REIya0xLQVh0TEp5R3p0SQp3Y25oOWNtUFNrSzVhU2NuS21YS2hpd1lrNWVlNUdXVVpuZjFBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVoajl0cWszcDNDaWdEeU5naXZ3WWIvTEdUVzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFHa0twTnJRYk82b2NOLzc0ZWNKcERxeVJCQWt3cElVVTk2K0xpNGExcGlFTUR3dTZWTXVLTmhzCkRMQk5jODc2WWtoSzNGY1JiU0UveFU4cnByV3VqWjkyOFFieXhuVDRIMjloM1pmajJOR3lxU3NtL040VTNwUTkKcENJNjVLU3Q5NnN1bVdlKzVONmFHV085MVBNWWNJaGIvTW9wRmxCV2JVTTlXOTUzY3BFd1ZadWxoRElGQjlPKwp6MDZzd2NEaFl6cFBsTmVlRlJtTUsxL3h4aDFta2dlN1lEN1NvR3drbFFERVp4a0NmRWUwVkRkQ1NDNC9uWW4xCkI0Z2R6Q2pLNFV1TUN4SzdkUDFreWpoM2NTWG5KQ1h5akRKcUE3NzdmOGhVQ1JLYjFxZm50c3pncG1EWnQxVysKNlRaYW1tbzAzb1lRRWRnQVB0SmVXWm9YVnBoNWFGbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKRENDQWd5Z0F3SUJBZ0lSQU1uZjZVcmZ6TGNiMWlNOE9jekI0Z3N3RFFZSktvWklodmNOQVFFTEJRQXcKRkRFU01CQUdBMVVFQXhNSlEybHNhWFZ0SUVOQk1CNFhEVEl6TURFek1ERXhORGcwTUZvWERUSTJNREV5T1RFeApORGcwTUZvd0R6RU5NQXNHQTFVRUF4TUVjbTl2ZERDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt0SWJLUEIvQWp5Qk1mQjhURFhIRlV6emFMTXpTVmVTS3FTbmN6eWRLS3NWOFJuMzl6WW0vc1cKQWNSSTlhcnBYR21xd0ozWjJJY1ByWHhWMWRvY29EQ1hNRjg2Vm9FWU1GeDhQZDVkK3JuKzMrby9uUWxSeUJrMgp4SkhLNXFua0dZaFhZY3Zxd1lIWGVaaXRFSDhFZzFLYXVTcE16Y29PYVJhRlpqbjF6N1I2T293bjFCNkZUaGpCCnBPUjhJL2tXZExBMkdON3BwNzJidS8vTWJxMTF3SXY2THlWUkZBTk5HT2cxeEpFNHgwV2RIQnhWcHNyT3M0c1MKTTdvemd0YU1lcVdXbm1keCthY3NYSWNpVHRCVjJoUjB6QW9jY1A0N0RnbHptaXBNZEM3L1hiTFAwakZOOTFXTgpzRVVNM2daNitTa3Z0VnNSMTRaQWdsYjNDOThOZjJjQ0F3RUFBYU4yTUhRd0RnWURWUjBQQVFIL0JBUURBZ1dnCk1CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFNQmdOVkhSTUJBZjhFQWpBQU1COEcKQTFVZEl3UVlNQmFBRklZL2JhcE42ZHdvb0E4allJcjhHRy95eGsxdk1CUUdBMVVkRVFRTk1BdUNDV3h2WTJGcwphRzl6ZERBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp2czdCa2pQWC9ZaVJId2RDREY5aHc2dTdzUGtpaERmCkkwbUJYeVdjdzB2T0FzamVxL0wvSFZiRWdVRkZvdDNwQjdpUHRjaFJtYmpYMUp2Y0wvS2tqS0VrSUFWaG5XKzIKSFNHb0ZSRDJnTUpLYzRGQ2tNbzh6Um1JZnVlRkFXazV1b1JhS3laNEVVWHQxZFUxRXdXcWdDaENtckgyazI1UApzWTJhYlJnUFh4Uy9lSytnRkJiRHF2SHJtVlFmRGRkbGRWeUIxMi9reGZacjNqa1pZWlBKODVyUzZ3bXBEQWRuClVNcUlxTDVWY0ZDbDdjWXNCNXFRU1QyTnNSSWF1U0Q0WFNKR2JteUFOSk1PQVJOYnl5QzMwTkl3TktDajRaUFYKRVVTU0ZBLytSY2FDcDdxQzFxejIwMjVJTXh3YmJ3MTYwSk9XbDI3aGo3cUo5UEJXZk43bHJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBcTBoc284SDhDUElFeDhIeE1OY2NWVFBOb3N6TkpWNUlxcEtkelBKMG9xeFh4R2ZmCjNOaWIreFlCeEVqMXF1bGNhYXJBbmRuWWh3K3RmRlhWMmh5Z01KY3dYenBXZ1Jnd1hIdzkzbDM2dWY3ZjZqK2QKQ1ZISUdUYkVrY3JtcWVRWmlGZGh5K3JCZ2RkNW1LMFFmd1NEVXBxNUtrek55ZzVwRm9WbU9mWFB0SG82akNmVQpIb1ZPR01HazVId2orUlowc0RZWTN1bW52WnU3Lzh4dXJYWEFpL292SlZFVUEwMFk2RFhFa1RqSFJaMGNIRldtCnlzNnppeEl6dWpPQzFveDZwWmFlWjNINXB5eGNoeUpPMEZYYUZIVE1DaHh3L2pzT0NYT2FLa3gwTHY5ZHNzL1MKTVUzM1ZZMndSUXplQm5yNUtTKzFXeEhYaGtDQ1Z2Y0wzdzEvWndJREFRQUJBb0lCQUNlQmtPMUVkT2xyU1FiNgpDTE9IS2hYTTJRVlB6NUZxNmIvT0NXK1lES2Jvc1dXdnY4YWtmM1d1WWNId1FobWxzWmI5dDJleE0yd1RoYVJECitBdFN4dS91TDA0SG1xUXovQk9ZNUh4Qm1POEZob2YxSERkbUVZMGZRTCtQMlJ3ZWJIVXlFbkNDT1JmRnAxbzcKc0s1YlVCN2hhUXdFb3dLVHlGRlZlM3FxNDdsd2h5d0dZc3J4dkd4alg1SUJQUjUvVktaZStsbTF6MGd3LzlUSgpTaDV4d1ZsTzhVQkVRdkF0cjJQUVVwUis5ZkhqZjl5dGFnN0RSc0xXdTkrU3FyV1FVQ1BFZ3dxeU9kbDg3dDUxCjNteXo2SjQrSkxwNU5rL2FDUlpXVTRQWjE2ZS9SRE9Gd1FVUnRvNUU2UTg0Q3dnL1JRRGR4R291UU0wa05NNzkKZDhzaHVRRUNnWUVBemRZVnBtL1Y1QTBGN1hRa0FCMHVoUXU2aDR3a3JhOHJpSlpLMjk0c2RGUEIzM3p1cTdnawpmTkp4Rm1wZEpiN3V3SWE5V0EvUzNJYmhxSkx5ZUZPRG1PdUE2YVJRcDVPZFZJZWh2UmpTTklOVExJS01OVzNvCklpL0RMdXpmeHRFS21vbFZjQ3hCM1RsSFFwUnZMaThVbFc4Skx2OU1xeHk1TnFiRjd5OURoSWNDZ1lFQTFRYVgKUHN4N3EyR3p5cFl5NVhqdEdWZmZOSUVJK1ViL3JmOFFNTXBYM2EzaVhyWEZtS2VNbXZuTG5nUGdaanlkSHhaSQozZDR2K2Q0NmRMRC8rQ1pQdGp3U2VZQXR4cXFsVUFUWFpvVnByY3VMN2RScktnQVgrQnNBekZpaVZuNXNWRW1mCmJkT3ZLazBnYjZiNlVpWHhUeEEwWS9JdWgrQVBzbFVLQzRtZnhpRUNnWUFqb1ByK1pEMVJ6QzlLZXVBQVpReTQKV3Q5ZXR4TmlQUC84RklmQXB5UnF2bFRBcW85bGllcEc4T1pDU3diMGthZ2lDekNiSGFJU0tnYkZkeW9oU2ROdApsTllybXhXYTdDSS9qM3Fma0x4UitxbGErdjNxQWF3OHZxZTZaNllVYy9xeDVUTzB4dlJmcHBwL0c5SmkzQ05qCittUk1qa1JuR2dHMVJBamU3Zjl4NFFLQmdRQzl6NWlXU1Nkc2hxcm51VHR5Z25ScEg0WHZ4NFhTYjdQRU9zQVgKYVVRdmJ3K0VLbHo5YjFWMmhWc3IyZkpweGxxTjU1Slh0dkZ5cDlQWVJCcGY1dXNoeXBiL2tmbTN5amR3ZkUvZAp0c1I2S2lMdGNGZG9YaHI5WkRvcTJsTVQxS1A3Mm5ubkp6WXQ3L2tWNDJlcUtNckNFd05MaHZCMCsyMmhEZXJjCmF1MWxZUUtCZ0JZNFdBSHFRQVJIR3hxTk9vRXBsNnVRN2lJTUxwbFpCekZVVmsxZ05PYzFYS3Jpd0hWOVY3RFgKdkpXT1QrbEVLcitUbmE4KzRScE5oOXk2TTU3cTNGaUpwV0E0TktlVWczR3JXNFQ4OWNJWjB4Q3BIMEwrQ3Q5cApyUTlxY2w2QlRSOFhZMUtRenA5OG45Ym5iVlZlektvQmxFV01Xcnd2ZE1JL3dEM28wbnE1Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
---
# Source: cilium/templates/clustermesh-apiserver/tls-helm/ca-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: clustermesh-apiserver-ca-cert
  namespace: default
data:
  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRZXMwanVQWDFQQ2YrVGRUbkJzODJwVEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREFKNWlNR01ZSXovRko2YkxSQTFSRmIvNW5XUWRid2oyMmRnTU9kK050V0QxWEFZaTcKekRXK2ZuVzQ4emdIVHZQWEUrQlQyVmhjS1l0TkNoNnU1WlNNekNEbTJXbnRackRjZ3I3NUN5UTI4VGp1V2FZdQpXVnFxWndmR2ozVnBKUHVWemtCdXV5VThoV0hCNGhVdUZJc3AyVit4QmJBeVVHK0Q5VlFrbGVBaitNMkFZczJ5CnR4R3JXcTBGQVF3QWJndWhOVG43ZXVPRzNVeGc2ZERyVTNCcU95RkJZdm9SLzhKbFhhWDZFd2x4dHZrdDErbDYKNE1jQVE4bDRsRVIvUHQ5eE5PaXQ0UUJJWnJRbGlrR2ZXZkpZSE1qNElEVi9JVDJ6REIya0xLQVh0TEp5R3p0SQp3Y25oOWNtUFNrSzVhU2NuS21YS2hpd1lrNWVlNUdXVVpuZjFBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVoajl0cWszcDNDaWdEeU5naXZ3WWIvTEdUVzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFHa0twTnJRYk82b2NOLzc0ZWNKcERxeVJCQWt3cElVVTk2K0xpNGExcGlFTUR3dTZWTXVLTmhzCkRMQk5jODc2WWtoSzNGY1JiU0UveFU4cnByV3VqWjkyOFFieXhuVDRIMjloM1pmajJOR3lxU3NtL040VTNwUTkKcENJNjVLU3Q5NnN1bVdlKzVONmFHV085MVBNWWNJaGIvTW9wRmxCV2JVTTlXOTUzY3BFd1ZadWxoRElGQjlPKwp6MDZzd2NEaFl6cFBsTmVlRlJtTUsxL3h4aDFta2dlN1lEN1NvR3drbFFERVp4a0NmRWUwVkRkQ1NDNC9uWW4xCkI0Z2R6Q2pLNFV1TUN4SzdkUDFreWpoM2NTWG5KQ1h5akRKcUE3NzdmOGhVQ1JLYjFxZm50c3pncG1EWnQxVysKNlRaYW1tbzAzb1lRRWRnQVB0SmVXWm9YVnBoNWFGbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  ca.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBd0NlWWpCakdDTS94U2VteTBRTlVSVy8rWjFrSFc4STl0bllERG5mamJWZzlWd0dJCnU4dzF2bjUxdVBNNEIwN3oxeFBnVTlsWVhDbUxUUW9lcnVXVWpNd2c1dGxwN1dhdzNJSysrUXNrTnZFNDdsbW0KTGxsYXFtY0h4bzkxYVNUN2xjNUFicnNsUElWaHdlSVZMaFNMS2RsZnNRV3dNbEJ2Zy9WVUpKWGdJL2pOZ0dMTgpzcmNScTFxdEJRRU1BRzRMb1RVNSszcmpodDFNWU9uUTYxTndhanNoUVdMNkVmL0NaVjJsK2hNSmNiYjVMZGZwCmV1REhBRVBKZUpSRWZ6N2ZjVFRvcmVFQVNHYTBKWXBCbjFueVdCekkrQ0ExZnlFOXN3d2RwQ3lnRjdTeWNoczcKU01ISjRmWEpqMHBDdVdrbkp5cGx5b1lzR0pPWG51UmxsR1ozOVFJREFRQUJBb0lCQVFDaGNxTmhVbzlSYUNXNwpqSGVKMWRwQVhWRExWS295Rm9uemZFUWxLK1lTUVVtSWlPbHhvS3FuVzJsZDlEem5KeGNKWnRIY29ZajBKcE84Ckx2eUl4cXlCZ0NGRTFQZURWL3pSeWFqYlp0a09zSzY4MU9Zam16L3FYSmJUNWtVb0NzSzNvNHZQZmI1VGsxNEgKb1FWYXFqZ2krVmpGUzVvM0xBNEdPV0p4T3R3UVc4N1phMkFxaDJJdmt2M0hiM3JXNDNZS0lMeFRBdFlsNmdPeApCTkFyWCtGeTgxcStZSVQrbWU3a2lSNkg3TlpmRHdPelhzMlo3TUw4SGdnTnpsNThER1BpMVFYVW14OVc0QnM3CjJXQ3k1N0tGd3c2a2gvd0JXWk5GTytBR21OUnpCOTcwbTh6U2ZFaFRrd0dXUllwSlZDUTloVGkrakl3MmdUb04KWkFzbkpENEJBb0dCQU42MC9RaTEwTThWRTFYY1RGM0FZVERmV1J6N0FWUDhLckR2bGxJTW8xQW1GaGJiblZvTgoza1haMkthYmZ6WGVDckx4cUZ0WFpxTXA0WElxTTErZVAwdjgzS0RTOTZDTGdyZWFPV0ZCQjFJcWlNV01zVFgvClFlTVlYSWxqN0ZNcTF0OXE4K1ZPcTVYZ3AvSlZQd2dPNnNNUUZsWng1RU1raTl5MysvaHRsRFBSQW9HQkFOemgKWGtsTEhselFJSVh2eHFKa3AvYkdYYW43d1ZhRmMrUm13czhZTURKVU1KVEk4MlRpR3FlVm9zL24vWC84WWpYSQo0Q1M2NFJGUHFvTnZ2MzVLQkt2MzVIN2JLdVBORy8xT2p1U3pPNVAwRFQ0SnNsQ21DemhrWTA4UGN5cWRnM2tjCmh1RFRuN3Juc3lGMVMrZkVrc2k2RnI3MFZkWlhycS92dTBWOUw3N2xBb0dCQU5Nc2JRNllVSEk3K3NTY2l2RU8KM1ZuWlB3ZWkzdVNESlB2M2d1TTBScHRXTWZYa3NyVFVsNkpHYWcrNVBJdVlpeTZZeE5vdjZ3dm1SM2JZbXpRYwp1c3BUNytTemhzajk0S28ySEJpaTc4MHl0ZFFVajJpekxRZW9idjU3K0hmNEZCMXZyZXNPaU5jcVdqWUlMU2QzCjlaV1hLSWM1b1ljbEhWWGlRNU9TWEVneEFvR0FkUkZodHJrQW83S1B1azFHV3lXOFBEZ1F4cG92YzVzUnZKbVcKWU1yeUtJcWtvUWNNc1lpQkZoZGlEbzFudDJEZDhLSEI0dFhGbWpZK0txR2N2ZU9mTEVJYnNmeVpjOWx2SDBkMgp4dElVSHF1NEpReGduUXdVWUZRY3FuZUcwNnhlVlYrQVFVTUlvcmhSSWNlWWJvT3FSSWNVclNxMUlBQ2pEbzZpCkZBZHd1ZDBDZ1lCUUo5aUlMZCtNOFFYeE1RK1BhMVhGc2pkbmYvSGVvWUxIQ2JaQVkwRkw0RmhBenh5Y2lhbzQKRTJrd3RJZGN1anpwZ2xNa0U3d2JSL1RkU3BTeU9PY2ZoYU5yOWw3d3FwdlM2RGlyL0JaUlJKaWEzWmJLQlBGTQo1enVWa2pnelI4YnlPRkRvOWlhMjlPeVQwK05tTjZlY0xQZWFvaS92YmdIejc5NWt1d1pZR2c9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
---
# Source: cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: clustermesh-apiserver-remote-cert
  namespace: default
type: kubernetes.io/tls
data:
  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRZXMwanVQWDFQQ2YrVGRUbkJzODJwVEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREFKNWlNR01ZSXovRko2YkxSQTFSRmIvNW5XUWRid2oyMmRnTU9kK050V0QxWEFZaTcKekRXK2ZuVzQ4emdIVHZQWEUrQlQyVmhjS1l0TkNoNnU1WlNNekNEbTJXbnRackRjZ3I3NUN5UTI4VGp1V2FZdQpXVnFxWndmR2ozVnBKUHVWemtCdXV5VThoV0hCNGhVdUZJc3AyVit4QmJBeVVHK0Q5VlFrbGVBaitNMkFZczJ5CnR4R3JXcTBGQVF3QWJndWhOVG43ZXVPRzNVeGc2ZERyVTNCcU95RkJZdm9SLzhKbFhhWDZFd2x4dHZrdDErbDYKNE1jQVE4bDRsRVIvUHQ5eE5PaXQ0UUJJWnJRbGlrR2ZXZkpZSE1qNElEVi9JVDJ6REIya0xLQVh0TEp5R3p0SQp3Y25oOWNtUFNrSzVhU2NuS21YS2hpd1lrNWVlNUdXVVpuZjFBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVoajl0cWszcDNDaWdEeU5naXZ3WWIvTEdUVzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFHa0twTnJRYk82b2NOLzc0ZWNKcERxeVJCQWt3cElVVTk2K0xpNGExcGlFTUR3dTZWTXVLTmhzCkRMQk5jODc2WWtoSzNGY1JiU0UveFU4cnByV3VqWjkyOFFieXhuVDRIMjloM1pmajJOR3lxU3NtL040VTNwUTkKcENJNjVLU3Q5NnN1bVdlKzVONmFHV085MVBNWWNJaGIvTW9wRmxCV2JVTTlXOTUzY3BFd1ZadWxoRElGQjlPKwp6MDZzd2NEaFl6cFBsTmVlRlJtTUsxL3h4aDFta2dlN1lEN1NvR3drbFFERVp4a0NmRWUwVkRkQ1NDNC9uWW4xCkI0Z2R6Q2pLNFV1TUN4SzdkUDFreWpoM2NTWG5KQ1h5akRKcUE3NzdmOGhVQ1JLYjFxZm50c3pncG1EWnQxVysKNlRaYW1tbzAzb1lRRWRnQVB0SmVXWm9YVnBoNWFGbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lRSG54alZaeTZPSkFjRGZzVitKQWt3VEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBUk1ROHdEUVlEVlFRREV3WnlaVzF2ZEdVd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3CmdnRUtBb0lCQVFDekVzZ3JCU1R4ZWZ1TGVxNWJOVDVpTU44ZFZNM3RpUzhqZ3l1QjBWbHRNanU0REd0SC9wQlEKME84aE5uQy9HMTBWbVFsL0NZMG10aC9EenBOeHYzdkc4MUJOdXIzbUtFcDhTQ2IrR1RISitWQ051NXhkRlBvRApiODlLY3ZZVVEwSTN1a1h4Y3dOcUhvU3Z2U0l5RkRlOTlDUldJUEMrWFdYSy8xQzNBNUNSakVZcWZnM1RkYzNxCnB1ZE9KYmlIRkc3a09EY0FrQlNGTkNhNHNLOGJHdk5JbjNYcTk2NjNYMUozclBhaXFWMCtDR2VYeWlnOHVPZkIKMFFBaW1WbWNGSTgvbUlRa29pK0FzdDViVnhlZXhQUldIM0NSVGswMmRvTlN4L3dCYkNwckRMVjJ1TUtxbDI2eApCc2pzZTYxKzBlV2FvOVZRdWZBdU1MV3FtOHVNQWpOMUFnTUJBQUdqWURCZU1BNEdBMVVkRHdFQi93UUVBd0lGCm9EQWRCZ05WSFNVRUZqQVVCZ2dyQmdFRkJRY0RBUVlJS3dZQkJRVUhBd0l3REFZRFZSMFRBUUgvQkFJd0FEQWYKQmdOVkhTTUVHREFXZ0JTR1AyMnFUZW5jS0tBUEkyQ0svQmh2OHNaTmJ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQwpBUUVBTWxaNENGOVA4bWdRYk5FTDJ6cmhlaFJIZC92OERSOHRlYW9iV3JSQ2pqWUltNGVoT1UyQ2Z5Vko5Mzd1CkRIdEhrNE1NWVNlLzM3bG84S3pudmg3emM0b0Q1aVpLb0NpVlFRdHpBbWg1QkRJTk56NTArMGVjU3ZoNGJpcWwKcUQ1cGlmbmt2TkpWREsvdXJBNm5BNTBKQldGL0dSZDYrYlhvWUh5bXRhQkpQY2Rkekc2Titib3I0U2FVRnJWTQpZU2d6aUMzTzdqdTFtL041b3VYYXRveWNPSXlKOW4vY3NqdkNreWsrUmVLUjNoWWZSRU9telowSEJlaFNmU2xECjUwU1ZUeXB0KzFaQ0VpSllBbVh2SUV1L1EreThTSUxMYXFBeWRKdDhZUElHWnc0VlExMXkvdk1raXR5Yk9XcGYKWVVuQ2N4UUdJWXArclF2VVdIS1NTcXMwUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcFFJQkFBS0NBUUVBc3hMSUt3VWs4WG43aTNxdVd6VStZakRmSFZUTjdZa3ZJNE1yZ2RGWmJUSTd1QXhyClIvNlFVTkR2SVRad3Z4dGRGWmtKZndtTkpyWWZ3ODZUY2I5N3h2TlFUYnE5NWloS2ZFZ20vaGt4eWZsUWpidWMKWFJUNkEyL1BTbkwyRkVOQ043cEY4WE1EYWg2RXI3MGlNaFEzdmZRa1ZpRHd2bDFseXY5UXR3T1FrWXhHS240TgowM1hONnFiblRpVzRoeFJ1NURnM0FKQVVoVFFtdUxDdkd4cnpTSjkxNnZldXQxOVNkNnoyb3FsZFBnaG5sOG9vClBMam53ZEVBSXBsWm5CU1BQNWlFSktJdmdMTGVXMWNYbnNUMFZoOXdrVTVOTm5hRFVzZjhBV3dxYXd5MWRyakMKcXBkdXNRYkk3SHV0ZnRIbG1xUFZVTG53TGpDMXFwdkxqQUl6ZFFJREFRQUJBb0lCQVFDdi9jQitEME04azY3MQphSy9jOGRvS3RJOUNpMnNMald5bmtTMThHMXl4SmRKdFVyOUk5Vld1SjNrdEFnMFN0UGpwMWdyd01GbnA5c29ICkxZblpHK0N4S2NYOWJvOWRtTEdEcllHczd1UHc1VGNXNUpDTEpxZUVJeW50dUVoQ3A4dDNhM2w4RDVZR2dGSFYKU2FORzVubldGUkIxR1ZDaE5yZHBKejJUY0V4dnpYRDR3SThzdjJyNHF2eXY0cmNXOHpzaXc0cERGU281Q0swcwpnemxqOUgxU1NoK3hvZFNZaGZkQ2ZVaVROeUE3ZmJERWxZQVRoSU80dTc1and5cDJXQ3NocXE1a3RnQklIeEhkCnp4QnVGNThTVDhzNkdWZjZxekRXcWlzU0ZjZ09xVGh6citaMkdGOFYxNHgyTFRaS1hGemgvZHY4UkRKMWpzUGcKNkxTcmJzdmhBb0dCQU5iV1NIK1o0OHl1RmpqVEVvSzE1TkZaWkV1NlBzdExMYkkzdjBycWhuaVAycEVaa1FnbAp5UXh1ZDNjcnVVOVRJZU40dWM1ZlNRUWIraXhDMS9LWnF1VEkyenh3dWtOdFpJYm02RmFsVGtHQ3ZQamRYVzd3Ck9XZTFKOUhKSXo2Y3BYQmg3SFZJV05VNFAydW12UTZRUmc5ZmZlV1FlcmtPNklIRXozZ3p1QUdwQW9HQkFOVmkKVEF0TTQzVVpqSklHOElvMkRWZVN6bDNONUxYdlpnWUZYdnpFR0FGNE1penVHNENDc0I4TEdFR3JaVXFXWDNsYwphekFaamZURis5L1g4WFJUaHlHMDJlZW9zaTE3SHdVa0xvZ0JneFFwOThWelVjLzZTWkw5UzFMOGY5K1ZKZTlYCmIwN1hxN2VxZlpRamozVFVvUmFLNmx0OGFHR2ZvZ1hoaXdJNEFacnRBb0dCQU1ZUUlCNmp2Y1NCNnJMUXhZd0UKTGNSajZYZDNhVlQ3SmxIYjIxd3lBMjg3RUlJZFUveHkrWHVnakRzdDhGWVZpblN3Wkh6Q2xBcFowTGJsbVRscwpPb1ZhTitUcytJd1pXa2lVc1RiUWgra1ZveXE4eXRyd1Zid3E0MThoVklEdzRnVk9BalhPVVRlaDk3WkRycUN5Cm1pU3FJT04zNCt5Z3RmS05nOGlKeGVhaEFvR0JBSndXQ2pBZDd5Z2lKenhPRFRmY2NBZ0dJQ1Juem92eThUc28KUktJNndxQ1lqb05sTFFMbEZmV3ZSUEFNY3N5TGtJMFN1R2wzMStvYnhMR3BvVHFKT3dqQjVMOWJHL0srNUNMNwpvM25qT1VIUHJTbG13SXFVdDZybzAyZUJ3ZndIZXJkSHl1anVRL0xXcUlOck82Mm5ONnBvdFNOMHJsbnl6aTdsCkc2emswTy9GQW9HQURNSCsxZ2RscGxXcUJmR0JRd01rNXVLSTVGZWEzNFJGMm1DeFBDbFhpTmJhcmJkeDZpQnoKcEZoY2MxcjhURnFMeElObU1TWEZ3ZkNwekNKaXhZVmFLWElmMFAwOXQ3anhsbVJ6dmI3cVZLakxtTjZmWFVGbQpVRjRBalFqN2g5TmRhYWRyTGJJQUV5em9nZDNWZ1A2L3NRSFhSM3hGNHdrRktaUkdyZmFEcGlFPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
---
# Source: cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: clustermesh-apiserver-server-cert
  namespace: default
type: kubernetes.io/tls
data:
  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRZXMwanVQWDFQQ2YrVGRUbkJzODJwVEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREFKNWlNR01ZSXovRko2YkxSQTFSRmIvNW5XUWRid2oyMmRnTU9kK050V0QxWEFZaTcKekRXK2ZuVzQ4emdIVHZQWEUrQlQyVmhjS1l0TkNoNnU1WlNNekNEbTJXbnRackRjZ3I3NUN5UTI4VGp1V2FZdQpXVnFxWndmR2ozVnBKUHVWemtCdXV5VThoV0hCNGhVdUZJc3AyVit4QmJBeVVHK0Q5VlFrbGVBaitNMkFZczJ5CnR4R3JXcTBGQVF3QWJndWhOVG43ZXVPRzNVeGc2ZERyVTNCcU95RkJZdm9SLzhKbFhhWDZFd2x4dHZrdDErbDYKNE1jQVE4bDRsRVIvUHQ5eE5PaXQ0UUJJWnJRbGlrR2ZXZkpZSE1qNElEVi9JVDJ6REIya0xLQVh0TEp5R3p0SQp3Y25oOWNtUFNrSzVhU2NuS21YS2hpd1lrNWVlNUdXVVpuZjFBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVoajl0cWszcDNDaWdEeU5naXZ3WWIvTEdUVzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFHa0twTnJRYk82b2NOLzc0ZWNKcERxeVJCQWt3cElVVTk2K0xpNGExcGlFTUR3dTZWTXVLTmhzCkRMQk5jODc2WWtoSzNGY1JiU0UveFU4cnByV3VqWjkyOFFieXhuVDRIMjloM1pmajJOR3lxU3NtL040VTNwUTkKcENJNjVLU3Q5NnN1bVdlKzVONmFHV085MVBNWWNJaGIvTW9wRmxCV2JVTTlXOTUzY3BFd1ZadWxoRElGQjlPKwp6MDZzd2NEaFl6cFBsTmVlRlJtTUsxL3h4aDFta2dlN1lEN1NvR3drbFFERVp4a0NmRWUwVkRkQ1NDNC9uWW4xCkI0Z2R6Q2pLNFV1TUN4SzdkUDFreWpoM2NTWG5KQ1h5akRKcUE3NzdmOGhVQ1JLYjFxZm50c3pncG1EWnQxVysKNlRaYW1tbzAzb1lRRWRnQVB0SmVXWm9YVnBoNWFGbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lRZERlaTNuUzV4RWxqOG5sSjV3WTFRekFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBcU1TZ3dKZ1lEVlFRREV4OWpiSFZ6ZEdWeWJXVnphQzFoY0dselpYSjJaWEl1WTJsc2FYVnRMbWx2Ck1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBME1IM0c4dWFMbnMxR2drVlZsL3gKdjNIY21NOVpPQUI3NndGS0phQW9qN0xFa2FBbnZPU21OaHhCK1p5b3dHbU9GYkJtMEttd0QvWVJ5NXdxai95Tgo1MmV0ZXpPOG9YLyszQmdDMEk4c2ducTV4cmV1YkxSeXJ5YnBkTzBHaUs1dHRvUmJwRzloRGFMQ0JuZ0kzU3dKClZxemZaNEx5OFprT2poUU1hZ2YrQ1NMaGtPd0dhVENSMGJVbVhFc0NaaFJPSUhYanVTM3dlSHdiaHlYS1RxOEkKZHltTjNqcXBsWFBycDdjeFRvQWpzOFg2azJ6OXV2K0piNk1RQmJnRU9EdXdIMTB6dmpzNGZZb04xUmhMMm5uUApkdXdpbTFVMkZVN0M0N3lHZXBzbTU1b1pVRWNKQStPZlU0dDZJQUdJSjI4b09oN3JmVmpoWm5oMmJqbHFNdkcyCkh3SURBUUFCbzRHM01JRzBNQTRHQTFVZER3RUIvd1FFQXdJRm9EQWRCZ05WSFNVRUZqQVVCZ2dyQmdFRkJRY0QKQVFZSUt3WUJCUVVIQXdJd0RBWURWUjBUQVFIL0JBSXdBREFmQmdOVkhTTUVHREFXZ0JTR1AyMnFUZW5jS0tBUApJMkNLL0JodjhzWk5iekJVQmdOVkhSRUVUVEJMZ2g5amJIVnpkR1Z5YldWemFDMWhjR2x6WlhKMlpYSXVZMmxzCmFYVnRMbWx2Z2hBcUxtMWxjMmd1WTJsc2FYVnRMbWx2aHdSL0FBQUJoeEFBQUFBQUFBQUFBQUFBQUFBQUFBQUIKTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBb3ZhWGtjV0NBSHdvMGlMTHM1SDZrSXUybStCSnV0dlB2LzF6dQp0SHVnUG9QL2RiMEg0YjNJT0F2NzQzL3laQzc1cGxFamFDWEFBSG5VbUJtb3VQMTBjc3FwU0hwY3crTkwwc3VpCjg4eEtrdzJrYm1TKzRGV3ZTb0JaUno0aHRzQWZCK1Jpa3NxakYrSURjNVF2Z2kxdHVhQ3ArNG5zbmwwdEVEcjUKY3Z3b2d3VjFMb0pyWGt5dDY0OGU5V2x1Q2FOSjJKZm1BSm01ZnZyaU9WNW8reGRnMHFMU0h2RDVqeFppMjNNbApCdmZ4eEtiNmhMSlJITERFTHg0eHZQZ2p1Mzh4THVsMGhWdzcvelJVcjkreVBmT3dwU1dkSEpCdEF5OWk3dGNiCjBlQUJVSDRBL3F0Z0ZFUk9rT2YrSWdkck9xMzF5WmNHMDdlbHlRd0xOMnpGcU4vVQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBME1IM0c4dWFMbnMxR2drVlZsL3h2M0hjbU05Wk9BQjc2d0ZLSmFBb2o3TEVrYUFuCnZPU21OaHhCK1p5b3dHbU9GYkJtMEttd0QvWVJ5NXdxai95TjUyZXRlek84b1gvKzNCZ0MwSThzZ25xNXhyZXUKYkxSeXJ5YnBkTzBHaUs1dHRvUmJwRzloRGFMQ0JuZ0kzU3dKVnF6Zlo0THk4WmtPamhRTWFnZitDU0xoa093RwphVENSMGJVbVhFc0NaaFJPSUhYanVTM3dlSHdiaHlYS1RxOElkeW1OM2pxcGxYUHJwN2N4VG9BanM4WDZrMno5CnV2K0piNk1RQmJnRU9EdXdIMTB6dmpzNGZZb04xUmhMMm5uUGR1d2ltMVUyRlU3QzQ3eUdlcHNtNTVvWlVFY0oKQStPZlU0dDZJQUdJSjI4b09oN3JmVmpoWm5oMmJqbHFNdkcySHdJREFRQUJBb0lCQVFDZElnTVFwdmFOR2l4awpSb1lMRi9qdHM1VHFhTml0TUtBVnlraTNmWkJLYWJOUU1nNzNQZHhtU21yV3FqYlRiaUNHN3RyVklZVG0zcitTClZTQXNkVnVTM1JWVjhTR0JKc2o5ZmcxUVV4U2J1aWp3RFA1NzBHK3FxMDE2dDViOWR0NGFUaEowK1dsQ1RFcGoKZUNLajZDdTNWRFJzdzhKK1hFajZaTmpiVHR6R25tQ0RzcWdubzkreXRZVW5yR0NrYm1sTktpbEZsWWtTbWppbwpxSnJIb2huSjhJWTZYbHZRL0RCR0tReHVadXRldFNyR1cxNW9iRzcyaDRZWDd4MnJ0RmhPa0RKVDlCVlFpSHIxCjVLVTNSM0lhTHpiNG5ja0EvMVpFWXN0SWNMb0JJRHBLUFJzQmt4LzlNbllCbis3ZFFUelFNT3RIQURWc29VUUUKYmtyYzZhanhBb0dCQU40bGpDTm9ncWtSb2RVek1iaVFuZGdBZ2hVdkJzTURhVGorWWJlaTQxbURTekl4S2wrdwpLbHl4aytDQXhsb0JuV21PNytOaWtiVHR4OEdlMDVueFgwbDI5R05pZVdkZUZGMDloR3JqQ2d3TFVzM1N0YkQzCnFOYUpQcXQ2cjVRckxBdFVDZ2lzQkJDaHhNd3RlNU0wbm1XWm1ZRjVYRDJYekxxb1gyWUJoeXlOQW9HQkFQQ1MKRlJzeGhld0psWXRHOWpuckk2Q2J6Ri9aSE9ZY1hoQjgvVTVjSkZyWnlNb2RmSjA0NlZ2TkdrTVRMNWR6NXVhVgp5NGlkSlFEWGVKNWxkQ0xsUnRsS1FoaG1HbGdHNTJVdnAycTFMRkFjVTd2RUNzSXorTVhiNGRGdkpISy9uWFY3CnFsYW04MmVLK2d5MzRieUsyNnNYR29DQjZKWFZMTWlhWEphLzhHQmJBb0dBWkNMOHhzRkhsTHF6L296ekxzVlIKd1pxSkNNK0g5c1JFM0VJZS9rNVl1WExycEpaeENXMDV5MHJvNDl4b2pRNEpUUm4zbk1KRCtCRHZhS0lWdEdFUAptT2djUmVpUDNUNlZZMnBsbEdEL21HcEtTeWxlYVlWYUFFc2hpdDdrNHArTFhSZm01ZjNVWDBMc21UVXZiUzNjCjhPT0tSTWpXQVpXNTNiSWtQckVWbzhrQ2dZQThNSUNCWGtHZ2pjRlJxSDZBZlRsYnZMOUVsK0NvSGg3V3h6N2wKTlI2UGNIL1JPZEZzME1scUE0WDNsRHhMQzErUS81ZDk1YnRWVzVPOUphc0o5QTFtM2pKdFFsYURBYTh4WE52cApVY3oxZWpEbEFLYWtjalppNHFHOE1hK1AyaXMrTXFPcXJIaW54bGpMaDlJOXh3d3c0VVhyTXhXTEwxdldFUERyCmNyaGtrd0tCZ0RIY0p1SWJIMS9HTHV4NU55SkRhdFZkQVBNbUw0cUp0MmRPMzhoOUZZVUkxbGdRSm4zTmZabHoKRmpHWUVMSHR5LytodjBDdmVLL1dqejM0dHRkaUdNOU5FNitsOU9CQ3IySzNxS3l0OEF1VWNEM29PN2Z5ZzRQNApPWVREdmUxM0hKN1VUcDhNMGJ0czMzRXJrOHZRdVBPeG8yZWtmbXN5UFNLaHJNYzhGUVlpCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
---
# Source: cilium/templates/hubble/tls-helm/ca-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: hubble-ca-secret
  namespace: default
data:
  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRZXMwanVQWDFQQ2YrVGRUbkJzODJwVEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREFKNWlNR01ZSXovRko2YkxSQTFSRmIvNW5XUWRid2oyMmRnTU9kK050V0QxWEFZaTcKekRXK2ZuVzQ4emdIVHZQWEUrQlQyVmhjS1l0TkNoNnU1WlNNekNEbTJXbnRackRjZ3I3NUN5UTI4VGp1V2FZdQpXVnFxWndmR2ozVnBKUHVWemtCdXV5VThoV0hCNGhVdUZJc3AyVit4QmJBeVVHK0Q5VlFrbGVBaitNMkFZczJ5CnR4R3JXcTBGQVF3QWJndWhOVG43ZXVPRzNVeGc2ZERyVTNCcU95RkJZdm9SLzhKbFhhWDZFd2x4dHZrdDErbDYKNE1jQVE4bDRsRVIvUHQ5eE5PaXQ0UUJJWnJRbGlrR2ZXZkpZSE1qNElEVi9JVDJ6REIya0xLQVh0TEp5R3p0SQp3Y25oOWNtUFNrSzVhU2NuS21YS2hpd1lrNWVlNUdXVVpuZjFBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVoajl0cWszcDNDaWdEeU5naXZ3WWIvTEdUVzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFHa0twTnJRYk82b2NOLzc0ZWNKcERxeVJCQWt3cElVVTk2K0xpNGExcGlFTUR3dTZWTXVLTmhzCkRMQk5jODc2WWtoSzNGY1JiU0UveFU4cnByV3VqWjkyOFFieXhuVDRIMjloM1pmajJOR3lxU3NtL040VTNwUTkKcENJNjVLU3Q5NnN1bVdlKzVONmFHV085MVBNWWNJaGIvTW9wRmxCV2JVTTlXOTUzY3BFd1ZadWxoRElGQjlPKwp6MDZzd2NEaFl6cFBsTmVlRlJtTUsxL3h4aDFta2dlN1lEN1NvR3drbFFERVp4a0NmRWUwVkRkQ1NDNC9uWW4xCkI0Z2R6Q2pLNFV1TUN4SzdkUDFreWpoM2NTWG5KQ1h5akRKcUE3NzdmOGhVQ1JLYjFxZm50c3pncG1EWnQxVysKNlRaYW1tbzAzb1lRRWRnQVB0SmVXWm9YVnBoNWFGbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  ca.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBd0NlWWpCakdDTS94U2VteTBRTlVSVy8rWjFrSFc4STl0bllERG5mamJWZzlWd0dJCnU4dzF2bjUxdVBNNEIwN3oxeFBnVTlsWVhDbUxUUW9lcnVXVWpNd2c1dGxwN1dhdzNJSysrUXNrTnZFNDdsbW0KTGxsYXFtY0h4bzkxYVNUN2xjNUFicnNsUElWaHdlSVZMaFNMS2RsZnNRV3dNbEJ2Zy9WVUpKWGdJL2pOZ0dMTgpzcmNScTFxdEJRRU1BRzRMb1RVNSszcmpodDFNWU9uUTYxTndhanNoUVdMNkVmL0NaVjJsK2hNSmNiYjVMZGZwCmV1REhBRVBKZUpSRWZ6N2ZjVFRvcmVFQVNHYTBKWXBCbjFueVdCekkrQ0ExZnlFOXN3d2RwQ3lnRjdTeWNoczcKU01ISjRmWEpqMHBDdVdrbkp5cGx5b1lzR0pPWG51UmxsR1ozOVFJREFRQUJBb0lCQVFDaGNxTmhVbzlSYUNXNwpqSGVKMWRwQVhWRExWS295Rm9uemZFUWxLK1lTUVVtSWlPbHhvS3FuVzJsZDlEem5KeGNKWnRIY29ZajBKcE84Ckx2eUl4cXlCZ0NGRTFQZURWL3pSeWFqYlp0a09zSzY4MU9Zam16L3FYSmJUNWtVb0NzSzNvNHZQZmI1VGsxNEgKb1FWYXFqZ2krVmpGUzVvM0xBNEdPV0p4T3R3UVc4N1phMkFxaDJJdmt2M0hiM3JXNDNZS0lMeFRBdFlsNmdPeApCTkFyWCtGeTgxcStZSVQrbWU3a2lSNkg3TlpmRHdPelhzMlo3TUw4SGdnTnpsNThER1BpMVFYVW14OVc0QnM3CjJXQ3k1N0tGd3c2a2gvd0JXWk5GTytBR21OUnpCOTcwbTh6U2ZFaFRrd0dXUllwSlZDUTloVGkrakl3MmdUb04KWkFzbkpENEJBb0dCQU42MC9RaTEwTThWRTFYY1RGM0FZVERmV1J6N0FWUDhLckR2bGxJTW8xQW1GaGJiblZvTgoza1haMkthYmZ6WGVDckx4cUZ0WFpxTXA0WElxTTErZVAwdjgzS0RTOTZDTGdyZWFPV0ZCQjFJcWlNV01zVFgvClFlTVlYSWxqN0ZNcTF0OXE4K1ZPcTVYZ3AvSlZQd2dPNnNNUUZsWng1RU1raTl5MysvaHRsRFBSQW9HQkFOemgKWGtsTEhselFJSVh2eHFKa3AvYkdYYW43d1ZhRmMrUm13czhZTURKVU1KVEk4MlRpR3FlVm9zL24vWC84WWpYSQo0Q1M2NFJGUHFvTnZ2MzVLQkt2MzVIN2JLdVBORy8xT2p1U3pPNVAwRFQ0SnNsQ21DemhrWTA4UGN5cWRnM2tjCmh1RFRuN3Juc3lGMVMrZkVrc2k2RnI3MFZkWlhycS92dTBWOUw3N2xBb0dCQU5Nc2JRNllVSEk3K3NTY2l2RU8KM1ZuWlB3ZWkzdVNESlB2M2d1TTBScHRXTWZYa3NyVFVsNkpHYWcrNVBJdVlpeTZZeE5vdjZ3dm1SM2JZbXpRYwp1c3BUNytTemhzajk0S28ySEJpaTc4MHl0ZFFVajJpekxRZW9idjU3K0hmNEZCMXZyZXNPaU5jcVdqWUlMU2QzCjlaV1hLSWM1b1ljbEhWWGlRNU9TWEVneEFvR0FkUkZodHJrQW83S1B1azFHV3lXOFBEZ1F4cG92YzVzUnZKbVcKWU1yeUtJcWtvUWNNc1lpQkZoZGlEbzFudDJEZDhLSEI0dFhGbWpZK0txR2N2ZU9mTEVJYnNmeVpjOWx2SDBkMgp4dElVSHF1NEpReGduUXdVWUZRY3FuZUcwNnhlVlYrQVFVTUlvcmhSSWNlWWJvT3FSSWNVclNxMUlBQ2pEbzZpCkZBZHd1ZDBDZ1lCUUo5aUlMZCtNOFFYeE1RK1BhMVhGc2pkbmYvSGVvWUxIQ2JaQVkwRkw0RmhBenh5Y2lhbzQKRTJrd3RJZGN1anpwZ2xNa0U3d2JSL1RkU3BTeU9PY2ZoYU5yOWw3d3FwdlM2RGlyL0JaUlJKaWEzWmJLQlBGTQo1enVWa2pnelI4YnlPRkRvOWlhMjlPeVQwK05tTjZlY0xQZWFvaS92YmdIejc5NWt1d1pZR2c9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
---
# Source: cilium/templates/hubble/tls-helm/relay-client-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: hubble-relay-client-certs
  namespace: default
type: kubernetes.io/tls
data:
  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRZXMwanVQWDFQQ2YrVGRUbkJzODJwVEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREFKNWlNR01ZSXovRko2YkxSQTFSRmIvNW5XUWRid2oyMmRnTU9kK050V0QxWEFZaTcKekRXK2ZuVzQ4emdIVHZQWEUrQlQyVmhjS1l0TkNoNnU1WlNNekNEbTJXbnRackRjZ3I3NUN5UTI4VGp1V2FZdQpXVnFxWndmR2ozVnBKUHVWemtCdXV5VThoV0hCNGhVdUZJc3AyVit4QmJBeVVHK0Q5VlFrbGVBaitNMkFZczJ5CnR4R3JXcTBGQVF3QWJndWhOVG43ZXVPRzNVeGc2ZERyVTNCcU95RkJZdm9SLzhKbFhhWDZFd2x4dHZrdDErbDYKNE1jQVE4bDRsRVIvUHQ5eE5PaXQ0UUJJWnJRbGlrR2ZXZkpZSE1qNElEVi9JVDJ6REIya0xLQVh0TEp5R3p0SQp3Y25oOWNtUFNrSzVhU2NuS21YS2hpd1lrNWVlNUdXVVpuZjFBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVoajl0cWszcDNDaWdEeU5naXZ3WWIvTEdUVzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFHa0twTnJRYk82b2NOLzc0ZWNKcERxeVJCQWt3cElVVTk2K0xpNGExcGlFTUR3dTZWTXVLTmhzCkRMQk5jODc2WWtoSzNGY1JiU0UveFU4cnByV3VqWjkyOFFieXhuVDRIMjloM1pmajJOR3lxU3NtL040VTNwUTkKcENJNjVLU3Q5NnN1bVdlKzVONmFHV085MVBNWWNJaGIvTW9wRmxCV2JVTTlXOTUzY3BFd1ZadWxoRElGQjlPKwp6MDZzd2NEaFl6cFBsTmVlRlJtTUsxL3h4aDFta2dlN1lEN1NvR3drbFFERVp4a0NmRWUwVkRkQ1NDNC9uWW4xCkI0Z2R6Q2pLNFV1TUN4SzdkUDFreWpoM2NTWG5KQ1h5akRKcUE3NzdmOGhVQ1JLYjFxZm50c3pncG1EWnQxVysKNlRaYW1tbzAzb1lRRWRnQVB0SmVXWm9YVnBoNWFGbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURTVENDQWpHZ0F3SUJBZ0lSQVBsa0Y2OU9Nc3JITmRNNnd0Q1BnRUV3RFFZSktvWklodmNOQVFFTEJRQXcKRkRFU01CQUdBMVVFQXhNSlEybHNhWFZ0SUVOQk1CNFhEVEl6TURFek1ERXhORGd6T1ZvWERUSTJNREV5T1RFeApORGd6T1Zvd0l6RWhNQjhHQTFVRUF3d1lLaTVvZFdKaWJHVXRjbVZzWVhrdVkybHNhWFZ0TG1sdk1JSUJJakFOCkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXN2cUdZQVpQNEpmWWVranVyWXRDOWhkd0hJdHYKSHFrdTBiS0F0M0ZwLytvUnpLY0llbnc5QzVVTnlnREFId3pjWmlTTUlnVlQxOWtua09oUGxyM2h0MldrSjhzaApYczk2TzhIeUJnOWoxSnlSL0UwYjI5NWJwRDJWTitSYkhDZXZXem83ZVIxYjhjVm9vNEtKQ2hKc2w3MGJPc1EyClkyKy9uQ296b3NTcFpaTzl0K09JeXJFQ1VoWC9NN2p5b01rVmxKZ0JxNjNMN3VRZWtqSmZGMDZOVTlKdDNpN2EKaHJxNWdZUE4ySEZUbXZWVmthS3Y0NmxTdllGUTZFcGhacjlZNGIwUHFiVWtmc1ludnJMZ0ErMlVVQ3ZWeDJMTQp3Uldva2tJWCt3Z3dFUVZjWGY0V08wekFDZWt6Q05oUmZTaWoxZnBBZFJ4dHFZWkhDaS9HWTZWTnVRSURBUUFCCm80R0dNSUdETUE0R0ExVWREd0VCL3dRRUF3SUZvREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUIKQlFVSEF3SXdEQVlEVlIwVEFRSC9CQUl3QURBZkJnTlZIU01FR0RBV2dCU0dQMjJxVGVuY0tLQVBJMkNLL0Jodgo4c1pOYnpBakJnTlZIUkVFSERBYWdoZ3FMbWgxWW1Kc1pTMXlaV3hoZVM1amFXeHBkVzB1YVc4d0RRWUpLb1pJCmh2Y05BUUVMQlFBRGdnRUJBQXl4Z2lCdjlZeW15cGIyMENtN0FxUmthdkVGZFprNnZxNmpNUHJJK3RqWXVGb0kKbDk0RnFEMGZzbUpsVUVOU1dLNUw2OStXVFBQZXJvQWxUaS9ZU1pkcjV2Mng5UnhLM2xBTGgyeStPQ2lDaml3QgprNFQ3aHhxakZGK2dxZ1U3UlBHMWZJRmVwb1graXQ4WTA3a3pMdGxJOUI5U0oxVEU0NGprQTBZc0VxL2ZVSUhTCmdUaFZaeU1nb1haTFVLdmpEcGZOdFlvMGY1MUNqQmFCZXF6U3BPT2RhZEdrMEtmSGR0ak9XZ2k1OVAwZnJmamMKeXNBYXhPOW1JWlp0N01rdUVEaGNxNGh4ekdvd1kzcE1GL1ZCMlY2N0RZZTFyYlQzWitkMk1VWUZqdUhSOTZQQgpucWJiVk5HYy80c1ZqZUN6RnQrWEx0TXFZV1cxWTZkVHlmUW9HYTg9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBc3ZxR1lBWlA0SmZZZWtqdXJZdEM5aGR3SEl0dkhxa3UwYktBdDNGcC8rb1J6S2NJCmVudzlDNVVOeWdEQUh3emNaaVNNSWdWVDE5a25rT2hQbHIzaHQyV2tKOHNoWHM5Nk84SHlCZzlqMUp5Ui9FMGIKMjk1YnBEMlZOK1JiSENldld6bzdlUjFiOGNWb280S0pDaEpzbDcwYk9zUTJZMisvbkNvem9zU3BaWk85dCtPSQp5ckVDVWhYL003anlvTWtWbEpnQnE2M0w3dVFla2pKZkYwNk5VOUp0M2k3YWhycTVnWVBOMkhGVG12VlZrYUt2CjQ2bFN2WUZRNkVwaFpyOVk0YjBQcWJVa2ZzWW52ckxnQSsyVVVDdlZ4MkxNd1JXb2trSVgrd2d3RVFWY1hmNFcKTzB6QUNla3pDTmhSZlNpajFmcEFkUnh0cVlaSENpL0dZNlZOdVFJREFRQUJBb0lCQUhwYmsyb3Fab2xneGZvegp5aGlTMEdCMWZZdkdOMTE2eEN0UUlYZEg3Zk9yRGlnZk9VaWpqd2hRQ25GRE9oVUFNZDBTdDBxNjRhcjdKbldHCm5JS3RwWlkvd280QjdQcG9WV1J0SHd6TmtLNVZxK2dVdnlyOVJTRnZpSWdCY2RnNXVVUmc5eS9CeG8zdks2NDkKRzNyclJab25DbXFPb2JBeFFZbDl3SGRTZzR5UTRwVWNvcWFNbjdWQkE1c3pYQUh4bmZkSFI5enhURTR6cVdNUAo4dUgwL3NhdmRDVVhTTmFrMnlZSVh5R3NybGhjdUkrL3ZQczBlRitPeU9ackhiN2tJVlBJRS85VTlHbFdpY2RPCmczbUpwSGlrWGRsdmJIQm5BV1JTTkdubFNYRFNNNmtxcGZoYnVmYWFrcWhqZU91VjdJTWZ6bkwyZzBXK1U4c0wKclZjb041RUNnWUVBdzdnUlZBSEZjK1E0Mng4ckNwTXhZRUZoalF1clVjR0pNSTcybGJVc1M1UjZWVW5mbnIyZQp6MVNISVc3UEIyRUhVaHFRNzIrUEU5dUtLbUlxZTZkblVkeEExMXQxbTdMQXArKzJQSlloN21oMFVpbkx5V3I0ClhQUGdlc0FjeHg3MExMMmlTa1lYZU9rS3JZdXZkaVlvK1VZcTNndW0zNHFmNHhUSlo3d05VOXNDZ1lFQTZocUYKTlczd0tRS2xlOTJTSTZEL3JUcXVuQmd5c2NOOWxKYUJFbnhsSUcwd3JYb3FvYW1ndlFVNHpIR2NpY1RrNDVvNApBYzFqbk9pTmNXbkl3QUNQeFEvbUxXNFVkRGJhSzhoYmNzVWtMV0NNQjR3OFVETDNhZ3JzS0ZrOUV6UThGUktICmk5cmVqV1QvU2RmUVNTbjdFbUx4bHVyS2JSM1JEdERFSkZ1akl2c0NnWUFEbGk3ekhDa3pLMzZEUFhuN2NxRVkKQTNxM0sveVN2Zm8yb3BnUVBFYTRoOXNLRHhXREFqU1QxaGUzM0NEOUlLRVN0eHZxMTErRzNLSVdqci82amlITgpsVHkyOVowZElsUjNmMlFXamlYSENiRUFCSFlRbGQ1QlRkTFNUUXo1OVM1Q1Y2Tk91eVFZK2lSUTg5dGVUZXE0ClRybmdZZFJJQ25GTnB3YmQyTXRodXdLQmdRQ1hJSy9HSWtiYjhyMXFEVXYrZkQwU1U4UE5PVUhneUZjVnlXTmgKejdScERwUlNLWC9FQllHakJPLzU2NDRtMGxrQkpkbnFML0dTcGY1SnJRVFFEb3pCcHRYdGxoYldQMkx3eU5OZwpjQ3crcndrM0JpMFppUTE0QTcwWS95TVNkcklpMkdkd3ZjYldlTkRsbHREN3FvSlBDRmoyR0hTOXBIWUZubmhCCkVIZHNhUUtCZ0RZS2Y3QzU3cUIyUUVwazFtSGdNM3RMMFJEZ3hNcVFrUWxSZkJ5TlllOW11bFBwbXB4cVpoMFEKQTNQVE1PSnVaRWtlQzExRmF3aEg3Z0MybHRSRjAwYXl1VXhDbXRtbXNXSUdpSXZIUExtOFVEZ2lHZlB0RG9tMQpMdUM1UEFUSlBlbmhiRWY5bjhGZVUzMURjNUpzM1FOTWRqQTF3UWNjMkgyVzZPZjRHOUUvCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
---
# Source: cilium/templates/hubble/tls-helm/server-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: hubble-server-certs
  namespace: default
type: kubernetes.io/tls
data:
  ca.crt:  LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFekNDQWZ1Z0F3SUJBZ0lRZXMwanVQWDFQQ2YrVGRUbkJzODJwVEFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBVU1SSXdFQVlEVlFRREV3bERhV3hwZFcwZ1EwRXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRREFKNWlNR01ZSXovRko2YkxSQTFSRmIvNW5XUWRid2oyMmRnTU9kK050V0QxWEFZaTcKekRXK2ZuVzQ4emdIVHZQWEUrQlQyVmhjS1l0TkNoNnU1WlNNekNEbTJXbnRackRjZ3I3NUN5UTI4VGp1V2FZdQpXVnFxWndmR2ozVnBKUHVWemtCdXV5VThoV0hCNGhVdUZJc3AyVit4QmJBeVVHK0Q5VlFrbGVBaitNMkFZczJ5CnR4R3JXcTBGQVF3QWJndWhOVG43ZXVPRzNVeGc2ZERyVTNCcU95RkJZdm9SLzhKbFhhWDZFd2x4dHZrdDErbDYKNE1jQVE4bDRsRVIvUHQ5eE5PaXQ0UUJJWnJRbGlrR2ZXZkpZSE1qNElEVi9JVDJ6REIya0xLQVh0TEp5R3p0SQp3Y25oOWNtUFNrSzVhU2NuS21YS2hpd1lrNWVlNUdXVVpuZjFBZ01CQUFHallUQmZNQTRHQTFVZER3RUIvd1FFCkF3SUNwREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QWRCZ05WSFE0RUZnUVVoajl0cWszcDNDaWdEeU5naXZ3WWIvTEdUVzh3RFFZSktvWklodmNOQVFFTApCUUFEZ2dFQkFHa0twTnJRYk82b2NOLzc0ZWNKcERxeVJCQWt3cElVVTk2K0xpNGExcGlFTUR3dTZWTXVLTmhzCkRMQk5jODc2WWtoSzNGY1JiU0UveFU4cnByV3VqWjkyOFFieXhuVDRIMjloM1pmajJOR3lxU3NtL040VTNwUTkKcENJNjVLU3Q5NnN1bVdlKzVONmFHV085MVBNWWNJaGIvTW9wRmxCV2JVTTlXOTUzY3BFd1ZadWxoRElGQjlPKwp6MDZzd2NEaFl6cFBsTmVlRlJtTUsxL3h4aDFta2dlN1lEN1NvR3drbFFERVp4a0NmRWUwVkRkQ1NDNC9uWW4xCkI0Z2R6Q2pLNFV1TUN4SzdkUDFreWpoM2NTWG5KQ1h5akRKcUE3NzdmOGhVQ1JLYjFxZm50c3pncG1EWnQxVysKNlRaYW1tbzAzb1lRRWRnQVB0SmVXWm9YVnBoNWFGbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURWakNDQWo2Z0F3SUJBZ0lRREk4Y2JnOEVrUGhkOXdid1FmR29qakFOQmdrcWhraUc5dzBCQVFzRkFEQVUKTVJJd0VBWURWUVFERXdsRGFXeHBkVzBnUTBFd0hoY05Nak13TVRNd01URTBPRE01V2hjTk1qWXdNVEk1TVRFMApPRE01V2pBcU1TZ3dKZ1lEVlFRRERCOHFMbVJsWm1GMWJIUXVhSFZpWW14bExXZHljR011WTJsc2FYVnRMbWx2Ck1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBMThjaDFlZWlIdWJVZ2MzTzFBbGcKdStIaHk2UkVJOVVlMEcrQmxSM1J5YTlCYlJFOUdkbER6OXE5Q1U2cWdVcjQvZisxRXdoL0x6TGppYjZ6ZHVDWApWVmN2QVFXcHZnUnZlbHJSNlpWNzlOeUlNRGJ6elVXbnRKQnBiQlZpUGlHSGZpdzB4eTh0amFQVFhaVVZNQ1RhCjQrRjFZandQenRJQ2VrOURMeUJQMm1TMjZHTDg1SytlWXNORlZmb0RWNi92NHptTjVoNXJsWDhZbHVYV1lqa0YKZHMvZ2FhTm5QYXJWbUZBbFdYdFVFNDhkc2gvZllFcXdkb1JFUStwMTVqWTZTeXk5Z0N1V2RGbU1ac1p6MWhlVQpxZlBwQWFTS2pSR0xhVVNlSFg2czkrQjhZUEhuQURHVHltMG1VS2VXeEQydFRvdW1UU3lmNGdndWV3OUJQQkdyCkxRSURBUUFCbzRHTk1JR0tNQTRHQTFVZER3RUIvd1FFQXdJRm9EQWRCZ05WSFNVRUZqQVVCZ2dyQmdFRkJRY0QKQVFZSUt3WUJCUVVIQXdJd0RBWURWUjBUQVFIL0JBSXdBREFmQmdOVkhTTUVHREFXZ0JTR1AyMnFUZW5jS0tBUApJMkNLL0JodjhzWk5iekFxQmdOVkhSRUVJekFoZ2g4cUxtUmxabUYxYkhRdWFIVmlZbXhsTFdkeWNHTXVZMmxzCmFYVnRMbWx2TUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCT3NMZllPcWlaSWpONGlXTFpnTTJrZHJGSG5EMUUKZW5QSlRsQzJWTWd4YStkeXo5SW5xSDYreTM0VGhCZ0pNRHk0SkRScTRhT2pEb1YxakJZbnJqYjJrcFFwbVArWgpHUk5hSHQxYXVaZHFRL0xNN2hpc0srMEdIdy9MOTdhWFJRenBFODc3Umpwa2tTMys0Z3kyeUVpeTRuZ0pLZ1lxCmYyZTR1Rkl6SXo1Vk55N05qeGxTeWlGcHlIbC90SVZTaWR0VlhLcHRCNU9yRXdxQ2NpV3phRzVWcmVUa3NqQmgKY2lMQXVOdmo5U3hlUXN3Nk1vYno0Um1tMjZBdzJhblEwRDJBS1Bzb01WK1k1eFlRS203RkY4UlU1WkZ5NWFpWgpwbHBTS2NVd21YeWlPMkFWQUhLMDFEeVY5ZFpXdFJBeE5JdWdJVGhxbTdrRExONGxPMlVGWVptRwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBMThjaDFlZWlIdWJVZ2MzTzFBbGd1K0hoeTZSRUk5VWUwRytCbFIzUnlhOUJiUkU5CkdkbER6OXE5Q1U2cWdVcjQvZisxRXdoL0x6TGppYjZ6ZHVDWFZWY3ZBUVdwdmdSdmVsclI2WlY3OU55SU1EYnoKelVXbnRKQnBiQlZpUGlHSGZpdzB4eTh0amFQVFhaVVZNQ1RhNCtGMVlqd1B6dElDZWs5REx5QlAybVMyNkdMOAo1SytlWXNORlZmb0RWNi92NHptTjVoNXJsWDhZbHVYV1lqa0Zkcy9nYWFOblBhclZtRkFsV1h0VUU0OGRzaC9mCllFcXdkb1JFUStwMTVqWTZTeXk5Z0N1V2RGbU1ac1p6MWhlVXFmUHBBYVNLalJHTGFVU2VIWDZzOStCOFlQSG4KQURHVHltMG1VS2VXeEQydFRvdW1UU3lmNGdndWV3OUJQQkdyTFFJREFRQUJBb0lCQUJveDNuV3RUUTBiVUtrQgpaeDV1bFFPNkJFTklpYzBmemtIWGg0K21zeFVjNVlCc0cxTE1BV04yVm9TT3ZEdzk4Y1JFQ3FObzRLZkdNY0ZECkdWNVJIWTRLcTNZZ1RkNzNndUVEcllBQjJhNThKenhUTDMyMyt3ZjhrQS9DK000Nkc4ekJhUmJWTDE2R2lONVAKZnViOVVtVmZ0WFJiZmovSlZ1dXFPNm00N25qQWtDQk50K08zQTM1RHZkL3IwZTN2RHlzVU1HejVKUVNabnpzVgpEL2tlanhsQW8rbTB5Mk1JZEREZGtKcC8wMDJ3OU1DMXZ1UzFSYklIRWtXakxGTlJBTTgxYWxHNEwyYmgwN0V6ClN1NC9xRmhEZk9JbzF6L0VZdTBsUGhvVm9IMDBxVEZ2cEU0dDhUbHhrWmwyY21xSWlqWFJEd0hjekVNMlpHRXQKZlVoQS9RRUNnWUVBMzFvY3g4Y3A3eU5wR2dIVnp2dXFXMm45bWY3ZmxGazVneDVRR2FVcElZSkhXbHBwdEwvdApsaEdkQ3ByeW40eUhrUU42ckg4L3dITDJnc25NbTlNWi9xNUdqMnlpVXU5emdvK2s2UVlnRFRTUTFCOXhNMllHCktic05NN1dlYjZ3RTZ4alBJTWYydTlQM0p6ejhHR0d3VGRFNWJITS9lTlp5RWs5VlRhcm5zSEVDZ1lFQTkxR1gKN2tlbEhXRmJFTk5oQmhqTjhWVDFrTUxGUnNUZjZQclQ3djQ4U2FQNGRrZ1hiUDZVdXVvaVk3ZzJxUVlPU3R2ZQp2bks4RjByVlRzYUZ5T0JiUzdIT2s4aU1NQjAveXpEZmdzaHJKM0hxMU56ZU9CMUdQanlQM0xoVHZIOU55RzRUCjZyYk9YSzRxZWNSQmNUbW9IczFtcWYyVnNRVVF5Q050emxCNnhIMENnWUVBbXM5SjNZc0ZYTlN0ZDdKSDhUUnMKcXZuM0puTUxvemFJNzRIbVFUQkNKeEMyeGtDZXZnSzkrZU54ZHpWWThBK21zM08yNXJNNGkvcmpORm9OTVFDTQpKd1BDc295NG9rV0lTYm1vc3o5a25lS09kQWpySEpZZHRYVUtQSW9wSy93T1dLbVVmNE02V0l3ZDVodVdISXd4CmVHNkpuOHJ0OXFLazVGNEtvVS9SVVhFQ2dZQk9FRFVTZ3c2OC9WUFBOY2swTVhRZnJwOXNOKzRvN2s5MnJHVmsKMUY2WEoraHUvVVpYb3V1eks5LzY5ZFJhK1l4ZFdKVXdLK3J1dHpJcEVVUjlLVVBuMnBISDE4OVlDSU53VVZiYgpZd05maWZlRGhNdW5qcVh6VXc1ZHJ0alBjS2RPa21BNi84U1hRR29yMFNTTzVwSUlWdkVHeXdJS3cveU9ENUREClJHZmJ5UUtCZ1FEWGMraTBWMDRLeC9OZlZNWkpCckpCRjN1a295cUFMa2JSNkNzVnhsODVvczQwd0tZV0pHbnUKQmhWRzdOM3dJSkIveDZoQjdUdE1oMjJmYVBidEpQUmwrR1NCRmdIUUZKT2ZNRjBkN2ZKQmVtOTVSQU8rVWxkNApOakIrdXdpZDcwaU5iMXQxT291bGRQb1hBK1dLdXNZWVZjLzhVQmVxcEFRdW1ySmZTZlEvWXc9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
---
# Source: cilium/templates/cilium-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cilium-config
  namespace: default
data:
  # The kvstore configuration is used to enable use of a kvstore for state
  # storage. This can either be provided with an external kvstore or with the
  # help of cilium-etcd-operator which operates an etcd cluster automatically.
  kvstore: etcd
  kvstore-opt: '{"etcd.config": "/var/lib/etcd-config/etcd.config"}'

  # This etcd-config contains the etcd endpoints of your cluster. If you use
  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
  etcd-config: |-
    ---
    endpoints:
      - https://cilium-etcd-client.default.svc:2379
    trusted-ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
    key-file: '/var/lib/etcd-secrets/etcd-client.key'
    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'

  # Identity allocation mode selects how identities are shared between cilium
  # nodes by setting how they are stored. The options are "crd" or "kvstore".
  # - "crd" stores identities in kubernetes as CRDs (custom resource definition).
  #   These can be queried with:
  #     kubectl get ciliumid
  # - "kvstore" stores identities in an etcd kvstore, that is
  #   configured below. Cilium versions before 1.6 supported only the kvstore
  #   backend. Upgrades from these older cilium versions should continue using
  #   the kvstore by commenting out the identity-allocation-mode below, or
  #   setting it to "kvstore".
  identity-allocation-mode: crd
  identity-heartbeat-timeout: "30m0s"
  identity-gc-interval: "15m0s"
  cilium-endpoint-gc-interval: "5m0s"
  nodes-gc-interval: "5m0s"
  skip-cnp-status-startup-clean: "false"
  # Disable the usage of CiliumEndpoint CRD
  disable-endpoint-crd: "false"

  # If you want to run cilium in debug mode change this value to true
  debug: "false"
  debug-verbose: ""
  # The agent can be put into the following three policy enforcement modes
  # default, always and never.
  # https://docs.cilium.io/en/latest/security/policy/intro/#policy-enforcement-modes
  enable-policy: "default"

  # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
  # address.
  enable-ipv4: "true"

  # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
  # address.
  enable-ipv6: "false"
  # Users who wish to specify their own custom CNI configuration file must set
  # custom-cni-conf to "true", otherwise Cilium may overwrite the configuration.
  custom-cni-conf: "false"
  enable-bpf-clock-probe: "true"
  # If you want cilium monitor to aggregate tracing for packets, set this level
  # to "low", "medium", or "maximum". The higher the level, the less packets
  # that will be seen in monitor output.
  monitor-aggregation: medium

  # The monitor aggregation interval governs the typical time between monitor
  # notification events for each allowed connection.
  #
  # Only effective when monitor aggregation is set to "medium" or higher.
  monitor-aggregation-interval: "5s"

  # The monitor aggregation flags determine which TCP flags which, upon the
  # first observation, cause monitor notifications to be generated.
  #
  # Only effective when monitor aggregation is set to "medium" or higher.
  monitor-aggregation-flags: all
  # Specifies the ratio (0.0-1.0] of total system memory to use for dynamic
  # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
  bpf-map-dynamic-size-ratio: "0.0025"
  # bpf-policy-map-max specifies the maximum number of entries in endpoint
  # policy map (per endpoint)
  bpf-policy-map-max: "16384"
  # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
  # backend and affinity maps.
  bpf-lb-map-max: "65536"
  bpf-lb-external-clusterip: "false"

  # Pre-allocation of map entries allows per-packet latency to be reduced, at
  # the expense of up-front memory allocation for the entries in the maps. The
  # default value below will minimize memory usage in the default installation;
  # users who are sensitive to latency may consider setting this to "true".
  #
  # This option was introduced in Cilium 1.4. Cilium 1.3 and earlier ignore
  # this option and behave as though it is set to "true".
  #
  # If this value is modified, then during the next Cilium startup the restore
  # of existing endpoints and tracking of ongoing connections may be disrupted.
  # As a result, reply packets may be dropped and the load-balancing decisions
  # for established connections may change.
  #
  # If this option is set to "false" during an upgrade from 1.3 or earlier to
  # 1.4 or later, then it may cause one-time disruptions during the upgrade.
  preallocate-bpf-maps: "false"

  # Regular expression matching compatible Istio sidecar istio-proxy
  # container image names
  sidecar-istio-proxy-image: "cilium/istio_proxy"

  # Name of the cluster. Only relevant when building a mesh of clusters.
  cluster-name: default
  # Unique ID of the cluster. Must be unique across all conneted clusters and
  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
  cluster-id: "0"

  # Encapsulation mode for communication between nodes
  # Possible values:
  #   - disabled
  #   - vxlan (default)
  #   - geneve
  tunnel: "vxlan"


  # Enables L7 proxy for L7 policy enforcement and visibility
  enable-l7-proxy: "true"

  enable-ipv4-masquerade: "true"
  enable-ipv6-big-tcp: "false"
  enable-ipv6-masquerade: "true"

  enable-xt-socket-fallback: "true"
  install-iptables-rules: "true"
  install-no-conntrack-iptables-rules: "false"

  auto-direct-node-routes: "false"
  enable-local-redirect-policy: "false"

  kube-proxy-replacement: "disabled"
  bpf-lb-sock: "false"
  enable-health-check-nodeport: "true"
  node-port-bind-protection: "true"
  enable-auto-protect-node-port-range: "true"
  enable-svc-source-range-check: "true"
  enable-l2-neigh-discovery: "true"
  arping-refresh-period: "30s"
  enable-endpoint-health-checking: "true"
  enable-health-checking: "true"
  enable-well-known-identities: "true"
  enable-remote-node-identity: "true"
  synchronize-k8s-nodes: "true"
  operator-api-serve-addr: "127.0.0.1:9234"
  # Enable Hubble gRPC service.
  enable-hubble: "true"
  # UNIX domain socket for Hubble server to listen to.
  hubble-socket-path: "/var/run/cilium/hubble.sock"
  # An additional address for Hubble server to listen to (e.g. ":4244").
  hubble-listen-address: ":4244"
  hubble-disable-tls: "false"
  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
  hubble-tls-key-file: /var/lib/cilium/tls/hubble/server.key
  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
  ipam: "cluster-pool"
  ipam-cilium-node-update-rate: "15s"
  cluster-pool-ipv4-cidr: "10.0.0.0/8"
  cluster-pool-ipv4-mask-size: "24"
  disable-cnp-status-updates: "true"
  enable-vtep: "false"
  vtep-endpoint: ""
  vtep-cidr: ""
  vtep-mask: ""
  vtep-mac: ""
  enable-bgp-control-plane: "false"
  procfs: "/host/proc"
  bpf-root: "/sys/fs/bpf"
  cgroup-root: "/run/cilium/cgroupv2"
  enable-k8s-terminating-endpoint: "true"
  enable-sctp: "false"
  remove-cilium-node-taints: "true"
  set-cilium-is-up-condition: "true"
  unmanaged-pod-watcher-interval: "15"
  tofqdns-dns-reject-response-code: "refused"
  tofqdns-enable-dns-compression: "true"
  tofqdns-endpoint-max-ip-per-hostname: "50"
  tofqdns-idle-connection-grace-period: "0s"
  tofqdns-max-deferred-connection-deletes: "10000"
  tofqdns-min-ttl: "3600"
  tofqdns-proxy-response-max-delay: "100ms"
  agent-not-ready-taint-key: "node.cilium.io/agent-not-ready"
---
# Source: cilium/templates/hubble-relay/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: hubble-relay-config
  namespace: default
data:
  config.yaml: |
    cluster-name: default
    peer-service: "hubble-peer.default.svc.cluster.local:443"
    listen-address: :4245
    dial-timeout: 
    retry-timeout: 
    sort-buffer-len-max: 
    sort-buffer-drain-timeout: 
    tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
    tls-client-key-file: /var/lib/hubble-relay/tls/client.key
    tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
    disable-server-tls: true
---
# Source: cilium/templates/hubble-ui/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: hubble-ui-nginx
  namespace: default
data:
  nginx.conf: "server {\n    listen       8081;\n    listen       [::]:8081;\n    server_name  localhost;\n    root /app;\n    index index.html;\n    client_max_body_size 1G;\n\n    location / {\n        proxy_set_header Host $host;\n        proxy_set_header X-Real-IP $remote_addr;\n\n        # CORS\n        add_header Access-Control-Allow-Methods \"GET, POST, PUT, HEAD, DELETE, OPTIONS\";\n        add_header Access-Control-Allow-Origin *;\n        add_header Access-Control-Max-Age 1728000;\n        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;\n        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;\n        if ($request_method = OPTIONS) {\n            return 204;\n        }\n        # /CORS\n\n        location /api {\n            proxy_http_version 1.1;\n            proxy_pass_request_headers on;\n            proxy_hide_header Access-Control-Allow-Origin;\n            proxy_pass http://127.0.0.1:8090;\n        }\n\n        location / {\n            try_files $uri $uri/ /index.html;\n        }\n    }\n}"
---
# Source: cilium/templates/cilium-agent/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: cilium
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - networking.k8s.io
  resources:
  - networkpolicies
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - discovery.k8s.io
  resources:
  - endpointslices
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - namespaces
  - services
  - pods
  - endpoints
  - nodes
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - list
  - watch
  # This is used when validating policies in preflight. This will need to stay
  # until we figure out how to avoid "get" inside the preflight, and then
  # should be removed ideally.
  - get
- apiGroups:
  - cilium.io
  resources:
  - ciliumloadbalancerippools
  - ciliumbgppeeringpolicies
  - ciliumclusterwideenvoyconfigs
  - ciliumclusterwidenetworkpolicies
  - ciliumegressgatewaypolicies
  - ciliumendpoints
  - ciliumendpointslices
  - ciliumenvoyconfigs
  - ciliumidentities
  - ciliumlocalredirectpolicies
  - ciliumnetworkpolicies
  - ciliumnodes
  - ciliumnodeconfigs
  verbs:
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - ciliumidentities
  - ciliumendpoints
  - ciliumnodes
  verbs:
  - create
- apiGroups:
  - cilium.io
  # To synchronize garbage collection of such resources
  resources:
  - ciliumidentities
  verbs:
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumendpoints
  verbs:
  - delete
  - get
- apiGroups:
  - cilium.io
  resources:
  - ciliumnodes
  - ciliumnodes/status
  verbs:
  - get
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumnetworkpolicies/status
  - ciliumclusterwidenetworkpolicies/status
  - ciliumendpoints/status
  - ciliumendpoints
  verbs:
  - patch
---
# Source: cilium/templates/cilium-operator/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: cilium-operator
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - get
  - list
  - watch
  # to automatically delete [core|kube]dns pods so that are starting to being
  # managed by Cilium
  - delete
- apiGroups:
  - ""
  resources:
  - nodes
  verbs:
  - list
  - watch
- apiGroups:
  - ""
  resources:
  # To remove node taints
  - nodes
  # To set NetworkUnavailable false on startup
  - nodes/status
  verbs:
  - patch
- apiGroups:
  - discovery.k8s.io
  resources:
  - endpointslices
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  # to perform LB IP allocation for BGP
  - services/status
  verbs:
  - update
  - patch
- apiGroups:
  - ""
  resources:
  # to check apiserver connectivity
  - namespaces
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
  - services
  - endpoints
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - ciliumnetworkpolicies
  - ciliumclusterwidenetworkpolicies
  verbs:
  # Create auto-generated CNPs and CCNPs from Policies that have 'toGroups'
  - create
  - update
  - deletecollection
  # To update the status of the CNPs and CCNPs
  - patch
  - get
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - ciliumnetworkpolicies/status
  - ciliumclusterwidenetworkpolicies/status
  verbs:
  # Update the auto-generated CNPs and CCNPs status.
  - patch
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumendpoints
  - ciliumidentities
  verbs:
  # To perform garbage collection of such resources
  - delete
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - ciliumidentities
  verbs:
  # To synchronize garbage collection of such resources
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumnodes
  verbs:
  - create
  - update
  - get
  - list
  - watch
    # To perform CiliumNode garbage collector
  - delete
- apiGroups:
  - cilium.io
  resources:
  - ciliumnodes/status
  verbs:
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumendpointslices
  - ciliumenvoyconfigs
  verbs:
  - create
  - update
  - get
  - list
  - watch
  - delete
  - patch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - create
  - get
  - list
  - watch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - update
  resourceNames:
  - ciliumloadbalancerippools.cilium.io
  - ciliumbgppeeringpolicies.cilium.io
  - ciliumclusterwideenvoyconfigs.cilium.io
  - ciliumclusterwidenetworkpolicies.cilium.io
  - ciliumegressgatewaypolicies.cilium.io
  - ciliumendpoints.cilium.io
  - ciliumendpointslices.cilium.io
  - ciliumenvoyconfigs.cilium.io
  - ciliumexternalworkloads.cilium.io
  - ciliumidentities.cilium.io
  - ciliumlocalredirectpolicies.cilium.io
  - ciliumnetworkpolicies.cilium.io
  - ciliumnodes.cilium.io
  - ciliumnodeconfigs.cilium.io
- apiGroups:
  - cilium.io
  resources:
  - ciliumloadbalancerippools
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - ciliumloadbalancerippools/status
  verbs:
  - patch
# For cilium-operator running in HA mode.
#
# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
# between multiple running instances.
# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
# common and fewer objects in the cluster watch "all Leases".
- apiGroups:
  - coordination.k8s.io
  resources:
  - leases
  verbs:
  - create
  - get
  - update
---
# Source: cilium/templates/clustermesh-apiserver/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: clustermesh-apiserver
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - cilium.io
  resources:
  - ciliumnodes
  - ciliumendpoints
  - ciliumidentities
  verbs:
  - create
- apiGroups:
  - cilium.io
  resources:
  - ciliumexternalworkloads/status
  - ciliumnodes
  - ciliumidentities
  verbs:
  - update
- apiGroups:
  - cilium.io
  resources:
  - ciliumendpoints
  - ciliumendpoints/status
  verbs:
  - patch
- apiGroups:
  - cilium.io
  resources:
  - ciliumidentities
  - ciliumexternalworkloads
  - ciliumendpoints
  - ciliumnodes
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - endpoints
  - namespaces
  - services
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - discovery.k8s.io
  resources:
  - endpointslices
  verbs:
  - get
  - list
  - watch
---
# Source: cilium/templates/etcd-operator/cilium-etcd-operator-clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: cilium-etcd-operator
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - etcd.database.coreos.com
  resources:
  - etcdclusters
  verbs:
  - get
  - delete
  - create
  - update
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - delete
  - get
  - create
- apiGroups:
  - ""
  resources:
  - deployments
  verbs:
  - delete
  - create
  - get
  - update
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - list
  - get
  - delete
- apiGroups:
  - apps
  resources:
  - deployments
  verbs:
  - delete
  - create
  - get
  - update
- apiGroups:
  - ""
  resources:
  - componentstatuses
  verbs:
  - get
- apiGroups:
  - extensions
  resources:
  - deployments
  verbs:
  - delete
  - create
  - get
  - update
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - create
  - delete
---
# Source: cilium/templates/etcd-operator/etcd-operator-clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: etcd-operator
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - etcd.database.coreos.com
  resources:
  - etcdclusters
  - etcdbackups
  - etcdrestores
  verbs:
  - '*'
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - '*'
- apiGroups:
  - ""
  resources:
  - pods
  - services
  - endpoints
  - persistentvolumeclaims
  - events
  - deployments
  verbs:
  - '*'
- apiGroups:
  - apps
  resources:
  - deployments
  verbs:
  - '*'
- apiGroups:
  - extensions
  resources:
  - deployments
  verbs:
  - create
  - get
  - list
  - patch
  - update
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
---
# Source: cilium/templates/hubble-ui/clusterrole.yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: hubble-ui
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - networking.k8s.io
  resources:
  - networkpolicies
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - componentstatuses
  - endpoints
  - namespaces
  - nodes
  - pods
  - services
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - cilium.io
  resources:
  - "*"
  verbs:
  - get
  - list
  - watch
---
# Source: cilium/templates/cilium-agent/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: cilium
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cilium
subjects:
- kind: ServiceAccount
  name: "cilium"
  namespace: default
---
# Source: cilium/templates/cilium-operator/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: cilium-operator
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cilium-operator
subjects:
- kind: ServiceAccount
  name: "cilium-operator"
  namespace: default
---
# Source: cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: clustermesh-apiserver
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: clustermesh-apiserver
subjects:
- kind: ServiceAccount
  name: "clustermesh-apiserver"
  namespace: default
---
# Source: cilium/templates/etcd-operator/cilium-etcd-operator-clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: cilium-etcd-operator
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cilium-etcd-operator
subjects:
- kind: ServiceAccount
  name: "cilium-etcd-operator"
  namespace: default
---
# Source: cilium/templates/etcd-operator/etcd-operator-clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: etcd-operator
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: etcd-operator
subjects:
- kind: ServiceAccount
  name: cilium-etcd-sa
  namespace: default
---
# Source: cilium/templates/hubble-ui/clusterrolebinding.yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: hubble-ui
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: hubble-ui
subjects:
- kind: ServiceAccount
  name: "hubble-ui"
  namespace: default
---
# Source: cilium/templates/cilium-agent/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: cilium-config-agent
  namespace: default
  labels:
    app.kubernetes.io/part-of: cilium
rules:
- apiGroups:
  - ""
  resources:
  - configmaps
  verbs:
  - get
  - list
  - watch
---
# Source: cilium/templates/cilium-agent/rolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: cilium-config-agent
  namespace: default
  labels:
    app.kubernetes.io/part-of: cilium
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: cilium-config-agent
subjects:
  - kind: ServiceAccount
    name: "cilium"
    namespace: default
---
# Source: cilium/templates/clustermesh-apiserver/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: clustermesh-apiserver
  namespace: default
  labels:
    k8s-app: clustermesh-apiserver
    app.kubernetes.io/part-of: cilium
    app.kubernetes.io/name: clustermesh-apiserver
spec:
  type: NodePort
  selector:
    k8s-app: clustermesh-apiserver
  ports:
  - port: 2379
    nodePort: 32379
---
# Source: cilium/templates/hubble-relay/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: hubble-relay
  namespace: default
  labels:
    k8s-app: hubble-relay
    app.kubernetes.io/name: hubble-relay
    app.kubernetes.io/part-of: cilium
spec:
  type: "ClusterIP"
  selector:
    k8s-app: hubble-relay
  ports:
  - protocol: TCP
    port: 80
    targetPort: 4245
---
# Source: cilium/templates/hubble-ui/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: hubble-ui
  namespace: default
  labels:
    k8s-app: hubble-ui
    app.kubernetes.io/name: hubble-ui
    app.kubernetes.io/part-of: cilium
spec:
  type: "ClusterIP"
  selector:
    k8s-app: hubble-ui
  ports:
    - name: http
      port: 80
      targetPort: 8081
---
# Source: cilium/templates/hubble/peer-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: hubble-peer
  namespace: default
  labels:
    k8s-app: cilium
    app.kubernetes.io/part-of: cilium
    app.kubernetes.io/name: hubble-peer
spec:
  selector:
    k8s-app: cilium
  ports:
  - name: peer-service
    port: 443
    protocol: TCP
    targetPort: 4244
  internalTrafficPolicy: Local
---
# Source: cilium/templates/cilium-agent/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: cilium
  namespace: default
  labels:
    k8s-app: cilium
    app.kubernetes.io/part-of: cilium
    app.kubernetes.io/name: cilium-agent
spec:
  selector:
    matchLabels:
      k8s-app: cilium
  updateStrategy:
    rollingUpdate:
      maxUnavailable: 2
    type: RollingUpdate
  template:
    metadata:
      annotations:
        # Set app AppArmor's profile to "unconfined". The value of this annotation
        # can be modified as long users know which profiles they have available
        # in AppArmor.
        container.apparmor.security.beta.kubernetes.io/cilium-agent: "unconfined"
        container.apparmor.security.beta.kubernetes.io/clean-cilium-state: "unconfined"
        container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: "unconfined"
      labels:
        k8s-app: cilium
        app.kubernetes.io/name: cilium-agent
        app.kubernetes.io/part-of: cilium
    spec:
      securityContext:
        runAsUser: 9999
      containers:
      - name: cilium-agent
        image: "quay.io/cilium/cilium-ci:latest"
        imagePullPolicy: Always
        command:
        - cilium-agent
        args:
        - --config-dir=/tmp/cilium/config-map
        startupProbe:
          httpGet:
            host: "127.0.0.1"
            path: /healthz
            port: 9879
            scheme: HTTP
            httpHeaders:
            - name: "brief"
              value: "true"
          failureThreshold: 105
          periodSeconds: 2
          successThreshold: 1
        livenessProbe:
          httpGet:
            host: "127.0.0.1"
            path: /healthz
            port: 9879
            scheme: HTTP
            httpHeaders:
            - name: "brief"
              value: "true"
          periodSeconds: 30
          successThreshold: 1
          failureThreshold: 10
          timeoutSeconds: 5
        readinessProbe:
          httpGet:
            host: "127.0.0.1"
            path: /healthz
            port: 9879
            scheme: HTTP
            httpHeaders:
            - name: "brief"
              value: "true"
          periodSeconds: 30
          successThreshold: 1
          failureThreshold: 3
          timeoutSeconds: 5
        env:
        - name: K8S_NODE_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: spec.nodeName
        - name: CILIUM_K8S_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: CILIUM_CLUSTERMESH_CONFIG
          value: /var/lib/cilium/clustermesh/
        - name: CILIUM_CNI_CHAINING_MODE
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: cni-chaining-mode
              optional: true
        - name: CILIUM_CUSTOM_CNI_CONF
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: custom-cni-conf
              optional: true
        lifecycle:
          postStart:
            exec:
              command:
              - "/cni-install.sh"
              - "--enable-debug=false"
              - "--cni-exclusive=true"
              - "--log-file=/var/run/cilium/cilium-cni.log"
          preStop:
            exec:
              command:
              - /cni-uninstall.sh
        securityContext:
          seLinuxOptions:
            level: s0
            type: spc_t
          capabilities:
            add:
              - CHOWN
              - KILL
              - NET_ADMIN
              - NET_RAW
              - IPC_LOCK
              - SYS_MODULE
              - SYS_ADMIN
              - SYS_RESOURCE
              - DAC_OVERRIDE
              - FOWNER
              - SETGID
              - SETUID
            drop:
              - ALL
        terminationMessagePolicy: FallbackToLogsOnError
        volumeMounts:
        # Unprivileged containers need to mount /proc/sys/net from the host
        # to have write access
        - mountPath: /host/proc/sys/net
          name: host-proc-sys-net
        # Unprivileged containers need to mount /proc/sys/kernel from the host
        # to have write access
        - mountPath: /host/proc/sys/kernel
          name: host-proc-sys-kernel
        - name: bpf-maps
          mountPath: /sys/fs/bpf
          # Unprivileged containers can't set mount propagation to bidirectional
          # in this case we will mount the bpf fs from an init container that
          # is privileged and set the mount propagation from host to container
          # in Cilium.
          mountPropagation: HostToContainer
        - name: cilium-run
          mountPath: /var/run/cilium
        - name: cni-path
          mountPath: /host/opt/cni/bin
        - name: etc-cni-netd
          mountPath: /host/etc/cni/net.d
        - name: etcd-config-path
          mountPath: /var/lib/etcd-config
          readOnly: true
        - name: etcd-secrets
          mountPath: /var/lib/etcd-secrets
          readOnly: true
        - name: clustermesh-secrets
          mountPath: /var/lib/cilium/clustermesh
          readOnly: true
          # Needed to be able to load kernel modules
        - name: lib-modules
          mountPath: /lib/modules
          readOnly: true
        - name: xtables-lock
          mountPath: /run/xtables.lock
        - name: hubble-tls
          mountPath: /var/lib/cilium/tls/hubble
          readOnly: true
        - name: tmp
          mountPath: /tmp
      initContainers:
      - name: config
        image: "quay.io/cilium/cilium-ci:latest"
        imagePullPolicy: Always
        command:
        - cilium
        - build-config
        env:
        - name: K8S_NODE_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: spec.nodeName
        - name: CILIUM_K8S_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        volumeMounts:
        - name: tmp
          mountPath: /tmp
        terminationMessagePolicy: FallbackToLogsOnError
      # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
      # We use nsenter command with host's cgroup and mount namespaces enabled.
      - name: mount-cgroup
        image: "quay.io/cilium/cilium-ci:latest"
        imagePullPolicy: Always
        env:
        - name: CGROUP_ROOT
          value: /run/cilium/cgroupv2
        - name: BIN_PATH
          value: /opt/cni/bin
        command:
        - sh
        - -ec
        # The statically linked Go program binary is invoked to avoid any
        # dependency on utilities like sh and mount that can be missing on certain
        # distros installed on the underlying host. Copy the binary to the
        # same directory where we install cilium cni plugin so that exec permissions
        # are available.
        - |
          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
          rm /hostbin/cilium-mount
        volumeMounts:
        - name: hostproc
          mountPath: /hostproc
        - name: cni-path
          mountPath: /hostbin
        terminationMessagePolicy: FallbackToLogsOnError
        securityContext:
          seLinuxOptions:
            level: s0
            type: spc_t
          capabilities:
            add:
              - SYS_ADMIN
              - SYS_CHROOT
              - SYS_PTRACE
            drop:
              - ALL
      - name: apply-sysctl-overwrites
        image: "quay.io/cilium/cilium-ci:latest"
        imagePullPolicy: Always
        env:
        - name: BIN_PATH
          value: /opt/cni/bin
        command:
        - sh
        - -ec
        # The statically linked Go program binary is invoked to avoid any
        # dependency on utilities like sh that can be missing on certain
        # distros installed on the underlying host. Copy the binary to the
        # same directory where we install cilium cni plugin so that exec permissions
        # are available.
        - |
          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
          rm /hostbin/cilium-sysctlfix
        volumeMounts:
        - name: hostproc
          mountPath: /hostproc
        - name: cni-path
          mountPath: /hostbin
        terminationMessagePolicy: FallbackToLogsOnError
        securityContext:
          seLinuxOptions:
            level: s0
            type: spc_t
          capabilities:
            add:
              - SYS_ADMIN
              - SYS_CHROOT
              - SYS_PTRACE
            drop:
              - ALL
      # Mount the bpf fs if it is not mounted. We will perform this task
      # from a privileged container because the mount propagation bidirectional
      # only works from privileged containers.
      - name: mount-bpf-fs
        image: "quay.io/cilium/cilium-ci:latest"
        imagePullPolicy: Always
        args:
        - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
        command:
        - /bin/bash
        - -c
        - --
        terminationMessagePolicy: FallbackToLogsOnError
        securityContext:
          privileged: true
        volumeMounts:
        - name: bpf-maps
          mountPath: /sys/fs/bpf
          mountPropagation: Bidirectional
      - name: clean-cilium-state
        image: "quay.io/cilium/cilium-ci:latest"
        imagePullPolicy: Always
        command:
        - /init-container.sh
        env:
        - name: CILIUM_ALL_STATE
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: clean-cilium-state
              optional: true
        - name: CILIUM_BPF_STATE
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: clean-cilium-bpf-state
              optional: true
        terminationMessagePolicy: FallbackToLogsOnError
        securityContext:
          seLinuxOptions:
            level: s0
            type: spc_t
          capabilities:
            add:
              - NET_ADMIN
              - SYS_MODULE
              - SYS_ADMIN
              - SYS_RESOURCE
            drop:
              - ALL
        volumeMounts:
        - name: bpf-maps
          mountPath: /sys/fs/bpf
          # Required to mount cgroup filesystem from the host to cilium agent pod
        - name: cilium-cgroup
          mountPath: /run/cilium/cgroupv2
          mountPropagation: HostToContainer
        - name: cilium-run
          mountPath: /var/run/cilium
        resources:
          requests:
            cpu: 100m
            memory: 100Mi # wait-for-kube-proxy
      restartPolicy: Always
      priorityClassName: system-node-critical
      serviceAccount: "cilium"
      serviceAccountName: "cilium"
      terminationGracePeriodSeconds: 1
      hostNetwork: true
      # In managed etcd mode, Cilium must be able to resolve the DNS name of
      # the etcd service
      dnsPolicy: ClusterFirstWithHostNet
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                k8s-app: cilium
            topologyKey: kubernetes.io/hostname
      nodeSelector:
        kubernetes.io/os: linux
      tolerations:
        - operator: Exists
      volumes:
        # For sharing configuration between the "config" initContainer and the agent
      - name: tmp
        emptyDir: {}
        # To keep state between restarts / upgrades
      - name: cilium-run
        hostPath:
          path: /var/run/cilium
          type: DirectoryOrCreate
        # To keep state between restarts / upgrades for bpf maps
      - name: bpf-maps
        hostPath:
          path: /sys/fs/bpf
          type: DirectoryOrCreate
      # To mount cgroup2 filesystem on the host
      - name: hostproc
        hostPath:
          path: /proc
          type: Directory
      # To keep state between restarts / upgrades for cgroup2 filesystem
      - name: cilium-cgroup
        hostPath:
          path: /run/cilium/cgroupv2
          type: DirectoryOrCreate
      # To install cilium cni plugin in the host
      - name: cni-path
        hostPath:
          path:  /opt/cni/bin
          type: DirectoryOrCreate
        # To install cilium cni configuration in the host
      - name: etc-cni-netd
        hostPath:
          path: /etc/cni/net.d
          type: DirectoryOrCreate
        # To be able to load kernel modules
      - name: lib-modules
        hostPath:
          path: /lib/modules
        # To access iptables concurrently with other processes (e.g. kube-proxy)
      - name: xtables-lock
        hostPath:
          path: /run/xtables.lock
          type: FileOrCreate
        # To read the etcd config stored in config maps
      - name: etcd-config-path
        configMap:
          name: cilium-config
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          items:
          - key: etcd-config
            path: etcd.config
        # To read the k8s etcd secrets in case the user might want to use TLS
      - name: etcd-secrets
        secret:
          secretName: cilium-etcd-secrets
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          optional: true
        # To read the clustermesh configuration
      - name: clustermesh-secrets
        secret:
          secretName: cilium-clustermesh
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          optional: true
      - name: host-proc-sys-net
        hostPath:
          path: /proc/sys/net
          type: Directory
      - name: host-proc-sys-kernel
        hostPath:
          path: /proc/sys/kernel
          type: Directory
      - name: hubble-tls
        projected:
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          sources:
          - secret:
              name: hubble-server-certs
              optional: true
              items:
              - key: ca.crt
                path: client-ca.crt
              - key: tls.crt
                path: server.crt
              - key: tls.key
                path: server.key
---
# Source: cilium/templates/cilium-operator/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cilium-operator
  namespace: default
  labels:
    io.cilium/app: operator
    name: cilium-operator
    app.kubernetes.io/part-of: cilium
    app.kubernetes.io/name: cilium-operator
spec:
  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
  # for more details.
  replicas: 2
  selector:
    matchLabels:
      io.cilium/app: operator
      name: cilium-operator
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      annotations:
      labels:
        io.cilium/app: operator
        name: cilium-operator
        app.kubernetes.io/part-of: cilium
        app.kubernetes.io/name: cilium-operator
    spec:
      securityContext:
        runAsUser: 1001
      containers:
      - name: cilium-operator
        image: "quay.io/cilium/operator-generic-ci:latest"
        imagePullPolicy: Always
        command:
        - cilium-operator-generic
        args:
        - --config-dir=/tmp/cilium/config-map
        - --debug=$(CILIUM_DEBUG)
        env:
        - name: K8S_NODE_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: spec.nodeName
        - name: CILIUM_K8S_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: CILIUM_DEBUG
          valueFrom:
            configMapKeyRef:
              key: debug
              name: cilium-config
              optional: true
        livenessProbe:
          httpGet:
            host: "127.0.0.1"
            path: /healthz
            port: 9234
            scheme: HTTP
          initialDelaySeconds: 60
          periodSeconds: 10
          timeoutSeconds: 3
        volumeMounts:
        - name: cilium-config-path
          mountPath: /tmp/cilium/config-map
          readOnly: true
        - name: etcd-config-path
          mountPath: /var/lib/etcd-config
          readOnly: true
        - name: etcd-secrets
          mountPath: /var/lib/etcd-secrets
          readOnly: true
        terminationMessagePolicy: FallbackToLogsOnError
      hostNetwork: true
      # In managed etcd mode, Cilium must be able to resolve the DNS name of
      # the etcd service
      dnsPolicy: ClusterFirstWithHostNet
      restartPolicy: Always
      priorityClassName: system-cluster-critical
      serviceAccount: "cilium-operator"
      serviceAccountName: "cilium-operator"
      # In HA mode, cilium-operator pods must not be scheduled on the same
      # node as they will clash with each other.
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                io.cilium/app: operator
            topologyKey: kubernetes.io/hostname
      nodeSelector:
        kubernetes.io/os: linux
      tolerations:
        - operator: Exists
      volumes:
        # To read the configuration from the config map
      - name: cilium-config-path
        configMap:
          name: cilium-config
      # To read the etcd config stored in config maps
      - name: etcd-config-path
        configMap:
          name: cilium-config
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          items:
          - key: etcd-config
            path: etcd.config
        # To read the k8s etcd secrets in case the user might want to use TLS
      - name: etcd-secrets
        secret:
          secretName: cilium-etcd-secrets
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          optional: true
---
# Source: cilium/templates/clustermesh-apiserver/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: clustermesh-apiserver
  namespace: default
  labels:
    k8s-app: clustermesh-apiserver
    app.kubernetes.io/part-of: cilium
    app.kubernetes.io/name: clustermesh-apiserver
spec:
  replicas: 1
  selector:
    matchLabels:
      k8s-app: clustermesh-apiserver
  strategy:
    rollingUpdate:
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      annotations:
      labels:
        app.kubernetes.io/part-of: cilium
        app.kubernetes.io/name: clustermesh-apiserver
        k8s-app: clustermesh-apiserver
    spec:
      initContainers:
      - name: etcd-init
        image: "quay.io/coreos/etcd:v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"
        imagePullPolicy: Always
        command: ["/bin/sh", "-c"]
        args:
        - |
          rm -rf /var/run/etcd/*;
          /usr/local/bin/etcd --data-dir=/var/run/etcd --name=clustermesh-apiserver --listen-client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster-token=clustermesh-apiserver --initial-cluster-state=new --auto-compaction-retention=1 &
          export rootpw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
          echo $rootpw | etcdctl --interactive=false user add root;
          etcdctl user grant-role root root;
          export vmpw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
          echo $vmpw | etcdctl --interactive=false user add externalworkload;
          etcdctl role add externalworkload;
          etcdctl role grant-permission externalworkload --from-key read '';
          etcdctl role grant-permission externalworkload readwrite --prefix cilium/state/noderegister/v1/;
          etcdctl role grant-permission externalworkload readwrite --prefix cilium/.initlock/;
          etcdctl user grant-role externalworkload externalworkload;
          export remotepw=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16`;
          echo $remotepw | etcdctl --interactive=false user add remote;
          etcdctl role add remote;
          etcdctl role grant-permission remote --from-key read '';
          etcdctl user grant-role remote remote;
          etcdctl auth enable;
          exit
        env:
        - name: ETCDCTL_API
          value: "3"
        - name: HOSTNAME_IP
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
        volumeMounts:
        - name: etcd-data-dir
          mountPath: /var/run/etcd
        terminationMessagePolicy: FallbackToLogsOnError
      containers:
      - name: etcd
        image: "quay.io/coreos/etcd:v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"
        imagePullPolicy: Always
        command:
        - /usr/local/bin/etcd
        args:
        - --data-dir=/var/run/etcd
        - --name=clustermesh-apiserver
        - --client-cert-auth
        - --trusted-ca-file=/var/lib/etcd-secrets/ca.crt
        - --cert-file=/var/lib/etcd-secrets/tls.crt
        - --key-file=/var/lib/etcd-secrets/tls.key
        # Surrounding the IPv4 address with brackets works in this case, since etcd
        # uses net.SplitHostPort() internally and it accepts the that format.
        - --listen-client-urls=https://127.0.0.1:2379,https://[$(HOSTNAME_IP)]:2379
        - --advertise-client-urls=https://[$(HOSTNAME_IP)]:2379
        - --initial-cluster-token=clustermesh-apiserver
        - --auto-compaction-retention=1
        env:
        - name: ETCDCTL_API
          value: "3"
        - name: HOSTNAME_IP
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
        volumeMounts:
        - name: etcd-server-secrets
          mountPath: /var/lib/etcd-secrets
          readOnly: true
        - name: etcd-data-dir
          mountPath: /var/run/etcd
        terminationMessagePolicy: FallbackToLogsOnError
        securityContext:
          runAsUser: 1003
      - name: apiserver
        image: "quay.io/cilium/clustermesh-apiserver-ci:latest"
        imagePullPolicy: Always
        command:
        - /usr/bin/clustermesh-apiserver
        args:
        - --cluster-name=$(CLUSTER_NAME)
        - --cluster-id=$(CLUSTER_ID)
        - --kvstore-opt
        - etcd.config=/var/lib/cilium/etcd-config.yaml
        env:
        - name: CLUSTER_NAME
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: cluster-name
        - name: CLUSTER_ID
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: cluster-id
              optional: true
        - name: IDENTITY_ALLOCATION_MODE
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: identity-allocation-mode
        - name: ENABLE_K8S_ENDPOINT_SLICE
          valueFrom:
            configMapKeyRef:
              name: cilium-config
              key: enable-k8s-endpoint-slice
              optional: true
        volumeMounts:
        - name: etcd-admin-client
          mountPath: /var/lib/cilium/etcd-secrets
          readOnly: true
        terminationMessagePolicy: FallbackToLogsOnError
      volumes:
      - name: etcd-server-secrets
        secret:
          secretName: clustermesh-apiserver-server-cert
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
      - name: etcd-admin-client
        secret:
          secretName: clustermesh-apiserver-admin-cert
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
      - name: etcd-data-dir
        emptyDir: {}
      restartPolicy: Always
      priorityClassName: system-cluster-critical
      serviceAccount: "clustermesh-apiserver"
      serviceAccountName: "clustermesh-apiserver"
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                k8s-app: clustermesh-apiserver
            topologyKey: kubernetes.io/hostname
      nodeSelector:
        kubernetes.io/os: linux
---
# Source: cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    io.cilium/app: etcd-operator
    name: cilium-etcd-operator
    app.kubernetes.io/name: cilium-etcd-operator
    app.kubernetes.io/part-of: cilium
  name: cilium-etcd-operator
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      io.cilium/app: etcd-operator
      name: cilium-etcd-operator
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      labels:
        io.cilium/app: etcd-operator
        app.kubernetes.io/part-of: cilium
        app.kubernetes.io/name: cilium-etcd-operator
        name: cilium-etcd-operator
    spec:
      securityContext:
        runAsUser: 1000
      containers:
      - args:
        #- --etcd-node-selector=disktype=ssd,cputype=high
        command:
        - /usr/bin/cilium-etcd-operator
        env:
        - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
          value: "cluster.local"
        - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
          value: ""
        - name: CILIUM_ETCD_OPERATOR_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: CILIUM_ETCD_OPERATOR_POD_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.name
        - name: CILIUM_ETCD_OPERATOR_POD_UID
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.uid
        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
          value: "revision"
        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
          value: "25000"
        image: "quay.io/cilium/cilium-etcd-operator:v2.0.7@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc"
        imagePullPolicy: Always
        name: cilium-etcd-operator
        terminationMessagePolicy: FallbackToLogsOnError
      dnsPolicy: ClusterFirst
      hostNetwork: true
      priorityClassName: system-cluster-critical
      restartPolicy: Always
      serviceAccount: "cilium-etcd-operator"
      serviceAccountName: "cilium-etcd-operator"
      nodeSelector:
        kubernetes.io/os: linux
      tolerations:
      - operator: Exists
---
# Source: cilium/templates/hubble-relay/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hubble-relay
  namespace: default
  labels:
    k8s-app: hubble-relay
    app.kubernetes.io/name: hubble-relay
    app.kubernetes.io/part-of: cilium
spec:
  replicas: 1
  selector:
    matchLabels:
      k8s-app: hubble-relay
  strategy:
    rollingUpdate:
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      annotations:
      labels:
        k8s-app: hubble-relay
        app.kubernetes.io/name: hubble-relay
        app.kubernetes.io/part-of: cilium
    spec:
      securityContext:
        fsGroup: 65532
      containers:
        - name: hubble-relay
          securityContext:
            capabilities:
              drop:
              - ALL
            runAsGroup: 65532
            runAsNonRoot: true
            runAsUser: 65532
          image: "quay.io/cilium/hubble-relay-ci:latest"
          imagePullPolicy: Always
          command:
            - hubble-relay
          args:
            - serve
          ports:
            - name: grpc
              containerPort: 4245
          readinessProbe:
            tcpSocket:
              port: grpc
          livenessProbe:
            tcpSocket:
              port: grpc
          volumeMounts:
          - name: config
            mountPath: /etc/hubble-relay
            readOnly: true
          - name: tls
            mountPath: /var/lib/hubble-relay/tls
            readOnly: true
          terminationMessagePolicy: FallbackToLogsOnError
      restartPolicy: Always
      priorityClassName: 
      serviceAccount: "hubble-relay"
      serviceAccountName: "hubble-relay"
      automountServiceAccountToken: false
      terminationGracePeriodSeconds: 1
      affinity:
        podAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                k8s-app: cilium
            topologyKey: kubernetes.io/hostname
      nodeSelector:
        kubernetes.io/os: linux
      volumes:
      - name: config
        configMap:
          name: hubble-relay-config
          items:
          - key: config.yaml
            path: config.yaml
      - name: tls
        projected:
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          sources:
          - secret:
              name: hubble-relay-client-certs
              items:
                - key: ca.crt
                  path: hubble-server-ca.crt
                - key: tls.crt
                  path: client.crt
                - key: tls.key
                  path: client.key
---
# Source: cilium/templates/hubble-ui/deployment.yaml
kind: Deployment
apiVersion: apps/v1
metadata:
  name: hubble-ui
  namespace: default
  labels:
    k8s-app: hubble-ui
    app.kubernetes.io/name: hubble-ui
    app.kubernetes.io/part-of: cilium
spec:
  replicas: 1
  selector:
    matchLabels:
      k8s-app: hubble-ui
  template:
    metadata:
      annotations:
      labels:
        k8s-app: hubble-ui
        app.kubernetes.io/name: hubble-ui
        app.kubernetes.io/part-of: cilium
    spec:
      securityContext:
        fsGroup: 1001
        runAsGroup: 1001
        runAsUser: 1001
      priorityClassName: 
      serviceAccount: "hubble-ui"
      serviceAccountName: "hubble-ui"
      containers:
      - name: frontend
        image: "quay.io/cilium/hubble-ui:v0.10.0@sha256:118ad2fcfd07fabcae4dde35ec88d33564c9ca7abe520aa45b1eb13ba36c6e0a"
        imagePullPolicy: Always
        ports:
        - name: http
          containerPort: 8081
        volumeMounts:
          - name: hubble-ui-nginx-conf
            mountPath: /etc/nginx/conf.d/default.conf
            subPath: nginx.conf
          - name: tmp-dir
            mountPath: /tmp
        terminationMessagePolicy: FallbackToLogsOnError
        securityContext:
          allowPrivilegeEscalation: false
      - name: backend
        image: "quay.io/cilium/hubble-ui-backend:v0.10.0@sha256:cc5e2730b3be6f117b22176e25875f2308834ced7c3aa34fb598aa87a2c0a6a4"
        imagePullPolicy: Always
        env:
        - name: EVENTS_SERVER_PORT
          value: "8090"
        - name: FLOWS_API_ADDR
          value: "hubble-relay:80"
        ports:
        - name: grpc
          containerPort: 8090
        volumeMounts:
        terminationMessagePolicy: FallbackToLogsOnError
        securityContext:
          allowPrivilegeEscalation: false
      nodeSelector:
        kubernetes.io/os: linux
      volumes:
      - configMap:
          defaultMode: 420
          name: hubble-ui-nginx
        name: hubble-ui-nginx-conf
      - emptyDir: {}
        name: tmp-dir
---
# Source: cilium/templates/cilium-secrets-namespace.yaml
# Only create the namespace if it's different from Ingress secret namespace or Ingress is not enabled.
```

</details>