### PR TITLE
bpf: Fix usage of tunnel map structs

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -302,7 +302,7 @@ skip_host_firewall:
 						      info->key, secctx, info->sec_label,
 						      &trace);
 	} else {
-		struct endpoint_key key = {};
+		struct tunnel_key key = {};
 
 		/* IPv6 lookup key: daddr/96 */
 		dst = (union v6addr *) &ip6->daddr;
@@ -599,7 +599,7 @@ skip_vtep:
 						      &trace);
 	} else {
 		/* IPv4 lookup key: daddr & IPV4_MASK */
-		struct endpoint_key key = {};
+		struct tunnel_key key = {};
 
 		key.ip4 = ip4->daddr & IPV4_MASK;
 		key.family = ENDPOINT_KEY_IPV4;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -464,7 +464,7 @@ ct_recreate6:
 	/* The packet goes to a peer not managed by this agent instance */
 #ifdef TUNNEL_MODE
 	{
-		struct endpoint_key key = {};
+		struct tunnel_key key = {};
 		union v6addr *daddr = (union v6addr *)&ip6->daddr;
 
 		/* Lookup the destination prefix in the list of known
@@ -1028,7 +1028,7 @@ skip_vtep:
 
 #ifdef TUNNEL_MODE
 	{
-		struct endpoint_key key = {};
+		struct tunnel_key key = {};
 
 		key.ip4 = ip4->daddr & IPV4_MASK;
 		key.family = ENDPOINT_KEY_IPV4;

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -243,10 +243,10 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
  */
 static __always_inline int
 encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
-		       __u8 encrypt_key, struct endpoint_key *key, __u32 seclabel,
+		       __u8 encrypt_key, struct tunnel_key *key, __u32 seclabel,
 		       __u32 dstid, const struct trace_ctx *trace)
 {
-	struct endpoint_key *tunnel;
+	struct tunnel_value *tunnel;
 
 	if (tunnel_endpoint)
 		return __encap_and_redirect_lxc(ctx, tunnel_endpoint,
@@ -271,10 +271,10 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 }
 
 static __always_inline int
-encap_and_redirect_netdev(struct __ctx_buff *ctx, struct endpoint_key *k,
+encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
 			  __u32 seclabel, const struct trace_ctx *trace)
 {
-	struct endpoint_key *tunnel;
+	struct tunnel_value *tunnel;
 
 	tunnel = map_lookup_elem(&TUNNEL_MAP, k);
 	if (!tunnel)


### PR DESCRIPTION
Commit 16e132ee4 ("bpf, maps: Give the tunnel map its own structs") gave the tunnel map its own structs for key and value. In that commit, I however forgot to replace the structs in the lookups, on the BPF side. CI passed nonetheless because the fields used in the former and new structs are currently identical (because the cluster ID isn't used).

This pull request fixes it by actually using the new `tunnel_{key,value}` structs.

Fixes: https://github.com/cilium/cilium/pull/23202.