### PR TITLE
Fix RKE doc link

### DIFF
--- a/Documentation/installation/requirements-rke.rst
+++ b/Documentation/installation/requirements-rke.rst
@@ -4,7 +4,7 @@ perform the following steps:
 .. note::
 
    If you are using RKE2, Cilium has been directly integrated. Please see
-   `Using Cilium <https://docs.rke2.io/install/network_options/#using-cilium-or-calico-instead-of-canal>`_
+   `Using Cilium <https://docs.rke2.io/install/network_options/#install-a-cni-plugin>`_
    in the RKE2 documentation. You can use either method.
 
 **Default Configuration:**


### PR DESCRIPTION
Fixed link to broken anchor in RKE doc

```release-note
Fixed link to broken anchor in RKE doc
```

Signed-off-by: Raphaël Pinson <raphael@isovalent.com>
