### PR TITLE
node: require ipv4 address when wireguard is enabled

### DIFF
--- a/Documentation/security/network/encryption-wireguard.rst
+++ b/Documentation/security/network/encryption-wireguard.rst
@@ -231,6 +231,9 @@ which may be resolved in upcoming Cilium releases:
 
 The current status of these limitations is tracked in :gh-issue:`15462`.
 
+In addition, WireGuard encryption is not currently supported in combination with
+IPv6-only clusters.
+
 Legal
 =====
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -551,7 +551,7 @@ const mismatchRouterIPsMsg = "Mismatch of router IPs found during restoration. T
 // ValidatePostInit validates the entire addressing setup and completes it as
 // required
 func ValidatePostInit() error {
-	if option.Config.EnableIPv4 || option.Config.Tunnel != option.TunnelDisabled {
+	if option.Config.EnableIPv4 || option.Config.Tunnel != option.TunnelDisabled || option.Config.EnableWireguard {
 		if GetIPv4() == nil {
 			return fmt.Errorf("external IPv4 node address could not be derived, please configure via --ipv4-node")
 		}


### PR DESCRIPTION
Currently, wireguard encryption is not performed when the nodes have ipv6-only addresses, since it relies on the `tunnel_endpoint` field of the ipcache map (which is not set in such case). This limitation has been removed with the reworking performed as part of #19401 (not backported to 1.13). As for previous versions, this PR adds a check to prevent the agent from starting in this configuration. Additionally, it adds a note about the limitation in the docs page.

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>

<!-- Description of change -->

Related: #23545

```release-note
node: require ipv4 address when wireguard is enabled
```
