### PR TITLE
pkg/service: Fix leaking service entries with terminating backends

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -973,7 +973,7 @@ func (s *Service) deleteServiceLocked(svc *svcInfo) error {
 	})
 	scopedLog.Debug("Deleting service")
 
-	if err := s.lbmap.DeleteService(svc.frontend, len(svc.backends), svc.useMaglev()); err != nil {
+	if err := s.lbmap.DeleteService(svc.frontend, svc.activeBackendsCount, svc.useMaglev()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Terminating backends are gracefully deleted: they are removed from
the service maps so that they are not selected to service new traffic,
but they are kept in the backends map so that existing connections can
be gracefully terminated.
When a service with terminating backends was previously deleted, we didn't
account for the terminating backends. As a result, the deletion from BPF maps
failed, and we ended up leaking other active backends of the service.
This also led to duplicate backend entries getting created as we had already
ref counted, and deleted the service's backends.
Fix this issue by only considering active backends during deletion of a service.
Extended unit tests to catch such regressions in future.

Note: The issue is only on v1.11. We updated the logic on 1.12+ branches.

Reported-by: Hemanth Malla <hemanth.malla@datadoghq.com>
Signed-off-by: Aditi Ghag <aditi@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/23551

```release-note
Fix leaking service backend entries when services with terminating backends were deleted.
```