### PR TITLE
Fix TLS policies after certificatemanager modularization

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -179,6 +179,7 @@ func NewPolicyRepository(
 		RuleReactionQueue:     ruleReactionQueue,
 		selectorCache:         selectorCache,
 		certManager:           certManager,
+		secretManager:         secretManager,
 	}
 	repo.policyCache = NewPolicyCache(repo, true)
 	return repo

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -27,11 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
-type CertificateManager interface {
-	GetTLSContext(ctx context.Context, tls *api.TLSContext, defaultNs string) (ca, public, private string, err error)
-	GetSecretString(ctx context.Context, secret *api.Secret, defaultNs string) (string, error)
-}
-
 // PolicyContext is an interface policy resolution functions use to access the Repository.
 // This way testing code can run without mocking a full Repository.
 type PolicyContext interface {


### PR DESCRIPTION
PR #23132 modularized the `certificatemanager` and inadvertently broke TLS policies. The respective tests are currently quarantined:

https://github.com/cilium/cilium/blob/aaeb26023a8509d4f9273f2a825ccd539fc9fa87/test/k8s/net_policies.go#L140

Thus the breakage was not caught in CI on the PR.

