### PR TITLE
bpf, ebpf: remove GetMapType() and mock probing

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -548,9 +548,8 @@ func (m *Map) openOrCreate(pin bool) (bool, error) {
 		os.Remove(m.path)
 	}
 
-	mapType := GetMapType(m.MapType)
-	flags := m.Flags | GetPreAllocateMapFlags(mapType)
-	fd, isNew, err := OpenOrCreateMap(m.path, mapType, m.KeySize, m.ValueSize, m.MaxEntries, flags, m.InnerID, pin)
+	flags := m.Flags | GetPreAllocateMapFlags(m.MapType)
+	fd, isNew, err := OpenOrCreateMap(m.path, m.MapType, m.KeySize, m.ValueSize, m.MaxEntries, flags, m.InnerID, pin)
 	if err != nil {
 		return false, err
 	}
@@ -558,7 +557,6 @@ func (m *Map) openOrCreate(pin bool) (bool, error) {
 	registerMap(m.path, m)
 
 	m.fd = fd
-	m.MapType = mapType
 	m.Flags = flags
 	return isNew, nil
 }
@@ -592,7 +590,6 @@ func (m *Map) open() error {
 	registerMap(m.path, m)
 
 	m.fd = fd
-	m.MapType = GetMapType(m.MapType)
 	return nil
 }
 
@@ -1252,13 +1249,12 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 //
 // Returns true if the map was upgraded.
 func (m *Map) CheckAndUpgrade(desired *MapInfo) bool {
-	desiredMapType := GetMapType(desired.MapType)
-	desired.Flags |= GetPreAllocateMapFlags(desiredMapType)
+	desired.Flags |= GetPreAllocateMapFlags(desired.MapType)
 
 	return objCheck(
 		m.fd,
 		m.path,
-		desiredMapType,
+		desired.MapType,
 		desired.KeySize,
 		desired.ValueSize,
 		desired.MaxEntries,

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 )
@@ -689,123 +688,44 @@ func (s *BPFPrivilegedTestSuite) TestGetModel(c *C) {
 }
 
 func (s *BPFPrivilegedTestSuite) TestCheckAndUpgrade(c *C) {
-	tests := []struct {
-		name    string
-		run     func() []*Map
-		postRun func(maps ...*Map)
-	}{
-		{
-			name: "MapTypeHash: no prealloc to prealloc upgrade",
-			run: func() []*Map {
-				// CheckAndUpgrade removes map file if upgrade is needed
-				// so we setup and use another map.
-				upgradeMap := NewMap("cilium_test_upgrade",
-					MapTypeHash,
-					&TestKey{},
-					int(unsafe.Sizeof(TestKey{})),
-					&TestValue{},
-					int(unsafe.Sizeof(TestValue{})),
-					maxEntries,
-					BPF_F_NO_PREALLOC,
-					0,
-					ConvertKeyValue).WithCache()
-				_, err := upgradeMap.OpenOrCreate()
-				c.Assert(err, IsNil)
+	// CheckAndUpgrade removes map file if upgrade is needed
+	// so we setup and use another map.
+	upgradeMap := NewMap("cilium_test_upgrade",
+		MapTypeHash,
+		&TestKey{},
+		int(unsafe.Sizeof(TestKey{})),
+		&TestValue{},
+		int(unsafe.Sizeof(TestValue{})),
+		maxEntries,
+		BPF_F_NO_PREALLOC,
+		0,
+		ConvertKeyValue).WithCache()
+	_, err := upgradeMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer func() {
+		_ = upgradeMap.Unpin()
+		upgradeMap.Close()
+	}()
 
-				// Exactly the same MapInfo so it won't be upgraded.
-				upgrade := upgradeMap.CheckAndUpgrade(&upgradeMap.MapInfo)
-				c.Assert(upgrade, Equals, false)
+	// Exactly the same MapInfo so it won't be upgraded.
+	upgrade := upgradeMap.CheckAndUpgrade(&upgradeMap.MapInfo)
+	c.Assert(upgrade, Equals, false)
 
-				// preallocMap unsets BPF_F_NO_PREALLOC so upgrade is needed.
-				EnableMapPreAllocation()
-				preallocMap := NewMap("cilium_test_upgrade",
-					MapTypeHash,
-					&TestKey{},
-					int(unsafe.Sizeof(TestKey{})),
-					&TestValue{},
-					int(unsafe.Sizeof(TestValue{})),
-					maxEntries,
-					0,
-					0,
-					ConvertKeyValue).WithCache()
-				upgrade = upgradeMap.CheckAndUpgrade(&preallocMap.MapInfo)
-				c.Assert(upgrade, Equals, true)
-				DisableMapPreAllocation()
-
-				return []*Map{upgradeMap, preallocMap}
-			},
-			postRun: func(maps ...*Map) {
-				for _, m := range maps {
-					path, _ := m.Path()
-					os.Remove(path)
-
-					m.Close()
-				}
-			},
-		},
-		{
-			name: "MapTypeLRUHash on 4.9 kernel: no prealloc to no prealloc upgrade",
-			run: func() []*Map {
-				// Asserts that maps with type MapTypeLRUHash on 4.9 kernels
-				// are normalized to MapTypeHash and that when preallocation is
-				// disabled, maps can be recreated without requiring them to be
-				// removed due to a flag mismatch (upgrade).
-
-				// Specify 4.9 kernel supported maps types and disable preallocation.
-				setMapTypesFromProber(newMockProber(mapTypes49))
-				DisableMapPreAllocation()
-
-				upgradeMap := NewMap("cilium_test_upgrade",
-					MapTypeLRUHash,
-					&TestKey{},
-					int(unsafe.Sizeof(TestKey{})),
-					&TestValue{},
-					int(unsafe.Sizeof(TestValue{})),
-					maxEntries,
-					0,
-					0,
-					ConvertKeyValue).WithCache()
-				_, err := upgradeMap.OpenOrCreate()
-				c.Assert(err, IsNil)
-
-				// Typically, MapTypeLRUHash requires preallocation. Given the
-				// underlying lack of LRU support in 4.9 kernels, this map type
-				// would actually use MapTypeHash.
-				//
-				// Since the map type is switched to hashmap, now preallocation
-				// can be disabled. When we try to upgrade the map, defining
-				// that its type should be LRU, there's no intermediate state
-				// where we decide that the map should be upgraded because the
-				// desired type is LRU (or the preallocation flags are
-				// mismatched).
-				//
-				// Instead, every single time the map info is evaluated, the
-				// type & flags are evaluated first and then the upgrade
-				// decision is made based on the attributes afterwards.
-				//
-				// In this case, we disabled preallocation and attempting to
-				// upgrade the map of type LRU results in a no-op because it
-				// was normalized to hashmap.
-				upgrade := upgradeMap.CheckAndUpgrade(&upgradeMap.MapInfo)
-				c.Assert(upgrade, Equals, false)
-
-				return []*Map{upgradeMap}
-			},
-			postRun: func(maps ...*Map) {
-				for _, m := range maps {
-					path, _ := m.Path()
-					os.Remove(path)
-
-					m.Close()
-				}
-			},
-		},
-	}
-	for _, tt := range tests {
-		c.Log(tt.name)
-		maps := tt.run()
-		tt.postRun(maps...)
-	}
+	// preallocMap unsets BPF_F_NO_PREALLOC so upgrade is needed.
+	EnableMapPreAllocation()
+	preallocMap := NewMap("cilium_test_upgrade",
+		MapTypeHash,
+		&TestKey{},
+		int(unsafe.Sizeof(TestKey{})),
+		&TestValue{},
+		int(unsafe.Sizeof(TestValue{})),
+		maxEntries,
+		0,
+		0,
+		ConvertKeyValue).WithCache()
+	upgrade = upgradeMap.CheckAndUpgrade(&preallocMap.MapInfo)
+	c.Assert(upgrade, Equals, true)
+	DisableMapPreAllocation()
 }
 
 func (s *BPFPrivilegedTestSuite) TestUnpin(c *C) {
@@ -875,47 +795,4 @@ func (s *BPFPrivilegedTestSuite) TestCreateUnpinned(c *C) {
 	err = LookupElement(m.fd, unsafe.Pointer(key1), unsafe.Pointer(&value2))
 	c.Assert(err, IsNil)
 	c.Assert(*value1, Equals, value2)
-}
-
-func newMockProber(mt probes.MapTypes) *mockProber {
-	return &mockProber{
-		mt: mt,
-	}
-}
-
-func (m *mockProber) Probe() probes.Features {
-	var f probes.Features
-	f.MapTypes = m.mt
-	return f
-}
-
-type mockProber struct {
-	mt probes.MapTypes
-}
-
-// mapTypes49 represents the supported map types on 4.9 kernels.
-var mapTypes49 = probes.MapTypes{
-	HaveHashMapType:                true,
-	HaveArrayMapType:               true,
-	HaveProgArrayMapType:           true,
-	HavePerfEventArrayMapType:      true,
-	HavePercpuHashMapType:          true,
-	HavePercpuArrayMapType:         true,
-	HaveStackTraceMapType:          true,
-	HaveCgroupArrayMapType:         true,
-	HaveLruHashMapType:             false,
-	HaveLruPercpuHashMapType:       false,
-	HaveLpmTrieMapType:             false,
-	HaveArrayOfMapsMapType:         false,
-	HaveHashOfMapsMapType:          false,
-	HaveDevmapMapType:              false,
-	HaveSockmapMapType:             false,
-	HaveCpumapMapType:              false,
-	HaveXskmapMapType:              false,
-	HaveSockhashMapType:            false,
-	HaveCgroupStorageMapType:       false,
-	HaveReuseportSockarrayMapType:  false,
-	HavePercpuCgroupStorageMapType: false,
-	HaveQueueMapType:               false,
-	HaveStackMapType:               false,
 }

--- a/pkg/ebpf/map.go
+++ b/pkg/ebpf/map.go
@@ -110,8 +110,7 @@ func (m *Map) OpenOrCreate() error {
 		PinPath: bpf.MapPrefixPath(),
 	}
 
-	mapType := bpf.GetMapType(bpf.MapType(m.spec.Type))
-	m.spec.Flags = m.spec.Flags | bpf.GetPreAllocateMapFlags(mapType)
+	m.spec.Flags = m.spec.Flags | bpf.GetPreAllocateMapFlags(bpf.MapType(m.spec.Type))
 
 	path := bpf.MapPath(m.spec.Name)
 


### PR DESCRIPTION
As a follow up to #20556 and in line with cleaning up 4.9 leftovers[1] this removes GetMapType() which was only useful on 4.9 kernels. Removing GetMapType() allows removing leftover dependencies on ProbeManger.

[1] #22116

Fixes: #21214

Signed-off-by: Robin Gögge <r.goegge@isovalent.com>