### PR TITLE
operator: proper rolling update

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1776,7 +1776,7 @@
    * - operator.updateStrategy
      - cilium-operator update strategy
      - object
-     - ``{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}``
+     - ``{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"50%"},"type":"RollingUpdate"}``
    * - pmtuDiscovery.enabled
      - Enable path MTU discovery to send ICMP fragmentation-needed replies to the client.
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -494,7 +494,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for cilium-operator |
 | operator.unmanagedPodWatcher.intervalSeconds | int | `15` | Interval, in seconds, to check if there are any pods that are not managed by Cilium. |
 | operator.unmanagedPodWatcher.restart | bool | `true` | Restart any pod that are not managed by Cilium. |
-| operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}` | cilium-operator update strategy |
+| operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"50%"},"type":"RollingUpdate"}` | cilium-operator update strategy |
 | pmtuDiscovery.enabled | bool | `false` | Enable path MTU discovery to send ICMP fragmentation-needed replies to the client. |
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -18,9 +18,21 @@ spec:
     matchLabels:
       io.cilium/app: operator
       name: cilium-operator
+  # ensure operator update on single node k8s clusters, by using rolling update with maxUnavailable=100% in case
+  # of one replica and no user configured Recreate strategy.
+  # otherwise an update might get stuck due to the default maxUnavailable=50% in combination with the
+  # podAntiAffinity which prevents deployments of multiple operator replicas on the same node.
+  {{- if and (eq (.Values.operator.replicas | toString) "1") (eq .Values.operator.updateStrategy.type "RollingUpdate") }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.operator.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: 100%
+    type: RollingUpdate
+  {{- else }}
   {{- with .Values.operator.updateStrategy }}
   strategy:
     {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -163,6 +163,16 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 5
         volumeMounts:
         - name: cilium-config-path
           mountPath: /tmp/cilium/config-map

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1889,8 +1889,8 @@ operator:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
+      maxSurge: 25%
+      maxUnavailable: 50%
 
   # -- Affinity for cilium-operator
   affinity:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1886,8 +1886,8 @@ operator:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
+      maxSurge: 25%
+      maxUnavailable: 50%
 
   # -- Affinity for cilium-operator
   affinity:


### PR DESCRIPTION
To support a proper rolling update for the Cilium Operator deployment in HA mode, maxSurge & maxUnavailable are configured with the default of 25% and 50% respectively. In addition, a k8s readiness probe has been configured, which prevents a new rollout to be marked as ready too early.

Without this change, the newly scheduled operator pod might gets marked as ready even though it's not running properly (e.g. k8s api server is not available) - which in turn results in having no operator pod running because the old pod was already removed.

To ensure operator updates on single node k8s clusters, the operator deployment automatically gets configured with a RollingUpdate strategy with maxUnavailable=100% in case of a single operator replica.

Without this customization, the operator update might get stuck on single node clusters due to the default maxUnavailable=50% in combination with the podAntiAffinity which prevents multiple operator replicas to be deployed on the same k8s node.

Therefore, it's recommended to use at least 2 operator replicas on clusters with multiple nodes. Otherwise the rolling update still isn't working as expected.

Fixes: #16681