### PR TITLE
contrib/kind: default to dual-stack clusters

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -9,7 +9,7 @@ default_workers=1
 default_cluster_name=""
 default_image=""
 default_kubeproxy_mode="iptables"
-default_ipfamily="ipv4"
+default_ipfamily="dual"
 
 PROG=${0}
 controlplanes="${1:-${CONTROLPLANES:=${default_controlplanes}}}"

--- a/contrib/testing/kind-values.yaml
+++ b/contrib/testing/kind-values.yaml
@@ -8,6 +8,10 @@ operator:
     suffix: ""
 ipam:
   mode: kubernetes
+ipv6:
+  enabled: true
+ipv4:
+  enabled: true
 monitor-aggregation: none
 livenessProbe:
   failureThreshold: 9999


### PR DESCRIPTION
It takes a small magical incantation to enable dual-stack. Let's just enable dual-stack for development environments by default.