### PR TITLE
contrib: Set IPv6 for dual-stack Kubenetes nodeIP on dev VM

### DIFF
--- a/contrib/k8s/k8s-extract-clustermesh-nodeport-secret.sh
+++ b/contrib/k8s/k8s-extract-clustermesh-nodeport-secret.sh
@@ -7,7 +7,7 @@ set -e
 
 NAMESPACE=$(kubectl get pod -l k8s-app=clustermesh-apiserver -o jsonpath='{.items[0].metadata.namespace}' --all-namespaces)
 NODE_NAME=$(kubectl -n $NAMESPACE get pod -l k8s-app=clustermesh-apiserver -o jsonpath='{.items[0].spec.nodeName}')
-NODE_IP=$(kubectl -n $NAMESPACE get node $NODE_NAME -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+NODE_IP=$(kubectl -n $NAMESPACE get node $NODE_NAME -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}' | awk '{print $1}')
 NODE_PORT=$(kubectl -n $NAMESPACE get svc clustermesh-apiserver -o jsonpath='{.spec.ports[0].nodePort}')
 CLUSTER_NAME=$(kubectl -n $NAMESPACE get cm cilium-config -o jsonpath='{.data.cluster-name}')
 # TODO: once v1.10 is the minimum version supported, we can replace the


### PR DESCRIPTION
The development setup using the provided Vagrantfile will give a dual-stack Kubernetes cluster in the dev VM, but a hostNetwork pod deployed on it cannot show an IPv6 address.

This is because the kubelet is deployed using the incomplete `--node-ip` parameter: to enable dual-stack mode, we must pass both IPv6 address and IPv4 address via `--node-ip` to kubelet.

This PR completes the `--node-ip` parameter and fixes the issue.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>

Fixes: #23503
