### PR TITLE
CI: Fixes flake in kubectl wait in CI

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -124,7 +124,8 @@ jobs:
             --set securityContext.privileged=true \
             --set gatewayAPI.enabled=true
 
-          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=${{ env.timeout }}
+          kubectl wait -n kube-system --for=condition=Ready -l app.kubernetes.io/part-of=cilium pod --timeout=${{ env.timeout }}
+          kubectl rollout -n kube-system status deploy/coredns --timeout=${{ env.timeout }}
 
           # To make sure that cilium envoy CRs are available
           kubectl wait --for condition=Established crd/ciliumenvoyconfigs.cilium.io --timeout=${{ env.timeout }}

--- a/.github/workflows/conformance-ingress-shared.yaml
+++ b/.github/workflows/conformance-ingress-shared.yaml
@@ -126,7 +126,8 @@ jobs:
             --set ingressController.loadbalancerMode=shared \
             --set extraConfig.bpf-lb-acceleration=native # This is to make sure we have the coverage for XDP.
 
-          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=${{ env.timeout }}
+          kubectl wait -n kube-system --for=condition=Ready -l app.kubernetes.io/part-of=cilium pod --timeout=${{ env.timeout }}
+          kubectl rollout -n kube-system status deploy/coredns --timeout=${{ env.timeout }}
 
           # To make sure that cilium envoy CRs are available
           kubectl wait --for condition=Established crd/ciliumenvoyconfigs.cilium.io --timeout=${{ env.timeout }}

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -123,7 +123,8 @@ jobs:
             --set ingressController.enabled=true \
             --set ingressController.loadbalancerMode=dedicated
 
-          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=${{ env.timeout }}
+          kubectl wait -n kube-system --for=condition=Ready -l app.kubernetes.io/part-of=cilium pod --timeout=${{ env.timeout }}
+          kubectl rollout -n kube-system status deploy/coredns --timeout=${{ env.timeout }}
 
           # To make sure that cilium envoy CRs are available
           kubectl wait --for condition=Established crd/ciliumenvoyconfigs.cilium.io --timeout=${{ env.timeout }}

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -104,7 +104,9 @@ jobs:
              --set hubble.enabled=true \
              --set hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}"
 
-          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=5m
+          kubectl wait -n kube-system --for=condition=Ready -l app.kubernetes.io/part-of=cilium pod --timeout=${{ env.timeout }}
+          kubectl rollout -n kube-system status deploy/coredns --timeout=${{ env.timeout }}
+
           # To make sure that cilium CRD is available (default timeout is 5m)
           # https://github.com/cilium/cilium/blob/master/operator/crd.go#L34
           kubectl wait --for condition=Established crd/ciliumnetworkpolicies.cilium.io --timeout=5m

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -132,7 +132,9 @@ jobs:
             --set ipv6NativeRoutingCIDR=2001:db8:1::/64 \
             --set ingressController.enabled=true
 
-          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=${{ env.TIMEOUT }}
+          kubectl wait -n kube-system --for=condition=Ready -l app.kubernetes.io/part-of=cilium pod --timeout=5m
+          kubectl rollout -n kube-system status deploy/coredns --timeout=5m
+
           # To make sure that cilium CRD is available (default timeout is 5m)
           kubectl wait --for condition=Established crd/ciliumnetworkpolicies.cilium.io --timeout=5m
 

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -148,7 +148,9 @@ jobs:
              --set hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}" \
              --set ingressController.enabled=true
 
-          kubectl wait -n kube-system --for=condition=Ready --all pod --timeout=5m
+          kubectl wait -n kube-system --for=condition=Ready -l app.kubernetes.io/part-of=cilium pod --timeout=5m
+          kubectl rollout -n kube-system status deploy/coredns --timeout=5m
+
           # To make sure that cilium CRD is available (default timeout is 5m)
           # https://github.com/cilium/cilium/blob/master/operator/crd.go#L34
           kubectl wait --for condition=Established crd/ciliumnetworkpolicies.cilium.io --timeout=5m


### PR DESCRIPTION
This fixes a flake where `kubectl wait` would wait for CoreDNS to be ready but as Cilium removed the pods it crashed causing the wait command to fail.

This change will only watch Cilium pods to become ready after which it will do a rollout check on CoreDNS' deployment to be ready

Signed-off-by: Maartje Eyskens <maartje.eyskens@isovalent.com>

```release-note
Fixes a flake in the kubectl wait part of the CI
```

**Note** this is an attempt to improve this as I hit it several times in my PR all suggestions very welcome :) 