### PR TITLE
hubble: Fix the condition to apply for syn-only flag

### DIFF
--- a/pkg/hubble/metrics/flows-to-world/handler.go
+++ b/pkg/hubble/metrics/flows-to-world/handler.go
@@ -94,7 +94,7 @@ func (h *flowsToWorldHandler) ProcessFlow(_ context.Context, flow *flowpb.Flow) 
 		return nil
 	}
 	// if this is potentially a forwarded reply packet, ignore it to avoid collecting statistics about ephemeral ports
-	isReply := flow.GetIsReply() == nil || flow.GetIsReply().GetValue()
+	isReply := flow.GetIsReply() != nil && flow.GetIsReply().GetValue()
 	if flow.GetVerdict() != flowpb.Verdict_DROPPED && isReply {
 		return nil
 	}

--- a/pkg/hubble/metrics/flows-to-world/handler_test.go
+++ b/pkg/hubble/metrics/flows-to-world/handler_test.go
@@ -220,6 +220,10 @@ func TestFlowsToWorldHandler_SynOnly(t *testing.T) {
 	}
 	h.ProcessFlow(context.Background(), &flow)
 
+	// flows without is_reply field should be counted.
+	flow.IsReply = nil
+	h.ProcessFlow(context.Background(), &flow)
+
 	// reply flows should not be counted
 	flow.IsReply = wrapperspb.Bool(true)
 	h.ProcessFlow(context.Background(), &flow)
@@ -231,7 +235,7 @@ func TestFlowsToWorldHandler_SynOnly(t *testing.T) {
 
 	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world
 # TYPE hubble_flows_to_world_total counter
-hubble_flows_to_world_total{destination="cilium.io",protocol="TCP",source="src-a",verdict="DROPPED"} 1
+hubble_flows_to_world_total{destination="cilium.io",protocol="TCP",source="src-a",verdict="DROPPED"} 2
 `)
 	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, expected))
 }


### PR DESCRIPTION
It turned out that is_reply field is not set for dropped flows, so don't ignore flows unless it's explicitly set to true.

Fixes: c29141fd54c3 ("hubble: Add "syn-only" option to flows-to-world metric")
Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

```release-note
Fix a bug where Hubble flows-to-world metric doesn't count dropped flows when syn-only flag is used.
```