### PR TITLE
Fix docker-cilium-image target for DOCKER_FLAGS=--push

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -106,7 +106,7 @@ else
     ifeq ($(findstring --push,$(DOCKER_FLAGS)),)
 	@echo 'Define "DOCKER_FLAGS=--push" to push the build results.'
     else
-	$(CONTAINER_ENGINE) buildx imagetools inspect $(IMAGE_REPOSITORY)/$(IMAGE_NAME):$(4)
+	$(CONTAINER_ENGINE) buildx imagetools inspect $(IMAGE_REPOSITORY)/$(IMAGE_NAME)$${UNSTRIPPED}$(DOCKER_IMAGE_SUFFIX):$(4)
 	@echo '^^^ Images pushed, multi-arch manifest should be above. ^^^'
     endif
 endif


### PR DESCRIPTION
When using the docker-cilium-image Makefile target with DOCKER_FLAGS set to `--push` and DOCKER_IMAGE_SUFFIX defined, each step of the build that reference the image name should take into account the specified suffix.

Instead, the build fails while trying to fetch and inspect the manifest:

```
$ DOCKER_DEV_ACCOUNT=docker.io/pippolo84 DOCKER_IMAGE_SUFFIX=-ci DOCKER_IMAGE_TAG=makefiletest DOCKER_FLAGS=--push make docker-cilium-image
...
docker buildx imagetools inspect docker.io/pippolo84/cilium:makefiletest
ERROR: docker.io/pippolo84/cilium:makefiletest: not found
make: *** [Makefile.docker:124: docker-cilium-image] Error 1
```

The error message highlights that the suffix is not added when generating the fully qualified image name in the manifest inspection command.

The commit adds the missing $(DOCKER_IMAGE_SUFFIX) variable to fix the issue.

Fixes: 3fd3691ef39 ("build: Makefile support for DOCKER_IMAGE_SUFFIX, CI_BUILD, and KIND_LOAD")