### PR TITLE
workflow: fixes LLVM, Clang cache and install path

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -70,9 +70,19 @@ jobs:
         with:
           entrypoint: ./contrib/coccinelle/check-cocci.sh
 
+  set_clang_dir:
+    name: Set clang directory
+    runs-on: ubuntu-latest
+    outputs:
+      clang_dir: ${{ steps.set_dir.outputs.clang_dir }}
+    steps:
+    - name: Set directory
+      id: set_dir
+      run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
+
   # Runs only if code under bpf/ is changed.
   build_all:
-    needs: check_changes
+    needs: [check_changes, set_clang_dir]
     if: ${{ needs.check_changes.outputs.bpf-tree == 'true' }}
     name: build datapath
     runs-on: ubuntu-22.04
@@ -85,7 +95,7 @@ jobs:
         id: cache-llvm
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # v3.2.5
         with:
-          path: $HOME/.clang
+          path: ${{ needs.set_clang_dir.outputs.clang_dir }}
           key: llvm-10.0
       - name: Install LLVM and Clang prerequisites
         run: |
@@ -95,7 +105,7 @@ jobs:
         uses: KyleMayes/install-llvm-action@ef175530927af66c61e4e8da4fea4e15de63f780 # v1.7.0
         with:
           version: "10.0"
-          directory: $HOME/.clang
+          directory: ${{ needs.set_clang_dir.outputs.clang_dir }}
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -109,7 +119,7 @@ jobs:
           make --quiet -C bpf build_all || (echo "Run 'make -C bpf build_all' locally to investigate build breakages"; exit 1)
 
   bpf_tests:
-    needs: check_changes
+    needs: [check_changes, set_clang_dir]
     if: ${{ needs.check_changes.outputs.bpf-tree == 'true' || needs.check_changes.outputs.bpf-tests-runner == 'true' }}
     name: BPF unit/integration Tests
     runs-on: ubuntu-22.04
@@ -122,7 +132,7 @@ jobs:
         id: cache-llvm
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # v3.2.5
         with:
-          path: $HOME/.clang
+          path: ${{ needs.set_clang_dir.outputs.clang_dir }}
           key: llvm-10.0
       - name: Install LLVM and Clang prerequisites
         run: |
@@ -132,7 +142,7 @@ jobs:
         uses: KyleMayes/install-llvm-action@ef175530927af66c61e4e8da4fea4e15de63f780 # v1.7.0
         with:
           version: "10.0"
-          directory: $HOME/.clang
+          directory: ${{ needs.set_clang_dir.outputs.clang_dir }}
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -25,11 +25,15 @@ jobs:
         with:
           go-version: 1.19.5
 
+      - name: Set clang directory
+        id: set_clang_dir
+        run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
+
       - name: Cache LLVM and Clang
         id: cache-llvm
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # v3.2.5
         with:
-          path: $HOME/.clang
+          path: ${{ steps.set_clang_dir.outputs.clang_dir }}
           key: llvm-10.0
 
       - name: Install LLVM and Clang prerequisites
@@ -41,7 +45,7 @@ jobs:
         uses: KyleMayes/install-llvm-action@ef175530927af66c61e4e8da4fea4e15de63f780 # v1.7.0
         with:
           version: "10.0"
-          directory: $HOME/.clang
+          directory: ${{ steps.set_clang_dir.outputs.clang_dir }}
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
       - name: Install ginkgo


### PR DESCRIPTION
`Cache LLVM and Clang` and `Install LLVM and Clang` steps in workflows use `$HOME/.clang` as the path argument. But `install-llvm-action` does not resolve `$HOME` and use it literary which results in installation to go under workspace directory as literal name `'$HOME'/.clang`. This behavior has not been a problem until `actions/checkout` version 3.2.0. After this version when the repo is checked out, it removes the clang path resulting in tests failing.

This commit sets the clang path as `$HOME/.clang` properly as a step or job whichever is appropriate for the workflow. After this is merged `actions/checkout` can be upgraded.

Fixes: #23268

Signed-off-by: Birol Bilgin <birol@cilium.io>