### PR TITLE
Fix connectivity issue upon agent restart in case of ipv6 + direct routing + KPR replacement

### DIFF
--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
@@ -482,6 +483,13 @@ func findK8SNodeIPLink() (netlink.Link, error) {
 				if err != nil {
 					return nil, err
 				}
+
+				// When IPv6 is enabled and the node has an IPv6 address, the 'cilium_host'
+				// interface is assigned the same IP of the node itself. Let's skip it here.
+				if link.Attrs().Name == defaults.HostDevice {
+					continue
+				}
+
 				return link, nil
 			}
 		}


### PR DESCRIPTION
Automatic detection of the direct routing device is performed when tunneling is not enabled, and certain conditions are met (i.e., BPF NodePort, BPF HostRouting or Wireguard are enabled), as well as if IPv6 NDP is enabled. In such cases, the device is identified as the one having the IP address of the k8s node.

Still, when IPv6 support is enabled, the cilium_host device is also assigned the same IPv6 address as the node, hence being possibly selected as the target direct routing device (based on interface ordering) when the agent is restarted. If this happens, cilium then attaches the `cil_*_netdev` programs, overriding the correct ones (`cil_*_host`) and breaking the connectivity from the node to hosted pods.

The occurrence of the issue is highlighted by the following log lines:

```
level=info msg="Direct routing device detected" direct-routing-device=cilium_host subsys=linux-datapath
level=info msg="Detected devices" devices="[cilium_host eth0]" subsys=linux-datapath

level=debug msg="Attaching program to interface" device=cilium_host direction=ingress ifindex=3 objPath=1020_next/bpf_host.o progName=cil_to_host subsys=datapath-loader
level=debug msg="Attaching program to interface" device=cilium_host direction=egress ifindex=3 objPath=1020_next/bpf_host.o progName=cil_from_host subsys=datapath-loader
level=debug msg="Attaching program to interface" device=cilium_host direction=ingress ifindex=3 objPath=1020_next/bpf_netdev_cilium_host.o progName=cil_from_netdev subsys=datapath-loader
level=debug msg="Attaching program to interface" device=cilium_host direction=egress ifindex=3 objPath=1020_next/bpf_netdev_cilium_host.o progName=cil_to_netdev subsys=datapath-loader
```

This PR introduces an additional check to exclude cilium_host during the detection process.

I'm marking this PR for backport to all supported versions, given it matches the criteria "Major bugfix relevant to the correct operation of Cilium". Indeed, although rare, when all the conditions for the issue to occur are met, it causes complete connectivity disruption.

<!-- Description of change -->

Fixes: #23840

```release-note
Fix connectivity issue upon agent restart in case of ipv6 + direct routing + KPR replacement
```
