### PR TITLE
.gitattributes: Mark install/kubernetes/cilium/values.yaml as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /install/kubernetes/cilium/values.yaml.tmpl linguist-language=yml
+/install/kubernetes/cilium/values.yaml linguist-generated
 *.Jenkinsfile linguist-language=Groovy
 go.sum linguist-generated
 examples/kubernetes/connectivity-check/connectivity-*.yaml linguist-generated


### PR DESCRIPTION
Since commit 11333b291de3 ("install: Templatize image repositories and tags"), we've been using install/kubernetes/cilium/values.yaml.tmpl as a template to generate .../values.yaml, which should no longer be edited by hand. Pull Requests on GitHub usually display changes on the two files, but what we want instead is to see only the diff for the template (the CI should ensure that both files are in a consistent state).
