### PR TITLE
k8s: Handle EndpointSlice AddressType field properly

### DIFF
--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -585,6 +585,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1Beta1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1beta1.EndpointSlice{
+						AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -747,6 +748,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1Beta1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1beta1.EndpointSlice{
+						AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -812,6 +814,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1Beta1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1beta1.EndpointSlice{
+						AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -870,6 +873,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1Beta1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1beta1.EndpointSlice{
+						AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -924,6 +928,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1Beta1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1beta1.EndpointSlice{
+						AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -987,6 +992,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1Beta1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1beta1.EndpointSlice{
+						AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -1041,6 +1047,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1Beta1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1beta1.EndpointSlice{
+						AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -1194,6 +1201,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -1356,6 +1364,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -1420,6 +1429,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -1483,6 +1493,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -1541,6 +1552,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -1595,6 +1607,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -1658,6 +1671,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",
@@ -1712,6 +1726,7 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1(c *check.C) {
 			setupArgs: func() args {
 				return args{
 					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
 						ObjectMeta: slim_metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "bar",

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -1079,6 +1079,75 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1Beta1(c *check.C) {
 				return svcEP
 			},
 		},
+		{
+			name: "endpoint with IPv6 address type",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1beta1.EndpointSlice{
+						AddressType: slim_discovery_v1beta1.AddressTypeIPv6,
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Endpoints: []slim_discovery_v1beta1.Endpoint{
+							{
+								Addresses: []string{
+									"fd00::1",
+								},
+							},
+						},
+						Ports: []slim_discovery_v1beta1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				svcEP := newEndpoints()
+				svcEP.Backends[cmtypes.MustParseAddrCluster("fd00::1")] = &Backend{
+					Ports: serviceStore.PortConfiguration{
+						"http-test-svc": loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+					},
+				}
+				return svcEP
+			},
+		},
+		{
+			name: "endpoint with FQDN address type",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1beta1.EndpointSlice{
+						AddressType: slim_discovery_v1beta1.AddressTypeFQDN,
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Endpoints: []slim_discovery_v1beta1.Endpoint{
+							{
+								Addresses: []string{
+									"foo.example.com",
+								},
+							},
+						},
+						Ports: []slim_discovery_v1beta1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				// We don't support FQDN address types. Should be empty.
+				return newEndpoints()
+			},
+		},
 	}
 	for _, tt := range tests {
 		args := tt.setupArgs()
@@ -1758,6 +1827,75 @@ func (s *K8sSuite) Test_parseK8sEPSlicev1(c *check.C) {
 					HintsForZones: []string{"testing"},
 				}
 				return svcEP
+			},
+		},
+		{
+			name: "endpoint with IPv6 address type",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv6,
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Endpoints: []slim_discovery_v1.Endpoint{
+							{
+								Addresses: []string{
+									"fd00::1",
+								},
+							},
+						},
+						Ports: []slim_discovery_v1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				svcEP := newEndpoints()
+				svcEP.Backends[cmtypes.MustParseAddrCluster("fd00::1")] = &Backend{
+					Ports: serviceStore.PortConfiguration{
+						"http-test-svc": loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+					},
+				}
+				return svcEP
+			},
+		},
+		{
+			name: "endpoint with FQDN address type",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeFQDN,
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Endpoints: []slim_discovery_v1.Endpoint{
+							{
+								Addresses: []string{
+									"foo.example.com",
+								},
+							},
+						},
+						Ports: []slim_discovery_v1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				// We don't support FQDN address types. Should be empty.
+				return newEndpoints()
 			},
 		},
 	}


### PR DESCRIPTION
Reported and investigated by community user and @nathanjsweet.
https://cilium.slack.com/archives/C53TG4J4R/p1676493971471509

This affects the users who are using [ExternalName](https://kubernetes.io/docs/concepts/services-networking/service/#externalname). Please see the commit messages for more details.

Fixes: #21161

```release-note
k8s: Handle EndpointSlice AddressType field properly
```
