### PR TITLE
v1.10 backports 2023-02-07

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -8,7 +8,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:0122ba734281d24da7e779c0c
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:3b70fad0b9514720f33db82841907821202c1f02@sha256:8cca16ce66a0960a207cbf518ee2e0d923ae2a49207b154cdc37c2d95f583180 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:d59b7f950565d4ccad5c9e30f725740271b7f1c2@sha256:a9c20ee37fe8b280606b096f34f074fed02a347381ded71f1853a214a324a9ef as cilium-envoy
 
 #
 # Hubble CLI

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -952,7 +952,9 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 					CleanupInterval:               &duration.Duration{Seconds: connectTimeout, Nanos: 500000000},
 					LbPolicy:                      envoy_config_cluster.Cluster_CLUSTER_PROVIDED,
 					TypedExtensionProtocolOptions: useDownstreamProtocolAutoSNI,
-					TransportSocket:               &envoy_config_core.TransportSocket{Name: "cilium.tls_wrapper"},
+					TransportSocket: &envoy_config_core.TransportSocket{
+						Name: "cilium.tls_wrapper",
+					},
 				},
 				{
 					Name:                          ingressClusterName,
@@ -969,7 +971,9 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 					CleanupInterval:               &duration.Duration{Seconds: connectTimeout, Nanos: 500000000},
 					LbPolicy:                      envoy_config_cluster.Cluster_CLUSTER_PROVIDED,
 					TypedExtensionProtocolOptions: useDownstreamProtocolAutoSNI,
-					TransportSocket:               &envoy_config_core.TransportSocket{Name: "cilium.tls_wrapper"},
+					TransportSocket: &envoy_config_core.TransportSocket{
+						Name: "cilium.tls_wrapper",
+					},
 				},
 				{
 					Name:                 "xds-grpc-cilium",
@@ -1053,6 +1057,16 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 							"overload": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 								"global_downstream_max_connections": {Kind: &structpb.Value_NumberValue{NumberValue: 50000}},
 							}}}},
+						}},
+					},
+				},
+				{
+					Name: "deprecation",
+					LayerSpecifier: &envoy_config_bootstrap.RuntimeLayer_StaticLayer{
+						StaticLayer: &structpb.Struct{Fields: map[string]*structpb.Value{
+							// This is to avoid empty type URL issue for cilium.tls_wrapper
+							// TODO: Remove this once we have a type URL for upstream and downstream cilium.tls_wrapper
+							"envoy.reloadable_features.no_extension_lookup_by_name": {Kind: &structpb.Value_BoolValue{BoolValue: false}},
 						}},
 					},
 				},

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1803,7 +1803,10 @@ var _ = SkipDescribeIf(func() bool {
 					By("Reconfiguring Cilium to enable BPF TProxy")
 					RedeployCiliumWithMerge(kubectl, ciliumFilename, daemonCfg,
 						map[string]string{
-							"bpf.tproxy": "true",
+							// bpf tproxy socket lookup fails on sockets
+							// that have SO_REUSEPORT on, so disable for
+							// now.
+							// "bpf.tproxy": "true",
 						})
 				}
 			})

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -535,21 +535,21 @@ var _ = Describe("RuntimePolicies", func() {
 		// * the count for requests forwarded, and responses forwarded / received to be the same
 		// as from the prior test since the requests were denied, and thus no new requests
 		// were forwarded, and no new responses forwarded nor received.
-		checkProxyStatistics(app3EndpointID, 2, 4, 2, 2, 2)
+		checkProxyStatistics(app3EndpointID, 2, 4, 2, 4, 4)
 
 		connectivityTest(httpRequestsPublic, helpers.App3, helpers.Httpd2, true)
 
 		// Since policy allows connectivity on L3 from app3 to httpd2, and such
 		// packets are not forwarded to the proxy, we expect no changes in proxy
 		// stats.
-		checkProxyStatistics(app3EndpointID, 2, 4, 2, 2, 2)
+		checkProxyStatistics(app3EndpointID, 2, 4, 2, 4, 4)
 
 		connectivityTest(httpRequestsPrivate, helpers.App3, helpers.Httpd2, true)
 
 		// Since policy allows connectivity on L3 from app3 to httpd2, and such
 		// packets are not forwarded to the proxy, we expect no changes in proxy
 		// stats.
-		checkProxyStatistics(app3EndpointID, 2, 4, 2, 2, 2)
+		checkProxyStatistics(app3EndpointID, 2, 4, 2, 4, 4)
 	})
 
 	Context("CIDR L3 Policy", func() {


### PR DESCRIPTION
 - [x] #23502 -- envoy: Bump envoy version to 1.22.7 (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 23502; do contrib/backporting/set-labels.py $pr done 1.10; done
```