### PR TITLE
test: bump upgrade tests to test 1.13

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -175,9 +175,9 @@ const (
 
 	// CiliumStableHelmChartVersion should be the chart version that points
 	// to the v1.X branch
-	CiliumStableHelmChartVersion = "1.12"
+	CiliumStableHelmChartVersion = "1.13"
 	CiliumStableVersion          = "v" + CiliumStableHelmChartVersion
-	CiliumLatestHelmChartVersion = "1.12.90"
+	CiliumLatestHelmChartVersion = "1.13.90"
 
 	MonitorLogFileName = "monitor.log"
 


### PR DESCRIPTION
We have released 1.13.0 so it's time for us to start testing 1.13.0 upgrade.