### PR TITLE
hubble/relay: fix uptime value in ServerStatus implementation

### DIFF
--- a/pkg/hubble/relay/observer/server.go
+++ b/pkg/hubble/relay/observer/server.go
@@ -304,7 +304,7 @@ func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusR
 		resp.SeenFlows += status.SeenFlows
 		// use the oldest uptime as a reference for the uptime as cumulating
 		// values would make little sense
-		if resp.UptimeNs == 0 || resp.UptimeNs > status.UptimeNs {
+		if resp.UptimeNs < status.UptimeNs {
 			resp.UptimeNs = status.UptimeNs
 		}
 	}

--- a/pkg/hubble/relay/observer/server_test.go
+++ b/pkg/hubble/relay/observer/server_test.go
@@ -932,7 +932,7 @@ func TestServerStatus(t *testing.T) {
 					NumFlows:            3333,
 					MaxFlows:            3333,
 					SeenFlows:           3333,
-					UptimeNs:            111111111,
+					UptimeNs:            222222222,
 					NumConnectedNodes:   &wrapperspb.UInt32Value{Value: 2},
 					NumUnavailableNodes: &wrapperspb.UInt32Value{Value: 0},
 				},


### PR DESCRIPTION
Hubble Relay implements Hubble's `observer.ServerStatus` endpoint from a cluster-wide perspective. It forwards `ServerStatus` requests to Hubble peers in the cluster and aggregates the responses. However, while the total number of seen flows can be accumulated, the uptime value cannot. Therefore, the intent for Relay's implementation of `ServerStatus` regarding the uptime value was to return the uptime of the oldest running Hubble server in the cluster. However, the implementation is wrong and Relay reports the newest uptime from all the nodes in the cluster.

In both the Hubble CLI and Hubble UI, the flow rate is reported as the number of flows per second, e.g. when `hubble status`, which is computed as the number of seen flows divided by the uptime. As you can imagine, the flows/s rate would be very wrong when a Hubble server is restarted as the accumulated seen flows in the cluster would be a large number while the uptime, because of the bug mentioned above, would be a very small number resulting in wrong reporting of the flows rate.

This patch fixes this bug by correctly reporting the oldest uptime from all connected Hubble peers instead of the newest one.

Fixes: https://github.com/cilium/hubble/issues/911

```release-note
Hubble Relay: fix reported uptime
```