### PR TITLE
renovate: update source import paths on Go module major updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,6 +74,10 @@
         "go.mod",
         "go.sum"
       ],
+      "postUpdateOptions": [
+	// update source import paths on major updates
+        "gomodUpdateImportPaths",
+      ]
       "matchUpdateTypes": [
         "major",
         "minor",


### PR DESCRIPTION
Try to update source import paths on major updates. In some cases, API
changes might be necessary but due to the source changes, the
appropriate code owners will already be pulled in for reviews on the PR.