### PR TITLE
etcd: print debug message event value as string

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -976,7 +976,7 @@ reList:
 				}
 
 				localCache.MarkInUse(key.Key)
-				scopedLog.Debugf("Emitting list result as %v event for %s=%v", t, key.Key, key.Value)
+				scopedLog.Debugf("Emitting list result as %s event for %s=%s", t, key.Key, key.Value)
 
 				queueStart := spanstat.Start()
 				w.Events <- KeyValueEvent{
@@ -1077,7 +1077,7 @@ reList:
 						localCache.MarkInUse(ev.Kv.Key)
 					}
 
-					scopedLog.Debugf("Emitting %v event for %s=%v", event.Typ, event.Key, event.Value)
+					scopedLog.Debugf("Emitting %s event for %s=%s", event.Typ, event.Key, event.Value)
 
 					queueStart := spanstat.Start()
 					w.Events <- event


### PR DESCRIPTION
Change the print modifier of the debug messages about etcd emitted events to '%s', to print the retrieved value as human-readable string rather than array of bytes.

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>

<!-- Description of change -->

```release-note
etcd: print debug message event value as string
```
