### PR TITLE
Design: Add CFP design folder and template

### DIFF
--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -169,9 +169,11 @@ in development. We label issues with `good-first-issue`_ to help new potential
 contributors find issues and feature requests that are relatively self-contained
 and could be a good place to start. Please also read the :ref:`dev_guide` for
 details of our pull request process and expectations, along with instructions
-for setting up your development environment. We encourage you to discuss your
-ideas for significant enhancements and feature requests on the #development
-channel on `Cilium Slack <slack_>`_ and/or bring them to the :ref:`weekly-community-meeting`. 
+for setting up your development environment.
+
+We encourage you to discuss your ideas for significant enhancements and feature
+requests on the #development channel on `Cilium Slack <slack_>`_, bring them to 
+the :ref:`weekly-community-meeting`, and/or create a CFP design doc.
 
 This roadmap does not give date commitments since the work is dependent on the
 community. If you're looking for commitments to apply engineering resources to

--- a/design-cfps/CFP-YYYY-MM-DD-template.md
+++ b/design-cfps/CFP-YYYY-MM-DD-template.md
@@ -49,7 +49,7 @@ _List crucial impacts and key questions. They likely require discussion and are 
 
 _Describe crucial impacts and key questions that likely require discussion and debate._
 
-### Key question: … 2
+### Key Question: ... 2
 
 _Describe a key question_
 

--- a/design-cfps/CFP-YYYY-MM-DD-template.md
+++ b/design-cfps/CFP-YYYY-MM-DD-template.md
@@ -2,11 +2,11 @@
 
 **SIG: SIG-NAME**
 
-**Begin Design Discussion: ** YYYY-MM-DD
+**Begin Design Discussion:** YYYY-MM-DD
 
-**End Design Discussion: ** YYYY-MM-DD
+**End Design Discussion:** YYYY-MM-DD
 
-**Cilium Release: ** X.XX
+**Cilium Release:** X.XX
 
 **Authors:** alice <alice@example.com>, bob jones <bob@example.com>
 

--- a/design-cfps/CFP-YYYY-MM-DD-template.md
+++ b/design-cfps/CFP-YYYY-MM-DD-template.md
@@ -1,0 +1,84 @@
+# CFP-YYYY-MM-DD: Template
+
+**SIG: SIG-NAME**
+
+**Begin Design Discussion: ** YYYY-MM-DD
+
+**End Design Discussion: ** YYYY-MM-DD
+
+**Cilium Release: ** X.XX
+
+**Authors:** alice <alice@example.com> ,  bob jones <bob@example.com>
+
+## Summary
+
+_Provide a high-level summary. Keep it short._
+
+## **Motivation**
+
+_Provide the motivation for the feature. Also provide any context required to understand the motivation. The motivation should justify any potential impact_
+
+## **Goals**
+
+* _List goals that this CFP achieves_
+
+## **Non-Goals**
+
+* _List aspects which are specifically out of context for this CFP_
+
+## **Proposal**
+
+### Overview
+
+_Provide a high-level overview of the design aspect of the proposal_
+
+### Section 1
+
+_Section with proposal content_
+
+### Section 2
+
+_Section with proposal content_
+
+
+## Impacts / Key Questions
+
+_List crucial impacts and key questions. They likely require discussion and are required to understand the trade-offs of the CFP. During the lifecycle of a CFP, discussion on design aspects can be moved into this section. After reading through this section, it should be possible to understand any potentially negative or controversial impact of this CFP. it should also be possible to derive the key design questions: X vs Y._
+
+### Impact: ... 1
+
+_Describe crucial impacts and key questions that likely require discussion and debate._
+
+### Key question: … 2
+
+_Describe a key question_
+
+### Option 1:
+
+#### Pros
+
+* ...
+
+#### Cons
+
+* ...
+
+### Option 2:
+
+#### Pros
+
+* ...
+
+#### Cons
+
+* ...
+
+## Future Milestones
+
+_List things that this CFP will enable but that are out of scope for now. This can help understand the greater impact of a proposal without requiring to extend the scope of a CFP unnecessarily._
+
+### Deferred Milestone 1
+
+_Description of deferred milestone_
+
+### Deferred Milestone 2

--- a/design-cfps/CFP-YYYY-MM-DD-template.md
+++ b/design-cfps/CFP-YYYY-MM-DD-template.md
@@ -43,7 +43,7 @@ _Section with proposal content_
 
 ## Impacts / Key Questions
 
-_List crucial impacts and key questions. They likely require discussion and are required to understand the trade-offs of the CFP. During the lifecycle of a CFP, discussion on design aspects can be moved into this section. After reading through this section, it should be possible to understand any potentially negative or controversial impact of this CFP. it should also be possible to derive the key design questions: X vs Y._
+_List crucial impacts and key questions. They likely require discussion and are required to understand the trade-offs of the CFP. During the lifecycle of a CFP, discussion on design aspects can be moved into this section. After reading through this section, it should be possible to understand any potentially negative or controversial impact of this CFP. It should also be possible to derive the key design questions: X vs Y._
 
 ### Impact: ... 1
 

--- a/design-cfps/CFP-YYYY-MM-DD-template.md
+++ b/design-cfps/CFP-YYYY-MM-DD-template.md
@@ -8,7 +8,7 @@
 
 **Cilium Release: ** X.XX
 
-**Authors:** alice <alice@example.com> ,  bob jones <bob@example.com>
+**Authors:** alice <alice@example.com>, bob jones <bob@example.com>
 
 ## Summary
 

--- a/design-cfps/CFP-YYYY-MM-DD-template.md
+++ b/design-cfps/CFP-YYYY-MM-DD-template.md
@@ -16,21 +16,21 @@ _Provide a high-level summary. Keep it short._
 
 ## **Motivation**
 
-_Provide the motivation for the feature. Also provide any context required to understand the motivation. The motivation should justify any potential impact_
+_Provide the motivation for the feature. Also provide any context required to understand the motivation. The motivation should justify any potential impact._
 
 ## **Goals**
 
-* _List goals that this CFP achieves_
+* _List goals that this CFP achieves._
 
 ## **Non-Goals**
 
-* _List aspects which are specifically out of context for this CFP_
+* _List aspects which are specifically out of context for this CFP._
 
 ## **Proposal**
 
 ### Overview
 
-_Provide a high-level overview of the design aspect of the proposal_
+_Provide a high-level overview of the design aspects of the proposal._
 
 ### Section 1
 

--- a/design-cfps/README.md
+++ b/design-cfps/README.md
@@ -22,7 +22,8 @@ accept.
 To create a CFP, it is recommended to use the `CFP-YYYY-MM-DD-template.md`
 file as an outline. The structure of this template is meant to provide a starting
 point for people. Feel free to edit and modify your outline to best fit your
-needs when creating a proposal.
+needs when creating a proposal. The title should be `CFP-YYYY-MM-DD-subject.md` 
+where the date is the day the discussion opened.
 
 Many design docs also begin their life as a Google doc or other shareable
 file for easy commenting and editing when still in the early stages of discussion.

--- a/design-cfps/README.md
+++ b/design-cfps/README.md
@@ -9,7 +9,7 @@ executing on the design. By going through the design process, developers gain a
 have a high level of confidence that their designs are viable and will be
 accepted.
 
-NOTE: This is process is not mandatory. Anyone can execute on their own design
+NOTE: This process is not mandatory. Anyone can execute on their own design
 without going through this process and submit code to the respective repos.
 However, depending on the complexity of the design and how experienced the
 developer is within the community, they could greatly benefit from going through

--- a/design-cfps/README.md
+++ b/design-cfps/README.md
@@ -1,4 +1,4 @@
-This repo contains CFP design proposals for features impacting repos across the
+This directory contains CFP design proposals for features impacting repos across the
 Cilium Github organization.
 
 # Purpose of CFPs

--- a/design-cfps/README.md
+++ b/design-cfps/README.md
@@ -1,0 +1,51 @@
+This repo contains CFP design proposals for features impacting repos across the
+Cilium Github organization.
+
+# Purpose of CFPs
+
+The purpose of a CFP is to allow community members to gain feedback
+on their designs from the Committers before the community member commits to
+executing on the design. By going through the design process, developers gain a
+have a high level of confidence that their designs are viable and will be
+accepted.
+
+NOTE: This is process is not mandatory. Anyone can execute on their own design
+without going through this process and submit code to the respective repos.
+However, depending on the complexity of the design and how experienced the
+developer is within the community, they could greatly benefit from going through
+this design process first. The risk of not getting a design proposal approved
+is that a developer may not arrive at a viable architecture that the community will
+accept.
+
+# How to create CFPs
+
+To create a CFP, it is recommended to use the `CFP-YYYY-MM-DD-template.md`
+file as an outline. The structure of this template is meant to provide a starting
+point for people. Feel free to edit and modify your outline to best fit your
+needs when creating a proposal.
+
+Many design docs also begin their life as a Google doc or other shareable
+file for easy commenting and editing when still in the early stages of discussion.
+Once your proposal is done, submit it as a PR to the design-cfps folder.
+
+If you want to bring further attention to your design, you may want to
+raise the design during the weekly community call and on the [#development
+channel in Slack](https://cilium.slack.com/archives/C2B917YHE).
+
+# Getting a design approved
+
+For a CFP to be considered viable, a CODEOWNER from each area impacted by
+the design needs to provide an approval. Once all the approvals are collected,
+the design can be merged. A merged design proposal means the proposal is
+viable to be executed on.
+
+# Design proposal drift
+
+After a design proposal is merged, it's likely that the actual implementation
+will begin to drift slightly from the original design. This is expected and
+there is no expectation that the original design proposal needs to be updated
+to reflect these differences.
+
+The code and our documentation are the ultimate sources of truth. CFPs are merely
+the starting point for the implementation.
+

--- a/design-cfps/README.md
+++ b/design-cfps/README.md
@@ -6,7 +6,7 @@ Cilium Github organization.
 The purpose of a CFP is to allow community members to gain feedback
 on their designs from the Committers before the community member commits to
 executing on the design. By going through the design process, developers gain a
-have a high level of confidence that their designs are viable and will be
+high level of confidence that their designs are viable and will be
 accepted.
 
 NOTE: This process is not mandatory. Anyone can execute on their own design

--- a/design-cfps/README.md
+++ b/design-cfps/README.md
@@ -3,7 +3,7 @@ Cilium Github organization.
 
 # Purpose of CFPs
 
-The purpose of a CFP is to allow community members to gain feedback
+The purpose of a Cilium Feature Proposal (CFP) is to allow community members to gain feedback
 on their designs from the Committers before the community member commits to
 executing on the design. By going through the design process, developers gain a
 high level of confidence that their designs are viable and will be


### PR DESCRIPTION
Signed-off-by: Bill Mulligan <billmulligan516@gmail.com>

As discussed in the [January 25th community meeting](https://docs.google.com/document/d/1Y_4chDk4rznD6UgXPlPvn3Dc7l-ZutGajUv1eF0VDwQ/edit#heading=h.4xn75iybcned), this folder will let us keep track of CFP for future design discussions.


```release-note
Folder added to keep track of design CFPs
```
