### PR TITLE
ipsec + ipv6-only nodes: add limitation note and better error handling

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -214,3 +214,4 @@ Limitations
     * Transparent encryption is not currently supported when chaining Cilium on
       top of other CNI plugins. For more information, see :gh-issue:`15596`.
     * :ref:`HostPolicies` are not currently supported with IPsec encryption.
+    * IPsec encryption is not currently supported in combination with IPv6-only clusters.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1351,6 +1351,10 @@ func initEnv() {
 		log.Fatal("L7 proxy requires iptables rules (--install-iptables-rules=\"true\")")
 	}
 
+	if option.Config.EnableIPSec && !option.Config.EnableIPv4 {
+		log.Fatal("IPSec requires IPv4 addressing to be enabled (--enable-ipv4=\"true\")")
+	}
+
 	if option.Config.EnableIPSec && option.Config.TunnelingEnabled() {
 		if err := ipsec.ProbeXfrmStateOutputMask(); err != nil {
 			log.WithError(err).Fatal("IPSec with tunneling requires support for xfrm state output masks (Linux 4.19 or later).")

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -528,7 +529,12 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	}
 
 	if option.Config.EnableIPSec {
-		a := byteorder.NetIPv4ToHost32(node.GetIPv4())
+		nodeAddress := node.GetIPv4()
+		if nodeAddress == nil {
+			return errors.New("external IPv4 node address is required when IPSec is enabled, but none found")
+		}
+
+		a := byteorder.NetIPv4ToHost32(nodeAddress)
 		cDefinesMap["IPV4_ENCRYPT_IFACE"] = fmt.Sprintf("%d", a)
 		if iface := option.Config.EncryptInterface; len(iface) != 0 {
 			link, err := netlink.LinkByName(iface[0])


### PR DESCRIPTION
This PR adds a limitation note about IPsec encryption not being currently supported in combination with ipv6-only clusters, and improves the error handling to return an error message in place of a panic if nodes have no ipv4 address associated.

Signed-off-by: Marco Iorio [marco.iorio@isovalent.com](mailto:marco.iorio@isovalent.com)

Related: #23545

<!-- Description of change -->

```release-note
ipsec + ipv6-only nodes: add limitation note and better error handling
```
