### PR TITLE
daemon: ignore CILIUM_CUSTOM_CNI_CONF when writing cni configuration

### DIFF
--- a/daemon/cmd/cni.go
+++ b/daemon/cmd/cni.go
@@ -119,12 +119,6 @@ func (d *Daemon) startCNIConfWriter(opts *option.DaemonConfig, cleaner *daemonCl
 		return
 	}
 
-	// We used to disable CNI generation with this environment variable
-	// It's no longer documented, but we need to still support it.
-	if os.Getenv("CILIUM_CUSTOM_CNI_CONF") == "true" {
-		return
-	}
-
 	d.controllers.UpdateController(cniControllerName,
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {


### PR DESCRIPTION
This file was overly-cautious when mimicking cni-install.sh's behavior. It turns out we want to be able to disable cni-install.sh but still have the daemon write the configuration file. This preserves existing behavior in 1.12.

Thus, we need to remove the bit that bails out if the environment variable is set.

Fixes: 12b7b11e1
Signed-off-by: Casey Callendrello <cdc@isovalent.com>

```release-note
Fixes a bug where the Helm value `cni.configMap` no longer worked.
```
