### PR TITLE
datapath: Switch to LPM policy map

### DIFF
--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -67,12 +67,12 @@ struct {
 #ifdef POLICY_MAP
 /* Per-endpoint policy enforcement map */
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
 	__type(key, struct policy_key);
 	__type(value, struct policy_entry);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, POLICY_MAP_SIZE);
-	__uint(map_flags, CONDITIONAL_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } POLICY_MAP __section_maps_btf;
 #endif
 

--- a/cilium/cmd/bpf_policy_get.go
+++ b/cilium/cmd/bpf_policy_get.go
@@ -162,7 +162,7 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 			proxyPort = strconv.FormatUint(uint64(pp), 10)
 		}
 		var policyStr string
-		if policymap.PolicyEntryFlags(stat.Flags).IsDeny() {
+		if stat.IsDeny() {
 			policyStr = "Deny"
 		} else {
 			policyStr = "Allow"

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1351,7 +1351,7 @@ func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
 		// Convert from policymap.PolicyEntry to policy.MapStateEntry.
 		policyEntry := policy.MapStateEntry{
 			ProxyPort: policymapEntry.GetProxyPort(),
-			IsDeny:    policymap.PolicyEntryFlags(policymapEntry.GetFlags()).IsDeny(),
+			IsDeny:    policymapEntry.IsDeny(),
 		}
 		currentMap[policyKey] = policyEntry
 	}

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -220,12 +220,14 @@ func (key *PolicyKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(key) }
 func (key *PolicyKey) NewValue() bpf.MapValue    { return &PolicyEntry{} }
 
 func (key *PolicyKey) String() string {
-
 	trafficDirectionString := (trafficdirection.TrafficDirection)(key.TrafficDirection).String()
-	if key.DestPortNetwork != 0 {
-		return fmt.Sprintf("%s: %d %d/%d", trafficDirectionString, key.Identity, key.GetDestPort(), key.Nexthdr)
+	dport := key.GetDestPort()
+	protoStr := u8proto.U8proto(key.Nexthdr).String()
+
+	if dport != 0 {
+		return fmt.Sprintf("%s: %d %d/%s", trafficDirectionString, key.Identity, dport, protoStr)
 	}
-	return fmt.Sprintf("%s: %d", trafficDirectionString, key.Identity)
+	return fmt.Sprintf("%s: %d %s", trafficDirectionString, key.Identity, protoStr)
 }
 
 // NewKey returns a PolicyKey representing the specified parameters in network

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -63,13 +63,9 @@ func (pef PolicyEntryFlags) is(pf policyFlag) bool {
 	return uint8(pef)&uint8(pf) != 0
 }
 
-func (pef PolicyEntryFlags) IsDeny() bool {
-	return pef.is(policyFlagDeny)
-}
-
 // String returns the string implementation of PolicyEntryFlags.
 func (pef PolicyEntryFlags) String() string {
-	if pef.IsDeny() {
+	if pef.is(policyFlagDeny) {
 		return "Deny"
 	}
 	return "Allow"
@@ -86,6 +82,10 @@ var (
 
 type PolicyMap struct {
 	*bpf.Map
+}
+
+func (pe PolicyEntry) IsDeny() bool {
+	return PolicyEntryFlags(pe.Flags).is(policyFlagDeny)
 }
 
 func (pe *PolicyEntry) String() string {
@@ -216,8 +216,8 @@ func (p PolicyEntriesDump) String() string {
 // (Deny / Allow), TrafficDirection (Ingress / Egress) and Identity
 // (ascending order).
 func (p PolicyEntriesDump) Less(i, j int) bool {
-	iDeny := PolicyEntryFlags(p[i].PolicyEntry.GetFlags()).IsDeny()
-	jDeny := PolicyEntryFlags(p[j].PolicyEntry.GetFlags()).IsDeny()
+	iDeny := p[i].PolicyEntry.IsDeny()
+	jDeny := p[j].PolicyEntry.IsDeny()
 	switch {
 	case iDeny && !jDeny:
 		return true

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -77,9 +77,6 @@ func (pm *PolicyMapPrivilegedTestSuite) TestPolicyMapDumpToSlice(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(dump), Equals, 1)
 
-	// FIXME: It's weird that AllowKey() does the implicit byteorder
-	//        conversion above. But not really a bug, so work around it.
-	fooEntry = fooEntry.ToNetwork()
 	c.Assert(dump[0].Key, checker.DeepEquals, fooEntry)
 
 	// Special case: allow-all entry
@@ -113,9 +110,6 @@ func (pm *PolicyMapPrivilegedTestSuite) TestDenyPolicyMapDumpToSlice(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(dump), Equals, 1)
 
-	// FIXME: It's weird that AllowKey() does the implicit byteorder
-	//        conversion above. But not really a bug, so work around it.
-	fooEntry = fooEntry.ToNetwork()
 	c.Assert(dump[0].Key, checker.DeepEquals, fooEntry)
 	c.Assert(dump[0].PolicyEntry, checker.DeepEquals, fooValue)
 

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -102,7 +102,7 @@ func (pm *PolicyMapPrivilegedTestSuite) TestDenyPolicyMapDumpToSlice(c *C) {
 	c.Assert(testMap, NotNil)
 
 	fooEntry := newKey(1, 1, 1, 1)
-	fooValue := newEntry(0, 0, NewPolicyEntryFlag(&PolicyEntryFlagParam{IsDeny: true}))
+	fooValue := newEntry(0, 0, getPolicyEntryFlags(policyEntryFlagParams{IsDeny: true}))
 	err := testMap.DenyKey(fooEntry)
 	c.Assert(err, IsNil)
 

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -90,7 +90,7 @@ func (pm *PolicyMapPrivilegedTestSuite) TestPolicyMapDumpToSlice(c *C) {
 }
 
 func (pm *PolicyMapPrivilegedTestSuite) TestDeleteNonexistentKey(c *C) {
-	key := newKey(27, 80, u8proto.ANY, trafficdirection.Ingress)
+	key := newKey(27, 80, u8proto.TCP, trafficdirection.Ingress)
 	err := testMap.Map.Delete(&key)
 	c.Assert(err, Not(IsNil))
 	var errno unix.Errno

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -101,21 +101,21 @@ func (pm *PolicyMapPrivilegedTestSuite) TestDeleteNonexistentKey(c *C) {
 func (pm *PolicyMapPrivilegedTestSuite) TestDenyPolicyMapDumpToSlice(c *C) {
 	c.Assert(testMap, NotNil)
 
-	fooEntry := newKey(1, 1, 1, 1)
-	fooValue := newEntry(0, 0, getPolicyEntryFlags(policyEntryFlagParams{IsDeny: true}))
-	err := testMap.DenyKey(fooEntry)
+	fooKey := newKey(1, 1, 1, 1)
+	fooEntry := newDenyEntry(fooKey)
+	err := testMap.DenyKey(fooKey)
 	c.Assert(err, IsNil)
 
 	dump, err := testMap.DumpToSlice()
 	c.Assert(err, IsNil)
 	c.Assert(len(dump), Equals, 1)
 
-	c.Assert(dump[0].Key, checker.DeepEquals, fooEntry)
-	c.Assert(dump[0].PolicyEntry, checker.DeepEquals, fooValue)
+	c.Assert(dump[0].Key, checker.DeepEquals, fooKey)
+	c.Assert(dump[0].PolicyEntry, checker.DeepEquals, fooEntry)
 
 	// Special case: deny-all entry
-	barEntry := newKey(0, 0, 0, 0)
-	err = testMap.DenyKey(barEntry)
+	barKey := newKey(0, 0, 0, 0)
+	err = testMap.DenyKey(barKey)
 	c.Assert(err, IsNil)
 
 	dump, err = testMap.DumpToSlice()

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -36,7 +36,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 				{
 					Key: PolicyKey{
 						Identity:         uint32(0),
-						DestPort:         0,
+						DestPortNetwork:  0,
 						Nexthdr:          0,
 						TrafficDirection: uint8(trafficdirection.Ingress),
 					},
@@ -54,7 +54,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 				{
 					Key: PolicyKey{
 						Identity:         uint32(0),
-						DestPort:         0,
+						DestPortNetwork:  0,
 						Nexthdr:          0,
 						TrafficDirection: uint8(trafficdirection.Ingress),
 					},
@@ -62,7 +62,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 				{
 					Key: PolicyKey{
 						Identity:         uint32(1),
-						DestPort:         0,
+						DestPortNetwork:  0,
 						Nexthdr:          0,
 						TrafficDirection: uint8(trafficdirection.Ingress),
 					},
@@ -80,7 +80,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 				{
 					Key: PolicyKey{
 						Identity:         uint32(0),
-						DestPort:         0,
+						DestPortNetwork:  0,
 						Nexthdr:          0,
 						TrafficDirection: uint8(trafficdirection.Ingress),
 					},
@@ -88,7 +88,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 				{
 					Key: PolicyKey{
 						Identity:         uint32(1),
-						DestPort:         0,
+						DestPortNetwork:  0,
 						Nexthdr:          0,
 						TrafficDirection: uint8(trafficdirection.Egress),
 					},
@@ -106,7 +106,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 				{
 					Key: PolicyKey{
 						Identity:         uint32(1),
-						DestPort:         0,
+						DestPortNetwork:  0,
 						Nexthdr:          0,
 						TrafficDirection: uint8(trafficdirection.Egress),
 					},
@@ -114,7 +114,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 				{
 					Key: PolicyKey{
 						Identity:         uint32(0),
-						DestPort:         0,
+						DestPortNetwork:  0,
 						Nexthdr:          0,
 						TrafficDirection: uint8(trafficdirection.Egress),
 					},
@@ -132,7 +132,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 				{
 					Key: PolicyKey{
 						Identity:         uint32(1),
-						DestPort:         0,
+						DestPortNetwork:  0,
 						Nexthdr:          0,
 						TrafficDirection: uint8(trafficdirection.Egress),
 					},
@@ -140,7 +140,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 				{
 					Key: PolicyKey{
 						Identity:         uint32(0),
-						DestPort:         0,
+						DestPortNetwork:  0,
 						Nexthdr:          0,
 						TrafficDirection: uint8(trafficdirection.Egress),
 					},

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -289,7 +289,7 @@ var badLogMessages = map[string][]string{
 	segmentationFault:   nil,
 	NACKreceived:        nil,
 	RunInitFailed:       {"signal: terminated", "signal: killed"},
-	sizeMismatch:        nil,
+	sizeMismatch:        {"globals/cilium_policy"},
 	emptyBPFInitArg:     nil,
 	RemovingMapMsg:      nil,
 	logBufferMessage:    nil,


### PR DESCRIPTION
Change to use LPM trie map for endpoint policy, as this allows prefix based wildcarding of protocol and port, when placed at the end of the map key. This helps eliminate two policy map lookups, which should help offset the performance penalty of a more complex map lookup.

This involves both changing the map type, and extending the policymap key with the prefix length field that is customary to all LPM maps. At the same time we need to reorganise the key fields so that the fields we plan to wildcard are at the end of the key and in the order of the port being the last field and protocol before it, as it can be wildcarded also when the protocol is not wildcarded, but the protocol can be wildcarded only if the port is also (completely) wildcarded.

With this new LPM policy map we still need a second lookup with an explicitly wildcarded security ID, as it can be wildcarded also when protocol and/or port are being matched.

As Cilium agent can re-populate policy maps from scratch there is no need for any specific upgrade/downgrade support for the map type and key layout change. Old programs keep using the old policy maps they were started with, while new programs for all endpoints upon the start of the upgraded Cilium agent will the new maps when they are loaded.

This change is a prerequisite for port range support in network policy.
