### PR TITLE
Add leader requirement to watch from Etcd.

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1018,7 +1018,7 @@ reList:
 		scopedLog.WithField(fieldRev, nextRev).Debug("Starting to watch a prefix")
 
 		e.limiter.Wait(ctx)
-		etcdWatch := e.client.Watch(ctx, w.Prefix,
+		etcdWatch := e.client.Watch(client.WithRequireLeader(ctx), w.Prefix,
 			client.WithPrefix(), client.WithRev(nextRev))
 		for {
 			select {


### PR DESCRIPTION
In the case of network partition of Etcd, the watch may be hanging without any updates, which can lead to hard-to-debug issues. This adds leader requirement. In this case, if a leader is not elected within 3 election cycles, the watch will return an error.

Signed-off-by: Marcel Zięba <marseel@gmail.com>

