### PR TITLE
v1.11 backport: In service recovery, don't skip if one of the service recovery fails

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -592,4 +592,16 @@ const (
 
 	// IPSec old SPI
 	OldSPI = "oldSPI"
+
+	// Number of Backends failed while restoration.
+	RestoredBackends = "restoredBackends"
+
+	// Number of Backends failed while restoration.
+	FailedBackends = "failedBackends"
+
+	// Number of Services failed while restoration.
+	RestoredSVCs = "restoredServices"
+
+	// Number of Services failed while restoration.
+	FailedSVCs = "failedServices"
 )


### PR DESCRIPTION
This is a backport of https://github.com/cilium/cilium/pull/18422 as without it, issues like https://github.com/cilium/cilium/issues/23551 can be greatly exacerbated when agents are restarted (i.e. any daemonset update). I directly cherry-picked `018856602b7637b8ae1c796f4ed02fe1bbeb5905` to the v1.11 branch and only had a small merge conflict in `pkg/logging/logfields/logfields.go` which was easily fixable. 


- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: N/A

```release-note
In service recovery, don't skip if one of the service recovery fails
```
