### PR TITLE
v1.12 Backports 2023-01-30

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Set up QEMU
         id: qemu
@@ -71,6 +69,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_release_runtime
         with:
+          provenance: false
           context: ./images/runtime
           file: ./images/runtime/Dockerfile
           push: true
@@ -130,6 +129,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_release_builder
         with:
+          provenance: false
           context: ./images/builder
           file: ./images/builder/Dockerfile
           push: true

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -50,8 +50,6 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -83,6 +81,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_release
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -51,8 +51,6 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to quay.io for CI
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -82,6 +80,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_v1_12
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           # Only push when the event name was a GitHub push, this is to avoid
@@ -100,6 +99,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_v1_12_detect_race_condition
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           # Only push when the event name was a GitHub push, this is to avoid
@@ -121,6 +121,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_v1_12_unstripped
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           # Only push when the event name was a GitHub push, this is to avoid
@@ -153,6 +154,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_pr
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
@@ -174,6 +176,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_pr_detect_race_condition
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
@@ -191,6 +194,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_pr_unstripped
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
@@ -256,6 +260,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_ci_v1_12
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -44,8 +44,6 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -77,6 +75,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_release
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -45,8 +45,6 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to DockerHub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -75,6 +73,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         id: docker_build_release
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true

--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -18,7 +18,53 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+        # Detect if the secret 'CHECK_TEAM_ORG' is set. If it's not set, don't
+        # bother running this GH workflow.
+      - name: Check if CHECK_TEAM_ORG is set in github secrets
+        id: check_secret
+        run: |
+          echo "is_CHECK_TEAM_ORG_set: ${{ secrets.CHECK_TEAM_ORG != '' }}"
+          echo is_CHECK_TEAM_ORG_set="${{ secrets.CHECK_TEAM_ORG != '' }}" >> $GITHUB_OUTPUT
+
+      - name: Get token
+        # Get a token with the read:org permissions so that the GH action
+        # can read the team membership for a user. We need to do this over a
+        # GH app because GH actions don't have support for these type of
+        # permissions.
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        id: get_token
+        uses: cilium/actions-app-token@350a14155dd9be79227f081310f4d77fdf792e76
+        with:
+          APP_PEM: ${{ secrets.CHECK_TEAM_ORG_PEM }}
+          APP_ID: ${{ secrets.CHECK_TEAM_ORG_APP_ID }}
+
+      - name: Check author association
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        id: author_association
+        # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+        with:
+          github-token: ${{ steps.get_token.outputs.app_token }}
+          script: |
+            try {
+              const result = await github.rest.orgs.checkMembershipForUser({
+                org: "${{ github.repository_owner }},"
+                username: "${{github.event.pull_request.user.login}}",
+              })
+              return result.status == 204;
+            } catch {
+              return false;
+            }
+
+      - name: Print author association
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        run: |
+          echo author_association_from_event=${{ github.event.pull_request.author_association }}
+          echo author_association_from_api=${{ steps.author_association.outputs.result }}
+
       - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }} && \
+            ${{ steps.author_association.outputs.result != 'true' }}
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -48,7 +48,7 @@ jobs:
           script: |
             try {
               const result = await github.rest.orgs.checkMembershipForUser({
-                org: "${{ github.repository_owner }},"
+                org: "${{ github.repository_owner }}",
                 username: "${{github.event.pull_request.user.login}}",
               })
               return result.status == 204;

--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -18,20 +18,20 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-        # Detect if the secret 'CHECK_TEAM_ORG' is set. If it's not set, don't
+        # Detect if the secret 'CHECK_TEAM_ORG_APP_ID' is set. If it's not set, don't
         # bother running this GH workflow.
-      - name: Check if CHECK_TEAM_ORG is set in github secrets
+      - name: Check if CHECK_TEAM_ORG_APP_ID is set in github secrets
         id: check_secret
         run: |
-          echo "is_CHECK_TEAM_ORG_set: ${{ secrets.CHECK_TEAM_ORG != '' }}"
-          echo is_CHECK_TEAM_ORG_set="${{ secrets.CHECK_TEAM_ORG != '' }}" >> $GITHUB_OUTPUT
+          echo "is_CHECK_TEAM_ORG_APP_ID_set: ${{ secrets.CHECK_TEAM_ORG_APP_ID != '' }}"
+          echo is_CHECK_TEAM_ORG_APP_ID_set="${{ secrets.CHECK_TEAM_ORG_APP_ID != '' }}" >> $GITHUB_OUTPUT
 
       - name: Get token
         # Get a token with the read:org permissions so that the GH action
         # can read the team membership for a user. We need to do this over a
         # GH app because GH actions don't have support for these type of
         # permissions.
-        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }}
         id: get_token
         uses: cilium/actions-app-token@350a14155dd9be79227f081310f4d77fdf792e76
         with:
@@ -39,7 +39,7 @@ jobs:
           APP_ID: ${{ secrets.CHECK_TEAM_ORG_APP_ID }}
 
       - name: Check author association
-        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }}
         uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
         id: author_association
         # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
@@ -57,13 +57,13 @@ jobs:
             }
 
       - name: Print author association
-        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }}
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }}
         run: |
           echo author_association_from_event=${{ github.event.pull_request.author_association }}
           echo author_association_from_api=${{ steps.author_association.outputs.result }}
 
       - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975
-        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_set == 'true' }} && \
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }} && \
             ${{ steps.author_association.outputs.result != 'true' }}
         with:
           script: |

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -66,6 +66,7 @@ Deploy Cilium via Helm:
    helm install cilium |CHART_RELEASE| \\
      --namespace kube-system \\
      --set cni.chainingMode=aws-cni \\
+     --set cni.exclusive=false \\
      --set enableIPv4Masquerade=false \\
      --set tunnel=disabled \\
      --set endpointRoutes.enabled=true

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -352,7 +352,7 @@ esac
 		[ -n "$(ip -6 addr show to $IP6_HOST dev $HOST_DEV1)" ] || ip -6 addr add $IP6_HOST dev $HOST_DEV1
 	fi
 	if [ "$IP4_HOST" != "<nil>" ]; then
-		[ -n "$(ip -4 addr show to $IP4_HOST dev $HOST_DEV1)" ] || ip -4 addr add $IP4_HOST dev $HOST_DEV1 scope link
+		[ -n "$(ip -4 addr show to $IP4_HOST dev $HOST_DEV1)" ] || ip -4 addr add $IP4_HOST dev $HOST_DEV1
 	fi
 
 if [ "$PROXY_RULE" = "true" ]; then

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -646,7 +646,7 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 	}
 
 	if option.Config.EnableIPv4EgressGateway {
-		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(&d, d.identityAllocator)
+		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(&d, d.identityAllocator, option.Config.InstallEgressGatewayRoutes)
 	}
 
 	d.k8sWatcher = watchers.NewK8sWatcher(

--- a/pkg/crypto/certloader/client_test.go
+++ b/pkg/crypto/certloader/client_test.go
@@ -126,8 +126,20 @@ func TestWatchedClientConfigRotation(t *testing.T) {
 	assert.NotNil(t, c)
 	defer c.Stop()
 
+	prevKeypairGeneration, prevCaCertPoolGeneration := c.generations()
 	rotate(t, hubble, relay)
-	<-time.After(testReloadDelay)
+
+	// wait until both keypair and caCertPool have been reloaded
+	ticker := time.NewTicker(testReloadDelay)
+	defer ticker.Stop()
+	for range ticker.C {
+		keypairGeneration, caCertPoolGeneration := c.generations()
+		keypairUpdated := keypairGeneration > prevKeypairGeneration
+		caCertPoolUpdated := caCertPoolGeneration > prevCaCertPoolGeneration
+		if keypairUpdated && caCertPoolUpdated {
+			break
+		}
+	}
 
 	tlsConfig := c.ClientConfig(&tls.Config{
 		MinVersion: tls.VersionTLS13,

--- a/pkg/crypto/certloader/reloader_test.go
+++ b/pkg/crypto/certloader/reloader_test.go
@@ -451,15 +451,30 @@ func TestReload(t *testing.T) {
 				t.Error(err)
 				return
 			}
+			prevKeypairGeneration, prevCaCertPoolGeneration := r.generations()
 			keypair, caCertPool, err := r.Reload()
 			assert.Nil(t, err)
+			// keypair check
 			assert.Equal(t, tt.expectedKeypair, keypair)
+			// caCertPool check
 			if tt.expectedCaCertPool != nil {
 				assert.Equal(t, tt.expectedCaCertPool.Subjects(), caCertPool.Subjects())
 			} else {
 				assert.Nil(t, caCertPool)
 			}
-
+			// generations check
+			keypairGeneration, caCertPoolGeneration := r.generations()
+			if tt.expectedKeypair != nil {
+				assert.Equal(t, prevKeypairGeneration+1, keypairGeneration)
+			} else {
+				assert.Equal(t, prevKeypairGeneration, keypairGeneration)
+			}
+			if tt.expectedCaCertPool != nil {
+				assert.Equal(t, prevCaCertPoolGeneration+1, caCertPoolGeneration)
+			} else {
+				assert.Equal(t, prevCaCertPoolGeneration, caCertPoolGeneration)
+			}
+			// ensures that KeypairAndCACertPool() returns the expected values
 			keypair, caCertPool = r.KeypairAndCACertPool()
 			assert.Equal(t, tt.expectedKeypair, keypair)
 			if tt.expectedCaCertPool != nil {
@@ -482,10 +497,9 @@ func TestReloadKeypair(t *testing.T) {
 	}
 
 	tests := []struct {
-		name               string
-		constructor        func() (*FileReloader, error)
-		expectedKeypair    *tls.Certificate
-		expectedCaCertPool *x509.CertPool
+		name            string
+		constructor     func() (*FileReloader, error)
+		expectedKeypair *tls.Certificate
 	}{
 		{
 			name: "empty",
@@ -524,10 +538,19 @@ func TestReloadKeypair(t *testing.T) {
 				t.Error(err)
 				return
 			}
+			prevKeypairGeneration, _ := r.generations()
 			keypair, err := r.ReloadKeypair()
 			assert.Nil(t, err)
+			// keypair check
 			assert.Equal(t, tt.expectedKeypair, keypair)
-
+			// generations check
+			keypairGeneration, _ := r.generations()
+			if tt.expectedKeypair != nil {
+				assert.Equal(t, prevKeypairGeneration+1, keypairGeneration)
+			} else {
+				assert.Equal(t, prevKeypairGeneration, keypairGeneration)
+			}
+			// ensures that KeypairAndCACertPool() returns the expected values
 			keypair, caCertPool := r.KeypairAndCACertPool()
 			assert.Equal(t, tt.expectedKeypair, keypair)
 			assert.Nil(t, caCertPool)
@@ -587,14 +610,23 @@ func TestReloadCA(t *testing.T) {
 				t.Error(err)
 				return
 			}
+			_, prevCaCertPoolGeneration := r.generations()
 			caCertPool, err := r.ReloadCA()
 			assert.Nil(t, err)
+			// caCertPool check
 			if tt.expectedCaCertPool != nil {
 				assert.Equal(t, tt.expectedCaCertPool.Subjects(), caCertPool.Subjects())
 			} else {
 				assert.Nil(t, caCertPool)
 			}
-
+			// generations check
+			_, caCertPoolGeneration := r.generations()
+			if tt.expectedCaCertPool != nil {
+				assert.Equal(t, prevCaCertPoolGeneration+1, caCertPoolGeneration)
+			} else {
+				assert.Equal(t, prevCaCertPoolGeneration, caCertPoolGeneration)
+			}
+			// ensures that KeypairAndCACertPool() returns the expected values
 			keypair, caCertPool := r.KeypairAndCACertPool()
 			assert.Nil(t, keypair)
 			if tt.expectedCaCertPool != nil {
@@ -635,6 +667,7 @@ func TestReloadError(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	prevKeypairGeneration, prevCaCertPoolGeneration := r.generations()
 	_, _, err = r.Reload()
 	assert.NotNil(t, err)
 
@@ -642,4 +675,8 @@ func TestReloadError(t *testing.T) {
 	keypair, caCertPool = r.KeypairAndCACertPool()
 	assert.Equal(t, &expectedKeypair, keypair)
 	assert.Equal(t, expectedCaCertPool.Subjects(), caCertPool.Subjects())
+	// generations should not have changed
+	keypairGeneration, caCertPoolGeneration := r.generations()
+	assert.Equal(t, prevKeypairGeneration, keypairGeneration)
+	assert.Equal(t, prevCaCertPoolGeneration, caCertPoolGeneration)
 }

--- a/pkg/crypto/certloader/server_test.go
+++ b/pkg/crypto/certloader/server_test.go
@@ -83,7 +83,6 @@ func TestFutureWatchedServerConfig(t *testing.T) {
 	assert.Nil(t, err)
 
 	// the files don't exists, expect the config to not be ready yet.
-	var s *WatchedServerConfig
 	select {
 	case <-ch:
 		t.Fatal("FutureWatchedServerConfig should not be ready without the TLS files")
@@ -93,11 +92,7 @@ func TestFutureWatchedServerConfig(t *testing.T) {
 	setup(t, hubble, relay)
 
 	// the files exists now, expect the watcher to become ready.
-	select {
-	case s = <-ch:
-	case <-time.After(testReloadDelay):
-		t.Fatal("FutureWatchedServerConfig should be ready one the TLS files exists")
-	}
+	s := <-ch
 	s.Stop()
 }
 

--- a/pkg/crypto/certloader/watcher_test.go
+++ b/pkg/crypto/certloader/watcher_test.go
@@ -94,12 +94,7 @@ func TestFutureWatcherImmediately(t *testing.T) {
 	assert.Nil(t, err)
 
 	// the files already exists, expect the watcher to be readily available.
-	var w *Watcher
-	select {
-	case w = <-ch:
-	case <-time.After(testReloadDelay):
-		t.Fatal("FutureWatcher should be ready immediately")
-	}
+	w := <-ch
 	defer w.Stop()
 
 	keypair, caCertPool := w.KeypairAndCACertPool()
@@ -137,11 +132,7 @@ func TestFutureWatcher(t *testing.T) {
 	setup(t, hubble, relay)
 
 	// the files exists now, expect the watcher to become ready.
-	select {
-	case w = <-ch:
-	case <-time.After(testReloadDelay):
-		t.Fatal("FutureWatcher should be ready once the TLS files exists")
-	}
+	w = <-ch
 	defer w.Stop()
 
 	keypair, caCertPool := w.KeypairAndCACertPool()
@@ -168,12 +159,7 @@ func TestKubernetesMount(t *testing.T) {
 	k8Setup(t, dir)
 
 	// the files exists now, expect the watcher to become ready.
-	var w *Watcher
-	select {
-	case w = <-ch:
-	case <-time.After(testReloadDelay):
-		t.Fatal("FutureWatcher should be ready once the TLS files exists")
-	}
+	w := <-ch
 	defer w.Stop()
 
 	expectedInitialCaCertPool := x509.NewCertPool()

--- a/pkg/crypto/certloader/watcher_test.go
+++ b/pkg/crypto/certloader/watcher_test.go
@@ -67,8 +67,20 @@ func TestRotation(t *testing.T) {
 	assert.Nil(t, err)
 	defer w.Stop()
 
+	prevKeypairGeneration, prevCaCertPoolGeneration := w.generations()
 	rotate(t, hubble, relay)
-	<-time.After(testReloadDelay)
+
+	// wait until both keypair and caCertPool have been reloaded
+	ticker := time.NewTicker(testReloadDelay)
+	defer ticker.Stop()
+	for range ticker.C {
+		keypairGeneration, caCertPoolGeneration := w.generations()
+		keypairUpdated := keypairGeneration > prevKeypairGeneration
+		caCertPoolUpdated := caCertPoolGeneration > prevCaCertPoolGeneration
+		if keypairUpdated && caCertPoolUpdated {
+			break
+		}
+	}
 
 	keypair, caCertPool := w.KeypairAndCACertPool()
 	assert.Equal(t, &expectedKeypair, keypair)
@@ -175,8 +187,20 @@ func TestKubernetesMount(t *testing.T) {
 	assert.Equal(t, &expectedInitialKeypair, keypair)
 	assert.Equal(t, expectedInitialCaCertPool.Subjects(), caCertPool.Subjects())
 
+	prevKeypairGeneration, prevCaCertPoolGeneration := w.generations()
 	k8sRotate(t, dir)
-	<-time.After(testReloadDelay)
+
+	// wait until both keypair and caCertPool have been reloaded
+	ticker := time.NewTicker(testReloadDelay)
+	defer ticker.Stop()
+	for range ticker.C {
+		keypairGeneration, caCertPoolGeneration := w.generations()
+		keypairUpdated := keypairGeneration > prevKeypairGeneration
+		caCertPoolUpdated := caCertPoolGeneration > prevCaCertPoolGeneration
+		if keypairUpdated && caCertPoolUpdated {
+			break
+		}
+	}
 
 	expectedRotatedCaCertPool := x509.NewCertPool()
 	if ok := expectedRotatedCaCertPool.AppendCertsFromPEM(rotatedHubbleServerCA); !ok {

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -254,13 +254,9 @@ func compileAndLink(ctx context.Context, prog *progInfo, dir *directoryInfo, deb
 			"linker-pid":   pidFromProcess(linkCmd.Process),
 		}).Error(err)
 		if compileOut != nil {
-			scopedLog := log.Warn
-			if debug {
-				scopedLog = log.Debug
-			}
 			scanner := bufio.NewScanner(bytes.NewReader(compileOut))
 			for scanner.Scan() {
-				scopedLog(scanner.Text())
+				log.Warn(scanner.Text())
 			}
 		}
 	}

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -285,6 +285,22 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 		{ep1IP, destCIDR, egressCIDR1, testInterface1Idx},
 	})
 
+	// Test if disabling the --install-egress-gateway-routes agent option
+	// will result in stale IP routes/rules getting removed
+	egressGatewayManager.installRoutes = false
+	egressGatewayManager.reconcile()
+
+	assertIPRules(c, []ipRule{})
+
+	// Enabling it back should result in the routes/rules being in place
+	// again
+	egressGatewayManager.installRoutes = true
+	egressGatewayManager.reconcile()
+
+	assertIPRules(c, []ipRule{
+		{ep1IP, destCIDR, egressCIDR1, testInterface1Idx},
+	})
+
 	// Update the endpoint labels in order for it to not be a match
 	id1 = updateEndpointAndIdentity(&ep1, id1, map[string]string{})
 	egressGatewayManager.OnUpdateEndpoint(&ep1)

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -137,7 +137,7 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 
 	k8sCacheSyncedChecker := &k8sCacheSyncedCheckerMock{}
 
-	egressGatewayManager := NewEgressGatewayManager(k8sCacheSyncedChecker, identityAllocator)
+	egressGatewayManager := NewEgressGatewayManager(k8sCacheSyncedChecker, identityAllocator, option.Config.InstallEgressGatewayRoutes)
 	c.Assert(egressGatewayManager, NotNil)
 	assertIPRules(c, []ipRule{})
 

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -232,14 +232,15 @@ const (
 	routerIPMismatch    = "Mismatch of router IPs found during restoration"
 
 	// ...and their exceptions.
-	lrpExists                = "local-redirect service exists for frontend"                         // cf. https://github.com/cilium/cilium/issues/16400
-	opCantBeFulfilled        = "Operation cannot be fulfilled on leases.coordination.k8s.io"        // cf. https://github.com/cilium/cilium/issues/16402
-	initLeaderElection       = "error initially creating leader election record: leases."           // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-861544964
-	globalDataSupport        = "kernel doesn't support global data"                                 // cf. https://github.com/cilium/cilium/issues/16418
-	removeInexistentID       = "removing identity not added to the identity manager!"               // cf. https://github.com/cilium/cilium/issues/16419
-	failedToListCRDs         = "the server could not find the requested resource"                   // cf. https://github.com/cilium/cilium/issues/16425
-	retrieveResLock          = "retrieving resource lock kube-system/cilium-operator-resource-lock" // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-871155492
-	failedToRelLockEmptyName = "Failed to release lock: resource name may not be empty"             // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-985819560
+	lrpExists                    = "local-redirect service exists for frontend"                         // cf. https://github.com/cilium/cilium/issues/16400
+	opCantBeFulfilled            = "Operation cannot be fulfilled on leases.coordination.k8s.io"        // cf. https://github.com/cilium/cilium/issues/16402
+	initLeaderElection           = "error initially creating leader election record: leases."           // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-861544964
+	globalDataSupport            = "kernel doesn't support global data"                                 // cf. https://github.com/cilium/cilium/issues/16418
+	removeInexistentID           = "removing identity not added to the identity manager!"               // cf. https://github.com/cilium/cilium/issues/16419
+	failedToListCRDs             = "the server could not find the requested resource"                   // cf. https://github.com/cilium/cilium/issues/16425
+	retrieveResLock              = "retrieving resource lock kube-system/cilium-operator-resource-lock" // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-871155492
+	failedToRelLockEmptyName     = "Failed to release lock: resource name may not be empty"             // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-985819560
+	failedToUpdateLockReqTimeout = "Failed to update lock: etcdserver: request timed out"
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -300,7 +301,7 @@ var badLogMessages = map[string][]string{
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
-	"level=error": {lrpExists, opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName},
+	"level=error": {lrpExists, opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLockReqTimeout},
 }
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -463,8 +463,8 @@ func failIfContainsBadLogMsg(logs, label string, blacklist map[string][]string) 
 					}
 				}
 				if !ok {
-					count, _ := uniqueFailures[fail]
-					uniqueFailures[fail] = count + 1
+					count, _ := uniqueFailures[msg]
+					uniqueFailures[msg] = count + 1
 				}
 			}
 		}


### PR DESCRIPTION
 * [x] #23286 -- egressgw: ensure stale IP routes/rules are deleted (@jibi)
 * [x] #23241 -- bpf: Remove link scope of `cilium_host`'s IPv4 address (@pchaigno)
 * [ ] #23159 -- docs: Disable exclusive lock when chaining with aws-cni (@jaygridley)
   * Minor conflict
 * [x] #22995 -- certloader flake fixes (@kaworu)
 * [x] #23339 -- cilium: Fix missing error log dump from compilation (@borkmann)
   * Minor conflict
 * [x] #23338 -- test: print log messages that need to be investigated (@aanm)
 * [x] #23334 -- tests: add exception for etcd error (@aanm)
   * Minor conflict
 * [x] #23377 -- proxy: Fix deadlock in error path of CreateOrUpdateRedirect (@gandro)
   * Minor conflict
 * [x] #23406 -- .github/workflows: fix external contribution detection (@aanm)
   * Minor conflict
 * [x] #23424 -- .github/workflows: fix typo in organization parameter (@aanm)
 * [x] #23431 -- .github: set do not use provenance from docker buildx (@aanm)
   * Minor conflict
 * [x] #23437 -- .github/workflows: set right secret name (@aanm)
   * Minor conflict

PRs skipped due conflicts:

 * #23202 -- Introduce node IDs (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 23286 23241 23159 22995 23339 23338 23334 23377 23406 23424 23431 23437; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
$ make add-label BRANCH=v1.12 ISSUES=23286,23241,23159,22995,23339,23338,23334,23377,23406,23424,23431,23437
```