### PR TITLE
Reduce number of CES updates sent to API server in short time for the same CES

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -49,8 +49,9 @@ const (
 	// Delayed CES Synctime, CES's are synced with k8s-apiserver after certain delay
 	// Some CES's are delayed to sync with k8s-apiserver.
 	DelayedCESSyncTime = 15 * time.Second
-	// Default CES Synctime, sync instantaeously with k8s-apiserver.
-	DefaultCESSyncTime = 0
+	// Default CES Synctime, multiple consecutive syncs with k8s-apiserver are
+	// batched and synced together after a short delay.
+	DefaultCESSyncTime = 500 * time.Millisecond
 )
 
 type CiliumEndpointSliceController struct {

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -668,11 +668,8 @@ func (c *cesMgr) insertCESInWorkQueue(ces *cesTracker, baseDelay time.Duration) 
 	if ces.cesInsertedAt.IsZero() {
 		ces.cesInsertedAt = time.Now()
 	}
-	if baseDelay == DefaultCESSyncTime {
-		c.queue.Add(ces.ces.GetName())
-	} else {
-		c.queue.AddAfter(ces.ces.GetName(), baseDelay)
-	}
+
+	c.queue.AddAfter(ces.ces.GetName(), baseDelay)
 }
 
 // Return the CES queue delay in seconds and reset cesInsert time.


### PR DESCRIPTION
Change the `DefaultCESSyncTime` to 500ms.

The Cilium operator watches CiliumEndpoints (CEP) and batches them into CiliumEndpointSlices (CES). During high pod churn (Create, Update, Delete) rate, there are many CEPs created and batched into the same CES. Kube-apiserver logs show that it sometimes receives up to 10 CES updates from the Cilium operator for the same CES in less than 1 second.

This behavior is degrading the performance of CEP batching, because the rate limiter for CES updates is based on the specified number of mutating requests per second. It is also inefficient, because adding up to 500ms delay to propagate CiliumEndpoints through the cluster is currently considered insignificant.

The estimated and tested improvement is to reduce the number of CES update requests sent to the API server by a factor of 5 when there is a high pod churn rate.

500ms delay is insignificant because:
1. CiliumEndpoint batching is a feature to improve performance at scale, by reducing the load on the kube-apiserver, and also keeping the propagation latency low. The bottleneck at scale is the rate at which CES updates can be sent to the kube-apiserver, which is rate limited by the CES workqueue in the Cilium operator. In large clusters it can go into minutes, or even hours in the worst case with Identity batching mode. Without appropriate rate limiting, CES updates can overload kube-apiserver. There is a scalability/performance feature of kube-apiserver called [Priority & Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/), which should help here, but it’s still not at a stage that it can be relied on. With this in mind, clusters that need to use CEP batching will want to accept the delay of 500ms of sending CES updates, because it actually improves performance -- has lower latency to configure all nodes to communicate with every new pod. This is because multiple CES updates for the same CES will not be taking up nearly as many updates per second, and that other CES updates waiting in the queue are processed quicker.

2. The workqueue’s `AddAfter()` works in a way that it enqueues the item for the first CES event right away, and adds delay only when there are subsequent events for the same CES. This means that in the worst case, only some CEPs that were added to CES may have up to 500ms delay to be processed. Here is an example that shows how the first update is immediately enqueued and processed, and that delay only affects subsequent updates and is always lower than 500ms:
Time 0ms - Update A is immediately enqueued to be processed.
Time 200ms - Update B is delayed to be enqueued at 500ms after the most recent enqueued update
Time 300ms - Update C is delayed to be enqueued at 500ms after the most recent enqueued update
Time 400ms - Update D is delayed to be enqueued at 500ms after the most recent enqueued update
Time 500ms - A single CES update is enqueued to be processed, that covers all changes in updates B, C and D.

Delay for update B was 300ms, for update C 200ms and for update D 100ms.

3. Pods are communicating with each other through services. Both default clusterIP or headless service and DNS require Endpoints/EndpointSlice objects to be populated with pod IPs first. This means that new pods already have some similar delay to be truly reachable (not just network ready). As I mentioned above, EndpointSlices already have 1 second delay for updates, which makes 500ms insignificant.

4. 500ms is a very small price to pay for using network policies at scale. There are no SLOs for network policies that cover this, or would indicate it as a regression, although some users might rely on lower latency. Also compared to Cilium’s pod startup latency regression of a few seconds, which was recently reduced, it wasn’t presenting real issues for Cilium’s performance.

```release-note
Increase the default CiliumEndpointSlice sync time from 0 to 500ms
```

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>

---

Fixes: https://github.com/cilium/cilium/issues/21005