### PR TITLE
gateway-api: Combine metrics registry with operator

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
+	controllerRuntimeMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/cilium/cilium/api/v1/operator/models"
 	operatorOption "github.com/cilium/cilium/operator/option"
@@ -24,9 +25,14 @@ var (
 // Namespace is the namespace key to use for cilium operator metrics.
 const Namespace = "cilium_operator"
 
+type RegisterGatherer interface {
+	prometheus.Registerer
+	prometheus.Gatherer
+}
+
 var (
 	// Registry is the global prometheus registry for cilium-operator metrics.
-	Registry   *prometheus.Registry
+	Registry   RegisterGatherer
 	shutdownCh chan struct{}
 )
 
@@ -34,7 +40,18 @@ var (
 func Register() {
 	log.Info("Registering Operator metrics")
 
-	Registry = prometheus.NewPedanticRegistry()
+	if operatorOption.Config.EnableGatewayAPI {
+		// Use the same Registry as controller-runtime, so that we don't need
+		// to expose multiple metrics endpoints or servers.
+		//
+		// Ideally, we should use our own Registry instance, but the metrics
+		// registration is done by init() functions, which are executed before
+		// this function is called.
+		Registry = controllerRuntimeMetrics.Registry
+	} else {
+		Registry = prometheus.NewPedanticRegistry()
+	}
+
 	registerMetrics()
 
 	m := http.NewServeMux()

--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -57,6 +57,8 @@ type Controller struct {
 func NewController(enableSecretSync bool, secretsNamespace string) (*Controller, error) {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
+		// Disable controller metrics server in favour of cilium's metrics server.
+		MetricsBindAddress: "0",
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/api/metrics/metrics.go
+++ b/pkg/api/metrics/metrics.go
@@ -7,19 +7,21 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/cilium/cilium/operator/metrics"
 )
 
 // PrometheusMetrics is an implementation of Prometheus metrics for external
 // API usage
 type PrometheusMetrics struct {
-	registry    *prometheus.Registry
+	registry    metrics.RegisterGatherer
 	APIDuration *prometheus.HistogramVec
 	RateLimit   *prometheus.HistogramVec
 }
 
 // NewPrometheusMetrics returns a new metrics tracking implementation to cover
 // external API usage.
-func NewPrometheusMetrics(namespace, subsystem string, registry *prometheus.Registry) *PrometheusMetrics {
+func NewPrometheusMetrics(namespace, subsystem string, registry metrics.RegisterGatherer) *PrometheusMetrics {
 	m := &PrometheusMetrics{registry: registry}
 
 	m.APIDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/cilium/cilium/operator/metrics"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 
 const ipamSubsystem = "ipam"
 
 type prometheusMetrics struct {
-	registry             *prometheus.Registry
+	registry             metrics.RegisterGatherer
 	Allocation           *prometheus.HistogramVec
 	Release              *prometheus.HistogramVec
 	AllocateInterfaceOps *prometheus.CounterVec
@@ -36,7 +37,7 @@ type prometheusMetrics struct {
 
 // NewPrometheusMetrics returns a new interface metrics implementation backed by
 // Prometheus metrics.
-func NewPrometheusMetrics(namespace string, registry *prometheus.Registry) *prometheusMetrics {
+func NewPrometheusMetrics(namespace string, registry metrics.RegisterGatherer) *prometheusMetrics {
 	m := &prometheusMetrics{
 		registry: registry,
 	}
@@ -254,7 +255,7 @@ func NewTriggerMetrics(namespace, name string) *triggerMetrics {
 	}
 }
 
-func (t *triggerMetrics) Register(registry *prometheus.Registry) {
+func (t *triggerMetrics) Register(registry metrics.RegisterGatherer) {
 	registry.MustRegister(t.total)
 	registry.MustRegister(t.folds)
 	registry.MustRegister(t.callDuration)


### PR DESCRIPTION
### Description

By default, controller runtime is having its own metrics server, which will require another port binding, and also incur a risk of port conflicts on the host network.

- Disable metric server from controller runtime.
- Use the same Prometheus registry instance in operator and controller
  runtime, so that we can leverage the same metrics server with existing
  port number. Alternatively, gateway api related metrics can be served
  via different endpoints (e.g. /gateway-api/metrics), however, it's
  confusing to users.

Fixes: #23082

Suggested-by: Casey Callendrello <cdc@isovalent.com>
Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

Testing was done locally to make sure that we have both existing operator and  gateway-api related metrics.


```
$ ksysgpoowide cilium-operator-7c7f45d489-n62h5 
NAME                               READY   STATUS    RESTARTS   AGE     IP             NODE       NOMINATED NODE   READINESS GATES
cilium-operator-7c7f45d489-n62h5   1/1     Running   0          2m27s   192.168.49.2   minikube   <none>           <none>

$ ksysex ds/cilium -- curl http://192.168.49.2:9963/metrics > metrics.txt
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), wait-for-node-init (init), clean-cilium-state (init)

$ cat metrics.txt | grep cilium_operator | wc -l
58

$ cat metrics.txt | grep gateway | wc -l        
162

```

<details>
<summary>Full metrics dump</summary>

```
# HELP certwatcher_read_certificate_errors_total Total number of certificate read errors
# TYPE certwatcher_read_certificate_errors_total counter
certwatcher_read_certificate_errors_total 0
# HELP certwatcher_read_certificate_total Total number of certificate reads
# TYPE certwatcher_read_certificate_total counter
certwatcher_read_certificate_total 0
# HELP cilium_operator_ces_queueing_delay_seconds CiliumEndpointSlice queueing delay in seconds
# TYPE cilium_operator_ces_queueing_delay_seconds histogram
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.005"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.01"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.025"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.05"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.1"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.25"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="0.5"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="1"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="2.5"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="5"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="10"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="60"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="300"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="900"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="1800"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="3600"} 0
cilium_operator_ces_queueing_delay_seconds_bucket{le="+Inf"} 0
cilium_operator_ces_queueing_delay_seconds_sum 0
cilium_operator_ces_queueing_delay_seconds_count 0
# HELP cilium_operator_ces_sync_errors_total Number of CES sync errors
# TYPE cilium_operator_ces_sync_errors_total counter
cilium_operator_ces_sync_errors_total 0
# HELP cilium_operator_number_of_ceps_per_ces The number of CEPs batched in a CES
# TYPE cilium_operator_number_of_ceps_per_ces histogram
cilium_operator_number_of_ceps_per_ces_bucket{le="1"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="10"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="25"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="50"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="100"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="200"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="500"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="1000"} 0
cilium_operator_number_of_ceps_per_ces_bucket{le="+Inf"} 0
cilium_operator_number_of_ceps_per_ces_sum 0
cilium_operator_number_of_ceps_per_ces_count 0
# HELP cilium_operator_process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE cilium_operator_process_cpu_seconds_total counter
cilium_operator_process_cpu_seconds_total 0.72
# HELP cilium_operator_process_max_fds Maximum number of open file descriptors.
# TYPE cilium_operator_process_max_fds gauge
cilium_operator_process_max_fds 102400
# HELP cilium_operator_process_open_fds Number of open file descriptors.
# TYPE cilium_operator_process_open_fds gauge
cilium_operator_process_open_fds 13
# HELP cilium_operator_process_resident_memory_bytes Resident memory size in bytes.
# TYPE cilium_operator_process_resident_memory_bytes gauge
cilium_operator_process_resident_memory_bytes 7.6136448e+07
# HELP cilium_operator_process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE cilium_operator_process_start_time_seconds gauge
cilium_operator_process_start_time_seconds 1.67521613414e+09
# HELP cilium_operator_process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE cilium_operator_process_virtual_memory_bytes gauge
cilium_operator_process_virtual_memory_bytes 8.04388864e+08
# HELP cilium_operator_process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE cilium_operator_process_virtual_memory_max_bytes gauge
cilium_operator_process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP controller_runtime_active_workers Number of currently used workers per controller
# TYPE controller_runtime_active_workers gauge
controller_runtime_active_workers{controller="gateway"} 0
controller_runtime_active_workers{controller="gatewayclass"} 0
controller_runtime_active_workers{controller="httproute"} 0
controller_runtime_active_workers{controller="referencegrant"} 0
controller_runtime_active_workers{controller="secret"} 0
# HELP controller_runtime_max_concurrent_reconciles Maximum number of concurrent reconciles per controller
# TYPE controller_runtime_max_concurrent_reconciles gauge
controller_runtime_max_concurrent_reconciles{controller="gateway"} 1
controller_runtime_max_concurrent_reconciles{controller="gatewayclass"} 1
controller_runtime_max_concurrent_reconciles{controller="httproute"} 1
controller_runtime_max_concurrent_reconciles{controller="referencegrant"} 1
controller_runtime_max_concurrent_reconciles{controller="secret"} 1
# HELP controller_runtime_reconcile_errors_total Total number of reconciliation errors per controller
# TYPE controller_runtime_reconcile_errors_total counter
controller_runtime_reconcile_errors_total{controller="gateway"} 16
controller_runtime_reconcile_errors_total{controller="gatewayclass"} 0
controller_runtime_reconcile_errors_total{controller="httproute"} 0
controller_runtime_reconcile_errors_total{controller="referencegrant"} 0
controller_runtime_reconcile_errors_total{controller="secret"} 0
# HELP controller_runtime_reconcile_time_seconds Length of time per reconciliation per controller
# TYPE controller_runtime_reconcile_time_seconds histogram
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.005"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.01"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.025"} 15
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.05"} 15
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.1"} 15
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.15"} 15
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.2"} 15
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.25"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.3"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.35"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.4"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.45"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.5"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.6"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.7"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.8"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="0.9"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="1"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="1.25"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="1.5"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="1.75"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="2"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="2.5"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="3"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="3.5"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="4"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="4.5"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="5"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="6"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="7"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="8"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="9"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="10"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="15"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="20"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="25"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="30"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="40"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="50"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="60"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gateway",le="+Inf"} 16
controller_runtime_reconcile_time_seconds_sum{controller="gateway"} 0.4484847599999999
controller_runtime_reconcile_time_seconds_count{controller="gateway"} 16
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.005"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.01"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.025"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.05"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.1"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.15"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.2"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.25"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.3"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.35"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.4"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.45"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.6"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.7"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.8"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="0.9"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="1"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="1.25"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="1.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="1.75"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="2"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="2.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="3"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="3.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="4"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="4.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="6"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="7"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="8"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="9"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="10"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="15"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="20"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="25"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="30"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="40"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="50"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="60"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="gatewayclass",le="+Inf"} 1
controller_runtime_reconcile_time_seconds_sum{controller="gatewayclass"} 0.005564186
controller_runtime_reconcile_time_seconds_count{controller="gatewayclass"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.005"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.01"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.025"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.05"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.1"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.15"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.2"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.25"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.3"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.35"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.4"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.45"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.5"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.6"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.7"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.8"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="0.9"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="1"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="1.25"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="1.5"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="1.75"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="2"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="2.5"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="3"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="3.5"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="4"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="4.5"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="5"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="6"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="7"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="8"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="9"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="10"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="15"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="20"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="25"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="30"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="40"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="50"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="60"} 2
controller_runtime_reconcile_time_seconds_bucket{controller="httproute",le="+Inf"} 2
controller_runtime_reconcile_time_seconds_sum{controller="httproute"} 0.00039848499999999996
controller_runtime_reconcile_time_seconds_count{controller="httproute"} 2
# HELP controller_runtime_reconcile_total Total number of reconciliations per controller
# TYPE controller_runtime_reconcile_total counter
controller_runtime_reconcile_total{controller="gateway",result="error"} 16
controller_runtime_reconcile_total{controller="gateway",result="requeue"} 0
controller_runtime_reconcile_total{controller="gateway",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="gateway",result="success"} 0
controller_runtime_reconcile_total{controller="gatewayclass",result="error"} 0
controller_runtime_reconcile_total{controller="gatewayclass",result="requeue"} 0
controller_runtime_reconcile_total{controller="gatewayclass",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="gatewayclass",result="success"} 1
controller_runtime_reconcile_total{controller="httproute",result="error"} 0
controller_runtime_reconcile_total{controller="httproute",result="requeue"} 0
controller_runtime_reconcile_total{controller="httproute",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="httproute",result="success"} 2
controller_runtime_reconcile_total{controller="referencegrant",result="error"} 0
controller_runtime_reconcile_total{controller="referencegrant",result="requeue"} 0
controller_runtime_reconcile_total{controller="referencegrant",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="referencegrant",result="success"} 0
controller_runtime_reconcile_total{controller="secret",result="error"} 0
controller_runtime_reconcile_total{controller="secret",result="requeue"} 0
controller_runtime_reconcile_total{controller="secret",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="secret",result="success"} 0
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 5.0326e-05
go_gc_duration_seconds{quantile="0.25"} 6.8139e-05
go_gc_duration_seconds{quantile="0.5"} 8.8017e-05
go_gc_duration_seconds{quantile="0.75"} 0.000170052
go_gc_duration_seconds{quantile="1"} 0.000648598
go_gc_duration_seconds_sum 0.002040433
go_gc_duration_seconds_count 14
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 299
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.19.4"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 1.202836e+07
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 5.7742368e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.491707e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 448143
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 1.0184832e+07
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 1.202836e+07
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 1.3713408e+07
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.6433152e+07
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 65080
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 8.298496e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 3.014656e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.6752162589724767e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 513223
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 38400
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 46800
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 423360
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 471888
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 2.1488944e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 5.480301e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 3.407872e+06
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 3.407872e+06
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 5.122996e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 33
# HELP leader_election_master_status Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.
# TYPE leader_election_master_status gauge
leader_election_master_status{name="cilium-operator-resource-lock"} 1
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.72
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 102400
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 13
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 7.6136448e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.67521613414e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 8.04388864e+08
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP rest_client_requests_total Number of HTTP requests, partitioned by status code, method, and host.
# TYPE rest_client_requests_total counter
rest_client_requests_total{code="200",host="10.96.0.1:443",method="GET"} 266
rest_client_requests_total{code="200",host="10.96.0.1:443",method="PATCH"} 48
rest_client_requests_total{code="200",host="10.96.0.1:443",method="PUT"} 104
# HELP workqueue_adds_total Total number of adds handled by workqueue
# TYPE workqueue_adds_total counter
workqueue_adds_total{name="cilium-pod-queue"} 25
workqueue_adds_total{name="gateway"} 16
workqueue_adds_total{name="gatewayclass"} 1
workqueue_adds_total{name="httproute"} 2
workqueue_adds_total{name="node-queue"} 2
workqueue_adds_total{name="referencegrant"} 0
workqueue_adds_total{name="secret"} 0
# HELP workqueue_depth Current depth of workqueue
# TYPE workqueue_depth gauge
workqueue_depth{name="cilium-pod-queue"} 0
workqueue_depth{name="gateway"} 0
workqueue_depth{name="gatewayclass"} 0
workqueue_depth{name="httproute"} 0
workqueue_depth{name="node-queue"} 0
workqueue_depth{name="referencegrant"} 0
workqueue_depth{name="secret"} 0
# HELP workqueue_longest_running_processor_seconds How many seconds has the longest running processor for workqueue been running.
# TYPE workqueue_longest_running_processor_seconds gauge
workqueue_longest_running_processor_seconds{name="cilium-pod-queue"} 0
workqueue_longest_running_processor_seconds{name="gateway"} 0
workqueue_longest_running_processor_seconds{name="gatewayclass"} 0
workqueue_longest_running_processor_seconds{name="httproute"} 0
workqueue_longest_running_processor_seconds{name="node-queue"} 0
workqueue_longest_running_processor_seconds{name="referencegrant"} 0
workqueue_longest_running_processor_seconds{name="secret"} 0
# HELP workqueue_queue_duration_seconds How long in seconds an item stays in workqueue before being requested
# TYPE workqueue_queue_duration_seconds histogram
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="9.999999999999999e-06"} 23
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="9.999999999999999e-05"} 25
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="0.001"} 25
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="0.01"} 25
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="0.1"} 25
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="1"} 25
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="10"} 25
workqueue_queue_duration_seconds_bucket{name="cilium-pod-queue",le="+Inf"} 25
workqueue_queue_duration_seconds_sum{name="cilium-pod-queue"} 0.00017326999999999995
workqueue_queue_duration_seconds_count{name="cilium-pod-queue"} 25
workqueue_queue_duration_seconds_bucket{name="gateway",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="gateway",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="gateway",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="gateway",le="9.999999999999999e-06"} 3
workqueue_queue_duration_seconds_bucket{name="gateway",le="9.999999999999999e-05"} 15
workqueue_queue_duration_seconds_bucket{name="gateway",le="0.001"} 15
workqueue_queue_duration_seconds_bucket{name="gateway",le="0.01"} 15
workqueue_queue_duration_seconds_bucket{name="gateway",le="0.1"} 15
workqueue_queue_duration_seconds_bucket{name="gateway",le="1"} 16
workqueue_queue_duration_seconds_bucket{name="gateway",le="10"} 16
workqueue_queue_duration_seconds_bucket{name="gateway",le="+Inf"} 16
workqueue_queue_duration_seconds_sum{name="gateway"} 0.10061514599999997
workqueue_queue_duration_seconds_count{name="gateway"} 16
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="9.999999999999999e-05"} 1
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="0.001"} 1
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="0.01"} 1
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="0.1"} 1
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="1"} 1
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="10"} 1
workqueue_queue_duration_seconds_bucket{name="gatewayclass",le="+Inf"} 1
workqueue_queue_duration_seconds_sum{name="gatewayclass"} 4.6979e-05
workqueue_queue_duration_seconds_count{name="gatewayclass"} 1
workqueue_queue_duration_seconds_bucket{name="httproute",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="httproute",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="httproute",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="httproute",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="httproute",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="httproute",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="httproute",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="httproute",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="httproute",le="1"} 2
workqueue_queue_duration_seconds_bucket{name="httproute",le="10"} 2
workqueue_queue_duration_seconds_bucket{name="httproute",le="+Inf"} 2
workqueue_queue_duration_seconds_sum{name="httproute"} 0.201483426
workqueue_queue_duration_seconds_count{name="httproute"} 2
workqueue_queue_duration_seconds_bucket{name="node-queue",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="node-queue",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="node-queue",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="node-queue",le="9.999999999999999e-06"} 1
workqueue_queue_duration_seconds_bucket{name="node-queue",le="9.999999999999999e-05"} 1
workqueue_queue_duration_seconds_bucket{name="node-queue",le="0.001"} 1
workqueue_queue_duration_seconds_bucket{name="node-queue",le="0.01"} 1
workqueue_queue_duration_seconds_bucket{name="node-queue",le="0.1"} 2
workqueue_queue_duration_seconds_bucket{name="node-queue",le="1"} 2
workqueue_queue_duration_seconds_bucket{name="node-queue",le="10"} 2
workqueue_queue_duration_seconds_bucket{name="node-queue",le="+Inf"} 2
workqueue_queue_duration_seconds_sum{name="node-queue"} 0.098973029
workqueue_queue_duration_seconds_count{name="node-queue"} 2
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="1"} 0
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="10"} 0
workqueue_queue_duration_seconds_bucket{name="referencegrant",le="+Inf"} 0
workqueue_queue_duration_seconds_sum{name="referencegrant"} 0
workqueue_queue_duration_seconds_count{name="referencegrant"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="1e-06"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="9.999999999999999e-06"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="9.999999999999999e-05"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="0.001"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="0.01"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="0.1"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="1"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="10"} 0
workqueue_queue_duration_seconds_bucket{name="secret",le="+Inf"} 0
workqueue_queue_duration_seconds_sum{name="secret"} 0
workqueue_queue_duration_seconds_count{name="secret"} 0
# HELP workqueue_retries_total Total number of retries handled by workqueue
# TYPE workqueue_retries_total counter
workqueue_retries_total{name="cilium-pod-queue"} 0
workqueue_retries_total{name="gateway"} 16
workqueue_retries_total{name="gatewayclass"} 0
workqueue_retries_total{name="httproute"} 0
workqueue_retries_total{name="node-queue"} 0
workqueue_retries_total{name="referencegrant"} 0
workqueue_retries_total{name="secret"} 0
# HELP workqueue_unfinished_work_seconds How many seconds of work has been done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases.
# TYPE workqueue_unfinished_work_seconds gauge
workqueue_unfinished_work_seconds{name="cilium-pod-queue"} 0
workqueue_unfinished_work_seconds{name="gateway"} 0
workqueue_unfinished_work_seconds{name="gatewayclass"} 0
workqueue_unfinished_work_seconds{name="httproute"} 0
workqueue_unfinished_work_seconds{name="node-queue"} 0
workqueue_unfinished_work_seconds{name="referencegrant"} 0
workqueue_unfinished_work_seconds{name="secret"} 0
# HELP workqueue_work_duration_seconds How long in seconds processing an item from workqueue takes.
# TYPE workqueue_work_duration_seconds histogram
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="9.999999999999999e-05"} 25
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="0.001"} 25
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="0.01"} 25
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="0.1"} 25
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="1"} 25
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="10"} 25
workqueue_work_duration_seconds_bucket{name="cilium-pod-queue",le="+Inf"} 25
workqueue_work_duration_seconds_sum{name="cilium-pod-queue"} 0.00108232
workqueue_work_duration_seconds_count{name="cilium-pod-queue"} 25
workqueue_work_duration_seconds_bucket{name="gateway",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="gateway",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="gateway",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="gateway",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="gateway",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="gateway",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="gateway",le="0.01"} 1
workqueue_work_duration_seconds_bucket{name="gateway",le="0.1"} 15
workqueue_work_duration_seconds_bucket{name="gateway",le="1"} 16
workqueue_work_duration_seconds_bucket{name="gateway",le="10"} 16
workqueue_work_duration_seconds_bucket{name="gateway",le="+Inf"} 16
workqueue_work_duration_seconds_sum{name="gateway"} 0.448779929
workqueue_work_duration_seconds_count{name="gateway"} 16
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="0.01"} 1
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="0.1"} 1
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="1"} 1
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="10"} 1
workqueue_work_duration_seconds_bucket{name="gatewayclass",le="+Inf"} 1
workqueue_work_duration_seconds_sum{name="gatewayclass"} 0.005595816
workqueue_work_duration_seconds_count{name="gatewayclass"} 1
workqueue_work_duration_seconds_bucket{name="httproute",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="httproute",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="httproute",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="httproute",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="httproute",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="httproute",le="0.001"} 2
workqueue_work_duration_seconds_bucket{name="httproute",le="0.01"} 2
workqueue_work_duration_seconds_bucket{name="httproute",le="0.1"} 2
workqueue_work_duration_seconds_bucket{name="httproute",le="1"} 2
workqueue_work_duration_seconds_bucket{name="httproute",le="10"} 2
workqueue_work_duration_seconds_bucket{name="httproute",le="+Inf"} 2
workqueue_work_duration_seconds_sum{name="httproute"} 0.000424283
workqueue_work_duration_seconds_count{name="httproute"} 2
workqueue_work_duration_seconds_bucket{name="node-queue",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="node-queue",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="node-queue",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="node-queue",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="node-queue",le="9.999999999999999e-05"} 1
workqueue_work_duration_seconds_bucket{name="node-queue",le="0.001"} 2
workqueue_work_duration_seconds_bucket{name="node-queue",le="0.01"} 2
workqueue_work_duration_seconds_bucket{name="node-queue",le="0.1"} 2
workqueue_work_duration_seconds_bucket{name="node-queue",le="1"} 2
workqueue_work_duration_seconds_bucket{name="node-queue",le="10"} 2
workqueue_work_duration_seconds_bucket{name="node-queue",le="+Inf"} 2
workqueue_work_duration_seconds_sum{name="node-queue"} 0.000182125
workqueue_work_duration_seconds_count{name="node-queue"} 2
workqueue_work_duration_seconds_bucket{name="referencegrant",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="referencegrant",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="referencegrant",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="referencegrant",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="referencegrant",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="referencegrant",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="referencegrant",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="referencegrant",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="referencegrant",le="1"} 0
workqueue_work_duration_seconds_bucket{name="referencegrant",le="10"} 0
workqueue_work_duration_seconds_bucket{name="referencegrant",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="referencegrant"} 0
workqueue_work_duration_seconds_count{name="referencegrant"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="1e-08"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="1e-07"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="1e-06"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="9.999999999999999e-06"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="9.999999999999999e-05"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="0.001"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="0.01"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="0.1"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="1"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="10"} 0
workqueue_work_duration_seconds_bucket{name="secret",le="+Inf"} 0
workqueue_work_duration_seconds_sum{name="secret"} 0
workqueue_work_duration_seconds_count{name="secret"} 0
```

</details>
