### PR TITLE
clustermesh: correctly remove remoteCache on connection disruption

### DIFF
--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -322,6 +322,8 @@ jobs:
 
       - name: Wait for cluster mesh status to be ready
         run: |
+          cilium status --wait --context ${{ steps.contexts.outputs.context1 }}
+          cilium status --wait --context ${{ steps.contexts.outputs.context2 }}
           cilium clustermesh status --wait --context ${{ steps.contexts.outputs.context1 }}
           cilium clustermesh status --wait --context ${{ steps.contexts.outputs.context2 }}
 

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -113,9 +113,11 @@ func (f *FakeRefcountingIdentityAllocator) Close() {
 func (f *FakeRefcountingIdentityAllocator) InitIdentityAllocator(versioned.Interface, k8sCache.Store) <-chan struct{} {
 	return nil
 }
-func (f *FakeRefcountingIdentityAllocator) WatchRemoteIdentities(kvstore.BackendOperations) (*allocator.RemoteCache, error) {
+func (f *FakeRefcountingIdentityAllocator) WatchRemoteIdentities(string, kvstore.BackendOperations) (*allocator.RemoteCache, error) {
 	return nil, nil
 }
+
+func (f *FakeRefcountingIdentityAllocator) RemoveRemoteIdentities(string) {}
 
 func (ds *DaemonFQDNSuite) SetUpTest(c *C) {
 	d := &Daemon{}

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -13,13 +13,12 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
-	"github.com/cilium/cilium/pkg/allocator"
+	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	identitymodel "github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -93,9 +92,9 @@ func (h *getIdentityEndpoints) Handle(params GetIdentityEndpointsParams) middlew
 // in unit tests.
 type CachingIdentityAllocator interface {
 	cache.IdentityAllocator
+	clustermesh.RemoteIdentityWatcher
 
 	InitIdentityAllocator(versioned.Interface, k8sCache.Store) <-chan struct{}
-	WatchRemoteIdentities(kvstore.BackendOperations) (*allocator.RemoteCache, error)
 	Close()
 }
 

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -129,7 +129,7 @@ type Allocator struct {
 
 	// remoteCaches is the list of additional remote caches being watched
 	// in addition to the main cache
-	remoteCaches map[*RemoteCache]struct{}
+	remoteCaches map[string]*RemoteCache
 
 	// stopGC is the channel used to stop the garbage collector
 	stopGC chan struct{}
@@ -289,7 +289,7 @@ func NewAllocator(typ AllocatorKey, backend Backend, opts ...AllocatorOption) (*
 		localKeys:    newLocalKeys(),
 		stopGC:       make(chan struct{}),
 		suffix:       uuid.New().String()[:10],
-		remoteCaches: map[*RemoteCache]struct{}{},
+		remoteCaches: map[string]*RemoteCache{},
 		backoffTemplate: backoff.Exponential{
 			Min:    time.Duration(20) * time.Millisecond,
 			Factor: 2.0,
@@ -415,7 +415,7 @@ func (a *Allocator) ForeachCache(cb RangeFunc) {
 	a.mainCache.foreach(cb)
 
 	a.remoteCachesMutex.RLock()
-	for rc := range a.remoteCaches {
+	for _, rc := range a.remoteCaches {
 		rc.cache.foreach(cb)
 	}
 	a.remoteCachesMutex.RUnlock()
@@ -727,7 +727,7 @@ func (a *Allocator) GetIncludeRemoteCaches(ctx context.Context, key AllocatorKey
 
 	// check remote caches
 	a.remoteCachesMutex.RLock()
-	for rc := range a.remoteCaches {
+	for _, rc := range a.remoteCaches {
 		if id := rc.cache.get(encoded); id != idpool.NoID {
 			a.remoteCachesMutex.RUnlock()
 			return id, nil
@@ -757,7 +757,7 @@ func (a *Allocator) GetByIDIncludeRemoteCaches(ctx context.Context, id idpool.ID
 
 	// check remote caches
 	a.remoteCachesMutex.RLock()
-	for rc := range a.remoteCaches {
+	for _, rc := range a.remoteCaches {
 		if key := rc.cache.getByID(id); key != nil {
 			a.remoteCachesMutex.RUnlock()
 			return key, nil
@@ -894,19 +894,26 @@ type RemoteCache struct {
 // represents by the provided backend. A local cache of all identities of that
 // kvstore will be maintained in the RemoteCache structure returned and will
 // start being reported in the identities returned by the ForeachCache()
-// function.
-func (a *Allocator) WatchRemoteKVStore(remoteAlloc *Allocator) *RemoteCache {
+// function. RemoteName should be unique per logical "remote".
+func (a *Allocator) WatchRemoteKVStore(remoteName string, remoteAlloc *Allocator) *RemoteCache {
 	rc := &RemoteCache{
 		cache: newCache(remoteAlloc),
 	}
 
 	a.remoteCachesMutex.Lock()
-	a.remoteCaches[rc] = struct{}{}
+	a.remoteCaches[remoteName] = rc
 	a.remoteCachesMutex.Unlock()
 
 	rc.cache.start()
 
 	return rc
+}
+
+// RemoveRemoteKVStore removes any reference to a remote allocator / kvstore.
+func (a *Allocator) RemoveRemoteKVStore(remoteName string) {
+	a.remoteCachesMutex.Lock()
+	delete(a.remoteCaches, remoteName)
+	a.remoteCachesMutex.Unlock()
 }
 
 // NumEntries returns the number of entries in the remote cache
@@ -919,11 +926,7 @@ func (rc *RemoteCache) NumEntries() int {
 }
 
 // Close stops watching for identities in the kvstore associated with the
-// remote cache and will clear the local cache.
+// remote cache.
 func (rc *RemoteCache) Close() {
-	rc.cache.allocator.remoteCachesMutex.Lock()
-	delete(rc.cache.allocator.remoteCaches, rc)
-	rc.cache.allocator.remoteCachesMutex.Unlock()
-
 	rc.cache.stop()
 }

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -887,7 +887,7 @@ type AllocatorEvent struct {
 // identities. The contents are not directly accessible but will be merged into
 // the ForeachCache() function.
 type RemoteCache struct {
-	cache cache
+	cache *cache
 }
 
 // WatchRemoteKVStore starts watching an allocator base prefix the kvstore
@@ -897,14 +897,12 @@ type RemoteCache struct {
 // function. RemoteName should be unique per logical "remote".
 func (a *Allocator) WatchRemoteKVStore(remoteName string, remoteAlloc *Allocator) *RemoteCache {
 	rc := &RemoteCache{
-		cache: newCache(remoteAlloc),
+		cache: &remoteAlloc.mainCache,
 	}
 
 	a.remoteCachesMutex.Lock()
 	a.remoteCaches[remoteName] = rc
 	a.remoteCachesMutex.Unlock()
-
-	rc.cache.start()
 
 	return rc
 }

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -122,8 +122,12 @@ func GetClusterConfig(clusterName string, backend kvstore.BackendOperations) (*c
 // allocated on a remote cluster.
 type RemoteIdentityWatcher interface {
 	// WatchRemoteIdentities starts watching for identities in another kvstore and
-	// syncs all identities to the local identity cache.
-	WatchRemoteIdentities(backend kvstore.BackendOperations) (*allocator.RemoteCache, error)
+	// syncs all identities to the local identity cache. RemoteName should be unique
+	// unless replacing an existing remote's backend.
+	WatchRemoteIdentities(remoteName string, backend kvstore.BackendOperations) (*allocator.RemoteCache, error)
+
+	// RemoveRemoteIdentities removes any reference to a remote identity source.
+	RemoveRemoteIdentities(name string)
 
 	// Close stops the watcher.
 	Close()

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -239,7 +239,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				}
 				rc.swg.Stop()
 
-				remoteIdentityCache, err := allocator.WatchRemoteIdentities(backend)
+				remoteIdentityCache, err := allocator.WatchRemoteIdentities(rc.name, backend)
 				if err != nil {
 					remoteServices.Close(ctx)
 					remoteNodes.Close(ctx)
@@ -269,6 +269,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				rc.releaseOldConnection()
 				rc.mesh.metricTotalNodes.WithLabelValues(rc.mesh.conf.Name, rc.mesh.conf.NodeName, rc.name).Set(float64(rc.remoteNodes.NumEntries()))
 				rc.mesh.metricReadinessStatus.WithLabelValues(rc.mesh.conf.Name, rc.mesh.conf.NodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
+				allocator.RemoveRemoteIdentities(rc.name)
 				rc.getLogger().Info("All resources of remote cluster cleaned up")
 				return nil
 			},

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -439,19 +439,26 @@ func (m *CachingIdentityAllocator) ReleaseSlice(ctx context.Context, owner Ident
 }
 
 // WatchRemoteIdentities starts watching for identities in another kvstore and
-// syncs all identities to the local identity cache.
-func (m *CachingIdentityAllocator) WatchRemoteIdentities(backend kvstore.BackendOperations) (*allocator.RemoteCache, error) {
+// syncs all identities to the local identity cache. remoteName must be unique,
+// unless replacing the kvstore for an existing remote.
+func (m *CachingIdentityAllocator) WatchRemoteIdentities(remoteName string, backend kvstore.BackendOperations) (*allocator.RemoteCache, error) {
 	<-m.globalIdentityAllocatorInitialized
 
 	remoteAllocatorBackend, err := kvstoreallocator.NewKVStoreBackend(m.identitiesPath, m.owner.GetNodeSuffix(), &key.GlobalIdentity{}, backend)
 	if err != nil {
-		return nil, fmt.Errorf("Error setting up remote allocator backend: %s", err)
+		return nil, fmt.Errorf("error setting up remote allocator backend: %s", err)
 	}
 
 	remoteAlloc, err := allocator.NewAllocator(&key.GlobalIdentity{}, remoteAllocatorBackend, allocator.WithEvents(m.IdentityAllocator.GetEvents()))
 	if err != nil {
-		return nil, fmt.Errorf("Unable to initialize remote Identity Allocator: %s", err)
+		return nil, fmt.Errorf("unable to initialize remote Identity Allocator: %s", err)
 	}
 
-	return m.IdentityAllocator.WatchRemoteKVStore(remoteAlloc), nil
+	return m.IdentityAllocator.WatchRemoteKVStore(remoteName, remoteAlloc), nil
+}
+
+func (m *CachingIdentityAllocator) RemoveRemoteIdentities(name string) {
+	if m.IdentityAllocator != nil {
+		m.IdentityAllocator.RemoveRemoteKVStore(name)
+	}
 }

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -616,7 +616,7 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 	c.Assert(err, IsNil)
 	a2, err := allocator.NewAllocator(TestAllocatorKey(""), backend2, allocator.WithMax(idpool.ID(256)))
 	c.Assert(err, IsNil)
-	rc := a.WatchRemoteKVStore(a2)
+	rc := a.WatchRemoteKVStore("", a2)
 	c.Assert(rc, Not(IsNil))
 
 	// wait for remote cache to be populated


### PR DESCRIPTION
Upon reconnect, we failed to remove the old remoteCache (we were looking at the wrong Allocator on cleanup), meaning that every time we reconnected, all old remoteCaches were kept around.

This was, at best, a memory leak, and at worst meant that we continued to read stale data even after reconnecting, depending on the ordering of a map iteration.

Many thanks to @oblazek, who found the root cause.

Fixes: #22988
Fixes: #13446

Signed-off-by: Casey Callendrello <cdc@isovalent.com>

```release-note
Fixes a memory leak and (possible) source of stale data for Clustermesh whenever the connection to the remote cluster is disrupted or restarted.
```
