### PR TITLE
egressgw: add support for excludedCIDRs

### DIFF
--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -209,6 +209,20 @@ One or more IPv4 destination CIDRs can be specified with ``destinationCIDRs``:
     pods, nodes, Kubernetes API server) will be excluded from the egress gateway
     SNAT logic.
 
+It's possible to specify exceptions to the ``destinationCIDRs`` list with
+``excludedCIDRs``:
+
+.. code-block:: yaml
+
+    destinationCIDRs:
+    - "a.b.0.0/16"
+    excludedCIDRs:
+    - "a.b.c.0/24"
+
+In this case traffic destined to the ``a.b.0.0/16`` CIDR, except for the
+``a.b.c.0/24`` destination, will go through egress gateway and leave the cluster
+with the designated egress IP.
+
 Selecting and configuring the gateway node
 ------------------------------------------
 

--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -38,6 +38,12 @@ bool egress_gw_request_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint)
 	if (!egress_gw_policy)
 		return false;
 
+	/* If the gateway IP is 0.0.0.0 it means this is an excluded CIDR, so
+	 * skip redirection
+	 */
+	if (!egress_gw_policy->gateway_ip)
+		return false;
+
 	/* If the gateway node is the local node, then just let the
 	 * packet go through, as it will be SNATed later on by
 	 * handle_nat_fwd().
@@ -59,6 +65,12 @@ bool egress_gw_snat_needed(struct iphdr *ip4, __be32 *snat_addr)
 	if (!egress_gw_policy)
 		return false;
 
+	/* If the gateway IP is 0.0.0.0 it means this is an excluded CIDR, so
+	 * skip SNAT
+	 */
+	if (!egress_gw_policy->gateway_ip)
+		return false;
+
 	*snat_addr = egress_gw_policy->egress_ip;
 	return true;
 }
@@ -73,6 +85,12 @@ bool egress_gw_reply_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint,
 	/* Find a matching policy by looking up the reverse address tuple: */
 	egress_policy = lookup_ip4_egress_gw_policy(ip4->daddr, ip4->saddr);
 	if (!egress_policy)
+		return false;
+
+	/* If the gateway IP is 0.0.0.0 it means this is an excluded CIDR, so
+	 * skip reply redirect
+	 */
+	if (!egress_policy->gateway_ip)
 		return false;
 
 	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -147,3 +147,127 @@ int egressgw_redirect_check(const struct __ctx_buff *ctx)
 
 	test_finish();
 }
+
+/* Test that a packet matching an excluded CIDR egress gateway policy on the
+ * from-container program does not get redirected to the gateway node.
+ */
+PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_redirect")
+int egressgw_skip_excluded_cidr_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = EXTERNAL_SVC_IP;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = EXTERNAL_SVC_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect")
+int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
+{
+	struct egress_gw_policy_key in_key = {
+		.lpm_key = { 32 + 24, {} },
+		.saddr   = CLIENT_IP,
+		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
+	};
+
+	struct egress_gw_policy_entry in_val = {
+		.egress_ip  = 0,
+		.gateway_ip = NODE_IP,
+	};
+
+	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
+
+	struct egress_gw_policy_key in_key_excluded_cidr = {
+		.lpm_key = { 32 + 32, {} },
+		.saddr   = CLIENT_IP,
+		.daddr   = EXTERNAL_SVC_IP,
+	};
+
+	struct egress_gw_policy_entry in_val_excluded_cidr = {
+		.egress_ip  = 0,
+		.gateway_ip = 0,
+	};
+
+	map_update_elem(&EGRESS_POLICY_MAP, &in_key_excluded_cidr, &in_val_excluded_cidr, 0);
+
+	struct policy_key policy_key = {
+		.egress = 1,
+	};
+	struct policy_entry policy_value = {
+		.deny = 0,
+	};
+
+	/* avoid policy drop */
+	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_skip_excluded_cidr_redirect")
+int egressgw_skip_excluded_cidr_redirect_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Delete the excluded CIDR entry otherwise other tests may fail as this
+	 * entry will persist across the different tests.
+	 */
+	struct egress_gw_policy_key in_key_excluded_cidr = {
+		.lpm_key = { 32 + 32, {} },
+		.saddr   = CLIENT_IP,
+		.daddr   = EXTERNAL_SVC_IP,
+	};
+
+	map_delete_elem(&EGRESS_POLICY_MAP, &in_key_excluded_cidr);
+
+	test_finish();
+}

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define HAVE_LPM_TRIE_MAP_TYPE
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+#define LXC_IPV4 (__be32)v4_pod_one
+#include "config_replacement.h"
+
+/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
+#define ETH_HLEN 14
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_EGRESS_GATEWAY
+#define ENABLE_MASQUERADE
+#define ENCAP_IFINDEX 0
+
+#define CLIENT_IP		v4_pod_one
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define EXTERNAL_SVC_IP		v4_ext_one
+#define EXTERNAL_SVC_PORT	__bpf_htons(1234)
+
+#define NODE_IP			v4_node_one
+
+#define SECCTX_FROM_IPCACHE 1
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *ext_svc_mac = mac_two;
+
+#include "bpf_lxc.c"
+
+#define FROM_CONTAINER 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+	},
+};
+
+/* Test that a packet matching an egress gateway policy on the from-container
+ * program gets redirected to the gateway node.
+ */
+PKTGEN("tc", "tc_egressgw_redirect")
+int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = EXTERNAL_SVC_IP;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = EXTERNAL_SVC_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_egressgw_redirect")
+int egressgw_redirect_setup(struct __ctx_buff *ctx)
+{
+	struct egress_gw_policy_key in_key = {
+		.lpm_key = { 32 + 24, {} },
+		.saddr   = CLIENT_IP,
+		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
+	};
+
+	struct egress_gw_policy_entry in_val = {
+		.egress_ip  = 0,
+		.gateway_ip = NODE_IP,
+	};
+
+	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
+
+	struct policy_key policy_key = {
+		.egress = 1,
+	};
+	struct policy_entry policy_value = {
+		.deny = 0,
+	};
+
+	/* avoid policy drop */
+	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_redirect")
+int egressgw_redirect_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	test_finish();
+}

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -100,7 +100,7 @@ SETUP("tc", "tc_egressgw_redirect")
 int egressgw_redirect_setup(struct __ctx_buff *ctx)
 {
 	struct egress_gw_policy_key in_key = {
-		.lpm_key = { 32 + 24, {} },
+		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
 		.saddr   = CLIENT_IP,
 		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
 	};
@@ -200,7 +200,7 @@ SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect")
 int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 {
 	struct egress_gw_policy_key in_key = {
-		.lpm_key = { 32 + 24, {} },
+		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
 		.saddr   = CLIENT_IP,
 		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
 	};
@@ -213,7 +213,7 @@ int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
 
 	struct egress_gw_policy_key in_key_excluded_cidr = {
-		.lpm_key = { 32 + 32, {} },
+		.lpm_key = { EGRESS_PREFIX_LEN(32), {} },
 		.saddr   = CLIENT_IP,
 		.daddr   = EXTERNAL_SVC_IP,
 	};
@@ -262,7 +262,7 @@ int egressgw_skip_excluded_cidr_redirect_check(const struct __ctx_buff *ctx)
 	 * entry will persist across the different tests.
 	 */
 	struct egress_gw_policy_key in_key_excluded_cidr = {
-		.lpm_key = { 32 + 32, {} },
+		.lpm_key = { EGRESS_PREFIX_LEN(32), {} },
 		.saddr   = CLIENT_IP,
 		.daddr   = EXTERNAL_SVC_IP,
 	};

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -100,7 +100,7 @@ SETUP("tc", "tc_egressgw_snat")
 int egressgw_snat_setup(struct __ctx_buff *ctx)
 {
 	struct egress_gw_policy_key in_key = {
-		.lpm_key = { 32 + 24, {} },
+		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
 		.saddr   = CLIENT_IP,
 		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
 	};
@@ -237,7 +237,7 @@ SETUP("tc", "tc_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_setup(struct __ctx_buff *ctx)
 {
 	struct egress_gw_policy_key in_key = {
-		.lpm_key = { 32 + 24, {} },
+		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
 		.saddr   = CLIENT_IP,
 		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
 	};
@@ -250,7 +250,7 @@ int egressgw_skip_excluded_cidr_snat_setup(struct __ctx_buff *ctx)
 	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
 
 	struct egress_gw_policy_key in_key_excluded_cidr = {
-		.lpm_key = { 32 + 32, {} },
+		.lpm_key = { EGRESS_PREFIX_LEN(32), {} },
 		.saddr   = CLIENT_IP,
 		.daddr   = EXTERNAL_SVC_IP,
 	};
@@ -322,7 +322,7 @@ int egressgw_skip_excluded_cidr_snat_check(const struct __ctx_buff *ctx)
 	 * entry will persist across the different tests.
 	 */
 	struct egress_gw_policy_key in_key_excluded_cidr = {
-		.lpm_key = { 32 + 32, {} },
+		.lpm_key = { EGRESS_PREFIX_LEN(32), {} },
 		.saddr   = CLIENT_IP,
 		.daddr   = EXTERNAL_SVC_IP,
 	};

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -52,7 +52,7 @@ struct {
  * gets correctly SNATed with the egress IP of the policy.
  */
 PKTGEN("tc", "tc_egressgw_snat")
-int egressgw_pktgen(struct __ctx_buff *ctx)
+int egressgw_snat_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -97,7 +97,7 @@ int egressgw_pktgen(struct __ctx_buff *ctx)
 }
 
 SETUP("tc", "tc_egressgw_snat")
-int egressgw_setup(struct __ctx_buff *ctx)
+int egressgw_snat_setup(struct __ctx_buff *ctx)
 {
 	struct egress_gw_policy_key in_key = {
 		.lpm_key = { 32 + 24, {} },
@@ -119,7 +119,7 @@ int egressgw_setup(struct __ctx_buff *ctx)
 }
 
 CHECK("tc", "tc_egressgw_snat")
-int egressgw_check(const struct __ctx_buff *ctx)
+int egressgw_snat_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -184,3 +184,150 @@ int egressgw_snat_check(const struct __ctx_buff *ctx)
 
 	test_finish();
 }
+
+/* Test that a packet matching an excluded CIDR egress gateway policy on the
+ * to-netdev program does not get SNATed with the egress IP of the policy.
+ */
+PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_snat")
+int egressgw_skip_excluded_cidr_snat_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = EXTERNAL_SVC_IP;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = EXTERNAL_SVC_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_egressgw_skip_excluded_cidr_snat")
+int egressgw_skip_excluded_cidr_snat_setup(struct __ctx_buff *ctx)
+{
+	struct egress_gw_policy_key in_key = {
+		.lpm_key = { 32 + 24, {} },
+		.saddr   = CLIENT_IP,
+		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
+	};
+
+	struct egress_gw_policy_entry in_val = {
+		.egress_ip  = 0,
+		.gateway_ip = NODE_IP,
+	};
+
+	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
+
+	struct egress_gw_policy_key in_key_excluded_cidr = {
+		.lpm_key = { 32 + 32, {} },
+		.saddr   = CLIENT_IP,
+		.daddr   = EXTERNAL_SVC_IP,
+	};
+
+	struct egress_gw_policy_entry in_val_excluded_cidr = {
+		.egress_ip  = 0,
+		.gateway_ip = 0,
+	};
+
+	map_update_elem(&EGRESS_POLICY_MAP, &in_key_excluded_cidr, &in_val_excluded_cidr, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_skip_excluded_cidr_snat")
+int egressgw_skip_excluded_cidr_snat_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the client MAC")
+
+	if (memcmp(l2->h_dest, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the external svc MAC")
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != EXTERNAL_SVC_IP)
+		test_fatal("dst IP has changed");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src TCP port has changed");
+
+	if (l4->dest != EXTERNAL_SVC_PORT)
+		test_fatal("dst port has changed");
+
+	/* Delete the excluded CIDR entry otherwise other tests may fail as this
+	 * entry will persist across the different tests.
+	 */
+	struct egress_gw_policy_key in_key_excluded_cidr = {
+		.lpm_key = { 32 + 32, {} },
+		.saddr   = CLIENT_IP,
+		.daddr   = EXTERNAL_SVC_IP,
+	};
+
+	map_delete_elem(&EGRESS_POLICY_MAP, &in_key_excluded_cidr);
+
+	test_finish();
+}

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -318,9 +318,15 @@ func (manager *Manager) removeUnusedIpRulesAndRoutes() {
 nextIpRule:
 	for _, ipRule := range ipRules {
 		matchFunc := func(endpointIP net.IP, dstCIDR *net.IPNet, gwc *gatewayConfig) bool {
-			return manager.installRoutes &&
-				gwc.localNodeConfiguredAsGateway &&
-				ipRule.Src.IP.Equal(endpointIP) && ipRule.Dst.String() == dstCIDR.String()
+			if !manager.installRoutes {
+				return false
+			}
+
+			if !gwc.localNodeConfiguredAsGateway {
+				return false
+			}
+
+			return ipRule.Src.IP.Equal(endpointIP) && ipRule.Dst.String() == dstCIDR.String()
 		}
 
 		for _, policyConfig := range manager.policyConfigs {

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -572,7 +572,7 @@ func rangeToCIDRs(firstIP, lastIP net.IP) []*net.IPNet {
 		} else {
 			bitLen = ipv6BitLen
 		}
-		_, _, right := partitionCIDR(spanningCIDR, net.IPNet{IP: prevFirstRangeIP, Mask: net.CIDRMask(bitLen, bitLen)})
+		_, _, right := PartitionCIDR(spanningCIDR, net.IPNet{IP: prevFirstRangeIP, Mask: net.CIDRMask(bitLen, bitLen)})
 
 		// Append all CIDRs but the first, as this CIDR includes the upper
 		// bound of the spanning CIDR, which we still need to partition on.
@@ -595,7 +595,7 @@ func rangeToCIDRs(firstIP, lastIP net.IP) []*net.IPNet {
 		} else {
 			bitLen = ipv6BitLen
 		}
-		left, _, _ := partitionCIDR(spanningCIDR, net.IPNet{IP: nextFirstRangeIP, Mask: net.CIDRMask(bitLen, bitLen)})
+		left, _, _ := PartitionCIDR(spanningCIDR, net.IPNet{IP: nextFirstRangeIP, Mask: net.CIDRMask(bitLen, bitLen)})
 		cidrList = append(cidrList, left...)
 	} else {
 		// Otherwise, there is no need to partition; just use add the spanning
@@ -605,13 +605,13 @@ func rangeToCIDRs(firstIP, lastIP net.IP) []*net.IPNet {
 	return cidrList
 }
 
-// partitionCIDR returns a list of IP Networks partitioned upon excludeCIDR.
+// PartitionCIDR returns a list of IP Networks partitioned upon excludeCIDR.
 // The first list contains the networks to the left of the excludeCIDR in the
 // partition,  the second is a list containing the excludeCIDR itself if it is
 // contained within the targetCIDR (nil otherwise), and the
 // third is a list containing the networks to the right of the excludeCIDR in
 // the partition.
-func partitionCIDR(targetCIDR net.IPNet, excludeCIDR net.IPNet) ([]*net.IPNet, []*net.IPNet, []*net.IPNet) {
+func PartitionCIDR(targetCIDR net.IPNet, excludeCIDR net.IPNet) ([]*net.IPNet, []*net.IPNet, []*net.IPNet) {
 	var targetIsIPv4 bool
 	if targetCIDR.IP.To4() != nil {
 		targetIsIPv4 = true

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -622,7 +622,7 @@ func (s *IPTestSuite) TestCreateSpanningCIDR(c *C) {
 func (s *IPTestSuite) TestPartitionCIDR(c *C) {
 	targetCIDR := createIPNet("10.0.0.0", 8, ipv4BitLen)
 	excludeCIDR := createIPNet("10.255.255.255", 32, ipv4BitLen)
-	left, exclude, right := partitionCIDR(*targetCIDR, *excludeCIDR)
+	left, exclude, right := PartitionCIDR(*targetCIDR, *excludeCIDR)
 	// Exclude should just contain exclude CIDR
 	s.testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, c)
 	// Nothing should be in right list.
@@ -656,7 +656,7 @@ func (s *IPTestSuite) TestPartitionCIDR(c *C) {
 
 	targetCIDR = createIPNet("10.0.0.0", 8, ipv4BitLen)
 	excludeCIDR = createIPNet("10.0.0.0", 32, ipv4BitLen)
-	left, exclude, right = partitionCIDR(*targetCIDR, *excludeCIDR)
+	left, exclude, right = PartitionCIDR(*targetCIDR, *excludeCIDR)
 	// Exclude should just contain exclude CIDR
 	s.testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, c)
 	// Nothing should be in left list.
@@ -691,7 +691,7 @@ func (s *IPTestSuite) TestPartitionCIDR(c *C) {
 	// exclude is not in target CIDR and is to left.
 	targetCIDR = createIPNet("10.0.0.0", 8, ipv4BitLen)
 	excludeCIDR = createIPNet("9.0.0.255", 32, ipv4BitLen)
-	left, exclude, right = partitionCIDR(*targetCIDR, *excludeCIDR)
+	left, exclude, right = PartitionCIDR(*targetCIDR, *excludeCIDR)
 	c.Assert(len(left), Equals, 0)
 	c.Assert(len(exclude), Equals, 0)
 	s.testIPNetsEqual([]*net.IPNet{targetCIDR}, right, c)
@@ -699,7 +699,7 @@ func (s *IPTestSuite) TestPartitionCIDR(c *C) {
 	// exclude is not in target CIDR and is to right.
 	targetCIDR = createIPNet("10.255.255.254", 32, ipv4BitLen)
 	excludeCIDR = createIPNet("10.255.255.255", 32, ipv4BitLen)
-	left, exclude, right = partitionCIDR(*targetCIDR, *excludeCIDR)
+	left, exclude, right = PartitionCIDR(*targetCIDR, *excludeCIDR)
 	c.Assert(len(right), Equals, 0)
 	c.Assert(len(exclude), Equals, 0)
 	s.testIPNetsEqual([]*net.IPNet{targetCIDR}, left, c)
@@ -707,7 +707,7 @@ func (s *IPTestSuite) TestPartitionCIDR(c *C) {
 	// exclude CIDR larger than target CIDR
 	targetCIDR = createIPNet("10.96.0.0", 12, ipv4BitLen)
 	excludeCIDR = createIPNet("10.0.0.0", 8, ipv4BitLen)
-	left, exclude, right = partitionCIDR(*targetCIDR, *excludeCIDR)
+	left, exclude, right = PartitionCIDR(*targetCIDR, *excludeCIDR)
 	c.Assert(len(left), Equals, 0)
 	c.Assert(len(right), Equals, 0)
 	s.testIPNetsEqual([]*net.IPNet{targetCIDR}, exclude, c)
@@ -715,7 +715,7 @@ func (s *IPTestSuite) TestPartitionCIDR(c *C) {
 	targetCIDR = createIPNet("fd44:7089:ff32:712b:ff00::", 64, ipv6BitLen)
 	excludeCIDR = createIPNet("fd44:7089:ff32:712b::", 66, ipv6BitLen)
 
-	_, exclude, right = partitionCIDR(*targetCIDR, *excludeCIDR)
+	_, exclude, right = PartitionCIDR(*targetCIDR, *excludeCIDR)
 
 	expectedCIDRs := []*net.IPNet{createIPNet("fd44:7089:ff32:712b:8000::", 65, ipv6BitLen),
 		createIPNet("fd44:7089:ff32:712b:4000::", 66, ipv6BitLen)}

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
@@ -135,6 +135,15 @@ spec:
                 required:
                 - nodeSelector
                 type: object
+              excludedCIDRs:
+                description: ExcludedCIDRs is a list of destination CIDRs that will
+                  be excluded from the egress gateway redirection and SNAT logic.
+                  Should be a subset of destinationCIDRs otherwise it will not have
+                  any effect.
+                items:
+                  pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                  type: string
+                type: array
               selectors:
                 description: Egress represents a list of rules by which egress traffic
                   is filtered from the source pods.

--- a/pkg/k8s/apis/cilium.io/v2/cegp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cegp_types.go
@@ -52,6 +52,14 @@ type CiliumEgressGatewayPolicySpec struct {
 	// If a destination IP matches any one CIDR, it will be selected.
 	DestinationCIDRs []IPv4CIDR `json:"destinationCIDRs"`
 
+	// ExcludedCIDRs is a list of destination CIDRs that will be excluded
+	// from the egress gateway redirection and SNAT logic.
+	// Should be a subset of destinationCIDRs otherwise it will not have any
+	// effect.
+	//
+	// +kubebuilder:validation:Optional
+	ExcludedCIDRs []IPv4CIDR `json:"excludedCIDRs"`
+
 	// EgressGateway is the gateway node responsible for SNATing traffic.
 	EgressGateway *EgressGateway `json:"egressGateway"`
 }

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -23,7 +23,7 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.26.6"
+	CustomResourceDefinitionSchemaVersion = "1.26.7"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
@@ -226,6 +226,11 @@ func (in *CiliumEgressGatewayPolicySpec) DeepCopyInto(out *CiliumEgressGatewayPo
 		*out = make([]IPv4CIDR, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExcludedCIDRs != nil {
+		in, out := &in.ExcludedCIDRs, &out.ExcludedCIDRs
+		*out = make([]IPv4CIDR, len(*in))
+		copy(*out, *in)
+	}
 	if in.EgressGateway != nil {
 		in, out := &in.EgressGateway, &out.EgressGateway
 		*out = new(EgressGateway)

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -163,6 +163,23 @@ func (in *CiliumEgressGatewayPolicySpec) DeepEqual(other *CiliumEgressGatewayPol
 		}
 	}
 
+	if ((in.ExcludedCIDRs != nil) && (other.ExcludedCIDRs != nil)) || ((in.ExcludedCIDRs == nil) != (other.ExcludedCIDRs == nil)) {
+		in, other := &in.ExcludedCIDRs, &other.ExcludedCIDRs
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	if (in.EgressGateway == nil) != (other.EgressGateway == nil) {
 		return false
 	} else if in.EgressGateway != nil {

--- a/test/k8s/egress.go
+++ b/test/k8s/egress.go
@@ -17,6 +17,16 @@ import (
 	"github.com/cilium/cilium/test/helpers"
 )
 
+type egressGatewayTestOpts struct {
+	fromGateway    bool
+	shouldBeSNATed bool
+}
+
+type egressGatewayConnectivityTestOpts struct {
+	fromGateway bool
+	ciliumOpts  map[string]string
+}
+
 var _ = SkipDescribeIf(func() bool {
 	return helpers.RunsOnEKS() || helpers.RunsOnGKE() || helpers.DoesNotRunWithKubeProxyReplacement() || helpers.DoesNotExistNodeWithoutCilium() || helpers.DoesNotRunOn54OrLaterKernel()
 }, "K8sDatapathEgressGatewayTest", func() {
@@ -41,7 +51,6 @@ var _ = SkipDescribeIf(func() bool {
 
 		assignIPYAML string
 		echoPodYAML  string
-		policyYAML   string
 	)
 
 	runEchoServer := func() {
@@ -126,40 +135,54 @@ var _ = SkipDescribeIf(func() bool {
 		kubectl.OutsideNodeReport(outsideName, "ip -d route")
 	})
 
-	testEgressGateway := func(fromGateway bool) {
-		if fromGateway {
+	testEgressGateway := func(testOpts *egressGatewayTestOpts) {
+		if testOpts.fromGateway {
 			By("Check egress policy from gateway node")
 		} else {
 			By("Check egress policy from non-gateway node")
 		}
 
 		hostIP := k8s1IP
-		if fromGateway {
+		if testOpts.fromGateway {
 			hostIP = k8s2IP
 		}
 
 		src, _ := fetchPodsWithOffset(kubectl, randomNamespace, "client", testDSClient, hostIP, false, 1)
 
-		By("Testing that a request from pod %s to outside is SNATed with the egressIP %s", src, egressIP)
-		ctEntriesBeforeConnection := ctEntriesOnNode(helpers.K8s2, outsideIP, "80")
+		var (
+			targetDestinationIP       string
+			ctEntriesBeforeConnection int
+		)
+
+		if testOpts.shouldBeSNATed {
+			By("Testing that a request from pod %s to outside is SNATed with the egressIP %s", src, egressIP)
+			targetDestinationIP = egressIP
+			ctEntriesBeforeConnection = ctEntriesOnNode(helpers.K8s2, outsideIP, "80")
+		} else {
+			By("Testing that a request from pod %s to outside is not SNATed with the egressIP %s", src, egressIP)
+			targetDestinationIP = hostIP
+		}
+
 		res := kubectl.ExecPodCmd(randomNamespace, src, helpers.CurlFail("http://%s:80", outsideIP))
 
 		res.ExpectSuccess()
-		res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", egressIP))
+		res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", targetDestinationIP))
 
-		ctEntriesAfterConnection := ctEntriesOnNode(helpers.K8s2, outsideIP, "80")
-		Expect(ctEntriesAfterConnection - ctEntriesBeforeConnection).Should(Equal(1))
+		if testOpts.shouldBeSNATed {
+			ctEntriesAfterConnection := ctEntriesOnNode(helpers.K8s2, outsideIP, "80")
+			Expect(ctEntriesAfterConnection - ctEntriesBeforeConnection).Should(Equal(1))
+		}
 	}
 
-	testConnectivity := func(fromGateway bool, ciliumOpts map[string]string) {
-		if fromGateway {
+	testConnectivity := func(testOpts *egressGatewayConnectivityTestOpts) {
+		if testOpts.fromGateway {
 			By("Check connectivity from gateway node")
 		} else {
 			By("Check connectivity from non-gateway node")
 		}
 		hostName := k8s1Name
 		hostIP := k8s1IP
-		if fromGateway {
+		if testOpts.fromGateway {
 			hostName = k8s2Name
 			hostIP = k8s2IP
 		}
@@ -202,7 +225,7 @@ var _ = SkipDescribeIf(func() bool {
 		res.ExpectSuccess()
 		res.ExpectMatchesRegexp(fmt.Sprintf("client_address=::ffff:%s\n", outsideIP))
 
-		if ciliumOpts["tunnel"] == "disabled" {
+		if testOpts.ciliumOpts["tunnel"] == "disabled" {
 			// When connecting from outside the cluster directly to a pod which is
 			// selected by an egress policy, the reply traffic should not be SNATed with
 			// the egress IP (only connections originating from these pods should go
@@ -243,18 +266,20 @@ var _ = SkipDescribeIf(func() bool {
 		}
 	}
 
-	applyEgressPolicy := func(manifest string) {
+	applyEgressPolicy := func(manifest string) string {
 		// Apply egress policy yaml
 		originalPolicyYAML := helpers.ManifestGet(kubectl.BasePath(), manifest)
 		res := kubectl.ExecMiddle("mktemp")
 		res.ExpectSuccess()
-		policyYAML = strings.Trim(res.Stdout(), "\n")
+		policyYAML := strings.Trim(res.Stdout(), "\n")
 		kubectl.ExecMiddle(fmt.Sprintf("sed 's/INPUT_EGRESS_IP/%s/' %s > %s",
 			egressIP, originalPolicyYAML, policyYAML)).ExpectSuccess()
 		kubectl.ExecMiddle(fmt.Sprintf("sed 's/INPUT_OUTSIDE_NODE_IP/%s/' -i %s",
 			outsideIP, policyYAML)).ExpectSuccess()
 		res = kubectl.ApplyDefault(policyYAML)
 		Expect(res).Should(helpers.CMDSuccess(), "unable to apply %s", policyYAML)
+
+		return policyYAML
 	}
 
 	doContext := func(name string, ciliumOpts map[string]string) {
@@ -272,14 +297,23 @@ var _ = SkipDescribeIf(func() bool {
 
 			Context("no egress gw policy", func() {
 				It("connectivity works", func() {
-					testConnectivity(false, ciliumOpts)
-					testConnectivity(true, ciliumOpts)
+					testConnectivity(&egressGatewayConnectivityTestOpts{
+						fromGateway: false,
+						ciliumOpts:  ciliumOpts,
+					})
+
+					testConnectivity(&egressGatewayConnectivityTestOpts{
+						fromGateway: true,
+						ciliumOpts:  ciliumOpts,
+					})
 				})
 			})
 
 			Context("egress gw policy", func() {
+				var policyYAML string
+
 				BeforeAll(func() {
-					applyEgressPolicy("egress-gateway-policy.yaml")
+					policyYAML = applyEgressPolicy("egress-gateway-policy.yaml")
 					kubectl.WaitForEgressPolicyEntry(k8s1IP, outsideIP)
 					kubectl.WaitForEgressPolicyEntry(k8s2IP, outsideIP)
 				})
@@ -292,10 +326,54 @@ var _ = SkipDescribeIf(func() bool {
 				})
 
 				It("both egress gw and basic connectivity work", func() {
-					testEgressGateway(false)
-					testEgressGateway(true)
-					testConnectivity(false, ciliumOpts)
-					testConnectivity(true, ciliumOpts)
+					testEgressGateway(&egressGatewayTestOpts{
+						fromGateway:    false,
+						shouldBeSNATed: true,
+					})
+
+					testEgressGateway(&egressGatewayTestOpts{
+						fromGateway:    true,
+						shouldBeSNATed: true,
+					})
+
+					testConnectivity(&egressGatewayConnectivityTestOpts{
+						fromGateway: false,
+						ciliumOpts:  ciliumOpts,
+					})
+
+					testConnectivity(&egressGatewayConnectivityTestOpts{
+						fromGateway: true,
+						ciliumOpts:  ciliumOpts,
+					})
+				})
+			})
+
+			Context("egress gw policy with exclusion CIDRs", func() {
+				var policyYAML string
+
+				BeforeAll(func() {
+					policyYAML = applyEgressPolicy("egress-gateway-policy-excl-cidr.yaml")
+					kubectl.WaitForEgressPolicyEntry(k8s1IP, outsideIP)
+					kubectl.WaitForEgressPolicyEntry(k8s2IP, outsideIP)
+				})
+				AfterAll(func() {
+					kubectl.Delete(policyYAML)
+				})
+
+				AfterFailed(func() {
+					kubectl.CiliumReport("cilium bpf egress list", "cilium bpf nat list")
+				})
+
+				It("Traffic is not SNATed with egress gateway IP", func() {
+					testEgressGateway(&egressGatewayTestOpts{
+						fromGateway:    false,
+						shouldBeSNATed: false,
+					})
+
+					testEgressGateway(&egressGatewayTestOpts{
+						fromGateway:    true,
+						shouldBeSNATed: false,
+					})
 				})
 			})
 		})

--- a/test/k8s/manifests/egress-gateway-policy-excl-cidr.yaml
+++ b/test/k8s/manifests/egress-gateway-policy-excl-cidr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumEgressGatewayPolicy
+metadata:
+  name: cegp-sample
+spec:
+  selectors:
+  - podSelector:
+      matchLabels:
+        zgroup: testDSClient
+    namespaceSelector:
+      matchLabels:
+        ns: cilium-test
+  destinationCIDRs:
+  - 0.0.0.0/0
+  excludedCIDRs:
+  - INPUT_OUTSIDE_NODE_IP/32
+  egressGateway:
+    nodeSelector:
+      matchLabels:
+        cilium.io/ci-node: k8s2
+    egressIP: INPUT_EGRESS_IP


### PR DESCRIPTION
Add support to the egress gateway manager for the new excludedCIDRs
policy property.

The implementation is based on the idea of adding, for each excluded
CIDR, "zero" entries to the egress policy map (i.e. entries with the
gateway IP set to 0.0.0.0). When traffic is then matched against these
entries in the datapath, it will skip altogether all the egress gateway
logic.

Fixes: https://github.com/cilium/cilium/issues/23002