### PR TITLE
egressgw: cache matching endpoints in policy config

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -235,6 +235,18 @@ func (manager *Manager) onChangeNodeLocked() {
 	manager.reconcile()
 }
 
+func (manager *Manager) updatePoliciesMatchedEndpointIDs() {
+	for _, policy := range manager.policyConfigs {
+		policy.matchedEndpointIDs = make(map[endpointID]struct{})
+
+		for _, endpoint := range manager.epDataStore {
+			if policy.matchesEndpointLabels(endpoint) {
+				policy.matchedEndpointIDs[endpoint.id] = struct{}{}
+			}
+		}
+	}
+}
+
 func (manager *Manager) regenerateGatewayConfigs() {
 	for _, policyConfig := range manager.policyConfigs {
 		policyConfig.regenerateGatewayConfig(manager)
@@ -419,6 +431,8 @@ func (manager *Manager) reconcile() {
 	if !manager.k8sCacheSyncedChecker.K8sCacheIsSynced() {
 		return
 	}
+
+	manager.updatePoliciesMatchedEndpointIDs()
 
 	manager.regenerateGatewayConfigs()
 

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -208,14 +208,14 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	// Test if disabling the --install-egress-gateway-routes agent option
 	// will result in stale IP routes/rules getting removed
 	egressGatewayManager.installRoutes = false
-	egressGatewayManager.reconcile()
+	egressGatewayManager.reconcile(eventNone)
 
 	assertIPRules(c, []ipRule{})
 
 	// Enabling it back should result in the routes/rules being in place
 	// again
 	egressGatewayManager.installRoutes = true
-	egressGatewayManager.reconcile()
+	egressGatewayManager.reconcile(eventNone)
 
 	assertIPRules(c, []ipRule{
 		{ep1IP, destCIDR, egressCIDR1, testInterface1Idx},

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -81,6 +81,17 @@ func (config *PolicyConfig) matchesEndpointLabels(endpointInfo *endpointMetadata
 	return false
 }
 
+// updateMatchedEndpointIDs update the policy's cache of matched endpoint IDs
+func (config *PolicyConfig) updateMatchedEndpointIDs(epDataStore map[endpointID]*endpointMetadata) {
+	config.matchedEndpointIDs = make(map[endpointID]struct{})
+
+	for _, endpoint := range epDataStore {
+		if config.matchesEndpointLabels(endpoint) {
+			config.matchedEndpointIDs[endpoint.id] = struct{}{}
+		}
+	}
+}
+
 // selectsEndpoint determines if the given endpoint is selected by the policy
 // config
 func (config *PolicyConfig) selectsEndpoint(endpointInfo *endpointMetadata) bool {


### PR DESCRIPTION
Currently whenever we need to determine if a policy matches an endpoint, we call the `(*EndpointSelector).Matches()` method passing the target endpoint's labels.

Turns out this method is quite expensive so instead of recomputing each time if a policy matches a given endpoint, cache this information once for each `(*Manager)reconcile()` invocation, and then in `(*PolicyConfig)selectsEndpoint()` use the cached information.