### PR TITLE
ipcache: Fix incorrect CIDR labels associated with reserved identities

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -373,6 +373,17 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 	}
 
 	lbls := info.ToLabels()
+	if lbls.Has(labels.LabelWorld[labels.IDNameWorld]) &&
+		(lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) ||
+			lbls.Has(labels.LabelHost[labels.IDNameHost])) {
+		// If the prefix is associated with both world and (remote-node or
+		// host), then the latter (remote-node or host) take precedence to
+		// avoid allocating a CIDR identity for an entity within the cluster.
+		n := lbls.Remove(labels.LabelWorld)
+		n = n.Remove(cidrlabels.GetCIDRLabels(prefix))
+		lbls = n
+	}
+
 	if lbls.Has(labels.LabelHost[labels.IDNameHost]) {
 		// Associate any new labels with the host identity.
 		//


### PR DESCRIPTION
An IP / CIDR can be associated with the reserved:world + CIDR labels in
the IPcache, for example if a user applies a ToCIDR. Later, if this CIDR
is then associated with an entity within the cluster, then the IPcache
subsystem will not correctly handle this scenario. It will append the
reserved:remote-node or reserved:host label, while keeping the
reserved:world + CIDR labels.

This doesn't make sense as reserved:world + CIDR labels are meant to
represent entities outside of the cluster.

This scenario can happen when a user wants to allow traffic to an IP
that is firstly outside of the cluster, and then later joins the
cluster.

For example, a user has a K8s cluster and an external VM with an IP of
x.y.z.w. The user wants to allow traffic to x.y.z.w so they create a
ToCIDR rule allowing it. Later, the user joins the VM to the cluster and
it becomes a worker node. Now x.y.z.w is an entity within the cluster
and is therefore associated with either the reserved:remote-node or
reserved:host label.

Fix this by disassociating the reserved:world + CIDR labels from an
entity that's now within the cluster.

Related: https://github.com/cilium/cilium/issues/17962
Fixes: https://github.com/cilium/cilium/issues/23750

Signed-off-by: Chris Tarazi <chris@isovalent.com>

```release-note
Fix bug where ingress policies for remote-note identities are not applied correctly new nodes join the cluster, specifically when the nodes joining the cluster had IP addresses specified in CIDR policies
```