### PR TITLE
init.sh: move socketlb creation into own pkg

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -632,12 +632,15 @@ int cil_sock4_recvmsg(struct bpf_sock_addr *ctx)
 	return SYS_PROCEED;
 }
 
+#ifdef ENABLE_SOCKET_LB_PEER
 __section("cgroup/getpeername4")
 int cil_sock4_getpeername(struct bpf_sock_addr *ctx)
 {
 	__sock4_xlate_rev(ctx, ctx);
 	return SYS_PROCEED;
 }
+#endif /* ENABLE_SOCKET_LB_PEER */
+
 #endif /* ENABLE_IPV4 */
 
 #if defined(ENABLE_IPV6) || defined(ENABLE_IPV4)
@@ -1223,12 +1226,15 @@ int cil_sock6_recvmsg(struct bpf_sock_addr *ctx)
 	return SYS_PROCEED;
 }
 
+#ifdef ENABLE_SOCKET_LB_PEER
 __section("cgroup/getpeername6")
 int cil_sock6_getpeername(struct bpf_sock_addr *ctx)
 {
 	__sock6_xlate_rev(ctx);
 	return SYS_PROCEED;
 }
+#endif /* ENABLE_SOCKET_LB_PEER */
+
 #endif /* ENABLE_IPV6 || ENABLE_IPV4 */
 
 BPF_LICENSE("Dual BSD/GPL");

--- a/cilium/cmd/bpf_migrate_maps.go
+++ b/cilium/cmd/bpf_migrate_maps.go
@@ -24,10 +24,10 @@ func init() {
 	// Allow configuring bpffs path using env variable, default to /sys/fs/bpf.
 	bpffsRoot := os.Getenv("TC_BPF_MNT")
 	if bpffsRoot == "" {
-		bpffsRoot = defaults.DefaultMapRoot
+		bpffsRoot = defaults.BPFFSRoot
 	}
 
-	bpffsPath = filepath.Join(bpffsRoot, defaults.DefaultMapPrefix)
+	bpffsPath = filepath.Join(bpffsRoot, defaults.TCGlobalsPath)
 }
 
 var (

--- a/cilium/cmd/bpf_policy_get.go
+++ b/cilium/cmd/bpf_policy_get.go
@@ -54,7 +54,7 @@ func init() {
 }
 
 func listAllMaps() {
-	mapRootPrefixPath := bpf.MapPrefixPath()
+	mapRootPrefixPath := bpf.TCGlobalsPath()
 	mapMatchExpr := filepath.Join(mapRootPrefixPath, "cilium_policy_*")
 
 	matchFiles, err := filepath.Glob(mapMatchExpr)

--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -111,8 +111,8 @@ type bpfCleanup struct{}
 func (c bpfCleanup) whatWillBeRemoved() []string {
 	return []string{
 		fmt.Sprintf("all BPF maps in %s containing '%s' and '%s'",
-			bpf.MapPrefixPath(), ciliumLinkPrefix, tunnel.MapName),
-		fmt.Sprintf("mounted bpffs at %s", bpf.GetMapRoot()),
+			bpf.TCGlobalsPath(), ciliumLinkPrefix, tunnel.MapName),
+		fmt.Sprintf("mounted bpffs at %s", bpf.BPFFSRoot()),
 	}
 }
 
@@ -399,7 +399,7 @@ func removeDirs() error {
 }
 
 func removeAllMaps() error {
-	mapDir := bpf.MapPrefixPath()
+	mapDir := bpf.TCGlobalsPath()
 	maps, err := os.ReadDir(mapDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -285,7 +285,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args[initArgLib] = option.Config.BpfDir
 	args[initArgRundir] = option.Config.StateDir
 	args[initArgCgroupRoot] = cgroups.GetCgroupRoot()
-	args[initArgBpffsRoot] = bpf.GetMapRoot()
+	args[initArgBpffsRoot] = bpf.BPFFSRoot()
 
 	if option.Config.EnableIPv4 {
 		args[initArgIPv4NodeIP] = node.GetInternalIPv4Router().String()

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -103,7 +103,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 	// bpffs in the process.
 	finalize := func() {}
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{PinPath: bpf.MapPrefixPath()},
+		Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 	}
 	l.Debug("Loading Collection into kernel")
 	coll, err := bpf.LoadCollection(spec, opts)
@@ -111,13 +111,13 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 		// Temporarily rename bpffs pins of maps whose definitions have changed in
 		// a new version of a datapath ELF.
 		l.Debug("Starting bpffs map migration")
-		if err := bpf.StartBPFFSMigration(bpf.MapPrefixPath(), spec); err != nil {
+		if err := bpf.StartBPFFSMigration(bpf.TCGlobalsPath(), spec); err != nil {
 			return nil, fmt.Errorf("Failed to start bpffs map migration: %w", err)
 		}
 
 		finalize = func() {
 			l.Debug("Finalizing bpffs map migration")
-			if err := bpf.FinalizeBPFFSMigration(bpf.MapPrefixPath(), spec, false); err != nil {
+			if err := bpf.FinalizeBPFFSMigration(bpf.TCGlobalsPath(), spec, false); err != nil {
 				l.WithError(err).Error("Could not finalize bpffs map migration")
 			}
 		}
@@ -148,7 +148,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 		if err := attachProgram(link, coll.Programs[prog.progName], prog.progName, directionToParent(prog.direction), xdpModeToFlag(xdpMode)); err != nil {
 			// Program replacement unsuccessful, revert bpffs migration.
 			l.Debug("Reverting bpffs map migration")
-			if err := bpf.FinalizeBPFFSMigration(bpf.MapPrefixPath(), spec, true); err != nil {
+			if err := bpf.FinalizeBPFFSMigration(bpf.TCGlobalsPath(), spec, true); err != nil {
 				l.WithError(err).Error("Failed to revert bpffs map migration")
 			}
 

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -112,7 +112,7 @@ func (ms *MapSweeper) walk(path string, _ os.FileInfo, _ error) error {
 // CollectStaleMapGarbage cleans up stale content in the BPF maps from the
 // datapath.
 func (ms *MapSweeper) CollectStaleMapGarbage() {
-	if err := filepath.Walk(bpf.MapPrefixPath(), ms.walk); err != nil {
+	if err := filepath.Walk(bpf.TCGlobalsPath(), ms.walk); err != nil {
 		log.WithError(err).Warn("Error while scanning for stale maps")
 	}
 }
@@ -217,7 +217,7 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 	}
 
 	for _, m := range maps {
-		p := path.Join(bpf.MapPrefixPath(), m)
+		p := path.Join(bpf.TCGlobalsPath(), m)
 		if _, err := os.Stat(p); !os.IsNotExist(err) {
 			ms.RemoveMapPath(p)
 		}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -103,21 +103,21 @@ const (
 	// from previous state automatically
 	EnableHostIPRestore = true
 
-	// DefaultMapRoot is the default path where BPFFS should be mounted
-	DefaultMapRoot = "/sys/fs/bpf"
+	// BPFFSRoot is the default path where BPFFS should be mounted
+	BPFFSRoot = "/sys/fs/bpf"
+
+	// BPFFSRootFallback is the path which is used when /sys/fs/bpf has
+	// a mount, but with the other filesystem than BPFFS.
+	BPFFSRootFallback = "/run/cilium/bpffs"
+
+	// TCGlobalsPath is the default prefix for all BPF maps.
+	TCGlobalsPath = "tc/globals"
 
 	// DefaultCgroupRoot is the default path where cilium cgroup2 should be mounted
 	DefaultCgroupRoot = "/run/cilium/cgroupv2"
 
 	// SockopsEnable controsl whether sockmap should be used
 	SockopsEnable = false
-
-	// DefaultMapRootFallback is the path which is used when /sys/fs/bpf has
-	// a mount, but with the other filesystem than BPFFS.
-	DefaultMapRootFallback = "/run/cilium/bpffs"
-
-	// DefaultMapPrefix is the default prefix for all BPF maps.
-	DefaultMapPrefix = "tc/globals"
 
 	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
 	// for each FQDN selector in endpoint's restored DNS rules.

--- a/pkg/ebpf/map.go
+++ b/pkg/ebpf/map.go
@@ -107,7 +107,7 @@ func (m *Map) OpenOrCreate() error {
 	}
 
 	opts := ciliumebpf.MapOptions{
-		PinPath: bpf.MapPrefixPath(),
+		PinPath: bpf.TCGlobalsPath(),
 	}
 
 	m.spec.Flags = m.spec.Flags | bpf.GetPreAllocateMapFlags(bpf.MapType(m.spec.Type))

--- a/pkg/envoy/ciliumenvoyconfig_test.go
+++ b/pkg/envoy/ciliumenvoyconfig_test.go
@@ -629,7 +629,7 @@ func (s *JSONSuite) TestCiliumEnvoyConfigTCPProxy(c *C) {
 	c.Assert(lf, Not(IsNil))
 	c.Assert(lf.IsIngress, Equals, false)
 	c.Assert(lf.MayUseOriginalSourceAddress, Equals, true)
-	c.Assert(lf.BpfRoot, Equals, bpf.GetMapRoot())
+	c.Assert(lf.BpfRoot, Equals, bpf.BPFFSRoot())
 	c.Assert(lf.EgressMarkSourceEndpointId, Equals, false)
 
 	c.Assert(resources.Listeners[0].FilterChains, HasLen, 1)
@@ -761,7 +761,7 @@ func (s *JSONSuite) TestCiliumEnvoyConfigTCPProxyTermination(c *C) {
 	c.Assert(lf, Not(IsNil))
 	c.Assert(lf.IsIngress, Equals, false)
 	c.Assert(lf.MayUseOriginalSourceAddress, Equals, false)
-	c.Assert(lf.BpfRoot, Equals, bpf.GetMapRoot())
+	c.Assert(lf.BpfRoot, Equals, bpf.BPFFSRoot())
 	c.Assert(lf.EgressMarkSourceEndpointId, Equals, true)
 
 	c.Assert(resources.Listeners[0].FilterChains, HasLen, 1)

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -744,7 +744,7 @@ func getListenerFilter(isIngress bool, mayUseOriginalSourceAddr bool, l7lb bool)
 	conf := &cilium.BpfMetadata{
 		IsIngress:                   isIngress,
 		MayUseOriginalSourceAddress: mayUseOriginalSourceAddr,
-		BpfRoot:                     bpf.GetMapRoot(),
+		BpfRoot:                     bpf.BPFFSRoot(),
 		EgressMarkSourceEndpointId:  l7lb,
 	}
 	// Set Ingress source addresses if configuring for L7 LB

--- a/pkg/socketlb/cgroup.go
+++ b/pkg/socketlb/cgroup.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// attachCgroup and detachCgroup have to deal with two different kernel APIs:
+//
+// bpf_link (available with kernel version >= 5.7): in order for the program<->cgroup
+// association to outlive the userspace process, the link (not the program) needs to be pinned.
+// Removing the pinned link on bpffs breaks the association.
+// Cilium will only use links on fresh installs and if available in the kernel.
+// On upgrade, a link can be updated using link.Update(), which will atomically replace the
+// currently running bpf program.
+//
+// PROG_ATTACH (all kernel versions pre 5.7 that cilium supports): by definition the association
+// outlives userspace as the cgroup will hold a reference  to the attached program and detaching
+// must be done explicitly using PROG_DETACH.
+// This API is what cilium has been using prior to the 1.14 release and will continue to use if
+// bpf_link is not available.
+// On upgrade, cilium will continue to seamlessly replace old programs with the PROG_ATTACH API,
+// because updating it with a bpf_link could cause connectivity interruptions.
+
+package socketlb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"golang.org/x/sys/unix"
+)
+
+var attachTypes = map[string]ebpf.AttachType{
+	Connect4:     ebpf.AttachCGroupInet4Connect,
+	SendMsg4:     ebpf.AttachCGroupUDP4Sendmsg,
+	RecvMsg4:     ebpf.AttachCGroupUDP4Recvmsg,
+	GetPeerName4: ebpf.AttachCgroupInet4GetPeername,
+	PostBind4:    ebpf.AttachCGroupInet4PostBind,
+	PreBind4:     ebpf.AttachCGroupInet4Bind,
+	Connect6:     ebpf.AttachCGroupInet6Connect,
+	SendMsg6:     ebpf.AttachCGroupUDP6Sendmsg,
+	RecvMsg6:     ebpf.AttachCGroupUDP6Recvmsg,
+	GetPeerName6: ebpf.AttachCgroupInet6GetPeername,
+	PostBind6:    ebpf.AttachCGroupInet6PostBind,
+	PreBind6:     ebpf.AttachCGroupInet6Bind,
+}
+
+// attachCgroup attaches a program from spec with the given name to cgroupRoot.
+// If the kernel supports it, the resulting bpf_link is pinned to pinPath.
+//
+// Upgrades from prior Cilium versions will continue to be handled by a PROG_ATTACH
+// to replace an old program attached to a cgroup.
+func attachCgroup(spec *ebpf.Collection, name, cgroupRoot, pinPath string) error {
+	prog := spec.Programs[name]
+	if prog == nil {
+		return fmt.Errorf("program %s not found in ELF", name)
+	}
+
+	// Attempt to open and update an existing link.
+	pin := filepath.Join(pinPath, name)
+	err := updateLink(pin, prog)
+	switch {
+	// Update successful, nothing left to do.
+	case err == nil:
+		log.Infof("Updated link %s for program %s", pin, name)
+
+		return nil
+
+	// Link exists, but is defunct, and needs to be recreated against a new
+	// cgroup. This can happen in environments like dind where we're attaching
+	// to a sub-cgroup that goes away if the container is destroyed, but the
+	// link persists in the host's /sys/fs/bpf. The program no longer gets
+	// triggered at this point and the link needs to be removed to proceed.
+	case errors.Is(err, unix.ENOLINK):
+		if err := os.Remove(pin); err != nil {
+			return fmt.Errorf("unpinning defunct link %s: %w", pin, err)
+		}
+
+		log.Infof("Unpinned defunct link %s for program %s", pin, name)
+
+	// No existing link found, continue trying to create one.
+	case errors.Is(err, os.ErrNotExist):
+		log.Infof("No existing link found at %s for program %s", pin, name)
+
+	default:
+		return fmt.Errorf("updating link %s for program %s: %w", pin, name, err)
+	}
+
+	cg, err := os.Open(cgroupRoot)
+	if err != nil {
+		return fmt.Errorf("open cgroup %s: %w", cgroupRoot, err)
+	}
+	defer cg.Close()
+
+	// Create a new link. This will only succeed on nodes that support bpf_link
+	// and don't have any attached PROG_ATTACH programs.
+	l, err := link.AttachRawLink(link.RawLinkOptions{
+		Target:  int(cg.Fd()),
+		Program: prog,
+		Attach:  attachTypes[name],
+	})
+	if err == nil {
+		defer func() {
+			// The program was successfully attached using bpf_link. Closing a link
+			// does not detach the program if the link is pinned.
+			if err := l.Close(); err != nil {
+				log.Warnf("Failed to close bpf_link for program %s", name)
+			}
+		}()
+
+		if err := l.Pin(pin); err != nil {
+			return fmt.Errorf("pin link at %s for program %s : %w", pin, name, err)
+		}
+
+		// Successfully created and pinned bpf_link.
+		log.Debugf("Program %s attached using bpf_link", name)
+
+		return nil
+	}
+
+	// Kernels before 5.7 don't support bpf_link. In that case link.AttachRawLink
+	// returns ErrNotSupported.
+	//
+	// If the kernel supports bpf_link, but an older version of Cilium attached a
+	// cgroup program without flags (old init.sh behaviour), link.AttachRawLink
+	// will return EPERM because bpf_link implicitly uses the multi flag.
+	if !errors.Is(err, unix.EPERM) && !errors.Is(err, link.ErrNotSupported) {
+		// Unrecoverable error from AttachRawLink.
+		return fmt.Errorf("attach program %s using bpf_link: %w", name, err)
+	}
+
+	log.Debugf("Performing PROG_ATTACH for program %s", name)
+
+	// Call PROG_ATTACH without flags to attach the program if bpf_link is not
+	// available or a previous PROG_ATTACH without flags has to be seamlessly
+	// replaced.
+	if err := link.RawAttachProgram(link.RawAttachProgramOptions{
+		Target:  int(cg.Fd()),
+		Program: prog,
+		Attach:  attachTypes[name],
+	}); err != nil {
+		return fmt.Errorf("PROG_ATTACH for program %s: %w", name, err)
+	}
+
+	// Nothing left to do, the cgroup now holds a reference to the prog
+	// so we don't need to hold a reference in the agent/bpffs to ensure
+	// the program stays active.
+	log.Debugf("Program %s was attached using PROG_ATTACH", name)
+
+	return nil
+
+}
+
+// updateLink opens a link at the given pin path and updates its program.
+func updateLink(pin string, prog *ebpf.Program) error {
+	l, err := link.LoadPinnedLink(pin, &ebpf.LoadPinOptions{})
+	if err != nil {
+		return fmt.Errorf("opening pinned link %s: %w", pin, err)
+	}
+	defer l.Close()
+
+	// Attempt to update the link. This can fail if the link is defunct (the
+	// cgroup it points to no longer exists).
+	if err = l.Update(prog); err != nil {
+		return fmt.Errorf("update link %s: %w", pin, err)
+	}
+
+	return nil
+}
+
+// detachCgroup detaches a program with the given name from cgroupRoot. Attempts
+// to open a pinned link with the given name from directory pinPath first,
+// falling back to PROG_DETACH if no pin is present.
+func detachCgroup(name, cgroupRoot, pinPath string) error {
+	pin := filepath.Join(pinPath, name)
+	l, err := link.LoadPinnedLink(pin, &ebpf.LoadPinOptions{})
+	if err == nil {
+		if err := l.Unpin(); err != nil {
+			return fmt.Errorf("unpin link %s: %w", pin, err)
+		}
+		if err := l.Close(); err != nil {
+			return fmt.Errorf("close link %s: %w", name, err)
+		}
+		return nil
+	}
+
+	// No bpf_link pin found, detach all prog_attach progs.
+	log.Debugf("No pinned link '%s', querying cgroup", pin)
+	err = detachAll(attachTypes[name], cgroupRoot)
+	// Treat detaching unsupported attach types as successful.
+	if errors.Is(err, link.ErrNotSupported) {
+		return nil
+	}
+	return err
+}
+
+// detachAll detaches all programs attached to cgroupRoot with the corresponding attach type.
+func detachAll(attach ebpf.AttachType, cgroupRoot string) error {
+	// Query the program ids of all programs currently attached to the given cgroup
+	// with the given attach type. In ciliums case this should always return only one id.
+	ids, err := link.QueryPrograms(link.QueryOptions{
+		Path:   cgroupRoot,
+		Attach: attach,
+	})
+	// We know the cgroup root exists, so EINVAL will likely mean querying
+	// the given attach type is not supported.
+	if errors.Is(err, unix.EINVAL) {
+		err = fmt.Errorf("%s: %w", err, link.ErrNotSupported)
+	}
+	if err != nil {
+		return fmt.Errorf("query cgroup %s for type %s: %w", cgroupRoot, attach, err)
+	}
+
+	if len(ids) == 0 {
+		log.Debugf("No programs in cgroup %s with attach type %s", cgroupRoot, attach)
+		return nil
+	}
+
+	cg, err := os.Open(cgroupRoot)
+	if err != nil {
+		return fmt.Errorf("open cgroup %s: %w", cg.Name(), err)
+	}
+	defer cg.Close()
+
+	// cilium owns the cgroup and assumes only one program is attached.
+	// This allows to remove all ids returned in the query phase.
+	for _, id := range ids {
+		prog, err := ebpf.NewProgramFromID(id)
+		if err != nil {
+			return fmt.Errorf("could not open program id %d: %w", id, err)
+		}
+		defer prog.Close()
+
+		if err := link.RawDetachProgram(link.RawDetachProgramOptions{
+			Target:  int(cg.Fd()),
+			Program: prog,
+			Attach:  attach,
+		}); err != nil {
+			return fmt.Errorf("detach programs from cgroup %s attach type %s: %w", cgroupRoot, attach, err)
+		}
+
+		log.Debugf("Detached program id %d", id)
+	}
+
+	return nil
+}

--- a/pkg/socketlb/cgroup_test.go
+++ b/pkg/socketlb/cgroup_test.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package socketlb
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/link"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func mustCgroupProgram(t *testing.T) *ebpf.Program {
+	p, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type: ebpf.CGroupSKB,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "Apache-2.0",
+	})
+	if err != nil {
+		t.Skipf("cgroup programs not supported: %s", err)
+	}
+	return p
+}
+
+// Attach a program to a clean cgroup hook, no replacing necessary.
+func TestAttachCgroup(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	coll := &ebpf.Collection{
+		Programs: map[string]*ebpf.Program{"test": mustCgroupProgram(t)},
+	}
+	linkPath := testutils.TempBPFFS(t)
+	cgroupPath := testutils.TempCgroup(t)
+
+	if err := attachCgroup(coll, "test", cgroupPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := detachCgroup("test", cgroupPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Replace an existing program attached using PROG_ATTACH. On newer kernels,
+// this will attempt to replace a PROG_ATTACH with a bpf_link.
+func TestAttachCgroupWithPreviousAttach(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	prog := mustCgroupProgram(t)
+	coll := &ebpf.Collection{
+		Programs: map[string]*ebpf.Program{"test": prog},
+	}
+
+	linkPath := testutils.TempBPFFS(t)
+	cgroupPath := testutils.TempCgroup(t)
+	f, err := os.Open(cgroupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := link.RawAttachProgram(link.RawAttachProgramOptions{
+		Target:  int(f.Fd()),
+		Program: prog,
+		// Dummy attach type, must match the conclusion made by attachCgroup.
+		Attach: ebpf.AttachCGroupInetIngress,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := attachCgroup(coll, "test", cgroupPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := detachCgroup("test", cgroupPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// On kernels that support it, update a bpf_link attachment by opening a pin.
+func TestAttachCgroupWithExistingLink(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	prog := mustCgroupProgram(t)
+	coll := &ebpf.Collection{
+		Programs: map[string]*ebpf.Program{"test": prog},
+	}
+
+	linkPath := testutils.TempBPFFS(t)
+	cgroupPath := testutils.TempCgroup(t)
+	f, err := os.Open(cgroupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := link.AttachRawLink(link.RawLinkOptions{
+		Target:  int(f.Fd()),
+		Program: prog,
+		// Dummy attach type, must match the conclusion made by attachCgroup.
+		Attach: ebpf.AttachCGroupInetIngress,
+	})
+	if errors.Is(err, ebpf.ErrNotSupported) {
+		t.Skip("bpf_link is not supported")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := l.Pin(filepath.Join(linkPath, "test")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := attachCgroup(coll, "test", cgroupPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := detachCgroup("test", cgroupPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Detach an existing PROG_ATTACH.
+func TestDetachCGroupWithPreviousAttach(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	prog := mustCgroupProgram(t)
+	linkPath := testutils.TempBPFFS(t)
+	cgroupPath := testutils.TempCgroup(t)
+	f, err := os.Open(cgroupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := link.RawAttachProgram(link.RawAttachProgramOptions{
+		Target:  int(f.Fd()),
+		Program: prog,
+		// Dummy attach type, must match the conclusion made by attachCgroup.
+		Attach: ebpf.AttachCGroupInetIngress,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := detachCgroup("test", cgroupPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Detach an existing bpf_link.
+func TestDetachCGroupWithExistingLink(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	prog := mustCgroupProgram(t)
+	linkPath := testutils.TempBPFFS(t)
+	cgroupPath := testutils.TempCgroup(t)
+	f, err := os.Open(cgroupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := link.AttachRawLink(link.RawLinkOptions{
+		Target:  int(f.Fd()),
+		Program: prog,
+		// Dummy attach type, must match the conclusion made by attachCgroup.
+		Attach: ebpf.AttachCGroupInetIngress,
+	})
+	if errors.Is(err, ebpf.ErrNotSupported) {
+		t.Skip("bpf_link is not supported")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Pin(filepath.Join(linkPath, "test")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := detachCgroup("test", cgroupPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package socketlb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/cgroups"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/sysctl"
+)
+
+const (
+	Subsystem = "socketlb"
+
+	Connect4     = "cil_sock4_connect"
+	SendMsg4     = "cil_sock4_sendmsg"
+	RecvMsg4     = "cil_sock4_recvmsg"
+	GetPeerName4 = "cil_sock4_getpeername"
+	PostBind4    = "cil_sock4_post_bind"
+	PreBind4     = "cil_sock4_pre_bind"
+	Connect6     = "cil_sock6_connect"
+	SendMsg6     = "cil_sock6_sendmsg"
+	RecvMsg6     = "cil_sock6_recvmsg"
+	GetPeerName6 = "cil_sock6_getpeername"
+	PostBind6    = "cil_sock6_post_bind"
+	PreBind6     = "cil_sock6_pre_bind"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, Subsystem)
+
+	cgroupProgs = []string{
+		Connect4, SendMsg4, RecvMsg4, GetPeerName4,
+		PostBind4, PreBind4, Connect6, SendMsg6,
+		RecvMsg6, GetPeerName6, PostBind6, PreBind6}
+)
+
+// TODO: Clean up bpffs root logic and make this a var.
+func cgroupLinkPath() string {
+	return filepath.Join(bpf.CiliumPath(), Subsystem, "links/cgroup")
+}
+
+// Enable attaches necessary bpf programs for socketlb based on ciliums config.
+//
+// On restart, Enable can also detach unnecessary programs if specific configuration
+// options have changed.
+// It expects bpf_sock.c to be compiled previously, so that bpf_sock.o is present
+// in the Runtime dir.
+func Enable() (err error) {
+	if err := os.MkdirAll(cgroupLinkPath(), 0777); err != nil {
+		return fmt.Errorf("create bpffs link directory: %w", err)
+	}
+
+	spec, err := bpf.LoadCollectionSpec(filepath.Join(option.Config.StateDir, "bpf_sock.o"))
+	if err != nil {
+		return fmt.Errorf("failed to load collection spec for bpf_sock.o: %w", err)
+	}
+
+	if err := bpf.StartBPFFSMigration(bpf.TCGlobalsPath(), spec); err != nil {
+		return fmt.Errorf("failed to start bpffs map migration: %w", err)
+	}
+
+	// This captures named return variable err.
+	defer func() {
+		if err != nil {
+			log.WithError(err).Debug("Reverting bpffs map migration")
+			if e := bpf.FinalizeBPFFSMigration(bpf.TCGlobalsPath(), spec, true); e != nil {
+				log.WithError(e).Error("Could not revert bpffs map migration")
+				return
+			}
+		}
+
+		log.Debug("Finalizing bpffs map migration")
+		if e := bpf.FinalizeBPFFSMigration(bpf.TCGlobalsPath(), spec, false); e != nil {
+			log.WithError(e).Error("Could not finalize bpffs map migration")
+		}
+	}()
+
+	coll, err := bpf.LoadCollection(spec, ebpf.CollectionOptions{
+		Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+	})
+	var ve *ebpf.VerifierError
+	if errors.As(err, &ve) {
+		if _, err := fmt.Fprintf(os.Stderr, "Verifier error: %s\nVerifier log: %v\n", err, ve); err != nil {
+			return fmt.Errorf("writing verifier log to stderr: %w", err)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("failed loading eBPF collection into the kernel: %w", err)
+	}
+	defer coll.Close()
+
+	// Map a program name to its enabled status. Programs disabled by default.
+	enabled := make(map[string]bool)
+	for _, p := range cgroupProgs {
+		enabled[p] = false
+	}
+
+	if option.Config.EnableIPv4 {
+		enabled[Connect4] = true
+		enabled[SendMsg4] = true
+		enabled[RecvMsg4] = true
+
+		if option.Config.EnableSocketLBPeer {
+			enabled[GetPeerName4] = true
+		}
+
+		if option.Config.EnableNodePort && option.Config.NodePortBindProtection {
+			enabled[PostBind4] = true
+		}
+
+		if option.Config.EnableHealthDatapath {
+			enabled[PreBind4] = true
+		}
+	}
+
+	// v6 will be non-nil if v6 support is compiled out.
+	_, v6 := sysctl.ReadInt("net.ipv6.conf.all.forwarding")
+
+	if option.Config.EnableIPv6 ||
+		(option.Config.EnableIPv4 && v6 == nil) {
+		enabled[Connect6] = true
+		enabled[SendMsg6] = true
+		enabled[RecvMsg6] = true
+
+		if option.Config.EnableSocketLBPeer {
+			enabled[GetPeerName6] = true
+		}
+
+		if option.Config.EnableNodePort && option.Config.NodePortBindProtection {
+			enabled[PostBind6] = true
+		}
+
+		if option.Config.EnableHealthDatapath {
+			enabled[PreBind6] = true
+		}
+	}
+
+	for p, s := range enabled {
+		if s {
+			if err := attachCgroup(coll, p, cgroups.GetCgroupRoot(), cgroupLinkPath()); err != nil {
+				return fmt.Errorf("cgroup attach: %w", err)
+			}
+			continue
+		}
+		if err := detachCgroup(p, cgroups.GetCgroupRoot(), cgroupLinkPath()); err != nil {
+			return fmt.Errorf("cgroup detach: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Disable detaches all bpf programs for socketlb.
+func Disable() error {
+	for _, p := range cgroupProgs {
+		if err := detachCgroup(p, cgroups.GetCgroupRoot(), cgroupLinkPath()); err != nil {
+			return fmt.Errorf("detach cgroup: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/sockops/sockops.go
+++ b/pkg/sockops/sockops.go
@@ -36,7 +36,7 @@ const (
 	sockMap = "cilium_sock_ops"
 
 	// Default prefix for map objects
-	mapPrefix = defaults.DefaultMapPrefix
+	mapPrefix = defaults.TCGlobalsPath
 
 	contextTimeout = 5 * time.Minute
 )
@@ -62,7 +62,7 @@ func bpftoolMapAttach(progID string, mapID string) error {
 // #bpftool cgroup attach $cgrp sock_ops /sys/fs/bpf/$bpfObject
 func bpftoolAttach(bpfObject string) error {
 	prog := "bpftool"
-	bpffs := filepath.Join(bpf.GetMapRoot(), bpfObject)
+	bpffs := filepath.Join(bpf.BPFFSRoot(), bpfObject)
 	cgrp := cgroups.GetCgroupRoot()
 
 	args := []string{"cgroup", "attach", cgrp, "sock_ops", "pinned", bpffs}
@@ -80,7 +80,7 @@ func bpftoolAttach(bpfObject string) error {
 // #bpftool cgroup detach $cgrp sock_ops /sys/fs/bpf/$bpfObject
 func bpftoolDetach(bpfObject string) error {
 	prog := "bpftool"
-	bpffs := filepath.Join(bpf.GetMapRoot(), bpfObject)
+	bpffs := filepath.Join(bpf.BPFFSRoot(), bpfObject)
 	cgrp := cgroups.GetCgroupRoot()
 
 	args := []string{"cgroup", "detach", cgrp, "sock_ops", "pinned", bpffs}
@@ -114,9 +114,9 @@ func bpftoolLoad(bpfObject string, bpfFsFile string) error {
 
 	prog := "bpftool"
 	var mapArgList []string
-	bpffs := filepath.Join(bpf.GetMapRoot(), bpfFsFile)
+	bpffs := filepath.Join(bpf.BPFFSRoot(), bpfFsFile)
 
-	maps, err := os.ReadDir(filepath.Join(bpf.GetMapRoot(), "/tc/globals/"))
+	maps, err := os.ReadDir(filepath.Join(bpf.BPFFSRoot(), "/tc/globals/"))
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func bpftoolLoad(bpfObject string, bpfFsFile string) error {
 			continue
 		}
 
-		mapString := []string{"map", "name", f.Name(), "pinned", filepath.Join(bpf.GetMapRoot(), "/tc/globals/", f.Name())}
+		mapString := []string{"map", "name", f.Name(), "pinned", filepath.Join(bpf.BPFFSRoot(), "/tc/globals/", f.Name())}
 		mapArgList = append(mapArgList, mapString...)
 	}
 
@@ -159,14 +159,14 @@ func bpftoolLoad(bpfObject string, bpfFsFile string) error {
 
 // #rm $bpfObject
 func bpftoolUnload(bpfObject string) {
-	bpffs := filepath.Join(bpf.GetMapRoot(), bpfObject)
+	bpffs := filepath.Join(bpf.BPFFSRoot(), bpfObject)
 
 	os.Remove(bpffs)
 }
 
 // #bpftool prog show pinned /sys/fs/bpf/
 func bpftoolGetProgID(progName string) (string, error) {
-	bpffs := filepath.Join(bpf.GetMapRoot(), progName)
+	bpffs := filepath.Join(bpf.BPFFSRoot(), progName)
 	prog := "bpftool"
 
 	args := []string{"prog", "show", "pinned", bpffs}
@@ -192,7 +192,7 @@ func bpftoolGetProgID(progName string) (string, error) {
 // #bpftool prog show pinned /sys/fs/bpf/bpf_sockops
 // #bpftool map show id 21
 func bpftoolGetMapID(progName string, mapName string) (int, error) {
-	bpffs := filepath.Join(bpf.GetMapRoot(), progName)
+	bpffs := filepath.Join(bpf.BPFFSRoot(), progName)
 	prog := "bpftool"
 
 	args := []string{"prog", "show", "pinned", bpffs}
@@ -230,7 +230,7 @@ func bpftoolGetMapID(progName string, mapName string) (int, error) {
 
 // #bpftool map pin id map_id /sys/fs/bpf/tc/globals
 func bpftoolPinMapID(mapName string, mapID int) error {
-	mapFile := filepath.Join(bpf.GetMapRoot(), mapPrefix, mapName)
+	mapFile := filepath.Join(bpf.BPFFSRoot(), mapPrefix, mapName)
 	prog := "bpftool"
 
 	args := []string{"map", "pin", "id", strconv.Itoa(mapID), mapFile}

--- a/pkg/testutils/bpffs.go
+++ b/pkg/testutils/bpffs.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"os"
+	"testing"
+)
+
+// TempBPFFS creates a temporary directory on a BPF FS.
+//
+// The directory is automatically cleaned up at the end of the test run.
+func TempBPFFS(tb testing.TB) string {
+	tb.Helper()
+
+	tmp, err := os.MkdirTemp("/sys/fs/bpf", "cilium-test")
+	if err != nil {
+		tb.Fatal("Create temporary directory on bpffs:", err)
+	}
+	tb.Cleanup(func() { os.RemoveAll(tmp) })
+
+	return tmp
+}

--- a/pkg/testutils/cgroup.go
+++ b/pkg/testutils/cgroup.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type cache struct {
+	once sync.Once
+	path string
+	err  error
+}
+
+var c cache
+
+func cgroup2Path() (string, error) {
+	c.once.Do(func() {
+		mounts, err := os.ReadFile("/proc/mounts")
+		if err != nil {
+			c.path, c.err = "", err
+			return
+		}
+
+		for _, line := range strings.Split(string(mounts), "\n") {
+			mount := strings.SplitN(line, " ", 3)
+			if mount[0] == "cgroup2" {
+				c.path, c.err = mount[1], nil
+				return
+			}
+			continue
+		}
+		c.path, c.err = "", errors.New("cgroup2 not mounted")
+	})
+
+	return c.path, c.err
+}
+
+// TempCgroup finds the first cgroup2 mount point on the host and creates a
+// temporary cgroup in it. Returns the absolute path to the cgroup.
+//
+// The cgroup is automatically cleaned up at the end of the test run.
+func TempCgroup(tb testing.TB) string {
+	tb.Helper()
+
+	cg2, err := cgroup2Path()
+	if err != nil {
+		tb.Fatal("Can't locate cgroup2 mount:", err)
+	}
+
+	cgdir, err := os.MkdirTemp(cg2, "cilium-test")
+	if err != nil {
+		tb.Fatal("Can't create cgroupv2:", err)
+	}
+
+	tb.Cleanup(func() {
+		os.Remove(cgdir)
+	})
+
+	return cgdir
+}

--- a/test/k8s/custom_calls.go
+++ b/test/k8s/custom_calls.go
@@ -48,7 +48,7 @@ var _ = SkipDescribeIf(func() bool {
 		IngressIPv6 customCallDirection = 2
 		EgressIPv6  customCallDirection = 3
 		// eBPF virtual file system
-		bpffsDir string = defaults.DefaultMapRoot + "/" + defaults.DefaultMapPrefix + "/"
+		bpffsDir string = defaults.BPFFSRoot + "/" + defaults.TCGlobalsPath + "/"
 	)
 
 	BeforeAll(func() {

--- a/vendor/github.com/cilium/ebpf/link/cgroup.go
+++ b/vendor/github.com/cilium/ebpf/link/cgroup.go
@@ -1,0 +1,165 @@
+package link
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/cilium/ebpf"
+)
+
+type cgroupAttachFlags uint32
+
+// cgroup attach flags
+const (
+	flagAllowOverride cgroupAttachFlags = 1 << iota
+	flagAllowMulti
+	flagReplace
+)
+
+type CgroupOptions struct {
+	// Path to a cgroupv2 folder.
+	Path string
+	// One of the AttachCgroup* constants
+	Attach ebpf.AttachType
+	// Program must be of type CGroup*, and the attach type must match Attach.
+	Program *ebpf.Program
+}
+
+// AttachCgroup links a BPF program to a cgroup.
+func AttachCgroup(opts CgroupOptions) (Link, error) {
+	cgroup, err := os.Open(opts.Path)
+	if err != nil {
+		return nil, fmt.Errorf("can't open cgroup: %s", err)
+	}
+
+	clone, err := opts.Program.Clone()
+	if err != nil {
+		cgroup.Close()
+		return nil, err
+	}
+
+	var cg Link
+	cg, err = newLinkCgroup(cgroup, opts.Attach, clone)
+	if errors.Is(err, ErrNotSupported) {
+		cg, err = newProgAttachCgroup(cgroup, opts.Attach, clone, flagAllowMulti)
+	}
+	if errors.Is(err, ErrNotSupported) {
+		cg, err = newProgAttachCgroup(cgroup, opts.Attach, clone, flagAllowOverride)
+	}
+	if err != nil {
+		cgroup.Close()
+		clone.Close()
+		return nil, err
+	}
+
+	return cg, nil
+}
+
+type progAttachCgroup struct {
+	cgroup     *os.File
+	current    *ebpf.Program
+	attachType ebpf.AttachType
+	flags      cgroupAttachFlags
+}
+
+var _ Link = (*progAttachCgroup)(nil)
+
+func (cg *progAttachCgroup) isLink() {}
+
+func newProgAttachCgroup(cgroup *os.File, attach ebpf.AttachType, prog *ebpf.Program, flags cgroupAttachFlags) (*progAttachCgroup, error) {
+	if flags&flagAllowMulti > 0 {
+		if err := haveProgAttachReplace(); err != nil {
+			return nil, fmt.Errorf("can't support multiple programs: %w", err)
+		}
+	}
+
+	err := RawAttachProgram(RawAttachProgramOptions{
+		Target:  int(cgroup.Fd()),
+		Program: prog,
+		Flags:   uint32(flags),
+		Attach:  attach,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cgroup: %w", err)
+	}
+
+	return &progAttachCgroup{cgroup, prog, attach, flags}, nil
+}
+
+func (cg *progAttachCgroup) Close() error {
+	defer cg.cgroup.Close()
+	defer cg.current.Close()
+
+	err := RawDetachProgram(RawDetachProgramOptions{
+		Target:  int(cg.cgroup.Fd()),
+		Program: cg.current,
+		Attach:  cg.attachType,
+	})
+	if err != nil {
+		return fmt.Errorf("close cgroup: %s", err)
+	}
+	return nil
+}
+
+func (cg *progAttachCgroup) Update(prog *ebpf.Program) error {
+	new, err := prog.Clone()
+	if err != nil {
+		return err
+	}
+
+	args := RawAttachProgramOptions{
+		Target:  int(cg.cgroup.Fd()),
+		Program: prog,
+		Attach:  cg.attachType,
+		Flags:   uint32(cg.flags),
+	}
+
+	if cg.flags&flagAllowMulti > 0 {
+		// Atomically replacing multiple programs requires at least
+		// 5.5 (commit 7dd68b3279f17921 "bpf: Support replacing cgroup-bpf
+		// program in MULTI mode")
+		args.Flags |= uint32(flagReplace)
+		args.Replace = cg.current
+	}
+
+	if err := RawAttachProgram(args); err != nil {
+		new.Close()
+		return fmt.Errorf("can't update cgroup: %s", err)
+	}
+
+	cg.current.Close()
+	cg.current = new
+	return nil
+}
+
+func (cg *progAttachCgroup) Pin(string) error {
+	return fmt.Errorf("can't pin cgroup: %w", ErrNotSupported)
+}
+
+func (cg *progAttachCgroup) Unpin() error {
+	return fmt.Errorf("can't unpin cgroup: %w", ErrNotSupported)
+}
+
+func (cg *progAttachCgroup) Info() (*Info, error) {
+	return nil, fmt.Errorf("can't get cgroup info: %w", ErrNotSupported)
+}
+
+type linkCgroup struct {
+	RawLink
+}
+
+var _ Link = (*linkCgroup)(nil)
+
+func newLinkCgroup(cgroup *os.File, attach ebpf.AttachType, prog *ebpf.Program) (*linkCgroup, error) {
+	link, err := AttachRawLink(RawLinkOptions{
+		Target:  int(cgroup.Fd()),
+		Program: prog,
+		Attach:  attach,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &linkCgroup{*link}, err
+}

--- a/vendor/github.com/cilium/ebpf/link/doc.go
+++ b/vendor/github.com/cilium/ebpf/link/doc.go
@@ -1,0 +1,2 @@
+// Package link allows attaching eBPF programs to various kernel hooks.
+package link

--- a/vendor/github.com/cilium/ebpf/link/iter.go
+++ b/vendor/github.com/cilium/ebpf/link/iter.go
@@ -1,0 +1,85 @@
+package link
+
+import (
+	"fmt"
+	"io"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/sys"
+)
+
+type IterOptions struct {
+	// Program must be of type Tracing with attach type
+	// AttachTraceIter. The kind of iterator to attach to is
+	// determined at load time via the AttachTo field.
+	//
+	// AttachTo requires the kernel to include BTF of itself,
+	// and it to be compiled with a recent pahole (>= 1.16).
+	Program *ebpf.Program
+
+	// Map specifies the target map for bpf_map_elem and sockmap iterators.
+	// It may be nil.
+	Map *ebpf.Map
+}
+
+// AttachIter attaches a BPF seq_file iterator.
+func AttachIter(opts IterOptions) (*Iter, error) {
+	if err := haveBPFLink(); err != nil {
+		return nil, err
+	}
+
+	progFd := opts.Program.FD()
+	if progFd < 0 {
+		return nil, fmt.Errorf("invalid program: %s", sys.ErrClosedFd)
+	}
+
+	var info bpfIterLinkInfoMap
+	if opts.Map != nil {
+		mapFd := opts.Map.FD()
+		if mapFd < 0 {
+			return nil, fmt.Errorf("invalid map: %w", sys.ErrClosedFd)
+		}
+		info.map_fd = uint32(mapFd)
+	}
+
+	attr := sys.LinkCreateIterAttr{
+		ProgFd:      uint32(progFd),
+		AttachType:  sys.AttachType(ebpf.AttachTraceIter),
+		IterInfo:    sys.NewPointer(unsafe.Pointer(&info)),
+		IterInfoLen: uint32(unsafe.Sizeof(info)),
+	}
+
+	fd, err := sys.LinkCreateIter(&attr)
+	if err != nil {
+		return nil, fmt.Errorf("can't link iterator: %w", err)
+	}
+
+	return &Iter{RawLink{fd, ""}}, err
+}
+
+// Iter represents an attached bpf_iter.
+type Iter struct {
+	RawLink
+}
+
+// Open creates a new instance of the iterator.
+//
+// Reading from the returned reader triggers the BPF program.
+func (it *Iter) Open() (io.ReadCloser, error) {
+	attr := &sys.IterCreateAttr{
+		LinkFd: it.fd.Uint(),
+	}
+
+	fd, err := sys.IterCreate(attr)
+	if err != nil {
+		return nil, fmt.Errorf("can't create iterator: %w", err)
+	}
+
+	return fd.File("bpf_iter"), nil
+}
+
+// union bpf_iter_link_info.map
+type bpfIterLinkInfoMap struct {
+	map_fd uint32
+}

--- a/vendor/github.com/cilium/ebpf/link/kprobe.go
+++ b/vendor/github.com/cilium/ebpf/link/kprobe.go
@@ -1,0 +1,574 @@
+package link
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+var (
+	kprobeEventsPath = filepath.Join(tracefsPath, "kprobe_events")
+)
+
+type probeType uint8
+
+type probeArgs struct {
+	symbol, group, path          string
+	offset, refCtrOffset, cookie uint64
+	pid, retprobeMaxActive       int
+	ret                          bool
+}
+
+// KprobeOptions defines additional parameters that will be used
+// when loading Kprobes.
+type KprobeOptions struct {
+	// Arbitrary value that can be fetched from an eBPF program
+	// via `bpf_get_attach_cookie()`.
+	//
+	// Needs kernel 5.15+.
+	Cookie uint64
+	// Offset of the kprobe relative to the traced symbol.
+	// Can be used to insert kprobes at arbitrary offsets in kernel functions,
+	// e.g. in places where functions have been inlined.
+	Offset uint64
+	// Increase the maximum number of concurrent invocations of a kretprobe.
+	// Required when tracing some long running functions in the kernel.
+	//
+	// Deprecated: this setting forces the use of an outdated kernel API and is not portable
+	// across kernel versions.
+	RetprobeMaxActive int
+}
+
+const (
+	kprobeType probeType = iota
+	uprobeType
+)
+
+func (pt probeType) String() string {
+	if pt == kprobeType {
+		return "kprobe"
+	}
+	return "uprobe"
+}
+
+func (pt probeType) EventsPath() string {
+	if pt == kprobeType {
+		return kprobeEventsPath
+	}
+	return uprobeEventsPath
+}
+
+func (pt probeType) PerfEventType(ret bool) perfEventType {
+	if pt == kprobeType {
+		if ret {
+			return kretprobeEvent
+		}
+		return kprobeEvent
+	}
+	if ret {
+		return uretprobeEvent
+	}
+	return uprobeEvent
+}
+
+// Kprobe attaches the given eBPF program to a perf event that fires when the
+// given kernel symbol starts executing. See /proc/kallsyms for available
+// symbols. For example, printk():
+//
+//	kp, err := Kprobe("printk", prog, nil)
+//
+// Losing the reference to the resulting Link (kp) will close the Kprobe
+// and prevent further execution of prog. The Link must be Closed during
+// program shutdown to avoid leaking system resources.
+func Kprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions) (Link, error) {
+	k, err := kprobe(symbol, prog, opts, false)
+	if err != nil {
+		return nil, err
+	}
+
+	lnk, err := attachPerfEvent(k, prog)
+	if err != nil {
+		k.Close()
+		return nil, err
+	}
+
+	return lnk, nil
+}
+
+// Kretprobe attaches the given eBPF program to a perf event that fires right
+// before the given kernel symbol exits, with the function stack left intact.
+// See /proc/kallsyms for available symbols. For example, printk():
+//
+//	kp, err := Kretprobe("printk", prog, nil)
+//
+// Losing the reference to the resulting Link (kp) will close the Kretprobe
+// and prevent further execution of prog. The Link must be Closed during
+// program shutdown to avoid leaking system resources.
+//
+// On kernels 5.10 and earlier, setting a kretprobe on a nonexistent symbol
+// incorrectly returns unix.EINVAL instead of os.ErrNotExist.
+func Kretprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions) (Link, error) {
+	k, err := kprobe(symbol, prog, opts, true)
+	if err != nil {
+		return nil, err
+	}
+
+	lnk, err := attachPerfEvent(k, prog)
+	if err != nil {
+		k.Close()
+		return nil, err
+	}
+
+	return lnk, nil
+}
+
+// isValidKprobeSymbol implements the equivalent of a regex match
+// against "^[a-zA-Z_][0-9a-zA-Z_.]*$".
+func isValidKprobeSymbol(s string) bool {
+	if len(s) < 1 {
+		return false
+	}
+
+	for i, c := range []byte(s) {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c == '_':
+		case i > 0 && c >= '0' && c <= '9':
+
+		// Allow `.` in symbol name. GCC-compiled kernel may change symbol name
+		// to have a `.isra.$n` suffix, like `udp_send_skb.isra.52`.
+		// See: https://gcc.gnu.org/gcc-10/changes.html
+		case i > 0 && c == '.':
+
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
+// kprobe opens a perf event on the given symbol and attaches prog to it.
+// If ret is true, create a kretprobe.
+func kprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions, ret bool) (*perfEvent, error) {
+	if symbol == "" {
+		return nil, fmt.Errorf("symbol name cannot be empty: %w", errInvalidInput)
+	}
+	if prog == nil {
+		return nil, fmt.Errorf("prog cannot be nil: %w", errInvalidInput)
+	}
+	if !isValidKprobeSymbol(symbol) {
+		return nil, fmt.Errorf("symbol '%s' must be a valid symbol in /proc/kallsyms: %w", symbol, errInvalidInput)
+	}
+	if prog.Type() != ebpf.Kprobe {
+		return nil, fmt.Errorf("eBPF program type %s is not a Kprobe: %w", prog.Type(), errInvalidInput)
+	}
+
+	args := probeArgs{
+		pid:    perfAllThreads,
+		symbol: symbol,
+		ret:    ret,
+	}
+
+	if opts != nil {
+		args.retprobeMaxActive = opts.RetprobeMaxActive
+		args.cookie = opts.Cookie
+		args.offset = opts.Offset
+	}
+
+	// Use kprobe PMU if the kernel has it available.
+	tp, err := pmuKprobe(args)
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL) {
+		args.symbol = platformPrefix(symbol)
+		tp, err = pmuKprobe(args)
+	}
+	if err == nil {
+		return tp, nil
+	}
+	if err != nil && !errors.Is(err, ErrNotSupported) {
+		return nil, fmt.Errorf("creating perf_kprobe PMU: %w", err)
+	}
+
+	// Use tracefs if kprobe PMU is missing.
+	args.symbol = symbol
+	tp, err = tracefsKprobe(args)
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL) {
+		args.symbol = platformPrefix(symbol)
+		tp, err = tracefsKprobe(args)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("creating trace event '%s' in tracefs: %w", symbol, err)
+	}
+
+	return tp, nil
+}
+
+// pmuKprobe opens a perf event based on the kprobe PMU.
+// Returns os.ErrNotExist if the given symbol does not exist in the kernel.
+func pmuKprobe(args probeArgs) (*perfEvent, error) {
+	return pmuProbe(kprobeType, args)
+}
+
+// pmuProbe opens a perf event based on a Performance Monitoring Unit.
+//
+// Requires at least a 4.17 kernel.
+// e12f03d7031a "perf/core: Implement the 'perf_kprobe' PMU"
+// 33ea4b24277b "perf/core: Implement the 'perf_uprobe' PMU"
+//
+// Returns ErrNotSupported if the kernel doesn't support perf_[k,u]probe PMU
+func pmuProbe(typ probeType, args probeArgs) (*perfEvent, error) {
+	// Getting the PMU type will fail if the kernel doesn't support
+	// the perf_[k,u]probe PMU.
+	et, err := readUint64FromFileOnce("%d\n", "/sys/bus/event_source/devices", typ.String(), "type")
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("%s: %w", typ, ErrNotSupported)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Use tracefs if we want to set kretprobe's retprobeMaxActive.
+	if args.retprobeMaxActive != 0 {
+		return nil, fmt.Errorf("pmu probe: non-zero retprobeMaxActive: %w", ErrNotSupported)
+	}
+
+	var config uint64
+	if args.ret {
+		bit, err := readUint64FromFileOnce("config:%d\n", "/sys/bus/event_source/devices", typ.String(), "/format/retprobe")
+		if err != nil {
+			return nil, err
+		}
+		config |= 1 << bit
+	}
+
+	var (
+		attr  unix.PerfEventAttr
+		sp    unsafe.Pointer
+		token string
+	)
+	switch typ {
+	case kprobeType:
+		// Create a pointer to a NUL-terminated string for the kernel.
+		sp, err = unsafeStringPtr(args.symbol)
+		if err != nil {
+			return nil, err
+		}
+
+		token = kprobeToken(args)
+
+		attr = unix.PerfEventAttr{
+			// The minimum size required for PMU kprobes is PERF_ATTR_SIZE_VER1,
+			// since it added the config2 (Ext2) field. Use Ext2 as probe_offset.
+			Size:   unix.PERF_ATTR_SIZE_VER1,
+			Type:   uint32(et),          // PMU event type read from sysfs
+			Ext1:   uint64(uintptr(sp)), // Kernel symbol to trace
+			Ext2:   args.offset,         // Kernel symbol offset
+			Config: config,              // Retprobe flag
+		}
+	case uprobeType:
+		sp, err = unsafeStringPtr(args.path)
+		if err != nil {
+			return nil, err
+		}
+
+		if args.refCtrOffset != 0 {
+			config |= args.refCtrOffset << uprobeRefCtrOffsetShift
+		}
+
+		token = uprobeToken(args)
+
+		attr = unix.PerfEventAttr{
+			// The minimum size required for PMU uprobes is PERF_ATTR_SIZE_VER1,
+			// since it added the config2 (Ext2) field. The Size field controls the
+			// size of the internal buffer the kernel allocates for reading the
+			// perf_event_attr argument from userspace.
+			Size:   unix.PERF_ATTR_SIZE_VER1,
+			Type:   uint32(et),          // PMU event type read from sysfs
+			Ext1:   uint64(uintptr(sp)), // Uprobe path
+			Ext2:   args.offset,         // Uprobe offset
+			Config: config,              // RefCtrOffset, Retprobe flag
+		}
+	}
+
+	rawFd, err := unix.PerfEventOpen(&attr, args.pid, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
+
+	// On some old kernels, kprobe PMU doesn't allow `.` in symbol names and
+	// return -EINVAL. Return ErrNotSupported to allow falling back to tracefs.
+	// https://github.com/torvalds/linux/blob/94710cac0ef4/kernel/trace/trace_kprobe.c#L340-L343
+	if errors.Is(err, unix.EINVAL) && strings.Contains(args.symbol, ".") {
+		return nil, fmt.Errorf("token %s: older kernels don't accept dots: %w", token, ErrNotSupported)
+	}
+	// Since commit 97c753e62e6c, ENOENT is correctly returned instead of EINVAL
+	// when trying to create a retprobe for a missing symbol.
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("token %s: not found: %w", token, err)
+	}
+	// Since commit ab105a4fb894, EILSEQ is returned when a kprobe sym+offset is resolved
+	// to an invalid insn boundary. The exact conditions that trigger this error are
+	// arch specific however.
+	if errors.Is(err, unix.EILSEQ) {
+		return nil, fmt.Errorf("token %s: bad insn boundary: %w", token, os.ErrNotExist)
+	}
+	// Since at least commit cb9a19fe4aa51, ENOTSUPP is returned
+	// when attempting to set a uprobe on a trap instruction.
+	if errors.Is(err, sys.ENOTSUPP) {
+		return nil, fmt.Errorf("token %s: failed setting uprobe on offset %#x (possible trap insn): %w", token, args.offset, err)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("token %s: opening perf event: %w", token, err)
+	}
+
+	// Ensure the string pointer is not collected before PerfEventOpen returns.
+	runtime.KeepAlive(sp)
+
+	fd, err := sys.NewFD(rawFd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Kernel has perf_[k,u]probe PMU available, initialize perf event.
+	return &perfEvent{
+		typ:    typ.PerfEventType(args.ret),
+		name:   args.symbol,
+		pmuID:  et,
+		cookie: args.cookie,
+		fd:     fd,
+	}, nil
+}
+
+// tracefsKprobe creates a Kprobe tracefs entry.
+func tracefsKprobe(args probeArgs) (*perfEvent, error) {
+	return tracefsProbe(kprobeType, args)
+}
+
+// tracefsProbe creates a trace event by writing an entry to <tracefs>/[k,u]probe_events.
+// A new trace event group name is generated on every call to support creating
+// multiple trace events for the same kernel or userspace symbol.
+// Path and offset are only set in the case of uprobe(s) and are used to set
+// the executable/library path on the filesystem and the offset where the probe is inserted.
+// A perf event is then opened on the newly-created trace event and returned to the caller.
+func tracefsProbe(typ probeType, args probeArgs) (*perfEvent, error) {
+	// Generate a random string for each trace event we attempt to create.
+	// This value is used as the 'group' token in tracefs to allow creating
+	// multiple kprobe trace events with the same name.
+	group, err := randomGroup("ebpf")
+	if err != nil {
+		return nil, fmt.Errorf("randomizing group name: %w", err)
+	}
+	args.group = group
+
+	// Create the [k,u]probe trace event using tracefs.
+	tid, err := createTraceFSProbeEvent(typ, args)
+	if err != nil {
+		return nil, fmt.Errorf("creating probe entry on tracefs: %w", err)
+	}
+
+	// Kprobes are ephemeral tracepoints and share the same perf event type.
+	fd, err := openTracepointPerfEvent(tid, args.pid)
+	if err != nil {
+		// Make sure we clean up the created tracefs event when we return error.
+		// If a livepatch handler is already active on the symbol, the write to
+		// tracefs will succeed, a trace event will show up, but creating the
+		// perf event will fail with EBUSY.
+		_ = closeTraceFSProbeEvent(typ, args.group, args.symbol)
+		return nil, err
+	}
+
+	return &perfEvent{
+		typ:       typ.PerfEventType(args.ret),
+		group:     group,
+		name:      args.symbol,
+		tracefsID: tid,
+		cookie:    args.cookie,
+		fd:        fd,
+	}, nil
+}
+
+var errInvalidMaxActive = errors.New("can only set maxactive on kretprobes")
+
+// createTraceFSProbeEvent creates a new ephemeral trace event.
+//
+// Returns os.ErrNotExist if symbol is not a valid
+// kernel symbol, or if it is not traceable with kprobes. Returns os.ErrExist
+// if a probe with the same group and symbol already exists. Returns an error if
+// args.retprobeMaxActive is used on non kprobe types. Returns ErrNotSupported if
+// the kernel is too old to support kretprobe maxactive.
+func createTraceFSProbeEvent(typ probeType, args probeArgs) (uint64, error) {
+	// Before attempting to create a trace event through tracefs,
+	// check if an event with the same group and name already exists.
+	// Kernels 4.x and earlier don't return os.ErrExist on writing a duplicate
+	// entry, so we need to rely on reads for detecting uniqueness.
+	_, err := getTraceEventID(args.group, args.symbol)
+	if err == nil {
+		return 0, fmt.Errorf("trace event %s/%s: %w", args.group, args.symbol, os.ErrExist)
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return 0, fmt.Errorf("checking trace event %s/%s: %w", args.group, args.symbol, err)
+	}
+
+	// Open the kprobe_events file in tracefs.
+	f, err := os.OpenFile(typ.EventsPath(), os.O_APPEND|os.O_WRONLY, 0666)
+	if err != nil {
+		return 0, fmt.Errorf("error opening '%s': %w", typ.EventsPath(), err)
+	}
+	defer f.Close()
+
+	var pe, token string
+	switch typ {
+	case kprobeType:
+		// The kprobe_events syntax is as follows (see Documentation/trace/kprobetrace.txt):
+		// p[:[GRP/]EVENT] [MOD:]SYM[+offs]|MEMADDR [FETCHARGS] : Set a probe
+		// r[MAXACTIVE][:[GRP/]EVENT] [MOD:]SYM[+0] [FETCHARGS] : Set a return probe
+		// -:[GRP/]EVENT                                        : Clear a probe
+		//
+		// Some examples:
+		// r:ebpf_1234/r_my_kretprobe nf_conntrack_destroy
+		// p:ebpf_5678/p_my_kprobe __x64_sys_execve
+		//
+		// Leaving the kretprobe's MAXACTIVE set to 0 (or absent) will make the
+		// kernel default to NR_CPUS. This is desired in most eBPF cases since
+		// subsampling or rate limiting logic can be more accurately implemented in
+		// the eBPF program itself.
+		// See Documentation/kprobes.txt for more details.
+		if args.retprobeMaxActive != 0 && !args.ret {
+			return 0, errInvalidMaxActive
+		}
+		token = kprobeToken(args)
+		pe = fmt.Sprintf("%s:%s/%s %s", probePrefix(args.ret, args.retprobeMaxActive), args.group, sanitizeSymbol(args.symbol), token)
+	case uprobeType:
+		// The uprobe_events syntax is as follows:
+		// p[:[GRP/]EVENT] PATH:OFFSET [FETCHARGS] : Set a probe
+		// r[:[GRP/]EVENT] PATH:OFFSET [FETCHARGS] : Set a return probe
+		// -:[GRP/]EVENT                           : Clear a probe
+		//
+		// Some examples:
+		// r:ebpf_1234/readline /bin/bash:0x12345
+		// p:ebpf_5678/main_mySymbol /bin/mybin:0x12345(0x123)
+		//
+		// See Documentation/trace/uprobetracer.txt for more details.
+		if args.retprobeMaxActive != 0 {
+			return 0, errInvalidMaxActive
+		}
+		token = uprobeToken(args)
+		pe = fmt.Sprintf("%s:%s/%s %s", probePrefix(args.ret, 0), args.group, args.symbol, token)
+	}
+	_, err = f.WriteString(pe)
+
+	// Since commit 97c753e62e6c, ENOENT is correctly returned instead of EINVAL
+	// when trying to create a retprobe for a missing symbol.
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, fmt.Errorf("token %s: not found: %w", token, err)
+	}
+	// Since commit ab105a4fb894, EILSEQ is returned when a kprobe sym+offset is resolved
+	// to an invalid insn boundary. The exact conditions that trigger this error are
+	// arch specific however.
+	if errors.Is(err, syscall.EILSEQ) {
+		return 0, fmt.Errorf("token %s: bad insn boundary: %w", token, os.ErrNotExist)
+	}
+	// ERANGE is returned when the `SYM[+offs]` token is too big and cannot
+	// be resolved.
+	if errors.Is(err, syscall.ERANGE) {
+		return 0, fmt.Errorf("token %s: offset too big: %w", token, os.ErrNotExist)
+	}
+
+	if err != nil {
+		return 0, fmt.Errorf("token %s: writing '%s': %w", token, pe, err)
+	}
+
+	// Get the newly-created trace event's id.
+	tid, err := getTraceEventID(args.group, args.symbol)
+	if args.retprobeMaxActive != 0 && errors.Is(err, os.ErrNotExist) {
+		// Kernels < 4.12 don't support maxactive and therefore auto generate
+		// group and event names from the symbol and offset. The symbol is used
+		// without any sanitization.
+		// See https://elixir.bootlin.com/linux/v4.10/source/kernel/trace/trace_kprobe.c#L712
+		event := fmt.Sprintf("kprobes/r_%s_%d", args.symbol, args.offset)
+		if err := removeTraceFSProbeEvent(typ, event); err != nil {
+			return 0, fmt.Errorf("failed to remove spurious maxactive event: %s", err)
+		}
+		return 0, fmt.Errorf("create trace event with non-default maxactive: %w", ErrNotSupported)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("get trace event id: %w", err)
+	}
+
+	return tid, nil
+}
+
+// closeTraceFSProbeEvent removes the [k,u]probe with the given type, group and symbol
+// from <tracefs>/[k,u]probe_events.
+func closeTraceFSProbeEvent(typ probeType, group, symbol string) error {
+	pe := fmt.Sprintf("%s/%s", group, sanitizeSymbol(symbol))
+	return removeTraceFSProbeEvent(typ, pe)
+}
+
+func removeTraceFSProbeEvent(typ probeType, pe string) error {
+	f, err := os.OpenFile(typ.EventsPath(), os.O_APPEND|os.O_WRONLY, 0666)
+	if err != nil {
+		return fmt.Errorf("error opening %s: %w", typ.EventsPath(), err)
+	}
+	defer f.Close()
+
+	// See [k,u]probe_events syntax above. The probe type does not need to be specified
+	// for removals.
+	if _, err = f.WriteString("-:" + pe); err != nil {
+		return fmt.Errorf("remove event %q from %s: %w", pe, typ.EventsPath(), err)
+	}
+
+	return nil
+}
+
+// randomGroup generates a pseudorandom string for use as a tracefs group name.
+// Returns an error when the output string would exceed 63 characters (kernel
+// limitation), when rand.Read() fails or when prefix contains characters not
+// allowed by isValidTraceID.
+func randomGroup(prefix string) (string, error) {
+	if !isValidTraceID(prefix) {
+		return "", fmt.Errorf("prefix '%s' must be alphanumeric or underscore: %w", prefix, errInvalidInput)
+	}
+
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("reading random bytes: %w", err)
+	}
+
+	group := fmt.Sprintf("%s_%x", prefix, b)
+	if len(group) > 63 {
+		return "", fmt.Errorf("group name '%s' cannot be longer than 63 characters: %w", group, errInvalidInput)
+	}
+
+	return group, nil
+}
+
+func probePrefix(ret bool, maxActive int) string {
+	if ret {
+		if maxActive > 0 {
+			return fmt.Sprintf("r%d", maxActive)
+		}
+		return "r"
+	}
+	return "p"
+}
+
+// kprobeToken creates the SYM[+offs] token for the tracefs api.
+func kprobeToken(args probeArgs) string {
+	po := args.symbol
+
+	if args.offset != 0 {
+		po += fmt.Sprintf("+%#x", args.offset)
+	}
+
+	return po
+}

--- a/vendor/github.com/cilium/ebpf/link/kprobe_multi.go
+++ b/vendor/github.com/cilium/ebpf/link/kprobe_multi.go
@@ -1,0 +1,180 @@
+package link
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+// KprobeMultiOptions defines additional parameters that will be used
+// when opening a KprobeMulti Link.
+type KprobeMultiOptions struct {
+	// Symbols takes a list of kernel symbol names to attach an ebpf program to.
+	//
+	// Mutually exclusive with Addresses.
+	Symbols []string
+
+	// Addresses takes a list of kernel symbol addresses in case they can not
+	// be referred to by name.
+	//
+	// Note that only start addresses can be specified, since the fprobe API
+	// limits the attach point to the function entry or return.
+	//
+	// Mutually exclusive with Symbols.
+	Addresses []uint64
+
+	// Cookies specifies arbitrary values that can be fetched from an eBPF
+	// program via `bpf_get_attach_cookie()`.
+	//
+	// If set, its length should be equal to the length of Symbols or Addresses.
+	// Each Cookie is assigned to the Symbol or Address specified at the
+	// corresponding slice index.
+	Cookies []uint64
+}
+
+// KprobeMulti attaches the given eBPF program to the entry point of a given set
+// of kernel symbols.
+//
+// The difference with Kprobe() is that multi-kprobe accomplishes this in a
+// single system call, making it significantly faster than attaching many
+// probes one at a time.
+//
+// Requires at least Linux 5.18.
+func KprobeMulti(prog *ebpf.Program, opts KprobeMultiOptions) (Link, error) {
+	return kprobeMulti(prog, opts, 0)
+}
+
+// KretprobeMulti attaches the given eBPF program to the return point of a given
+// set of kernel symbols.
+//
+// The difference with Kretprobe() is that multi-kprobe accomplishes this in a
+// single system call, making it significantly faster than attaching many
+// probes one at a time.
+//
+// Requires at least Linux 5.18.
+func KretprobeMulti(prog *ebpf.Program, opts KprobeMultiOptions) (Link, error) {
+	return kprobeMulti(prog, opts, unix.BPF_F_KPROBE_MULTI_RETURN)
+}
+
+func kprobeMulti(prog *ebpf.Program, opts KprobeMultiOptions, flags uint32) (Link, error) {
+	if prog == nil {
+		return nil, errors.New("cannot attach a nil program")
+	}
+
+	syms := uint32(len(opts.Symbols))
+	addrs := uint32(len(opts.Addresses))
+	cookies := uint32(len(opts.Cookies))
+
+	if syms == 0 && addrs == 0 {
+		return nil, fmt.Errorf("one of Symbols or Addresses is required: %w", errInvalidInput)
+	}
+	if syms != 0 && addrs != 0 {
+		return nil, fmt.Errorf("Symbols and Addresses are mutually exclusive: %w", errInvalidInput)
+	}
+	if cookies > 0 && cookies != syms && cookies != addrs {
+		return nil, fmt.Errorf("Cookies must be exactly Symbols or Addresses in length: %w", errInvalidInput)
+	}
+
+	if err := haveBPFLinkKprobeMulti(); err != nil {
+		return nil, err
+	}
+
+	attr := &sys.LinkCreateKprobeMultiAttr{
+		ProgFd:           uint32(prog.FD()),
+		AttachType:       sys.BPF_TRACE_KPROBE_MULTI,
+		KprobeMultiFlags: flags,
+	}
+
+	switch {
+	case syms != 0:
+		attr.Count = syms
+		attr.Syms = sys.NewStringSlicePointer(opts.Symbols)
+
+	case addrs != 0:
+		attr.Count = addrs
+		attr.Addrs = sys.NewPointer(unsafe.Pointer(&opts.Addresses[0]))
+	}
+
+	if cookies != 0 {
+		attr.Cookies = sys.NewPointer(unsafe.Pointer(&opts.Cookies[0]))
+	}
+
+	fd, err := sys.LinkCreateKprobeMulti(attr)
+	if errors.Is(err, unix.ESRCH) {
+		return nil, fmt.Errorf("couldn't find one or more symbols: %w", os.ErrNotExist)
+	}
+	if errors.Is(err, unix.EINVAL) {
+		return nil, fmt.Errorf("%w (missing kernel symbol or prog's AttachType not AttachTraceKprobeMulti?)", err)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &kprobeMultiLink{RawLink{fd, ""}}, nil
+}
+
+type kprobeMultiLink struct {
+	RawLink
+}
+
+var _ Link = (*kprobeMultiLink)(nil)
+
+func (kml *kprobeMultiLink) Update(prog *ebpf.Program) error {
+	return fmt.Errorf("update kprobe_multi: %w", ErrNotSupported)
+}
+
+func (kml *kprobeMultiLink) Pin(string) error {
+	return fmt.Errorf("pin kprobe_multi: %w", ErrNotSupported)
+}
+
+func (kml *kprobeMultiLink) Unpin() error {
+	return fmt.Errorf("unpin kprobe_multi: %w", ErrNotSupported)
+}
+
+var haveBPFLinkKprobeMulti = internal.NewFeatureTest("bpf_link_kprobe_multi", "5.18", func() error {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: "probe_kpm_link",
+		Type: ebpf.Kprobe,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		AttachType: ebpf.AttachTraceKprobeMulti,
+		License:    "MIT",
+	})
+	if errors.Is(err, unix.E2BIG) {
+		// Kernel doesn't support AttachType field.
+		return internal.ErrNotSupported
+	}
+	if err != nil {
+		return err
+	}
+	defer prog.Close()
+
+	fd, err := sys.LinkCreateKprobeMulti(&sys.LinkCreateKprobeMultiAttr{
+		ProgFd:     uint32(prog.FD()),
+		AttachType: sys.BPF_TRACE_KPROBE_MULTI,
+		Count:      1,
+		Syms:       sys.NewStringSlicePointer([]string{"vprintk"}),
+	})
+	switch {
+	case errors.Is(err, unix.EINVAL):
+		return internal.ErrNotSupported
+	// If CONFIG_FPROBE isn't set.
+	case errors.Is(err, unix.EOPNOTSUPP):
+		return internal.ErrNotSupported
+	case err != nil:
+		return err
+	}
+
+	fd.Close()
+
+	return nil
+})

--- a/vendor/github.com/cilium/ebpf/link/link.go
+++ b/vendor/github.com/cilium/ebpf/link/link.go
@@ -1,0 +1,315 @@
+package link
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
+)
+
+var ErrNotSupported = internal.ErrNotSupported
+
+// Link represents a Program attached to a BPF hook.
+type Link interface {
+	// Replace the current program with a new program.
+	//
+	// Passing a nil program is an error. May return an error wrapping ErrNotSupported.
+	Update(*ebpf.Program) error
+
+	// Persist a link by pinning it into a bpffs.
+	//
+	// May return an error wrapping ErrNotSupported.
+	Pin(string) error
+
+	// Undo a previous call to Pin.
+	//
+	// May return an error wrapping ErrNotSupported.
+	Unpin() error
+
+	// Close frees resources.
+	//
+	// The link will be broken unless it has been successfully pinned.
+	// A link may continue past the lifetime of the process if Close is
+	// not called.
+	Close() error
+
+	// Info returns metadata on a link.
+	//
+	// May return an error wrapping ErrNotSupported.
+	Info() (*Info, error)
+
+	// Prevent external users from implementing this interface.
+	isLink()
+}
+
+// LoadPinnedLink loads a link that was persisted into a bpffs.
+func LoadPinnedLink(fileName string, opts *ebpf.LoadPinOptions) (Link, error) {
+	raw, err := loadPinnedRawLink(fileName, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return wrapRawLink(raw)
+}
+
+// wrap a RawLink in a more specific type if possible.
+//
+// The function takes ownership of raw and closes it on error.
+func wrapRawLink(raw *RawLink) (Link, error) {
+	info, err := raw.Info()
+	if err != nil {
+		raw.Close()
+		return nil, err
+	}
+
+	switch info.Type {
+	case RawTracepointType:
+		return &rawTracepoint{*raw}, nil
+	case TracingType:
+		return &tracing{*raw}, nil
+	case CgroupType:
+		return &linkCgroup{*raw}, nil
+	case IterType:
+		return &Iter{*raw}, nil
+	case NetNsType:
+		return &NetNsLink{*raw}, nil
+	default:
+		return raw, nil
+	}
+}
+
+// ID uniquely identifies a BPF link.
+type ID = sys.LinkID
+
+// RawLinkOptions control the creation of a raw link.
+type RawLinkOptions struct {
+	// File descriptor to attach to. This differs for each attach type.
+	Target int
+	// Program to attach.
+	Program *ebpf.Program
+	// Attach must match the attach type of Program.
+	Attach ebpf.AttachType
+	// BTF is the BTF of the attachment target.
+	BTF btf.TypeID
+	// Flags control the attach behaviour.
+	Flags uint32
+}
+
+// Info contains metadata on a link.
+type Info struct {
+	Type    Type
+	ID      ID
+	Program ebpf.ProgramID
+	extra   interface{}
+}
+
+type TracingInfo sys.TracingLinkInfo
+type CgroupInfo sys.CgroupLinkInfo
+type NetNsInfo sys.NetNsLinkInfo
+type XDPInfo sys.XDPLinkInfo
+
+// Tracing returns tracing type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) Tracing() *TracingInfo {
+	e, _ := r.extra.(*TracingInfo)
+	return e
+}
+
+// Cgroup returns cgroup type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) Cgroup() *CgroupInfo {
+	e, _ := r.extra.(*CgroupInfo)
+	return e
+}
+
+// NetNs returns netns type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) NetNs() *NetNsInfo {
+	e, _ := r.extra.(*NetNsInfo)
+	return e
+}
+
+// ExtraNetNs returns XDP type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) XDP() *XDPInfo {
+	e, _ := r.extra.(*XDPInfo)
+	return e
+}
+
+// RawLink is the low-level API to bpf_link.
+//
+// You should consider using the higher level interfaces in this
+// package instead.
+type RawLink struct {
+	fd         *sys.FD
+	pinnedPath string
+}
+
+// AttachRawLink creates a raw link.
+func AttachRawLink(opts RawLinkOptions) (*RawLink, error) {
+	if err := haveBPFLink(); err != nil {
+		return nil, err
+	}
+
+	if opts.Target < 0 {
+		return nil, fmt.Errorf("invalid target: %s", sys.ErrClosedFd)
+	}
+
+	progFd := opts.Program.FD()
+	if progFd < 0 {
+		return nil, fmt.Errorf("invalid program: %s", sys.ErrClosedFd)
+	}
+
+	attr := sys.LinkCreateAttr{
+		TargetFd:    uint32(opts.Target),
+		ProgFd:      uint32(progFd),
+		AttachType:  sys.AttachType(opts.Attach),
+		TargetBtfId: uint32(opts.BTF),
+		Flags:       opts.Flags,
+	}
+	fd, err := sys.LinkCreate(&attr)
+	if err != nil {
+		return nil, fmt.Errorf("create link: %w", err)
+	}
+
+	return &RawLink{fd, ""}, nil
+}
+
+func loadPinnedRawLink(fileName string, opts *ebpf.LoadPinOptions) (*RawLink, error) {
+	fd, err := sys.ObjGet(&sys.ObjGetAttr{
+		Pathname:  sys.NewStringPointer(fileName),
+		FileFlags: opts.Marshal(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load pinned link: %w", err)
+	}
+
+	return &RawLink{fd, fileName}, nil
+}
+
+func (l *RawLink) isLink() {}
+
+// FD returns the raw file descriptor.
+func (l *RawLink) FD() int {
+	return l.fd.Int()
+}
+
+// Close breaks the link.
+//
+// Use Pin if you want to make the link persistent.
+func (l *RawLink) Close() error {
+	return l.fd.Close()
+}
+
+// Pin persists a link past the lifetime of the process.
+//
+// Calling Close on a pinned Link will not break the link
+// until the pin is removed.
+func (l *RawLink) Pin(fileName string) error {
+	if err := internal.Pin(l.pinnedPath, fileName, l.fd); err != nil {
+		return err
+	}
+	l.pinnedPath = fileName
+	return nil
+}
+
+// Unpin implements the Link interface.
+func (l *RawLink) Unpin() error {
+	if err := internal.Unpin(l.pinnedPath); err != nil {
+		return err
+	}
+	l.pinnedPath = ""
+	return nil
+}
+
+// IsPinned returns true if the Link has a non-empty pinned path.
+func (l *RawLink) IsPinned() bool {
+	return l.pinnedPath != ""
+}
+
+// Update implements the Link interface.
+func (l *RawLink) Update(new *ebpf.Program) error {
+	return l.UpdateArgs(RawLinkUpdateOptions{
+		New: new,
+	})
+}
+
+// RawLinkUpdateOptions control the behaviour of RawLink.UpdateArgs.
+type RawLinkUpdateOptions struct {
+	New   *ebpf.Program
+	Old   *ebpf.Program
+	Flags uint32
+}
+
+// UpdateArgs updates a link based on args.
+func (l *RawLink) UpdateArgs(opts RawLinkUpdateOptions) error {
+	newFd := opts.New.FD()
+	if newFd < 0 {
+		return fmt.Errorf("invalid program: %s", sys.ErrClosedFd)
+	}
+
+	var oldFd int
+	if opts.Old != nil {
+		oldFd = opts.Old.FD()
+		if oldFd < 0 {
+			return fmt.Errorf("invalid replacement program: %s", sys.ErrClosedFd)
+		}
+	}
+
+	attr := sys.LinkUpdateAttr{
+		LinkFd:    l.fd.Uint(),
+		NewProgFd: uint32(newFd),
+		OldProgFd: uint32(oldFd),
+		Flags:     opts.Flags,
+	}
+	return sys.LinkUpdate(&attr)
+}
+
+// Info returns metadata about the link.
+func (l *RawLink) Info() (*Info, error) {
+	var info sys.LinkInfo
+
+	if err := sys.ObjInfo(l.fd, &info); err != nil {
+		return nil, fmt.Errorf("link info: %s", err)
+	}
+
+	var extra interface{}
+	switch info.Type {
+	case CgroupType:
+		extra = &CgroupInfo{}
+	case NetNsType:
+		extra = &NetNsInfo{}
+	case TracingType:
+		extra = &TracingInfo{}
+	case XDPType:
+		extra = &XDPInfo{}
+	case RawTracepointType, IterType,
+		PerfEventType, KprobeMultiType:
+		// Extra metadata not supported.
+	default:
+		return nil, fmt.Errorf("unknown link info type: %d", info.Type)
+	}
+
+	if extra != nil {
+		buf := bytes.NewReader(info.Extra[:])
+		err := binary.Read(buf, internal.NativeEndian, extra)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read extra link info: %w", err)
+		}
+	}
+
+	return &Info{
+		info.Type,
+		info.Id,
+		ebpf.ProgramID(info.ProgId),
+		extra,
+	}, nil
+}

--- a/vendor/github.com/cilium/ebpf/link/netns.go
+++ b/vendor/github.com/cilium/ebpf/link/netns.go
@@ -1,0 +1,36 @@
+package link
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+)
+
+// NetNsLink is a program attached to a network namespace.
+type NetNsLink struct {
+	RawLink
+}
+
+// AttachNetNs attaches a program to a network namespace.
+func AttachNetNs(ns int, prog *ebpf.Program) (*NetNsLink, error) {
+	var attach ebpf.AttachType
+	switch t := prog.Type(); t {
+	case ebpf.FlowDissector:
+		attach = ebpf.AttachFlowDissector
+	case ebpf.SkLookup:
+		attach = ebpf.AttachSkLookup
+	default:
+		return nil, fmt.Errorf("can't attach %v to network namespace", t)
+	}
+
+	link, err := AttachRawLink(RawLinkOptions{
+		Target:  ns,
+		Program: prog,
+		Attach:  attach,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &NetNsLink{*link}, nil
+}

--- a/vendor/github.com/cilium/ebpf/link/perf_event.go
+++ b/vendor/github.com/cilium/ebpf/link/perf_event.go
@@ -1,0 +1,434 @@
+package link
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+// Getting the terminology right is usually the hardest part. For posterity and
+// for staying sane during implementation:
+//
+// - trace event: Representation of a kernel runtime hook. Filesystem entries
+//   under <tracefs>/events. Can be tracepoints (static), kprobes or uprobes.
+//   Can be instantiated into perf events (see below).
+// - tracepoint: A predetermined hook point in the kernel. Exposed as trace
+//   events in (sub)directories under <tracefs>/events. Cannot be closed or
+//   removed, they are static.
+// - k(ret)probe: Ephemeral trace events based on entry or exit points of
+//   exported kernel symbols. kprobe-based (tracefs) trace events can be
+//   created system-wide by writing to the <tracefs>/kprobe_events file, or
+//   they can be scoped to the current process by creating PMU perf events.
+// - u(ret)probe: Ephemeral trace events based on user provides ELF binaries
+//   and offsets. uprobe-based (tracefs) trace events can be
+//   created system-wide by writing to the <tracefs>/uprobe_events file, or
+//   they can be scoped to the current process by creating PMU perf events.
+// - perf event: An object instantiated based on an existing trace event or
+//   kernel symbol. Referred to by fd in userspace.
+//   Exactly one eBPF program can be attached to a perf event. Multiple perf
+//   events can be created from a single trace event. Closing a perf event
+//   stops any further invocations of the attached eBPF program.
+
+var (
+	tracefsPath = "/sys/kernel/debug/tracing"
+
+	errInvalidInput = errors.New("invalid input")
+)
+
+const (
+	perfAllThreads = -1
+)
+
+type perfEventType uint8
+
+const (
+	tracepointEvent perfEventType = iota
+	kprobeEvent
+	kretprobeEvent
+	uprobeEvent
+	uretprobeEvent
+)
+
+// A perfEvent represents a perf event kernel object. Exactly one eBPF program
+// can be attached to it. It is created based on a tracefs trace event or a
+// Performance Monitoring Unit (PMU).
+type perfEvent struct {
+	// The event type determines the types of programs that can be attached.
+	typ perfEventType
+
+	// Group and name of the tracepoint/kprobe/uprobe.
+	group string
+	name  string
+
+	// PMU event ID read from sysfs. Valid IDs are non-zero.
+	pmuID uint64
+	// ID of the trace event read from tracefs. Valid IDs are non-zero.
+	tracefsID uint64
+
+	// User provided arbitrary value.
+	cookie uint64
+
+	// This is the perf event FD.
+	fd *sys.FD
+}
+
+func (pe *perfEvent) Close() error {
+	if err := pe.fd.Close(); err != nil {
+		return fmt.Errorf("closing perf event fd: %w", err)
+	}
+
+	switch pe.typ {
+	case kprobeEvent, kretprobeEvent:
+		// Clean up kprobe tracefs entry.
+		if pe.tracefsID != 0 {
+			return closeTraceFSProbeEvent(kprobeType, pe.group, pe.name)
+		}
+	case uprobeEvent, uretprobeEvent:
+		// Clean up uprobe tracefs entry.
+		if pe.tracefsID != 0 {
+			return closeTraceFSProbeEvent(uprobeType, pe.group, pe.name)
+		}
+	case tracepointEvent:
+		// Tracepoint trace events don't hold any extra resources.
+		return nil
+	}
+
+	return nil
+}
+
+// perfEventLink represents a bpf perf link.
+type perfEventLink struct {
+	RawLink
+	pe *perfEvent
+}
+
+func (pl *perfEventLink) isLink() {}
+
+// Pinning requires the underlying perf event FD to stay open.
+//
+// | PerfEvent FD | BpfLink FD | Works |
+// |--------------|------------|-------|
+// | Open         | Open       | Yes   |
+// | Closed       | Open       | No    |
+// | Open         | Closed     | No (Pin() -> EINVAL) |
+// | Closed       | Closed     | No (Pin() -> EINVAL) |
+//
+// There is currently no pretty way to recover the perf event FD
+// when loading a pinned link, so leave as not supported for now.
+func (pl *perfEventLink) Pin(string) error {
+	return fmt.Errorf("perf event link pin: %w", ErrNotSupported)
+}
+
+func (pl *perfEventLink) Unpin() error {
+	return fmt.Errorf("perf event link unpin: %w", ErrNotSupported)
+}
+
+func (pl *perfEventLink) Close() error {
+	if err := pl.pe.Close(); err != nil {
+		return fmt.Errorf("perf event link close: %w", err)
+	}
+	return pl.fd.Close()
+}
+
+func (pl *perfEventLink) Update(prog *ebpf.Program) error {
+	return fmt.Errorf("perf event link update: %w", ErrNotSupported)
+}
+
+// perfEventIoctl implements Link and handles the perf event lifecycle
+// via ioctl().
+type perfEventIoctl struct {
+	*perfEvent
+}
+
+func (pi *perfEventIoctl) isLink() {}
+
+// Since 4.15 (e87c6bc3852b "bpf: permit multiple bpf attachments for a single perf event"),
+// calling PERF_EVENT_IOC_SET_BPF appends the given program to a prog_array
+// owned by the perf event, which means multiple programs can be attached
+// simultaneously.
+//
+// Before 4.15, calling PERF_EVENT_IOC_SET_BPF more than once on a perf event
+// returns EEXIST.
+//
+// Detaching a program from a perf event is currently not possible, so a
+// program replacement mechanism cannot be implemented for perf events.
+func (pi *perfEventIoctl) Update(prog *ebpf.Program) error {
+	return fmt.Errorf("perf event ioctl update: %w", ErrNotSupported)
+}
+
+func (pi *perfEventIoctl) Pin(string) error {
+	return fmt.Errorf("perf event ioctl pin: %w", ErrNotSupported)
+}
+
+func (pi *perfEventIoctl) Unpin() error {
+	return fmt.Errorf("perf event ioctl unpin: %w", ErrNotSupported)
+}
+
+func (pi *perfEventIoctl) Info() (*Info, error) {
+	return nil, fmt.Errorf("perf event ioctl info: %w", ErrNotSupported)
+}
+
+// attach the given eBPF prog to the perf event stored in pe.
+// pe must contain a valid perf event fd.
+// prog's type must match the program type stored in pe.
+func attachPerfEvent(pe *perfEvent, prog *ebpf.Program) (Link, error) {
+	if prog == nil {
+		return nil, errors.New("cannot attach a nil program")
+	}
+	if prog.FD() < 0 {
+		return nil, fmt.Errorf("invalid program: %w", sys.ErrClosedFd)
+	}
+
+	switch pe.typ {
+	case kprobeEvent, kretprobeEvent, uprobeEvent, uretprobeEvent:
+		if t := prog.Type(); t != ebpf.Kprobe {
+			return nil, fmt.Errorf("invalid program type (expected %s): %s", ebpf.Kprobe, t)
+		}
+	case tracepointEvent:
+		if t := prog.Type(); t != ebpf.TracePoint {
+			return nil, fmt.Errorf("invalid program type (expected %s): %s", ebpf.TracePoint, t)
+		}
+	default:
+		return nil, fmt.Errorf("unknown perf event type: %d", pe.typ)
+	}
+
+	if err := haveBPFLinkPerfEvent(); err == nil {
+		return attachPerfEventLink(pe, prog)
+	}
+	return attachPerfEventIoctl(pe, prog)
+}
+
+func attachPerfEventIoctl(pe *perfEvent, prog *ebpf.Program) (*perfEventIoctl, error) {
+	if pe.cookie != 0 {
+		return nil, fmt.Errorf("cookies are not supported: %w", ErrNotSupported)
+	}
+
+	// Assign the eBPF program to the perf event.
+	err := unix.IoctlSetInt(pe.fd.Int(), unix.PERF_EVENT_IOC_SET_BPF, prog.FD())
+	if err != nil {
+		return nil, fmt.Errorf("setting perf event bpf program: %w", err)
+	}
+
+	// PERF_EVENT_IOC_ENABLE and _DISABLE ignore their given values.
+	if err := unix.IoctlSetInt(pe.fd.Int(), unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
+		return nil, fmt.Errorf("enable perf event: %s", err)
+	}
+
+	pi := &perfEventIoctl{pe}
+
+	// Close the perf event when its reference is lost to avoid leaking system resources.
+	runtime.SetFinalizer(pi, (*perfEventIoctl).Close)
+	return pi, nil
+}
+
+// Use the bpf api to attach the perf event (BPF_LINK_TYPE_PERF_EVENT, 5.15+).
+//
+// https://github.com/torvalds/linux/commit/b89fbfbb854c9afc3047e8273cc3a694650b802e
+func attachPerfEventLink(pe *perfEvent, prog *ebpf.Program) (*perfEventLink, error) {
+	fd, err := sys.LinkCreatePerfEvent(&sys.LinkCreatePerfEventAttr{
+		ProgFd:     uint32(prog.FD()),
+		TargetFd:   pe.fd.Uint(),
+		AttachType: sys.BPF_PERF_EVENT,
+		BpfCookie:  pe.cookie,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot create bpf perf link: %v", err)
+	}
+
+	pl := &perfEventLink{RawLink{fd: fd}, pe}
+
+	// Close the perf event when its reference is lost to avoid leaking system resources.
+	runtime.SetFinalizer(pl, (*perfEventLink).Close)
+	return pl, nil
+}
+
+// unsafeStringPtr returns an unsafe.Pointer to a NUL-terminated copy of str.
+func unsafeStringPtr(str string) (unsafe.Pointer, error) {
+	p, err := unix.BytePtrFromString(str)
+	if err != nil {
+		return nil, err
+	}
+	return unsafe.Pointer(p), nil
+}
+
+// getTraceEventID reads a trace event's ID from tracefs given its group and name.
+// The kernel requires group and name to be alphanumeric or underscore.
+//
+// name automatically has its invalid symbols converted to underscores so the caller
+// can pass a raw symbol name, e.g. a kernel symbol containing dots.
+func getTraceEventID(group, name string) (uint64, error) {
+	name = sanitizeSymbol(name)
+	path, err := sanitizePath(tracefsPath, "events", group, name, "id")
+	if err != nil {
+		return 0, err
+	}
+	tid, err := readUint64FromFile("%d\n", path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, err
+	}
+	if err != nil {
+		return 0, fmt.Errorf("reading trace event ID of %s/%s: %w", group, name, err)
+	}
+
+	return tid, nil
+}
+
+// openTracepointPerfEvent opens a tracepoint-type perf event. System-wide
+// [k,u]probes created by writing to <tracefs>/[k,u]probe_events are tracepoints
+// behind the scenes, and can be attached to using these perf events.
+func openTracepointPerfEvent(tid uint64, pid int) (*sys.FD, error) {
+	attr := unix.PerfEventAttr{
+		Type:        unix.PERF_TYPE_TRACEPOINT,
+		Config:      tid,
+		Sample_type: unix.PERF_SAMPLE_RAW,
+		Sample:      1,
+		Wakeup:      1,
+	}
+
+	fd, err := unix.PerfEventOpen(&attr, pid, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
+	if err != nil {
+		return nil, fmt.Errorf("opening tracepoint perf event: %w", err)
+	}
+
+	return sys.NewFD(fd)
+}
+
+func sanitizePath(base string, path ...string) (string, error) {
+	l := filepath.Join(path...)
+	p := filepath.Join(base, l)
+	if !strings.HasPrefix(p, base) {
+		return "", fmt.Errorf("path '%s' attempts to escape base path '%s': %w", l, base, errInvalidInput)
+	}
+	return p, nil
+}
+
+// readUint64FromFile reads a uint64 from a file.
+//
+// format specifies the contents of the file in fmt.Scanf syntax.
+func readUint64FromFile(format string, path ...string) (uint64, error) {
+	filename := filepath.Join(path...)
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return 0, fmt.Errorf("reading file %q: %w", filename, err)
+	}
+
+	var value uint64
+	n, err := fmt.Fscanf(bytes.NewReader(data), format, &value)
+	if err != nil {
+		return 0, fmt.Errorf("parsing file %q: %w", filename, err)
+	}
+	if n != 1 {
+		return 0, fmt.Errorf("parsing file %q: expected 1 item, got %d", filename, n)
+	}
+
+	return value, nil
+}
+
+type uint64FromFileKey struct {
+	format, path string
+}
+
+var uint64FromFileCache = struct {
+	sync.RWMutex
+	values map[uint64FromFileKey]uint64
+}{
+	values: map[uint64FromFileKey]uint64{},
+}
+
+// readUint64FromFileOnce is like readUint64FromFile but memoizes the result.
+func readUint64FromFileOnce(format string, path ...string) (uint64, error) {
+	filename := filepath.Join(path...)
+	key := uint64FromFileKey{format, filename}
+
+	uint64FromFileCache.RLock()
+	if value, ok := uint64FromFileCache.values[key]; ok {
+		uint64FromFileCache.RUnlock()
+		return value, nil
+	}
+	uint64FromFileCache.RUnlock()
+
+	value, err := readUint64FromFile(format, filename)
+	if err != nil {
+		return 0, err
+	}
+
+	uint64FromFileCache.Lock()
+	defer uint64FromFileCache.Unlock()
+
+	if value, ok := uint64FromFileCache.values[key]; ok {
+		// Someone else got here before us, use what is cached.
+		return value, nil
+	}
+
+	uint64FromFileCache.values[key] = value
+	return value, nil
+}
+
+// Probe BPF perf link.
+//
+// https://elixir.bootlin.com/linux/v5.16.8/source/kernel/bpf/syscall.c#L4307
+// https://github.com/torvalds/linux/commit/b89fbfbb854c9afc3047e8273cc3a694650b802e
+var haveBPFLinkPerfEvent = internal.NewFeatureTest("bpf_link_perf_event", "5.15", func() error {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: "probe_bpf_perf_link",
+		Type: ebpf.Kprobe,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "MIT",
+	})
+	if err != nil {
+		return err
+	}
+	defer prog.Close()
+
+	_, err = sys.LinkCreatePerfEvent(&sys.LinkCreatePerfEventAttr{
+		ProgFd:     uint32(prog.FD()),
+		AttachType: sys.BPF_PERF_EVENT,
+	})
+	if errors.Is(err, unix.EINVAL) {
+		return internal.ErrNotSupported
+	}
+	if errors.Is(err, unix.EBADF) {
+		return nil
+	}
+	return err
+})
+
+// isValidTraceID implements the equivalent of a regex match
+// against "^[a-zA-Z_][0-9a-zA-Z_]*$".
+//
+// Trace event groups, names and kernel symbols must adhere to this set
+// of characters. Non-empty, first character must not be a number, all
+// characters must be alphanumeric or underscore.
+func isValidTraceID(s string) bool {
+	if len(s) < 1 {
+		return false
+	}
+	for i, c := range []byte(s) {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c == '_':
+		case i > 0 && c >= '0' && c <= '9':
+
+		default:
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/cilium/ebpf/link/platform.go
+++ b/vendor/github.com/cilium/ebpf/link/platform.go
@@ -1,0 +1,25 @@
+package link
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func platformPrefix(symbol string) string {
+
+	prefix := runtime.GOARCH
+
+	// per https://github.com/golang/go/blob/master/src/go/build/syslist.go
+	switch prefix {
+	case "386":
+		prefix = "ia32"
+	case "amd64", "amd64p32":
+		prefix = "x64"
+	case "arm64", "arm64be":
+		prefix = "arm64"
+	default:
+		return symbol
+	}
+
+	return fmt.Sprintf("__%s_%s", prefix, symbol)
+}

--- a/vendor/github.com/cilium/ebpf/link/program.go
+++ b/vendor/github.com/cilium/ebpf/link/program.go
@@ -1,0 +1,76 @@
+package link
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/sys"
+)
+
+type RawAttachProgramOptions struct {
+	// File descriptor to attach to. This differs for each attach type.
+	Target int
+	// Program to attach.
+	Program *ebpf.Program
+	// Program to replace (cgroups).
+	Replace *ebpf.Program
+	// Attach must match the attach type of Program (and Replace).
+	Attach ebpf.AttachType
+	// Flags control the attach behaviour. This differs for each attach type.
+	Flags uint32
+}
+
+// RawAttachProgram is a low level wrapper around BPF_PROG_ATTACH.
+//
+// You should use one of the higher level abstractions available in this
+// package if possible.
+func RawAttachProgram(opts RawAttachProgramOptions) error {
+	if err := haveProgAttach(); err != nil {
+		return err
+	}
+
+	var replaceFd uint32
+	if opts.Replace != nil {
+		replaceFd = uint32(opts.Replace.FD())
+	}
+
+	attr := sys.ProgAttachAttr{
+		TargetFd:     uint32(opts.Target),
+		AttachBpfFd:  uint32(opts.Program.FD()),
+		ReplaceBpfFd: replaceFd,
+		AttachType:   uint32(opts.Attach),
+		AttachFlags:  uint32(opts.Flags),
+	}
+
+	if err := sys.ProgAttach(&attr); err != nil {
+		return fmt.Errorf("can't attach program: %w", err)
+	}
+	return nil
+}
+
+type RawDetachProgramOptions struct {
+	Target  int
+	Program *ebpf.Program
+	Attach  ebpf.AttachType
+}
+
+// RawDetachProgram is a low level wrapper around BPF_PROG_DETACH.
+//
+// You should use one of the higher level abstractions available in this
+// package if possible.
+func RawDetachProgram(opts RawDetachProgramOptions) error {
+	if err := haveProgAttach(); err != nil {
+		return err
+	}
+
+	attr := sys.ProgDetachAttr{
+		TargetFd:    uint32(opts.Target),
+		AttachBpfFd: uint32(opts.Program.FD()),
+		AttachType:  uint32(opts.Attach),
+	}
+	if err := sys.ProgDetach(&attr); err != nil {
+		return fmt.Errorf("can't detach program: %w", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/cilium/ebpf/link/query.go
+++ b/vendor/github.com/cilium/ebpf/link/query.go
@@ -1,0 +1,63 @@
+package link
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/sys"
+)
+
+// QueryOptions defines additional parameters when querying for programs.
+type QueryOptions struct {
+	// Path can be a path to a cgroup, netns or LIRC2 device
+	Path string
+	// Attach specifies the AttachType of the programs queried for
+	Attach ebpf.AttachType
+	// QueryFlags are flags for BPF_PROG_QUERY, e.g. BPF_F_QUERY_EFFECTIVE
+	QueryFlags uint32
+}
+
+// QueryPrograms retrieves ProgramIDs associated with the AttachType.
+//
+// It only returns IDs of programs that were attached using PROG_ATTACH and not bpf_link.
+// Returns (nil, nil) if there are no programs attached to the queried kernel resource.
+// Calling QueryPrograms on a kernel missing PROG_QUERY will result in ErrNotSupported.
+func QueryPrograms(opts QueryOptions) ([]ebpf.ProgramID, error) {
+	if haveProgQuery() != nil {
+		return nil, fmt.Errorf("can't query program IDs: %w", ErrNotSupported)
+	}
+
+	f, err := os.Open(opts.Path)
+	if err != nil {
+		return nil, fmt.Errorf("can't open file: %s", err)
+	}
+	defer f.Close()
+
+	// query the number of programs to allocate correct slice size
+	attr := sys.ProgQueryAttr{
+		TargetFd:   uint32(f.Fd()),
+		AttachType: sys.AttachType(opts.Attach),
+		QueryFlags: opts.QueryFlags,
+	}
+	if err := sys.ProgQuery(&attr); err != nil {
+		return nil, fmt.Errorf("can't query program count: %w", err)
+	}
+
+	// return nil if no progs are attached
+	if attr.ProgCount == 0 {
+		return nil, nil
+	}
+
+	// we have at least one prog, so we query again
+	progIds := make([]ebpf.ProgramID, attr.ProgCount)
+	attr.ProgIds = sys.NewPointer(unsafe.Pointer(&progIds[0]))
+	attr.ProgCount = uint32(len(progIds))
+	if err := sys.ProgQuery(&attr); err != nil {
+		return nil, fmt.Errorf("can't query program IDs: %w", err)
+	}
+
+	return progIds, nil
+
+}

--- a/vendor/github.com/cilium/ebpf/link/raw_tracepoint.go
+++ b/vendor/github.com/cilium/ebpf/link/raw_tracepoint.go
@@ -1,0 +1,87 @@
+package link
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/sys"
+)
+
+type RawTracepointOptions struct {
+	// Tracepoint name.
+	Name string
+	// Program must be of type RawTracepoint*
+	Program *ebpf.Program
+}
+
+// AttachRawTracepoint links a BPF program to a raw_tracepoint.
+//
+// Requires at least Linux 4.17.
+func AttachRawTracepoint(opts RawTracepointOptions) (Link, error) {
+	if t := opts.Program.Type(); t != ebpf.RawTracepoint && t != ebpf.RawTracepointWritable {
+		return nil, fmt.Errorf("invalid program type %s, expected RawTracepoint(Writable)", t)
+	}
+	if opts.Program.FD() < 0 {
+		return nil, fmt.Errorf("invalid program: %w", sys.ErrClosedFd)
+	}
+
+	fd, err := sys.RawTracepointOpen(&sys.RawTracepointOpenAttr{
+		Name:   sys.NewStringPointer(opts.Name),
+		ProgFd: uint32(opts.Program.FD()),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = haveBPFLink()
+	if errors.Is(err, ErrNotSupported) {
+		// Prior to commit 70ed506c3bbc ("bpf: Introduce pinnable bpf_link abstraction")
+		// raw_tracepoints are just a plain fd.
+		return &simpleRawTracepoint{fd}, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &rawTracepoint{RawLink{fd: fd}}, nil
+}
+
+type simpleRawTracepoint struct {
+	fd *sys.FD
+}
+
+var _ Link = (*simpleRawTracepoint)(nil)
+
+func (frt *simpleRawTracepoint) isLink() {}
+
+func (frt *simpleRawTracepoint) Close() error {
+	return frt.fd.Close()
+}
+
+func (frt *simpleRawTracepoint) Update(_ *ebpf.Program) error {
+	return fmt.Errorf("update raw_tracepoint: %w", ErrNotSupported)
+}
+
+func (frt *simpleRawTracepoint) Pin(string) error {
+	return fmt.Errorf("pin raw_tracepoint: %w", ErrNotSupported)
+}
+
+func (frt *simpleRawTracepoint) Unpin() error {
+	return fmt.Errorf("unpin raw_tracepoint: %w", ErrNotSupported)
+}
+
+func (frt *simpleRawTracepoint) Info() (*Info, error) {
+	return nil, fmt.Errorf("can't get raw_tracepoint info: %w", ErrNotSupported)
+}
+
+type rawTracepoint struct {
+	RawLink
+}
+
+var _ Link = (*rawTracepoint)(nil)
+
+func (rt *rawTracepoint) Update(_ *ebpf.Program) error {
+	return fmt.Errorf("update raw_tracepoint: %w", ErrNotSupported)
+}

--- a/vendor/github.com/cilium/ebpf/link/socket_filter.go
+++ b/vendor/github.com/cilium/ebpf/link/socket_filter.go
@@ -1,0 +1,40 @@
+package link
+
+import (
+	"syscall"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+// AttachSocketFilter attaches a SocketFilter BPF program to a socket.
+func AttachSocketFilter(conn syscall.Conn, program *ebpf.Program) error {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var ssoErr error
+	err = rawConn.Control(func(fd uintptr) {
+		ssoErr = syscall.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_ATTACH_BPF, program.FD())
+	})
+	if ssoErr != nil {
+		return ssoErr
+	}
+	return err
+}
+
+// DetachSocketFilter detaches a SocketFilter BPF program from a socket.
+func DetachSocketFilter(conn syscall.Conn) error {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var ssoErr error
+	err = rawConn.Control(func(fd uintptr) {
+		ssoErr = syscall.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_DETACH_BPF, 0)
+	})
+	if ssoErr != nil {
+		return ssoErr
+	}
+	return err
+}

--- a/vendor/github.com/cilium/ebpf/link/syscalls.go
+++ b/vendor/github.com/cilium/ebpf/link/syscalls.go
@@ -1,0 +1,123 @@
+package link
+
+import (
+	"errors"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+// Type is the kind of link.
+type Type = sys.LinkType
+
+// Valid link types.
+const (
+	UnspecifiedType   = sys.BPF_LINK_TYPE_UNSPEC
+	RawTracepointType = sys.BPF_LINK_TYPE_RAW_TRACEPOINT
+	TracingType       = sys.BPF_LINK_TYPE_TRACING
+	CgroupType        = sys.BPF_LINK_TYPE_CGROUP
+	IterType          = sys.BPF_LINK_TYPE_ITER
+	NetNsType         = sys.BPF_LINK_TYPE_NETNS
+	XDPType           = sys.BPF_LINK_TYPE_XDP
+	PerfEventType     = sys.BPF_LINK_TYPE_PERF_EVENT
+	KprobeMultiType   = sys.BPF_LINK_TYPE_KPROBE_MULTI
+)
+
+var haveProgAttach = internal.NewFeatureTest("BPF_PROG_ATTACH", "4.10", func() error {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type:    ebpf.CGroupSKB,
+		License: "MIT",
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+	})
+	if err != nil {
+		return internal.ErrNotSupported
+	}
+
+	// BPF_PROG_ATTACH was introduced at the same time as CGgroupSKB,
+	// so being able to load the program is enough to infer that we
+	// have the syscall.
+	prog.Close()
+	return nil
+})
+
+var haveProgAttachReplace = internal.NewFeatureTest("BPF_PROG_ATTACH atomic replacement", "5.5", func() error {
+	if err := haveProgAttach(); err != nil {
+		return err
+	}
+
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type:       ebpf.CGroupSKB,
+		AttachType: ebpf.AttachCGroupInetIngress,
+		License:    "MIT",
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+	})
+	if err != nil {
+		return internal.ErrNotSupported
+	}
+	defer prog.Close()
+
+	// We know that we have BPF_PROG_ATTACH since we can load CGroupSKB programs.
+	// If passing BPF_F_REPLACE gives us EINVAL we know that the feature isn't
+	// present.
+	attr := sys.ProgAttachAttr{
+		// We rely on this being checked after attachFlags.
+		TargetFd:    ^uint32(0),
+		AttachBpfFd: uint32(prog.FD()),
+		AttachType:  uint32(ebpf.AttachCGroupInetIngress),
+		AttachFlags: uint32(flagReplace),
+	}
+
+	err = sys.ProgAttach(&attr)
+	if errors.Is(err, unix.EINVAL) {
+		return internal.ErrNotSupported
+	}
+	if errors.Is(err, unix.EBADF) {
+		return nil
+	}
+	return err
+})
+
+var haveBPFLink = internal.NewFeatureTest("bpf_link", "5.7", func() error {
+	attr := sys.LinkCreateAttr{
+		// This is a hopefully invalid file descriptor, which triggers EBADF.
+		TargetFd:   ^uint32(0),
+		ProgFd:     ^uint32(0),
+		AttachType: sys.AttachType(ebpf.AttachCGroupInetIngress),
+	}
+	_, err := sys.LinkCreate(&attr)
+	if errors.Is(err, unix.EINVAL) {
+		return internal.ErrNotSupported
+	}
+	if errors.Is(err, unix.EBADF) {
+		return nil
+	}
+	return err
+})
+
+var haveProgQuery = internal.NewFeatureTest("BPF_PROG_QUERY", "4.15", func() error {
+	attr := sys.ProgQueryAttr{
+		// We rely on this being checked during the syscall.
+		// With an otherwise correct payload we expect EBADF here
+		// as an indication that the feature is present.
+		TargetFd:   ^uint32(0),
+		AttachType: sys.AttachType(ebpf.AttachCGroupInetIngress),
+	}
+
+	err := sys.ProgQuery(&attr)
+	if errors.Is(err, unix.EINVAL) {
+		return internal.ErrNotSupported
+	}
+	if errors.Is(err, unix.EBADF) {
+		return nil
+	}
+	return err
+})

--- a/vendor/github.com/cilium/ebpf/link/tracepoint.go
+++ b/vendor/github.com/cilium/ebpf/link/tracepoint.go
@@ -1,0 +1,77 @@
+package link
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+)
+
+// TracepointOptions defines additional parameters that will be used
+// when loading Tracepoints.
+type TracepointOptions struct {
+	// Arbitrary value that can be fetched from an eBPF program
+	// via `bpf_get_attach_cookie()`.
+	//
+	// Needs kernel 5.15+.
+	Cookie uint64
+}
+
+// Tracepoint attaches the given eBPF program to the tracepoint with the given
+// group and name. See /sys/kernel/debug/tracing/events to find available
+// tracepoints. The top-level directory is the group, the event's subdirectory
+// is the name. Example:
+//
+//	tp, err := Tracepoint("syscalls", "sys_enter_fork", prog, nil)
+//
+// Losing the reference to the resulting Link (tp) will close the Tracepoint
+// and prevent further execution of prog. The Link must be Closed during
+// program shutdown to avoid leaking system resources.
+//
+// Note that attaching eBPF programs to syscalls (sys_enter_*/sys_exit_*) is
+// only possible as of kernel 4.14 (commit cf5f5ce).
+func Tracepoint(group, name string, prog *ebpf.Program, opts *TracepointOptions) (Link, error) {
+	if group == "" || name == "" {
+		return nil, fmt.Errorf("group and name cannot be empty: %w", errInvalidInput)
+	}
+	if prog == nil {
+		return nil, fmt.Errorf("prog cannot be nil: %w", errInvalidInput)
+	}
+	if !isValidTraceID(group) || !isValidTraceID(name) {
+		return nil, fmt.Errorf("group and name '%s/%s' must be alphanumeric or underscore: %w", group, name, errInvalidInput)
+	}
+	if prog.Type() != ebpf.TracePoint {
+		return nil, fmt.Errorf("eBPF program type %s is not a Tracepoint: %w", prog.Type(), errInvalidInput)
+	}
+
+	tid, err := getTraceEventID(group, name)
+	if err != nil {
+		return nil, err
+	}
+
+	fd, err := openTracepointPerfEvent(tid, perfAllThreads)
+	if err != nil {
+		return nil, err
+	}
+
+	var cookie uint64
+	if opts != nil {
+		cookie = opts.Cookie
+	}
+
+	pe := &perfEvent{
+		typ:       tracepointEvent,
+		group:     group,
+		name:      name,
+		tracefsID: tid,
+		cookie:    cookie,
+		fd:        fd,
+	}
+
+	lnk, err := attachPerfEvent(pe, prog)
+	if err != nil {
+		pe.Close()
+		return nil, err
+	}
+
+	return lnk, nil
+}

--- a/vendor/github.com/cilium/ebpf/link/tracing.go
+++ b/vendor/github.com/cilium/ebpf/link/tracing.go
@@ -1,0 +1,150 @@
+package link
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/internal/sys"
+)
+
+type tracing struct {
+	RawLink
+}
+
+func (f *tracing) Update(new *ebpf.Program) error {
+	return fmt.Errorf("tracing update: %w", ErrNotSupported)
+}
+
+// AttachFreplace attaches the given eBPF program to the function it replaces.
+//
+// The program and name can either be provided at link time, or can be provided
+// at program load time. If they were provided at load time, they should be nil
+// and empty respectively here, as they will be ignored by the kernel.
+// Examples:
+//
+//	AttachFreplace(dispatcher, "function", replacement)
+//	AttachFreplace(nil, "", replacement)
+func AttachFreplace(targetProg *ebpf.Program, name string, prog *ebpf.Program) (Link, error) {
+	if (name == "") != (targetProg == nil) {
+		return nil, fmt.Errorf("must provide both or neither of name and targetProg: %w", errInvalidInput)
+	}
+	if prog == nil {
+		return nil, fmt.Errorf("prog cannot be nil: %w", errInvalidInput)
+	}
+	if prog.Type() != ebpf.Extension {
+		return nil, fmt.Errorf("eBPF program type %s is not an Extension: %w", prog.Type(), errInvalidInput)
+	}
+
+	var (
+		target int
+		typeID btf.TypeID
+	)
+	if targetProg != nil {
+		btfHandle, err := targetProg.Handle()
+		if err != nil {
+			return nil, err
+		}
+		defer btfHandle.Close()
+
+		spec, err := btfHandle.Spec()
+		if err != nil {
+			return nil, err
+		}
+
+		var function *btf.Func
+		if err := spec.TypeByName(name, &function); err != nil {
+			return nil, err
+		}
+
+		target = targetProg.FD()
+		typeID, err = spec.TypeID(function)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	link, err := AttachRawLink(RawLinkOptions{
+		Target:  target,
+		Program: prog,
+		Attach:  ebpf.AttachNone,
+		BTF:     typeID,
+	})
+	if errors.Is(err, sys.ENOTSUPP) {
+		// This may be returned by bpf_tracing_prog_attach via bpf_arch_text_poke.
+		return nil, fmt.Errorf("create raw tracepoint: %w", ErrNotSupported)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &tracing{*link}, nil
+}
+
+type TracingOptions struct {
+	// Program must be of type Tracing with attach type
+	// AttachTraceFEntry/AttachTraceFExit/AttachModifyReturn or
+	// AttachTraceRawTp.
+	Program *ebpf.Program
+}
+
+type LSMOptions struct {
+	// Program must be of type LSM with attach type
+	// AttachLSMMac.
+	Program *ebpf.Program
+}
+
+// attachBTFID links all BPF program types (Tracing/LSM) that they attach to a btf_id.
+func attachBTFID(program *ebpf.Program) (Link, error) {
+	if program.FD() < 0 {
+		return nil, fmt.Errorf("invalid program %w", sys.ErrClosedFd)
+	}
+
+	fd, err := sys.RawTracepointOpen(&sys.RawTracepointOpenAttr{
+		ProgFd: uint32(program.FD()),
+	})
+	if errors.Is(err, sys.ENOTSUPP) {
+		// This may be returned by bpf_tracing_prog_attach via bpf_arch_text_poke.
+		return nil, fmt.Errorf("create raw tracepoint: %w", ErrNotSupported)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create raw tracepoint: %w", err)
+	}
+
+	raw := RawLink{fd: fd}
+	info, err := raw.Info()
+	if err != nil {
+		raw.Close()
+		return nil, err
+	}
+
+	if info.Type == RawTracepointType {
+		// Sadness upon sadness: a Tracing program with AttachRawTp returns
+		// a raw_tracepoint link. Other types return a tracing link.
+		return &rawTracepoint{raw}, nil
+	}
+
+	return &tracing{RawLink: RawLink{fd: fd}}, nil
+}
+
+// AttachTracing links a tracing (fentry/fexit/fmod_ret) BPF program or
+// a BTF-powered raw tracepoint (tp_btf) BPF Program to a BPF hook defined
+// in kernel modules.
+func AttachTracing(opts TracingOptions) (Link, error) {
+	if t := opts.Program.Type(); t != ebpf.Tracing {
+		return nil, fmt.Errorf("invalid program type %s, expected Tracing", t)
+	}
+
+	return attachBTFID(opts.Program)
+}
+
+// AttachLSM links a Linux security module (LSM) BPF Program to a BPF
+// hook defined in kernel modules.
+func AttachLSM(opts LSMOptions) (Link, error) {
+	if t := opts.Program.Type(); t != ebpf.LSM {
+		return nil, fmt.Errorf("invalid program type %s, expected LSM", t)
+	}
+
+	return attachBTFID(opts.Program)
+}

--- a/vendor/github.com/cilium/ebpf/link/uprobe.go
+++ b/vendor/github.com/cilium/ebpf/link/uprobe.go
@@ -1,0 +1,359 @@
+package link
+
+import (
+	"debug/elf"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal"
+)
+
+var (
+	uprobeEventsPath = filepath.Join(tracefsPath, "uprobe_events")
+
+	uprobeRefCtrOffsetPMUPath = "/sys/bus/event_source/devices/uprobe/format/ref_ctr_offset"
+	// elixir.bootlin.com/linux/v5.15-rc7/source/kernel/events/core.c#L9799
+	uprobeRefCtrOffsetShift = 32
+	haveRefCtrOffsetPMU     = internal.NewFeatureTest("RefCtrOffsetPMU", "4.20", func() error {
+		_, err := os.Stat(uprobeRefCtrOffsetPMUPath)
+		if err != nil {
+			return internal.ErrNotSupported
+		}
+		return nil
+	})
+
+	// ErrNoSymbol indicates that the given symbol was not found
+	// in the ELF symbols table.
+	ErrNoSymbol = errors.New("not found")
+)
+
+// Executable defines an executable program on the filesystem.
+type Executable struct {
+	// Path of the executable on the filesystem.
+	path string
+	// Parsed ELF and dynamic symbols' addresses.
+	addresses map[string]uint64
+}
+
+// UprobeOptions defines additional parameters that will be used
+// when loading Uprobes.
+type UprobeOptions struct {
+	// Symbol address. Must be provided in case of external symbols (shared libs).
+	// If set, overrides the address eventually parsed from the executable.
+	Address uint64
+	// The offset relative to given symbol. Useful when tracing an arbitrary point
+	// inside the frame of given symbol.
+	//
+	// Note: this field changed from being an absolute offset to being relative
+	// to Address.
+	Offset uint64
+	// Only set the uprobe on the given process ID. Useful when tracing
+	// shared library calls or programs that have many running instances.
+	PID int
+	// Automatically manage SDT reference counts (semaphores).
+	//
+	// If this field is set, the Kernel will increment/decrement the
+	// semaphore located in the process memory at the provided address on
+	// probe attach/detach.
+	//
+	// See also:
+	// sourceware.org/systemtap/wiki/UserSpaceProbeImplementation (Semaphore Handling)
+	// github.com/torvalds/linux/commit/1cc33161a83d
+	// github.com/torvalds/linux/commit/a6ca88b241d5
+	RefCtrOffset uint64
+	// Arbitrary value that can be fetched from an eBPF program
+	// via `bpf_get_attach_cookie()`.
+	//
+	// Needs kernel 5.15+.
+	Cookie uint64
+}
+
+// To open a new Executable, use:
+//
+//	OpenExecutable("/bin/bash")
+//
+// The returned value can then be used to open Uprobe(s).
+func OpenExecutable(path string) (*Executable, error) {
+	if path == "" {
+		return nil, fmt.Errorf("path cannot be empty")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open file '%s': %w", path, err)
+	}
+	defer f.Close()
+
+	se, err := internal.NewSafeELFFile(f)
+	if err != nil {
+		return nil, fmt.Errorf("parse ELF file: %w", err)
+	}
+
+	if se.Type != elf.ET_EXEC && se.Type != elf.ET_DYN {
+		// ELF is not an executable or a shared object.
+		return nil, errors.New("the given file is not an executable or a shared object")
+	}
+
+	ex := Executable{
+		path:      path,
+		addresses: make(map[string]uint64),
+	}
+
+	if err := ex.load(se); err != nil {
+		return nil, err
+	}
+
+	return &ex, nil
+}
+
+func (ex *Executable) load(f *internal.SafeELFFile) error {
+	syms, err := f.Symbols()
+	if err != nil && !errors.Is(err, elf.ErrNoSymbols) {
+		return err
+	}
+
+	dynsyms, err := f.DynamicSymbols()
+	if err != nil && !errors.Is(err, elf.ErrNoSymbols) {
+		return err
+	}
+
+	syms = append(syms, dynsyms...)
+
+	for _, s := range syms {
+		if elf.ST_TYPE(s.Info) != elf.STT_FUNC {
+			// Symbol not associated with a function or other executable code.
+			continue
+		}
+
+		address := s.Value
+
+		// Loop over ELF segments.
+		for _, prog := range f.Progs {
+			// Skip uninteresting segments.
+			if prog.Type != elf.PT_LOAD || (prog.Flags&elf.PF_X) == 0 {
+				continue
+			}
+
+			if prog.Vaddr <= s.Value && s.Value < (prog.Vaddr+prog.Memsz) {
+				// If the symbol value is contained in the segment, calculate
+				// the symbol offset.
+				//
+				// fn symbol offset = fn symbol VA - .text VA + .text offset
+				//
+				// stackoverflow.com/a/40249502
+				address = s.Value - prog.Vaddr + prog.Off
+				break
+			}
+		}
+
+		ex.addresses[s.Name] = address
+	}
+
+	return nil
+}
+
+// address calculates the address of a symbol in the executable.
+//
+// opts must not be nil.
+func (ex *Executable) address(symbol string, opts *UprobeOptions) (uint64, error) {
+	if opts.Address > 0 {
+		return opts.Address + opts.Offset, nil
+	}
+
+	address, ok := ex.addresses[symbol]
+	if !ok {
+		return 0, fmt.Errorf("symbol %s: %w", symbol, ErrNoSymbol)
+	}
+
+	// Symbols with location 0 from section undef are shared library calls and
+	// are relocated before the binary is executed. Dynamic linking is not
+	// implemented by the library, so mark this as unsupported for now.
+	//
+	// Since only offset values are stored and not elf.Symbol, if the value is 0,
+	// assume it's an external symbol.
+	if address == 0 {
+		return 0, fmt.Errorf("cannot resolve %s library call '%s': %w "+
+			"(consider providing UprobeOptions.Address)", ex.path, symbol, ErrNotSupported)
+	}
+
+	return address + opts.Offset, nil
+}
+
+// Uprobe attaches the given eBPF program to a perf event that fires when the
+// given symbol starts executing in the given Executable.
+// For example, /bin/bash::main():
+//
+//	ex, _ = OpenExecutable("/bin/bash")
+//	ex.Uprobe("main", prog, nil)
+//
+// When using symbols which belongs to shared libraries,
+// an offset must be provided via options:
+//
+//	up, err := ex.Uprobe("main", prog, &UprobeOptions{Offset: 0x123})
+//
+// Note: Setting the Offset field in the options supersedes the symbol's offset.
+//
+// Losing the reference to the resulting Link (up) will close the Uprobe
+// and prevent further execution of prog. The Link must be Closed during
+// program shutdown to avoid leaking system resources.
+//
+// Functions provided by shared libraries can currently not be traced and
+// will result in an ErrNotSupported.
+func (ex *Executable) Uprobe(symbol string, prog *ebpf.Program, opts *UprobeOptions) (Link, error) {
+	u, err := ex.uprobe(symbol, prog, opts, false)
+	if err != nil {
+		return nil, err
+	}
+
+	lnk, err := attachPerfEvent(u, prog)
+	if err != nil {
+		u.Close()
+		return nil, err
+	}
+
+	return lnk, nil
+}
+
+// Uretprobe attaches the given eBPF program to a perf event that fires right
+// before the given symbol exits. For example, /bin/bash::main():
+//
+//	ex, _ = OpenExecutable("/bin/bash")
+//	ex.Uretprobe("main", prog, nil)
+//
+// When using symbols which belongs to shared libraries,
+// an offset must be provided via options:
+//
+//	up, err := ex.Uretprobe("main", prog, &UprobeOptions{Offset: 0x123})
+//
+// Note: Setting the Offset field in the options supersedes the symbol's offset.
+//
+// Losing the reference to the resulting Link (up) will close the Uprobe
+// and prevent further execution of prog. The Link must be Closed during
+// program shutdown to avoid leaking system resources.
+//
+// Functions provided by shared libraries can currently not be traced and
+// will result in an ErrNotSupported.
+func (ex *Executable) Uretprobe(symbol string, prog *ebpf.Program, opts *UprobeOptions) (Link, error) {
+	u, err := ex.uprobe(symbol, prog, opts, true)
+	if err != nil {
+		return nil, err
+	}
+
+	lnk, err := attachPerfEvent(u, prog)
+	if err != nil {
+		u.Close()
+		return nil, err
+	}
+
+	return lnk, nil
+}
+
+// uprobe opens a perf event for the given binary/symbol and attaches prog to it.
+// If ret is true, create a uretprobe.
+func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOptions, ret bool) (*perfEvent, error) {
+	if prog == nil {
+		return nil, fmt.Errorf("prog cannot be nil: %w", errInvalidInput)
+	}
+	if prog.Type() != ebpf.Kprobe {
+		return nil, fmt.Errorf("eBPF program type %s is not Kprobe: %w", prog.Type(), errInvalidInput)
+	}
+	if opts == nil {
+		opts = &UprobeOptions{}
+	}
+
+	offset, err := ex.address(symbol, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	pid := opts.PID
+	if pid == 0 {
+		pid = perfAllThreads
+	}
+
+	if opts.RefCtrOffset != 0 {
+		if err := haveRefCtrOffsetPMU(); err != nil {
+			return nil, fmt.Errorf("uprobe ref_ctr_offset: %w", err)
+		}
+	}
+
+	args := probeArgs{
+		symbol:       symbol,
+		path:         ex.path,
+		offset:       offset,
+		pid:          pid,
+		refCtrOffset: opts.RefCtrOffset,
+		ret:          ret,
+		cookie:       opts.Cookie,
+	}
+
+	// Use uprobe PMU if the kernel has it available.
+	tp, err := pmuUprobe(args)
+	if err == nil {
+		return tp, nil
+	}
+	if err != nil && !errors.Is(err, ErrNotSupported) {
+		return nil, fmt.Errorf("creating perf_uprobe PMU: %w", err)
+	}
+
+	// Use tracefs if uprobe PMU is missing.
+	args.symbol = sanitizeSymbol(symbol)
+	tp, err = tracefsUprobe(args)
+	if err != nil {
+		return nil, fmt.Errorf("creating trace event '%s:%s' in tracefs: %w", ex.path, symbol, err)
+	}
+
+	return tp, nil
+}
+
+// pmuUprobe opens a perf event based on the uprobe PMU.
+func pmuUprobe(args probeArgs) (*perfEvent, error) {
+	return pmuProbe(uprobeType, args)
+}
+
+// tracefsUprobe creates a Uprobe tracefs entry.
+func tracefsUprobe(args probeArgs) (*perfEvent, error) {
+	return tracefsProbe(uprobeType, args)
+}
+
+// sanitizeSymbol replaces every invalid character for the tracefs api with an underscore.
+// It is equivalent to calling regexp.MustCompile("[^a-zA-Z0-9]+").ReplaceAllString("_").
+func sanitizeSymbol(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	var skip bool
+	for _, c := range []byte(s) {
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9':
+			skip = false
+			b.WriteByte(c)
+
+		default:
+			if !skip {
+				b.WriteByte('_')
+				skip = true
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// uprobeToken creates the PATH:OFFSET(REF_CTR_OFFSET) token for the tracefs api.
+func uprobeToken(args probeArgs) string {
+	po := fmt.Sprintf("%s:%#x", args.path, args.offset)
+
+	if args.refCtrOffset != 0 {
+		// This is not documented in Documentation/trace/uprobetracer.txt.
+		// elixir.bootlin.com/linux/v5.15-rc7/source/kernel/trace/trace.c#L5564
+		po += fmt.Sprintf("(%#x)", args.refCtrOffset)
+	}
+
+	return po
+}

--- a/vendor/github.com/cilium/ebpf/link/xdp.go
+++ b/vendor/github.com/cilium/ebpf/link/xdp.go
@@ -1,0 +1,54 @@
+package link
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+)
+
+// XDPAttachFlags represents how XDP program will be attached to interface.
+type XDPAttachFlags uint32
+
+const (
+	// XDPGenericMode (SKB) links XDP BPF program for drivers which do
+	// not yet support native XDP.
+	XDPGenericMode XDPAttachFlags = 1 << (iota + 1)
+	// XDPDriverMode links XDP BPF program into the driver’s receive path.
+	XDPDriverMode
+	// XDPOffloadMode offloads the entire XDP BPF program into hardware.
+	XDPOffloadMode
+)
+
+type XDPOptions struct {
+	// Program must be an XDP BPF program.
+	Program *ebpf.Program
+
+	// Interface is the interface index to attach program to.
+	Interface int
+
+	// Flags is one of XDPAttachFlags (optional).
+	//
+	// Only one XDP mode should be set, without flag defaults
+	// to driver/generic mode (best effort).
+	Flags XDPAttachFlags
+}
+
+// AttachXDP links an XDP BPF program to an XDP hook.
+func AttachXDP(opts XDPOptions) (Link, error) {
+	if t := opts.Program.Type(); t != ebpf.XDP {
+		return nil, fmt.Errorf("invalid program type %s, expected XDP", t)
+	}
+
+	if opts.Interface < 1 {
+		return nil, fmt.Errorf("invalid interface index: %d", opts.Interface)
+	}
+
+	rawLink, err := AttachRawLink(RawLinkOptions{
+		Program: opts.Program,
+		Attach:  ebpf.AttachXDP,
+		Target:  opts.Interface,
+		Flags:   uint32(opts.Flags),
+	})
+
+	return rawLink, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -192,6 +192,7 @@ github.com/cilium/ebpf/internal
 github.com/cilium/ebpf/internal/epoll
 github.com/cilium/ebpf/internal/sys
 github.com/cilium/ebpf/internal/unix
+github.com/cilium/ebpf/link
 github.com/cilium/ebpf/perf
 github.com/cilium/ebpf/rlimit
 # github.com/cilium/ipam v0.0.0-20220824141044-46ef3d556735


### PR DESCRIPTION
Description taken from the main commit:
```
With this PR we translate code from bpf/init.sh that compiled and
loaded bpf code for the socketlb feature to a pure go implementation.

The main difference to the init.sh code is that now on a fresh install
of cilium, cilium will leverage bpf links to attach programs to cgroups
if bpf_link is available in the kernel.

Test cases focus on testing scenarios that occur on clean agent
startup, restart and upgrade for both attaching and detaching bpf
programs to/from cgroups.
```

Fixes: #20739
