### PR TITLE
Add check for nil endpoint indexer

### DIFF
--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -994,10 +994,16 @@ func (k *K8sWatcher) K8sEventReceived(apiResourceName, scope, action string, val
 func (k *K8sWatcher) GetIndexer(name string) cache.Indexer {
 	switch name {
 	case "ciliumendpointslice":
+		if k.ciliumEndpointSliceIndexer == nil {
+			panic("tried to get endpoint slice indexer but it is nil")
+		}
 		k.ciliumEndpointSliceIndexerMU.RLock()
 		defer k.ciliumEndpointSliceIndexerMU.RUnlock()
 		return k.ciliumEndpointSliceIndexer
 	case "ciliumendpoint":
+		if k.ciliumEndpointIndexer == nil {
+			panic("tried to get endpoint indexer but it is nil")
+		}
 		k.ciliumEndpointIndexerMU.RLock()
 		defer k.ciliumEndpointIndexerMU.RUnlock()
 		return k.ciliumEndpointIndexer


### PR DESCRIPTION
It is possible to call `GetIndexer` on a `K8sWatcher` that has not initialized its `Indexer` fields, resulting in a nil indexer being returned.

When upgrading from 1.11.13 -> 1.11.14 I noticed an NPE in the `cleanStaleCEPs` method that is a result of using the nil indexer returned by `GetIndexer`. I discovered that both `indexer` fields appear to be `nil` as they have not been initialized so the resulting call to `indexer.ByIndex` panics.

From what I can tell the `--enable-cilium-endpoint-slice` must be `true` for these fields to be initialized and if not the NPE described above is hit. Current workaround in https://github.com/cilium/cilium/pull/23874. Opening this PR to add a check and determine best way to handle.