### PR TITLE
workflows: add trigger sentence in ci-verifier workflow file

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -1,4 +1,4 @@
-name: Datapath BPF Complexity
+name: Datapath BPF Complexity (ci-verifier)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:


### PR DESCRIPTION
Had to look at the workflow file to find which trigger comment I needed to re-run the Datapath BPF Complexity CI job, so document it as we do for other jobs, e.g. https://github.com/cilium/cilium/commit/434d9f9294c960ecac7e785c1e7adf8dcaedbcd0.