### PR TITLE
cni: add option to keep CNI configuration file on agent shutdown

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -429,6 +429,10 @@
      - Configure the log file for CNI logging with retention policy of 7 days. Disable CNI file logging by setting this field to empty explicitly.
      - string
      - ``"/var/run/cilium/cilium-cni.log"``
+   * - cni.uninstall
+     - Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable.
+     - bool
+     - ``true``
    * - conntrackGCInterval
      - Configure how frequently garbage collection should occur for the datapath connection tracking table.
      - string

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -158,6 +158,7 @@ contributors across the globe, there is almost always someone available to help.
 | cni.hostConfDirMountPath | string | `"/host/etc/cni/net.d"` | Configure the path to where the CNI configuration directory is mounted inside the agent pod. |
 | cni.install | bool | `true` | Install the CNI configuration and binary files into the filesystem. |
 | cni.logFile | string | `"/var/run/cilium/cilium-cni.log"` | Configure the log file for CNI logging with retention policy of 7 days. Disable CNI file logging by setting this field to empty explicitly. |
+| cni.uninstall | bool | `true` | Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable. |
 | conntrackGCInterval | string | `"0s"` | Configure how frequently garbage collection should occur for the datapath connection tracking table. |
 | containerRuntime | object | `{"integration":"none"}` | Configure container runtime specific integration. |
 | containerRuntime.integration | string | `"none"` | Enables specific integrations for container runtimes. Supported values: - containerd - crio - docker - none - auto (automatically detect the container runtime) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -710,6 +710,9 @@ data:
 {{- else if .Values.cni.readCniConf }}
   read-cni-conf: {{ .Values.cni.readCniConf }}
 {{- end }}
+{{- if .Values.cni.uninstall }}
+  cni-uninstall: {{ .Values.cni.uninstall | quote }}
+{{- end }}
 {{- if .Values.kubeConfigPath }}
   k8s-kubeconfig-path: {{ .Values.kubeConfigPath | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -456,6 +456,12 @@ cni:
   # -- Install the CNI configuration and binary files into the filesystem.
   install: true
 
+  # -- Remove the CNI configuration and binary files on agent shutdown. Enable this
+  # if you're removing Cilium from the cluster. Disable this to prevent the CNI
+  # configuration file from being removed during agent upgrade, which can cause
+  # nodes to go unmanageable.
+  uninstall: true
+
   # -- Configure chaining on top of other CNI plugins. Possible values:
   #  - none
   #  - aws-cni

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -453,6 +453,12 @@ cni:
   # -- Install the CNI configuration and binary files into the filesystem.
   install: true
 
+  # -- Remove the CNI configuration and binary files on agent shutdown. Enable this
+  # if you're removing Cilium from the cluster. Disable this to prevent the CNI
+  # configuration file from being removed during agent upgrade, which can cause
+  # nodes to go unmanageable.
+  uninstall: true
+
   # -- Configure chaining on top of other CNI plugins. Possible values:
   #  - none
   #  - aws-cni

--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -8,6 +8,11 @@ CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
 CNI_CONF_DIR=${CNI_CONF_DIR:-${HOST_PREFIX}/etc/cni/net.d}
 CILIUM_CUSTOM_CNI_CONF=${CILIUM_CUSTOM_CNI_CONF:-false}
 
+if [[ "$(cat /tmp/cilium/config-map/cni-uninstall 2>/dev/null || true)" != "true" ]]; then
+    echo "cni-uninstall disabled, not removing CNI configuration"
+    exit
+fi
+
 # Do not interact with the host's CNI directory when the user specified they
 # are managing CNI configs externally.
 if [ "${CILIUM_CUSTOM_CNI_CONF}" != "true" ]; then


### PR DESCRIPTION
(note: this is a slimmed-down version of #23486 intended for backporting. Once this merges, I'll rebase that PR.)

When enabled, the CNI configuration file and plugin binaries will remain on disk, even when the agent is shut down. Without this, it is impossible to delete pods on the node. That can cause issues in hot clusters, where Cilium is deleted for an upgrade, another pod takes its place, and the node has no more capacity -- plus, none can be freed up since CNI deletion no longer works.

When enabled, it does one cosmetic effect: pods will be scheduled to nodes that cannot immediately start them. CNI ADDs and DELs will fail until the agent comes back. The CNI plugin itself always waits 30 seconds for the agent to start, which should mean that few, if any, deletes will actually fail. Likewise, the kubelet will retry.

In the case of DEL, the kubelet will eventually give up, marking the pod as deleted and allowing the node to be recovered.

In the case where someone is migrating off of Cilium, the value `cni.uninstall=true` will keep the original behavior.

Fixes: #22067

```release-note
Add the option to preserve CNI configuration file on agent shutdown. This can help prevent issues where pods can no longer be deleted. This may cause some transient error messages to be displayed if a pod is scheduled while Cilium is being upgraded.
```
