### PR TITLE
docs: replace usage of api.twitter.com

### DIFF
--- a/Documentation/network/kubernetes/local-redirect-policy.rst
+++ b/Documentation/network/kubernetes/local-redirect-policy.rst
@@ -101,10 +101,11 @@ the configurations specified in the CiliumLocalRedirectPolicy.
 
 .. parsed-literal::
 
-    $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-sw-app.yaml
-    $ kubectl get po
-    NAME                             READY   STATUS    RESTARTS   AGE
-    pod/mediabot                     1/1     Running   0          14s
+   $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-sw-app.yaml
+   $ kubectl wait pod/mediabot --for=condition=Ready
+   $ kubectl get pods
+   NAME                             READY   STATUS    RESTARTS   AGE
+   pod/mediabot                     1/1     Running   0          14s
 
 Create Cilium Local Redirect Policy Custom Resources
 =====================================================

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -225,7 +225,7 @@ Requirements for IPsec
 The :ref:`encryption_ipsec` feature requires a lot of kernel configuration
 options, most of which to enable the actual encryption. Note that the
 specific options required depend on the algorithm. The list below
-corresponds to requirements for GMC-128-AES.
+corresponds to requirements for GCM-128-AES.
 
 ::
 

--- a/Documentation/security/dns.rst
+++ b/Documentation/security/dns.rst
@@ -26,13 +26,15 @@ In this guide we will learn about:
 - Using patterns (or wildcards) to whitelist a subset of DNS domains
 - Combining DNS, port and L7 rules for restricting access to external service
 
-In line with our Star Wars theme examples, we will use a simple scenario where the Empire's ``mediabot`` pods need access to Twitter for managing the Empire's tweets. The pods shouldn't have access to any other external service.
+In line with our Star Wars theme examples, we will use a simple scenario where
+the Empire's ``mediabot`` pods need access to GitHub for managing the Empire's
+git repositories. The pods shouldn't have access to any other external service.
 
 .. parsed-literal::
 
-   kubectl create -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-sw-app.yaml
-   kubectl wait pod/mediabot --for=condition=Ready
-   kubectl get po
+   $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-sw-app.yaml
+   $ kubectl wait pod/mediabot --for=condition=Ready
+   $ kubectl get pods
    NAME                             READY   STATUS    RESTARTS   AGE
    pod/mediabot                     1/1     Running   0          14s
 
@@ -40,7 +42,7 @@ In line with our Star Wars theme examples, we will use a simple scenario where t
 Apply DNS Egress Policy
 =======================
 
-The following Cilium network policy allows ``mediabot`` pods to only access ``api.twitter.com``.
+The following Cilium network policy allows ``mediabot`` pods to only access ``api.github.com``.
 
 .. tabs::
 
@@ -60,32 +62,46 @@ The following Cilium network policy allows ``mediabot`` pods to only access ``ap
 
 Let's take a closer look at the policy:
 
-* The first egress section uses ``toFQDNs: matchName`` specification to allow egress to ``api.twitter.com``. The destination DNS should match exactly the name specified in the rule. The ``endpointSelector`` allows only pods with labels ``class: mediabot, org:empire`` to have the egress access.
-* The second egress section (``toEndpoints``) allows ``mediabot`` pods to access ``kube-dns`` service. Note that ``rules: dns`` instructs Cilium to inspect and allow DNS lookups matching specified patterns. In this case, inspect and allow all DNS queries.
+* The first egress section uses ``toFQDNs: matchName`` specification to allow
+  egress to ``api.github.com``. The destination DNS should match exactly the
+  name specified in the rule. The ``endpointSelector`` allows only pods with
+  labels ``class: mediabot, org:empire`` to have the egress access.
+* The second egress section (``toEndpoints``) allows ``mediabot`` pods to access
+  ``kube-dns`` service. Note that ``rules: dns`` instructs Cilium to inspect and
+  allow DNS lookups matching specified patterns. In this case, inspect and allow
+  all DNS queries.
 
-Note that with this policy the ``mediabot`` doesn't have access to any internal cluster service other than ``kube-dns``. Refer to :ref:`Network Policy` to learn more about policies for controlling access to internal cluster services.
+Note that with this policy the ``mediabot`` doesn't have access to any internal
+cluster service other than ``kube-dns``. Refer to :ref:`Network Policy` to learn
+more about policies for controlling access to internal cluster services.
 
 Let's apply the policy:
 
 .. parsed-literal::
 
-  kubectl create -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-matchname.yaml
+  kubectl apply -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-matchname.yaml
 
-Testing the policy, we see that ``mediabot`` has access to ``api.twitter.com`` but doesn't have access to any other external service, e.g., ``help.twitter.com``.
+Testing the policy, we see that ``mediabot`` has access to ``api.github.com``
+but doesn't have access to any other external service, e.g.,
+``support.github.com``.
 
 .. code-block:: shell-session
 
-   $ kubectl exec mediabot -- curl -I -s https://api.twitter.com | head -1
-   HTTP/1.1 404 Not Found
+   $ kubectl exec mediabot -- curl -I -s https://api.github.com | head -1
+   HTTP/2 200
 
-   $ kubectl exec mediabot -- curl -I -s --max-time 5 https://help.twitter.com | head -1
+   $ kubectl exec mediabot -- curl -I -s --max-time 5 https://support.github.com | head -1
    curl: (28) Connection timed out after 5000 milliseconds
    command terminated with exit code 28
 
 DNS Policies Using Patterns
 ===========================
 
-The above policy controlled DNS access based on exact match of the DNS domain name. Often, it is required to allow access to a subset of domains. Let's say, in the above example, ``mediabot`` pods need access to any Twitter sub-domain, e.g., the pattern ``*.twitter.com``. We can achieve this easily by changing the ``toFQDN`` rule to use ``matchPattern`` instead of ``matchName``.
+The above policy controlled DNS access based on exact match of the DNS domain
+name. Often, it is required to allow access to a subset of domains. Let's say,
+in the above example, ``mediabot`` pods need access to any GitHub sub-domain,
+e.g., the pattern ``*.github.com``. We can achieve this easily by changing the
+``toFQDN`` rule to use ``matchPattern`` instead of ``matchName``.
 
 .. literalinclude:: ../../examples/kubernetes-dns/dns-pattern.yaml
 
@@ -93,25 +109,33 @@ The above policy controlled DNS access based on exact match of the DNS domain na
 
    kubectl apply -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-pattern.yaml
 
-Test that ``mediabot`` has access to multiple Twitter services for which the DNS matches the pattern ``*.twitter.com``. It is important to note and test that this doesn't allow access to ``twitter.com`` because the ``*.`` in the pattern requires one subdomain to be present in the DNS name. You can simply add more ``matchName`` and ``matchPattern`` clauses to extend the access.
-(See :ref:`DNS based` policies to learn more about specifying DNS rules using patterns and names.)
+Test that ``mediabot`` has access to multiple GitHub services for which the DNS
+matches the pattern ``*.github.com``. It is important to note and test that this
+doesn't allow access to ``github.com`` because the ``*.`` in the pattern
+requires one subdomain to be present in the DNS name. You can simply add more
+``matchName`` and ``matchPattern`` clauses to extend the access. (See :ref:`DNS based`
+policies to learn more about specifying DNS rules using patterns and names.)
 
 .. code-block:: shell-session
 
-   $ kubectl exec mediabot -- curl -I -s https://help.twitter.com | head -1
-   HTTP/1.1 302 Found
-
-   $ kubectl exec mediabot -- curl -I -s https://about.twitter.com | head -1
+   $ kubectl exec mediabot -- curl -I -s https://support.github.com | head -1
    HTTP/1.1 200 OK
 
-   $ kubectl exec mediabot -- curl -I -s --max-time 5 https://twitter.com | head -1
-   curl: (7) Failed to connect to twitter.com port 443: Operation timed out
-   command terminated with exit code 7
+   $ kubectl exec mediabot -- curl -I -s https://gist.github.com | head -1
+   HTTP/1.1 302 Found
+
+   $ kubectl exec mediabot -- curl -I -s --max-time 5 https://github.com | head -1
+   curl: (28) Connection timed out after 5000 milliseconds
+   command terminated with exit code 28
 
 Combining DNS, Port and L7 Rules
 ================================
 
-The DNS-based policies can be combined with port (L4) and API (L7) rules to further restrict the access. In our example, we will restrict ``mediabot`` pods to access Twitter services only on ports ``443``. The ``toPorts`` section in the policy below achieves the port-based restrictions along with the DNS-based policies.
+The DNS-based policies can be combined with port (L4) and API (L7) rules to
+further restrict the access. In our example, we will restrict ``mediabot`` pods
+to access GitHub services only on ports ``443``. The ``toPorts`` section in the
+policy below achieves the port-based restrictions along with the DNS-based
+policies.
 
 .. literalinclude:: ../../examples/kubernetes-dns/dns-port.yaml
 
@@ -119,18 +143,21 @@ The DNS-based policies can be combined with port (L4) and API (L7) rules to furt
 
   kubectl apply -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-port.yaml
 
-Testing, the access to ``https://help.twitter.com`` on port ``443`` will succeed but the access to ``http://help.twitter.com`` on port ``80`` will be denied.
+Testing, the access to ``https://support.github.com`` on port ``443`` will
+succeed but the access to ``http://support.github.com`` on port ``80`` will be
+denied.
 
 .. code-block:: shell-session
 
-   $ kubectl exec mediabot -- curl -I -s https://help.twitter.com | head -1
-   HTTP/1.1 302 Found
+   $ kubectl exec mediabot -- curl -I -s https://support.github.com | head -1
+   HTTP/1.1 200 OK
 
-   $ kubectl exec mediabot -- curl -I -s --max-time 5 http://help.twitter.com | head -1
+   $ kubectl exec mediabot -- curl -I -s --max-time 5 http://support.github.com | head -1
    curl: (28) Connection timed out after 5001 milliseconds
    command terminated with exit code 28
 
-Refer to :ref:`l4_policy` and :ref:`l7_policy` to learn more about Cilium L4 and L7 network policies.
+Refer to :ref:`l4_policy` and :ref:`l7_policy` to learn more about Cilium L4 and
+L7 network policies.
 
 Clean-up
 ========

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -38,7 +38,7 @@ value is an IPSec configuration in the following format::
     ``Secret`` resources need to be deployed in the same namespace as Cilium!
     In our example, we use ``kube-system``.
 
-In the example below, GMC-128-AES is used. However, any of the algorithms
+In the example below, GCM-128-AES is used. However, any of the algorithms
 supported by Linux may be used. To generate the secret, you may use the
 following command:
 

--- a/Documentation/security/policy/troubleshooting.rst
+++ b/Documentation/security/policy/troubleshooting.rst
@@ -120,7 +120,7 @@ the state of applying FQDN policy in multiple layers of the daemon:
           {
             "toFQDNs": [
               {
-                "matchName": "api.twitter.com"
+                "matchName": "api.github.com"
               }
             ]
           },
@@ -170,12 +170,11 @@ the state of applying FQDN policy in multiple layers of the daemon:
           },
           {
             "key": "io.cilium.k8s.policy.uid",
-            "value": "fc9d6022-2ffa-4f72-b59e-b9067c3cfecf",
+            "value": "f213c6b2-c87b-449c-a66c-e19a288062ba",
             "source": "k8s"
           }
         ]
       }
-
 
 #. After making a DNS request, the FQDN to IP mapping should be available via
    ``cilium fqdn cache list``:
@@ -183,15 +182,16 @@ the state of applying FQDN policy in multiple layers of the daemon:
    .. code-block:: shell-session
 
       # cilium fqdn cache list
-      Endpoint   FQDN                TTL      ExpirationTime             IPs
-      2761       help.twitter.com.   604800   2019-07-16T17:57:38.179Z   104.244.42.67,104.244.42.195,104.244.42.3,104.244.42.131
-      2761       api.twitter.com.    604800   2019-07-16T18:11:38.627Z   104.244.42.194,104.244.42.130,104.244.42.66,104.244.42.2
+      Endpoint   Source   FQDN                  TTL    ExpirationTime             IPs
+      725        lookup   api.github.com.       3600   2023-02-10T18:16:05.842Z   140.82.121.6
+      725        lookup   support.github.com.   3600   2023-02-10T18:16:09.371Z   185.199.111.133,185.199.109.133,185.199.110.133,185.199.108.133
+
 
 #. If the traffic is allowed, then these IPs should have corresponding local identities via
    ``cilium identity list | grep <IP>``:
 
    .. code-block:: shell-session
 
-      # cilium identity list | grep -A 1 104.244.42.194
-      16777220   cidr:104.244.42.194/32
-                 reserved:world
+      # cilium identity list | grep -A 1 140.82.121.6
+      16777230   cidr:140.82.121.6/32
+           reserved:world

--- a/Documentation/security/tls-visibility.rst
+++ b/Documentation/security/tls-visibility.rst
@@ -64,10 +64,11 @@ First off, we will create a single pod ``mediabot`` application:
 
 .. parsed-literal::
 
-    $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-sw-app.yaml
-    $ kubectl get po
-    NAME                             READY   STATUS    RESTARTS   AGE
-    pod/mediabot                     1/1     Running   0          14s
+   $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-sw-app.yaml
+   $ kubectl wait pod/mediabot --for=condition=Ready
+   $ kubectl get pods
+   NAME                             READY   STATUS    RESTARTS   AGE
+   pod/mediabot                     1/1     Running   0          14s
 
 
 A Brief Overview of the TLS Certificate Model

--- a/examples/kubernetes-dns/dns-matchname-openshift.yaml
+++ b/examples/kubernetes-dns/dns-matchname-openshift.yaml
@@ -9,7 +9,7 @@ spec:
       class: mediabot
   egress:
   - toFQDNs:
-    - matchName: "api.twitter.com"  
+    - matchName: "api.github.com"  
   - toEndpoints:
     - matchLabels:
         "k8s:io.kubernetes.pod.namespace": openshift-dns

--- a/examples/kubernetes-dns/dns-matchname.yaml
+++ b/examples/kubernetes-dns/dns-matchname.yaml
@@ -9,7 +9,7 @@ spec:
       class: mediabot
   egress:
   - toFQDNs:
-    - matchName: "api.twitter.com"  
+    - matchName: "api.github.com"
   - toEndpoints:
     - matchLabels:
         "k8s:io.kubernetes.pod.namespace": kube-system

--- a/examples/kubernetes-dns/dns-pattern.yaml
+++ b/examples/kubernetes-dns/dns-pattern.yaml
@@ -9,7 +9,7 @@ spec:
       class: mediabot
   egress:
   - toFQDNs:
-    - matchPattern: "*.twitter.com" 
+    - matchPattern: "*.github.com"
   - toEndpoints:
     - matchLabels:
         "k8s:io.kubernetes.pod.namespace": kube-system

--- a/examples/kubernetes-dns/dns-port.yaml
+++ b/examples/kubernetes-dns/dns-port.yaml
@@ -9,11 +9,11 @@ spec:
       class: mediabot
   egress:
   - toFQDNs:
-    - matchPattern: "*.twitter.com" 
+    - matchPattern: "*.github.com"
     toPorts:
     - ports:
       - port: "443"
-        protocol: TCP 
+        protocol: TCP
   - toEndpoints:
     - matchLabels:
         "k8s:io.kubernetes.pod.namespace": kube-system
@@ -24,4 +24,4 @@ spec:
         protocol: ANY
       rules:
         dns:
-        - matchPattern: "*"    
+        - matchPattern: "*"


### PR DESCRIPTION
Free access to the Twitter API [is not supported anymore](https://twitter.com/TwitterDev/status/1621026986784337922), replace examples using it by `api.github.com`.
