### PR TITLE
 install: add chart-checker

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -514,6 +514,7 @@ jenkinsfiles @cilium/ci-structure
 /test/runtime/chaos_agent.go @cilium/sig-agent @cilium/ci-structure
 /test/runtime/chaos_endpoint.go @cilium/endpoint @cilium/ci-structure
 /tools/ @cilium/contributing
+/tools/chart-checker @cilium/helm
 /USERS.md @cilium/tophat
 Vagrantfile @cilium/ci-structure
 /Vagrantfile @cilium/contributing

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -66,6 +66,7 @@ lint:
 		|| (echo -e "$$crd not found in $(CHART_FILE).\nPlease update the chart to include $$crd."; exit 1); \
 	done
 	$(QUIET)$(HELM) lint --with-subcharts --values ./cilium/values.yaml ./cilium
+	go run ../../tools/chart-checker --chart-path ./cilium
 
 docs:
 	$(QUIET)$(HELM_DOCS)

--- a/tools/chart-checker/chart-linter.go
+++ b/tools/chart-checker/chart-linter.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cilium/cilium/tools/chart-checker/linters"
+)
+
+// Chart-linter enforces some cilium-specific requirements when rendering charts
+
+func main() {
+	var chartPath string
+	var values []string
+
+	cmd := &cobra.Command{
+		Short: "helm linter",
+		RunE: func(_ *cobra.Command, _ []string) error {
+
+			if chartPath == "" {
+				return fmt.Errorf("chart-path is required")
+			}
+
+			err := lint(chartPath, values)
+			if err == nil {
+				log.Println("lint OK!")
+			}
+			return err
+		},
+
+		SilenceUsage: true,
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.StringVar(&chartPath, "chart-path", "", "Path to helm chart")
+	cmd.Flags().StringArrayVar(&values, "set", []string{}, "Set helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func lint(chartPath string, values []string) error {
+	failed := false
+	for _, linter := range linters.Linters {
+		if err := linter.Lint(chartPath, values); err != nil {
+			log.Printf("%s failed: %v\t(%s)",
+				linter.Name(), err.Error(), linter.Description())
+			failed = true
+		} else {
+			log.Printf("OK %s", linter.Name())
+		}
+	}
+
+	if failed {
+		return fmt.Errorf("some linters failed")
+	}
+	return nil
+}

--- a/tools/chart-checker/linters/linters.go
+++ b/tools/chart-checker/linters/linters.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package linters
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type Linter interface {
+	Lint(chartPath string, values []string) error
+	Name() string
+	Description() string
+}
+
+var Linters = []Linter{
+	&PreFlightLinter{},
+}
+
+const (
+	DefaultNamespace   = "test-cilium-namespace"
+	PlaceholderVersion = "99.99.0"
+)
+
+// render renders a given template + set of values
+// just shells out to helm, rather than implementing it in go
+func render(name, chartPath string, values []string) ([]*unstructured.Unstructured, error) {
+	_, err := exec.LookPath("helm")
+	if err != nil {
+		return nil, fmt.Errorf("could not find helm binary, please install: %w", err)
+	}
+
+	sets := make([]string, 0, 2*len(values))
+	for _, v := range values {
+		sets = append(sets, "--set", v)
+	}
+
+	cmd := exec.Command("helm", "template",
+		"--namespace", DefaultNamespace,
+		name, chartPath,
+		"--version", PlaceholderVersion,
+	)
+	cmd.Args = append(cmd.Args, sets...)
+	log.Println(cmd.Args)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if err, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("failed to execute %v: %s %w", cmd.Args, err.Stderr, err)
+		}
+		return nil, fmt.Errorf("failed to execute %v: %w", cmd.Args, err)
+	}
+
+	return parseManifests(out)
+}
+
+func parseManifests(in []byte) ([]*unstructured.Unstructured, error) {
+	out := []*unstructured.Unstructured{}
+
+	buf := bytes.NewBuffer(in)
+	decoder := yaml.NewYAMLOrJSONDecoder(buf, 4096)
+	for {
+		u := unstructured.Unstructured{}
+		if err := decoder.Decode(&u); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("failed to parse manifest as k8s object: %w", err)
+		}
+		if u.GetKind() == "" { // The YAML decoder saw an empty file
+			continue
+		}
+		out = append(out, &u)
+	}
+	log.Printf("got %d objects", len(out))
+
+	return out, nil
+}

--- a/tools/chart-checker/linters/preflight.go
+++ b/tools/chart-checker/linters/preflight.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package linters
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// PreFlightLinter ensures that enabling preflight produces an
+// entirely distinct set of objects.
+//
+// This is because we expect to be able to install cilium in pre-flight
+// mode on top of an existing cilium installation during upgrades.
+type PreFlightLinter struct{}
+
+var _ Linter = (*PreFlightLinter)(nil)
+
+func (*PreFlightLinter) Name() string {
+	return "PreFlightLinter"
+}
+
+func (*PreFlightLinter) Description() string {
+	return "We must be able to install the preflight daemonset in the same " +
+		"namespace next to an existing Cilium installation. So, by disabling the agent, " +
+		"nodeinit, and operator, and enabling preflight, there should be no overlapping Kubernetes resources."
+}
+
+func (p *PreFlightLinter) Lint(chartPath string, values []string) error {
+	getAllObjs := func(withPreflight bool) (sets.Set[string], error) {
+		v := append([]string{}, values...)
+		if withPreflight {
+			v = append(v, "preflight.enabled=true", "config.enabled=false",
+				"agent=false", "nodeinit.enabled=false", "operator.enabled=false")
+		} else {
+			v = append(v, "preflight.enabled=false")
+		}
+
+		name := "cilium"
+		if withPreflight {
+			name = "cilium-prefight"
+		}
+
+		objs, err := render(name, chartPath, v)
+		if err != nil {
+			return nil, err
+		}
+
+		out := sets.New[string]()
+
+		for _, obj := range objs {
+			key := fmt.Sprintf("<%s %s/%s>",
+				obj.GetObjectKind().GroupVersionKind().GroupKind(),
+				obj.GetNamespace(),
+				obj.GetName())
+			if out.Has(key) {
+				return nil, fmt.Errorf("object %s is duplicated", key)
+			}
+
+			out.Insert(key)
+		}
+
+		return out, nil
+	}
+
+	objsNoPreflight, err := getAllObjs(false)
+	if err != nil {
+		return fmt.Errorf("failed to render without preflight: %w", err)
+	}
+
+	objsWithPreflight, err := getAllObjs(true)
+	if err != nil {
+		return fmt.Errorf("failed to render with preflight: %w", err)
+	}
+
+	// compute the union, it should be empty
+	overlap := objsNoPreflight.Intersection(objsWithPreflight)
+
+	if len(overlap) > 0 {
+		return fmt.Errorf("colliding objects when when preflight is disabled and enabled: %v",
+			overlap.UnsortedList())
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds a go chart-checker that adds certain Cilium-specific checks.
 
The first linter ensures that the preflight mode can be installed alongside an existing installation.
