### PR TITLE
kvstore: prevent deletion delay for node-unrelated events  

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -585,9 +585,10 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, servi
 	}
 
 	_, err = store.JoinSharedStore(store.Configuration{
-		Prefix:     nodeStore.NodeRegisterStorePrefix,
-		KeyCreator: nodeStore.RegisterKeyCreator,
-		Observer:   mgr,
+		Prefix:               nodeStore.NodeRegisterStorePrefix,
+		KeyCreator:           nodeStore.RegisterKeyCreator,
+		SharedKeyDeleteDelay: defaults.NodeDeleteDelay,
+		Observer:             mgr,
 	})
 	if err != nil {
 		log.WithError(err).Fatal("Unable to set up node register store in etcd")

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -115,7 +115,6 @@ func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, clients
 		store, err := store.JoinSharedStore(store.Configuration{
 			Prefix:                  serviceStore.ServiceStorePrefix,
 			SynchronizationInterval: 5 * time.Minute,
-			SharedKeyDeleteDelay:    0,
 			KeyCreator: func() store.Key {
 				return &serviceStore.ClusterService{}
 			},

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -115,7 +115,7 @@ func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, clients
 		store, err := store.JoinSharedStore(store.Configuration{
 			Prefix:                  serviceStore.ServiceStorePrefix,
 			SynchronizationInterval: 5 * time.Minute,
-			SharedKeyDeleteDelay:    func() *time.Duration { a := time.Duration(0); return &a }(),
+			SharedKeyDeleteDelay:    0,
 			KeyCreator: func() store.Key {
 				return &serviceStore.ClusterService{}
 			},

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -66,14 +66,6 @@ type Configuration struct {
 	RemoteIdentityWatcher RemoteIdentityWatcher
 
 	IPCache *ipcache.IPCache
-
-	// ServicesSharedKeyDeleteDelay is the delay before a shared service delete
-	// event is handled. This parameter is optional.
-	ServicesSharedKeyDeleteDelay *time.Duration
-
-	// NodesSharedKeyDeleteDelay is the delay before a shared node delete event
-	// is handled. This parameter is optional.
-	NodesSharedKeyDeleteDelay *time.Duration
 }
 
 func SetClusterConfig(clusterName string, config *cmtypes.CiliumClusterConfig, backend kvstore.BackendOperations) error {

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/allocator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -209,6 +210,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 					Prefix:                  path.Join(nodeStore.NodeStorePrefix, rc.name),
 					KeyCreator:              rc.mesh.conf.NodeKeyCreator,
 					SynchronizationInterval: time.Minute,
+					SharedKeyDeleteDelay:    defaults.NodeDeleteDelay,
 					Backend:                 backend,
 					Observer:                rc.mesh.conf.NodeObserver(),
 				})

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -208,7 +208,6 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				remoteNodes, err := store.JoinSharedStore(store.Configuration{
 					Prefix:                  path.Join(nodeStore.NodeStorePrefix, rc.name),
 					KeyCreator:              rc.mesh.conf.NodeKeyCreator,
-					SharedKeyDeleteDelay:    rc.mesh.conf.NodesSharedKeyDeleteDelay,
 					SynchronizationInterval: time.Minute,
 					Backend:                 backend,
 					Observer:                rc.mesh.conf.NodeObserver(),
@@ -219,8 +218,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				}
 
 				remoteServices, err := store.JoinSharedStore(store.Configuration{
-					Prefix:               path.Join(serviceStore.ServiceStorePrefix, rc.name),
-					SharedKeyDeleteDelay: rc.mesh.conf.ServicesSharedKeyDeleteDelay,
+					Prefix: path.Join(serviceStore.ServiceStorePrefix, rc.name),
 					KeyCreator: func() store.Key {
 						svc := serviceStore.ClusterService{}
 						return &svc

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -92,14 +92,13 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	})
 	defer ipc.Shutdown()
 	cm, err := NewClusterMesh(Configuration{
-		Name:                         "test2",
-		ConfigDirectory:              dir,
-		NodeKeyCreator:               testNodeCreator,
-		nodeObserver:                 &testObserver{},
-		ServiceMerger:                &s.svcCache,
-		RemoteIdentityWatcher:        mgr,
-		IPCache:                      ipc,
-		ServicesSharedKeyDeleteDelay: func() *time.Duration { a := time.Duration(0); return &a }(),
+		Name:                  "test2",
+		ConfigDirectory:       dir,
+		NodeKeyCreator:        testNodeCreator,
+		nodeObserver:          &testObserver{},
+		ServiceMerger:         &s.svcCache,
+		RemoteIdentityWatcher: mgr,
+		IPCache:               ipc,
 	})
 	c.Assert(err, IsNil)
 	c.Assert(cm, Not(IsNil))

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -54,8 +53,8 @@ type Configuration struct {
 	// are synchronized with the kvstore. This parameter is optional.
 	SynchronizationInterval time.Duration
 
-	// SharedKeyDeleteDelay is the delay before an shared key delete is
-	// handled. This parameter is optional
+	// SharedKeyDeleteDelay is the delay before a shared key delete is
+	// handled. This parameter is optional, and defaults to 0 if unset.
 	SharedKeyDeleteDelay time.Duration
 
 	// KeyCreator is called to allocate a Key instance when a new shared
@@ -85,10 +84,6 @@ func (c *Configuration) validate() error {
 
 	if c.SynchronizationInterval == 0 {
 		c.SynchronizationInterval = option.Config.KVstorePeriodicSync
-	}
-
-	if c.SharedKeyDeleteDelay == 0 {
-		c.SharedKeyDeleteDelay = defaults.NodeDeleteDelay
 	}
 
 	if c.Backend == nil {

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -54,9 +54,9 @@ type Configuration struct {
 	// are synchronized with the kvstore. This parameter is optional.
 	SynchronizationInterval time.Duration
 
-	// SharedKeyDeleteDelay is the delay before a shared key delete is
+	// SharedKeyDeleteDelay is the delay before an shared key delete is
 	// handled. This parameter is optional
-	SharedKeyDeleteDelay *time.Duration
+	SharedKeyDeleteDelay time.Duration
 
 	// KeyCreator is called to allocate a Key instance when a new shared
 	// key is discovered. This parameter is required.
@@ -87,8 +87,8 @@ func (c *Configuration) validate() error {
 		c.SynchronizationInterval = option.Config.KVstorePeriodicSync
 	}
 
-	if c.SharedKeyDeleteDelay == nil {
-		c.SharedKeyDeleteDelay = func() *time.Duration { a := defaults.NodeDeleteDelay; return &a }()
+	if c.SharedKeyDeleteDelay == 0 {
+		c.SharedKeyDeleteDelay = defaults.NodeDeleteDelay
 	}
 
 	if c.Backend == nil {
@@ -416,16 +416,12 @@ func (s *SharedStore) deleteSharedKey(name string) {
 
 	if ok {
 		go func() {
-			var timeWindow time.Duration
-			if s.conf.SharedKeyDeleteDelay != nil {
-				timeWindow = *s.conf.SharedKeyDeleteDelay
-				time.Sleep(timeWindow)
-			}
+			time.Sleep(s.conf.SharedKeyDeleteDelay)
 			s.mutex.RLock()
 			_, ok := s.sharedKeys[name]
 			s.mutex.RUnlock()
 			if ok {
-				s.getLogger().WithFields(logrus.Fields{"key": name, "timeWindow": timeWindow}).
+				s.getLogger().WithFields(logrus.Fields{"key": name, "timeWindow": s.conf.SharedKeyDeleteDelay}).
 					Warning("Received delete event for key which re-appeared within delay time window")
 				return
 			}

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -171,7 +171,7 @@ func (s *StoreSuite) TestStoreOperations(c *C) {
 		Prefix:               rand.RandomString(),
 		KeyCreator:           newTestType,
 		Observer:             &observer{},
-		SharedKeyDeleteDelay: func() *time.Duration { a := sharedKeyDeleteDelay; return &a }(),
+		SharedKeyDeleteDelay: sharedKeyDeleteDelay,
 	})
 	c.Assert(err, IsNil)
 	c.Assert(store, Not(IsNil))

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
@@ -218,6 +219,7 @@ func (s *StoreSuite) TestStorePeriodicSync(c *C) {
 		Prefix:                  rand.RandomString(),
 		KeyCreator:              newTestType,
 		SynchronizationInterval: 10 * time.Millisecond,
+		SharedKeyDeleteDelay:    defaults.NodeDeleteDelay,
 		Observer:                &observer{},
 	})
 	c.Assert(err, IsNil)

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -135,9 +135,10 @@ func (nr *NodeRegistrar) JoinCluster(name string) (*nodeTypes.Node, error) {
 	registerObserver := NewRegisterObserver(n.GetKeyName(), make(chan *nodeTypes.RegisterNode, 10))
 	// Join the shared store for node registrations
 	registerStore, err := store.JoinSharedStore(store.Configuration{
-		Prefix:     NodeRegisterStorePrefix,
-		KeyCreator: RegisterKeyCreator,
-		Observer:   registerObserver,
+		Prefix:               NodeRegisterStorePrefix,
+		KeyCreator:           RegisterKeyCreator,
+		SharedKeyDeleteDelay: defaults.NodeDeleteDelay,
+		Observer:             registerObserver,
 	})
 	if err != nil {
 		return nil, err
@@ -176,9 +177,10 @@ func (nr *NodeRegistrar) RegisterNode(n *nodeTypes.Node, manager NodeManager) er
 
 	// Join the shared store holding node information of entire cluster
 	nodeStore, err := store.JoinSharedStore(store.Configuration{
-		Prefix:     NodeStorePrefix,
-		KeyCreator: KeyCreator,
-		Observer:   NewNodeObserver(manager),
+		Prefix:               NodeStorePrefix,
+		KeyCreator:           KeyCreator,
+		SharedKeyDeleteDelay: defaults.NodeDeleteDelay,
+		Observer:             NewNodeObserver(manager),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Please, refer to the commit messages for more information.

<!-- Description of change -->

```release-note
kvstore: prevent deletion delay for node-unrelated events  
```
