### PR TITLE
clustermesh: fix cluster synchronization wait group increment

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -400,10 +400,11 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 				// Also wait for all cluster mesh to be synchronized with the
 				// datapath before proceeding.
 				if d.clustermesh != nil {
-					err := d.clustermesh.ClustersSynced(context.Background())
+					err := d.clustermesh.ClustersSynced(d.ctx)
 					if err != nil {
 						log.WithError(err).Fatal("timeout while waiting for all clusters to be locally synchronized")
 					}
+					log.Debug("all clusters have been correctly synchronized locally")
 				}
 				// Start controller which removes any leftover Kubernetes
 				// services that may have been deleted while Cilium was not

--- a/pkg/clustermesh/services.go
+++ b/pkg/clustermesh/services.go
@@ -156,7 +156,6 @@ func (r *remoteServiceObserver) OnUpdate(key store.Key) {
 		mesh.globalServices.onUpdate(svc)
 
 		if merger := mesh.conf.ServiceMerger; merger != nil {
-			r.swg.Add()
 			merger.MergeExternalServiceUpdate(svc, r.swg)
 		} else {
 			scopedLog.Debugf("Ignoring remote service update. Missing merger function")
@@ -176,7 +175,6 @@ func (r *remoteServiceObserver) OnDelete(key store.NamedKey) {
 		mesh.globalServices.onDelete(svc)
 
 		if merger := mesh.conf.ServiceMerger; merger != nil {
-			r.swg.Add()
 			merger.MergeExternalServiceDelete(svc, r.swg)
 		} else {
 			scopedLog.Debugf("Ignoring remote service delete. Missing merger function")


### PR DESCRIPTION
Previously, the StoppableWaitGroup associated with a given remote cluster was incremented twice every service notification (both before the merging process into the cache, and when sending the event notification), and decremented once after the event was processed.

This delayed the start of the controller responsible for the removal of possible leftover services deleted while Cilium was not running, until it had reached zero through subsequent service notifications.

This PR removes the redundant Add operations, and changes the context used to wait for the synchronization to the one associated with the daemon.

Signed-off-by: Marco Iorio <marco.iorio@isovalent.com>

<!-- Description of change -->

```release-note
clustermesh: fix cluster synchronization wait group increment
```
