### PR TITLE
ci: Add forcetypeassert to Golangci-lint

### DIFF
--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -49,6 +49,8 @@ jobs:
         with:
           version: v1.48.0
           skip-cache: true
+          args: --enable forcetypeassert
+
 
   precheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Unchecked type assertions can be dangerous. The Adalogics security and fuzzing audit of Cilium rated removing unchecked type assertions as a "medium" severity issue.