### PR TITLE
dev: disable bpf monitor aggregation in kind helm values

### DIFF
--- a/contrib/testing/kind-values.yaml
+++ b/contrib/testing/kind-values.yaml
@@ -12,7 +12,8 @@ ipv6:
   enabled: true
 ipv4:
   enabled: true
-monitor-aggregation: none
+bpf:
+  monitorAggregation: none
 livenessProbe:
   failureThreshold: 9999
 readinessProbe:


### PR DESCRIPTION
The current attempt to disable bpf monitor aggregation via kind helm chart values is using the wrong property and therefore isn't working. Changing from 'monitor-aggregation' to 'bpf.monitorAggregation' fixes this - and is reflected properly in the k8s ConfigMap.
