### PR TITLE
Enable configuration of the source IP verification per endpoint

### DIFF
--- a/bpf/lib/lxc.h
+++ b/bpf/lib/lxc.h
@@ -18,7 +18,7 @@
 
 #define TEMPLATE_LXC_ID 0xffff
 
-#ifndef DISABLE_SIP_VERIFICATION
+#ifdef ENABLE_SIP_VERIFICATION
 static __always_inline
 int is_valid_lxc_src_ip(struct ipv6hdr *ip6 __maybe_unused)
 {
@@ -43,7 +43,7 @@ int is_valid_lxc_src_ipv4(const struct iphdr *ip4 __maybe_unused)
 	return 0;
 #endif
 }
-#else
+#else /* ENABLE_SIP_VERIFICATION */
 static __always_inline
 int is_valid_lxc_src_ip(struct ipv6hdr *ip6 __maybe_unused)
 {
@@ -55,6 +55,6 @@ int is_valid_lxc_src_ipv4(struct iphdr *ip4 __maybe_unused)
 {
 	return 1;
 }
-#endif
+#endif /* ENABLE_SIP_VERIFICATION */
 
 #endif /* __LIB_LXC_H_ */

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1299,6 +1299,7 @@ func initEnv() {
 	option.Config.Opts.SetBool(option.ConntrackAccounting, true)
 	option.Config.Opts.SetBool(option.ConntrackLocal, false)
 	option.Config.Opts.SetBool(option.PolicyAuditMode, option.Config.PolicyAuditMode)
+	option.Config.Opts.SetBool(option.SourceIPVerification, true)
 
 	monitorAggregationLevel, err := option.ParseMonitorAggregationLevel(option.Config.MonitorAggregation)
 	if err != nil {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -903,8 +903,8 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
 	}
 
-	if e.DisableSIPVerification() {
-		fmt.Fprintf(fw, "#define DISABLE_SIP_VERIFICATION 1\n")
+	if !e.DisableSIPVerification() {
+		fmt.Fprintf(fw, "#define ENABLE_SIP_VERIFICATION 1\n")
 	}
 
 	if !option.Config.EnableHostLegacyRouting && option.Config.DirectRoutingDevice != "" {

--- a/pkg/option/daemon.go
+++ b/pkg/option/daemon.go
@@ -15,16 +15,17 @@ var (
 	}
 
 	DaemonMutableOptionLibrary = OptionLibrary{
-		ConntrackAccounting: &specConntrackAccounting,
-		ConntrackLocal:      &specConntrackLocal,
-		Debug:               &specDebug,
-		DebugLB:             &specDebugLB,
-		DebugPolicy:         &specDebugPolicy,
-		DropNotify:          &specDropNotify,
-		TraceNotify:         &specTraceNotify,
-		PolicyVerdictNotify: &specPolicyVerdictNotify,
-		PolicyAuditMode:     &specPolicyAuditMode,
-		MonitorAggregation:  &specMonitorAggregation,
+		ConntrackAccounting:  &specConntrackAccounting,
+		ConntrackLocal:       &specConntrackLocal,
+		Debug:                &specDebug,
+		DebugLB:              &specDebugLB,
+		DebugPolicy:          &specDebugPolicy,
+		DropNotify:           &specDropNotify,
+		TraceNotify:          &specTraceNotify,
+		PolicyVerdictNotify:  &specPolicyVerdictNotify,
+		PolicyAuditMode:      &specPolicyAuditMode,
+		MonitorAggregation:   &specMonitorAggregation,
+		SourceIPVerification: &specSourceIPVerification,
 	}
 )
 

--- a/pkg/option/endpoint.go
+++ b/pkg/option/endpoint.go
@@ -5,16 +5,17 @@ package option
 
 var (
 	endpointMutableOptionLibrary = OptionLibrary{
-		ConntrackAccounting: &specConntrackAccounting,
-		ConntrackLocal:      &specConntrackLocal,
-		Debug:               &specDebug,
-		DebugLB:             &specDebugLB,
-		DebugPolicy:         &specDebugPolicy,
-		DropNotify:          &specDropNotify,
-		TraceNotify:         &specTraceNotify,
-		PolicyVerdictNotify: &specPolicyVerdictNotify,
-		PolicyAuditMode:     &specPolicyAuditMode,
-		MonitorAggregation:  &specMonitorAggregation,
+		ConntrackAccounting:  &specConntrackAccounting,
+		ConntrackLocal:       &specConntrackLocal,
+		Debug:                &specDebug,
+		DebugLB:              &specDebugLB,
+		DebugPolicy:          &specDebugPolicy,
+		DropNotify:           &specDropNotify,
+		TraceNotify:          &specTraceNotify,
+		PolicyVerdictNotify:  &specPolicyVerdictNotify,
+		PolicyAuditMode:      &specPolicyAuditMode,
+		MonitorAggregation:   &specMonitorAggregation,
+		SourceIPVerification: &specSourceIPVerification,
 	}
 )
 

--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -4,21 +4,22 @@
 package option
 
 const (
-	PolicyTracing       = "PolicyTracing"
-	ConntrackAccounting = "ConntrackAccounting"
-	ConntrackLocal      = "ConntrackLocal"
-	Debug               = "Debug"
-	DebugLB             = "DebugLB"
-	DebugPolicy         = "DebugPolicy"
-	DropNotify          = "DropNotification"
-	TraceNotify         = "TraceNotification"
-	TraceSockNotify     = "TraceSockNotification"
-	PolicyVerdictNotify = "PolicyVerdictNotification"
-	PolicyAuditMode     = "PolicyAuditMode"
-	MonitorAggregation  = "MonitorAggregationLevel"
-	AlwaysEnforce       = "always"
-	NeverEnforce        = "never"
-	DefaultEnforcement  = "default"
+	PolicyTracing        = "PolicyTracing"
+	ConntrackAccounting  = "ConntrackAccounting"
+	ConntrackLocal       = "ConntrackLocal"
+	Debug                = "Debug"
+	DebugLB              = "DebugLB"
+	DebugPolicy          = "DebugPolicy"
+	DropNotify           = "DropNotification"
+	TraceNotify          = "TraceNotification"
+	TraceSockNotify      = "TraceSockNotification"
+	PolicyVerdictNotify  = "PolicyVerdictNotification"
+	PolicyAuditMode      = "PolicyAuditMode"
+	MonitorAggregation   = "MonitorAggregationLevel"
+	SourceIPVerification = "SourceIPVerification"
+	AlwaysEnforce        = "always"
+	NeverEnforce         = "never"
+	DefaultEnforcement   = "default"
 )
 
 var (
@@ -75,5 +76,10 @@ var (
 		Verify:      VerifyMonitorAggregationLevel,
 		Parse:       ParseMonitorAggregationLevel,
 		Format:      FormatMonitorAggregationLevel,
+	}
+
+	specSourceIPVerification = Option{
+		Define:      "ENABLE_SIP_VERIFICATION",
+		Description: "Enable the check of the source IP on pod egress",
 	}
 )


### PR DESCRIPTION
This pull request exposes as a per-endpoint config the existing setting to disable the source IP verification pods' egress. That setting was introduced in https://github.com/cilium/cilium/pull/16134. See commits for details.

@oblazek I'd love a review from you :slightly_smiling_face: 