### PR TITLE
bpf: encap: endianness cleanups

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -686,13 +686,12 @@ do_netdev_encrypt_pools(struct __ctx_buff *ctx __maybe_unused)
 {
 	int ret = 0;
 #ifdef IP_POOLS
-	__u32 tunnel_endpoint = 0;
+	__be32 tunnel_endpoint = ctx_get_encrypt_dip(ctx);
 	void *data, *data_end;
 	__u32 tunnel_source = IPV4_ENCRYPT_IFACE;
 	struct iphdr *iphdr;
 	__be32 sum;
 
-	tunnel_endpoint = ctx_load_meta(ctx, CB_ENCRYPT_DST);
 	ctx->mark = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &iphdr)) {
@@ -748,9 +747,8 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 		.reason = TRACE_REASON_ENCRYPTED,
 		.monitor = TRACE_PAYLOAD_LEN,
 	};
-	__u32 tunnel_endpoint = 0;
+	__be32 tunnel_endpoint = ctx_get_encrypt_dip(ctx);
 
-	tunnel_endpoint = ctx_load_meta(ctx, CB_ENCRYPT_DST);
 	ctx->mark = 0;
 
 	bpf_clear_meta(ctx);

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -30,8 +30,8 @@ encap_and_redirect_nomark_ipsec(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 	 * use cb[4] here so it doesn't need to be reset by
 	 * bpf_host.
 	 */
-	ctx_store_meta(ctx, CB_ENCRYPT_MAGIC, or_encrypt_key(key));
-	ctx_store_meta(ctx, CB_ENCRYPT_IDENTITY, seclabel);
+	set_encrypt_key_meta(ctx, key);
+	set_identity_meta(ctx, seclabel);
 	set_encrypt_dip(ctx, tunnel_endpoint);
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -13,7 +13,7 @@
 #ifdef HAVE_ENCAP
 #ifdef ENABLE_IPSEC
 static __always_inline int
-encap_and_redirect_nomark_ipsec(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
+encap_and_redirect_nomark_ipsec(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 				__u8 key, __u32 seclabel)
 {
 	/* Traffic from local host in tunnel mode will be passed to
@@ -37,7 +37,7 @@ encap_and_redirect_nomark_ipsec(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 }
 
 static __always_inline int
-encap_and_redirect_ipsec(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
+encap_and_redirect_ipsec(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 			 __u8 key, __u32 seclabel)
 {
 	/* IPSec is performed by the stack on any packets with the
@@ -114,7 +114,7 @@ encap_remap_v6_host_address(struct __ctx_buff *ctx __maybe_unused,
 }
 
 static __always_inline int
-__encap_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
+__encap_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 		    __u32 seclabel, __u32 dstid, __u32 vni __maybe_unused,
 		    enum trace_reason ct_reason, __u32 monitor, __u32 *ifindex)
 {
@@ -128,7 +128,7 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 	if (seclabel == HOST_ID)
 		seclabel = LOCAL_NODE_ID;
 
-	node_id = bpf_htonl(tunnel_endpoint);
+	node_id = bpf_ntohl(tunnel_endpoint);
 
 	cilium_dbg(ctx, DBG_ENCAP, node_id, seclabel);
 
@@ -141,7 +141,7 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 }
 
 static __always_inline int
-__encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
+__encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 				 __u32 seclabel, __u32 dstid, __u32 vni,
 				 const struct trace_ctx *trace)
 {
@@ -181,7 +181,7 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
  * On error returns CTX_ACT_DROP or DROP_WRITE_ERROR.
  */
 static __always_inline int
-encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
+encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 			       __u8 key __maybe_unused, __u32 seclabel,
 			       __u32 dstid, const struct trace_ctx *trace)
 {
@@ -197,7 +197,7 @@ encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
  * that requires a valid tunnel_endpoint.
  */
 static __always_inline int
-__encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
+__encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 			 __u8 encrypt_key __maybe_unused, __u32 seclabel,
 			 __u32 dstid, const struct trace_ctx *trace)
 {
@@ -242,7 +242,7 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
  * and finally on successful redirect returns CTX_ACT_REDIRECT.
  */
 static __always_inline int
-encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
+encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 		       __u8 encrypt_key, struct tunnel_key *key, __u32 seclabel,
 		       __u32 dstid, const struct trace_ctx *trace)
 {

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -32,7 +32,7 @@ encap_and_redirect_nomark_ipsec(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 	 */
 	ctx_store_meta(ctx, CB_ENCRYPT_MAGIC, or_encrypt_key(key));
 	ctx_store_meta(ctx, CB_ENCRYPT_IDENTITY, seclabel);
-	ctx_store_meta(ctx, CB_ENCRYPT_DST, tunnel_endpoint);
+	set_encrypt_dip(ctx, tunnel_endpoint);
 	return CTX_ACT_OK;
 }
 

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -37,9 +37,15 @@ get_epid(const struct __sk_buff *ctx)
 }
 
 static __always_inline __maybe_unused void
-set_encrypt_dip(struct __sk_buff *ctx, __u32 ip_endpoint)
+set_encrypt_dip(struct __sk_buff *ctx, __be32 ip_endpoint)
 {
 	ctx->cb[CB_ENCRYPT_DST] = ip_endpoint;
+}
+
+static __always_inline __maybe_unused __be32
+ctx_get_encrypt_dip(struct __sk_buff *ctx)
+{
+	return ctx->cb[CB_ENCRYPT_DST];
 }
 
 /**

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -17,7 +17,7 @@ get_identity(struct xdp_md *ctx __maybe_unused)
 
 static __always_inline __maybe_unused void
 set_encrypt_dip(struct xdp_md *ctx __maybe_unused,
-		__u32 ip_endpoint __maybe_unused)
+		__be32 ip_endpoint __maybe_unused)
 {
 }
 


### PR DESCRIPTION
Some innocent cleanups to what the encap code expects in terms of endianness. I stumbled over that misplaced `bpf_htonl()` a while ago, this should make it easier to understand what's going on.