### PR TITLE
bpf: L3 cleanups

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -712,8 +712,7 @@ do_netdev_encrypt_pools(struct __ctx_buff *ctx __maybe_unused)
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
 	}
-	if (l3_csum_replace(ctx, ETH_HLEN + offsetof(struct iphdr, check),
-	    0, sum, 0) < 0) {
+	if (ipv4_csum_update_by_diff(ctx, ETH_HLEN, sum) < 0) {
 		ret = DROP_CSUM_L3;
 		goto drop_err;
 	}
@@ -730,8 +729,7 @@ do_netdev_encrypt_pools(struct __ctx_buff *ctx __maybe_unused)
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
 	}
-	if (l3_csum_replace(ctx, ETH_HLEN + offsetof(struct iphdr, check),
-	    0, sum, 0) < 0) {
+	if (ipv4_csum_update_by_diff(ctx, ETH_HLEN, sum) < 0) {
 		ret = DROP_CSUM_L3;
 		goto drop_err;
 	}

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -707,23 +707,14 @@ do_netdev_encrypt_pools(struct __ctx_buff *ctx __maybe_unused)
 	 */
 	sum = csum_diff(&iphdr->daddr, sizeof(__u32), &tunnel_endpoint,
 			sizeof(tunnel_endpoint), 0);
+	sum = csum_diff(&iphdr->saddr, sizeof(__u32), &tunnel_source,
+			sizeof(tunnel_source), sum);
+
 	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, daddr),
 	    &tunnel_endpoint, sizeof(tunnel_endpoint), 0) < 0) {
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
 	}
-	if (ipv4_csum_update_by_diff(ctx, ETH_HLEN, sum) < 0) {
-		ret = DROP_CSUM_L3;
-		goto drop_err;
-	}
-
-	if (!revalidate_data(ctx, &data, &data_end, &iphdr)) {
-		ret = DROP_INVALID;
-		goto drop_err;
-	}
-
-	sum = csum_diff(&iphdr->saddr, sizeof(__u32), &tunnel_source,
-			sizeof(tunnel_source), 0);
 	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, saddr),
 	    &tunnel_source, sizeof(tunnel_source), 0) < 0) {
 		ret = DROP_WRITE_ERROR;

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -56,30 +56,11 @@ static __always_inline int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 }
 
 #ifndef SKIP_POLICY_MAP
-#ifdef ENABLE_IPV6
-/* Performs IPv6 L2/L3 handling and delivers the packet to the destination pod
- * on the same node, either via the stack or via a redirect call.
- * Depending on the configuration, it may also enforce ingress policies for the
- * destination pod via a tail call.
- */
-static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
-					       __u32 seclabel,
-					       const struct endpoint_info *ep,
-					       __u8 direction,
-					       bool from_host __maybe_unused,
-					       bool hairpin_flow __maybe_unused)
+static __always_inline int
+l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
+		  const struct endpoint_info *ep, __u8 direction __maybe_unused,
+		  bool from_host __maybe_unused, bool hairpin_flow __maybe_unused)
 {
-	mac_t router_mac = ep->node_mac;
-	mac_t lxc_mac = ep->mac;
-	int ret;
-
-	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, ep->lxc_id, seclabel);
-
-	/* This will invalidate the size check */
-	ret = ipv6_l3(ctx, l3_off, (__u8 *) &router_mac, (__u8 *) &lxc_mac, direction);
-	if (ret != CTX_ACT_OK)
-		return ret;
-
 #ifdef LOCAL_DELIVERY_METRICS
 	/*
 	 * Special LXC case for updating egress forwarding metrics.
@@ -127,6 +108,32 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 	return DROP_MISSED_TAIL_CALL;
 #endif
 }
+
+#ifdef ENABLE_IPV6
+/* Performs IPv6 L2/L3 handling and delivers the packet to the destination pod
+ * on the same node, either via the stack or via a redirect call.
+ * Depending on the configuration, it may also enforce ingress policies for the
+ * destination pod via a tail call.
+ */
+static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
+					       __u32 seclabel,
+					       const struct endpoint_info *ep,
+					       __u8 direction, bool from_host,
+					       bool hairpin_flow)
+{
+	mac_t router_mac = ep->node_mac;
+	mac_t lxc_mac = ep->mac;
+	int ret;
+
+	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, ep->lxc_id, seclabel);
+
+	/* This will invalidate the size check */
+	ret = ipv6_l3(ctx, l3_off, (__u8 *)&router_mac, (__u8 *)&lxc_mac, direction);
+	if (ret != CTX_ACT_OK)
+		return ret;
+
+	return l3_local_delivery(ctx, seclabel, ep, direction, from_host, hairpin_flow);
+}
 #endif /* ENABLE_IPV6 */
 
 /* Performs IPv4 L2/L3 handling and delivers the packet to the destination pod
@@ -137,9 +144,8 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_off,
 					       __u32 seclabel, struct iphdr *ip4,
 					       const struct endpoint_info *ep,
-					       __u8 direction __maybe_unused,
-					       bool from_host __maybe_unused,
-					       bool hairpin_flow __maybe_unused)
+					       __u8 direction, bool from_host,
+					       bool hairpin_flow)
 {
 	mac_t router_mac = ep->node_mac;
 	mac_t lxc_mac = ep->mac;
@@ -151,52 +157,7 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 	if (ret != CTX_ACT_OK)
 		return ret;
 
-#ifdef LOCAL_DELIVERY_METRICS
-	/*
-	 * Special LXC case for updating egress forwarding metrics.
-	 * Note that the packet could still be dropped but it would show up
-	 * as an ingress drop counter in metrics.
-	 */
-	update_metrics(ctx_full_len(ctx), direction, REASON_FORWARDED);
-#endif
-
-#ifndef DISABLE_LOOPBACK_LB
-	/* Skip ingress policy enforcement for hairpin traffic.	As the hairpin
-	 * traffic is destined to a local pod (more specifically, the same pod the
-	 * traffic originated from, we skip the tail call for ingress policy
-	 * enforcement, and directly redirect it to the endpoint).
-	 */
-	if (unlikely(hairpin_flow))
-		return redirect_ep(ctx, ep->ifindex, from_host);
-#endif /* DISABLE_LOOPBACK_LB */
-
-#if defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && \
-	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)
-	ctx->mark |= MARK_MAGIC_IDENTITY;
-	set_identity_mark(ctx, seclabel);
-
-# if defined(TUNNEL_MODE) && !defined(ENABLE_NODEPORT)
-	/* In tunneling mode, we execute this code to send the packet from
-	 * cilium_vxlan to lxc*. If we're using kube-proxy, we don't want to use
-	 * redirect() because that would bypass conntrack and the reverse DNAT.
-	 * Thus, we send packets to the stack, but since they have the wrong
-	 * Ethernet addresses, we need to mark them as PACKET_HOST or the kernel
-	 * will drop them.
-	 */
-	ctx_change_type(ctx, PACKET_HOST);
-	return CTX_ACT_OK;
-# else
-	return redirect_ep(ctx, ep->ifindex, from_host);
-# endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
-#else
-	/* Jumps to destination pod's BPF program to enforce ingress policies. */
-	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
-	ctx_store_meta(ctx, CB_IFINDEX, ep->ifindex);
-	ctx_store_meta(ctx, CB_FROM_HOST, from_host ? 1 : 0);
-
-	tail_call_dynamic(ctx, &POLICY_CALL_MAP, ep->lxc_id);
-	return DROP_MISSED_TAIL_CALL;
-#endif
+	return l3_local_delivery(ctx, seclabel, ep, direction, from_host, hairpin_flow);
 }
 #endif /* SKIP_POLICY_MAP */
 

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1093,7 +1093,7 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 		return DROP_WRITE_ERROR;
 
 	sum = csum_diff(&old_sip, 4, &new_sip, 4, sum);
-	if (l3_csum_replace(ctx, l3_off + offsetof(struct iphdr, check), 0, sum, 0) < 0)
+	if (ipv4_csum_update_by_diff(ctx, l3_off, sum) < 0)
 		return DROP_CSUM_L3;
 
 	if (csum_off->offset &&
@@ -1388,8 +1388,7 @@ lb4_xlate(struct __ctx_buff *ctx, __be32 *new_daddr, __be32 *new_saddr __maybe_u
 		sum = csum_diff(old_saddr, 4, new_saddr, 4, sum);
 	}
 #endif /* DISABLE_LOOPBACK_LB */
-	if (l3_csum_replace(ctx, l3_off + offsetof(struct iphdr, check),
-			    0, sum, 0) < 0)
+	if (ipv4_csum_update_by_diff(ctx, l3_off, sum) < 0)
 		return DROP_CSUM_L3;
 	if (csum_off->offset) {
 		if (csum_l4_replace(ctx, l4_off, csum_off, 0, sum,

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -423,8 +423,7 @@ static __always_inline int snat_v4_rewrite_egress(struct __ctx_buff *ctx,
 	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, saddr),
 			    &state->to_saddr, 4, 0) < 0)
 		return DROP_WRITE_ERROR;
-	if (l3_csum_replace(ctx, ETH_HLEN + offsetof(struct iphdr, check),
-			    0, sum, 0) < 0)
+	if (ipv4_csum_update_by_diff(ctx, ETH_HLEN, sum) < 0)
 		return DROP_CSUM_L3;
 	if (tuple->nexthdr == IPPROTO_ICMP)
 		sum = sum_l4;
@@ -489,8 +488,7 @@ static __always_inline int snat_v4_rewrite_ingress(struct __ctx_buff *ctx,
 	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, daddr),
 			    &state->to_daddr, 4, 0) < 0)
 		return DROP_WRITE_ERROR;
-	if (l3_csum_replace(ctx, ETH_HLEN + offsetof(struct iphdr, check),
-			    0, sum, 0) < 0)
+	if (ipv4_csum_update_by_diff(ctx, ETH_HLEN, sum) < 0)
 		return DROP_CSUM_L3;
 	if (tuple->nexthdr == IPPROTO_ICMP)
 		sum = sum_l4;

--- a/bpf/lib/nat_46x64.h
+++ b/bpf/lib/nat_46x64.h
@@ -346,7 +346,7 @@ static __always_inline int ipv6_to_ipv4(struct __ctx_buff *ctx,
 	if (ctx_store_bytes(ctx, nh_off, &v4, sizeof(v4), 0) < 0 ||
 	    ctx_store_bytes(ctx, nh_off - 2, &protocol, 2, 0) < 0)
 		return DROP_WRITE_ERROR;
-	if (l3_csum_replace(ctx, nh_off + csum_off, 0, csum, 0) < 0)
+	if (ipv4_csum_update_by_diff(ctx, nh_off, csum) < 0)
 		return DROP_CSUM_L3;
 	if (v6.nexthdr == IPPROTO_ICMPV6) {
 		__be32 csum1 = 0;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1399,8 +1399,7 @@ static __always_inline int dsr_set_ipip4(struct __ctx_buff *ctx,
 	if (ctx_store_bytes(ctx, l3_off + offsetof(struct iphdr, saddr),
 			    &tp_new.saddr, 8, 0) < 0)
 		return DROP_WRITE_ERROR;
-	if (l3_csum_replace(ctx, l3_off + offsetof(struct iphdr, check),
-			    0, sum, 0) < 0)
+	if (ipv4_csum_update_by_diff(ctx, l3_off, sum) < 0)
 		return DROP_CSUM_L3;
 	return 0;
 }
@@ -1457,8 +1456,7 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 	if (ctx_store_bytes(ctx, ETH_HLEN + sizeof(*ip4),
 			    &opt, sizeof(opt), 0) < 0)
 		return DROP_INVALID;
-	if (l3_csum_replace(ctx, ETH_HLEN + offsetof(struct iphdr, check),
-			    0, sum, 0) < 0)
+	if (ipv4_csum_update_by_diff(ctx, ETH_HLEN, sum) < 0)
 		return DROP_CSUM_L3;
 
 	return 0;


### PR DESCRIPTION
Some L3-related cleanups that have accumulated. The csum helpers follow the usage outlined in the `l3_csum_replace()` man page.