### PR TITLE
ci: Update docs-builder image for documentation workflow

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run pre-requisites for validation
         run: |
           make -C Documentation copy-api # necessary for check-build.sh
-      - uses: docker://cilium/docs-builder:2022-12-21@sha256:745e868e60d2aa35f24895668a27ea3b49864f6ab6d54daa9983936462aa5cd4
+      - uses: docker://cilium/docs-builder:2023-02-04@sha256:67c383332f63708fc40f3d12b0ffff8ec94a9a83d1b819dbe23b226ef076e6f2
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html


### PR DESCRIPTION
Update the docs-builder image used by the CI workflow to pick-up the changes introduced in commit e4889d72f9a8 ("docs: Drop sphinxcontrib-openapi fork, switch back to upstream"), so we can get rid of our openapi fork. Thank you Joe for updating the image!

Branches v1.12 and older use images that were created before the introduction of the openapi fork (commit 4f893e8d3e0f ("docs: Switch to our own fork of sphinxcontrib-openapi")), so they don't need a backport.

We should be able to remove the fork after this PR has been merged and backported to 1.13.