### PR TITLE
ingress conformance test: Wait for availability of loadbalancer

### DIFF
--- a/.github/workflows/conformance-ingress-default.yaml
+++ b/.github/workflows/conformance-ingress-default.yaml
@@ -141,7 +141,11 @@ jobs:
           kubectl apply -n default -f examples/kubernetes/servicemesh/basic-ingress.yaml
           kubectl wait -n default --for=condition=Ready --all pod --timeout=${{ env.timeout }}
 
-          lb=$(kubectl get ingress basic-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          echo 'Waiting for available loadbalancer...'
+          lb=$(kubectl -n kube-system get svc cilium-ingress -o jsonpath='{.spec.clusterIP}')
+          kubectl -n default wait ingress basic-ingress --for=jsonpath='{.status.loadBalancer.ingress[0].ip}'="$lb" --timeout=${{ env.timeout }}
+          
+          echo 'Calling ingress...'
           curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail -- http://"$lb"
           curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail -- http://"$lb"/details/1
 

--- a/.github/workflows/conformance-ingress-shared.yaml
+++ b/.github/workflows/conformance-ingress-shared.yaml
@@ -141,7 +141,11 @@ jobs:
           kubectl apply -n default -f examples/kubernetes/servicemesh/basic-ingress.yaml
           kubectl wait -n default --for=condition=Ready --all pod --timeout=${{ env.timeout }}
 
-          lb=$(kubectl get ingress basic-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          echo 'Waiting for available loadbalancer...'
+          lb=$(kubectl -n default get svc cilium-ingress-basic-ingress -o jsonpath='{.spec.clusterIP}')
+          kubectl -n default wait ingress basic-ingress --for=jsonpath='{.status.loadBalancer.ingress[0].ip}'="$lb" --timeout=${{ env.timeout }}
+          
+          echo 'Calling ingress...'
           curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail -- http://"$lb"
           curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail -- http://"$lb"/details/1
 

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -138,7 +138,11 @@ jobs:
           kubectl apply -n default -f examples/kubernetes/servicemesh/basic-ingress.yaml
           kubectl wait -n default --for=condition=Ready --all pod --timeout=${{ env.timeout }}
 
-          lb=$(kubectl get ingress basic-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          echo 'Waiting for available loadbalancer...'
+          lb=$(kubectl -n default get svc cilium-ingress-basic-ingress -o jsonpath='{.spec.clusterIP}')
+          kubectl -n default wait ingress basic-ingress --for=jsonpath='{.status.loadBalancer.ingress[0].ip}'="$lb" --timeout=${{ env.timeout }}
+          
+          echo 'Calling ingress...'
           curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail -- http://"$lb"
           curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail -- http://"$lb"/details/1
 


### PR DESCRIPTION
Before calling the ingress during ingress conformance tests - it must be ensured that the service loadbalancer is already setup with an external ip. If the ingress isn't available - the upcoming curl request fails.