### PR TITLE
Add virtualized to wordlist

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -1058,6 +1058,7 @@ virtIO
 virtio
 virtualbox
 virtualization
+virtualized
 vlan
 vlanBypass
 vmlinux


### PR DESCRIPTION
This PR adds "virtualized" to the linter's list of permissible words.

Fixes #23655 

```release-note
Title: Trivial additions to linter
Description: The linter now accepts "virtualized" as a correct spelling.
```