### PR TITLE
Gather cni logs in bugtool.

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -272,6 +272,7 @@ func catCommands() []string {
 		"/var/log/docker.log",
 		"/var/log/daemon.log",
 		"/var/log/messages",
+		"/var/run/cilium/cilium-cni.log",
 	}
 	// Only print the files that do exist to reduce number of errors in
 	// archive


### PR DESCRIPTION
Fixes: #23912

```release-note
sysdump: Added Kubernetes CNI logs to sysdump.
```