### PR TITLE
.github/workflows: PR labeler fix GH workflow if expression

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -63,8 +63,7 @@ jobs:
           echo author_association_from_api=${{ steps.author_association.outputs.result }}
 
       - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975
-        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }} && \
-            ${{ steps.author_association.outputs.result != 'true' }}
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' && steps.author_association.outputs.result != 'true' }}
         with:
           script: |
             github.rest.issues.addLabels({


### PR DESCRIPTION
The evaluation of the expression in the if statement was incorrect since the AND operator should be performed withing the ${{ }}.

Fixes: c6e037b557f2 (".github/workflows: set right secret name")
Signed-off-by: André Martins <andre@cilium.io>