### PR TITLE
hive: Don't log interrupt signal as error

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -412,6 +412,7 @@ jenkinsfiles @cilium/ci-structure
 /pkg/fqdn/ @cilium/sig-agent @cilium/proxy
 /pkg/fswatcher/ @cilium/sig-datapath @cilium/sig-hubble
 /pkg/health/ @cilium/health
+/pkg/hive/ @cilium/sig-agent
 /pkg/hubble/ @cilium/sig-hubble
 /pkg/hubble/metrics @cilium/sig-hubble @cilium/sig-hubble-api
 /pkg/identity @cilium/sig-policy

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -190,8 +190,8 @@ func (h *Hive) waitForSignalOrShutdown() error {
 	defer signal.Stop(signals)
 	signal.Notify(signals, os.Interrupt, unix.SIGINT, unix.SIGTERM)
 	select {
-	case <-signals:
-		log.Error("Interrupt received")
+	case sig := <-signals:
+		log.WithField("signal", sig).Info("Signal received")
 		return nil
 	case err := <-h.shutdown:
 		return err
@@ -238,6 +238,8 @@ func (h *Hive) Start(ctx context.Context) error {
 
 	defer close(h.fatalOnTimeout(ctx))
 
+	log.Info("Starting")
+
 	return h.lifecycle.Start(ctx)
 }
 
@@ -246,6 +248,7 @@ func (h *Hive) Start(ctx context.Context) error {
 // then after 5 more seconds the process will be terminated forcefully.
 func (h *Hive) Stop(ctx context.Context) error {
 	defer close(h.fatalOnTimeout(ctx))
+	log.Info("Stopping")
 	return h.lifecycle.Stop(ctx)
 }
 


### PR DESCRIPTION
Hive can be stopped by sending the process a INT or TERM signal to initiate the stop of the application. Hive was logging an error "Interrupt received" when this happened and this was causing CI jobs to fail as they were checking that no errors were logged. Since stopping via SIGINT/SIGTERM is not errornous, log the event at info level instead.

Fixes: #23637
Fixes: b407ffce15d1 ("hive: Reimplement on top of dig")