### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -20,7 +20,7 @@ yamllint==1.27.1
 alabaster==0.7.12
 attrs==22.1.0
 Babel==2.10.3
-certifi==2022.12.7
+certifi==2022.12.07
 charset-normalizer==2.1.1
 colorama==0.4.5
 deepmerge==1.0.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.12.7
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2022.12.7 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS