### PR TITLE
renovate: ignore cilium-test Dockerfile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,9 @@
     "images/**",
     "examples/hubble/*"
   ],
-  "ignorePaths": [],
+  "ignorePaths": [
+    "images/cilium-test/Dockerfile"
+  ],
   "ignorePresets": [":prHourlyLimit2"],
   "separateMajorMinor": true,
   "separateMultipleMajor": true,


### PR DESCRIPTION
This Dockerfile is no longer present in "master" branch and it's deprecated. Thus, we can ignore it from the list of files that need to be updated.

Signed-off-by: André Martins <andre@cilium.io>