### PR TITLE
docs: Add note for operator.extraEnv

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -401,6 +401,8 @@ Deprecated Options
 Helm Options
 ~~~~~~~~~~~~
 
+* The attribute ``operator.extraEnv`` type is changed from map to array. Please convert
+  the values from map to array before upgrading.
 * ``bandwidthManager`` has been deprecated in favor of ``bandwidthManager.enabled``,
   and will be removed in 1.13.
 * ``bpf.hostRouting`` has been deprecated in favor of ``bpf.hostLegacyRouting``, and


### PR DESCRIPTION
As part of the below refactor, the operator.extraEnv type was changed from map to array, this commit is to add a note in Upgrade helm options. Kindly note that this is consistent with extraEnv for all other workloads (e.g. agent, hubble, etc), so rollback the change will cause more confusion.

Thanks to @SerialVelocity for reporting this discrepancy.

Relates: https://github.com/cilium/cilium/pull/17243