### PR TITLE
fix(helm): add missing updateStrategy to hubble-ui deployment

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -13,6 +13,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: hubble-ui
+  {{- with .Values.hubble.ui.updateStrategy }}
+  strategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
<!-- Description of change -->

This PR ensures that helm value `hubble.ui.updateStrategy` is actually rendered.