### PR TITLE
k8s: use core/v1 consts for topology-aware hints annotation/label

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -31,8 +31,6 @@ const (
 	serviceAffinityNone   = ""
 	serviceAffinityLocal  = "local"
 	serviceAffinityRemote = "remote"
-
-	annotationTopologyAwareHints = "service.kubernetes.io/topology-aware-hints"
 )
 
 func getAnnotationIncludeExternal(svc *slim_corev1.Service) bool {
@@ -71,7 +69,7 @@ func getAnnotationServiceAffinity(svc *slim_corev1.Service) string {
 }
 
 func getAnnotationTopologyAwareHints(svc *slim_corev1.Service) bool {
-	if value, ok := svc.ObjectMeta.Annotations[annotationTopologyAwareHints]; ok {
+	if value, ok := svc.ObjectMeta.Annotations[v1.AnnotationTopologyAwareHints]; ok {
 		return strings.ToLower(value) == "auto"
 	}
 

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -34,9 +34,6 @@ const (
 	DeleteService
 )
 
-// Used to implement the topology aware hints.
-const LabelTopologyZone = "topology.kubernetes.io/zone"
-
 // String returns the cache action as a string
 func (c CacheAction) String() string {
 	switch c {
@@ -730,7 +727,7 @@ func (s *ServiceCache) updateSelfNodeLabels(labels map[string]string,
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	zone := labels[LabelTopologyZone]
+	zone := labels[core_v1.LabelTopologyZone]
 
 	if s.selfNodeZoneLabel == zone {
 		return

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -1068,7 +1068,7 @@ func (s *K8sSuite) TestServiceEndpointFiltering(c *check.C) {
 			Namespace: "bar",
 			Labels:    map[string]string{"foo": "bar"},
 			Annotations: map[string]string{
-				annotationTopologyAwareHints: "auto",
+				v1.AnnotationTopologyAwareHints: "auto",
 			},
 		},
 		Spec: slim_corev1.ServiceSpec{
@@ -1107,7 +1107,7 @@ func (s *K8sSuite) TestServiceEndpointFiltering(c *check.C) {
 	k8sNode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{LabelTopologyZone: "test-zone-2"},
+			Labels: map[string]string{v1.LabelTopologyZone: "test-zone-2"},
 		},
 	}
 
@@ -1152,7 +1152,7 @@ func (s *K8sSuite) TestServiceEndpointFiltering(c *check.C) {
 
 	// Set the node's zone to test-zone-1 to select the first endpoint
 	k8sNode.ObjectMeta.Labels = map[string]string{
-		LabelTopologyZone: "test-zone-1",
+		v1.LabelTopologyZone: "test-zone-1",
 	}
 	svcCache.OnUpdateNode(k8sNode, k8sNode, swg)
 	c.Assert(testutils.WaitUntil(func() bool {

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -201,7 +202,7 @@ func (s *K8sSuite) TestParseService(c *check.C) {
 		option.Config.EnableNodePort = oldNodePort
 	}()
 	objMeta.Annotations = map[string]string{
-		annotationTopologyAwareHints: "auto",
+		corev1.AnnotationTopologyAwareHints: "auto",
 	}
 	k8sSvc = &slim_corev1.Service{
 		ObjectMeta: objMeta,


### PR DESCRIPTION
No need to duplicate these in Cilium's `k8s` package, they are defined in `k8s.io/api/core/v1` already, see:

https://github.com/cilium/cilium/blob/b8786b36e93daf3c779216b6f23327ff19f8cc66/vendor/k8s.io/api/core/v1/annotation_key_constants.go#L147-L150 https://github.com/cilium/cilium/blob/b8786b36e93daf3c779216b6f23327ff19f8cc66/vendor/k8s.io/api/core/v1/well_known_labels.go#L22
