### PR TITLE
renovate: allow golang 1.20 in "v1.13" and "master" branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,9 +59,8 @@
         "docker.io/library/golang",
         "go"
       ],
-      "allowedVersions": "<1.20",
+      "allowedVersions": "<1.21",
       "matchBaseBranches": [
-        "master",
         "v1.13"
       ]
     },


### PR DESCRIPTION
Since we haven't released v1.13.0 we will allow renovate bot to update golang's dependency to the just released 1.20.

Also, removed any constrains in golang for the "master" branch since we will always use the latest golang version.

Signed-off-by: André Martins <andre@cilium.io>