### PR TITLE
clustermesh: fix services cache bloat due to incorrect deletion

### DIFF
--- a/pkg/clustermesh/services.go
+++ b/pkg/clustermesh/services.go
@@ -113,7 +113,7 @@ func (c *globalServiceCache) onDelete(svc *serviceStore.ClusterService) {
 
 	c.mutex.Lock()
 	if globalService, ok := c.byName[svc.NamespaceServiceName()]; ok {
-		c.delete(globalService, svc.NamespaceServiceName(), svc.Cluster)
+		c.delete(globalService, svc.Cluster, svc.NamespaceServiceName())
 	} else {
 		scopedLog.Debugf("Ignoring delete request for unknown global service")
 	}
@@ -126,7 +126,7 @@ func (c *globalServiceCache) onClusterDelete(clusterName string) {
 
 	c.mutex.Lock()
 	for serviceName, globalService := range c.byName {
-		c.delete(globalService, serviceName, clusterName)
+		c.delete(globalService, clusterName, serviceName)
 	}
 	c.mutex.Unlock()
 }

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/pkg/checker"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -28,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/rand"
+	serviceStore "github.com/cilium/cilium/pkg/service/store"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
@@ -328,4 +330,61 @@ func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesNonGlobal(c *C) {
 		swgSvcs.Wait()
 		return true
 	}, 2*time.Second), IsNil)
+}
+
+type fakeServiceMerger struct {
+	updated map[string]int
+	deleted map[string]int
+}
+
+func (f *fakeServiceMerger) init() {
+	f.updated = make(map[string]int)
+	f.deleted = make(map[string]int)
+}
+
+func (f *fakeServiceMerger) MergeExternalServiceUpdate(service *serviceStore.ClusterService, _ *lock.StoppableWaitGroup) {
+	f.updated[service.String()]++
+}
+
+func (f *fakeServiceMerger) MergeExternalServiceDelete(service *serviceStore.ClusterService, _ *lock.StoppableWaitGroup) {
+	f.deleted[service.String()]++
+}
+
+func (s *ClusterMeshServicesTestSuite) TestRemoteServiceObserver(c *C) {
+	svc1 := serviceStore.ClusterService{Cluster: "remote", Namespace: "namespace", Name: "name", IncludeExternal: true, Shared: true}
+	cache := newGlobalServiceCache("cluster", "node")
+	merger := fakeServiceMerger{}
+
+	observer := remoteServiceObserver{
+		remoteCluster: &remoteCluster{
+			mesh: &ClusterMesh{
+				globalServices: cache,
+				conf:           Configuration{ServiceMerger: &merger},
+			},
+		},
+		swg: lock.NewStoppableWaitGroup(),
+	}
+
+	// Observe a new service update (for a shared service), and assert it is correctly added to the cache
+	merger.init()
+	observer.OnUpdate(&svc1)
+
+	c.Assert(merger.updated[svc1.String()], Equals, 1)
+	c.Assert(merger.deleted[svc1.String()], Equals, 0)
+
+	c.Assert(cache.byName, HasLen, 1)
+	gs, ok := cache.byName[svc1.NamespaceServiceName()]
+	c.Assert(ok, Equals, true)
+	c.Assert(gs.clusterServices, HasLen, 1)
+	found, ok := gs.clusterServices[svc1.Cluster]
+	c.Assert(ok, Equals, true)
+	c.Assert(found, checker.DeepEquals, &svc1)
+
+	// Observe a new service deletion, and assert it is correctly removed from the cache
+	merger.init()
+	observer.OnDelete(&svc1)
+
+	c.Assert(merger.updated[svc1.String()], Equals, 0)
+	c.Assert(merger.deleted[svc1.String()], Equals, 1)
+	c.Assert(cache.byName, HasLen, 0)
 }


### PR DESCRIPTION
Due to a swap in the order of the parameters, deleted global services were never removed from the cache, which continued to grow in size. This commit fixes the issue and adds a new test to prevent regressions.

I'm marking this for backport to all versions, given that all are affected, and the change is trivial.

<!-- Description of change -->

```release-note
clustermesh: fix services cache bloat due to incorrect deletion
```
