### PR TITLE
v1.12 backports 2023-02-09

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,8 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:637850f4b8b44ab7d39539f86
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:48cbb2f88edca93ba80d1135dbb067a827b8adc2@sha256:2c21f4a37bf6d46da88758a6194c0e63ab26c80a91c41d679247a921c46d42d3 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:d59b7f950565d4ccad5c9e30f725740271b7f1c2@sha256:a9c20ee37fe8b280606b096f34f074fed02a347381ded71f1853a214a324a9ef as cilium-envoy
+
 #
 # Hubble CLI
 #

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1160,7 +1160,9 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 					CleanupInterval:               &durationpb.Duration{Seconds: connectTimeout, Nanos: 500000000},
 					LbPolicy:                      envoy_config_cluster.Cluster_CLUSTER_PROVIDED,
 					TypedExtensionProtocolOptions: useDownstreamProtocolAutoSNI,
-					TransportSocket:               &envoy_config_core.TransportSocket{Name: "cilium.tls_wrapper"},
+					TransportSocket: &envoy_config_core.TransportSocket{
+						Name: "cilium.tls_wrapper",
+					},
 				},
 				{
 					Name:                          ingressClusterName,
@@ -1177,7 +1179,9 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 					CleanupInterval:               &durationpb.Duration{Seconds: connectTimeout, Nanos: 500000000},
 					LbPolicy:                      envoy_config_cluster.Cluster_CLUSTER_PROVIDED,
 					TypedExtensionProtocolOptions: useDownstreamProtocolAutoSNI,
-					TransportSocket:               &envoy_config_core.TransportSocket{Name: "cilium.tls_wrapper"},
+					TransportSocket: &envoy_config_core.TransportSocket{
+						Name: "cilium.tls_wrapper",
+					},
 				},
 				{
 					Name:                 CiliumXDSClusterName,
@@ -1244,6 +1248,16 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 							"overload": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 								"global_downstream_max_connections": {Kind: &structpb.Value_NumberValue{NumberValue: 50000}},
 							}}}},
+						}},
+					},
+				},
+				{
+					Name: "deprecation",
+					LayerSpecifier: &envoy_config_bootstrap.RuntimeLayer_StaticLayer{
+						StaticLayer: &structpb.Struct{Fields: map[string]*structpb.Value{
+							// This is to avoid empty type URL issue for cilium.tls_wrapper
+							// TODO: Remove this once we have a type URL for upstream and downstream cilium.tls_wrapper
+							"envoy.reloadable_features.no_extension_lookup_by_name": {Kind: &structpb.Value_BoolValue{BoolValue: false}},
 						}},
 					},
 				},

--- a/test/runtime/net_policies.go
+++ b/test/runtime/net_policies.go
@@ -524,21 +524,21 @@ var _ = Describe("RuntimePolicies", func() {
 		// * the count for requests forwarded, and responses forwarded / received to be the same
 		// as from the prior test since the requests were denied, and thus no new requests
 		// were forwarded, and no new responses forwarded nor received.
-		checkProxyStatistics(app3EndpointID, 2, 4, 2, 2, 2)
+		checkProxyStatistics(app3EndpointID, 2, 4, 2, 4, 4)
 
 		connectivityTest(httpRequestsPublic, helpers.App3, helpers.Httpd2, true)
 
 		// Since policy allows connectivity on L3 from app3 to httpd2, and such
 		// packets are not forwarded to the proxy, we expect no changes in proxy
 		// stats.
-		checkProxyStatistics(app3EndpointID, 2, 4, 2, 2, 2)
+		checkProxyStatistics(app3EndpointID, 2, 4, 2, 4, 4)
 
 		connectivityTest(httpRequestsPrivate, helpers.App3, helpers.Httpd2, true)
 
 		// Since policy allows connectivity on L3 from app3 to httpd2, and such
 		// packets are not forwarded to the proxy, we expect no changes in proxy
 		// stats.
-		checkProxyStatistics(app3EndpointID, 2, 4, 2, 2, 2)
+		checkProxyStatistics(app3EndpointID, 2, 4, 2, 4, 4)
 	})
 
 	Context("CIDR L3 Policy", func() {


### PR DESCRIPTION
 - [x] #23502 -- envoy: Bump envoy version to 1.22.7 (@sayboras)

Once this PR is merged, you can update the PR labels via:

```upstream-prs
$ for pr in 23502; do contrib/backporting/set-labels.py $pr done 1.12; done
```