### PR TITLE
CODEOWNERS: assign /pkg/auth to sig-servicemesh

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -371,6 +371,7 @@ jenkinsfiles @cilium/ci-structure
 /pkg/alignchecker/ @cilium/sig-datapath @cilium/loader
 /pkg/allocator/ @cilium/kvstore
 /pkg/api/ @cilium/api
+/pkg/auth/ @cilium/sig-servicemesh
 /pkg/aws/ @cilium/aws
 /pkg/azure/ @cilium/azure
 /pkg/bandwidth/ @cilium/sig-datapath


### PR DESCRIPTION
These packages contain code specific to the servicemesh functionality
