### PR TITLE
cilium-health status: fix endpoint reachability in succinct view

### DIFF
--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -294,14 +294,14 @@ func GetEndpointSecondaryAddresses(node *models.NodeStatus) []*models.PathStatus
 }
 
 // GetAllEndpointAddresses returns a list of all addresses (primary and any
-// and any secondary) for the health endpoint within a given node.
+// secondary) for the health endpoint within a given node.
 // If node.HealthEndpoint is nil, returns nil.
 func GetAllEndpointAddresses(node *models.NodeStatus) []*models.PathStatus {
 	if node.HealthEndpoint == nil {
 		return nil
 	}
 
-	return node.HealthEndpoint.SecondaryAddresses
+	return append([]*models.PathStatus{node.HealthEndpoint.PrimaryAddress}, node.HealthEndpoint.SecondaryAddresses...)
 }
 
 func formatNodeStatus(w io.Writer, node *models.NodeStatus, printAll, succinct, verbose, localhost bool) {


### PR DESCRIPTION
This PR fixes the reporting of `cilium-health status --succinct`, and specifically of the endpoints reachability column in succinct view. The issue was caused by the `GetAllEndpointAddresses` function returning only secondary addresses, causing the status to be reported as reachable in case of failures associated with the primary address (or if this was the only one present).

It additionally fixes the reporting of the `cilium_unreachable_health_endpoints` metric, which was also affected by the same issue.

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>

<!-- Description of change -->

Fixes: #issue-number

```release-note
cilium-health status: fix endpoint reachability in succinct view
```
