### PR TITLE
helm: Add support of annotations in hubble ui service

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1244,7 +1244,11 @@
    * - hubble.ui.service
      - hubble-ui service configuration.
      - object
-     - ``{"nodePort":31235,"type":"ClusterIP"}``
+     - ``{"annotations":{},"nodePort":31235,"type":"ClusterIP"}``
+   * - hubble.ui.service.annotations
+     - Annotations to be added for the Hubble UI service
+     - object
+     - ``{}``
    * - hubble.ui.service.nodePort
      - - The port to use when the service type is set to NodePort.
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -361,7 +361,8 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.rollOutPods | bool | `false` | Roll out Hubble-ui pods automatically when configmap is updated. |
 | hubble.ui.securityContext | object | `{"enabled":true,"fsGroup":1001,"runAsGroup":1001,"runAsUser":1001}` | Security context to be added to Hubble UI pods |
 | hubble.ui.securityContext.enabled | bool | `true` | Deprecated in favor of hubble.ui.securityContext. Whether to set the security context on the Hubble UI pods. |
-| hubble.ui.service | object | `{"nodePort":31235,"type":"ClusterIP"}` | hubble-ui service configuration. |
+| hubble.ui.service | object | `{"annotations":{},"nodePort":31235,"type":"ClusterIP"}` | hubble-ui service configuration. |
+| hubble.ui.service.annotations | object | `{}` | Annotations to be added for the Hubble UI service |
 | hubble.ui.service.nodePort | int | `31235` | - The port to use when the service type is set to NodePort. |
 | hubble.ui.service.type | string | `"ClusterIP"` | - The type of service used for Hubble UI access, either ClusterIP or NodePort. |
 | hubble.ui.standalone.enabled | bool | `false` | When true, it will allow installing the Hubble UI only, without checking dependencies. It is useful if a cluster already has cilium and Hubble relay installed and you just want Hubble UI to be deployed. When installed via helm, installing UI should be done via `helm upgrade` and when installed via the cilium cli, then `cilium hubble enable --ui` |

--- a/install/kubernetes/cilium/templates/hubble-ui/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/service.yaml
@@ -4,6 +4,10 @@ apiVersion: v1
 metadata:
   name: hubble-ui
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.hubble.ui.service.annotations }}
+  annotations:
+    {{- toYaml .Values.hubble.ui.service.annotations | nindent 4 }}
+  {{- end }}
   labels:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1326,6 +1326,8 @@ hubble:
 
     # -- hubble-ui service configuration.
     service:
+      # -- Annotations to be added for the Hubble UI service
+      annotations: {}
       # --- The type of service used for Hubble UI access, either ClusterIP or NodePort.
       type: ClusterIP
       # --- The port to use when the service type is set to NodePort.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1323,6 +1323,8 @@ hubble:
 
     # -- hubble-ui service configuration.
     service:
+      # -- Annotations to be added for the Hubble UI service
+      annotations: {}
       # --- The type of service used for Hubble UI access, either ClusterIP or NodePort.
       type: ClusterIP
       # --- The port to use when the service type is set to NodePort.


### PR DESCRIPTION
Signed-off-by: brnck <a.berneckas@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->

We are using Cilium in EKS alongside with ALB ingress controller which requires the service to be annotated with particular information such as alb.ingress.kubernetes.io/target-type: ip in order to create a load balancer in the AWS. The problem is that the helm chart does not support annotating the service, therefore, we either need to manually annotate the service or use another hackish solutions

```release-note
helm: Add support of annotations in hubble ui service
```
