### PR TITLE
CODEOWNERS: Make Hubble team (not docs-structure) own examples/hubble

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -338,6 +338,7 @@ Makefile* @cilium/build
 /Documentation/yaml.config @cilium/docs-structure
 /envoy/ @cilium/proxy
 /examples/ @cilium/docs-structure
+/examples/hubble/ @cilium/sig-hubble
 /examples/kubernetes/ @cilium/sig-k8s
 /examples/kubernetes/clustermesh/ @cilium/sig-clustermesh
 /examples/minikube/ @cilium/sig-k8s


### PR DESCRIPTION
GitHub team docs-structure is the fallback owner for examples/, but it would make more sense to have members of the Hubble team look at what's under examples/hubble/.
