### PR TITLE
endpoint, proxy: Fix deadlock with ipcache and K8s watcher

### DIFF
--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -23,7 +23,6 @@ var (
 type dnsRedirect struct {
 	redirect             *Redirect
 	endpointInfoRegistry logger.EndpointInfoRegistry
-	conf                 dnsConfiguration
 	currentRules         policy.L7DataMap
 	proxyRuleUpdater     proxyRuleUpdater
 }
@@ -37,8 +36,6 @@ type proxyRuleUpdater interface {
 	// endpointID and destPort.
 	UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error
 }
-
-type dnsConfiguration struct{}
 
 // setRules replaces old l7 rules of a redirect with new ones.
 // TODO: Get rid of the duplication between 'currentRules' and 'r.rules'
@@ -78,17 +75,15 @@ func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, rev
 
 // creatednsRedirect creates a redirect to the dns proxy. The redirect structure passed
 // in is safe to access for reading and writing.
-func createDNSRedirect(r *Redirect, conf dnsConfiguration, endpointInfoRegistry logger.EndpointInfoRegistry) (RedirectImplementation, error) {
+func createDNSRedirect(r *Redirect, endpointInfoRegistry logger.EndpointInfoRegistry) (RedirectImplementation, error) {
 	dr := &dnsRedirect{
 		redirect:             r,
-		conf:                 conf,
 		endpointInfoRegistry: endpointInfoRegistry,
 		proxyRuleUpdater:     DefaultDNSProxy,
 	}
 
 	log.WithFields(logrus.Fields{
 		"dnsRedirect": dr,
-		"conf":        conf,
 	}).Debug("Creating DNS Proxy redirect")
 
 	return dr, dr.setRules(nil, r.rules)

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -25,10 +25,20 @@ type dnsRedirect struct {
 	endpointInfoRegistry logger.EndpointInfoRegistry
 	conf                 dnsConfiguration
 	currentRules         policy.L7DataMap
+	proxyRuleUpdater     proxyRuleUpdater
 }
 
-type dnsConfiguration struct {
+// proxyRuleUpdater updates L7 proxy rules per endpoint.
+//
+// Note: Implementations must not take the IPcache lock, as the usage of this
+// interface is within the endpoint regeneration critical section.
+type proxyRuleUpdater interface {
+	// UpdateAllowed updates the rules in the DNS proxy with newRules for the
+	// endpointID and destPort.
+	UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error
 }
+
+type dnsConfiguration struct{}
 
 // setRules replaces old l7 rules of a redirect with new ones.
 // TODO: Get rid of the duplication between 'currentRules' and 'r.rules'
@@ -37,7 +47,7 @@ func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7Data
 		"newRules":           newRules,
 		logfields.EndpointID: dr.redirect.endpointID,
 	}).Debug("DNS Proxy updating matchNames in allowed list during UpdateRules")
-	if err := DefaultDNSProxy.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPort, newRules); err != nil {
+	if err := dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPort, newRules); err != nil {
 		return err
 	}
 	dr.currentRules = copyRules(dr.redirect.rules)
@@ -60,7 +70,7 @@ func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc,
 // Close the redirect.
 func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
 	return func() {
-		DefaultDNSProxy.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPort, nil)
+		dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPort, nil)
 		dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(nil)
 		dr.currentRules = nil
 	}, nil
@@ -73,6 +83,7 @@ func createDNSRedirect(r *Redirect, conf dnsConfiguration, endpointInfoRegistry 
 		redirect:             r,
 		conf:                 conf,
 		endpointInfoRegistry: endpointInfoRegistry,
+		proxyRuleUpdater:     DefaultDNSProxy,
 	}
 
 	log.WithFields(logrus.Fields{

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -40,11 +40,6 @@ func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7Data
 	if err := DefaultDNSProxy.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPort, newRules); err != nil {
 		return err
 	}
-	rules, err := DefaultDNSProxy.GetRules(uint16(dr.redirect.endpointID))
-	if err != nil {
-		return err
-	}
-	dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(rules)
 	dr.currentRules = copyRules(dr.redirect.rules)
 
 	return nil

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -582,7 +582,7 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 
 		switch l4.GetL7Parser() {
 		case policy.ParserTypeDNS:
-			redir.implementation, err = createDNSRedirect(redir, dnsConfiguration{}, p.defaultEndpointInfoRegistry)
+			redir.implementation, err = createDNSRedirect(redir, p.defaultEndpointInfoRegistry)
 		default:
 			if pp.proxyType == ProxyTypeCRD {
 				// CRD Listeners already exist, create a no-op implementation


### PR DESCRIPTION
- endpoint, proxy: Fix deadlock with ipcache and K8s watcher
- proxy: Refactor dnsRedirect to prevent regressions
- proxy: Remove unused dnsConfiguration type

Fixes: https://github.com/cilium/cilium/issues/20915
Fixes: https://github.com/cilium/cilium/pull/18996

```release-note
[EKS] Fix deadlock causing network connectivity outages when kube-apiservers scale down
```
