### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/.github/workflows/conformance-ingress-default.yaml
+++ b/.github/workflows/conformance-ingress-default.yaml
@@ -79,7 +79,7 @@ jobs:
           minikube image load ${{ env.ECHO_SERVER_IMAGE }}
           minikube tunnel &
         env:
-          ECHO_SERVER_IMAGE: k8s.gcr.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
+          ECHO_SERVER_IMAGE: registry.k8s.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
 
       - name: Checkout ingress-controller-conformance
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.github/workflows/conformance-ingress-shared.yaml
+++ b/.github/workflows/conformance-ingress-shared.yaml
@@ -79,7 +79,7 @@ jobs:
           minikube image load ${{ env.ECHO_SERVER_IMAGE }}
           minikube tunnel &
         env:
-          ECHO_SERVER_IMAGE: k8s.gcr.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
+          ECHO_SERVER_IMAGE: registry.k8s.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
 
       - name: Checkout ingress-controller-conformance
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -79,7 +79,7 @@ jobs:
           minikube image load ${{ env.ECHO_SERVER_IMAGE }}
           minikube tunnel &
         env:
-          ECHO_SERVER_IMAGE: k8s.gcr.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
+          ECHO_SERVER_IMAGE: registry.k8s.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
 
       - name: Checkout ingress-controller-conformance
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/Documentation/operations/performance/scalability/report.rst
+++ b/Documentation/operations/performance/scalability/report.rst
@@ -128,7 +128,7 @@ and all metrics were being gathered.
 * Each deployment had 1 replica (125 pods in total).
 
 * To measure **only** the resources consumed by Cilium, all deployments used
-  the same base image ``k8s.gcr.io/pause:3.2``. This image does not have any
+  the same base image ``registry.k8s.io/pause:3.2``. This image does not have any
   CPU or memory overhead.
 
 * We provision a small number of pods in a small cluster to understand the CPU

--- a/examples/kubernetes-local-redirect/node-local-dns.yaml
+++ b/examples/kubernetes-local-redirect/node-local-dns.yaml
@@ -114,7 +114,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/dns/k8s-dns-node-cache:1.15.16
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.15.16
         resources:
           requests:
             cpu: 25m

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -261,8 +261,8 @@ var nodeSampleJSON = `{
             },
             {
                 "names": [
-                    "k8s.gcr.io/node-problem-detector@sha256:f95cab985c26b2f46e9bd43283e0bfa88860c14e0fb0649266babe8b65e9eb2b",
-                    "k8s.gcr.io/node-problem-detector:v0.4.1"
+                    "registry.k8s.io/node-problem-detector@sha256:f95cab985c26b2f46e9bd43283e0bfa88860c14e0fb0649266babe8b65e9eb2b",
+                    "registry.k8s.io/node-problem-detector:v0.4.1"
                 ],
                 "sizeBytes": 286572743
             },
@@ -282,59 +282,59 @@ var nodeSampleJSON = `{
             },
             {
                 "names": [
-                    "k8s.gcr.io/fluentd-elasticsearch@sha256:a54e7a450c0bdd19f49f56e487427a08c50f99ea8f8846179acf7d4182ce1fc0",
-                    "k8s.gcr.io/fluentd-elasticsearch:v2.2.0"
+                    "registry.k8s.io/fluentd-elasticsearch@sha256:a54e7a450c0bdd19f49f56e487427a08c50f99ea8f8846179acf7d4182ce1fc0",
+                    "registry.k8s.io/fluentd-elasticsearch:v2.2.0"
                 ],
                 "sizeBytes": 138313727
             },
             {
                 "names": [
-                    "k8s.gcr.io/fluentd-gcp-scaler@sha256:457a13df66534b94bab627c4c2dc2df0ee5153a5d0f0afd27502bd46bd8da81d",
-                    "k8s.gcr.io/fluentd-gcp-scaler:0.5"
+                    "registry.k8s.io/fluentd-gcp-scaler@sha256:457a13df66534b94bab627c4c2dc2df0ee5153a5d0f0afd27502bd46bd8da81d",
+                    "registry.k8s.io/fluentd-gcp-scaler:0.5"
                 ],
                 "sizeBytes": 103488147
             },
             {
                 "names": [
-                    "k8s.gcr.io/kubernetes-dashboard-amd64@sha256:dc4026c1b595435ef5527ca598e1e9c4343076926d7d62b365c44831395adbd0",
-                    "k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.3"
+                    "registry.k8s.io/kubernetes-dashboard-amd64@sha256:dc4026c1b595435ef5527ca598e1e9c4343076926d7d62b365c44831395adbd0",
+                    "registry.k8s.io/kubernetes-dashboard-amd64:v1.8.3"
                 ],
                 "sizeBytes": 102319441
             },
             {
                 "names": [
                     "gcr.io/google_containers/kube-proxy:v1.12.5-gke.10",
-                    "k8s.gcr.io/kube-proxy:v1.12.5-gke.10"
+                    "registry.k8s.io/kube-proxy:v1.12.5-gke.10"
                 ],
                 "sizeBytes": 101370340
             },
             {
                 "names": [
-                    "k8s.gcr.io/event-exporter@sha256:7f9cd7cb04d6959b0aa960727d04fa86759008048c785397b7b0d9dff0007516",
-                    "k8s.gcr.io/event-exporter:v0.2.3"
+                    "registry.k8s.io/event-exporter@sha256:7f9cd7cb04d6959b0aa960727d04fa86759008048c785397b7b0d9dff0007516",
+                    "registry.k8s.io/event-exporter:v0.2.3"
                 ],
                 "sizeBytes": 94171943
             },
             {
                 "names": [
                     "gcr.io/google-containers/prometheus-to-sd@sha256:6c0c742475363d537ff059136e5d5e4ab1f512ee0fd9b7ca42ea48bc309d1662",
-                    "k8s.gcr.io/prometheus-to-sd@sha256:6c0c742475363d537ff059136e5d5e4ab1f512ee0fd9b7ca42ea48bc309d1662",
+                    "registry.k8s.io/prometheus-to-sd@sha256:6c0c742475363d537ff059136e5d5e4ab1f512ee0fd9b7ca42ea48bc309d1662",
                     "gcr.io/google-containers/prometheus-to-sd:v0.3.1",
-                    "k8s.gcr.io/prometheus-to-sd:v0.3.1"
+                    "registry.k8s.io/prometheus-to-sd:v0.3.1"
                 ],
                 "sizeBytes": 88077694
             },
             {
                 "names": [
-                    "k8s.gcr.io/heapster-amd64@sha256:9fae0af136ce0cf4f88393b3670f7139ffc464692060c374d2ae748e13144521",
-                    "k8s.gcr.io/heapster-amd64:v1.6.0-beta.1"
+                    "registry.k8s.io/heapster-amd64@sha256:9fae0af136ce0cf4f88393b3670f7139ffc464692060c374d2ae748e13144521",
+                    "registry.k8s.io/heapster-amd64:v1.6.0-beta.1"
                 ],
                 "sizeBytes": 76016169
             },
             {
                 "names": [
-                    "k8s.gcr.io/ingress-gce-glbc-amd64@sha256:14f14351a03038b238232e60850a9cfa0dffbed0590321ef84216a432accc1ca",
-                    "k8s.gcr.io/ingress-gce-glbc-amd64:v1.2.3"
+                    "registry.k8s.io/ingress-gce-glbc-amd64@sha256:14f14351a03038b238232e60850a9cfa0dffbed0590321ef84216a432accc1ca",
+                    "registry.k8s.io/ingress-gce-glbc-amd64:v1.2.3"
                 ],
                 "sizeBytes": 71797285
             },
@@ -347,45 +347,45 @@ var nodeSampleJSON = `{
             },
             {
                 "names": [
-                    "k8s.gcr.io/kube-addon-manager@sha256:d53486c3a0b49ebee019932878dc44232735d5622a51dbbdcec7124199020d09",
-                    "k8s.gcr.io/kube-addon-manager:v8.7"
+                    "registry.k8s.io/kube-addon-manager@sha256:d53486c3a0b49ebee019932878dc44232735d5622a51dbbdcec7124199020d09",
+                    "registry.k8s.io/kube-addon-manager:v8.7"
                 ],
                 "sizeBytes": 63322109
             },
             {
                 "names": [
-                    "k8s.gcr.io/cpvpa-amd64@sha256:cfe7b0a11c9c8e18c87b1eb34fef9a7cbb8480a8da11fc2657f78dbf4739f869",
-                    "k8s.gcr.io/cpvpa-amd64:v0.6.0"
+                    "registry.k8s.io/cpvpa-amd64@sha256:cfe7b0a11c9c8e18c87b1eb34fef9a7cbb8480a8da11fc2657f78dbf4739f869",
+                    "registry.k8s.io/cpvpa-amd64:v0.6.0"
                 ],
                 "sizeBytes": 51785854
             },
             {
                 "names": [
-                    "k8s.gcr.io/k8s-dns-kube-dns-amd64@sha256:618a82fa66cf0c75e4753369a6999032372be7308866fc9afb381789b1e5ad52",
-                    "k8s.gcr.io/k8s-dns-kube-dns@sha256:c54a527a4ba8f1bc15e4796b09bf5d69313c7f42af9911dc437e056c0264a2fe",
-                    "k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13",
-                    "k8s.gcr.io/k8s-dns-kube-dns:1.14.13"
+                    "registry.k8s.io/k8s-dns-kube-dns-amd64@sha256:618a82fa66cf0c75e4753369a6999032372be7308866fc9afb381789b1e5ad52",
+                    "registry.k8s.io/k8s-dns-kube-dns@sha256:c54a527a4ba8f1bc15e4796b09bf5d69313c7f42af9911dc437e056c0264a2fe",
+                    "registry.k8s.io/k8s-dns-kube-dns-amd64:1.14.13",
+                    "registry.k8s.io/k8s-dns-kube-dns:1.14.13"
                 ],
                 "sizeBytes": 51157394
             },
             {
                 "names": [
-                    "k8s.gcr.io/cluster-proportional-autoscaler-amd64@sha256:36359630278b119e7dd78f5437be1c667080108fa59ecba1b81cda3610dcf4d7",
-                    "k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.2.0"
+                    "registry.k8s.io/cluster-proportional-autoscaler-amd64@sha256:36359630278b119e7dd78f5437be1c667080108fa59ecba1b81cda3610dcf4d7",
+                    "registry.k8s.io/cluster-proportional-autoscaler-amd64:1.2.0"
                 ],
                 "sizeBytes": 50258329
             },
             {
                 "names": [
-                    "k8s.gcr.io/cluster-proportional-autoscaler-amd64@sha256:003f98d9f411ddfa6ff6d539196355e03ddd69fa4ed38c7ffb8fec6f729afe2d",
-                    "k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2"
+                    "registry.k8s.io/cluster-proportional-autoscaler-amd64@sha256:003f98d9f411ddfa6ff6d539196355e03ddd69fa4ed38c7ffb8fec6f729afe2d",
+                    "registry.k8s.io/cluster-proportional-autoscaler-amd64:1.1.2-r2"
                 ],
                 "sizeBytes": 49648481
             },
             {
                 "names": [
-                    "k8s.gcr.io/ip-masq-agent-amd64@sha256:1ffda57d87901bc01324c82ceb2145fe6a0448d3f0dd9cb65aa76a867cd62103",
-                    "k8s.gcr.io/ip-masq-agent-amd64:v2.1.1"
+                    "registry.k8s.io/ip-masq-agent-amd64@sha256:1ffda57d87901bc01324c82ceb2145fe6a0448d3f0dd9cb65aa76a867cd62103",
+                    "registry.k8s.io/ip-masq-agent-amd64:v2.1.1"
                 ],
                 "sizeBytes": 49612505
             },

--- a/test/controlplane/node/ciliumnodes/v1.24/init.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/init.yaml
@@ -89,18 +89,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -108,7 +108,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -117,7 +117,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -219,18 +219,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -239,7 +239,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -248,7 +248,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/node/ciliumnodes/v1.24/state1.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state1.yaml
@@ -89,18 +89,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -108,7 +108,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -117,7 +117,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -220,18 +220,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -240,7 +240,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -249,7 +249,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/node/ciliumnodes/v1.24/state2.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state2.yaml
@@ -89,18 +89,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -108,7 +108,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -117,7 +117,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -219,18 +219,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -239,7 +239,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -248,7 +248,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/node/ciliumnodes/v1.24/state3.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state3.yaml
@@ -89,18 +89,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -108,7 +108,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -117,7 +117,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -220,18 +220,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -240,7 +240,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -249,7 +249,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/node/ciliumnodes/v1.24/state4.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state4.yaml
@@ -89,18 +89,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -108,7 +108,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -117,7 +117,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -220,18 +220,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -240,7 +240,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -249,7 +249,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/services/dualstack/v1.24/init.yaml
+++ b/test/controlplane/services/dualstack/v1.24/init.yaml
@@ -87,22 +87,22 @@ items:
     images:
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -111,7 +111,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -216,18 +216,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -236,7 +236,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -245,7 +245,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -350,18 +350,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -369,7 +369,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -378,7 +378,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/services/dualstack/v1.26/init.yaml
+++ b/test/controlplane/services/dualstack/v1.26/init.yaml
@@ -87,22 +87,22 @@ items:
     images:
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -111,7 +111,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -216,18 +216,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -236,7 +236,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -245,7 +245,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -350,18 +350,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -369,7 +369,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -378,7 +378,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/services/nodeport/v1.24/init.yaml
+++ b/test/controlplane/services/nodeport/v1.24/init.yaml
@@ -92,18 +92,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-13@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -111,7 +111,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -120,7 +120,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -225,18 +225,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-13@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -244,7 +244,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -253,7 +253,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -358,18 +358,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-13@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -378,7 +378,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -387,7 +387,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -130,7 +130,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.16/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/eks/coredns_deployment.yaml
@@ -118,7 +118,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/coredns_deployment.yaml
@@ -132,7 +132,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/eks/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/coredns_deployment.yaml
@@ -132,7 +132,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/eks/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.19/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/coredns_deployment.yaml
@@ -146,7 +146,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.19/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/eks/coredns_deployment.yaml
@@ -138,7 +138,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.20/coredns_deployment.yaml
+++ b/test/provision/manifest/1.20/coredns_deployment.yaml
@@ -145,7 +145,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.20/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.20/eks/coredns_deployment.yaml
@@ -145,7 +145,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.21/coredns_deployment.yaml
+++ b/test/provision/manifest/1.21/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.21/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.21/eks/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.22/coredns_deployment.yaml
+++ b/test/provision/manifest/1.22/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.22/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.22/eks/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.23/coredns_deployment.yaml
+++ b/test/provision/manifest/1.23/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.23/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.23/eks/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.24/coredns_deployment.yaml
+++ b/test/provision/manifest/1.24/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.24/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.24/eks/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.25/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.25/eks/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/coredns_deployment.yaml
+++ b/test/provision/manifest/coredns_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
k8s.gcr.io will be frozen on 2023/04/03.

Ref: https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/

Suggested-by: Dylan Reimerink <dylan.reimerink@isovalent.com>
Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>