### PR TITLE
bpf: Remove dead code for consistency between IPv4/v6

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -141,8 +141,7 @@ resolve_srcid_ipv6(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 
 	if (from_host)
 		src_id = srcid_from_ipcache;
-	else if (src_id == WORLD_ID &&
-		 identity_from_ipcache_ok())
+	else if (identity_from_ipcache_ok())
 		src_id = srcid_from_ipcache;
 	return src_id;
 }


### PR DESCRIPTION
In `resolve_srcid_ipv6()`, we check that `src_id` is equal to `WORLD_ID` before updating it's value. That was in case `derive_src_id()` changed its value.

Given commit 32a921aab ("bpf: Remove flowlabel optimization for identity") removed the call to `derive_src_id()`, `src_id` will now always be equal to `WORLD_ID`. Let's remove that check to be consistent with the sibling function `resolve_srcid_ipv4()`.