### PR TITLE
workflow: Disable monitor aggregation in IPv6 smoke test

### DIFF
--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -130,7 +130,8 @@ jobs:
             --set tunnel=disabled \
             --set autoDirectNodeRoutes=true \
             --set ipv6NativeRoutingCIDR=2001:db8:1::/64 \
-            --set ingressController.enabled=true
+            --set ingressController.enabled=true \
+            --set bpf.monitorAggregation=none
 
           kubectl wait -n kube-system --for=condition=Ready -l app.kubernetes.io/part-of=cilium pod --timeout=5m
           kubectl rollout -n kube-system status deploy/coredns --timeout=5m


### PR DESCRIPTION
That test is currently affected by a flake where DNS resolution times out. Disabling monitor aggregation should allow us to get full view of the connections to the DNS backends and see what is going on.

Related: https://github.com/cilium/cilium/issues/23812.