### PR TITLE
mlh: update Jenkins jobs following removal of kernel 4.9 support

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -53,124 +53,142 @@ flake-tracker:
     regex-trigger: (^/test)
     stable-jobs:
     - cilium-master-gke
-    - cilium-master-k8s-1.16-kernel-4.9
-    - cilium-master-k8s-1.17-kernel-4.9
-    - cilium-master-k8s-1.18-kernel-4.9
-    - cilium-master-k8s-1.19-kernel-4.9
-    - cilium-master-k8s-1.20-kernel-4.9
-    - cilium-master-k8s-1.21-kernel-4.9
-    - cilium-master-k8s-1.22-kernel-4.9
-    - cilium-master-k8s-1.23-kernel-4.9
-    - cilium-master-k8s-1.24-kernel-4.9
+    - cilium-master-k8s-1.16-kernel-4.19
+    - cilium-master-k8s-1.17-kernel-4.19
+    - cilium-master-k8s-1.18-kernel-4.19
+    - cilium-master-k8s-1.19-kernel-4.19
+    - cilium-master-k8s-1.20-kernel-4.19
+    - cilium-master-k8s-1.21-kernel-4.19
+    - cilium-master-k8s-1.22-kernel-4.19
+    - cilium-master-k8s-1.23-kernel-4.19
+    - cilium-master-k8s-1.24-kernel-4.19
     - cilium-master-k8s-1.24-kernel-5.4
     - cilium-master-k8s-1.25-kernel-4.19
     - cilium-master-k8s-1.26-kernel-net-next
     - cilium-master-k8s-upstream
     pr-jobs:
-      Cilium-PR-K8s-1.16-kernel-4.9:
+      Cilium-PR-K8s-1.16-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.9
-        - cilium-master-k8s-1.17-kernel-4.9
-        - cilium-master-k8s-1.18-kernel-4.9
-        - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.20-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.22-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
-        - cilium-master-k8s-1.24-kernel-4.9
-      Cilium-PR-K8s-1.17-kernel-4.9:
+        - cilium-master-k8s-1.16-kernel-4.19
+        - cilium-master-k8s-1.17-kernel-4.19
+        - cilium-master-k8s-1.18-kernel-4.19
+        - cilium-master-k8s-1.19-kernel-4.19
+        - cilium-master-k8s-1.20-kernel-4.19
+        - cilium-master-k8s-1.21-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.23-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-4.19
+        - cilium-master-k8s-1.25-kernel-4.19
+      Cilium-PR-K8s-1.17-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.9
-        - cilium-master-k8s-1.17-kernel-4.9
-        - cilium-master-k8s-1.18-kernel-4.9
-        - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.20-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.22-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
-        - cilium-master-k8s-1.24-kernel-4.9
-      Cilium-PR-K8s-1.18-kernel-4.9:
+        - cilium-master-k8s-1.16-kernel-4.19
+        - cilium-master-k8s-1.17-kernel-4.19
+        - cilium-master-k8s-1.18-kernel-4.19
+        - cilium-master-k8s-1.19-kernel-4.19
+        - cilium-master-k8s-1.20-kernel-4.19
+        - cilium-master-k8s-1.21-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.23-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-4.19
+        - cilium-master-k8s-1.25-kernel-4.19
+      Cilium-PR-K8s-1.18-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.9
-        - cilium-master-k8s-1.17-kernel-4.9
-        - cilium-master-k8s-1.18-kernel-4.9
-        - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.20-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.22-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
-        - cilium-master-k8s-1.24-kernel-4.9
-      Cilium-PR-K8s-1.19-kernel-4.9:
+        - cilium-master-k8s-1.16-kernel-4.19
+        - cilium-master-k8s-1.17-kernel-4.19
+        - cilium-master-k8s-1.18-kernel-4.19
+        - cilium-master-k8s-1.19-kernel-4.19
+        - cilium-master-k8s-1.20-kernel-4.19
+        - cilium-master-k8s-1.21-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.23-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-4.19
+        - cilium-master-k8s-1.25-kernel-4.19
+      Cilium-PR-K8s-1.19-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.9
-        - cilium-master-k8s-1.17-kernel-4.9
-        - cilium-master-k8s-1.18-kernel-4.9
-        - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.20-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.22-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
-        - cilium-master-k8s-1.24-kernel-4.9
-      Cilium-PR-K8s-1.20-kernel-4.9:
+        - cilium-master-k8s-1.16-kernel-4.19
+        - cilium-master-k8s-1.17-kernel-4.19
+        - cilium-master-k8s-1.18-kernel-4.19
+        - cilium-master-k8s-1.19-kernel-4.19
+        - cilium-master-k8s-1.20-kernel-4.19
+        - cilium-master-k8s-1.21-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.23-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-4.19
+        - cilium-master-k8s-1.25-kernel-4.19
+      Cilium-PR-K8s-1.20-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.9
-        - cilium-master-k8s-1.17-kernel-4.9
-        - cilium-master-k8s-1.18-kernel-4.9
-        - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.20-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.22-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
-        - cilium-master-k8s-1.24-kernel-4.9
-      Cilium-PR-K8s-1.21-kernel-4.9:
+        - cilium-master-k8s-1.16-kernel-4.19
+        - cilium-master-k8s-1.17-kernel-4.19
+        - cilium-master-k8s-1.18-kernel-4.19
+        - cilium-master-k8s-1.19-kernel-4.19
+        - cilium-master-k8s-1.20-kernel-4.19
+        - cilium-master-k8s-1.21-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.23-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-4.19
+        - cilium-master-k8s-1.25-kernel-4.19
+      Cilium-PR-K8s-1.21-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.9
-        - cilium-master-k8s-1.17-kernel-4.9
-        - cilium-master-k8s-1.18-kernel-4.9
-        - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.20-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.22-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
-        - cilium-master-k8s-1.24-kernel-4.9
-      Cilium-PR-K8s-1.22-kernel-4.9:
+        - cilium-master-k8s-1.16-kernel-4.19
+        - cilium-master-k8s-1.17-kernel-4.19
+        - cilium-master-k8s-1.18-kernel-4.19
+        - cilium-master-k8s-1.19-kernel-4.19
+        - cilium-master-k8s-1.20-kernel-4.19
+        - cilium-master-k8s-1.21-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.23-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-4.19
+        - cilium-master-k8s-1.25-kernel-4.19
+      Cilium-PR-K8s-1.22-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.9
-        - cilium-master-k8s-1.17-kernel-4.9
-        - cilium-master-k8s-1.18-kernel-4.9
-        - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.20-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.22-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
-        - cilium-master-k8s-1.24-kernel-4.9
-      Cilium-PR-K8s-1.23-kernel-4.9:
+        - cilium-master-k8s-1.16-kernel-4.19
+        - cilium-master-k8s-1.17-kernel-4.19
+        - cilium-master-k8s-1.18-kernel-4.19
+        - cilium-master-k8s-1.19-kernel-4.19
+        - cilium-master-k8s-1.20-kernel-4.19
+        - cilium-master-k8s-1.21-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.23-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-4.19
+        - cilium-master-k8s-1.25-kernel-4.19
+      Cilium-PR-K8s-1.23-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.9
-        - cilium-master-k8s-1.17-kernel-4.9
-        - cilium-master-k8s-1.18-kernel-4.9
-        - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.20-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.22-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
-        - cilium-master-k8s-1.24-kernel-4.9
-      Cilium-PR-K8s-1.24-kernel-4.9:
+        - cilium-master-k8s-1.16-kernel-4.19
+        - cilium-master-k8s-1.17-kernel-4.19
+        - cilium-master-k8s-1.18-kernel-4.19
+        - cilium-master-k8s-1.19-kernel-4.19
+        - cilium-master-k8s-1.20-kernel-4.19
+        - cilium-master-k8s-1.21-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.23-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-4.19
+        - cilium-master-k8s-1.25-kernel-4.19
+      Cilium-PR-K8s-1.24-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.9
-        - cilium-master-k8s-1.17-kernel-4.9
-        - cilium-master-k8s-1.18-kernel-4.9
-        - cilium-master-k8s-1.19-kernel-4.9
-        - cilium-master-k8s-1.20-kernel-4.9
-        - cilium-master-k8s-1.21-kernel-4.9
-        - cilium-master-k8s-1.22-kernel-4.9
-        - cilium-master-k8s-1.23-kernel-4.9
-        - cilium-master-k8s-1.24-kernel-4.9
+        - cilium-master-k8s-1.16-kernel-4.19
+        - cilium-master-k8s-1.17-kernel-4.19
+        - cilium-master-k8s-1.18-kernel-4.19
+        - cilium-master-k8s-1.19-kernel-4.19
+        - cilium-master-k8s-1.20-kernel-4.19
+        - cilium-master-k8s-1.21-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.23-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-4.19
+        - cilium-master-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.24-kernel-5.4:
         correlate-with-stable-jobs:
         - cilium-master-k8s-1.24-kernel-5.4
       Cilium-PR-K8s-1.25-kernel-4.19:
         correlate-with-stable-jobs:
+        - cilium-master-k8s-1.16-kernel-4.19
+        - cilium-master-k8s-1.17-kernel-4.19
+        - cilium-master-k8s-1.18-kernel-4.19
+        - cilium-master-k8s-1.19-kernel-4.19
+        - cilium-master-k8s-1.20-kernel-4.19
+        - cilium-master-k8s-1.21-kernel-4.19
+        - cilium-master-k8s-1.22-kernel-4.19
+        - cilium-master-k8s-1.23-kernel-4.19
+        - cilium-master-k8s-1.24-kernel-4.19
         - cilium-master-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.26-kernel-net-next:
         correlate-with-stable-jobs:


### PR DESCRIPTION
We removed support for kernel 4.9 in the CI via
bbda112037b8d95f8c084b81dd1dc2d0bc4aff82, as part of ongoing work to bump the minimal supprted kernel version (see [1]).

We have rotated / expanded the Jenkins test jobs as follow:

- Changed: K8s 1.16 on Kernel 4.19 (instead of 4.9, triggered on `/test`).
- Changed: K8s 1.17-1.24 on Kernel 4.19 (instead of 4.9, triggered on `/test-missed-k8s`).

See the Table of Truth™️ for up to date status on all trigger phrases: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0/edit#gid=0

[1]: https://github.com/cilium/cilium/issues/22116