### PR TITLE
add versioning schema for WireGuard in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -193,6 +193,12 @@
         "v1.12",
         "v1.11"
       ]
+    },
+    {
+      "matchDepNames": [
+        "golang.zx2c4.com/wireguard",
+      ],
+      "versioning": "regex:^v0.0.0-(<patch>\\d+)-.*$",
     }
   ],
   "kubernetes": {


### PR DESCRIPTION
Currently, Renovate assumes that the most recent tag in git.zx2c4.com/wireguard-go is the one that starts with "v", which is not always accurate. To resolve this issue, this commit introduces the correct versioning schema using a regex that matches tags without the "v" prefix. This will prevent confusion with Golang's mod versioning scheme, which does use the "v" prefix.