### PR TITLE
CNI: keep cni config on shutdown; taint instead, queue deletions

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -74,6 +74,7 @@ cilium-operator-alibabacloud [flags]
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                    Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                         When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -82,6 +82,7 @@ cilium-operator-aws [flags]
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                    Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                         When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -77,6 +77,7 @@ cilium-operator-azure [flags]
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                    Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                         When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -73,6 +73,7 @@ cilium-operator-generic [flags]
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                    Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                         When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -87,6 +87,7 @@ cilium-operator [flags]
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
       --remove-cilium-node-taints                 Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                    Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
       --skip-cnp-status-startup-clean             If set to true, the operator will not clean up CNP node status updates at startup
       --skip-crd-creation                         When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                 Subnets IDs (separated by commas)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -464,7 +464,7 @@
    * - cni.uninstall
      - Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable.
      - bool
-     - ``true``
+     - ``false``
    * - conntrackGCInterval
      - Configure how frequently garbage collection should occur for the datapath connection tracking table.
      - string

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1841,6 +1841,10 @@
      - Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod.
      - bool
      - ``true``
+   * - operator.setNodeTaints
+     - Taint nodes where Cilium is scheduled but not running. This prevents pods from being scheduled to nodes where Cilium is not the default CNI provider.
+     - string
+     - same as removeNodeTaints
    * - operator.skipCNPStatusStartupClean
      - Skip CNP node status clean up at operator startup.
      - bool

--- a/Documentation/installation/taints.rst
+++ b/Documentation/installation/taints.rst
@@ -44,6 +44,9 @@ node. The mechanism works as follows:
 3. From this point on, pods will start being scheduled and running on the node,
    having their networking managed by Cilium.
 
+4. If Cilium is temporarily removed from the node, the Operator will re-apply
+   the taint (but only with NoSchedule).
+
 By default, the taint key is ``node.cilium.io/agent-not-ready``, but in some
 scenarios (such as when Cluster Autoscaler is being used but its flags cannot be
 configured) this key may need to be tweaked. This can be done using the

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -925,6 +925,7 @@ serviceMonitor
 servicePort
 sessionAffinity
 setNodeNetworkStatus
+setNodeTaints
 setrlimit
 setupinterface
 setupiptables

--- a/daemon/cmd/deletion_queue.go
+++ b/daemon/cmd/deletion_queue.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/lock/lockfile"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// processQueuedDeletes is the agent-side of the identity deletion queue.
+// The CNI plugin queues deletions when the agent is down, because
+// containerd / crio expect CNI DEL to always succeed. It does so
+// by writing a file to /run/cilium/deleteQueue with the endpoint ID
+// to delete.
+//
+// On startup, we will grab a lockfile in this directory, then process
+// all deletions. Then, we start up the agent server, then drop the lock.
+// Any CNI processes waiting in that period of time will, after getting
+// the lock.
+//
+// Returns a done function that drops the lock. It should be called
+// after the server is running.
+func (d *Daemon) processQueuedDeletes() func() {
+	if err := os.MkdirAll(defaults.DeleteQueueDir, 0755); err != nil {
+		log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueDir).Error("Failed to ensure CNI deletion queue directory exists")
+		return func() {}
+	}
+
+	log.Infof("Processing queued endpoint deletion requests from %s", defaults.DeleteQueueDir)
+
+	var lf *lockfile.Lockfile
+	locked := false
+
+	unlock := func() {
+		if lf != nil && locked {
+			lf.Unlock()
+		}
+		if lf != nil {
+			lf.Close()
+		}
+	}
+
+	lf, err := lockfile.NewLockfile(defaults.DeleteQueueLockfile)
+	if err != nil {
+		log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueLockfile).Warn("Failed to lock queued deletion directory, proceeding anyways. This may cause CNI deletions to be missed.")
+	} else {
+		ctx, cancel := context.WithTimeout(d.ctx, 10*time.Second)
+		defer cancel()
+		err = lf.Lock(ctx, true)
+		if err != nil {
+			log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueLockfile).Warn("Failed to lock queued deletion directory, proceeding anyways. This may cause CNI deletions to be missed.")
+		} else {
+			locked = true
+		}
+	}
+
+	// OK, we have the lock; process the deletes
+	files, err := filepath.Glob(defaults.DeleteQueueDir + "/*.delete")
+	if err != nil {
+		log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueDir).Error("Failed to list queued CNI deletion requests. CNI deletions may be missed.")
+	}
+
+	log.Infof("processing %d queued deletion requests", len(files))
+	for _, file := range files {
+		// get the container id
+		epID, err := os.ReadFile(file)
+		if err != nil {
+			log.WithError(err).WithField(logfields.Path, file).Error("Failed to read queued CNI deletion entry. Endpoint will not be deleted.")
+		} else {
+			_, _ = d.DeleteEndpoint(string(epID)) // this will log errors elsewhere
+		}
+
+		if err := os.Remove(file); err != nil {
+			log.WithError(err).WithField(logfields.Path, file).Error("Failed to remve queued CNI deletion entry, but deletion was successful.")
+		}
+	}
+
+	return unlock
+}

--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -67,6 +67,7 @@ type bootstrapStatistics struct {
 	fqdn            spanstat.SpanStat
 	enableConntrack spanstat.SpanStat
 	kvstore         spanstat.SpanStat
+	deleteQueue     spanstat.SpanStat
 }
 
 func (b *bootstrapStatistics) updateMetrics() {
@@ -105,5 +106,6 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"fqdn":            &b.fqdn,
 		"enableConntrack": &b.enableConntrack,
 		"kvstore":         &b.kvstore,
+		"deleteQueue":     &b.deleteQueue,
 	}
 }

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -511,6 +511,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
 | operator.securityContext | object | `{}` | Security context to be added to cilium-operator pods |
 | operator.setNodeNetworkStatus | bool | `true` | Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod. |
+| operator.setNodeTaints | string | same as removeNodeTaints | Taint nodes where Cilium is scheduled but not running. This prevents pods from being scheduled to nodes where Cilium is not the default CNI provider. |
 | operator.skipCNPStatusStartupClean | bool | `false` | Skip CNP node status clean up at operator startup. |
 | operator.skipCRDCreation | bool | `false` | Skip CRDs creation for cilium-operator |
 | operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -166,7 +166,7 @@ contributors across the globe, there is almost always someone available to help.
 | cni.hostConfDirMountPath | string | `"/host/etc/cni/net.d"` | Configure the path to where the CNI configuration directory is mounted inside the agent pod. |
 | cni.install | bool | `true` | Install the CNI configuration and binary files into the filesystem. |
 | cni.logFile | string | `"/var/run/cilium/cilium-cni.log"` | Configure the log file for CNI logging with retention policy of 7 days. Disable CNI file logging by setting this field to empty explicitly. |
-| cni.uninstall | bool | `true` | Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable. |
+| cni.uninstall | bool | `false` | Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable. |
 | conntrackGCInterval | string | `"0s"` | Configure how frequently garbage collection should occur for the datapath connection tracking table. |
 | containerRuntime | object | `{"integration":"none"}` | Configure container runtime specific integration. Deprecated in favor of bpf.autoMount.enabled. To be removed in 1.15. |
 | containerRuntime.integration | string | `"none"` | Enables specific integrations for container runtimes. Supported values: - crio - none |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -947,8 +947,17 @@ data:
   annotate-k8s-node: "true"
 {{- end }}
 
+{{- if and .Values.operator.setNodeTaints (not .Values.operator.removeNodeTaints) -}}
+  {{ fail "Cannot have operator.setNodeTaintsMaxNodes and not operator.removeNodeTaints = false" }}
+{{- end -}}
 {{- if .Values.operator.removeNodeTaints }}
   remove-cilium-node-taints: "true"
+{{- end }}
+{{- /* set node taints if setNodeTaints is explicitly enabled or removeNodeTaints is set */ -}}
+{{- if or .Values.operator.setNodeTaints
+          ( and (kindIs "invalid" .Values.operator.setNodeTaints)
+                .Values.operator.removeNodeTaints ) }}
+  set-cilium-node-taints: "true"
 {{- end }}
 {{- if .Values.operator.setNodeNetworkStatus }}
   set-cilium-is-up-condition: "true"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2085,6 +2085,11 @@ operator:
   # pod running.
   removeNodeTaints: true
 
+  # -- Taint nodes where Cilium is scheduled but not running. This prevents pods
+  # from being scheduled to nodes where Cilium is not the default CNI provider.
+  # @default -- same as removeNodeTaints
+  setNodeTaints: ~
+
   # -- Set Node condition NetworkUnavailable to 'false' with the reason
   # 'CiliumIsUp' for nodes that have a healthy Cilium pod.
   setNodeNetworkStatus: true

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -472,7 +472,7 @@ cni:
   # if you're removing Cilium from the cluster. Disable this to prevent the CNI
   # configuration file from being removed during agent upgrade, which can cause
   # nodes to go unmanageable.
-  uninstall: true
+  uninstall: false
 
   # -- Configure chaining on top of other CNI plugins. Possible values:
   #  - none

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -469,7 +469,7 @@ cni:
   # if you're removing Cilium from the cluster. Disable this to prevent the CNI
   # configuration file from being removed during agent upgrade, which can cause
   # nodes to go unmanageable.
-  uninstall: true
+  uninstall: false
 
   # -- Configure chaining on top of other CNI plugins. Possible values:
   #  - none

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2082,6 +2082,11 @@ operator:
   # pod running.
   removeNodeTaints: true
 
+  # -- Taint nodes where Cilium is scheduled but not running. This prevents pods
+  # from being scheduled to nodes where Cilium is not the default CNI provider.
+  # @default -- same as removeNodeTaints
+  setNodeTaints: ~
+
   # -- Set Node condition NetworkUnavailable to 'false' with the reason
   # 'CiliumIsUp' for nodes that have a healthy Cilium pod.
   setNodeNetworkStatus: true

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -306,6 +306,9 @@ func init() {
 	flags.Bool(operatorOption.RemoveCiliumNodeTaints, true, fmt.Sprintf("Remove node taint %q from Kubernetes nodes once Cilium is up and running", option.Config.AgentNotReadyNodeTaintValue()))
 	option.BindEnv(Vp, operatorOption.RemoveCiliumNodeTaints)
 
+	flags.Bool(operatorOption.SetCiliumNodeTaints, false, fmt.Sprintf("Set node taint %q from Kubernetes nodes if Cilium is scheduled but not up and running", option.Config.AgentNotReadyNodeTaintValue()))
+	option.BindEnv(Vp, operatorOption.SetCiliumNodeTaints)
+
 	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")
 	option.BindEnv(Vp, operatorOption.SetCiliumIsUpCondition)
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -582,8 +582,9 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 			logfields.K8sNamespace:       operatorOption.Config.CiliumK8sNamespace,
 			"label-selector":             operatorOption.Config.CiliumPodLabels,
 			"remove-cilium-node-taints":  operatorOption.Config.RemoveCiliumNodeTaints,
+			"set-cilium-node-taints":     operatorOption.Config.SetCiliumNodeTaints,
 			"set-cilium-is-up-condition": operatorOption.Config.SetCiliumIsUpCondition,
-		}).Info("Removing Cilium Node Taints or Setting Cilium Is Up Condition for Kubernetes Nodes")
+		}).Info("Managing Cilium Node Taints or Setting Cilium Is Up Condition for Kubernetes Nodes")
 
 		operatorWatchers.HandleNodeTolerationAndTaints(&legacy.wg, legacy.clientset, legacy.ctx.Done())
 	}

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -282,6 +282,10 @@ const (
 	// should be removed in Kubernetes nodes.
 	RemoveCiliumNodeTaints = "remove-cilium-node-taints"
 
+	// SetCiliumNodeTaints is whether or not to taint nodes that do not have
+	// a running Cilium instance.
+	SetCiliumNodeTaints = "set-cilium-node-taints"
+
 	// SetCiliumIsUpCondition sets the CiliumIsUp node condition in Kubernetes
 	// nodes.
 	SetCiliumIsUpCondition = "set-cilium-is-up-condition"
@@ -537,6 +541,10 @@ type OperatorConfig struct {
 	// should be removed in Kubernetes nodes.
 	RemoveCiliumNodeTaints bool
 
+	// SetCiliumNodeTaints is whether or not to set taints on nodes that do not
+	// have a running Cilium pod.
+	SetCiliumNodeTaints bool
+
 	// SetCiliumIsUpCondition sets the CiliumIsUp node condition in Kubernetes
 	// nodes.
 	SetCiliumIsUpCondition bool
@@ -598,6 +606,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.EnableGatewayAPISecretsSync = vp.GetBool(EnableGatewayAPISecretsSync)
 	c.CiliumPodLabels = vp.GetString(CiliumPodLabels)
 	c.RemoveCiliumNodeTaints = vp.GetBool(RemoveCiliumNodeTaints)
+	c.SetCiliumNodeTaints = vp.GetBool(SetCiliumNodeTaints)
 	c.SetCiliumIsUpCondition = vp.GetBool(SetCiliumIsUpCondition)
 	c.IngressLBAnnotationPrefixes = vp.GetStringSlice(IngressLBAnnotationPrefixes)
 	c.IngressSharedLBServiceName = vp.GetString(IngressSharedLBServiceName)

--- a/operator/watchers/node.go
+++ b/operator/watchers/node.go
@@ -43,6 +43,7 @@ func NodeQueueShutDown() {
 
 type slimNodeGetter interface {
 	GetK8sSlimNode(nodeName string) (*slim_corev1.Node, error)
+	ListK8sSlimNode() []*slim_corev1.Node
 }
 
 type nodeGetter struct{}
@@ -62,6 +63,15 @@ func (nodeGetter) GetK8sSlimNode(nodeName string) (*slim_corev1.Node, error) {
 		}, nodeName)
 	}
 	return nodeInterface.(*slim_corev1.Node), nil
+}
+
+func (nodeGetter) ListK8sSlimNode() []*slim_corev1.Node {
+	nodesInt := slimNodeStore.List()
+	out := make([]*slim_corev1.Node, 0, len(nodesInt))
+	for i := range nodesInt {
+		out = append(out, nodesInt[i].(*slim_corev1.Node))
+	}
+	return out
 }
 
 // nodesInit starts up a node watcher to handle node events.

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -84,29 +84,31 @@ func checkTaintForNextNodeItem(c kubernetes.Interface, nodeGetter slimNodeGetter
 }
 
 // checkAndMarkNode checks if the node contains a Cilium pod in running state
-// so that it can remove the toleration and taints of that node.
+// so that it can set the taints / conditions of the node
 func checkAndMarkNode(c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string, options markNodeOptions) bool {
 	node, err := nodeGetter.GetK8sSlimNode(nodeName)
-	if err != nil && !k8sErrors.IsNotFound(err) {
-		return false
-	}
-	if node == nil {
+	if node == nil || err != nil {
 		return false
 	}
 
-	if (options.RemoveNodeTaint && hasAgentNotReadyTaint(node)) ||
-		(options.SetCiliumIsUpCondition && !HasCiliumIsUpCondition(node)) {
-		if isCiliumPodRunning(node.GetName()) {
-			markNode(c, nodeGetter, node.GetName(), options)
-		} else {
+	// should we remove the taint?
+	scheduled, running := nodeHasCiliumPod(node.GetName())
+	if running {
+		if (options.RemoveNodeTaint && hasAgentNotReadyTaint(node)) ||
+			(options.SetCiliumIsUpCondition && !HasCiliumIsUpCondition(node)) {
 			log.WithFields(logrus.Fields{
 				logfields.NodeName: node.GetName(),
-			}).Debug("Cilium pod not running for node")
+			}).Info("Cilium pod running for node; marking accordingly")
+
+			markNode(c, nodeGetter, node.GetName(), options, true)
 		}
-	} else {
-		log.WithFields(logrus.Fields{
-			logfields.NodeName: node.GetName(),
-		}).Debug("Node without taint and with CiliumIsUp condition")
+	} else if scheduled { // Taint nodes where the pod is scheduled but not running
+		if options.SetNodeTaint && !hasAgentNotReadyTaint(node) {
+			log.WithFields(logrus.Fields{
+				logfields.NodeName: node.GetName(),
+			}).Info("Cilium pod scheduled but not running for node; setting taint")
+			markNode(c, nodeGetter, node.GetName(), options, false)
+		}
 	}
 	return true
 }
@@ -197,23 +199,26 @@ func processNextCiliumPodItem(c kubernetes.Interface, nodeGetter slimNodeGetter,
 	return true
 }
 
-// isCiliumPodRunning returns true if there is a Cilium pod Ready on the given
-// nodeName.
-func isCiliumPodRunning(nodeName string) bool {
+// nodeHasCiliumPod determines if a the node has a Cilium agent pod scheduled
+// on it, and if it is running and ready.
+func nodeHasCiliumPod(nodeName string) (scheduled bool, ready bool) {
 	ciliumPodsInNode, err := ciliumPodsStore.ByIndex(hostnameIndexer, nodeName)
 	if err != nil {
-		return false
+		return false, false
 	}
 	if len(ciliumPodsInNode) == 0 {
-		return false
+		return false, false
 	}
 	for _, ciliumPodInterface := range ciliumPodsInNode {
 		ciliumPod := ciliumPodInterface.(*slim_corev1.Pod)
+		if ciliumPod.DeletionTimestamp != nil { // even if the pod is running, it will be down shortly
+			continue
+		}
 		if k8sUtils.GetLatestPodReadiness(ciliumPod.Status) == slim_corev1.ConditionTrue {
-			return true
+			return true, true
 		}
 	}
-	return false
+	return true, false
 }
 
 // hasAgentNotReadyTaint returns true if the given node has the Cilium Agent
@@ -288,6 +293,8 @@ func convertToCiliumPod(obj interface{}) interface{} {
 // setNodeNetworkUnavailableFalse sets Kubernetes NodeNetworkUnavailable to
 // false as Cilium is managing the network connectivity.
 // https://kubernetes.io/docs/concepts/architecture/nodes/#condition
+// This is because some clusters (notably GCP) come up with a NodeNetworkUnavailable condition set
+// and the network provider is expected to remove this manually.
 func setNodeNetworkUnavailableFalse(ctx context.Context, c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string) error {
 	n, err := nodeGetter.GetK8sSlimNode(nodeName)
 	if err != nil {
@@ -313,6 +320,9 @@ func setNodeNetworkUnavailableFalse(ctx context.Context, c kubernetes.Interface,
 	}
 	patch := []byte(fmt.Sprintf(`{"status":{"conditions":%s}}`, raw))
 	_, err = c.CoreV1().Nodes().PatchStatus(ctx, nodeName, patch)
+	if err != nil {
+		log.WithField(logfields.NodeName, nodeName).WithError(err).Info("Failed to patch node while setting condition")
+	}
 	return err
 }
 
@@ -381,36 +391,105 @@ func removeNodeTaint(ctx context.Context, c kubernetes.Interface, nodeGetter sli
 	}
 
 	_, err = c.CoreV1().Nodes().Patch(ctx, nodeName, k8sTypes.JSONPatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		log.WithField(logfields.NodeName, nodeName).WithError(err).Info("Failed to patch node while removing taint")
+	}
+	return err
+}
+
+// setNodeTaint sets the AgentNotReady taint on a node
+func setNodeTaint(ctx context.Context, c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string) error {
+	k8sNode, err := nodeGetter.GetK8sSlimNode(nodeName)
+	if err != nil {
+		return err
+	}
+
+	taintFound := false
+
+	taints := append([]slim_corev1.Taint{}, k8sNode.Spec.Taints...)
+	for _, taint := range k8sNode.Spec.Taints {
+		if taint.Key == pkgOption.Config.AgentNotReadyNodeTaintValue() {
+			taintFound = true
+			break
+		}
+	}
+
+	if taintFound {
+		log.WithFields(logrus.Fields{
+			logfields.NodeName: nodeName,
+			"taint":            pkgOption.Config.AgentNotReadyNodeTaintValue(),
+		}).Debug("Taint already set in node; skipping")
+		return nil
+	}
+	log.WithFields(logrus.Fields{
+		logfields.NodeName: nodeName,
+		"taint":            pkgOption.Config.AgentNotReadyNodeTaintValue(),
+	}).Debug("Setting Node Taint")
+
+	taints = append(taints, slim_corev1.Taint{
+		Key:    pkgOption.Config.AgentNotReadyNodeTaintValue(), // the function says value, but it's really a key
+		Value:  "",
+		Effect: slim_corev1.TaintEffectNoSchedule,
+	})
+
+	createStatusAndNodePatch := []k8s.JSONPatch{
+		{
+			OP:    "test",
+			Path:  "/spec/taints",
+			Value: k8sNode.Spec.Taints,
+		},
+		{
+			OP:    "replace",
+			Path:  "/spec/taints",
+			Value: taints,
+		},
+	}
+
+	patch, err := json.Marshal(createStatusAndNodePatch)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.CoreV1().Nodes().Patch(ctx, nodeName, k8sTypes.JSONPatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		log.WithField(logfields.NodeName, nodeName).WithError(err).Info("Failed to patch node while adding taint")
+	}
 	return err
 }
 
 type markNodeOptions struct {
 	RemoveNodeTaint        bool
+	SetNodeTaint           bool
 	SetCiliumIsUpCondition bool
 }
 
 // markNode marks the Kubernetes node depending on the modes that it is passed
 // on.
-func markNode(c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string, options markNodeOptions) {
-	log.WithField(logfields.NodeName, nodeName).Debug("Setting NetworkUnavailable=false and removing taint of node")
-
-	ctrlName := fmt.Sprintf("mark-k8s-node-%s-as-available", nodeName)
+func markNode(c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string, options markNodeOptions, running bool) {
+	ctrlName := fmt.Sprintf("mark-k8s-node-%s-taints-conditions", nodeName)
 
 	ctrlMgr.UpdateController(ctrlName,
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				if options.RemoveNodeTaint {
+				if running && options.RemoveNodeTaint {
 					err := removeNodeTaint(ctx, c, nodeGetter, nodeName)
 					if err != nil {
 						return err
 					}
 				}
-				if options.SetCiliumIsUpCondition {
+				if running && options.SetCiliumIsUpCondition {
 					err := setNodeNetworkUnavailableFalse(ctx, c, nodeGetter, nodeName)
 					if err != nil {
 						return err
 					}
 				}
+				if !running && options.SetNodeTaint {
+					err := setNodeTaint(ctx, c, nodeGetter, nodeName)
+					if err != nil {
+						return err
+					}
+				}
+
 				return nil
 			},
 		})
@@ -420,6 +499,7 @@ func markNode(c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string
 func HandleNodeTolerationAndTaints(wg *sync.WaitGroup, clientset k8sClient.Clientset, stopCh <-chan struct{}) {
 	mno = markNodeOptions{
 		RemoveNodeTaint:        option.Config.RemoveCiliumNodeTaints,
+		SetNodeTaint:           option.Config.SetCiliumNodeTaints,
 		SetCiliumIsUpCondition: option.Config.SetCiliumIsUpCondition,
 	}
 	nodesInit(wg, clientset.Slim(), stopCh)

--- a/operator/watchers/node_taint_test.go
+++ b/operator/watchers/node_taint_test.go
@@ -43,9 +43,14 @@ func (f *fakeNodeGetter) GetK8sSlimNode(nodeName string) (*slim_corev1.Node, err
 	panic("OnGetK8sSlimNode called but not implemented!")
 }
 
+func (f *fakeNodeGetter) ListK8sSlimNode() []*slim_corev1.Node {
+	panic("not implemented!")
+}
+
 func (n *NodeTaintSuite) TestNodeTaintWithoutCondition(c *check.C) {
 	mno = markNodeOptions{
 		RemoveNodeTaint:        true,
+		SetNodeTaint:           true,
 		SetCiliumIsUpCondition: false,
 	}
 
@@ -180,6 +185,7 @@ func (n *NodeTaintSuite) TestNodeTaintWithoutCondition(c *check.C) {
 func (n *NodeTaintSuite) TestNodeCondition(c *check.C) {
 	mno = markNodeOptions{
 		RemoveNodeTaint:        false,
+		SetNodeTaint:           false,
 		SetCiliumIsUpCondition: true,
 	}
 
@@ -313,6 +319,7 @@ func (n *NodeTaintSuite) TestNodeCondition(c *check.C) {
 func (n *NodeTaintSuite) TestNodeConditionIfCiliumIsNotReady(c *check.C) {
 	mno = markNodeOptions{
 		RemoveNodeTaint:        true,
+		SetNodeTaint:           true,
 		SetCiliumIsUpCondition: true,
 	}
 
@@ -420,6 +427,7 @@ func (n *NodeTaintSuite) TestNodeConditionIfCiliumAndNodeAreReady(c *check.C) {
 	mno = markNodeOptions{
 		RemoveNodeTaint:        true,
 		SetCiliumIsUpCondition: true,
+		SetNodeTaint:           false, // we don't test _setting_ node taints here, just because it's unergonomic
 	}
 
 	// create node1 with a taint and with CiliumIsUp Condition.
@@ -520,4 +528,174 @@ func (n *NodeTaintSuite) TestNodeConditionIfCiliumAndNodeAreReady(c *check.C) {
 		}
 	}, 1*time.Second)
 	c.Assert(err, check.Not(check.IsNil), check.Commentf("Something was sent to kube-apiserver and it shouldn't have been since the node is ready and it does not have a taint set"))
+}
+
+// TestTaintNodeCiliumDown checks that taints are correctly managed on nodes as Cilium
+// pods go up and down.
+func (n *NodeTaintSuite) TestTaintNodeCiliumDown(c *check.C) {
+	mno = markNodeOptions{
+		RemoveNodeTaint:        true,
+		SetCiliumIsUpCondition: false,
+		SetNodeTaint:           true,
+	}
+
+	// create node1 with an unrelated taint
+	node1 := &slim_corev1.Node{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name: "k8s1",
+		},
+		Spec: slim_corev1.NodeSpec{
+			Taints: []slim_corev1.Taint{
+				{
+					Key: "DoNoRemoveThisTaint", Value: "Foo",
+				},
+			},
+		},
+	}
+
+	// Cilium Pod is not ready
+	ciliumPodOnNode1 := &slim_corev1.Pod{
+		Spec: slim_corev1.PodSpec{
+			NodeName: "k8s1",
+		},
+		Status: slim_corev1.PodStatus{
+			Conditions: []slim_corev1.PodCondition{
+				{
+					Type:   slim_corev1.PodReady,
+					Status: slim_corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	// Add the cilium pod that is running on k8s1
+	err := ciliumPodsStore.Add(ciliumPodOnNode1)
+	c.Assert(err, check.IsNil)
+
+	// Create a fake client to receive the patch from cilium-operator
+	fakeClient := &fake.Clientset{}
+
+	patchReceived := make(chan bool)
+	// emit a true on the patchReceived chan if a patch comes where the taint is set
+	// false if the taint is not set
+	fakeClient.AddReactor("patch", "nodes", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		// If we are updating the spec, the subresource should be empty.
+		// If we update the status the subresource is 'status'
+		c.Assert(action.GetSubresource(), check.Equals, "")
+
+		pa := action.(k8sTesting.PatchAction)
+
+		patches := []struct {
+			OP    string              `json:"op,omitempty"`
+			Path  string              `json:"path,omitempty"`
+			Value []slim_corev1.Taint `json:"value"`
+		}{}
+		err = json.Unmarshal(pa.GetPatch(), &patches)
+		c.Assert(err, check.IsNil)
+		c.Assert(patches, check.HasLen, 2)
+
+		patch := patches[1]
+		c.Assert(patch.OP, check.Equals, "replace")
+		c.Assert(patch.Path, check.Equals, "/spec/taints")
+
+		// Check to see if our taint is included
+		for _, taint := range patch.Value {
+			if taint.Key == pkgOption.Config.AgentNotReadyNodeTaintValue() {
+				patchReceived <- true
+				return true, nil, nil
+			}
+		}
+
+		patchReceived <- false
+		return true, nil, nil
+	})
+
+	fng := &fakeNodeGetter{
+		OnGetK8sSlimNode: func(nodeName string) (*slim_corev1.Node, error) {
+			c.Assert(nodeName, check.Equals, "k8s1")
+			return node1, nil
+		},
+	}
+
+	ciliumPodQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cilium-pod-queue")
+
+	// Trigger the watcher with
+	// - node taint: not set
+	// - pod: scheduled, not ready
+	key, err := queueKeyFunc(ciliumPodOnNode1)
+	c.Assert(err, check.IsNil)
+	ciliumPodQueue.Add(key)
+	continueProcess := processNextCiliumPodItem(fakeClient, fng, ciliumPodQueue)
+	c.Assert(continueProcess, check.Equals, true)
+
+	// Ensure taint was set
+	taintSet := false
+	err = testutils.WaitUntil(func() bool {
+		select {
+		case p := <-patchReceived:
+			taintSet = p
+			return true
+		default:
+			return false
+		}
+	}, 1*time.Second)
+	c.Assert(err, check.IsNil)
+	c.Assert(taintSet, check.Equals, true, check.Commentf("NotReady Pod should cause node taint to be set"))
+
+	node1.Spec.Taints = []slim_corev1.Taint{
+		{
+			Key: pkgOption.Config.AgentNotReadyNodeTaintValue(), Value: "Foo",
+		},
+		{
+			Key: "DoNoRemoveThisTaint", Value: "Foo",
+		},
+	}
+
+	// Re-trigger pod; ensure no patch is received,
+	ciliumPodQueue.Add(key)
+	continueProcess = processNextCiliumPodItem(fakeClient, fng, ciliumPodQueue)
+	c.Assert(continueProcess, check.Equals, true)
+
+	err = testutils.WaitUntil(func() bool {
+		select {
+		case <-patchReceived:
+			return true
+		default:
+			return false
+		}
+	}, 1*time.Second)
+	c.Assert(err, check.Not(check.IsNil), check.Commentf("no patch should have been received; code should short-circuit"))
+
+	// Set pod to Ready, ensure taint is removed
+	ciliumPodOnNode1.Status.Conditions[0].Status = slim_corev1.ConditionTrue
+	ciliumPodQueue.Add(key)
+	continueProcess = processNextCiliumPodItem(fakeClient, fng, ciliumPodQueue)
+	c.Assert(continueProcess, check.Equals, true)
+	err = testutils.WaitUntil(func() bool {
+		select {
+		case p := <-patchReceived:
+			taintSet = p
+			return true
+		default:
+			return false
+		}
+	}, 1*time.Second)
+	c.Assert(err, check.IsNil)
+	c.Assert(taintSet, check.Equals, false, check.Commentf("Ready Pod should cause node taint to be removed"))
+
+	// Re-trigger pod; ensure no patch is received,
+	node1.Spec.Taints = []slim_corev1.Taint{node1.Spec.Taints[1]}
+	ciliumPodQueue.Add(key)
+	continueProcess = processNextCiliumPodItem(fakeClient, fng, ciliumPodQueue)
+	c.Assert(continueProcess, check.Equals, true)
+
+	err = testutils.WaitUntil(func() bool {
+		select {
+		case <-patchReceived:
+			return true
+		default:
+			return false
+		}
+	}, 1*time.Second)
+	c.Assert(err, check.Not(check.IsNil), check.Commentf("no patch should have been received; code should short-circuit"))
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -91,6 +91,14 @@ const (
 	// PidFilePath is the path to the pid file for the agent.
 	PidFilePath = RuntimePath + "/cilium.pid"
 
+	// DeletionQueueDir is the directory used for the CNI plugin to queue deletion requests
+	// if the agent is down
+	DeleteQueueDir = RuntimePath + "/deleteQueue"
+
+	// DeleteQueueLockfile is the file used to synchronize access of the queue directory between
+	// the agent and the CNI plugin processes
+	DeleteQueueLockfile = DeleteQueueDir + "/lockfile"
+
 	// EnableHostIPRestore controls whether the host IP should be restored
 	// from previous state automatically
 	EnableHostIPRestore = true

--- a/pkg/lock/lockfile/lockfile_linux.go
+++ b/pkg/lock/lockfile/lockfile_linux.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package lockfile
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Lockfile is a simple wrapper around POSIX file locking
+// but it uses Linux's per-fd locks, which makes it safe to
+// use within the same process
+type Lockfile struct {
+	fp *os.File
+}
+
+// Linux supports per-file-descriptor locks, which are safer
+// and, more importantly, testable
+
+const (
+	SETLK  = 37 // F_OFD_SETLK
+	SETLKW = 38 // F_OFD_SETLKW
+)
+
+// NewLockfile creates and opens a lockfile, but does not acquire
+// a lock.
+func NewLockfile(path string) (*Lockfile, error) {
+	fp, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create lockfile %s: %w", path, err)
+	}
+
+	return &Lockfile{
+		fp: fp,
+	}, nil
+}
+
+// Close will close the file, which implicitly removes all locks held.
+// It is an error to re-use a closed Lockfile.
+func (l *Lockfile) Close() error {
+	fp := l.fp
+	l.fp = nil
+	return fp.Close()
+}
+
+// TryLock will attempt to take a lock, returining error if it is not
+// possible to acquire the lock.
+// If exclusive is true, then it will attempt to obtain a write, or exclusive, lock
+func (l *Lockfile) TryLock(exclusive bool) error {
+	return l.flock(context.Background(), false, exclusive, false)
+}
+
+// Lock will attempt to take a lock, blocking until it is able to do so.
+// If exclusive is true, then it will obtain a write, or exclusive, lock
+func (l *Lockfile) Lock(ctx context.Context, exclusive bool) error {
+	return l.flock(ctx, false, exclusive, true)
+}
+
+// Unlock removes the lock, but keeps the file open.
+func (l *Lockfile) Unlock() error {
+	return l.flock(context.Background(), true, false, false)
+}
+
+// flock will perform the lock operation
+// - unlock: if true, remove the lock
+// - exclusive: if true, then obtain a write lock, else a read lock
+// - wait: if true, then block until the lock is obtained. Ignored when unlocking
+func (l *Lockfile) flock(ctx context.Context, unlock, exclusive, wait bool) error {
+	var lockType int16 = syscall.F_RDLCK
+	if unlock {
+		lockType = syscall.F_UNLCK // unlock is a lockType!? What an API.
+	} else if exclusive {
+		lockType = syscall.F_WRLCK
+	}
+
+	command := SETLK
+	if !unlock && wait {
+		command = SETLKW
+	}
+
+	flockT := syscall.Flock_t{
+		Type:   lockType,
+		Whence: 0,
+		Start:  0,
+		Len:    0,
+	}
+
+	// if no context is supplied, or the context is non-cancellable,
+	// then don't do the goroutine dance
+	if ctx.Done() == nil {
+		return syscall.FcntlFlock(l.fp.Fd(), command, &flockT)
+	}
+
+	// syscalls can't be cancelled, so just wrap in a goroutine so we can
+	// return early if the context closes
+	lockCh := make(chan error, 1)
+	go func() {
+		lockCh <- syscall.FcntlFlock(l.fp.Fd(), command, &flockT)
+	}()
+	select {
+	case err := <-lockCh:
+		return err
+	case <-ctx.Done():
+		// oops, we cancelled
+		// spin up a goroutine to drop the lock when we get it,
+		// since syscalls can't actually be cancelled
+		go func() {
+			err := <-lockCh
+			if err == nil {
+				l.flock(context.Background(), true, false, false)
+			}
+		}()
+		return ctx.Err()
+	}
+}

--- a/pkg/lock/lockfile/lockfile_other.go
+++ b/pkg/lock/lockfile/lockfile_other.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !linux
+
+package lockfile
+
+// Lockfile is a simple wrapper around POSIX file locking
+// but it uses Linux's per-fd locks, which makes it safe to
+// use within the same process
+type Lockfile struct {
+}
+
+// NewLockfile creates and opens a lockfile, but does not acquire
+// a lock.
+func NewLockfile(path string) (*Lockfile, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (l *Lockfile) Close() error {
+	return fmt.Errorf("not implemented")
+}
+
+func (l *Lockfile) TryLock(exclusive bool) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (l *Lockfile) Lock(ctx context.Context, exclusive bool) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (l *Lockfile) Unlock() error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/lock/lockfile/lockfile_test.go
+++ b/pkg/lock/lockfile/lockfile_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// this only runs on linux, since that supports per-file-descriptor posix advisory locking
+//go:build linux
+
+package lockfile
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLockfile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lockfile")
+
+	// Test lockfile creation
+	lf, err := NewLockfile(path)
+	assert.NoError(t, err)
+	assert.FileExists(t, path)
+	defer lf.Close()
+
+	err = lf.Lock(context.Background(), true)
+	assert.NoError(t, err)
+
+	err = lf.Unlock()
+	assert.NoError(t, err)
+}
+
+func TestLockfileShared(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lockfile")
+
+	// Now, ensure that shared locks work: take two shared locks
+	shared1, err := NewLockfile(path)
+	assert.NoError(t, err)
+	assert.NoError(t, shared1.Lock(context.Background(), false))
+	defer shared1.Close()
+
+	shared2, err := NewLockfile(path)
+	assert.NoError(t, err)
+	assert.NoError(t, shared2.TryLock(false))
+	defer shared2.Close()
+
+	// Try and take an exclusive lock; it will fail
+	exclusive, err := NewLockfile(path)
+	assert.NoError(t, err)
+	assert.Error(t, exclusive.TryLock(true))
+	defer exclusive.Close()
+
+	// Now, unlock
+	assert.NoError(t, shared1.Unlock())
+	assert.NoError(t, shared2.Unlock())
+
+	// Take an exclusive lock
+	assert.NoError(t, exclusive.TryLock(true))
+
+	// Ensure we can't take a shared lock with an exclusive one
+	assert.Error(t, shared1.TryLock(false))
+}
+
+func TestLockfileCancel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lockfile")
+
+	// take an exclusive lock
+	exclusive, err := NewLockfile(path)
+	assert.NoError(t, err)
+	defer exclusive.Close()
+	assert.NoError(t, exclusive.Lock(context.Background(), true))
+
+	// try and take another, but it will time out
+	fail, err := NewLockfile(path)
+	assert.NoError(t, err)
+	defer fail.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err = fail.Lock(ctx, true) // this will fail
+	assert.ErrorContains(t, err, "deadline")
+
+	exclusive.Unlock()
+}

--- a/plugins/cilium-cni/chaining/api/api.go
+++ b/plugins/cilium-cni/chaining/api/api.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/plugins/cilium-cni/lib"
 	"github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
@@ -33,14 +34,14 @@ type PluginContext struct {
 	Args    *skel.CmdArgs
 	CniArgs types.ArgsSpec
 	NetConf *types.NetConf
-	Client  *client.Client
+	//Client  *client.Client
 }
 
 // ChainingPlugin is the interface each chaining plugin must implement
 type ChainingPlugin interface {
 	// Add is called on CNI ADD. It is given the plugin context from the
 	// previous plugin. It must return a CNI result or an error.
-	Add(ctx context.Context, pluginContext PluginContext) (res *cniTypesVer.Result, err error)
+	Add(ctx context.Context, pluginContext PluginContext, client *client.Client) (res *cniTypesVer.Result, err error)
 
 	// ImplementsAdd returns true if the chaining plugin implements its own
 	// add logic
@@ -48,7 +49,7 @@ type ChainingPlugin interface {
 
 	// Delete is called on CNI DELETE. It is given the plugin context from
 	// the previous plugin.
-	Delete(ctx context.Context, pluginContext PluginContext) (err error)
+	Delete(ctx context.Context, pluginContext PluginContext, delClient *lib.DeletionFallbackClient) (err error)
 
 	// ImplementsDelete returns true if the chaining plugin implements its
 	// own delete logic
@@ -56,7 +57,7 @@ type ChainingPlugin interface {
 
 	// Check is called on CNI CHECK. The plugin should verify (to the best of its
 	// ability) that everything is reasonably configured, else return error.
-	Check(ctx context.Context, pluginContext PluginContext) error
+	Check(ctx context.Context, pluginContext PluginContext, client *client.Client) error
 }
 
 // Register is called by chaining plugins to register themselves. After

--- a/plugins/cilium-cni/chaining/api/api_test.go
+++ b/plugins/cilium-cni/chaining/api/api_test.go
@@ -9,6 +9,9 @@ import (
 
 	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
 	"gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/client"
+	"github.com/cilium/cilium/plugins/cilium-cni/lib"
 )
 
 func Test(t *testing.T) {
@@ -21,7 +24,7 @@ var _ = check.Suite(&APISuite{})
 
 type pluginTest struct{}
 
-func (p *pluginTest) Add(ctx context.Context, pluginContext PluginContext) (res *cniTypesVer.Result, err error) {
+func (p *pluginTest) Add(ctx context.Context, pluginContext PluginContext, cli *client.Client) (res *cniTypesVer.Result, err error) {
 	return nil, nil
 }
 
@@ -29,7 +32,7 @@ func (p *pluginTest) ImplementsAdd() bool {
 	return true
 }
 
-func (p *pluginTest) Delete(ctx context.Context, pluginContext PluginContext) (err error) {
+func (p *pluginTest) Delete(ctx context.Context, pluginContext PluginContext, cli *lib.DeletionFallbackClient) (err error) {
 	return nil
 }
 
@@ -37,7 +40,7 @@ func (p *pluginTest) ImplementsDelete() bool {
 	return true
 }
 
-func (p *pluginTest) Check(ctx context.Context, pluginContext PluginContext) error {
+func (p *pluginTest) Check(ctx context.Context, pluginContext PluginContext, cli *client.Client) error {
 	return nil
 }
 

--- a/plugins/cilium-cni/chaining/portmap/portmap.go
+++ b/plugins/cilium-cni/chaining/portmap/portmap.go
@@ -8,7 +8,9 @@ import (
 
 	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
 
+	"github.com/cilium/cilium/pkg/client"
 	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
+	"github.com/cilium/cilium/plugins/cilium-cni/lib"
 )
 
 type portmapChainer struct{}
@@ -17,7 +19,7 @@ func (p *portmapChainer) ImplementsAdd() bool {
 	return false
 }
 
-func (p *portmapChainer) Add(ctx context.Context, pluginCtx chainingapi.PluginContext) (res *cniTypesVer.Result, err error) {
+func (p *portmapChainer) Add(ctx context.Context, pluginCtx chainingapi.PluginContext, cli *client.Client) (res *cniTypesVer.Result, err error) {
 	return nil, nil
 }
 
@@ -25,11 +27,11 @@ func (p *portmapChainer) ImplementsDelete() bool {
 	return false
 }
 
-func (p *portmapChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext) (err error) {
+func (p *portmapChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext, cli *lib.DeletionFallbackClient) (err error) {
 	return nil
 }
 
-func (p *portmapChainer) Check(ctx context.Context, pluginContext chainingapi.PluginContext) error {
+func (p *portmapChainer) Check(ctx context.Context, pluginContext chainingapi.PluginContext, cli *client.Client) error {
 	return nil
 }
 

--- a/plugins/cilium-cni/lib/deletion_queue.go
+++ b/plugins/cilium-cni/lib/deletion_queue.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lib
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/client"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/lock/lockfile"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+type DeletionFallbackClient struct {
+	logger *logrus.Entry
+	cli    *client.Client
+
+	lockfile *lockfile.Lockfile
+}
+
+// the timeout for connecting and obtaining the lock
+// the default of 30 seconds is too long; kubelet will time us out before then
+const timeoutSeconds = 10
+
+// the maximum number of queued deletions allowed, to protect against kubelet insanity
+const maxDeletionFiles = 256
+
+// NewDeletionFallbackClient creates a client that will either issue an EndpointDelete
+// request via the api, *or* queue one in a temporary directory.
+// To prevent race conditions, the logic is:
+// 1. Try and connect to the socket. if that succeeds, done
+// 2. Otherwise, take a shared lock on the delete queue directory
+// 3. Once we get the lock, check to see if the socket now exists
+// 4. If it exists, drop the lock and use the api
+func NewDeletionFallbackClient(logger *logrus.Entry) (*DeletionFallbackClient, error) {
+	dc := &DeletionFallbackClient{
+		logger: logger,
+	}
+
+	// Try and connect (the usual case)
+	err := dc.tryConnect()
+	if err == nil {
+		return dc, nil
+	}
+	dc.logger.WithError(err).Warnf("Failed to connect to agent socket at %s.", client.DefaultSockPath())
+
+	// We failed to connect: get the queue lock
+	if err := dc.tryQueueLock(); err != nil {
+		return nil, fmt.Errorf("failed to acquire deletion queue: %w", err)
+	}
+
+	// We have the queue lock; try and connect again
+	// just in case the agent finished starting up while we were waiting
+	if err := dc.tryConnect(); err == nil {
+		dc.logger.Info("Successfully connected to API on second try.")
+		// hey, it's back up!
+		dc.lockfile.Unlock()
+		dc.lockfile = nil
+		return dc, nil
+	}
+
+	// We have the lockfile, but no valid client
+	dc.logger.Info("Agent is down, falling back to deletion queue directory")
+	return dc, nil
+}
+
+func (dc *DeletionFallbackClient) tryConnect() error {
+	c, err := client.NewDefaultClientWithTimeout(timeoutSeconds * time.Second)
+	if err != nil {
+		return err
+	}
+	dc.cli = c
+	return nil
+}
+
+func (dc *DeletionFallbackClient) tryQueueLock() error {
+	dc.logger.Debugf("attempting to acquire deletion queue lock at %s", defaults.DeleteQueueLockfile)
+
+	// Ensure deletion queue directory exists, obtain shared lock
+	err := os.MkdirAll(defaults.DeleteQueueDir, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create deletion queue directory %s: %w", defaults.DeleteQueueDir, err)
+	}
+
+	lf, err := lockfile.NewLockfile(defaults.DeleteQueueLockfile)
+	if err != nil {
+		return fmt.Errorf("failed to open lockfile %s: %w", defaults.DeleteQueueLockfile, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutSeconds*time.Second)
+	defer cancel()
+
+	err = lf.Lock(ctx, false) // get the shared lock
+	if err != nil {
+		return fmt.Errorf("failed to acquire lock: %w", err)
+	}
+	dc.lockfile = lf
+	return nil
+}
+
+// EndpointDelete deletes an endpoint given by an endpoint id, either
+// by directly accessing the API or dropping in a queued-deletion file.
+// endpoint-id is a qualified endpoint reference, e.g. "container-id:XXXXXXX"
+func (dc *DeletionFallbackClient) EndpointDelete(id string) error {
+	if dc.cli != nil {
+		return dc.cli.EndpointDelete(id)
+	}
+
+	// fall-back mode
+	if dc.lockfile != nil {
+		dc.logger.WithField(logfields.EndpointID, id).Info("Queueing deletion request for endpoint")
+
+		// sanity check: if there are too many queued deletes, just return error
+		// back up to the kubelet. If we get here, it's either because something
+		// has gone wrong with the kubelet, or the agent has been down for a very
+		// long time. To guard aganst long agent startup times (when it empties the
+		// queue), limit us to 256 queued deletions. If this does, indeed, overflow,
+		// then the kubelet will get the failure and eventually retry deletion.
+		files, err := os.ReadDir(defaults.DeleteQueueDir)
+		if err != nil {
+			dc.logger.WithField(logfields.Path, defaults.DeleteQueueDir).WithError(err).Error("failed to list deletion queue directory")
+			return err
+		}
+		if len(files) > maxDeletionFiles {
+			return fmt.Errorf("deletion queue directory %s has too many entries; aborting", defaults.DeleteQueueDir)
+		}
+
+		// hash endpoint id for a random filename
+		h := sha256.New()
+		h.Write([]byte(id))
+		filename := fmt.Sprintf("%x.delete", h.Sum(nil))
+		path := filepath.Join(defaults.DeleteQueueDir, filename)
+
+		err = os.WriteFile(path, []byte(id), 0644)
+		if err != nil {
+			dc.logger.WithField(logfields.Path, path).WithError(err).Error("failed to write deletion file")
+			return fmt.Errorf("failed to write deletion file %s: %w", path, err)
+		}
+		dc.logger.Info("wrote queued deletion file")
+		return nil
+	}
+
+	return fmt.Errorf("attempt to delete with no valid connection")
+}

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -49,6 +49,7 @@ import (
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/flannel"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/portmap"
+	"github.com/cilium/cilium/plugins/cilium-cni/lib"
 	"github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
@@ -422,12 +423,11 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 					Args:    args,
 					CniArgs: cniArgs,
 					NetConf: n,
-					Client:  c,
 				}
 			)
 
 			if chainAction.ImplementsAdd() {
-				res, err = chainAction.Add(context.TODO(), ctx)
+				res, err = chainAction.Add(context.TODO(), ctx, c)
 				if err != nil {
 					return
 				}
@@ -654,31 +654,24 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 	logger.Debugf("CNI Args: %#v", cniArgs)
 
-	c, err := client.NewDefaultClientWithTimeout(defaults.ClientConnectTimeout)
-	if err != nil {
-		// this error can be recovered from
-		return fmt.Errorf("unable to connect to Cilium daemon: %s", client.Hint(err))
-	}
+	logger = logger.WithField("containerID", args.ContainerID)
 
-	conf, err := getConfigFromCiliumAgent(c)
+	c, err := lib.NewDeletionFallbackClient(logger)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to connect to Cilium agent: %w", err)
 	}
 
 	if n.Name != chainingapi.DefaultConfigName {
 		if chainAction := chainingapi.Lookup(n.Name); chainAction != nil {
-			var (
-				ctx = chainingapi.PluginContext{
-					Logger:  logger,
-					Args:    args,
-					CniArgs: cniArgs,
-					NetConf: n,
-					Client:  c,
-				}
-			)
+			ctx := chainingapi.PluginContext{
+				Logger:  logger,
+				Args:    args,
+				CniArgs: cniArgs,
+				NetConf: n,
+			}
 
 			if chainAction.ImplementsDelete() {
-				return chainAction.Delete(context.TODO(), ctx)
+				return chainAction.Delete(context.TODO(), ctx, c)
 			}
 		} else {
 			logger.Warnf("Unknown CNI chaining configuration name '%s'", n.Name)
@@ -696,7 +689,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		log.WithError(err).Warning("Errors encountered while deleting endpoint")
 	}
 
-	if conf.IpamMode == ipamOption.IPAMDelegatedPlugin {
+	if n.IPAM.Type != "" {
 		// If using a delegated plugin for IPAM, attempt to release the IP.
 		// We do this *before* entering the network namespace, because the ns may
 		// have already been deleted, and we want to avoid leaking IPs.
@@ -781,12 +774,11 @@ func cmdCheck(args *skel.CmdArgs) error {
 					Args:    args,
 					CniArgs: cniArgs,
 					NetConf: n,
-					Client:  c,
 				}
 			)
 
 			// err is nil on success
-			err := chainAction.Check(context.TODO(), ctx)
+			err := chainAction.Check(context.TODO(), ctx, c)
 			logger.Debugf("Chained CHECK %s returned %s", n.Name, err)
 			return err
 


### PR DESCRIPTION
This change is made up of several commits, which build on each other. It fixes a wart with how CNI, Containerd, and Dockershim interact, and prevents some possible outage scenarios.

Ultimately, I'd like to make much of this less necessary with an improved CNI STATUS verb, but that will take some time to roll out across the ecosystem.

### Asynchronous CNI delete
The CNI plugin now queues DEL for later submission, rather than failing. It tries to connect to the agent socket, and if that fails, it will write a file in `/run/cilium` with the pod's details. When the agent starts up, it will read that queue and process all pending deletes.

This fixes #22067, where an end-user found themselves with an unrecoverable cluster.  Cilium got descheduled but their node was at its pod limit. They couldn't start any pods, and they couldn't delete any pods without Cilium running. Not good.

### Taint the node when Cilium is shut down

On nodes where Cilium is scheduled, if it is not running, taint the node with NoSchedule. This will prevent new pods from being scheduled there. This has two goals:
1. Minimize ignorable errors from pods failing to start because Cilium can't handle a CNI ADD
2. Minimize pods being started with a non-Cilium network provider

### Preserve CNI configuration 

Lastly, we no longer delete the CNI configuration file when stopping the agent. This has several important effects:
- the node no longer goes NotReady, so it won't be removed from cloud LB backends just because cilium is being upgraded. This prevents unneeded churn.
- CNI DEL will still succeed, so pods can always be cleaned up
- No chance of pods being started with a different CNI provider

```release-note
The Cilium operator now taints nodes where Cilium is scheduled to run but is not running. 
This prevents pods from being scheduled on nodes without Cilium.
The CNI configuration file is no longer removed on agent shutdown. 
This means that pod deletion will always succeed; previously it would fail if Cilium was down for an upgrade.
This should help prevent nodes accidentally entering an unmanageable state.
It also means that nodes are not removed from cloud LoadBalancer backends during Cilium upgrades.
```


Fixes: #22067.