### PR TITLE
bgpv1: Add BGP peer password

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -251,11 +251,23 @@
    * - :spelling:ignore:`bgpControlPlane`
      - This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs.
      - object
-     - ``{"enabled":false}``
+     - ``{"enabled":false,"secretsNamespace":{"create":true,"name":"cilium-bgp-secrets"}}``
    * - :spelling:ignore:`bgpControlPlane.enabled`
      - Enables the BGP control plane.
      - bool
      - ``false``
+   * - :spelling:ignore:`bgpControlPlane.secretsNamespace`
+     - SecretsNamespace is the namespace which BGP support will retrieve secrets from.
+     - object
+     - ``{"create":true,"name":"cilium-bgp-secrets"}``
+   * - :spelling:ignore:`bgpControlPlane.secretsNamespace.create`
+     - Create secrets namespace for BGP secrets.
+     - bool
+     - ``true``
+   * - :spelling:ignore:`bgpControlPlane.secretsNamespace.name`
+     - The name of the secret namespace to which Cilium agents are given read access
+     - string
+     - ``"cilium-bgp-secrets"``
    * - :spelling:ignore:`bpf.authMapMax`
      - Configure the maximum number of entries in auth map.
      - int

--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -112,6 +112,7 @@ Fields
            neighbors[*].peerAddress: The address of the peer neighbor
            neighbors[*].peerPort: Optional TCP port number of the neighbor. 1-65535 are valid values and defaults to 179 when unspecified.
            neighbors[*].peerASN: The ASN of the peer
+           neighbors[*].authSecretRef: Optional name of a secret in the BGP secrets namespace to use to retrieve a TCP MD5 password.
            neighbors[*].eBGPMultihopTTL: Time To Live (TTL) value used in BGP packets. The value 1 implies that eBGP multi-hop feature is disabled.
            neighbors[*].connectRetryTimeSeconds: Initial value for the BGP ConnectRetryTimer (RFC 4271, Section 8). Defaults to 120 seconds.
            neighbors[*].holdTimeSeconds: Initial value for the BGP HoldTimer (RFC 4271, Section 4.2). Defaults to 90 seconds.
@@ -291,6 +292,37 @@ values, graceful restart configuration and others.
    peering connection, which results in route flaps and transient packet loss while
    the session reestablishes and peers exchange their routes. To prevent packet loss,
    it is recommended to configure BGP graceful restart.
+
+MD5 passwords
+'''''''''''''
+
+By configuring ``authSecretRef`` for a neighbor you can configure that a
+`RFC-2385`_ TCP MD5 password should be configured on the session with this BGP
+peer.
+
+``authSecretRef`` should reference the name of a secret in the BGP secrets
+namespace (if using the Helm chart this is ``cilium-bgp-secrets`` by default).
+The secret should contain a key with a name of ``password``.
+
+BGP secrets are limited to a configured namespace to keep the permissions
+needed on each Cilium Agent instance to a minimum. The Helm chart will create
+this namespace and configure Cilium to be able to read from it by default.
+
+An example of creating a secret is:
+
+.. code-block:: shell-session
+
+  # kubectl create secret generic -n cilium-bgp-secrets --type=string secretName --from-literal=password=my-secret-password
+
+Because TCP MD5 passwords sign the header of the packet they cannot be used if
+the session will be address translated by Cilium (i.e. the Cilium Agent's pod
+IP address must be the address the BGP peer sees).
+
+If the password is incorrect, or the header is otherwise changed the TCP
+connection will not succeed. This will appear as ``dial: i/o timeout`` in the
+Cilium Agent's logs rather than a more specific error message.
+
+.. _RFC-2385 : https://www.rfc-editor.org/rfc/rfc2385.html
 
 Graceful Restart
 ''''''''''''''''

--- a/api/v1/models/bgp_peer.go
+++ b/api/v1/models/bgp_peer.go
@@ -78,6 +78,9 @@ type BgpPeer struct {
 	//
 	SessionState string `json:"session-state,omitempty"`
 
+	// Set when a TCP password is configured for communications with this peer
+	TCPPasswordEnabled bool `json:"tcp-password-enabled,omitempty"`
+
 	// BGP peer connection uptime in nano seconds.
 	UptimeNanoseconds int64 `json:"uptime-nanoseconds,omitempty"`
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3826,6 +3826,9 @@ definitions:
       peer-address:
         description: IP Address of peer
         type: string
+      tcp-password-enabled:
+        description: Set when a TCP password is configured for communications with this peer
+        type: boolean
       ebgp-multihop-ttl:
         description: |
           Time To Live (TTL) value used in BGP packets sent to the eBGP neighbor.

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2082,6 +2082,10 @@ func init() {
           "description": "BGP peer operational state as described here\nhttps://www.rfc-editor.org/rfc/rfc4271#section-8.2.2\n",
           "type": "string"
         },
+        "tcp-password-enabled": {
+          "description": "Set when a TCP password is configured for communications with this peer",
+          "type": "boolean"
+        },
         "uptime-nanoseconds": {
           "description": "BGP peer connection uptime in nano seconds.",
           "type": "integer"
@@ -7530,6 +7534,10 @@ func init() {
         "session-state": {
           "description": "BGP peer operational state as described here\nhttps://www.rfc-editor.org/rfc/rfc4271#section-8.2.2\n",
           "type": "string"
+        },
+        "tcp-password-enabled": {
+          "description": "Set when a TCP password is configured for communications with this peer",
+          "type": "boolean"
         },
         "uptime-nanoseconds": {
           "description": "BGP peer connection uptime in nano seconds.",

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -112,8 +112,11 @@ contributors across the globe, there is almost always someone available to help.
 | bgp.announce.loadbalancerIP | bool | `false` | Enable allocation and announcement of service LoadBalancer IPs |
 | bgp.announce.podCIDR | bool | `false` | Enable announcement of node pod CIDR |
 | bgp.enabled | bool | `false` | Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside cilium-agent and cilium-operator |
-| bgpControlPlane | object | `{"enabled":false}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
+| bgpControlPlane | object | `{"enabled":false,"secretsNamespace":{"create":true,"name":"cilium-bgp-secrets"}}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
 | bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |
+| bgpControlPlane.secretsNamespace | object | `{"create":true,"name":"cilium-bgp-secrets"}` | SecretsNamespace is the namespace which BGP support will retrieve secrets from. |
+| bgpControlPlane.secretsNamespace.create | bool | `true` | Create secrets namespace for BGP secrets. |
+| bgpControlPlane.secretsNamespace.name | string | `"cilium-bgp-secrets"` | The name of the secret namespace to which Cilium agents are given read access |
 | bpf.authMapMax | int | `524288` | Configure the maximum number of entries in auth map. |
 | bpf.autoMount.enabled | bool | `true` | Enable automatic mount of BPF filesystem When `autoMount` is enabled, the BPF filesystem is mounted at `bpf.root` path on the underlying host and inside the cilium agent pod. If users disable `autoMount`, it's expected that users have mounted bpffs filesystem at the specified `bpf.root` volume, and then the volume will be mounted inside the cilium agent pod at the same path. |
 | bpf.ctAnyMax | int | `262144` | Configure the maximum number of entries for the non-TCP connection tracking table. |

--- a/install/kubernetes/cilium/templates/cilium-agent/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/role.yaml
@@ -94,3 +94,23 @@ rules:
   - list
   - watch
 {{- end}}
+
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create .Values.bgpControlPlane.enabled .Values.bgpControlPlane.secretsNamespace.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-bgp-control-plane-secrets
+  namespace: {{ .Values.bgpControlPlane.secretsNamespace.name | quote }}
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{- end}}

--- a/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
@@ -89,3 +89,22 @@ subjects:
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
   namespace: {{ .Release.Namespace }}
 {{- end}}
+
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create .Values.bgpControlPlane.enabled .Values.bgpControlPlane.secretsNamespace.name}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-bgp-control-plane-secrets
+  namespace: {{ .Values.bgpControlPlane.secretsNamespace.name | quote }}
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-bgp-control-plane-secrets
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccounts.cilium.name | quote }}
+  namespace: {{ .Release.Namespace }}
+{{- end}}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1057,6 +1057,7 @@ data:
 
 {{- if .Values.bgpControlPlane.enabled }}
   enable-bgp-control-plane: "true"
+  bgp-secrets-namespace: {{ .Values.bgpControlPlane.secretsNamespace.name | quote }}
 {{- else }}
   enable-bgp-control-plane: "false"
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
+++ b/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
@@ -1,32 +1,14 @@
-{{- if and .Values.ingressController.enabled .Values.ingressController.secretsNamespace.create .Values.ingressController.secretsNamespace.name }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.ingressController.secretsNamespace.name | quote }}
-{{- end}}
+{{- $secretNamespaces := dict -}}
+{{- range $cfg := tuple .Values.ingressController .Values.gatewayAPI .Values.envoyConfig .Values.bgpControlPlane -}}
+{{- if and $cfg.enabled $cfg.secretsNamespace.create $cfg.secretsNamespace.name -}}
+{{- $_ := set $secretNamespaces $cfg.secretsNamespace.name 1 -}}
+{{- end -}}
+{{- end -}}
 
-# Only create the namespace if it's different from Ingress secret namespace or Ingress is not enabled.
-{{- if and .Values.gatewayAPI.enabled .Values.gatewayAPI.secretsNamespace.create .Values.gatewayAPI.secretsNamespace.name
-  (or (not (and .Values.ingressController.enabled .Values.ingressController.secretsNamespace.create .Values.ingressController.secretsNamespace.name))
-      (ne .Values.gatewayAPI.secretsNamespace.name .Values.ingressController.secretsNamespace.name)) }}
+{{- range $name, $_ := $secretNamespaces }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.gatewayAPI.secretsNamespace.name | quote }}
-{{- end}}
-
-# Only create the namespace if it's different from Ingress and Gateway API secret namespaces (if enabled).
-{{- if and .Values.envoyConfig.enabled .Values.envoyConfig.secretsNamespace.create .Values.envoyConfig.secretsNamespace.name
-  (and
-    (or (not (and .Values.ingressController.enabled .Values.ingressController.secretsNamespace.create .Values.ingressController.secretsNamespace.name))
-        (ne .Values.envoyConfig.secretsNamespace.name .Values.ingressController.secretsNamespace.name))
-    (or (not (and .Values.gatewayAPI.enabled .Values.gatewayAPI.secretsNamespace.create .Values.gatewayAPI.secretsNamespace.name))
-        (ne .Values.envoyConfig.secretsNamespace.name .Values.gatewayAPI.secretsNamespace.name))) }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.envoyConfig.secretsNamespace.name | quote }}
+  name: {{ $name | quote }}
 {{- end}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -409,6 +409,12 @@ bgp:
 bgpControlPlane:
   # -- Enables the BGP control plane.
   enabled: false
+  # -- SecretsNamespace is the namespace which BGP support will retrieve secrets from.
+  secretsNamespace:
+    # -- Create secrets namespace for BGP secrets.
+    create: true
+    # -- The name of the secret namespace to which Cilium agents are given read access
+    name: cilium-bgp-secrets
 
 pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -406,6 +406,12 @@ bgp:
 bgpControlPlane:
   # -- Enables the BGP control plane.
   enabled: false
+  # -- SecretsNamespace is the namespace which BGP support will retrieve secrets from.
+  secretsNamespace:
+    # -- Create secrets namespace for BGP secrets.
+    create: true
+    # -- The name of the secret namespace to which Cilium agents are given read access
+    name: cilium-bgp-secrets
 
 pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to

--- a/pkg/bgpv1/README.md
+++ b/pkg/bgpv1/README.md
@@ -352,15 +352,11 @@ This `Manager` groups `BgpServer` instances by their local ASNs.
 This leads to the following rule:
 * A `CiliumBGPPeeringPolicy` applying to node `A` must not have two or more `CiliumBGPVirtualRouters` with the same `localASN` fields.
 
-The `Manager` employs a set of `ConfigReconcilerFunc`(s) which perform the order-dependent reconciliation actions for each `BgpServer` it must reconcile.
+The `Manager` employs a set of `ConfigReconciler`(s) which perform the order-dependent reconciliation actions for each `BgpServer` it must reconcile.
 
-A `ConfigReconcilerFunc` is simply a function with a typed signature. 
+A `ConfigReconciler` is an interface where the reconciler is invoked via the `Reconcile` method.
 
-```go
-type ConfigReconcilerFunc func(ctx context.Context, params ReconcileParams) error
-``` 
-
-See the source code at `pkg/bgpv1/manager/reconcile.go` for a more in depth explanation of how each `ConfigReconcilerFunc` is called.
+See the source code at `pkg/bgpv1/manager/reconcile.go` for a more in depth explanation of how each `ConfigReconciler` is called.
 
 #### Router
 Underlying router implementation exposes imperative API for BGP related configuration, such as add/remove neighbor, add/remove routes etc. Currently, only gobgp is supported as

--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -61,6 +61,7 @@ type Controller struct {
 	PolicyResource resource.Resource[*v2alpha1api.CiliumBGPPeeringPolicy]
 	// PolicyLister is an interface which allows for the listing of all known policies
 	PolicyLister policyLister
+
 	// Sig informs the Controller that a Kubernetes
 	// event of interest has occurred.
 	//

--- a/pkg/bgpv1/gobgp/server.go
+++ b/pkg/bgpv1/gobgp/server.go
@@ -230,12 +230,19 @@ func (g *GoBGPServer) getPeerConfig(ctx context.Context, n types.NeighborRequest
 		if existingPeer.Transport.RemotePort != peerPort {
 			peer.Transport.RemotePort = peerPort
 		}
+
+		// Update the password if needed.
+		if existingPeer.Conf.AuthPassword != n.Password {
+			peer.Conf.AuthPassword = n.Password
+		}
+
 	} else {
 		// Create a new peer
 		peer = &gobgp.Peer{
 			Conf: &gobgp.PeerConf{
 				NeighborAddress: peerAddr.String(),
 				PeerAsn:         uint32(n.Neighbor.PeerASN),
+				AuthPassword:    n.Password,
 			},
 			Transport: &gobgp.Transport{
 				RemotePort: peerPort,

--- a/pkg/bgpv1/gobgp/state.go
+++ b/pkg/bgpv1/gobgp/state.go
@@ -60,6 +60,7 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context) (types.GetPeerStateRespo
 			peerState.LocalAsn = int64(peer.Conf.LocalAsn)
 			peerState.PeerAddress = peer.Conf.NeighborAddress
 			peerState.PeerAsn = int64(peer.Conf.PeerAsn)
+			peerState.TCPPasswordEnabled = peer.Conf.AuthPassword != ""
 		}
 
 		if peer.State != nil {

--- a/pkg/bgpv1/manager/reconcile.go
+++ b/pkg/bgpv1/manager/reconcile.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 	ciliumslices "github.com/cilium/cilium/pkg/slices"
 
 	"github.com/sirupsen/logrus"
@@ -197,13 +198,19 @@ type NeighborReconcilerOut struct {
 	Reconciler ConfigReconciler `group:"bgp-config-reconciler"`
 }
 
-// neighborReconciler is a ConfigReconcilerFunc which reconciles the peers of
-// the provided BGP server with the provided CiliumBGPVirtualRouter.
-type NeighborReconciler struct{}
+// NeighborReconciler is a ConfigReconciler which reconciles the peers of the
+// provided BGP server with the provided CiliumBGPVirtualRouter.
+type NeighborReconciler struct {
+	SecretStore  BGPCPResourceStore[*slim_corev1.Secret]
+	DaemonConfig *option.DaemonConfig
+}
 
-func NewNeighborReconciler() NeighborReconcilerOut {
+func NewNeighborReconciler(SecretStore BGPCPResourceStore[*slim_corev1.Secret], DaemonConfig *option.DaemonConfig) NeighborReconcilerOut {
 	return NeighborReconcilerOut{
-		Reconciler: &NeighborReconciler{},
+		Reconciler: &NeighborReconciler{
+			SecretStore:  SecretStore,
+			DaemonConfig: DaemonConfig,
+		},
 	}
 }
 
@@ -298,6 +305,15 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		if m.cur != nil && m.new != nil {
 			if !m.cur.DeepEqual(m.new) {
 				toUpdate = append(toUpdate, m.new)
+			} else {
+				// Fetch the secret to check if the TCP password changed.
+				tcpPassword, err := r.fetchPeerPassword(p.CurrentServer, m.new)
+				if err != nil {
+					return err
+				}
+				if r.changedPeerPassword(p.CurrentServer, m.new, tcpPassword) {
+					toUpdate = append(toUpdate, m.new)
+				}
 			}
 		}
 	}
@@ -311,16 +327,28 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 	// create new neighbors
 	for _, n := range toCreate {
 		l.Infof("Adding peer %v %v to local ASN %v", n.PeerAddress, n.PeerASN, p.DesiredConfig.LocalASN)
-		if err := p.CurrentServer.Server.AddNeighbor(ctx, types.NeighborRequest{Neighbor: n, VR: p.DesiredConfig}); err != nil {
+		tcpPassword, err := r.fetchPeerPassword(p.CurrentServer, n)
+		if err != nil {
+			return fmt.Errorf("failed fetching password for neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
+		}
+		if err := p.CurrentServer.Server.AddNeighbor(ctx, types.NeighborRequest{Neighbor: n, Password: tcpPassword, VR: p.DesiredConfig}); err != nil {
 			return fmt.Errorf("failed while reconciling neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
 		}
+		r.updatePeerPassword(p.CurrentServer, n, tcpPassword)
 	}
 
 	// update neighbors
 	for _, n := range toUpdate {
 		l.Infof("Updating peer %v %v in local ASN %v", n.PeerAddress, n.PeerASN, p.DesiredConfig.LocalASN)
-		if err := p.CurrentServer.Server.UpdateNeighbor(ctx, types.NeighborRequest{Neighbor: n, VR: p.DesiredConfig}); err != nil {
+		tcpPassword, err := r.fetchPeerPassword(p.CurrentServer, n)
+		if err != nil {
+			return fmt.Errorf("failed fetching password for neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
+		}
+		if err := p.CurrentServer.Server.UpdateNeighbor(ctx, types.NeighborRequest{Neighbor: n, Password: tcpPassword, VR: p.DesiredConfig}); err != nil {
 			return fmt.Errorf("failed while reconciling neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
+		}
+		if r.changedPeerPassword(p.CurrentServer, n, tcpPassword) {
+			r.updatePeerPassword(p.CurrentServer, n, tcpPassword)
 		}
 	}
 
@@ -342,7 +370,7 @@ type ExportPodCIDRReconcilerOut struct {
 	Reconciler ConfigReconciler `group:"bgp-config-reconciler"`
 }
 
-// exportPodCIDRReconciler is a ConfigReconcilerFunc which reconciles the
+// exportPodCIDRReconciler is a ConfigReconciler which reconciles the
 // advertisement of the private Kubernetes PodCIDR block.
 type ExportPodCIDRReconciler struct{}
 
@@ -538,6 +566,81 @@ endpointsLoop:
 	}
 
 	return ls
+}
+
+// NeighborReconcilerMetadata keeps a map of peers to passwords, fetched from
+// secrets. Key is PeerAddress+PeerASN.
+type NeighborReconcilerMetadata map[string]string
+
+func (r *NeighborReconciler) getMetadata(sc *ServerWithConfig) NeighborReconcilerMetadata {
+	if _, found := sc.ReconcilerMetadata[r.Name()]; !found {
+		sc.ReconcilerMetadata[r.Name()] = make(NeighborReconcilerMetadata)
+	}
+	return sc.ReconcilerMetadata[r.Name()].(NeighborReconcilerMetadata)
+}
+
+func (r *NeighborReconciler) fetchPeerPassword(sc *ServerWithConfig, n *v2alpha1api.CiliumBGPNeighbor) (string, error) {
+	peerPasswords := r.getMetadata(sc)
+
+	l := log.WithFields(
+		logrus.Fields{
+			"component": "manager.fetchPeerPassword",
+		},
+	)
+	if n.AuthSecretRef != nil {
+		secretRef := *n.AuthSecretRef
+		old := peerPasswords[fmt.Sprintf("%s%d", n.PeerAddress, n.PeerASN)]
+
+		secret, ok, err := r.fetchSecret(secretRef)
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch secret %q: %w", secretRef, err)
+		}
+		if !ok {
+			if old != "" {
+				l.Errorf("Failed to fetch secret %q: not found (will continue with old secret)", secretRef)
+				return old, nil
+			}
+			l.Errorf("Failed to fetch secret %q: not found (will continue with empty password)", secretRef)
+			return "", nil
+		}
+		tcpPassword := string(secret["password"])
+		if tcpPassword == "" {
+			return "", fmt.Errorf("failed to fetch secret %q: missing password key", secretRef)
+		}
+		l.Debugf("Using TCP password from secret %q", secretRef)
+		return tcpPassword, nil
+	}
+	return "", nil
+}
+
+func (r *NeighborReconciler) fetchSecret(name string) (map[string][]byte, bool, error) {
+	if r.SecretStore == nil {
+		return nil, false, fmt.Errorf("SecretsNamespace not configured")
+	}
+	item, ok, err := r.SecretStore.GetByKey(resource.Key{Namespace: r.DaemonConfig.BGPSecretsNamespace, Name: name})
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	result := map[string][]byte{}
+	for k, v := range item.Data {
+		result[k] = []byte(v)
+	}
+	return result, true, nil
+}
+
+func (r *NeighborReconciler) changedPeerPassword(sc *ServerWithConfig, n *v2alpha1api.CiliumBGPNeighbor, tcpPassword string) bool {
+	peerPasswords := r.getMetadata(sc)
+
+	key := fmt.Sprintf("%s%d", n.PeerAddress, n.PeerASN)
+	old := peerPasswords[key]
+	return old != tcpPassword
+}
+
+func (r *NeighborReconciler) updatePeerPassword(sc *ServerWithConfig, n *v2alpha1api.CiliumBGPNeighbor, tcpPassword string) {
+	peerPasswords := r.getMetadata(sc)
+
+	key := fmt.Sprintf("%s%d", n.PeerAddress, n.PeerASN)
+	peerPasswords[key] = tcpPassword
 }
 
 func hasLocalEndpoints(svc *slim_corev1.Service, ls localServices) bool {

--- a/pkg/bgpv1/manager/workdiff.go
+++ b/pkg/bgpv1/manager/workdiff.go
@@ -54,7 +54,7 @@ func newReconcileDiff(node *node.LocalNode, ciliumNode *v2api.CiliumNode) *recon
 // withdraw, or reconcile in the reconcileDiff's respective fields.
 func (wd *reconcileDiff) diff(m LocalASNMap, policy *v2alpha1api.CiliumBGPPeeringPolicy) error {
 	if err := wd.registerOrReconcileDiff(m, policy); err != nil {
-		return fmt.Errorf("encountered error creating reoncile diff: %v", err)
+		return fmt.Errorf("encountered error creating reconcile diff: %v", err)
 	}
 	if err := wd.withdrawDiff(m, policy); err != nil {
 		return fmt.Errorf("encountered error creating reconcile diff: %v", err)

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -26,6 +26,9 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	clientset_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/typed/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/types"
@@ -77,6 +80,7 @@ type fixture struct {
 	config        fixtureConfig
 	fakeClientSet *k8sClient.FakeClientset
 	policyClient  v2alpha1.CiliumBGPPeeringPolicyInterface
+	secretClient  clientset_core_v1.SecretInterface
 	hive          *hive.Hive
 	bgp           *agent.Controller
 	nodeStore     *node.LocalNodeStore
@@ -85,6 +89,7 @@ type fixture struct {
 
 type fixtureConfig struct {
 	policy    cilium_api_v2alpha1.CiliumBGPPeeringPolicy
+	secret    slim_core_v1.Secret
 	ipam      string
 	bgpEnable bool
 }
@@ -93,6 +98,14 @@ func newFixtureConf() fixtureConfig {
 	policyCfg := policyConfig{
 		nodeSelector: baseBGPPolicy.nodeSelector,
 	}
+	secret := slim_core_v1.Secret{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Namespace: "bgp-secrets",
+			Name:      "a-secret",
+		},
+		Data: map[string]slim_core_v1.Bytes{"password": slim_core_v1.Bytes("testing-123")},
+	}
+
 	// deepcopy the VirtualRouters as the tests modify them
 	for _, vr := range baseBGPPolicy.virtualRouters {
 		policyCfg.virtualRouters = append(policyCfg.virtualRouters, *vr.DeepCopy())
@@ -100,6 +113,7 @@ func newFixtureConf() fixtureConfig {
 	return fixtureConfig{
 		policy:    newPolicyObj(policyCfg),
 		ipam:      ipamOption.IPAMKubernetes,
+		secret:    secret,
 		bgpEnable: true,
 	}
 }
@@ -111,9 +125,11 @@ func newFixture(conf fixtureConfig) *fixture {
 
 	f.fakeClientSet, _ = k8sClient.NewFakeClientset()
 	f.policyClient = f.fakeClientSet.CiliumFakeClientset.CiliumV2alpha1().CiliumBGPPeeringPolicies()
+	f.secretClient = f.fakeClientSet.SlimFakeClientset.CoreV1().Secrets("bgp-secrets")
 
 	// create initial bgp policy
 	f.fakeClientSet.CiliumFakeClientset.Tracker().Add(&conf.policy)
+	f.fakeClientSet.SlimFakeClientset.Tracker().Add(&conf.secret)
 
 	// Construct a new Hive with mocked out dependency cells.
 	f.hive = hive.New(
@@ -145,6 +161,7 @@ func newFixture(conf fixtureConfig) *fixture {
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{
 				EnableBGPControlPlane: conf.bgpEnable,
+				BGPSecretsNamespace:   "bgp-secrets",
 				IPAM:                  conf.ipam,
 			}
 		}),

--- a/pkg/bgpv1/test/gobgp.go
+++ b/pkg/bgpv1/test/gobgp.go
@@ -81,6 +81,31 @@ var (
 			},
 		},
 	}
+	gbgpNeighConfPassword = &gobgpapi.Peer{
+		Conf: &gobgpapi.PeerConf{
+			NeighborAddress: dummies[ciliumLink].ipv4.Addr().String(),
+			PeerAsn:         ciliumASN,
+			AuthPassword:    "testing-123",
+		},
+		Transport: &gobgpapi.Transport{
+			RemoteAddress: dummies[ciliumLink].ipv4.Addr().String(),
+			RemotePort:    ciliumListenPort,
+			LocalAddress:  dummies[instance1Link].ipv4.Addr().String(),
+			PassiveMode:   false,
+		},
+		AfiSafis: []*gobgpapi.AfiSafi{
+			{
+				Config: &gobgpapi.AfiSafiConfig{
+					Family: gobgp.GoBGPIPv4Family,
+				},
+			},
+			{
+				Config: &gobgpapi.AfiSafiConfig{
+					Family: gobgp.GoBGPIPv6Family,
+				},
+			},
+		},
+	}
 
 	gobgpConf = gobgpConfig{
 		global: gobgpGlobal,
@@ -92,6 +117,12 @@ var (
 		global: gobgpGlobal2,
 		neighbors: []*gobgpapi.Peer{
 			gbgpNeighConf2,
+		},
+	}
+	gobgpConfPassword = gobgpConfig{
+		global: gobgpGlobal,
+		neighbors: []*gobgpapi.Peer{
+			gbgpNeighConfPassword,
 		},
 	}
 )

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -59,6 +59,7 @@ func Test_NeighborAddDel(t *testing.T) {
 					PeerASN:              int64(gobgpASN),
 					HoldTimeSeconds:      pointer.Int32(9), // must be lower than default (90s) to be applied on the peer
 					KeepAliveTimeSeconds: pointer.Int32(1), // must be lower than HoldTime
+					AuthSecretRef:        pointer.String("a-secret"),
 				},
 				{
 					PeerAddress:          dummies[instance2Link].ipv4.String(),
@@ -91,6 +92,7 @@ func Test_NeighborAddDel(t *testing.T) {
 					PeerASN:              int64(gobgpASN),
 					HoldTimeSeconds:      pointer.Int32(6), // updated, must be lower than the previous value to be applied on the peer
 					KeepAliveTimeSeconds: pointer.Int32(1), // must be lower than HoldTime
+					AuthSecretRef:        pointer.String("a-secret"),
 				},
 				{
 					PeerAddress:          dummies[instance2Link].ipv4.String(),
@@ -127,7 +129,7 @@ func Test_NeighborAddDel(t *testing.T) {
 	defer testDone()
 
 	// test setup, we configure two gobgp instances here.
-	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf, gobgpConf2}, newFixtureConf())
+	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConfPassword, gobgpConf2}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpInstances, 2)
 	defer cleanup()

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -44,6 +44,8 @@ type Path struct {
 type NeighborRequest struct {
 	Neighbor *v2alpha1api.CiliumBGPNeighbor
 	VR       *v2alpha1api.CiliumBGPVirtualRouter
+	// Password is the "AuthSecret" in the Neighbor, fetched from a secret
+	Password string
 }
 
 // SoftResetDirection defines the direction in which a BGP soft reset should be performed

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -262,6 +262,11 @@ spec:
                               - selectorType
                               type: object
                             type: array
+                          authSecretRef:
+                            description: AuthSecretRef is the name of the secret to
+                              use to fetch a TCP authentication password for this
+                              peer.
+                            type: string
                           connectRetryTimeSeconds:
                             default: 120
                             description: ConnectRetryTimeSeconds defines the initial

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -203,6 +203,10 @@ type CiliumBGPNeighbor struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=4294967295
 	PeerASN int64 `json:"peerASN"`
+	// AuthSecretRef is the name of the secret to use to fetch a TCP
+	// authentication password for this peer.
+	// +kubebuilder:validation:Optional
+	AuthSecretRef *string `json:"authSecretRef,omitempty"`
 	// EBGPMultihopTTL controls the multi-hop feature for eBGP peers.
 	// Its value defines the Time To Live (TTL) value used in BGP packets sent to the neighbor.
 	// The value 1 implies that eBGP multi-hop feature is disabled (only a single hop is allowed).

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
@@ -67,6 +67,11 @@ func (in *CiliumBGPNeighbor) DeepCopyInto(out *CiliumBGPNeighbor) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AuthSecretRef != nil {
+		in, out := &in.AuthSecretRef, &out.AuthSecretRef
+		*out = new(string)
+		**out = **in
+	}
 	if in.EBGPMultihopTTL != nil {
 		in, out := &in.EBGPMultihopTTL, &out.EBGPMultihopTTL
 		*out = new(int32)

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -90,6 +90,14 @@ func (in *CiliumBGPNeighbor) DeepEqual(other *CiliumBGPNeighbor) bool {
 	if in.PeerASN != other.PeerASN {
 		return false
 	}
+	if (in.AuthSecretRef == nil) != (other.AuthSecretRef == nil) {
+		return false
+	} else if in.AuthSecretRef != nil {
+		if *in.AuthSecretRef != *other.AuthSecretRef {
+			return false
+		}
+	}
+
 	if (in.EBGPMultihopTTL == nil) != (other.EBGPMultihopTTL == nil) {
 		return false
 	} else if in.EBGPMultihopTTL != nil {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1126,6 +1126,9 @@ const (
 	// compatible with MetalLB's configuration.
 	BGPConfigPath = "bgp-config-path"
 
+	// BGPSecretsNamespace is the Kubernetes namespace to get BGP control plane secrets from.
+	BGPSecretsNamespace = "bgp-secrets-namespace"
+
 	// ExternalClusterIPName is the name of the option to enable
 	// cluster external access to ClusterIP services.
 	ExternalClusterIPName = "bpf-lb-external-clusterip"
@@ -2383,6 +2386,9 @@ type DaemonConfig struct {
 	// compatible with MetalLB's configuration.
 	BGPConfigPath string
 
+	// BGPSecretsNamespace is the Kubernetes namespace to get BGP control plane secrets from.
+	BGPSecretsNamespace string
+
 	// ExternalClusterIP enables routing to ClusterIP services from outside
 	// the cluster. This mirrors the behaviour of kube-proxy.
 	ExternalClusterIP bool
@@ -3212,6 +3218,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.BGPAnnounceLBIP = vp.GetBool(BGPAnnounceLBIP)
 	c.BGPAnnouncePodCIDR = vp.GetBool(BGPAnnouncePodCIDR)
 	c.BGPConfigPath = vp.GetString(BGPConfigPath)
+	c.BGPSecretsNamespace = vp.GetString(BGPSecretsNamespace)
 	c.ExternalClusterIP = vp.GetBool(ExternalClusterIPName)
 	c.EnableNat46X64Gateway = vp.GetBool(EnableNat46X64Gateway)
 	c.EnableHighScaleIPcache = vp.GetBool(EnableHighScaleIPcache)


### PR DESCRIPTION
Add 'authSecret' to the BGP peering policies CRD.

This makes it possible to provide passwords for BGP peers through a Secret and CiliumBGPPeeringPolicy.

```release-note
Support BGP passwords in the Go BGP implementation.
```
