### PR TITLE
docs: Update Documentation on Deny Policy Bug Fix

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1241,43 +1241,13 @@ Deny policies do not support: policy enforcement at L7, i.e., specifically
 denying an URL and ``toFQDNs``, i.e., specifically denying traffic to a specific
 domain name.
 
-Limitations and known issues
-----------------------------
+Previous limitations and known issues
+-------------------------------------
 
-Deny policies for peers outside the cluster may be ineffectual due to
-:gh-issue:`15198`.
-
-One example of this would be a deny policy with ``toEntities`` "world" for
-which a ``toFQDNs`` can cause traffic to be allowed if such traffic is
-considered external to the cluster.
-
-.. code-block:: yaml
-
-  apiVersion: "cilium.io/v2"
-  kind: CiliumNetworkPolicy
-  metadata:
-    name: "deny-egress-to-world"
-  spec:
-    endpointSelector:
-      matchLabels:
-        k8s-app.guestbook: web
-    egressDeny:
-    - toEntities:
-      - "world"
-    egress:
-      - toEndpoints:
-        - matchLabels:
-            "k8s:io.kubernetes.pod.namespace": kube-system
-            "k8s:k8s-app": kube-dns
-        toPorts:
-          - ports:
-             - port: "53"
-               protocol: ANY
-            rules:
-              dns:
-                - matchPattern: "*"
-      - toFQDNs:
-          - matchName: "www.google.com"
+For Cilium versions prior to 1.14 deny-policies for peers outside the cluster
+sometimes did not work because of :gh-issue:`15198`.  Make sure that you are
+using version 1.14 or later if you are relying on deny policies to manage
+external traffic to your cluster.
 
 .. _HostPolicies:
 


### PR DESCRIPTION
docs: Update Documentation on Deny Policy Bug Fix

#15198 required Cilium to document the shortcoming
of CIDR deny policies. Since the bug has been fixed
this documentation is incorrect, it should be removed
with a remenant warning about the shortcoming in
prior versions.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

