### PR TITLE
bpf & envoy: Add support for authentication on ingress policies

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -245,7 +245,7 @@ cilium-agent [flags]
       --prepend-iptables-chains                                 Prepend custom iptables chains instead of appending (default true)
       --procfs string                                           Root's proc filesystem path (default "/proc")
       --prometheus-serve-addr string                            IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off) (default ":9962")
-      --proxy-connect-timeout uint                              Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-connect-timeout uint                              Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
       --proxy-gid uint                                          Group ID for proxy control plane sockets. (default 1337)
       --proxy-max-connection-duration-seconds int               Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
       --proxy-max-requests-per-connection int                   Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -145,7 +145,7 @@ ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id,
 	/* Perform policy lookup */
 	verdict = policy_can_access_ingress(ctx, *src_id, dst_id, tuple.dport,
 					    tuple.nexthdr, false,
-					    &policy_match_type, &audited, &proxy_port);
+					    &policy_match_type, &audited, NULL, &proxy_port);
 
 	/* Only create CT entry for accepted connections, or when auth is required */
 	if (ret == CT_NEW && (verdict == CTX_ACT_OK || verdict == DROP_POLICY_AUTH_REQUIRED)) {
@@ -366,7 +366,7 @@ ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id,
 	verdict = policy_can_access_ingress(ctx, *src_id, dst_id, tuple.dport,
 					    tuple.nexthdr,
 					    is_untracked_fragment,
-					    &policy_match_type, &audited, &proxy_port);
+					    &policy_match_type, &audited, NULL, &proxy_port);
 
 	/* Only create CT entry for accepted connections, or when auth is required */
 	if (ret == CT_NEW && (verdict == CTX_ACT_OK || verdict == DROP_POLICY_AUTH_REQUIRED)) {

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -275,6 +275,7 @@ policy_check_entry:
  * @arg is_untracked_fragment	True if packet is a TCP/UDP datagram fragment
  *				AND IPv4 fragment tracking is disabled
  * @arg match_type		Pointer to store layers used for policy match
+ * @arg ext_err		Pointer to store extended error information if this packet isn't allowed
  *
  * Returns:
  *   - Positive integer indicating the proxy_port to handle this traffic

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -284,13 +284,13 @@ policy_check_entry:
 static __always_inline int
 policy_can_access_ingress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 			  __u16 dport, __u8 proto, bool is_untracked_fragment,
-			  __u8 *match_type, __u8 *audited, __u16 *proxy_port)
+			  __u8 *match_type, __u8 *audited, __s8 *ext_err, __u16 *proxy_port)
 {
 	int ret;
 
 	ret = __policy_can_access(&POLICY_MAP, ctx, dst_id, src_id, dport,
 				  proto, CT_INGRESS, is_untracked_fragment,
-				  match_type, NULL, proxy_port);
+				  match_type, ext_err, proxy_port);
 	if (ret >= CTX_ACT_OK)
 		return ret;
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -388,7 +388,7 @@ func initializeFlags() {
 	flags.Uint(option.HTTPRetryTimeout, 0, "Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)")
 	option.BindEnv(Vp, option.HTTPRetryTimeout)
 
-	flags.Uint(option.ProxyConnectTimeout, 1, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
+	flags.Uint(option.ProxyConnectTimeout, 2, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
 	option.BindEnv(Vp, option.ProxyConnectTimeout)
 
 	flags.Uint(option.ProxyGID, 1337, "Group ID for proxy control plane sockets.")

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -34,8 +34,8 @@ func (a *AuthManager) AuthRequired(dn *monitor.DropNotify, ci *monitor.Connectio
 	srcAddr := ci.SrcIP.String() + ":" + strconv.FormatUint(uint64(ci.SrcPort), 10)
 	dstAddr := ci.DstIP.String() + ":" + strconv.FormatUint(uint64(ci.DstPort), 10)
 
-	log.Debugf("policy: Authentication type %s required for identity %d->%d, %s %s->%s",
-		authType.String(), dn.SrcLabel, dn.DstLabel, ci.Proto, srcAddr, dstAddr)
+	log.Debugf("policy: Authentication type %s required for identity %d->%d, %s %s->%s, ingress: %t",
+		authType.String(), dn.SrcLabel, dn.DstLabel, ci.Proto, srcAddr, dstAddr, ingress)
 
 	proto, err := u8proto.ParseProtocol(ci.Proto)
 	if err != nil {


### PR DESCRIPTION
Pass authentication type in case of ingress LXC traffic to support authentication on ingress policies.

Without this change, the auth type which gets passed to the monitor is always none which results in blocked ingress traffic.

In addition, the connect-timeout of the Envoy Proxy needs to be increased from 1s to 2s. This ensures that there's enough time for a re-delivery of a dropped packet due to authentication on the same connection.

Without this change, authentication on ingress network policies might not work in certain scenarios, because the connection times out before the packet gets re-delivered. (L7 policies applied (proxy is used), auth enabled, Pods on same node in a kind cluster)