### PR TITLE
daemon: Deprecate SockOps

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -255,7 +255,6 @@ cilium-agent [flags]
       --sidecar-istio-proxy-image string                        Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
       --single-cluster-route                                    Use a single cluster route instead of per node routes
       --socket-path string                                      Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
-      --sockops-enable                                          Enable sockops when kernel supported
       --state-dir string                                        Directory path to store runtime state (default "/var/run/cilium")
       --tofqdns-dns-reject-response-code string                 DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
       --tofqdns-enable-dns-compression                          Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -186,6 +186,7 @@ func initializeFlags() {
 
 	flags.Bool(option.SockopsEnableName, defaults.SockopsEnable, "Enable sockops when kernel supported")
 	option.BindEnv(Vp, option.SockopsEnableName)
+	flags.MarkDeprecated(option.SockopsEnableName, "This option will be removed in v1.14")
 
 	flags.Int(option.ClusterIDName, 0, "Unique identifier of the cluster")
 	option.BindEnv(Vp, option.ClusterIDName)


### PR DESCRIPTION
The feature will be removed in v1.14. The relevant docs change PR - https://github.com/cilium/cilium/pull/23554.