### PR TITLE
gha: Rename ConformanceKind1.19 to ConformanceKind

### DIFF
--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -1,4 +1,4 @@
-name: ConformanceKind1.19
+name: ConformanceKind
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:


### PR DESCRIPTION
After #22325 is merged, this job is no longer using k8s 1.19, so it's better to rename the job to just ConformanceKind to avoid any potential confusion.

Signed-off-by: Tam Mach <tam.mach@cilium.io>