### PR TITLE
bpf: remove redundant policy_mark_skip() in handle_ipv6_from_lxc()

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -399,12 +399,6 @@ ct_recreate6:
 					  ct_state->rev_nat_index, tuple, 0);
 			if (IS_ERR(ret))
 				return ret;
-
-			/* A reverse translate packet is always allowed except
-			 * for delivery on the local node in which case this
-			 * marking is cleared again.
-			 */
-			policy_mark_skip(ctx);
 		}
 		break;
 


### PR DESCRIPTION
A few lines up we already flag all CT_REPLY traffic as policy_mark_skip(). So remove the redundant second occurrence.

For IPv4 this was cleaned up way back with commit
44b706227494 ("bpf: All loopback back to origin via service IP (IPv4)").