### PR TITLE
Documentation: enable parallel builds

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -7,6 +7,7 @@ include ../Makefile.quiet
 HELM_VALUES := helm-values.rst
 REQUIREMENTS_NODEP := requirements-min/requirements.txt
 REQUIREMENTS := requirements.txt
+SPHINX_OPTS := "-j=auto"
 
 .PHONY: default clean help builder-image cilium-build cmdref epub latex html
 

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -50,7 +50,7 @@ snowballstemmer==2.2.0
 sphinx_mdinclude==0.5.3
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-googleanalytics==0.3
+sphinxcontrib-googleanalytics==0.4
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-httpdomain==1.8.0
 sphinxcontrib-jsmath==1.0.1


### PR DESCRIPTION
This speeds up docs building decently, especially when doing a live preview / iterating on docs.
    
Needed to bump sphinxcontrib-googleanalytics to v0.4 to enable parallelization.

Note that `make update-requirements` is hopelessly broken, so I didn't do that.
