### PR TITLE
kvstore: add clusterName suffix to session controllers

### DIFF
--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -163,10 +163,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 			DoFunc: func(ctx context.Context) error {
 				rc.releaseOldConnection()
 
-				extraOpts := kvstore.ExtraOptions{NoLockQuorumCheck: true}
-				if rc.mesh.conf.NodeManager != nil {
-					extraOpts.ClusterSizeDependantInterval = rc.mesh.conf.NodeManager.ClusterSizeDependantInterval
-				}
+				extraOpts := rc.makeExtraOpts()
 
 				backend, errChan := kvstore.NewClient(ctx, kvstore.EtcdBackendName,
 					map[string]string{
@@ -275,6 +272,17 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 			},
 		},
 	)
+}
+
+func (rc *remoteCluster) makeExtraOpts() kvstore.ExtraOptions {
+	extraOpts := kvstore.ExtraOptions{
+		NoLockQuorumCheck: true,
+		ClusterName:       rc.name,
+	}
+	if rc.mesh.conf.NodeManager != nil {
+		extraOpts.ClusterSizeDependantInterval = rc.mesh.conf.NodeManager.ClusterSizeDependantInterval
+	}
+	return extraOpts
 }
 
 func (rc *remoteCluster) onInsert(allocator RemoteIdentityWatcher) {

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -34,6 +34,9 @@ type ExtraOptions struct {
 
 	// NoLockQuorumCheck disables the lock acquisition quorum check
 	NoLockQuorumCheck bool
+
+	// ClusterName is the name of each etcd cluster
+	ClusterName string
 }
 
 // StatusCheckInterval returns the interval of status checks depending on the


### PR DESCRIPTION
Previously all session/locksession controllers used the same name as a controller name (even the ones for remote clusters) and it was not possible to distinguish between them.

`cilium status --verbose` would show this output for clustermesh with 4 remote clusters:
```
  kvstore-etcd-lock-session-renew      never          never        0       no error   
  kvstore-etcd-lock-session-renew      never          never        0       no error   
  kvstore-etcd-lock-session-renew      never          never        0       no error   
  kvstore-etcd-lock-session-renew      never          never        0       no error   
  kvstore-etcd-lock-session-renew      never          never        0       no error   
  kvstore-etcd-session-renew        never          never        0       no error   
  kvstore-etcd-session-renew        never          never        0       no error   
  kvstore-etcd-session-renew        never          never        0       no error   
  kvstore-etcd-session-renew        never          never        0       no error   
  kvstore-etcd-session-renew        never          never        0       no error 
  ```
And noone has any idea which belongs to which connection.

This commit adds a suffix with a cluster name to each session controller name i.e.:
```
  kvstore-etcd-lock-session-renew                                       never          never        0       no error   
  kvstore-etcd-lock-session-renew-tt-k8st1-oa                           never          never        0       no error   
  kvstore-etcd-lock-session-renew-tt-k8st3-ko                           never          never        0       no error   
  kvstore-etcd-lock-session-renew-uacl-test-hadoop                      never          never        0       no error   
  kvstore-etcd-lock-session-renew-uacl-test-labrador-test               never          never        0       no error   
  kvstore-etcd-session-renew                                            never          never        0       no error   
  kvstore-etcd-session-renew-tt-k8st1-oa                                never          never        0       no error   
  kvstore-etcd-session-renew-tt-k8st3-ko                                never          never        0       no error   
  kvstore-etcd-session-renew-uacl-test-hadoop                           never          never        0       no error   
  kvstore-etcd-session-renew-uacl-test-labrador-test                    never          never        0       no error
  ```
  
Had a small discussion with Andre about this https://cilium.slack.com/archives/C2B917YHE/p1676646945994179
