### PR TITLE
datapath: Do not send ICMP6 NA over cilium_wg0

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -22,6 +22,7 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 	__u16 proto = 0;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
+	__u8 __maybe_unused icmp_type = 0;
 
 	if (!validate_ethertype(ctx, &proto))
 		return DROP_UNSUPPORTED_L2;
@@ -31,6 +32,21 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 	case bpf_htons(ETH_P_IPV6):
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
+#ifdef ENABLE_NODE_ENCRYPTION
+		/* Previously, ICMPv6 NA (reply to NS) was sent over cilium_wg0,
+		 * which resulted in neigh entry not being created due to
+		 * IFF_POINTOPOINT | IFF_NOARP set on cilium_wg0. Therefore,
+		 * NA should not be sent over WG.
+		 */
+		if (ip6->nexthdr == IPPROTO_ICMPV6) {
+			if (data + sizeof(*ip6) + ETH_HLEN +
+			    sizeof(struct icmp6hdr) > data_end)
+				return DROP_INVALID;
+			icmp_type = icmp6_load_type(ctx, ETH_HLEN);
+			if (icmp_type == ICMP6_NA_MSG_TYPE)
+				goto out;
+		}
+#endif
 		dst = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
 #ifndef ENABLE_NODE_ENCRYPTION
 		src = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);


### PR DESCRIPTION
See commit msg.

Successful test run - https://github.com/cilium/cilium/actions/runs/4251516818/jobs/7393997184 (the upcoming IPv6 connectivity tests).

cc @gandro 

Fix #23899