### PR TITLE
identity, policy: remove unused arguments from interfaces

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -109,7 +109,7 @@ func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSel
 		}).Debug("getting identities for IPs associated with FQDNSelector")
 		var currentlyAllocatedIdentities []*identity.Identity
 		if currentlyAllocatedIdentities, err = identityAllocator.AllocateCIDRsForIPs(selectorIPs, newlyAllocatedIdentities); err != nil {
-			identityAllocator.ReleaseSlice(context.TODO(), nil, usedIdentities)
+			identityAllocator.ReleaseSlice(context.TODO(), usedIdentities)
 			log.WithError(err).WithField("prefixes", selectorIPs).Warn(
 				"failed to allocate identities for IPs")
 			return nil, nil, nil, err

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -91,7 +91,7 @@ type IdentityAllocator interface {
 	Release(context.Context, *identity.Identity, bool) (released bool, err error)
 
 	// ReleaseSlice is the slice variant of Release().
-	ReleaseSlice(context.Context, IdentityAllocatorOwner, []*identity.Identity) error
+	ReleaseSlice(context.Context, []*identity.Identity) error
 
 	// LookupIdentityByID returns the identity that corresponds to the given
 	// labels.
@@ -421,7 +421,7 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 // function that may be useful for cleaning up multiple identities in paths
 // where several identities may be allocated and another error means that they
 // should all be released.
-func (m *CachingIdentityAllocator) ReleaseSlice(ctx context.Context, owner IdentityAllocatorOwner, identities []*identity.Identity) error {
+func (m *CachingIdentityAllocator) ReleaseSlice(ctx context.Context, identities []*identity.Identity) error {
 	var err error
 	for _, id := range identities {
 		if id == nil {

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -63,7 +63,7 @@ func (ipc *IPCache) AllocateCIDRs(
 		}
 		id, isNew, err := ipc.resolveIdentity(allocateCtx, prefix, info, oldNID)
 		if err != nil {
-			ipc.IdentityAllocator.ReleaseSlice(context.Background(), nil, usedIdentities)
+			ipc.IdentityAllocator.ReleaseSlice(context.Background(), usedIdentities)
 			ipc.Unlock()
 			ipc.metadata.RUnlock()
 			return nil, err

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -147,7 +147,7 @@ type identitySelector interface {
 	// fetchIdentityMappings returns all of the identities currently
 	// reference-counted by this selector. It is used during cleanup of the
 	// selector.
-	fetchIdentityMappings(cache.IdentityAllocator) []identity.NumericIdentity
+	fetchIdentityMappings() []identity.NumericIdentity
 
 	// This may be called while the NameManager lock is held. wg.Wait()
 	// returns after user notifications have been completed, which may require
@@ -533,7 +533,7 @@ func (f *fqdnSelector) transferIdentityReferencesToSelector(currentlyAllocatedId
 // holds references for. This should be used during cleanup of the selector
 // to ensure that all remaining references to local identities are released,
 // in order to prevent leaking of identities.
-func (f *fqdnSelector) fetchIdentityMappings(idAllocator cache.IdentityAllocator) []identity.NumericIdentity {
+func (f *fqdnSelector) fetchIdentityMappings() []identity.NumericIdentity {
 	ids := make([]identity.NumericIdentity, 0, len(f.cachedSelections))
 	for id := range f.cachedSelections {
 		ids = append(ids, id)
@@ -637,7 +637,7 @@ func (l *labelIdentitySelector) matches(identity scIdentity) bool {
 	return l.matchesNamespace(identity.namespace) && l.selector.Matches(identity.lbls)
 }
 
-func (l *labelIdentitySelector) fetchIdentityMappings(idAllocator cache.IdentityAllocator) []identity.NumericIdentity {
+func (l *labelIdentitySelector) fetchIdentityMappings() []identity.NumericIdentity {
 	// labelIdentitySelectors don't retain identity references, so no-op.
 	return nil
 }
@@ -928,7 +928,7 @@ func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user Cach
 	if exists {
 		if sel.removeUser(user, sc.localIdentityNotifier) {
 			delete(sc.selectors, key)
-			identitiesToRelease = sel.fetchIdentityMappings(sc.idAllocator)
+			identitiesToRelease = sel.fetchIdentityMappings()
 		}
 	}
 	return identitiesToRelease

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -121,7 +121,7 @@ func (f *MockIdentityAllocator) Release(_ context.Context, id *identity.Identity
 }
 
 // ReleaseSlice wraps Release for slices.
-func (f *MockIdentityAllocator) ReleaseSlice(ctx context.Context, _ cache.IdentityAllocatorOwner, identities []*identity.Identity) error {
+func (f *MockIdentityAllocator) ReleaseSlice(ctx context.Context, identities []*identity.Identity) error {
 	for _, id := range identities {
 		if _, err := f.Release(ctx, id, false); err != nil {
 			return err


### PR DESCRIPTION
Remove unused arguments from two interface definitions.

This is a deliberately tiny PR so that I can figure out how to get things merged.