### PR TITLE
test: ensure cleanup in hubble "test L7 flow"

### DIFF
--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -225,8 +225,8 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 		})
 
 		It("Test L7 Flow", func() {
-			addVisibilityAnnotation(namespaceForTest, app1Labels, "Ingress", "80", "TCP", "HTTP")
 			defer removeVisibilityAnnotation(namespaceForTest, app1Labels)
+			addVisibilityAnnotation(namespaceForTest, app1Labels, "Ingress", "80", "TCP", "HTTP")
 
 			ctx, cancel := context.WithTimeout(context.Background(), helpers.MidCommandTimeout)
 			defer cancel()
@@ -250,8 +250,8 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 		})
 
 		It("Test L7 Flow with hubble-relay", func() {
-			addVisibilityAnnotation(namespaceForTest, app1Labels, "Ingress", "80", "TCP", "HTTP")
 			defer removeVisibilityAnnotation(namespaceForTest, app1Labels)
+			addVisibilityAnnotation(namespaceForTest, app1Labels, "Ingress", "80", "TCP", "HTTP")
 
 			res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))


### PR DESCRIPTION
Move the deferral of the annotation removal before its addition, to ensure it is removed if the post-addition check fails. This prevents cascading failures.

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>

<!-- Description of change -->

Fixes: #issue-number

```release-note
test: ensure cleanup in hubble "test L7 flow"
```
