### PR TITLE
watchers: endpointsync can manage already owned CiliumEndpoints.

### DIFF
--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -130,9 +130,6 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					return nil
 				}
 
-				// Initialize the CEP by deleting the upstream instance and recreating
-				// it. Deleting first allows for upgrade scenarios where the format has
-				// changed but our k8s CEP code cannot read in the upstream value.
 				if needInit {
 					state := e.GetState()
 					// Don't bother to create if the

--- a/pkg/k8s/watchers/endpointsynchronizer_test.go
+++ b/pkg/k8s/watchers/endpointsynchronizer_test.go
@@ -17,21 +17,53 @@ import (
 )
 
 func Test_updateCEPUID(t *testing.T) {
+	epWithUID := func(uid string) *endpoint.Endpoint {
+		ep := &endpoint.Endpoint{}
+		ep.SetCiliumEndpointUID(types.UID(uid))
+		return ep
+	}
+	someUID := func(s string) *types.UID {
+		id := types.UID(s)
+		return &id
+	}
 	for name, test := range map[string]struct {
 		err           error
 		cep           *v2.CiliumEndpoint
 		ep            *endpoint.Endpoint
-		expectedEPUID types.UID
+		expectedEPUID *types.UID
 	}{
+		// In this test, our CEP has a UID that is different from the local Endpoint.
+		// This means that the CEP is not owned by this EP.
+		// Ownership should fail due to Endpoint not having a network status.
 		"no net status": {
-			ep:  &endpoint.Endpoint{},
+			ep:  epWithUID("000"),
 			err: fmt.Errorf("no nodeIP"),
-			cep: &v2.CiliumEndpoint{Status: v2.EndpointStatus{}},
+			cep: &v2.CiliumEndpoint{
+				ObjectMeta: v1.ObjectMeta{
+					UID: "111", // Different UID from the local Endpoint.
+				},
+				Status: v2.EndpointStatus{},
+			},
 		},
-		"non local": {
-			ep:  &endpoint.Endpoint{},
+		"CiliumEndpoint not local": {
+			// The CEP is explicitly not local.
+			ep:  epWithUID("1234"),
 			err: fmt.Errorf("is not local"),
 			cep: &v2.CiliumEndpoint{
+				ObjectMeta: v1.ObjectMeta{UID: "1111"},
+				Status: v2.EndpointStatus{
+					Networking: &v2.EndpointNetworking{
+						NodeIP: "1.2.3.4", // in testing, the node ip is returned as "<nil>"
+					},
+				},
+			},
+		},
+		"CiliumEndpoint not local, but already owned": {
+			// The CEP is explicitly not local. But the CEP is already owned by the endpoint.
+			// So ownership should proceed without error.
+			ep: epWithUID("000"), // matches CEP.
+			cep: &v2.CiliumEndpoint{
+				ObjectMeta: v1.ObjectMeta{UID: "000"},
 				Status: v2.EndpointStatus{
 					Networking: &v2.EndpointNetworking{
 						NodeIP: "1.2.3.4", // in testing, the node ip is returned as "<nil>"
@@ -40,13 +72,15 @@ func Test_updateCEPUID(t *testing.T) {
 			},
 		},
 		"ciliumendpoint already exists": {
+			// CEP already exists, on the same node, we cannot take ownership of it
+			// due to differing UID ref.
+			//
+			// This would be the case where two endpoint sync controllers are running for
+			// a Pod with the same namespace/name on the same Agent, so we'd have to wait
+			// until the other controller terminates and cleans up the CEP.
 			err:           fmt.Errorf("did not match CEP UID"),
-			expectedEPUID: "b",
-			ep: func() *endpoint.Endpoint {
-				ep := &endpoint.Endpoint{}
-				ep.SetCiliumEndpointUID("b")
-				return ep
-			}(),
+			expectedEPUID: someUID("b"),
+			ep:            epWithUID("b"),
 			cep: &v2.CiliumEndpoint{
 				ObjectMeta: v1.ObjectMeta{UID: types.UID("a")},
 				Status: v2.EndpointStatus{
@@ -56,9 +90,9 @@ func Test_updateCEPUID(t *testing.T) {
 				},
 			},
 		},
-		"take ownership of cep": {
+		"take ownership of cep due to empty CiliumEndpointUID ref": {
 			ep:            &endpoint.Endpoint{},
-			expectedEPUID: "a",
+			expectedEPUID: someUID("a"),
 			cep: &v2.CiliumEndpoint{
 				ObjectMeta: v1.ObjectMeta{UID: types.UID("a")},
 				Status: v2.EndpointStatus{
@@ -77,7 +111,9 @@ func Test_updateCEPUID(t *testing.T) {
 			} else {
 				assert.ErrorContains(err, test.err.Error())
 			}
-			assert.Equal(test.expectedEPUID, test.ep.GetCiliumEndpointUID())
+			if test.expectedEPUID != nil {
+				assert.Equal(*test.expectedEPUID, test.ep.GetCiliumEndpointUID())
+			}
 		})
 
 	}


### PR DESCRIPTION
When attempting to take ownership of already created CiliumEndpoint resources, the endpoint sync controller will check that it is safe to do so.

One condition is that if the endpoint is to take ownership of a already created CEP, that CEP needs to be "local".
This comparison was being done in all cases, however in the case where the agent is restarted and given a different IP this would prevent restored endpoints from being managed correctly.

To fix this, this change will skip all checks if the endpoint UID already matches the CEP UID - and allow the endpointsync to backfill the new IP.

Fixes: #23487

Signed-off-by: Tom Hadlaw <tom.hadlaw@isovalent.com>

More context: https://github.com/cilium/cilium/issues/23487#issuecomment-1410885092