### PR TITLE
clustermesh: reduce memory consumption due to non-shared services

### DIFF
--- a/pkg/clustermesh/services.go
+++ b/pkg/clustermesh/services.go
@@ -60,6 +60,19 @@ func newGlobalServiceCache(clusterName, nodeName string) *globalServiceCache {
 	return gsc
 }
 
+// has returns whether a given service is present in the cache.
+func (c *globalServiceCache) has(svc *serviceStore.ClusterService) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if globalSvc, ok := c.byName[svc.NamespaceServiceName()]; ok {
+		_, ok = globalSvc.clusterServices[svc.Cluster]
+		return ok
+	}
+
+	return false
+}
+
 func (c *globalServiceCache) onUpdate(svc *serviceStore.ClusterService) {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.ServiceName: svc.String(),
@@ -84,7 +97,7 @@ func (c *globalServiceCache) onUpdate(svc *serviceStore.ClusterService) {
 }
 
 // must be called with c.mutex held
-func (c *globalServiceCache) delete(globalService *globalService, clusterName, serviceName string) {
+func (c *globalServiceCache) delete(globalService *globalService, clusterName, serviceName string) bool {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.ServiceName: serviceName,
 		logfields.ClusterName: clusterName,
@@ -92,7 +105,7 @@ func (c *globalServiceCache) delete(globalService *globalService, clusterName, s
 
 	if _, ok := globalService.clusterServices[clusterName]; !ok {
 		scopedLog.Debug("Ignoring delete request for unknown cluster")
-		return
+		return false
 	}
 
 	scopedLog.Debugf("Deleted service definition of remote cluster")
@@ -105,19 +118,23 @@ func (c *globalServiceCache) delete(globalService *globalService, clusterName, s
 		delete(c.byName, serviceName)
 		c.metricTotalGlobalServices.WithLabelValues(c.clusterName, c.nodeName).Set(float64(len(c.byName)))
 	}
+
+	return true
 }
 
-func (c *globalServiceCache) onDelete(svc *serviceStore.ClusterService) {
+func (c *globalServiceCache) onDelete(svc *serviceStore.ClusterService) bool {
 	scopedLog := log.WithFields(logrus.Fields{logfields.ServiceName: svc.String()})
 	scopedLog.Debug("Delete event for service")
 
 	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	if globalService, ok := c.byName[svc.NamespaceServiceName()]; ok {
-		c.delete(globalService, svc.Cluster, svc.NamespaceServiceName())
+		return c.delete(globalService, svc.Cluster, svc.NamespaceServiceName())
 	} else {
 		scopedLog.Debugf("Ignoring delete request for unknown global service")
+		return false
 	}
-	c.mutex.Unlock()
 }
 
 func (c *globalServiceCache) onClusterDelete(clusterName string) {
@@ -153,6 +170,18 @@ func (r *remoteServiceObserver) OnUpdate(key store.Key) {
 		scopedLog.Debugf("Update event of remote service %#v", svc)
 
 		mesh := r.remoteCluster.mesh
+
+		// Short-circuit the handling of non-shared services
+		if !(svc.IncludeExternal && svc.Shared) {
+			if mesh.globalServices.has(svc) {
+				scopedLog.Debug("Previously shared service is no longer shared: triggering deletion event")
+				r.OnDelete(key)
+			} else {
+				scopedLog.Debug("Ignoring remote service update: service is not shared")
+			}
+			return
+		}
+
 		mesh.globalServices.onUpdate(svc)
 
 		if merger := mesh.conf.ServiceMerger; merger != nil {
@@ -172,7 +201,11 @@ func (r *remoteServiceObserver) OnDelete(key store.NamedKey) {
 		scopedLog.Debugf("Delete event of remote service %#v", svc)
 
 		mesh := r.remoteCluster.mesh
-		mesh.globalServices.onDelete(svc)
+		// Short-circuit the deletion logic if the service was not present (i.e., not shared)
+		if !mesh.globalServices.onDelete(svc) {
+			scopedLog.Debugf("Ignoring remote service delete. Service was not shared")
+			return
+		}
 
 		if merger := mesh.conf.ServiceMerger; merger != nil {
 			merger.MergeExternalServiceDelete(svc, r.swg)

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -352,6 +352,7 @@ func (f *fakeServiceMerger) MergeExternalServiceDelete(service *serviceStore.Clu
 
 func (s *ClusterMeshServicesTestSuite) TestRemoteServiceObserver(c *C) {
 	svc1 := serviceStore.ClusterService{Cluster: "remote", Namespace: "namespace", Name: "name", IncludeExternal: true, Shared: true}
+	svc2 := serviceStore.ClusterService{Cluster: "remote", Namespace: "namespace", Name: "name"}
 	cache := newGlobalServiceCache("cluster", "node")
 	merger := fakeServiceMerger{}
 
@@ -364,6 +365,13 @@ func (s *ClusterMeshServicesTestSuite) TestRemoteServiceObserver(c *C) {
 		},
 		swg: lock.NewStoppableWaitGroup(),
 	}
+
+	// Observe a new service update (for a non-shared service), and assert it is not added to the cache
+	merger.init()
+	observer.OnUpdate(&svc2)
+
+	c.Assert(merger.updated[svc1.String()], Equals, 0)
+	c.Assert(cache.byName, HasLen, 0)
 
 	// Observe a new service update (for a shared service), and assert it is correctly added to the cache
 	merger.init()
@@ -385,6 +393,16 @@ func (s *ClusterMeshServicesTestSuite) TestRemoteServiceObserver(c *C) {
 	observer.OnDelete(&svc1)
 
 	c.Assert(merger.updated[svc1.String()], Equals, 0)
+	c.Assert(merger.deleted[svc1.String()], Equals, 1)
+	c.Assert(cache.byName, HasLen, 0)
+
+	// Observe two service updates in sequence (first shared, then non-shared),
+	// and assert that at the end it is not present in the cache (equivalent to update, then delete).
+	merger.init()
+	observer.OnUpdate(&svc1)
+	observer.OnUpdate(&svc2)
+
+	c.Assert(merger.updated[svc1.String()], Equals, 1)
 	c.Assert(merger.deleted[svc1.String()], Equals, 1)
 	c.Assert(cache.byName, HasLen, 0)
 }


### PR DESCRIPTION
Previously, all events received from the remote services observers were processed, regardless of whether the service was actually shared. This caused an increase in the memory consumed by the agent (due to the cache size growth) and unnecessary processing. This commit introduces a short-circuiting logic to avoid processing non-shared services, and updates the tests to cover such scenario.

As a byproduct, this changes the number of global services reported by `cilium status` (and the corresponding Prometheus metric), which now only include those marked as shared. This is still not 100% accurate, as a service is counted as global even if marked as shared remotely but not locally. Still, fixing this would require a complete rewriting of the metric logic, which is out of scope here.

<!-- Description of change -->

```release-note
clustermesh: reduce memory consumption due to non-shared services
```
