### PR TITLE
clustermesh: close etcd connection on config retrieval error

### DIFF
--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -191,11 +191,13 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 					rc.getLogger().Info("Found remote cluster configuration")
 				} else {
 					rc.getLogger().WithError(err).Warning("Unable to get remote cluster configuration")
+					backend.Close(ctx)
 					return err
 				}
 
 				if err := rc.mesh.canConnect(rc.name, config); err != nil {
 					rc.getLogger().WithError(err).Error("Unable to connect to the remote cluster")
+					backend.Close(ctx)
 					return err
 				}
 


### PR DESCRIPTION
Ensure that the backend connection to a remote etcd server in the context of clustermesh gets properly closed when the connect-time validation check fails due to an error, to prevent leaking the connection itself and associated resources, such as the goroutine performing the watch of 'cilium/.heartbeat'

Fixes: 5e5a26e5da4d ("clustermesh: Implement a basic connect-time validation")

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>

```release-note
clustermesh: close etcd connection on config retrieval error
```
