### PR TITLE
Remove / in RKE doc link as it causes redirect bug

### DIFF
--- a/Documentation/installation/requirements-rke.rst
+++ b/Documentation/installation/requirements-rke.rst
@@ -4,7 +4,7 @@ perform the following steps:
 .. note::
 
    If you are using RKE2, Cilium has been directly integrated. Please see
-   `Using Cilium <https://docs.rke2.io/install/network_options/#install-a-cni-plugin>`_
+   `Using Cilium <https://docs.rke2.io/install/network_options#install-a-cni-plugin>`_
    in the RKE2 documentation. You can use either method.
 
 **Default Configuration:**


### PR DESCRIPTION
Signed-off-by: Raphaël Pinson <raphael@isovalent.com>


```release-note
Remove / in RKE doc link as it causes redirect bug
```