### PR TITLE
hubble/metrics: handle SCTP port in flows to world metrics

### DIFF
--- a/pkg/hubble/metrics/flows-to-world/handler.go
+++ b/pkg/hubble/metrics/flows-to-world/handler.go
@@ -118,6 +118,8 @@ func (h *flowsToWorldHandler) ProcessFlow(_ context.Context, flow *flowpb.Flow) 
 			port = strconv.Itoa(int(tcp.GetDestinationPort()))
 		} else if udp := l4.GetUDP(); udp != nil {
 			port = strconv.Itoa(int(udp.GetDestinationPort()))
+		} else if sctp := l4.GetSCTP(); sctp != nil {
+			port = strconv.Itoa(int(sctp.GetDestinationPort()))
 		}
 		labels = append(labels, port)
 	}


### PR DESCRIPTION
Hubble now has support for the SCTP L4 protocol. When the "port" option is set for the flows to world metric, we should also update the port label for SCTP flows.

```release-note
hubble: handle SCTP port in flows to world metrics
```
