### PR TITLE
test: Skip K8sPolicyTestExtended on the 4.19

### DIFF
--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -1469,7 +1469,7 @@ var _ = SkipDescribeIf(func() bool {
 // two cases for that feature:
 //   - kube-apiserver running within the cluster (Vagrant VMs)
 //   - kube-apiserver running outside of the cluster (GKE)
-var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrLaterKernel,
+var _ = SkipDescribeIf(helpers.DoesNotRunOn54OrLaterKernel,
 	"K8sPolicyTestExtended", func() {
 		var (
 			kubectl *helpers.Kubectl


### PR DESCRIPTION
The 4.19 CI pipeline is intended to run with KPR=disabled. Unfortunately, it was not the case, as K8sPolicyTestExtended enabled the KPR which left some bpf_sock programs attached. Due to missing \[1\] the programs were in place when the K8sUpdates test was running which made the DNS lookups to fail (bpf_sock was handling them with stale backends instead of kube-proxy's iptables rules).

\[1\]: https://github.com/cilium/cilium/issues/10067

Fix #23845