### PR TITLE
clustermesh: correctly release allocator references for GC

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -389,10 +389,6 @@ func (a *Allocator) GetEvents() AllocatorEventChan {
 func (a *Allocator) Delete() {
 	close(a.stopGC)
 	a.mainCache.stop()
-
-	if a.events != nil {
-		close(a.events)
-	}
 }
 
 // WaitForInitialSync waits until the initial sync is complete
@@ -926,5 +922,5 @@ func (rc *RemoteCache) NumEntries() int {
 // Close stops watching for identities in the kvstore associated with the
 // remote cache.
 func (rc *RemoteCache) Close() {
-	rc.cache.stop()
+	rc.cache.allocator.Delete()
 }

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -248,8 +248,7 @@ func NewCachingIdentityAllocator(owner IdentityAllocatorOwner) *CachingIdentityA
 	return m
 }
 
-// Close closes the identity allocator and allows to call
-// InitIdentityAllocator() again.
+// Close closes the identity allocator
 func (m *CachingIdentityAllocator) Close() {
 	m.setupMutex.Lock()
 	defer m.setupMutex.Unlock()
@@ -264,6 +263,10 @@ func (m *CachingIdentityAllocator) Close() {
 	}
 
 	m.IdentityAllocator.Delete()
+	if m.events != nil {
+		close(m.events)
+	}
+
 	m.IdentityAllocator = nil
 	m.globalIdentityAllocatorInitialized = make(chan struct{})
 }

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -452,7 +452,7 @@ func (m *CachingIdentityAllocator) WatchRemoteIdentities(remoteName string, back
 		return nil, fmt.Errorf("error setting up remote allocator backend: %s", err)
 	}
 
-	remoteAlloc, err := allocator.NewAllocator(&key.GlobalIdentity{}, remoteAllocatorBackend, allocator.WithEvents(m.IdentityAllocator.GetEvents()))
+	remoteAlloc, err := allocator.NewAllocator(&key.GlobalIdentity{}, remoteAllocatorBackend, allocator.WithEvents(m.IdentityAllocator.GetEvents()), allocator.WithoutGC())
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize remote Identity Allocator: %s", err)
 	}


### PR DESCRIPTION
On each reconnect we failed to release all references to the old Allocator, meaning it was not GCed properly, leaving out some parts still in memory -> resulting in a memleak.

By launching NewAllocator (a remote one) with `WithoutGC()` option we save a goroutine which is noop anyway (for the remote connection) and which was preventing the remoteAlloc to be released.

This commit fixes it.

Parca memory profile comparisons:
 
Master (before https://github.com/cilium/cilium/pull/23532 got merged) :
![master1](https://user-images.githubusercontent.com/15906154/219064739-30731ff2-f744-4dee-91eb-04f7d0712848.png)

With https://github.com/cilium/cilium/pull/23532 fixes:
![PR-23532](https://user-images.githubusercontent.com/15906154/219061877-1ea61446-8a87-4c19-a7bb-7e28bd364b30.png)

After this fix:
![fixed](https://user-images.githubusercontent.com/15906154/219061913-4dc90d8c-115b-42d1-b324-bf2b2eebc371.png)

Fixes: #22988
Fixes: #13446

```release-note
Fix memory leak caused on clustermesh reconnect.
```

Signed-off-by: Ondrej Blazek <ondrej.blazek@firma.seznam.cz>