### PR TITLE
Uniform leftover annotations in clustermesh docs

### DIFF
--- a/Documentation/network/clustermesh/services.rst
+++ b/Documentation/network/clustermesh/services.rst
@@ -116,7 +116,7 @@ Global and Shared Services Reference
 
 The flow chart below summarizes the overall behavior considering a service present
 in two clusters (i.e., Cluster1 and Cluster2), and different combinations of the
-``io.cilium/global-service`` and ``io.cilium/shared-service`` annotation values.
+``service.cilium.io/global`` and ``service.cilium.io/shared`` annotation values.
 The terminating nodes represent the endpoints used in each combination by the two
 clusters for the service under examination.
 


### PR DESCRIPTION
This PR updates the annotation keys in the newly added global and shared services reference documentation.
#23395 and #23408 were merged almost at the same time, and these two occurrences happened to remain unchanged.

Marking for backport to v1.13, as both #23395 and #23408 were so. 

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>

<!-- Description of change -->

```release-note
Uniform leftover annotations in clustermesh docs
```
