### PR TITLE
ci: increase Jenkinsfile timeout for 1.10 branch

### DIFF
--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }

--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }

--- a/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-runtime-kernel.Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }

--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }


### PR DESCRIPTION
This is a hack to work around 1.10 Jenkins jobs timing out in backport testing due to having to download non-cached Vagrant boxes.

Full context:

We use a custom Vagrant cache to accelerate setting up Jenkins runners, but we only cache the latest 3 stable branches and `master` because testing is only conducted against those (or branches based off those).

There is an edge case for the overlap time where the newest stable branch (here 1.13) exists but has not been released yet, so the oldest stable (here 1.10) is still officially supported.

Caching an additional stable branch would increase the already long time it takes for runners to come up, and would not be much useful given the low volume of pipelines running against a soon-to-be deprecated branch.

Instead, we elect to allow a greater timeout on the 1.10 branch to compensate for the additional Vagrant box download time.