### PR TITLE
cilium: fib lookup consolidation

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -606,7 +606,7 @@ ct_recreate6:
 
 		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, ext_err,
 				      ctx->ingress_ifindex, &oif);
-		if (likely(ret == CTX_ACT_REDIRECT))
+		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_id, 0, oif,
 					  trace.reason, trace.monitor);
@@ -1110,7 +1110,7 @@ skip_vtep:
 
 		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, ext_err,
 				      ctx->ingress_ifindex, &oif);
-		if (likely(ret == CTX_ACT_REDIRECT))
+		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_id, 0, oif,
 					  trace.reason, trace.monitor);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -604,7 +604,7 @@ ct_recreate6:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif;
 
-		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6,
+		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false,
 				      ctx->ingress_ifindex, &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
@@ -1108,7 +1108,7 @@ skip_vtep:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif;
 
-		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4,
+		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false,
 				      ctx->ingress_ifindex, &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -602,9 +602,9 @@ ct_recreate6:
 	}
 #endif
 	if (is_defined(ENABLE_HOST_ROUTING)) {
-		int oif;
+		int oif, fib_err;
 
-		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false,
+		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, &fib_err,
 				      ctx->ingress_ifindex, &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
@@ -1106,9 +1106,9 @@ skip_vtep:
 	}
 #endif /* TUNNEL_MODE */
 	if (is_defined(ENABLE_HOST_ROUTING)) {
-		int oif;
+		int oif, fib_err;
 
-		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false,
+		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, &fib_err,
 				      ctx->ingress_ifindex, &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -604,7 +604,8 @@ ct_recreate6:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif;
 
-		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, &oif);
+		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6,
+				      ctx->ingress_ifindex, &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_id, 0, oif,
@@ -1107,7 +1108,8 @@ skip_vtep:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif;
 
-		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, &oif);
+		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4,
+				      ctx->ingress_ifindex, &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_id, 0, oif,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -602,9 +602,9 @@ ct_recreate6:
 	}
 #endif
 	if (is_defined(ENABLE_HOST_ROUTING)) {
-		int oif, fib_err;
+		int oif;
 
-		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, &fib_err,
+		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, ext_err,
 				      ctx->ingress_ifindex, &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
@@ -1106,9 +1106,9 @@ skip_vtep:
 	}
 #endif /* TUNNEL_MODE */
 	if (is_defined(ENABLE_HOST_ROUTING)) {
-		int oif, fib_err;
+		int oif;
 
-		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, &fib_err,
+		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, ext_err,
 				      ctx->ingress_ifindex, &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -604,7 +604,7 @@ ct_recreate6:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif;
 
-		ret = redirect_direct_v6(ctx, ETH_HLEN, ip6, &oif);
+		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_id, 0, oif,
@@ -1107,7 +1107,7 @@ skip_vtep:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif;
 
-		ret = redirect_direct_v4(ctx, ETH_HLEN, ip4, &oif);
+		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_id, 0, oif,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -602,7 +602,7 @@ ct_recreate6:
 	}
 #endif
 	if (is_defined(ENABLE_HOST_ROUTING)) {
-		int oif;
+		int oif = 0;
 
 		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, ext_err,
 				      ctx->ingress_ifindex, &oif);
@@ -1106,7 +1106,7 @@ skip_vtep:
 	}
 #endif /* TUNNEL_MODE */
 	if (is_defined(ENABLE_HOST_ROUTING)) {
-		int oif;
+		int oif = 0;
 
 		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, ext_err,
 				      ctx->ingress_ifindex, &oif);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -77,6 +77,9 @@ enum {
 	XFER_ENCAP_DSTID = 3,
 };
 
+/* FIB errors from BPF neighbor map. */
+#define BPF_FIB_MAP_NO_NEIGH	100
+
 /* These are shared with test/bpf/check-complexity.sh, when modifying any of
  * the below, that script should also be updated.
  */

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -114,7 +114,7 @@ encap_remap_v6_host_address(struct __ctx_buff *ctx __maybe_unused,
 static __always_inline int
 __encap_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 		    __u32 seclabel, __u32 dstid, __u32 vni __maybe_unused,
-		    enum trace_reason ct_reason, __u32 monitor, __u32 *ifindex)
+		    enum trace_reason ct_reason, __u32 monitor, int *ifindex)
 {
 	__u32 node_id;
 	int ret;
@@ -143,7 +143,7 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 				 __u32 seclabel, __u32 dstid, __u32 vni,
 				 const struct trace_ctx *trace)
 {
-	__u32 ifindex;
+	int ifindex;
 	int ret = 0;
 
 #ifdef ENABLE_WIREGUARD
@@ -202,7 +202,7 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 			 __u16 node_id __maybe_unused, __u32 seclabel,
 			 __u32 dstid, const struct trace_ctx *trace)
 {
-	__u32 ifindex __maybe_unused;
+	int ifindex __maybe_unused;
 	int ret __maybe_unused;
 
 #ifdef ENABLE_IPSEC

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -11,10 +11,6 @@
 #include "neigh.h"
 #include "l3.h"
 
-#ifndef IS_L3_DEV
-# define IS_L3_DEV(ifindex)	false
-#endif
-
 static __always_inline int
 maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
 		 __u32 ifindex __maybe_unused,

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -13,16 +13,15 @@
 
 #ifdef ENABLE_IPV6
 static __always_inline int
-fib_redirect_v6(struct __ctx_buff *ctx __maybe_unused,
-		int l3_off __maybe_unused,
-		struct ipv6hdr *ip6 __maybe_unused, int *oif)
+fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
+		struct ipv6hdr *ip6, int iif, int *oif)
 {
 	bool no_neigh = false;
 	struct bpf_redir_neigh *nh = NULL;
 	struct bpf_redir_neigh nh_params;
 	struct bpf_fib_lookup fib_params = {
 		.family		= AF_INET6,
-		.ifindex	= ctx->ingress_ifindex,
+		.ifindex	= iif,
 	};
 	int ret;
 
@@ -83,16 +82,15 @@ fib_redirect_v6(struct __ctx_buff *ctx __maybe_unused,
 
 #ifdef ENABLE_IPV4
 static __always_inline int
-fib_redirect_v4(struct __ctx_buff *ctx __maybe_unused,
-		int l3_off __maybe_unused,
-		struct iphdr *ip4 __maybe_unused, int *oif)
+fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
+		struct iphdr *ip4, int iif, int *oif)
 {
 	bool no_neigh = false;
 	struct bpf_redir_neigh *nh = NULL;
 	struct bpf_redir_neigh nh_params;
 	struct bpf_fib_lookup fib_params = {
 		.family		= AF_INET,
-		.ifindex	= ctx->ingress_ifindex,
+		.ifindex	= iif,
 		.ipv4_src	= ip4->saddr,
 		.ipv4_dst	= ip4->daddr,
 	};

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -43,7 +43,7 @@ maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
 static __always_inline int
 fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		struct ipv6hdr *ip6, const bool needs_l2_check,
-		int *fib_err, int iif, int *oif)
+		__s8 *fib_err, int iif, int *oif)
 {
 	bool no_neigh = false;
 	struct bpf_redir_neigh *nh = NULL;
@@ -62,7 +62,7 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
 			 BPF_FIB_LOOKUP_DIRECT);
 	if (ret != BPF_FIB_LKUP_RET_SUCCESS) {
-		*fib_err = ret;
+		*fib_err = (__s8)ret;
 		if (likely(ret == BPF_FIB_LKUP_RET_NO_NEIGH)) {
 			nh_params.nh_family = fib_params.family;
 			__bpf_memcpy_builtin(&nh_params.ipv6_nh,
@@ -125,7 +125,7 @@ out_send:
 static __always_inline int
 fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		struct iphdr *ip4, const bool needs_l2_check,
-		int *fib_err, int iif, int *oif)
+		__s8 *fib_err, int iif, int *oif)
 {
 	bool no_neigh = false;
 	struct bpf_redir_neigh *nh = NULL;
@@ -141,7 +141,7 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
 			 BPF_FIB_LOOKUP_DIRECT);
 	if (ret != BPF_FIB_LKUP_RET_SUCCESS) {
-		*fib_err = ret;
+		*fib_err = (__s8)ret;
 		if (likely(ret == BPF_FIB_LKUP_RET_NO_NEIGH)) {
 			/* GW could also be v6, so copy union. */
 			nh_params.nh_family = fib_params.family;

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -46,7 +46,6 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		__s8 *fib_err, int iif, int *oif)
 {
 	bool no_neigh = false;
-	struct bpf_redir_neigh *nh = NULL;
 	struct bpf_redir_neigh nh_params;
 	struct bpf_fib_lookup fib_params = {
 		.family		= AF_INET6,
@@ -69,7 +68,6 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 					     &fib_params.ipv6_dst,
 					     sizeof(nh_params.ipv6_nh));
 			no_neigh = true;
-			nh = &nh_params;
 		} else {
 			return DROP_NO_FIB;
 		}
@@ -91,14 +89,12 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 	}
 	if (no_neigh) {
 		if (neigh_resolver_available()) {
-			if (nh)
-				return redirect_neigh(*oif, nh, sizeof(*nh), 0);
-			else
-				return redirect_neigh(*oif, NULL, 0, 0);
+			return redirect_neigh(*oif, &nh_params,
+					      sizeof(nh_params), 0);
 		} else {
 			union macaddr *dmac, smac =
 				NATIVE_DEV_MAC_BY_IFINDEX(fib_params.ifindex);
-			dmac = (nh && nh_params.nh_family == AF_INET) ?
+			dmac = nh_params.nh_family == AF_INET ?
 			       neigh_lookup_ip4(&fib_params.ipv4_dst) :
 			       neigh_lookup_ip6((void *)&fib_params.ipv6_dst);
 			if (!dmac) {
@@ -128,7 +124,6 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		__s8 *fib_err, int iif, int *oif)
 {
 	bool no_neigh = false;
-	struct bpf_redir_neigh *nh = NULL;
 	struct bpf_redir_neigh nh_params;
 	struct bpf_fib_lookup fib_params = {
 		.family		= AF_INET,
@@ -149,7 +144,6 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 					     &fib_params.ipv6_dst,
 					     sizeof(nh_params.ipv6_nh));
 			no_neigh = true;
-			nh = &nh_params;
 		} else {
 			return DROP_NO_FIB;
 		}
@@ -171,14 +165,12 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 	}
 	if (no_neigh) {
 		if (neigh_resolver_available()) {
-			if (nh)
-				return redirect_neigh(*oif, nh, sizeof(*nh), 0);
-			else
-				return redirect_neigh(*oif, NULL, 0, 0);
+			return redirect_neigh(*oif, &nh_params,
+					      sizeof(nh_params), 0);
 		} else {
 			union macaddr *dmac, smac =
 				NATIVE_DEV_MAC_BY_IFINDEX(fib_params.ifindex);
-			dmac = (nh && nh_params.nh_family == AF_INET6) ?
+			dmac = nh_params.nh_family == AF_INET6 ?
 			       neigh_lookup_ip6((void *)&fib_params.ipv6_dst) :
 			       neigh_lookup_ip4(&fib_params.ipv4_dst);
 			if (!dmac) {

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -35,6 +35,11 @@ maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
 	return 0;
 }
 
+static __always_inline bool fib_ok(int ret)
+{
+	return likely(ret == CTX_ACT_TX || ret == CTX_ACT_REDIRECT);
+}
+
 /* fib_redirect() is common helper code which performs fib lookup, populates
  * the corresponding hardware addresses and pushes the packet to a target
  * device for the next hop. Calling fib_redirect_v{4,6} is preferred unless

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -13,9 +13,9 @@
 
 #ifdef ENABLE_IPV6
 static __always_inline int
-redirect_direct_v6(struct __ctx_buff *ctx __maybe_unused,
-		   int l3_off __maybe_unused,
-		   struct ipv6hdr *ip6 __maybe_unused, int *oif)
+fib_redirect_v6(struct __ctx_buff *ctx __maybe_unused,
+		int l3_off __maybe_unused,
+		struct ipv6hdr *ip6 __maybe_unused, int *oif)
 {
 	bool no_neigh = false;
 	struct bpf_redir_neigh *nh = NULL;
@@ -83,9 +83,9 @@ redirect_direct_v6(struct __ctx_buff *ctx __maybe_unused,
 
 #ifdef ENABLE_IPV4
 static __always_inline int
-redirect_direct_v4(struct __ctx_buff *ctx __maybe_unused,
-		   int l3_off __maybe_unused,
-		   struct iphdr *ip4 __maybe_unused, int *oif)
+fib_redirect_v4(struct __ctx_buff *ctx __maybe_unused,
+		int l3_off __maybe_unused,
+		struct iphdr *ip4 __maybe_unused, int *oif)
 {
 	bool no_neigh = false;
 	struct bpf_redir_neigh *nh = NULL;

--- a/bpf/lib/neigh.h
+++ b/bpf/lib/neigh.h
@@ -10,8 +10,7 @@
 #include "common.h"
 #include "eth.h"
 
-#ifdef ENABLE_NODEPORT
-#ifdef ENABLE_IPV6
+#if defined(ENABLE_NODEPORT) && defined(ENABLE_IPV6)
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, union v6addr);	/* ipv6 addr */
@@ -46,9 +45,15 @@ static __always_inline union macaddr *neigh_lookup_ip6(const union v6addr *addr)
 {
 	return map_lookup_elem(&NODEPORT_NEIGH6, addr);
 }
-#endif /* ENABLE_IPV6 */
+#else
+static __always_inline union macaddr *
+neigh_lookup_ip6(const union v6addr *addr __maybe_unused)
+{
+	return NULL;
+}
+#endif /* ENABLE_NODEPORT && ENABLE_IPV6 */
 
-#ifdef ENABLE_IPV4
+#if defined(ENABLE_NODEPORT) && defined(ENABLE_IPV4)
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, __be32);		/* ipv4 addr */
@@ -83,6 +88,11 @@ static __always_inline union macaddr *neigh_lookup_ip4(const __be32 *addr)
 {
 	return map_lookup_elem(&NODEPORT_NEIGH4, addr);
 }
-#endif /* ENABLE_IPV4 */
-#endif /* ENABLE_NODEPORT */
+#else
+static __always_inline union macaddr *
+neigh_lookup_ip4(const __be32 *addr __maybe_unused)
+{
+	return NULL;
+}
+#endif /* ENABLE_NODEPORT && ENABLE_IPV4 */
 #endif /* __LIB_NEIGH_H_ */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -446,7 +446,7 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_DSR)
 int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 {
 	__u16 port __maybe_unused;
-	int ret, oif, ohead = 0;
+	int ret, oif = 0, ohead = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	union v6addr addr;
@@ -496,7 +496,7 @@ drop_err:
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV46_RFC8215)
 int tail_nat_ipv46(struct __ctx_buff *ctx)
 {
-	int ret, oif, l3_off = ETH_HLEN;
+	int ret, oif = 0, l3_off = ETH_HLEN;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	struct iphdr *ip4;
@@ -528,7 +528,7 @@ drop_err:
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV64_RFC8215)
 int tail_nat_ipv64(struct __ctx_buff *ctx)
 {
-	int ret, oif, l3_off = ETH_HLEN;
+	int ret, oif = 0, l3_off = ETH_HLEN;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	struct iphdr *ip4;
@@ -612,7 +612,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 		.max_port = NODEPORT_PORT_MAX_NAT,
 		.src_from_world = true,
 	};
-	int ret, oif;
+	int ret, oif = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	__s8 ext_err = 0;
@@ -912,7 +912,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __s8 *ext_er
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	__u32 monitor = 0;
-	int ifindex;
+	int ifindex = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
@@ -1433,7 +1433,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	struct iphdr *ip4;
-	int ret, oif;
+	int ret, oif = 0;
 	__u32 addr;
 	__u16 port;
 	__be16 ohead = 0;
@@ -1547,7 +1547,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 		.max_port = NODEPORT_PORT_MAX_NAT,
 		.src_from_world = true,
 	};
-	int ret, oif;
+	int ret, oif = 0;
 	void *data, *data_end;
 	struct iphdr *ip4;
 	__s8 ext_err = 0;
@@ -1868,7 +1868,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_err)
 {
 	enum trace_reason __maybe_unused reason = TRACE_REASON_UNKNOWN;
-	int ifindex, ret, ret2, l3_off = ETH_HLEN, l4_off;
+	int ifindex = 0, ret, ret2, l3_off = ETH_HLEN, l4_off;
 	struct csum_offset csum_off = {};
 	struct ipv4_ct_tuple tuple = {};
 	struct ct_state ct_state = {};

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -100,32 +100,6 @@ static __always_inline bool dsr_is_too_big(struct __ctx_buff *ctx __maybe_unused
 	return false;
 }
 
-static __always_inline int
-maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
-		 __u32 ifindex __maybe_unused,
-		 bool *l2_hdr_required __maybe_unused)
-{
-	if (IS_L3_DEV(ifindex))
-		/* NodePort request is going to be redirected to L3 dev, so skip
-		 * L2 addr settings.
-		 */
-		*l2_hdr_required = false;
-	else if (ETH_HLEN == 0) {
-		/* NodePort request is going to be redirected from L3 to L2 dev,
-		 * so we need to create L2 hdr first.
-		 */
-		__u16 proto = ctx_get_protocol(ctx);
-
-		if (ctx_change_head(ctx, __ETH_HLEN, 0))
-			return DROP_INVALID;
-
-		if (eth_store_proto(ctx, proto, 0) < 0)
-			return DROP_WRITE_ERROR;
-	}
-
-	return 0;
-}
-
 #ifdef ENABLE_IPV6
 static __always_inline bool nodeport_uses_dsr6(const struct ipv6_ct_tuple *tuple)
 {
@@ -570,7 +544,8 @@ int tail_nat_ipv46(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v6(ctx, l3_off, ip6, ctx_get_ifindex(ctx), &oif);
+	ret = fib_redirect_v6(ctx, l3_off, ip6, false,
+			      ctx_get_ifindex(ctx), &oif);
 	if (likely(ret == CTX_ACT_REDIRECT)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -601,7 +576,8 @@ int tail_nat_ipv64(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v4(ctx, l3_off, ip4, ctx_get_ifindex(ctx), &oif);
+	ret = fib_redirect_v4(ctx, l3_off, ip4, false,
+			      ctx_get_ifindex(ctx), &oif);
 	if (likely(ret == CTX_ACT_REDIRECT)) {
 		cilium_capture_out(ctx);
 		return ret;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -446,11 +446,11 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_DSR)
 int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 {
 	__u16 port __maybe_unused;
+	int ret, oif, ohead = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	union v6addr addr;
-	int ret, ohead = 0;
-	int oif, ext_err = 0;
+	__s8 ext_err = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 		ret = DROP_INVALID;
@@ -496,11 +496,11 @@ drop_err:
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV46_RFC8215)
 int tail_nat_ipv46(struct __ctx_buff *ctx)
 {
-	int ret, oif, ext_err = 0;
+	int ret, oif, l3_off = ETH_HLEN;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	struct iphdr *ip4;
-	int l3_off = ETH_HLEN;
+	__s8 ext_err = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
 		ret = DROP_INVALID;
@@ -528,11 +528,11 @@ drop_err:
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV64_RFC8215)
 int tail_nat_ipv64(struct __ctx_buff *ctx)
 {
-	int ret, oif, ext_err = 0;
+	int ret, oif, l3_off = ETH_HLEN;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	struct iphdr *ip4;
-	int l3_off = ETH_HLEN;
+	__s8 ext_err = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 		ret = DROP_INVALID;
@@ -1515,12 +1515,13 @@ drop_err:
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_DSR)
 int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 {
-	int ret, oif, ext_err = 0;
 	void *data, *data_end;
 	struct iphdr *ip4;
+	int ret, oif;
 	__u32 addr;
 	__u16 port;
 	__be16 ohead = 0;
+	__s8 ext_err = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
 		ret = DROP_INVALID;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -482,7 +482,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 	}
 	ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, true, &ext_err,
 			      ctx_get_ifindex(ctx), &oif);
-	if (likely(ret == CTX_ACT_REDIRECT)) {
+	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
 	}
@@ -516,7 +516,7 @@ int tail_nat_ipv46(struct __ctx_buff *ctx)
 	}
 	ret = fib_redirect_v6(ctx, l3_off, ip6, false, &ext_err,
 			      ctx_get_ifindex(ctx), &oif);
-	if (likely(ret == CTX_ACT_REDIRECT)) {
+	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
 	}
@@ -548,7 +548,7 @@ int tail_nat_ipv64(struct __ctx_buff *ctx)
 	}
 	ret = fib_redirect_v4(ctx, l3_off, ip4, false, &ext_err,
 			      ctx_get_ifindex(ctx), &oif);
-	if (likely(ret == CTX_ACT_REDIRECT)) {
+	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
 	}
@@ -688,7 +688,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 			       (union v6addr *)&ip6->daddr);
 	}
 	ret = fib_redirect(ctx, true, &fib_params, &ext_err, &oif);
-	if (likely(ret == CTX_ACT_REDIRECT)) {
+	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
 	}
@@ -1033,7 +1033,7 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 		goto drop;
 	edt_set_aggregate(ctx, 0);
 	cilium_capture_out(ctx);
-	if (ret == CTX_ACT_REDIRECT)
+	if (fib_ok(ret))
 		return ret;
 	ctx_move_xfer(ctx);
 	return ret;
@@ -1481,7 +1481,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 	}
 	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true, &ext_err,
 			      ctx_get_ifindex(ctx), &oif);
-	if (likely(ret == CTX_ACT_REDIRECT)) {
+	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
 	}
@@ -1630,7 +1630,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	fib_params.l.ipv4_dst = ip4->daddr;
 
 	ret = fib_redirect(ctx, true, &fib_params, &ext_err, &oif);
-	if (likely(ret == CTX_ACT_REDIRECT)) {
+	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
 	}
@@ -1994,7 +1994,7 @@ int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 						  CTX_ACT_DROP, METRIC_EGRESS);
 	edt_set_aggregate(ctx, 0);
 	cilium_capture_out(ctx);
-	if (ret == CTX_ACT_REDIRECT)
+	if (fib_ok(ret))
 		return ret;
 	ctx_move_xfer(ctx);
 	return ret;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -480,7 +480,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, true,
+	ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, true, &ext_err,
 			      ctx_get_ifindex(ctx), &oif);
 	if (likely(ret == CTX_ACT_REDIRECT)) {
 		cilium_capture_out(ctx);
@@ -497,10 +497,10 @@ drop_err:
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV46_RFC8215)
 int tail_nat_ipv46(struct __ctx_buff *ctx)
 {
+	int ret, oif, ext_err = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	struct iphdr *ip4;
-	int ret, oif;
 	int l3_off = ETH_HLEN;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
@@ -515,7 +515,7 @@ int tail_nat_ipv46(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v6(ctx, l3_off, ip6, false,
+	ret = fib_redirect_v6(ctx, l3_off, ip6, false, &ext_err,
 			      ctx_get_ifindex(ctx), &oif);
 	if (likely(ret == CTX_ACT_REDIRECT)) {
 		cilium_capture_out(ctx);
@@ -523,16 +523,17 @@ int tail_nat_ipv46(struct __ctx_buff *ctx)
 	}
 	ret = DROP_NO_FIB;
 drop_err:
-	return send_drop_notify_error_ext(ctx, 0, ret, 0, CTX_ACT_DROP, METRIC_EGRESS);
+	return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
+					  CTX_ACT_DROP, METRIC_EGRESS);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV64_RFC8215)
 int tail_nat_ipv64(struct __ctx_buff *ctx)
 {
+	int ret, oif, ext_err = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	struct iphdr *ip4;
-	int ret, oif;
 	int l3_off = ETH_HLEN;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
@@ -547,7 +548,7 @@ int tail_nat_ipv64(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v4(ctx, l3_off, ip4, false,
+	ret = fib_redirect_v4(ctx, l3_off, ip4, false, &ext_err,
 			      ctx_get_ifindex(ctx), &oif);
 	if (likely(ret == CTX_ACT_REDIRECT)) {
 		cilium_capture_out(ctx);
@@ -555,7 +556,8 @@ int tail_nat_ipv64(struct __ctx_buff *ctx)
 	}
 	ret = DROP_NO_FIB;
 drop_err:
-	return send_drop_notify_error_ext(ctx, 0, ret, 0, CTX_ACT_DROP, METRIC_EGRESS);
+	return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
+					  CTX_ACT_DROP, METRIC_EGRESS);
 }
 #endif /* ENABLE_NAT_46X64_GATEWAY */
 
@@ -1549,7 +1551,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true,
+	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true, &ext_err,
 			      ctx_get_ifindex(ctx), &oif);
 	if (likely(ret == CTX_ACT_REDIRECT)) {
 		cilium_capture_out(ctx);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -486,7 +486,6 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 		cilium_capture_out(ctx);
 		return ret;
 	}
-	ret = DROP_NO_FIB;
 drop_err:
 	return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
 					  CTX_ACT_DROP, METRIC_EGRESS);
@@ -521,7 +520,6 @@ int tail_nat_ipv46(struct __ctx_buff *ctx)
 		cilium_capture_out(ctx);
 		return ret;
 	}
-	ret = DROP_NO_FIB;
 drop_err:
 	return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
 					  CTX_ACT_DROP, METRIC_EGRESS);
@@ -554,7 +552,6 @@ int tail_nat_ipv64(struct __ctx_buff *ctx)
 		cilium_capture_out(ctx);
 		return ret;
 	}
-	ret = DROP_NO_FIB;
 drop_err:
 	return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
 					  CTX_ACT_DROP, METRIC_EGRESS);
@@ -1557,7 +1554,6 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 		cilium_capture_out(ctx);
 		return ret;
 	}
-	ret = DROP_NO_FIB;
 drop_err:
 	return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
 					  CTX_ACT_DROP, METRIC_EGRESS);

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -169,7 +169,7 @@ static __always_inline bool ctx_snat_done(struct __sk_buff *ctx)
 static __always_inline __maybe_unused int
 ctx_set_encap_info(struct __sk_buff *ctx, __u32 node_id, __u32 seclabel,
 		   __u32 dstid __maybe_unused, __u32 vni __maybe_unused,
-		   __u32 *ifindex)
+		   int *ifindex)
 {
 	struct bpf_tunnel_key key = {};
 	int ret;

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -76,6 +76,12 @@ redirect_self(const struct __sk_buff *ctx)
 	return ctx_redirect(ctx, ctx->ifindex, 0);
 }
 
+static __always_inline __maybe_unused bool
+neigh_resolver_available(void)
+{
+	return is_defined(HAVE_FIB_NEIGH);
+}
+
 static __always_inline __maybe_unused void
 ctx_skip_nodeport_clear(struct __sk_buff *ctx __maybe_unused)
 {

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -50,6 +50,12 @@ redirect_self(struct xdp_md *ctx __maybe_unused)
 	return XDP_TX;
 }
 
+static __always_inline __maybe_unused bool
+neigh_resolver_available(void)
+{
+	return false;
+}
+
 #define RECIRC_MARKER	5 /* tail call recirculation */
 #define XFER_MARKER	6 /* xdp -> skb meta transfer */
 

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -50,6 +50,15 @@ redirect_self(struct xdp_md *ctx __maybe_unused)
 	return XDP_TX;
 }
 
+static __always_inline __maybe_unused int
+redirect_neigh(int ifindex __maybe_unused,
+	       struct bpf_redir_neigh *params __maybe_unused,
+	       int plen __maybe_unused,
+	       __u32 flags __maybe_unused)
+{
+	return XDP_DROP;
+}
+
 static __always_inline __maybe_unused bool
 neigh_resolver_available(void)
 {

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -167,7 +167,7 @@ ctx_set_encap_info(struct xdp_md *ctx __maybe_unused,
 		   __u32 node_id __maybe_unused,
 		   __u32 seclabel __maybe_unused,
 		   __u32 dstid __maybe_unused,
-		   __u32 vni __maybe_unused, __u32 *ifindex __maybe_unused)
+		   __u32 vni __maybe_unused, int *ifindex __maybe_unused)
 {
 	ctx_store_meta(ctx, CB_ENCAP_NODEID, bpf_ntohl(node_id));
 	ctx_store_meta(ctx, CB_ENCAP_SECLABEL, seclabel);

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -208,7 +208,10 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #  define IPV6_RSS_PREFIX IPV6_DIRECT_ROUTING
 #  define IPV6_RSS_PREFIX_BITS 128
 # endif
-#define IS_L3_DEV(ifindex) false
+#endif
+
+#ifndef IS_L3_DEV
+# define IS_L3_DEV(ifindex) false
 #endif
 
 #ifdef ENABLE_SRC_RANGE_CHECK

--- a/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
@@ -207,7 +207,7 @@ int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-	assert(*status_code == CTX_ACT_REDIRECT);
+	assert(fib_ok(*status_code));
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -400,7 +400,7 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-	assert(*status_code == CTX_ACT_REDIRECT);
+	assert(fib_ok(*status_code));
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
@@ -498,7 +498,7 @@ int check_reply(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-	assert(*status_code == CTX_ACT_REDIRECT);
+	assert(fib_ok(*status_code));
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -905,9 +905,6 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 			return err
 		}
 		fmt.Fprintf(fw, "#define DIRECT_ROUTING_DEV_IFINDEX %d\n", directRoutingIfIndex)
-		if len(option.Config.GetDevices()) == 1 {
-			fmt.Fprintf(fw, "#define ENABLE_SKIP_FIB 1\n")
-		}
 	}
 
 	if e.IsHost() {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -441,14 +441,15 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["NODEPORT_PORT_MAX"] = fmt.Sprintf("%d", option.Config.NodePortMax)
 		cDefinesMap["NODEPORT_PORT_MIN_NAT"] = fmt.Sprintf("%d", option.Config.NodePortMax+1)
 		cDefinesMap["NODEPORT_PORT_MAX_NAT"] = "65535"
-
-		macByIfIndexMacro, isL3DevMacro, err := devMacros()
-		if err != nil {
-			return err
-		}
-		cDefinesMap["NATIVE_DEV_MAC_BY_IFINDEX(IFINDEX)"] = macByIfIndexMacro
-		cDefinesMap["IS_L3_DEV(ifindex)"] = isL3DevMacro
 	}
+
+	macByIfIndexMacro, isL3DevMacro, err := devMacros()
+	if err != nil {
+		return err
+	}
+	cDefinesMap["NATIVE_DEV_MAC_BY_IFINDEX(IFINDEX)"] = macByIfIndexMacro
+	cDefinesMap["IS_L3_DEV(ifindex)"] = isL3DevMacro
+
 	const (
 		selectionRandom = iota + 1
 		selectionMaglev

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -477,7 +477,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			return err
 		}
 		cDefinesMap["DIRECT_ROUTING_DEV_IFINDEX"] = fmt.Sprintf("%d", directRoutingIfIndex)
-
 		if option.Config.EnableIPv4 {
 			ip, ok := node.GetNodePortIPv4AddrsWithDevices()[directRoutingIface]
 			if !ok {
@@ -905,6 +904,9 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 			return err
 		}
 		fmt.Fprintf(fw, "#define DIRECT_ROUTING_DEV_IFINDEX %d\n", directRoutingIfIndex)
+		if len(option.Config.GetDevices()) == 1 {
+			fmt.Fprintf(fw, "#define ENABLE_SKIP_FIB 1\n")
+		}
 	}
 
 	if e.IsHost() {

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -501,6 +501,7 @@ func ExecuteHeaderProbes() *FeatureProbes {
 		{ebpf.CGroupSockAddr, asm.FnSkLookupUdp},
 		{ebpf.CGroupSockAddr, asm.FnGetCurrentCgroupId},
 		{ebpf.CGroupSock, asm.FnSetRetval},
+		{ebpf.SchedCLS, asm.FnRedirectNeigh},
 
 		// skb related probes
 		{ebpf.SchedCLS, asm.FnSkbChangeTail},
@@ -542,6 +543,7 @@ func writeCommonHeader(writer io.Writer, probes *FeatureProbes) error {
 		"HAVE_DIRECT_ACCESS_TO_MAP_VALUES": probes.ProgramHelpers[ProgramHelper{ebpf.SchedCLS, asm.FnFibLookup}],
 		"HAVE_LARGE_INSN_LIMIT":            probes.Misc.HaveLargeInsnLimit,
 		"HAVE_SET_RETVAL":                  probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSock, asm.FnSetRetval}],
+		"HAVE_FIB_NEIGH":                   probes.ProgramHelpers[ProgramHelper{ebpf.SchedCLS, asm.FnRedirectNeigh}],
 	}
 
 	return writeFeatureHeader(writer, features, true)

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -502,6 +502,7 @@ func ExecuteHeaderProbes() *FeatureProbes {
 		{ebpf.CGroupSockAddr, asm.FnGetCurrentCgroupId},
 		{ebpf.CGroupSock, asm.FnSetRetval},
 		{ebpf.SchedCLS, asm.FnRedirectNeigh},
+		{ebpf.SchedCLS, asm.FnRedirectPeer},
 
 		// skb related probes
 		{ebpf.SchedCLS, asm.FnSkbChangeTail},
@@ -544,6 +545,10 @@ func writeCommonHeader(writer io.Writer, probes *FeatureProbes) error {
 		"HAVE_LARGE_INSN_LIMIT":            probes.Misc.HaveLargeInsnLimit,
 		"HAVE_SET_RETVAL":                  probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSock, asm.FnSetRetval}],
 		"HAVE_FIB_NEIGH":                   probes.ProgramHelpers[ProgramHelper{ebpf.SchedCLS, asm.FnRedirectNeigh}],
+		// Check if kernel has d1c362e1dd68 ("bpf: Always return target ifindex
+		// in bpf_fib_lookup") which is 5.10+. This got merged in the same kernel
+		// as the new redirect helpers.
+		"HAVE_FIB_IFINDEX": probes.ProgramHelpers[ProgramHelper{ebpf.SchedCLS, asm.FnRedirectPeer}],
 	}
 
 	return writeFeatureHeader(writer, features, true)

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -91,7 +91,7 @@ nsenter -t $CONTROL_PLANE_PID -n ip neigh add ${WORKER_IP6} dev eth0 lladdr ${WO
 
 # Issue 10 requests to LB
 for i in $(seq 1 10); do
-    curl -o /dev/null "${LB_VIP}:80"
+    curl -o /dev/null "${LB_VIP}:80" || (echo "Failed $i"; exit -1)
 done
 
 # Install Cilium as standalone L4LB: XDP/Maglev/SNAT
@@ -118,7 +118,7 @@ cilium_install \
 
 # Check that curl still works after restore
 for i in $(seq 1 10); do
-    curl -o /dev/null "${LB_VIP}:80"
+    curl -o /dev/null "${LB_VIP}:80" || (echo "Failed $i"; exit -1)
 done
 
 # Install Cilium as standalone L4LB: tc/Random/SNAT
@@ -130,7 +130,7 @@ cilium_install \
 
 # Check that curl also works for random selection
 for i in $(seq 1 10); do
-    curl -o /dev/null "${LB_VIP}:80"
+    curl -o /dev/null "${LB_VIP}:80" || (echo "Failed $i"; exit -1)
 done
 
 # Add another IPv6->IPv6 service and reuse backend
@@ -148,12 +148,12 @@ ip -6 r a "${LB_ALT}/128" via "$LB_NODE_IP"
 
 # Issue 10 requests to LB1
 for i in $(seq 1 10); do
-    curl -o /dev/null "${LB_VIP}:80"
+    curl -o /dev/null "${LB_VIP}:80" || (echo "Failed $i"; exit -1)
 done
 
 # Issue 10 requests to LB2
 for i in $(seq 1 10); do
-    curl -o /dev/null "[${LB_ALT}]:80"
+    curl -o /dev/null "[${LB_ALT}]:80" || (echo "Failed $i"; exit -1)
 done
 
 # Check if restore for both is proper and that this also works
@@ -169,12 +169,12 @@ cilium_install \
 
 # Issue 10 requests to LB1
 for i in $(seq 1 10); do
-    curl -o /dev/null "${LB_VIP}:80"
+    curl -o /dev/null "${LB_VIP}:80" || (echo "Failed $i"; exit -1)
 done
 
 # Issue 10 requests to LB2
 for i in $(seq 1 10); do
-    curl -o /dev/null "[${LB_ALT}]:80"
+    curl -o /dev/null "[${LB_ALT}]:80" || (echo "Failed $i"; exit -1)
 done
 
 ${CILIUM_EXEC} cilium service delete 1
@@ -212,7 +212,7 @@ nsenter -t $CONTROL_PLANE_PID -n ip neigh add ${WORKER_IP4} dev eth0 lladdr ${WO
 
 # Issue 10 requests to LB
 for i in $(seq 1 10); do
-    curl -o /dev/null "[${LB_VIP}]:80"
+    curl -o /dev/null "[${LB_VIP}]:80" || (echo "Failed $i"; exit -1)
 done
 
 # Install Cilium as standalone L4LB: XDP/Maglev/SNAT
@@ -239,7 +239,7 @@ cilium_install \
 
 # Check that curl still works after restore
 for i in $(seq 1 10); do
-    curl -o /dev/null "[${LB_VIP}]:80"
+    curl -o /dev/null "[${LB_VIP}]:80" || (echo "Failed $i"; exit -1)
 done
 
 # Install Cilium as standalone L4LB: tc/Random/SNAT
@@ -251,7 +251,7 @@ cilium_install \
 
 # Check that curl also works for random selection
 for i in $(seq 1 10); do
-    curl -o /dev/null "[${LB_VIP}]:80"
+    curl -o /dev/null "[${LB_VIP}]:80" || (echo "Failed $i"; exit -1)
 done
 
 # Add another IPv4->IPv4 service and reuse backend
@@ -269,12 +269,12 @@ ip r a "${LB_ALT}/32" via "$LB_NODE_IP"
 
 # Issue 10 requests to LB1
 for i in $(seq 1 10); do
-    curl -o /dev/null "[${LB_VIP}]:80"
+    curl -o /dev/null "[${LB_VIP}]:80" || (echo "Failed $i"; exit -1)
 done
 
 # Issue 10 requests to LB2
 for i in $(seq 1 10); do
-    curl -o /dev/null "${LB_ALT}:80"
+    curl -o /dev/null "${LB_ALT}:80" || (echo "Failed $i"; exit -1)
 done
 
 # Check if restore for both is proper and that this also works
@@ -290,12 +290,12 @@ cilium_install \
 
 # Issue 10 requests to LB1
 for i in $(seq 1 10); do
-    curl -o /dev/null "[${LB_VIP}]:80"
+    curl -o /dev/null "[${LB_VIP}]:80" || (echo "Failed $i"; exit -1)
 done
 
 # Issue 10 requests to LB2
 for i in $(seq 1 10); do
-    curl -o /dev/null "${LB_ALT}:80"
+    curl -o /dev/null "${LB_ALT}:80" || (echo "Failed $i"; exit -1)
 done
 
 ${CILIUM_EXEC} cilium service delete 1


### PR DESCRIPTION
This series reworks and consolidates all fib lookups in our BPF code to utilize common functionality.

For tc BPF, this means that redirect_neigh code can be used whenever neighbors cannot be resolved. XDP utilizes the BPF neighbor map as we cannot do this ad-hoc in this layer.

This affects KPR, standalone LB, NAT46x64 GW, DSR code.

Fixes: #22782 
Fixes: #22800