### PR TITLE
bpf: Remove unneeded orig_dip from ipv6_host_policy_egress

### DIFF
--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -25,7 +25,6 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple tuple = {};
 	__u32 dst_id = 0;
-	union v6addr orig_dip;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	__u16 proxy_port = 0;
@@ -41,7 +40,6 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	tuple.nexthdr = ip6->nexthdr;
 	ipv6_addr_copy(&tuple.saddr, (union v6addr *)&ip6->saddr);
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *)&ip6->daddr);
-	ipv6_addr_copy(&orig_dip, (union v6addr *)&ip6->daddr);
 	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
@@ -54,11 +52,11 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	trace->reason = (enum trace_reason)ret;
 
 	/* Retrieve destination identity. */
-	info = lookup_ip6_remote_endpoint(&orig_dip, 0);
+	info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
 	if (info && info->sec_label)
 		dst_id = info->sec_label;
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
-		   orig_dip.p4, dst_id);
+		   ip6->daddr.s6_addr32[3], dst_id);
 
 	/* Reply traffic and related are allowed regardless of policy verdict. */
 	if (ret == CT_REPLY || ret == CT_RELATED)


### PR DESCRIPTION
There is no need to copy the IPv6 address to a local variable, because the packet data is not going to change. Just use the address from the packet headers directly.

Signed-off-by: Maxim Mikityanskiy <maxim@isovalent.com>

See #23577, it's the same change in another function.