### PR TITLE
ci: pin managed clusters' K8s version to 1.24

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -69,6 +69,7 @@ env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
   location: westeurope
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
+  k8s_version: 1.24
   cilium_cli_version: v0.12.12
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -223,6 +224,7 @@ jobs:
             --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ env.location }} \
+            --kubernetes-version ${{ env.k8s_version }} \
             --network-plugin none \
             --node-count 2 \
             ${{ env.cost_reduction }} \

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -68,6 +68,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.12.12
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  k8s_version: 1.24
   eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
@@ -234,6 +235,7 @@ jobs:
             metadata:
               name: ${{ env.clusterName }}
               region: ${{ env.region }}
+              version: "${{ env.k8s_version }}"
               tags:
                usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
                owner: "${{ steps.vars.outputs.owner }}"

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -68,6 +68,7 @@ env:
   region: us-east-2
   cilium_cli_version: v0.12.12
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  k8s_version: 1.24
   eksctl_version: v0.122.0
   kubectl_version: v1.23.6
 
@@ -224,6 +225,7 @@ jobs:
           metadata:
             name: ${{ env.clusterName }}
             region: ${{ env.region }}
+            version: "${{ env.k8s_version }}"
             tags:
              usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
              owner: "${{ steps.vars.outputs.owner }}"

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -68,6 +68,7 @@ env:
   vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-vm
   zone: us-west2-a
   vmStartupScript: .github/gcp-vm-startup.sh
+  k8s_version: 1.24
   cilium_cli_version: v0.12.12
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -250,6 +251,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \

--- a/.github/workflows/conformance-multicluster.yaml
+++ b/.github/workflows/conformance-multicluster.yaml
@@ -69,6 +69,7 @@ env:
   clusterNameBase: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-mesh
   zone: us-west2-a
   firewallRuleName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-rule
+  k8s_version: 1.24
   cilium_cli_version: v0.12.12
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
@@ -229,6 +230,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName1 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \
@@ -244,6 +246,7 @@ jobs:
           gcloud container clusters create ${{ env.clusterName2 }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
             --create-subnetwork="" \
             --image-type COS_CONTAINERD \


### PR DESCRIPTION
Cilium `master` officially supports up to K8s 1.26. However, the cloud providers do not support creating managed clusters with K8s 1.26:

- AKS: 1.24 tops (1.25 in preview).
- EKS: 1.24 tops.
- GKE: 1.25 tops.

We pin CI workflows for the stable branch to use K8s 1.24 when creating managed clustersas it is the lowest common supported version.

This version should be updated as appropriate when new K8s versions are supported by the cloud providers.

Resources:

- AKS
  - Run `az aks get-versions --location westeurope --output table`
  - https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions

- EKS
  - Run `eksctl version -o json | jq -r '.EKSServerSupportedVersions[]'` (note: this asssumes `eksctl` is up to date, as this is static info)
  - https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
  - https://eksctl.io/usage/schema/#metadata-version

- GKE
  - Run `gcloud container get-server-config --format="yaml(channels)"`
  - https://cloud.google.com/kubernetes-engine/versioning
  - https://cloud.google.com/kubernetes-engine/docs/release-schedule

[Note:

The GKE workflow was already pinned to 1.24 to fix the CI, via a77007aa44893be9894311e2546529c6e3968865 and later 1ce7f1f097731fa175a6bdee399413cc370450b5.]