### PR TITLE
fix: add link to CFP repo

### DIFF
--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -169,9 +169,11 @@ in development. We label issues with `good-first-issue`_ to help new potential
 contributors find issues and feature requests that are relatively self-contained
 and could be a good place to start. Please also read the :ref:`dev_guide` for
 details of our pull request process and expectations, along with instructions
-for setting up your development environment. We encourage you to discuss your
-ideas for significant enhancements and feature requests on the #development
-channel on `Cilium Slack <slack_>`_ and/or bring them to the :ref:`weekly-community-meeting`. 
+for setting up your development environment.
+
+We encourage you to discuss your ideas for significant enhancements and feature
+requests on the #development channel on `Cilium Slack <slack_>`_, bring them to
+the :ref:`weekly-community-meeting`, and/or create a `CFP design doc`_.
 
 This roadmap does not give date commitments since the work is dependent on the
 community. If you're looking for commitments to apply engineering resources to
@@ -197,3 +199,4 @@ anything other than trivial fixes.
 .. _good-first-issue: https://github.com/cilium/cilium/labels/good-first-issue
 .. _slack: https://cilium.io/slack
 .. _enterprise: https://cilium.io/enterprise
+.. _CFP design doc: https://github.com/cilium/design-cfps/tree/main


### PR DESCRIPTION
As discussed in #23690

```release-note
Added link to CFP Design repo
```
