### PR TITLE
docs: Clarify basic kernel requirement

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -19,7 +19,7 @@ Summary
 When running Cilium using the container image ``cilium/cilium``, the host
 system must meet these requirements:
 
-- `Linux kernel`_ >= 4.19.57 (or equivalent)
+- `Linux kernel`_ >= 4.19.57 or equivalent (e.g., 4.18 on RHEL8)
 
 When running Cilium as a native process on your host (i.e. **not** running the
 ``cilium/cilium`` container image) these additional requirements must be met:
@@ -35,14 +35,14 @@ must be met:
 
 - :ref:`req_kvstore` etcd >= 3.1.0
 
-======================== ========================== ===================
-Requirement              Minimum Version            In cilium container
-======================== ========================== ===================
-`Linux kernel`_          >= 4.19.57                 no
-Key-Value store (etcd)   >= 3.1.0                   no
-clang+LLVM               >= 10.0                    yes
-iproute2                 >= 5.9.0 [#iproute2_foot]_ yes
-======================== ========================== ===================
+======================== ============================== ===================
+Requirement              Minimum Version                In cilium container
+======================== ============================== ===================
+`Linux kernel`_          >= 4.19.57 or >= 4.18 on RHEL8 no
+Key-Value store (etcd)   >= 3.1.0                       no
+clang+LLVM               >= 10.0                        yes
+iproute2                 >= 5.9.0 [#iproute2_foot]_     yes
+======================== ============================== ===================
 
 .. [#iproute2_foot] Requires support for eBPF templating as documented
    :ref:`below <iproute2_requirements>`.
@@ -151,8 +151,8 @@ subsystems which integrate with eBPF. Therefore, host systems are required to
 run a recent Linux kernel to run a Cilium agent. More recent kernels may
 provide additional eBPF functionality that Cilium will automatically detect and
 use on agent start. For this version of Cilium, it is recommended to use kernel
-4.19.57 or later (or equivalent). For a list of features that require newer
-kernels, see :ref:`advanced_features`.
+4.19.57 or later (or equivalent such as 4.18 on RHEL8). For a list of features
+that require newer kernels, see :ref:`advanced_features`.
 
 In order for the eBPF feature to be enabled properly, the following kernel
 configuration options must be enabled. This is typically the case with


### PR DESCRIPTION
We now require "4.19.57 or equivalent" kernel for Cilium v1.13+ to operate. Let's clarify what the "equivalent" means here given the RHEL8 case (4.18.x) is a common case.

Fixes: https://github.com/cilium/cilium/pull/23124.