### PR TITLE
docs: Promote Deny Policies out of Beta

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1174,8 +1174,6 @@ for instructions.
 Deny Policies
 =============
 
-.. include:: ../../beta.rst
-
 Deny policies, available and enabled by default since Cilium 1.9, allows to
 explicitly restrict certain traffic to and from a Pod.
 


### PR DESCRIPTION
Deny policies have been labeled as a "beta" feature in Cilium for a long time as they were not fully functional. Now that Deny policies have no major issues, they can be safely used as a non-beta feature.
