### PR TITLE
kvstore: Propagate ClusterID with Service

### DIFF
--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -122,7 +122,7 @@ func nodeOverrideFromCEW(n *nodeTypes.RegisterNode, cew *ciliumv2.CiliumExternal
 
 	// Override cluster
 	nk.Cluster = cfg.clusterName
-	nk.ClusterID = clusterID
+	nk.ClusterID = cfg.clusterID
 	nk.Labels[k8sConst.PolicyLabelCluster] = cfg.clusterName
 
 	// Override CIDRs if defined

--- a/pkg/service/store/store.go
+++ b/pkg/service/store/store.go
@@ -72,6 +72,9 @@ type ClusterService struct {
 
 	// Shared is true when the service should be exposed/shared to other clusters
 	Shared bool `json:"shared"`
+
+	// ClusterID is the cluster ID the service is configured in
+	ClusterID uint32 `json:"clusterID"`
 }
 
 func (s *ClusterService) String() string {


### PR DESCRIPTION
This is a part of Cluster Mesh with overlapping PodCIDR support. Please see the commit message for more details. This includes the kvstore data format change (added a new field), but shouldn't make any compatibility issue since no one using that yet.

```release-note
kvstore: Propagate ClusterID with Service
```
