### PR TITLE
test: Update policy for hairpin flow validation

### DIFF
--- a/test/k8s/manifests/echo-policy.yaml
+++ b/test/k8s/manifests/echo-policy.yaml
@@ -1,16 +1,22 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "allow-all-within-namespace"
+  name: "hairpin-validation-policy"
 spec:
   endpointSelector:
     matchLabels:
       name: echo
+  # L3 egress policy validates that policy enforcement is skipped for hairpin
+  # traffic that's SNAT'd. Ingress hairpin traffic can match on L3, but still
+  # fail on L4 policy, hence define an L4 policy on ingress for validation.
   egress:
     - toEndpoints:
         - matchLabels:
             "k8s:io.kubernetes.pod.namespace": default
   ingress:
-    - fromEndpoints:
-        - matchLabels:
-            "k8s:io.kubernetes.pod.namespace": default
+    - toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "69"
+              protocol: UDP


### PR DESCRIPTION
When a service pod connects to itself via its clusterIP, we skip policy validation on ingress and egress, as users aren't expected to write explicit policies to allow this path.

The current policy to test hairpin flow was allowing traffic on the ingress path via an L3 match. As a result, it failed to catch regressions introduced for hairpin flows with L4 ingress policies.
(See https://github.com/cilium/cilium/pull/22972).

Update the ingress policy so catch such regressions in the future.

Signed-off-by: Aditi Ghag <aditi@cilium.io>