### PR TITLE
ipcache: Fix wrong assertion in ipcache metadata test

### DIFF
--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -134,7 +134,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Len(t, remaining, 0)
-	assert.NotContains(t, IPIdentityCache.metadata.m[worldPrefix].ToLabels(), labels.LabelKubeAPIServer)
+	assert.NotContains(t, IPIdentityCache.metadata.m[worldPrefix].ToLabels(), labels.IDNameKubeAPIServer)
 	assert.Equal(t, 1, id.ReferenceCount) // CIDR policy is left
 }
 


### PR DESCRIPTION
By code inspection, I realized that labels.LabelKubeAPIServer was not
the right key to use, but rather labels.IDNameKubeAPIServer. The test
still passed because it was asserting if the label was NOT in the label
set, which it wasn't, but not for the right reasons.

Fix the assertion in case of regressions in the future.

Fixes: f1b30c1f432 ("ipcache: Generate new identity if label is removed")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
