### PR TITLE
Make private Envoy sockets localhost only 

### DIFF
--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -66,7 +66,7 @@ func (f *FakeDatapath) WriteEndpointConfig(io.Writer, datapath.EndpointConfigura
 	return nil
 }
 
-func (f *FakeDatapath) InstallProxyRules(context.Context, uint16, bool, string) error {
+func (f *FakeDatapath) InstallProxyRules(context.Context, uint16, bool, bool, string) error {
 	return nil
 }
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -416,7 +416,7 @@ func (m *IptablesManager) renameChains(prefix string) error {
 	return nil
 }
 
-func (m *IptablesManager) ingressProxyRule(l4Match, markMatch, mark, port, name string) []string {
+func (m *IptablesManager) ingressProxyRule(l4Match, markMatch, mark, ip, port, name string) []string {
 	return []string{
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
@@ -425,7 +425,9 @@ func (m *IptablesManager) ingressProxyRule(l4Match, markMatch, mark, port, name 
 		"-m", "comment", "--comment", "cilium: TPROXY to host " + name + " proxy",
 		"-j", "TPROXY",
 		"--tproxy-mark", mark,
-		"--on-port", port}
+		"--on-ip", ip,
+		"--on-port", port,
+	}
 }
 
 func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
@@ -448,7 +450,7 @@ func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
 		"--set-mark", toProxyMark}
 }
 
-func (m *IptablesManager) iptIngressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
+func (m *IptablesManager) iptIngressProxyRule(rules string, prog iptablesInterface, l4proto, ip string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork16(proxyPort)) << 16
 	ingressMarkMatch := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy|port)
@@ -460,11 +462,11 @@ func (m *IptablesManager) iptIngressProxyRule(rules string, prog iptablesInterfa
 		return nil
 	}
 
-	rule := m.ingressProxyRule(l4proto, ingressMarkMatch, ingressProxyMark, ingressProxyPort, name)
+	rule := m.ingressProxyRule(l4proto, ingressMarkMatch, ingressProxyMark, ip, ingressProxyPort, name)
 	return prog.runProg(rule)
 }
 
-func (m *IptablesManager) egressProxyRule(l4Match, markMatch, mark, port, name string) []string {
+func (m *IptablesManager) egressProxyRule(l4Match, markMatch, mark, ip, port, name string) []string {
 	return []string{
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
@@ -473,10 +475,12 @@ func (m *IptablesManager) egressProxyRule(l4Match, markMatch, mark, port, name s
 		"-m", "comment", "--comment", "cilium: TPROXY to host " + name + " proxy",
 		"-j", "TPROXY",
 		"--tproxy-mark", mark,
-		"--on-port", port}
+		"--on-ip", ip,
+		"--on-port", port,
+	}
 }
 
-func (m *IptablesManager) iptEgressProxyRule(rules string, prog iptablesInterface, l4proto string, proxyPort uint16, name string) error {
+func (m *IptablesManager) iptEgressProxyRule(rules string, prog iptablesInterface, l4proto, ip string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork16(proxyPort)) << 16
 	egressMarkMatch := fmt.Sprintf("%#x", linux_defaults.MagicMarkIsToProxy|port)
@@ -488,7 +492,7 @@ func (m *IptablesManager) iptEgressProxyRule(rules string, prog iptablesInterfac
 		return nil
 	}
 
-	rule := m.egressProxyRule(l4proto, egressMarkMatch, egressProxyMark, egressProxyPort, name)
+	rule := m.egressProxyRule(l4proto, egressMarkMatch, egressProxyMark, ip, egressProxyPort, name)
 	return prog.runProg(rule)
 }
 
@@ -703,7 +707,7 @@ func (m *IptablesManager) copyProxyRules(oldChain string, match string) error {
 
 // Redirect packets to the host proxy via TPROXY, as directed by the Cilium
 // datapath bpf programs via skb marks (egress) or DSCP (ingress).
-func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16, ingress bool, name string) error {
+func (m *IptablesManager) addProxyRules(prog iptablesInterface, ip string, proxyPort uint16, ingress bool, name string) error {
 	rules, err := prog.runProgOutput([]string{"-t", "mangle", "-S"})
 	if err != nil {
 		return err
@@ -711,11 +715,11 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 
 	for _, proto := range []string{"tcp", "udp"} {
 		if ingress {
-			if err := m.iptIngressProxyRule(rules, prog, proto, proxyPort, name); err != nil {
+			if err := m.iptIngressProxyRule(rules, prog, proto, ip, proxyPort, name); err != nil {
 				return err
 			}
 		} else {
-			if err := m.iptEgressProxyRule(rules, prog, proto, proxyPort, name); err != nil {
+			if err := m.iptEgressProxyRule(rules, prog, proto, ip, proxyPort, name); err != nil {
 				return err
 			}
 		}
@@ -747,14 +751,21 @@ func (m *IptablesManager) addProxyRules(prog iptablesInterface, proxyPort uint16
 }
 
 // install or remove rules for a single proxy port
-func (m *IptablesManager) iptProxyRules(proxyPort uint16, ingress bool, name string) error {
+func (m *IptablesManager) iptProxyRules(proxyPort uint16, ingress, localOnly bool, name string) error {
+	ipv4 := "0.0.0.0"
+	ipv6 := "::"
+
+	if localOnly {
+		ipv4 = "127.0.0.1"
+		ipv6 = "::1"
+	}
 	if option.Config.EnableIPv4 {
-		if err := m.addProxyRules(ip4tables, proxyPort, ingress, name); err != nil {
+		if err := m.addProxyRules(ip4tables, ipv4, proxyPort, ingress, name); err != nil {
 			return err
 		}
 	}
 	if option.Config.EnableIPv6 {
-		if err := m.addProxyRules(ip6tables, proxyPort, ingress, name); err != nil {
+		if err := m.addProxyRules(ip6tables, ipv6, proxyPort, ingress, name); err != nil {
 			return err
 		}
 	}
@@ -882,7 +893,7 @@ func (m *IptablesManager) RemoveNoTrackRules(IP string, port uint16, ipv6 bool) 
 	return nil
 }
 
-func (m *IptablesManager) InstallProxyRules(ctx context.Context, proxyPort uint16, ingress bool, name string) error {
+func (m *IptablesManager) InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error {
 	backoff := backoff.Exponential{
 		Min:  20 * time.Second,
 		Max:  3 * time.Minute,
@@ -894,7 +905,7 @@ func (m *IptablesManager) InstallProxyRules(ctx context.Context, proxyPort uint1
 
 	for {
 		attempt += 1
-		err := m.doInstallProxyRules(proxyPort, ingress, name)
+		err := m.doInstallProxyRules(proxyPort, ingress, localOnly, name)
 		if err == nil {
 			log.Info("Iptables proxy rules installed")
 			return nil
@@ -909,7 +920,7 @@ func (m *IptablesManager) InstallProxyRules(ctx context.Context, proxyPort uint1
 	}
 }
 
-func (m *IptablesManager) doInstallProxyRules(proxyPort uint16, ingress bool, name string) error {
+func (m *IptablesManager) doInstallProxyRules(proxyPort uint16, ingress, localOnly bool, name string) error {
 	m.Lock()
 	defer m.Unlock()
 
@@ -918,7 +929,7 @@ func (m *IptablesManager) doInstallProxyRules(proxyPort uint16, ingress bool, na
 			Debug("Skipping proxy rule install due to BPF support")
 		return nil
 	}
-	return m.iptProxyRules(proxyPort, ingress, name)
+	return m.iptProxyRules(proxyPort, ingress, localOnly, name)
 }
 
 // GetProxyPort finds a proxy port used for redirect 'name' installed earlier with InstallProxyRules.

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -219,14 +219,14 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 -A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip 0.0.0.0 --on-port 37379",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip 0.0.0.0 --on-port 37379",
 		},
 	}
 
 	// Adds new proxy rules
-	mockManager.addProxyRules(mockIp4tables, 37379, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, "0.0.0.0", 37379, false, "cilium-dns-egress")
 	err := mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -259,7 +259,7 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 	}
 
 	// Nothing to add
-	mockManager.addProxyRules(mockIp4tables, 37379, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, "0.0.0.0", 37379, false, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -287,14 +287,14 @@ func (s *iptablesTestSuite) TestAddProxyRulesv4(c *check.C) {
 -A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 37379 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip 0.0.0.0 --on-port 37379",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 37379",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0x3920200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip 0.0.0.0 --on-port 37379",
 		},
 	}
 
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
-	mockManager.addProxyRules(mockIp4tables, 37379, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp4tables, "0.0.0.0", 37379, false, "cilium-dns-egress")
 	err = mockIp4tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }
@@ -349,14 +349,14 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 -A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43477",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip :: --on-port 43477",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43477",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip :: --on-port 43477",
 		},
 	}
 
 	// Adds new proxy rules
-	mockManager.addProxyRules(mockIp6tables, 43477, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp6tables, "::", 43477, false, "cilium-dns-egress")
 	err := mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -389,7 +389,7 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 	}
 
 	// Nothing to add
-	mockManager.addProxyRules(mockIp6tables, 43477, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp6tables, "::", 43477, false, "cilium-dns-egress")
 	err = mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 
@@ -417,14 +417,14 @@ func (s *iptablesTestSuite) TestAddProxyRulesv6(c *check.C) {
 -A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip :: --tproxy-mark 0x200/0xffffffff
 `),
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43479",
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip :: --on-port 43479",
 		}, {
-			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-port 43479",
+			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd7a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --tproxy-mark 0x200 --on-ip :: --on-port 43479",
 		},
 	}
 
 	// New port number, adds new ones, deletes stale rules. Does not touch OLD_ chains
-	mockManager.addProxyRules(mockIp6tables, 43479, false, "cilium-dns-egress")
+	mockManager.addProxyRules(mockIp6tables, "::", 43479, false, "cilium-dns-egress")
 	err = mockIp6tables.checkExpectations()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -51,7 +51,7 @@ type Proxy interface {
 type IptablesManager interface {
 	// InstallProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress bool, name string) error
+	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error
 
 	// SupportsOriginalSourceAddr tells if the datapath supports
 	// use of original source addresses in proxy upstream

--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -365,7 +365,7 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 			if err != nil || port == 0 {
 				return Resources{}, fmt.Errorf("Listener port allocation for %q failed: %s", listener.Name, err)
 			}
-			listener.Address = getListenerAddress(port, option.Config.IPv4Enabled(), option.Config.IPv6Enabled())
+			listener.Address, listener.AdditionalAddresses = getLocalListenerAddresses(port, option.Config.IPv4Enabled(), option.Config.IPv6Enabled())
 			if resources.portAllocations == nil {
 				resources.portAllocations = make(map[string]uint16)
 			}

--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -60,7 +60,7 @@ type Resources struct {
 }
 
 type PortAllocator interface {
-	AllocateProxyPort(name string, ingress bool) (uint16, error)
+	AllocateProxyPort(name string, ingress, localOnly bool) (uint16, error)
 	AckProxyPort(ctx context.Context, name string) error
 	ReleaseProxyPort(name string) error
 }
@@ -361,7 +361,7 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 	// Do this only after all other possible error cases.
 	for _, listener := range resources.Listeners {
 		if listener.GetAddress() == nil {
-			port, err := portAllocator.AllocateProxyPort(listener.Name, false)
+			port, err := portAllocator.AllocateProxyPort(listener.Name, false, true)
 			if err != nil || port == 0 {
 				return Resources{}, fmt.Errorf("Listener port allocation for %q failed: %s", listener.Name, err)
 			}

--- a/pkg/envoy/ciliumenvoyconfig_test.go
+++ b/pkg/envoy/ciliumenvoyconfig_test.go
@@ -43,7 +43,7 @@ func NewMockPortAllocator() *MockPortAllocator {
 	}
 }
 
-func (m *MockPortAllocator) AllocateProxyPort(name string, ingress bool) (uint16, error) {
+func (m *MockPortAllocator) AllocateProxyPort(name string, ingress, localOnly bool) (uint16, error) {
 	if mp, exists := m.ports[name]; exists {
 		return mp.port, nil
 	}

--- a/pkg/envoy/server_test.go
+++ b/pkg/envoy/server_test.go
@@ -7,6 +7,11 @@ import (
 	"reflect"
 	"testing"
 
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
+	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
+	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
+	envoy_type_matcher "github.com/cilium/proxy/go/envoy/type/matcher/v3"
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/checker"
@@ -20,11 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/logger/test"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/u8proto"
-	cilium "github.com/cilium/proxy/go/cilium/api"
-	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
-	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
-	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
-	envoy_type_matcher "github.com/cilium/proxy/go/envoy/type/matcher/v3"
 )
 
 type ServerSuite struct{}

--- a/pkg/envoy/server_test.go
+++ b/pkg/envoy/server_test.go
@@ -4,10 +4,9 @@
 package envoy
 
 import (
-	cilium "github.com/cilium/proxy/go/cilium/api"
-	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
-	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
-	envoy_type_matcher "github.com/cilium/proxy/go/envoy/type/matcher/v3"
+	"reflect"
+	"testing"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/checker"
@@ -21,6 +20,11 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/logger/test"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/u8proto"
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
+	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
+	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
+	envoy_type_matcher "github.com/cilium/proxy/go/envoy/type/matcher/v3"
 )
 
 type ServerSuite struct{}
@@ -898,4 +902,152 @@ func (s *ServerSuite) TestGetNetworkPolicyTLSIngress(c *C) {
 		ConntrackMapName:       "global",
 	}
 	c.Assert(obtained, checker.ExportedEquals, expected)
+}
+
+func Test_getPublicListenerAddress(t *testing.T) {
+	type args struct {
+		port uint16
+		ipv4 bool
+		ipv6 bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want *envoy_config_core.Address
+	}{
+		{
+			name: "IPv4 only",
+			args: args{
+				port: 80,
+				ipv4: true,
+				ipv6: false,
+			},
+			want: &envoy_config_core.Address{
+				Address: &envoy_config_core.Address_SocketAddress{
+					SocketAddress: &envoy_config_core.SocketAddress{
+						Protocol:      envoy_config_core.SocketAddress_TCP,
+						Address:       "0.0.0.0",
+						PortSpecifier: &envoy_config_core.SocketAddress_PortValue{PortValue: uint32(80)},
+					},
+				},
+			},
+		},
+		{
+			name: "IPv6 only",
+			args: args{
+				port: 80,
+				ipv4: false,
+				ipv6: true,
+			},
+			want: &envoy_config_core.Address{
+				Address: &envoy_config_core.Address_SocketAddress{
+					SocketAddress: &envoy_config_core.SocketAddress{
+						Protocol:      envoy_config_core.SocketAddress_TCP,
+						Address:       "::",
+						PortSpecifier: &envoy_config_core.SocketAddress_PortValue{PortValue: uint32(80)},
+					},
+				},
+			},
+		},
+		{
+			name: "IPv4 and IPv6",
+			args: args{
+				port: 80,
+				ipv4: true,
+				ipv6: true,
+			},
+			want: &envoy_config_core.Address{
+				Address: &envoy_config_core.Address_SocketAddress{
+					SocketAddress: &envoy_config_core.SocketAddress{
+						Protocol:      envoy_config_core.SocketAddress_TCP,
+						Address:       "::",
+						PortSpecifier: &envoy_config_core.SocketAddress_PortValue{PortValue: uint32(80)},
+						Ipv4Compat:    true,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getPublicListenerAddress(tt.args.port, tt.args.ipv4, tt.args.ipv6); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getPublicListenerAddress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getLocalListenerAddresses(t *testing.T) {
+	v4Local := &envoy_config_core.Address_SocketAddress{
+		SocketAddress: &envoy_config_core.SocketAddress{
+			Protocol:      envoy_config_core.SocketAddress_TCP,
+			Address:       "127.0.0.1",
+			PortSpecifier: &envoy_config_core.SocketAddress_PortValue{PortValue: uint32(80)},
+		},
+	}
+
+	v6Local := &envoy_config_core.Address_SocketAddress{
+		SocketAddress: &envoy_config_core.SocketAddress{
+			Protocol:      envoy_config_core.SocketAddress_TCP,
+			Address:       "::1",
+			PortSpecifier: &envoy_config_core.SocketAddress_PortValue{PortValue: uint32(80)},
+		},
+	}
+	type args struct {
+		port uint16
+		ipv4 bool
+		ipv6 bool
+	}
+	tests := []struct {
+		name           string
+		args           args
+		want           *envoy_config_core.Address
+		wantAdditional []*envoy_config_listener.AdditionalAddress
+	}{
+		{
+			name: "IPv4 only",
+			args: args{
+				port: 80,
+				ipv4: true,
+				ipv6: false,
+			},
+			want: &envoy_config_core.Address{
+				Address: v4Local,
+			},
+		},
+		{
+			name: "IPv6 only",
+			args: args{
+				port: 80,
+				ipv4: false,
+				ipv6: true,
+			},
+			want: &envoy_config_core.Address{
+				Address: v6Local,
+			},
+		},
+		{
+			name: "IPv4 and IPv6",
+			args: args{
+				port: 80,
+				ipv4: true,
+				ipv6: true,
+			},
+			want: &envoy_config_core.Address{
+				Address: v4Local,
+			},
+			wantAdditional: []*envoy_config_listener.AdditionalAddress{{Address: &envoy_config_core.Address{Address: v6Local}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotAdditional := getLocalListenerAddresses(tt.args.port, tt.args.ipv4, tt.args.ipv6)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getLocalListenerAddresses() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(gotAdditional, tt.wantAdditional) {
+				t.Errorf("getLocalListenerAddresses() got1 = %v, want %v", gotAdditional, tt.wantAdditional)
+			}
+		})
+	}
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -180,7 +180,7 @@ type envoyConfigManager interface {
 	DeleteEnvoyResources(context.Context, envoy.Resources, envoy.PortAllocator) error
 
 	// envoy.PortAllocator
-	AllocateProxyPort(name string, ingress bool) (uint16, error)
+	AllocateProxyPort(name string, ingress, localOnly bool) (uint16, error)
 	AckProxyPort(ctx context.Context, name string) error
 	ReleaseProxyPort(name string) error
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -42,7 +42,7 @@ const (
 )
 
 type DatapathUpdater interface {
-	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress bool, name string) error
+	InstallProxyRules(ctx context.Context, proxyPort uint16, ingress, localOnly bool, name string) error
 	SupportsOriginalSourceAddr() bool
 }
 
@@ -94,6 +94,8 @@ type ProxyPort struct {
 	// is non-zero when a proxy has been successfully created and the
 	// datapath rules have been created.
 	rulesPort uint16
+	// localOnly is true when the proxy port is only accessible from the loopback device
+	localOnly bool
 }
 
 // Proxy maintains state about redirects
@@ -194,10 +196,12 @@ var (
 		"cilium-http-egress": {
 			proxyType: ProxyTypeHTTP,
 			ingress:   false,
+			localOnly: true,
 		},
 		"cilium-http-ingress": {
 			proxyType: ProxyTypeHTTP,
 			ingress:   true,
+			localOnly: true,
 		},
 		DNSProxyName: {
 			proxyType: ProxyTypeDNS,
@@ -206,10 +210,12 @@ var (
 		"cilium-proxylib-egress": {
 			proxyType: ProxyTypeAny,
 			ingress:   false,
+			localOnly: true,
 		},
 		"cilium-proxylib-ingress": {
 			proxyType: ProxyTypeAny,
 			ingress:   true,
+			localOnly: true,
 		},
 	}
 )
@@ -297,7 +303,7 @@ func (p *Proxy) ackProxyPort(ctx context.Context, name string, pp *ProxyPort) er
 		// Add rules for the new port
 		// This should always succeed if we have managed to start-up properly
 		scopedLog.Infof("Adding new proxy port rules for %s:%d", name, pp.proxyPort)
-		if err := p.datapathUpdater.InstallProxyRules(ctx, pp.proxyPort, pp.ingress, name); err != nil {
+		if err := p.datapathUpdater.InstallProxyRules(ctx, pp.proxyPort, pp.ingress, pp.localOnly, name); err != nil {
 			return fmt.Errorf("cannot install proxy rules for %s: %w", name, err)
 		}
 		pp.rulesPort = pp.proxyPort
@@ -397,13 +403,13 @@ func GetProxyPort(name string) (uint16, error) {
 // already allocated.
 // Each call has to be paired with AckProxyPort(name) to update the datapath rules accordingly.
 // Each allocated port must be eventually freed with ReleaseProxyPort().
-func (p *Proxy) AllocateProxyPort(name string, ingress bool) (uint16, error) {
+func (p *Proxy) AllocateProxyPort(name string, ingress, localOnly bool) (uint16, error) {
 	// Accessing pp.proxyPort requires the lock
 	proxyPortsMutex.Lock()
 	defer proxyPortsMutex.Unlock()
 	pp := proxyPorts[name]
 	if pp == nil {
-		pp = &ProxyPort{proxyType: ProxyTypeCRD, ingress: ingress}
+		pp = &ProxyPort{proxyType: ProxyTypeCRD, ingress: ingress, localOnly: localOnly}
 	}
 
 	// Allocate a new port only if a port was never allocated before.
@@ -465,7 +471,7 @@ func (p *Proxy) ReinstallRules(ctx context.Context) error {
 	for name, pp := range proxyPorts {
 		if pp.rulesPort > 0 {
 			// This should always succeed if we have managed to start-up properly
-			if err := p.datapathUpdater.InstallProxyRules(ctx, pp.rulesPort, pp.ingress, name); err != nil {
+			if err := p.datapathUpdater.InstallProxyRules(ctx, pp.rulesPort, pp.ingress, pp.localOnly, name); err != nil {
 				return fmt.Errorf("cannot install proxy rules for %s: %w", name, err)
 			}
 		}


### PR DESCRIPTION
This change makes parts of Envoy that do not need public access bind to
localhost only. This was previously not possible as it could not bind
on both ipv4 and v6. In Envoy 1.24 multi listeners were added making
this improvement possible.

~~Depends on https://github.com/cilium/cilium/pull/23940~~ (merged)

Fixes a part of https://github.com/cilium/cilium/issues/23353 (there are more cilium agent ports which are not managed by envoy)

```release-note
Make Envoy sockets for tproxy and the xDS API and bind to localhost only 
```
