### PR TITLE
policy: mapstate should respect authType in dataPath equality

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -263,7 +263,7 @@ func (e *MapStateEntry) IsRedirectEntry() bool {
 }
 
 // DatapathEqual returns true of two entries are equal in the datapath's PoV,
-// i.e., both Deny and ProxyPort are the same for both entries.
+// i.e., IsDeny, ProxyPort and AuthType are the same for both entries.
 func (e *MapStateEntry) DatapathEqual(o *MapStateEntry) bool {
 	if e == nil || o == nil {
 		return e == o

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -269,7 +269,7 @@ func (e *MapStateEntry) DatapathEqual(o *MapStateEntry) bool {
 		return e == o
 	}
 
-	return e.IsDeny == o.IsDeny && e.ProxyPort == o.ProxyPort
+	return e.IsDeny == o.IsDeny && e.ProxyPort == o.ProxyPort && e.AuthType == o.AuthType
 }
 
 // String returns a string representation of the MapStateEntry


### PR DESCRIPTION
Policy MapState needs to respect property authType when checking it for dataPath equality. Without this change, changing the auth type on existing CiliumNetworkPolicies isn't reflected in the eBPF policy map.