### PR TITLE
test: Remove IPsec + ep routes + VXLAN from ginkgo tests

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -200,23 +200,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}
 		})
 
-		SkipItIf(func() bool {
-			// IPsec + encapsulation requires Linux 4.19.
-			// We also can't disable KPR on GKE at the moment (cf. #16597).
-			return helpers.RunsWithoutKubeProxy() || helpers.DoesNotRunOn419OrLaterKernel() || helpers.RunsOnGKE() || helpers.RunsOnAKS()
-		}, "Check connectivity with transparent encryption, VXLAN, and endpoint routes", func() {
-			deploymentManager.Deploy(helpers.CiliumNamespace, IPSecSecret)
-			options := map[string]string{
-				"kubeProxyReplacement":   "disabled",
-				"encryption.enabled":     "true",
-				"endpointRoutes.enabled": "true",
-			}
-			enableVXLANTunneling(options)
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
-			validateBPFTunnelMap()
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test with IPsec between nodes failed")
-		}, 600)
-
 		It("Check iptables masquerading with random-fully", func() {
 			options := map[string]string{
 				"bpf.masquerade":       "false",


### PR DESCRIPTION
Commit 7dd3fc25 ("workflows: Cover IPsec+VXLAN+endpoint routes in datapath tests") added a new ginkgo test case to cover IPsec + VXLAN + endpoint routes. This test case is however now also covered in the Cilium Datapath workflow, so we can remove it from ginkgo. It was missed in 5c811513 ("test/k8s: Remove some encryption tests") because the two pull requests happened almost at the same time.

Fixes: https://github.com/cilium/cilium/pull/22830.