### PR TITLE
Use RouteMTU to configure interfaces

### DIFF
--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -505,7 +505,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 			peer      netlink.Link
 			tmpIfName string
 		)
-		veth, peer, tmpIfName, err = connector.SetupVeth(ep.ContainerID, int(conf.DeviceMTU), int(conf.GROMaxSize), int(conf.GSOMaxSize), ep)
+		veth, peer, tmpIfName, err = connector.SetupVeth(ep.ContainerID, int(conf.RouteMTU), int(conf.GROMaxSize), int(conf.GSOMaxSize), ep)
 		if err != nil {
 			err = fmt.Errorf("unable to set up veth on host side: %s", err)
 			return err


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/23711

```release-note
MTU on veth interfaces now sets correctly according to tunneling mode.
```
