### PR TITLE
docs: Make CRD compat script work on older trees

### DIFF
--- a/Documentation/check-crd-compat-table.sh
+++ b/Documentation/check-crd-compat-table.sh
@@ -2,6 +2,10 @@
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 dst_file="${PWD}/$(basename ${dir})/network/kubernetes/compatibility-table.rst"
+# Cilium 1.12 and earlier had a different path for the compatibility table.
+if [ ! -e "$dst_file" ]; then
+   dst_file="${PWD}/$(basename ${dir})/concepts/kubernetes/compatibility-table.rst"
+fi
 
 . "${dir}/../contrib/backporting/common.sh"
 remote="$(get_remote)"


### PR DESCRIPTION
Older branches had a different path for this file. In order to allow the
latest script to fix up the CRD versioning table in older trees, add a
fallback that detects if the target file doesn't exist, then in that
case fall back to the old path.
