### PR TITLE
Fix: clarify that security team is made of the community

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,5 +16,5 @@ We strongly encourage you to report security vulnerabilities to
 our private security mailing list: security@cilium.io - first, before
 disclosing them in any public forums.
 
-This is a private mailing list where only members of the Cilium internal
-security team are subscribed to, and is treated as top priority.
+This is a private mailing list where community members from the project
+across multiple organization are subscribed to, and is treated as top priority.


### PR DESCRIPTION
Signed-off-by: Bill Mulligan <billmulligan516@gmail.com>
