### PR TITLE
e2e-tests: git-ignore directory old-charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ test/cilium-[0-9a-f]*.yaml
 test/*tmp
 test/cilium-istioctl
 
+# Updates E2E Test
+old-charts/
+
 # generated test files
 test/k8s/manifests/cnp-second-namespaces.yaml
 test/cilium.conf.ginkgo


### PR DESCRIPTION
The e2e-test updates.go downloads old cilium releases to the directory old-charts. This directory should be ignored by GIT to prevent an unintentional commit after executing the e2e-tests locally.