### PR TITLE
envoy: Bump envoy version to 1.22.6

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,8 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:637850f4b8b44ab7d39539f86
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:48cbb2f88edca93ba80d1135dbb067a827b8adc2@sha256:2c21f4a37bf6d46da88758a6194c0e63ab26c80a91c41d679247a921c46d42d3 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy-dev:2b9e7a17831dbd409fc88faa36bed7a22689a38b@sha256:c46ba1620e12ce01fe74ced9561424063a62d26e9d07f32e8558fe849ae8b738 as cilium-envoy
+
 #
 # Hubble CLI
 #

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1160,7 +1160,9 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 					CleanupInterval:               &durationpb.Duration{Seconds: connectTimeout, Nanos: 500000000},
 					LbPolicy:                      envoy_config_cluster.Cluster_CLUSTER_PROVIDED,
 					TypedExtensionProtocolOptions: useDownstreamProtocolAutoSNI,
-					TransportSocket:               &envoy_config_core.TransportSocket{Name: "cilium.tls_wrapper"},
+					TransportSocket: &envoy_config_core.TransportSocket{
+						Name: "cilium.tls_wrapper",
+					},
 				},
 				{
 					Name:                          ingressClusterName,
@@ -1177,7 +1179,9 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 					CleanupInterval:               &durationpb.Duration{Seconds: connectTimeout, Nanos: 500000000},
 					LbPolicy:                      envoy_config_cluster.Cluster_CLUSTER_PROVIDED,
 					TypedExtensionProtocolOptions: useDownstreamProtocolAutoSNI,
-					TransportSocket:               &envoy_config_core.TransportSocket{Name: "cilium.tls_wrapper"},
+					TransportSocket: &envoy_config_core.TransportSocket{
+						Name: "cilium.tls_wrapper",
+					},
 				},
 				{
 					Name:                 CiliumXDSClusterName,
@@ -1244,6 +1248,16 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 							"overload": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 								"global_downstream_max_connections": {Kind: &structpb.Value_NumberValue{NumberValue: 50000}},
 							}}}},
+						}},
+					},
+				},
+				{
+					Name: "deprecation",
+					LayerSpecifier: &envoy_config_bootstrap.RuntimeLayer_StaticLayer{
+						StaticLayer: &structpb.Struct{Fields: map[string]*structpb.Value{
+							// This is to avoid empty type URL issue for cilium.tls_wrapper
+							// TODO: Remove this once we have a type URL for upstream and downstream cilium.tls_wrapper
+							"envoy.reloadable_features.no_extension_lookup_by_name": {Kind: &structpb.Value_BoolValue{BoolValue: false}},
 						}},
 					},
 				},


### PR DESCRIPTION
Just for testing purpose from PR build.

The runtime feature guard envoy.reloadable_features.no_extension_lookup_by_name is enabled to avoid proxy crash for cilium.tls_wrapper.

https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.22/v1.22.0.html

Relates: https://github.com/cilium/proxy/pull/101
Signed-off-by: Tam Mach <tam.mach@cilium.io>
