### PR TITLE
gha: Bump timeout to 90 minutes for build commit.

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -13,7 +13,7 @@ jobs:
   build_commits:
     name: Check if build works for every commit
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Configure git
         run: |


### PR DESCRIPTION
Follow-up action on https://github.com/cilium/cilium/pull/23959#issuecomment-1442074110

Relates: #23959
