### PR TITLE
hubble: fix Hubble Relay BASE_IMAGE

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -917,6 +917,14 @@
      - Additional hubble-relay environment variables.
      - list
      - ``[]``
+   * - hubble.relay.gops.enabled
+     - Enable gops for hubble-relay
+     - bool
+     - ``true``
+   * - hubble.relay.gops.port
+     - Configure gops listen port for hubble-relay
+     - int
+     - ``9893``
    * - hubble.relay.image
      - Hubble-relay container image.
      - object

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -202,10 +202,6 @@ GO_CLEAN = $(GO) clean $(GO_CLEAN_FLAGS)
 GO_VET = $(GO) vet
 GO_LIST = $(GO) list
 
-ifeq ($(BASE_IMAGE),)
-    BASE_IMAGE=scratch
-endif
-
 HELM_TOOLBOX_VERSION ?= "v1.0.1"
 HELM_TOOLBOX_SHA ?= "a1483fc036b15c290326ba7ed36b8f0b714e185913b72a6074c04225d74e034c"
 HELM_TOOLBOX_IMAGE ?= "quay.io/cilium/helm-toolbox:$(HELM_TOOLBOX_VERSION)@sha256:$(HELM_TOOLBOX_SHA)"

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -88,7 +88,7 @@ ifeq ($(5),debug)
 endif
 	$(QUIET) $(CONTAINER_ENGINE) buildx build -f $(subst %,$$*,$(2)) \
 		$(DOCKER_BUILD_FLAGS) $(DOCKER_FLAGS) \
-		--build-arg BASE_IMAGE=${BASE_IMAGE} \
+		$(if $(BASE_IMAGE),--build-arg BASE_IMAGE=$(BASE_IMAGE),) \
 		--build-arg NOSTRIP=$${NOSTRIP} \
 		--build-arg NOOPT=${NOOPT} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -60,6 +60,5 @@ COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/hubble-relay /usr/bin
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 # use uid:gid for the nonroot user for compatibility with runAsNonRoot
 USER 65532:65532
-WORKDIR /home/nonroot
 ENTRYPOINT ["/usr/bin/hubble-relay"]
 CMD ["serve"]

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -280,6 +280,8 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
 | hubble.relay.extraEnv | list | `[]` | Additional hubble-relay environment variables. |
+| hubble.relay.gops.enabled | bool | `true` | Enable gops for hubble-relay |
+| hubble.relay.gops.port | int | `9893` | Configure gops listen port for hubble-relay |
 | hubble.relay.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-relay-ci","tag":"latest","useDigest":false}` | Hubble-relay container image. |
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -18,6 +18,8 @@ data:
     peer-service: unix://{{ .Values.hubble.socketPath }}
     {{- end }}
     listen-address: {{ .Values.hubble.relay.listenHost }}:{{ .Values.hubble.relay.listenPort }}
+    gops: {{ .Values.hubble.relay.gops.enabled }}
+    gops-port: {{ .Values.hubble.relay.gops.port | quote }}
     {{- if .Values.hubble.relay.pprof.enabled }}
     pprof: {{ .Values.hubble.relay.pprof.enabled | quote }}
     pprof-address: {{ .Values.hubble.relay.pprof.address | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1159,6 +1159,12 @@ hubble:
         # -- Metrics relabeling configs for the ServiceMonitor hubble-relay
         metricRelabelings: ~
 
+    gops:
+      # -- Enable gops for hubble-relay
+      enabled: true
+      # -- Configure gops listen port for hubble-relay
+      port: 9893
+
     pprof:
       # -- Enable pprof for hubble-relay
       enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1156,6 +1156,12 @@ hubble:
         # -- Metrics relabeling configs for the ServiceMonitor hubble-relay
         metricRelabelings: ~
 
+    gops:
+      # -- Enable gops for hubble-relay
+      enabled: true
+      # -- Configure gops listen port for hubble-relay
+      port: 9893
+
     pprof:
       # -- Enable pprof for hubble-relay
       enabled: false


### PR DESCRIPTION
https://github.com/cilium/cilium/commit/95a4d37394be9010f9fa5691809a1ee3b8553178 ("hubble-relay: use distroless as the base image and run as non-root") attempted to use distroless as base image for Hubble Relay instead of `scratch`.

However, when running `make docker-hubble-relay-image` the image would be built with `--build-arg BASE_IMAGE=scratch` effectively overriding the base image "back" to `scratch`.

This patch make it so `BASE_IMAGE` is only overridden when set, and honor the Dockerfile's `BASE_IMAGE` otherwise.

Fix #23374, #23533