### PR TITLE
ipam/clusterpool: Verify that clientset is initialized

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -130,6 +130,9 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 		}
 	case ipamOption.IPAMClusterPoolV2:
 		log.Info("Initializing ClusterPool v2 IPAM")
+		if !clientset.IsEnabled() {
+			log.Fatal("ClusterPool v2 IPAM is not compatible with lb-only datamode")
+		}
 
 		if c.IPv6Enabled() {
 			ipam.IPv6Allocator = newClusterPoolAllocator(IPv6, c, owner, k8sEventReg, clientset)
@@ -139,6 +142,10 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 		}
 	case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
 		log.Info("Initializing CRD-based IPAM")
+		if !clientset.IsEnabled() {
+			log.Fatal("CRD-based IPAM is not compatible with lb-only datamode")
+		}
+
 		if c.IPv6Enabled() {
 			ipam.IPv6Allocator = newCRDAllocator(IPv6, c, owner, clientset, k8sEventReg, mtuConfig)
 		}


### PR DESCRIPTION
If a k8s client is not set up clientset.CiliumV2() returns nil. This code double checks that and avoids a stacktrace.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

clientset.CiliumV2() might be nil, check that to avoid stacktrace.

Fixes: #23818