### PR TITLE
gha: Bump timeout to 90 minutes for build commit.

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -13,7 +13,7 @@ jobs:
   build_commits:
     name: Check if build works for every commit
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Configure git
         run: |


### PR DESCRIPTION
The backport PR normally contains a lot of commits, which takes longer than 60 mins as per below run. We can either split the job into 2 parts: one for `make build` and one for `make -C bpf build_all`, or just bump timeout to 90 mins. The later one seems easier in terms of checking diff.

https://github.com/cilium/cilium/actions/runs/4248933091/jobs/7388610170