### PR TITLE
etcd kvstore: rate limit watch retries on list errors

### DIFF
--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -29,6 +29,26 @@ type NodeManager interface {
 	ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration
 }
 
+// nodeManager is a wrapper to enable using a plain function as NodeManager to implement
+// cluster size dependent intervals
+type nodeManager struct {
+	clusterSizeDependantInterval func(baseInterval time.Duration) time.Duration
+}
+
+// NewNodeManager returns a new NodeManager implementing cluster size dependent intervals
+// based on the given function. If the function is nil, then no tuning is performed.
+func NewNodeManager(clusterSizeDependantInterval func(baseInterval time.Duration) time.Duration) NodeManager {
+	return &nodeManager{clusterSizeDependantInterval: clusterSizeDependantInterval}
+}
+
+func (n *nodeManager) ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration {
+	if n.clusterSizeDependantInterval == nil {
+		return baseInterval
+	}
+
+	return n.clusterSizeDependantInterval(baseInterval)
+}
+
 // Exponential implements an exponential backoff
 type Exponential struct {
 	// Min is the minimal backoff time, if unspecified, 1 second will be

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -44,6 +44,14 @@ func (f *fakeNodeManager) ClusterSizeDependantInterval(baseInterval time.Duratio
 	return time.Duration(int64(waitNanoseconds))
 }
 
+func (b *BackoffSuite) TestNewNodeManager(c *check.C) {
+	mgr := NewNodeManager(func(baseInterval time.Duration) time.Duration { return 2 * baseInterval })
+	c.Assert(mgr.ClusterSizeDependantInterval(1*time.Second), check.Equals, 2*time.Second)
+
+	mgr = NewNodeManager(nil)
+	c.Assert(mgr.ClusterSizeDependantInterval(1*time.Second), check.Equals, 1*time.Second)
+}
+
 func (b *BackoffSuite) TestClusterSizeDependantInterval(c *check.C) {
 	var (
 		nnodes      = 0

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -163,11 +163,15 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 			DoFunc: func(ctx context.Context) error {
 				rc.releaseOldConnection()
 
+				extraOpts := kvstore.ExtraOptions{NoLockQuorumCheck: true}
+				if rc.mesh.conf.NodeManager != nil {
+					extraOpts.ClusterSizeDependantInterval = rc.mesh.conf.NodeManager.ClusterSizeDependantInterval
+				}
+
 				backend, errChan := kvstore.NewClient(ctx, kvstore.EtcdBackendName,
 					map[string]string{
 						kvstore.EtcdOptionConfig: rc.configPath,
-					},
-					&kvstore.ExtraOptions{NoLockQuorumCheck: true})
+					}, &extraOpts)
 
 				// Block until either an error is returned or
 				// the channel is closed due to success of the


### PR DESCRIPTION
Currently, operations performed by the cilium agent against an etcd server are controlled by a global token bucket rate limiter, configured with 20 QPS by default. ListAndWatch operations lead to a tight retry loop (moderated only by the above rate limiter) if the initial Get (List) operation fails due to server errors, e.g., due to a temporary overload ("etcdserver: too many requests" error), contributing to further overwelming the server. For instance, such situation occurred in the context of clustermesh, following a brief network disruption (#22037).

This commit introduces an exponential rate limiter to control the backoff in case of errors in the Get operation performed as part of ListAndWatch, to reduce the generated load against the server. The correct functioning of the rate limiter has been tested leveraging a mock etcd server configured to return the selected error on Range requests.

Note for the reviewers: the rate limiter is currently configured with default values that seemed sensible. Let me know if you deem other values would fit better, or if they should be made user-configurable.

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>

Fixes: #22037

```release-note
etcd kvstore: rate limit watch retries on list errors
```
