### PR TITLE
labelsfilter: add 'io.cilium.k8s.policy.cluster' to default label list

### DIFF
--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -193,6 +193,7 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 		regexp.QuoteMeta(k8sConst.PodNamespaceLabel),      // include io.kubernetes.pod.namespace
 		regexp.QuoteMeta(k8sConst.PodNamespaceMetaLabels), // include all namespace labels
 		regexp.QuoteMeta(k8sConst.AppKubernetes),          // include app.kubernetes.io
+		regexp.QuoteMeta(k8sConst.PolicyLabelCluster),     // include io.cilium.k8s.policy.cluster
 		`!io\.kubernetes`,                                 // ignore all other io.kubernetes labels
 		`!kubernetes\.io`,                                 // ignore all other kubernetes.io labels
 		`!.*beta\.kubernetes\.io`,                         // ignore all beta.kubernetes.io labels


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

When switching to an inclusive label filter, the default inclusion list is not compatible with ClusterMesh. Without the `io.cilium.k8s.policy.cluster` label, ClusterIP services do not forward traffic to their endpoints even within the local cluster. So it needs to be added manually to label filter.

Adding it to the default inclusion list should negates this gotcha.