### PR TITLE
add renovate support for go mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 5
-    rebase-strategy: "disabled"
-    ignore:
-        # using a cilium-specific fork
-      - dependency-name: "github.com/miekg/dns"
-        # k8s dependencies will be updated manually along with tests
-      - dependency-name: "k8s.io/*"
-      - dependency-name: "sigs.k8s.io/*"
-        # cloud provider SDKs are updated too frequently, update them manually
-      - dependency-name: "github.com/aliyun/alibaba-cloud-sdk-go"
-      - dependency-name: "github.com/aws/*"
-      - dependency-name: "github.com/Azure/*"
-        # need to update the gops binary in the runtime image in lockstep
-      - dependency-name: "github.com/google/gops"
-    labels:
-    - kind/enhancement
-    - release-note/misc
-
 # # # # # # # # # # # # # # # #
 #        Python modules       #
 # # # # # # # # # # # # # # # #
@@ -35,6 +13,3 @@ updates:
     labels:
     - kind/enhancement
     - release-note/misc
-
-
-

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,12 @@
   "includePaths": [
     ".github/workflows/**",
     "images/**",
-    "examples/hubble/*"
+    "examples/hubble/*",
+    "go.mod",
+    "go.sum"
+  ],
+  postUpdateOptions: [
+    "gomodTidy"
   ],
   // This ignorePaths configuration option overrides the config:base preset and
   // should not be removed.
@@ -37,6 +42,9 @@
     "v1.11",
     "v1.10"
   ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
   "labels": [
     "kind/enhancement",
     "release-note/misc"
@@ -58,6 +66,66 @@
       ],
       "schedule": [
         "on friday"
+      ]
+    },
+    {
+      "groupName": "all go dependencies master",
+      "groupSlug": "all-go-deps-master",
+      "matchFiles": [
+        "go.mod",
+        "go.sum"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "digest",
+        "patch",
+        "pin",
+        "pinDigest"
+      ],
+      "schedule": [
+        "on friday"
+      ],
+      matchBaseBranches: [
+        "master"
+      ]
+    },
+    {
+      // Do not allow any updates into stable branches.
+      "enabled": false,
+      "groupName": "all go dependencies stable",
+      "groupSlug": "all-go-deps-stable",
+      "matchFiles": [
+        "go.mod",
+        "go.sum"
+      ],
+      matchBaseBranches: [
+        "v1.13",
+        "v1.12",
+        "v1.11",
+        "v1.10"
+      ]
+    },
+    {
+      "enabled": false,
+      "matchPackageNames": [
+        // All of these packages are maintained on a Cilium fork. Thus, we don't
+        // want to update them automatically.
+        "go.universe.tf/metallb",
+        "github.com/cilium/metallb",
+        "github.com/miekg/dns",
+        "github.com/cilium/dns",
+        "sigs.k8s.io/controller-tools",
+        "github.com/cilium/controller-tools",
+        // We update this dependency manually together with envoy proxy updates
+        "github.com/cilium/proxy",
+        // need to update the gops binary in the runtime image in lockstep
+        "github.com/google/gops"
+      ],
+      "matchPackagePatterns": [
+        // k8s dependencies will be updated manually along with tests
+        "k8s.io/*",
+        "sigs.k8s.io/*"
       ]
     },
     {


### PR DESCRIPTION
This commit removes dependabot as the bot to manage go dependency updates in the repository. Since renovate provides a more flexible configuration we are able to set all go mod dependencies to happen every Friday.

Renovate also allows to specify configuration for stable branches. However, in this commit we will only configure it to receive updates for the 'master' branch exactly the same way dependabot is configured. Follow up work can be done to configure renovate to create PRs for stable branches.

An example of such dependency updates can be seen in https://github.com/aanm/cilium/pull/501