### PR TITLE
Check stale cilium endpoint flag before cleaning endpoints

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1784,7 +1784,7 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 			<-restoreComplete
 		}
 
-		if params.Clientset.IsEnabled() {
+		if params.Clientset.IsEnabled() && option.Config.EnableStaleCiliumEndpointCleanup {
 			// Use restored endpoints to delete local CiliumEndpoints which are not in the restored endpoint cache.
 			// This will clear out any CiliumEndpoints that may be stale.
 			// Likely causes for this are Pods having their init container restarted or the node being restarted.


### PR DESCRIPTION
The `--enable-stale-cilium-endpoint-cleanup` flag is never checked before running `cleanStaleCEPs`.

When this feature was introduced it appears there was a flag included to toggle the feature, but it's never checked and defaults to true.

```release-note
Fix enable-stale-cilium-endpoint-cleanup flag not actually disabling the cleanup init set when set to false. This provides a workaround for an existing panic that can occur when running using etcd kvstore. 
```