### PR TITLE
bpf: Remove flowlabel optimization for identity

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -521,9 +521,6 @@ pass_to_stack:
 		return ret;
 #endif
 
-	if (ipv6_store_flowlabel(ctx, ETH_HLEN, SECLABEL_NB) < 0)
-		return DROP_WRITE_ERROR;
-
 #ifndef TUNNEL_MODE
 # ifdef ENABLE_IPSEC
 	if (encrypt_key && tunnel_endpoint) {


### PR DESCRIPTION
For IPv6 traffic, we use the flowlabel field to transfer the source security identity across nodes and avoid an ipcache lookup. This misuse of the flowlabel field can however conflict with legitimate uses such as https://lpc.events/event/11/contributions/955/. This commit therefore removes this optimization.