### PR TITLE
cilium-cni: remove duplicated link set up operation

### DIFF
--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -262,10 +262,6 @@ func configureIface(ipam *models.IPAMResponse, ifName string, state *CmdState) (
 		}
 	}
 
-	if err := netlink.LinkSetUp(l); err != nil {
-		return "", fmt.Errorf("failed to set %q UP: %v", ifName, err)
-	}
-
 	if l.Attrs() != nil {
 		return l.Attrs().HardwareAddr.String(), nil
 	}


### PR DESCRIPTION
The container-side veth link was set up twice in the same function. This PR removes one of the two occurrences.

<!-- Description of change -->

```release-note
cilium-cni: remove duplicated link set up operation
```
