### PR TITLE
ci: replace deprecated set-output command in integraton test workflow

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -40,7 +40,7 @@ jobs:
         else
           SHA=${{ github.sha }}
         fi
-        echo ::set-output name=sha::${SHA}
+        echo sha=${SHA} >> $GITHUB_OUTPUT
 
     - name: Checkout
       uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
The same change was done for all other workflows in commit c55943fc0af9 ("gha: Replace deprecated set-output commands") but the integration test workflow was merged after that.

Fixes: 2ed5f9637f46 ("gha: Run integration tests in GHA")