### PR TITLE
Modularize API server (api/v1/server)

### DIFF
--- a/api/v1/operator/server/server.go
+++ b/api/v1/operator/server/server.go
@@ -15,17 +15,14 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/signal"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/swag"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/netutil"
-	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/operator/server/restapi"
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/metrics"
@@ -91,13 +88,35 @@ func init() {
 	}
 }
 
+var (
+	enabledListeners []string
+	gracefulTimeout  time.Duration
+	maxHeaderSize    int
+
+	socketPath string
+
+	host         string
+	port         int
+	listenLimit  int
+	keepAlive    time.Duration
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+
+	tlsHost           string
+	tlsPort           int
+	tlsListenLimit    int
+	tlsKeepAlive      time.Duration
+	tlsReadTimeout    time.Duration
+	tlsWriteTimeout   time.Duration
+	tlsCertificate    string
+	tlsCertificateKey string
+	tlsCACertificate  string
+)
+
 // NewServer creates a new api cilium operator server but does not configure it
 func NewServer(api *restapi.CiliumOperatorAPI) *Server {
 	s := new(Server)
-
-	s.shutdown = make(chan struct{})
 	s.api = api
-	s.interrupt = make(chan os.Signal, 1)
 	return s
 }
 
@@ -147,10 +166,7 @@ type Server struct {
 	api          *restapi.CiliumOperatorAPI
 	handler      http.Handler
 	hasListeners bool
-	shutdown     chan struct{}
-	shuttingDown int32
-	interrupted  bool
-	interrupt    chan os.Signal
+	servers      []*http.Server
 
 	wg         sync.WaitGroup
 	shutdowner hive.Shutdowner
@@ -226,6 +242,10 @@ func (s *Server) Start(hive.HookContext) (err error) {
 		}
 	}
 
+	if len(s.servers) != 0 {
+		return errors.New("already started")
+	}
+
 	// set default handler, if none is set
 	if s.handler == nil {
 		if s.api == nil {
@@ -234,12 +254,6 @@ func (s *Server) Start(hive.HookContext) (err error) {
 
 		s.SetHandler(s.api.Serve(nil))
 	}
-
-	once := new(sync.Once)
-	signalNotify(s.interrupt)
-	go handleInterrupt(once, s)
-
-	servers := []*http.Server{}
 
 	if s.hasScheme(schemeUnix) {
 		domainSocket := new(http.Server)
@@ -257,7 +271,7 @@ func (s *Server) Start(hive.HookContext) (err error) {
 				return err
 			}
 		}
-		servers = append(servers, domainSocket)
+		s.servers = append(s.servers, domainSocket)
 		s.wg.Add(1)
 		s.Logf("Serving cilium operator at unix://%s", s.SocketPath)
 		go func(l net.Listener) {
@@ -287,7 +301,7 @@ func (s *Server) Start(hive.HookContext) (err error) {
 
 		configureServer(httpServer, "http", s.httpServerL.Addr().String())
 
-		servers = append(servers, httpServer)
+		s.servers = append(s.servers, httpServer)
 		s.wg.Add(1)
 		s.Logf("Serving cilium operator at http://%s", s.httpServerL.Addr())
 		go func(l net.Listener) {
@@ -383,7 +397,7 @@ func (s *Server) Start(hive.HookContext) (err error) {
 
 		configureServer(httpsServer, "https", s.httpsServerL.Addr().String())
 
-		servers = append(servers, httpsServer)
+		s.servers = append(s.servers, httpsServer)
 		s.wg.Add(1)
 		s.Logf("Serving cilium operator at https://%s", s.httpsServerL.Addr())
 		go func(l net.Listener) {
@@ -395,20 +409,6 @@ func (s *Server) Start(hive.HookContext) (err error) {
 		}(tls.NewListener(s.httpsServerL, httpsServer.TLSConfig))
 	}
 
-	s.wg.Add(1)
-	go s.handleShutdown(&servers)
-
-	return nil
-}
-
-func (s *Server) Stop(hive.HookContext) error {
-	if err := s.Shutdown(); err != nil {
-		return err
-	}
-	// FIXME need to pass HookContext somehow into handleShutdown to make this
-	// respect the timeout. Probably want to fold "handleShutdown" into this
-	// function.
-	s.wg.Wait()
 	return nil
 }
 
@@ -489,38 +489,28 @@ func (s *Server) Listen() error {
 
 // Shutdown server and clean up resources
 func (s *Server) Shutdown() error {
-	if atomic.CompareAndSwapInt32(&s.shuttingDown, 0, 1) {
-		close(s.shutdown)
-	}
-	return nil
-}
-
-func (s *Server) handleShutdown(serversPtr *[]*http.Server) {
-	// s.wg.Done must occur last, after s.api.ServerShutdown()
-	// (to preserve old behaviour)
-	defer s.wg.Done()
-
-	<-s.shutdown
-
-	servers := *serversPtr
-
 	ctx, cancel := context.WithTimeout(context.TODO(), s.GracefulTimeout)
 	defer cancel()
+	return s.Stop(ctx)
+}
 
+func (s *Server) Stop(ctx hive.HookContext) error {
 	// first execute the pre-shutdown hook
 	s.api.PreServerShutdown()
 
 	shutdownChan := make(chan bool)
-	for i := range servers {
-		server := servers[i]
+	for i := range s.servers {
+		server := s.servers[i]
 		go func() {
 			var success bool
 			defer func() {
 				shutdownChan <- success
 			}()
 			if err := server.Shutdown(ctx); err != nil {
-				// Error from closing listeners, or context timeout:
 				s.Logf("HTTP server Shutdown: %v", err)
+
+				// Forcefully close open connections.
+				server.Close()
 			} else {
 				success = true
 			}
@@ -529,12 +519,17 @@ func (s *Server) handleShutdown(serversPtr *[]*http.Server) {
 
 	// Wait until all listeners have successfully shut down before calling ServerShutdown
 	success := true
-	for range servers {
+	for range s.servers {
 		success = success && <-shutdownChan
 	}
 	if success {
 		s.api.ServerShutdown()
 	}
+
+	s.wg.Wait()
+	s.servers = nil
+
+	return nil
 }
 
 // GetHandler returns a handler useful for testing
@@ -575,24 +570,4 @@ func (s *Server) TLSListener() (net.Listener, error) {
 		}
 	}
 	return s.httpsServerL, nil
-}
-
-func handleInterrupt(once *sync.Once, s *Server) {
-	once.Do(func() {
-		for range s.interrupt {
-			if s.interrupted {
-				s.Logf("Server already shutting down")
-				continue
-			}
-			s.interrupted = true
-			s.Logf("Shutting down... ")
-			if err := s.Shutdown(); err != nil {
-				s.Logf("HTTP server Shutdown: %v", err)
-			}
-		}
-	})
-}
-
-func signalNotify(interrupt chan<- os.Signal) {
-	signal.Notify(interrupt, unix.SIGINT, unix.SIGTERM)
 }

--- a/api/v1/operator/server/server.go
+++ b/api/v1/operator/server/server.go
@@ -21,13 +21,60 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-openapi/loads"
 	"github.com/go-openapi/swag"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/netutil"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/operator/server/restapi"
+	"github.com/cilium/cilium/api/v1/operator/server/restapi/metrics"
+	"github.com/cilium/cilium/api/v1/operator/server/restapi/operator"
+
 	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
 )
+
+// Cell implements the cilium operator REST API server when provided
+// the required request handlers.
+var Cell = cell.Module(
+	"cilium-operator-server",
+	"cilium operator server",
+
+	cell.Provide(newForCell),
+)
+
+type serverParams struct {
+	cell.In
+
+	Lifecycle  hive.Lifecycle
+	Shutdowner hive.Shutdowner
+	Logger     logrus.FieldLogger
+
+	OperatorGetHealthzHandler operator.GetHealthzHandler
+	MetricsGetMetricsHandler  metrics.GetMetricsHandler
+}
+
+func newForCell(p serverParams) (*Server, error) {
+	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to swagger spec: %w", err)
+	}
+	api := restapi.NewCiliumOperatorAPI(swaggerSpec)
+
+	// Construct the API from the provided handlers
+
+	api.OperatorGetHealthzHandler = p.OperatorGetHealthzHandler
+	api.MetricsGetMetricsHandler = p.MetricsGetMetricsHandler
+
+	s := NewServer(api)
+	s.shutdowner = p.Shutdowner
+	s.logger = p.Logger
+	p.Lifecycle.Append(s)
+
+	return s, nil
+}
 
 const (
 	schemeHTTP  = "http"
@@ -104,11 +151,17 @@ type Server struct {
 	shuttingDown int32
 	interrupted  bool
 	interrupt    chan os.Signal
+
+	wg         sync.WaitGroup
+	shutdowner hive.Shutdowner
+	logger     logrus.FieldLogger
 }
 
 // Logf logs message either via defined user logger or via system one if no user logger is defined.
 func (s *Server) Logf(f string, args ...interface{}) {
-	if s.api != nil && s.api.Logger != nil {
+	if s.logger != nil {
+		s.logger.Infof(f, args...)
+	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 	} else {
 		log.Printf(f, args...)
@@ -118,7 +171,9 @@ func (s *Server) Logf(f string, args ...interface{}) {
 // Fatalf logs message either via defined user logger or via system one if no user logger is defined.
 // Exits with non-zero status after printing
 func (s *Server) Fatalf(f string, args ...interface{}) {
-	if s.api != nil && s.api.Logger != nil {
+	if s.shutdowner != nil {
+		s.shutdowner.Shutdown(hive.ShutdownWithError(fmt.Errorf(f, args...)))
+	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 		os.Exit(1)
 	} else {
@@ -152,8 +207,19 @@ func (s *Server) hasScheme(scheme string) bool {
 	return false
 }
 
-// Serve the api
-func (s *Server) Serve() (err error) {
+func (s *Server) Serve() error {
+	// TODO remove when this is not needed for compatibility anymore
+	if err := s.Start(context.TODO()); err != nil {
+		return err
+	}
+	s.wg.Wait()
+	return nil
+}
+
+// Start the server
+func (s *Server) Start(hive.HookContext) (err error) {
+	s.ConfigureAPI()
+
 	if !s.hasListeners {
 		if err = s.Listen(); err != nil {
 			return err
@@ -169,7 +235,6 @@ func (s *Server) Serve() (err error) {
 		s.SetHandler(s.api.Serve(nil))
 	}
 
-	wg := new(sync.WaitGroup)
 	once := new(sync.Once)
 	signalNotify(s.interrupt)
 	go handleInterrupt(once, s)
@@ -193,10 +258,10 @@ func (s *Server) Serve() (err error) {
 			}
 		}
 		servers = append(servers, domainSocket)
-		wg.Add(1)
+		s.wg.Add(1)
 		s.Logf("Serving cilium operator at unix://%s", s.SocketPath)
 		go func(l net.Listener) {
-			defer wg.Done()
+			defer s.wg.Done()
 			if err := domainSocket.Serve(l); err != nil && err != http.ErrServerClosed {
 				s.Fatalf("%v", err)
 			}
@@ -223,10 +288,10 @@ func (s *Server) Serve() (err error) {
 		configureServer(httpServer, "http", s.httpServerL.Addr().String())
 
 		servers = append(servers, httpServer)
-		wg.Add(1)
+		s.wg.Add(1)
 		s.Logf("Serving cilium operator at http://%s", s.httpServerL.Addr())
 		go func(l net.Listener) {
-			defer wg.Done()
+			defer s.wg.Done()
 			if err := httpServer.Serve(l); err != nil && err != http.ErrServerClosed {
 				s.Fatalf("%v", err)
 			}
@@ -319,10 +384,10 @@ func (s *Server) Serve() (err error) {
 		configureServer(httpsServer, "https", s.httpsServerL.Addr().String())
 
 		servers = append(servers, httpsServer)
-		wg.Add(1)
+		s.wg.Add(1)
 		s.Logf("Serving cilium operator at https://%s", s.httpsServerL.Addr())
 		go func(l net.Listener) {
-			defer wg.Done()
+			defer s.wg.Done()
 			if err := httpsServer.Serve(l); err != nil && err != http.ErrServerClosed {
 				s.Fatalf("%v", err)
 			}
@@ -330,10 +395,20 @@ func (s *Server) Serve() (err error) {
 		}(tls.NewListener(s.httpsServerL, httpsServer.TLSConfig))
 	}
 
-	wg.Add(1)
-	go s.handleShutdown(wg, &servers)
+	s.wg.Add(1)
+	go s.handleShutdown(&servers)
 
-	wg.Wait()
+	return nil
+}
+
+func (s *Server) Stop(hive.HookContext) error {
+	if err := s.Shutdown(); err != nil {
+		return err
+	}
+	// FIXME need to pass HookContext somehow into handleShutdown to make this
+	// respect the timeout. Probably want to fold "handleShutdown" into this
+	// function.
+	s.wg.Wait()
 	return nil
 }
 
@@ -420,10 +495,10 @@ func (s *Server) Shutdown() error {
 	return nil
 }
 
-func (s *Server) handleShutdown(wg *sync.WaitGroup, serversPtr *[]*http.Server) {
-	// wg.Done must occur last, after s.api.ServerShutdown()
+func (s *Server) handleShutdown(serversPtr *[]*http.Server) {
+	// s.wg.Done must occur last, after s.api.ServerShutdown()
 	// (to preserve old behaviour)
-	defer wg.Done()
+	defer s.wg.Done()
 
 	<-s.shutdown
 

--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -14,10 +14,8 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/signal"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
   "github.com/go-openapi/swag"
@@ -27,7 +25,6 @@ import (
   "strings"
   {{ end -}}
   "golang.org/x/net/netutil"
-  "golang.org/x/sys/unix"
 
   {{ imports .DefaultImports }}
   {{ imports .Imports }}
@@ -96,11 +93,12 @@ func init() {
 	}
 }
 
-{{ if not .UseGoStructFlags}}
-var ({{ if .ExcludeSpec }}
+var (
+  {{ if .ExcludeSpec }}
   specFile         string
-  {{ end }}enabledListeners []string
-  cleanupTimeout   time.Duration
+  {{ end }}
+
+  enabledListeners []string
   gracefulTimeout  time.Duration
   maxHeaderSize    int
 
@@ -124,121 +122,10 @@ var ({{ if .ExcludeSpec }}
   tlsCACertificate  string
 )
 
-{{ if .UseFlags}}
-// StringSliceVar support for flag
-type sliceValue []string
-
-func newSliceValue(vals []string, p *[]string) *sliceValue {
-	*p = vals
-	return (*sliceValue)(p)
-}
-
-func (s *sliceValue) Set(val string) error {
-	*s = sliceValue(strings.Split(val, ","))
-	return nil
-}
-
-func (s *sliceValue) Get() interface{} { return []string(*s) }
-
-func (s *sliceValue) String() string { return strings.Join([]string(*s), ",") }
-// end StringSliceVar support for flag
-{{ end }}
-
-func init() {
-  maxHeaderSize = 1000000{{ if .ExcludeSpec }}
-  flag.StringVarP(&specFile, "spec", "", "", "the swagger specification to serve")
-  {{ end }}
-  {{ if .UseFlags }}
-	flag.Var(newSliceValue(defaultSchemes, &enabledListeners), "schema", "the listeners to enable, this can be repeated and defaults to the schemes in the swagger spec")
-	{{ end }}
-	{{ if .UsePFlags }}
-	flag.StringSliceVar(&enabledListeners, "scheme", defaultSchemes, "the listeners to enable, this can be repeated and defaults to the schemes in the swagger spec")
-	{{ end }}
-	flag.DurationVar(&cleanupTimeout, "cleanup-timeout", 10*time.Second, "grace period for which to wait before killing idle connections")
-	flag.DurationVar(&gracefulTimeout, "graceful-timeout", 15*time.Second, "grace period for which to wait before shutting down the server")
-	flag.Var(&maxHeaderSize, "max-header-size", "controls the maximum number of bytes the server will read parsing the request header's keys and values, including the request line. It does not limit the size of the request body")
-
-	flag.StringVar(&socketPath, "socket-path", "/var/run/todo-list.sock", "the unix socket to listen on")
-
-	flag.StringVar(&host, "host", "localhost", "the IP to listen on")
-	flag.IntVar(&port, "port", 0, "the port to listen on for insecure connections, defaults to a random value")
-	flag.IntVar(&listenLimit, "listen-limit", 0, "limit the number of outstanding requests")
-	flag.DurationVar(&keepAlive, "keep-alive", 3*time.Minute, "sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)")
-	flag.DurationVar(&readTimeout, "read-timeout", 30*time.Second, "maximum duration before timing out read of the request")
-	flag.DurationVar(&writeTimeout, "write-timeout", 30*time.Second, "maximum duration before timing out write of the response")
-
-	flag.StringVar(&tlsHost, "tls-host", "localhost", "the IP to listen on")
-	flag.IntVar(&tlsPort, "tls-port", 0, "the port to listen on for secure connections, defaults to a random value")
-	flag.StringVar(&tlsCertificate, "tls-certificate", "", "the certificate file to use for secure connections")
-	flag.StringVar(&tlsCertificateKey, "tls-key", "", "the private key file to use for secure connections (without passphrase)")
-	flag.StringVar(&tlsCACertificate, "tls-ca", "", "the certificate authority certificate file to be used with mutual tls auth")
-	flag.IntVar(&tlsListenLimit, "tls-listen-limit", 0, "limit the number of outstanding requests")
-	flag.DurationVar(&tlsKeepAlive, "tls-keep-alive", 3*time.Minute, "sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)")
-	flag.DurationVar(&tlsReadTimeout, "tls-read-timeout", 30*time.Second, "maximum duration before timing out read of the request")
-	flag.DurationVar(&tlsWriteTimeout, "tls-write-timeout", 30*time.Second, "maximum duration before timing out write of the response")
-}
-
-func stringEnvOverride(orig string, def string, keys ...string) string {
-	for _, k := range keys {
-		if os.Getenv(k) != "" {
-			return os.Getenv(k)
-		}
-	}
-	if def != "" && orig == "" {
-		return def
-	}
-	return orig
-}
-
-func intEnvOverride(orig int, def int, keys ...string) int {
-	for _, k := range keys {
-		if os.Getenv(k) != "" {
-			v, err := strconv.Atoi(os.Getenv(k))
-			if err != nil {
-				fmt.Fprintln(os.Stderr, k, "is not a valid number")
-				os.Exit(1)
-			}
-			return v
-		}
-	}
-	if def != 0 && orig == 0 {
-		return def
-	}
-	return orig
-}
-{{ end }}
-
 // NewServer creates a new api {{ humanize .Name }} server but does not configure it
 func NewServer(api *{{ .Package }}.{{ pascalize .Name }}API) *Server {
 	s := new(Server)
-  {{ if not .UseGoStructFlags }}
-	s.EnabledListeners = enabledListeners
-	s.CleanupTimeout = cleanupTimeout
-	s.GracefulTimeout = gracefulTimeout
-	s.MaxHeaderSize = maxHeaderSize
-	s.SocketPath = socketPath
-	s.Host = stringEnvOverride(host, "", "HOST")
-	s.Port = intEnvOverride(port, 0, "PORT")
-	s.ListenLimit = listenLimit
-	s.KeepAlive = keepAlive
-	s.ReadTimeout = readTimeout
-	s.WriteTimeout = writeTimeout
-	s.TLSHost = stringEnvOverride(tlsHost, s.Host, "TLS_HOST", "HOST")
-	s.TLSPort = intEnvOverride(tlsPort, 0, "TLS_PORT")
-	s.TLSCertificate = stringEnvOverride(tlsCertificate, "", "TLS_CERTIFICATE")
-	s.TLSCertificateKey = stringEnvOverride(tlsCertificateKey, "", "TLS_PRIVATE_KEY")
-	s.TLSCACertificate = stringEnvOverride(tlsCACertificate, "", "TLS_CA_CERTIFICATE")
-	s.TLSListenLimit = tlsListenLimit
-	s.TLSKeepAlive = tlsKeepAlive
-	s.TLSReadTimeout = tlsReadTimeout
-	s.TLSWriteTimeout = tlsWriteTimeout
-    {{- if .ExcludeSpec }}
-    s.Spec = specFile
-    {{- end }}
-  {{- end }}
-	s.shutdown = make(chan struct{})
 	s.api = api
-	s.interrupt = make(chan os.Signal, 1)
 	return s
 }
 
@@ -289,10 +176,7 @@ type Server struct {
 	api               *{{ .Package }}.{{ pascalize .Name }}API
 	handler           http.Handler
 	hasListeners      bool
-	shutdown          chan struct{}
-	shuttingDown      int32
-	interrupted       bool
-	interrupt         chan os.Signal
+	servers           []*http.Server
 
 	wg sync.WaitGroup
         shutdowner hive.Shutdowner
@@ -368,6 +252,10 @@ func (s *Server) Start(hive.HookContext) (err error) {
 		}
 	}
 
+	if len(s.servers) != 0 {
+		return errors.New("already started")
+	}
+
 	// set default handler, if none is set
 	if s.handler == nil {
 		if s.api == nil {
@@ -376,12 +264,6 @@ func (s *Server) Start(hive.HookContext) (err error) {
 
 		s.SetHandler(s.api.Serve(nil))
 	}
-
-	once := new(sync.Once)
-	signalNotify(s.interrupt)
-	go handleInterrupt(once, s)
-
-	servers := []*http.Server{}
 
 	if s.hasScheme(schemeUnix) {
 		domainSocket := new(http.Server)
@@ -399,7 +281,7 @@ func (s *Server) Start(hive.HookContext) (err error) {
 				return err
 			}
 		}
-		servers = append(servers, domainSocket)
+		s.servers = append(s.servers, domainSocket)
 		s.wg.Add(1)
 		s.Logf("Serving {{ humanize .Name }} at unix://%s", s.SocketPath)
 		go func(l net.Listener){
@@ -429,7 +311,7 @@ func (s *Server) Start(hive.HookContext) (err error) {
 
 		configureServer(httpServer, "http", s.httpServerL.Addr().String())
 
-		servers = append(servers, httpServer)
+		s.servers = append(s.servers, httpServer)
 		s.wg.Add(1)
 		s.Logf("Serving {{ humanize .Name }} at http://%s", s.httpServerL.Addr())
 		go func(l net.Listener) {
@@ -527,7 +409,7 @@ func (s *Server) Start(hive.HookContext) (err error) {
 
 		configureServer(httpsServer, "https", s.httpsServerL.Addr().String())
 
-		servers = append(servers, httpsServer)
+		s.servers = append(s.servers, httpsServer)
 		s.wg.Add(1)
 		s.Logf("Serving {{ humanize .Name }} at https://%s", s.httpsServerL.Addr())
 		go func(l net.Listener) {
@@ -539,23 +421,8 @@ func (s *Server) Start(hive.HookContext) (err error) {
 		}(tls.NewListener(s.httpsServerL, httpsServer.TLSConfig))
 	}
 
-	s.wg.Add(1)
-	go s.handleShutdown(&servers)
-
 	return nil
 }
-
-func (s *Server) Stop(hive.HookContext) error {
-	if err := s.Shutdown(); err != nil {
-		return err
-	}
-	// FIXME need to pass HookContext somehow into handleShutdown to make this
-        // respect the timeout. Probably want to fold "handleShutdown" into this
-	// function.
-	s.wg.Wait()
-        return nil
-}
-
 
 // Listen creates the listeners for the server
 func (s *Server) Listen() error {
@@ -634,38 +501,28 @@ func (s *Server) Listen() error {
 
 // Shutdown server and clean up resources
 func (s *Server) Shutdown() error {
-	if atomic.CompareAndSwapInt32(&s.shuttingDown, 0, 1) {
-		close(s.shutdown)
-	}
-	return nil
-}
-
-func (s *Server) handleShutdown(serversPtr *[]*http.Server) {
-	// s.wg.Done must occur last, after s.api.ServerShutdown()
-	// (to preserve old behaviour)
-	defer s.wg.Done()
-
-	<-s.shutdown
-
-	servers := *serversPtr
-
 	ctx, cancel := context.WithTimeout(context.TODO(), s.GracefulTimeout)
 	defer cancel()
+	return s.Stop(ctx)
+}
 
+func (s *Server) Stop(ctx hive.HookContext) error {
 	// first execute the pre-shutdown hook
 	s.api.PreServerShutdown()
 
 	shutdownChan := make(chan bool)
-	for i := range servers {
-		server := servers[i]
+	for i := range s.servers {
+		server := s.servers[i]
 		go func() {
 			var success bool
 			defer func() {
 				shutdownChan <- success
 			}()
 			if err := server.Shutdown(ctx); err != nil {
-				// Error from closing listeners, or context timeout:
 				s.Logf("HTTP server Shutdown: %v", err)
+
+				// Forcefully close open connections.
+				server.Close()
 			} else {
 				success = true
 			}
@@ -674,12 +531,17 @@ func (s *Server) handleShutdown(serversPtr *[]*http.Server) {
 
 	// Wait until all listeners have successfully shut down before calling ServerShutdown
 	success := true
-	for range servers {
+	for range s.servers {
 		success = success && <-shutdownChan
 	}
 	if success {
 		s.api.ServerShutdown()
 	}
+
+	s.wg.Wait()
+	s.servers = nil
+
+	return nil
 }
 
 // GetHandler returns a handler useful for testing
@@ -720,25 +582,5 @@ func (s *Server) TLSListener() (net.Listener, error) {
 		}
 	}
 	return s.httpsServerL, nil
-}
-
-func handleInterrupt(once *sync.Once, s *Server) {
-	once.Do(func(){
-	for range s.interrupt {
-		if s.interrupted {
-			s.Logf("Server already shutting down")
-			continue
-		}
-		s.interrupted = true
-		s.Logf("Shutting down... ")
-		if err := s.Shutdown(); err != nil {
-			s.Logf("HTTP server Shutdown: %v", err)
-		}
-	}
-	})
-}
-
-func signalNotify(interrupt chan<- os.Signal) {
-	signal.Notify(interrupt, unix.SIGINT, unix.SIGTERM)
 }
 

--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -31,7 +31,54 @@ import (
 
   {{ imports .DefaultImports }}
   {{ imports .Imports }}
+
+  "github.com/cilium/cilium/pkg/hive"
+  "github.com/cilium/cilium/pkg/hive/cell"
 )
+
+// Cell implements the {{ humanize .Name }} REST API server when provided
+// the required request handlers.
+var Cell = cell.Module(
+	"{{ dasherize .Name }}-server",
+	"{{ humanize .Name }} server",
+
+	cell.Provide(newForCell),
+)
+
+type serverParams struct {
+	cell.In
+
+	Lifecycle  hive.Lifecycle
+	Shutdowner hive.Shutdowner
+	Logger     logrus.FieldLogger
+
+	{{- $package := .Package }}
+	{{ range .Operations }}
+		{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler {{ .PackageAlias }}.{{ pascalize .Name }}Handler
+	{{- end }}
+}
+
+func newForCell(p serverParams) (*Server, error) {
+	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to swagger spec: %w", err)
+	}
+	api := {{ .Package }}.New{{pascalize .Name}}API(swaggerSpec)
+
+	// Construct the API from the provided handlers
+	{{- $package := .Package }}
+	{{ range .Operations }}
+	  api.{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler = p.{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler
+	{{- end }}
+
+	s := NewServer(api)
+	s.shutdowner = p.Shutdowner
+	s.logger = p.Logger
+	p.Lifecycle.Append(s)
+
+	return s, nil
+}
+
 
 const (
 	schemeHTTP  = "http"
@@ -246,11 +293,17 @@ type Server struct {
 	shuttingDown      int32
 	interrupted       bool
 	interrupt         chan os.Signal
+
+	wg sync.WaitGroup
+        shutdowner hive.Shutdowner
+	logger logrus.FieldLogger
 }
 
 // Logf logs message either via defined user logger or via system one if no user logger is defined.
 func (s *Server) Logf(f string, args ...interface{}) {
-	if s.api != nil && s.api.Logger != nil {
+	if s.logger != nil {
+		s.logger.Infof(f, args...)
+	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 	} else {
 		log.Printf(f, args...)
@@ -260,7 +313,9 @@ func (s *Server) Logf(f string, args ...interface{}) {
 // Fatalf logs message either via defined user logger or via system one if no user logger is defined.
 // Exits with non-zero status after printing
 func (s *Server) Fatalf(f string, args ...interface{}) {
-	if s.api != nil && s.api.Logger != nil {
+	if s.shutdowner != nil {
+		s.shutdowner.Shutdown(hive.ShutdownWithError(fmt.Errorf(f, args...)))
+        } else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 		os.Exit(1)
 	} else {
@@ -294,8 +349,19 @@ func (s *Server) hasScheme(scheme string) bool {
 	return false
 }
 
-// Serve the api
-func (s *Server) Serve() (err error) {
+func (s *Server) Serve() error {
+	// TODO remove when this is not needed for compatibility anymore
+        if err := s.Start(context.TODO()); err != nil {
+		return err
+	}
+	s.wg.Wait()
+	return nil
+}
+
+// Start the server
+func (s *Server) Start(hive.HookContext) (err error) {
+	s.ConfigureAPI()
+
 	if !s.hasListeners {
 		if err = s.Listen(); err != nil {
 		  return err
@@ -311,7 +377,6 @@ func (s *Server) Serve() (err error) {
 		s.SetHandler(s.api.Serve(nil))
 	}
 
-	wg := new(sync.WaitGroup)
 	once := new(sync.Once)
 	signalNotify(s.interrupt)
 	go handleInterrupt(once, s)
@@ -335,10 +400,10 @@ func (s *Server) Serve() (err error) {
 			}
 		}
 		servers = append(servers, domainSocket)
-		wg.Add(1)
+		s.wg.Add(1)
 		s.Logf("Serving {{ humanize .Name }} at unix://%s", s.SocketPath)
 		go func(l net.Listener){
-		  defer wg.Done()
+		  defer s.wg.Done()
 		  if err := domainSocket.Serve(l); err != nil && err != http.ErrServerClosed {
 			s.Fatalf("%v", err)
 		  }
@@ -365,10 +430,10 @@ func (s *Server) Serve() (err error) {
 		configureServer(httpServer, "http", s.httpServerL.Addr().String())
 
 		servers = append(servers, httpServer)
-		wg.Add(1)
+		s.wg.Add(1)
 		s.Logf("Serving {{ humanize .Name }} at http://%s", s.httpServerL.Addr())
 		go func(l net.Listener) {
-			defer wg.Done()
+			defer s.wg.Done()
 			if err := httpServer.Serve(l); err != nil && err != http.ErrServerClosed {
 				s.Fatalf("%v", err)
 			}
@@ -463,10 +528,10 @@ func (s *Server) Serve() (err error) {
 		configureServer(httpsServer, "https", s.httpsServerL.Addr().String())
 
 		servers = append(servers, httpsServer)
-		wg.Add(1)
+		s.wg.Add(1)
 		s.Logf("Serving {{ humanize .Name }} at https://%s", s.httpsServerL.Addr())
 		go func(l net.Listener) {
-			defer wg.Done()
+			defer s.wg.Done()
 			if err := httpsServer.Serve(l); err != nil && err != http.ErrServerClosed {
 				s.Fatalf("%v", err)
 			}
@@ -474,12 +539,23 @@ func (s *Server) Serve() (err error) {
 		}(tls.NewListener(s.httpsServerL, httpsServer.TLSConfig))
 	}
 
-	wg.Add(1)
-	go s.handleShutdown(wg, &servers)
+	s.wg.Add(1)
+	go s.handleShutdown(&servers)
 
-	wg.Wait()
 	return nil
 }
+
+func (s *Server) Stop(hive.HookContext) error {
+	if err := s.Shutdown(); err != nil {
+		return err
+	}
+	// FIXME need to pass HookContext somehow into handleShutdown to make this
+        // respect the timeout. Probably want to fold "handleShutdown" into this
+	// function.
+	s.wg.Wait()
+        return nil
+}
+
 
 // Listen creates the listeners for the server
 func (s *Server) Listen() error {
@@ -564,10 +640,10 @@ func (s *Server) Shutdown() error {
 	return nil
 }
 
-func (s *Server) handleShutdown(wg *sync.WaitGroup, serversPtr *[]*http.Server) {
-	// wg.Done must occur last, after s.api.ServerShutdown()
+func (s *Server) handleShutdown(serversPtr *[]*http.Server) {
+	// s.wg.Done must occur last, after s.api.ServerShutdown()
 	// (to preserve old behaviour)
-	defer wg.Done()
+	defer s.wg.Done()
 
 	<-s.shutdown
 
@@ -576,7 +652,7 @@ func (s *Server) handleShutdown(wg *sync.WaitGroup, serversPtr *[]*http.Server) 
 	ctx, cancel := context.WithTimeout(context.TODO(), s.GracefulTimeout)
 	defer cancel()
 
-  // first execute the pre-shutdown hook
+	// first execute the pre-shutdown hook
 	s.api.PreServerShutdown()
 
 	shutdownChan := make(chan bool)
@@ -665,3 +741,4 @@ func handleInterrupt(once *sync.Once, s *Server) {
 func signalNotify(interrupt chan<- os.Signal) {
 	signal.Notify(interrupt, unix.SIGINT, unix.SIGTERM)
 }
+

--- a/api/v1/server/server.go
+++ b/api/v1/server/server.go
@@ -15,17 +15,14 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/signal"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/swag"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/netutil"
-	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/server/restapi"
 	"github.com/cilium/cilium/api/v1/server/restapi/bgp"
@@ -195,13 +192,35 @@ func init() {
 	}
 }
 
+var (
+	enabledListeners []string
+	gracefulTimeout  time.Duration
+	maxHeaderSize    int
+
+	socketPath string
+
+	host         string
+	port         int
+	listenLimit  int
+	keepAlive    time.Duration
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+
+	tlsHost           string
+	tlsPort           int
+	tlsListenLimit    int
+	tlsKeepAlive      time.Duration
+	tlsReadTimeout    time.Duration
+	tlsWriteTimeout   time.Duration
+	tlsCertificate    string
+	tlsCertificateKey string
+	tlsCACertificate  string
+)
+
 // NewServer creates a new api cilium API server but does not configure it
 func NewServer(api *restapi.CiliumAPIAPI) *Server {
 	s := new(Server)
-
-	s.shutdown = make(chan struct{})
 	s.api = api
-	s.interrupt = make(chan os.Signal, 1)
 	return s
 }
 
@@ -251,10 +270,7 @@ type Server struct {
 	api          *restapi.CiliumAPIAPI
 	handler      http.Handler
 	hasListeners bool
-	shutdown     chan struct{}
-	shuttingDown int32
-	interrupted  bool
-	interrupt    chan os.Signal
+	servers      []*http.Server
 
 	wg         sync.WaitGroup
 	shutdowner hive.Shutdowner
@@ -330,6 +346,10 @@ func (s *Server) Start(hive.HookContext) (err error) {
 		}
 	}
 
+	if len(s.servers) != 0 {
+		return errors.New("already started")
+	}
+
 	// set default handler, if none is set
 	if s.handler == nil {
 		if s.api == nil {
@@ -338,12 +358,6 @@ func (s *Server) Start(hive.HookContext) (err error) {
 
 		s.SetHandler(s.api.Serve(nil))
 	}
-
-	once := new(sync.Once)
-	signalNotify(s.interrupt)
-	go handleInterrupt(once, s)
-
-	servers := []*http.Server{}
 
 	if s.hasScheme(schemeUnix) {
 		domainSocket := new(http.Server)
@@ -361,7 +375,7 @@ func (s *Server) Start(hive.HookContext) (err error) {
 				return err
 			}
 		}
-		servers = append(servers, domainSocket)
+		s.servers = append(s.servers, domainSocket)
 		s.wg.Add(1)
 		s.Logf("Serving cilium API at unix://%s", s.SocketPath)
 		go func(l net.Listener) {
@@ -391,7 +405,7 @@ func (s *Server) Start(hive.HookContext) (err error) {
 
 		configureServer(httpServer, "http", s.httpServerL.Addr().String())
 
-		servers = append(servers, httpServer)
+		s.servers = append(s.servers, httpServer)
 		s.wg.Add(1)
 		s.Logf("Serving cilium API at http://%s", s.httpServerL.Addr())
 		go func(l net.Listener) {
@@ -487,7 +501,7 @@ func (s *Server) Start(hive.HookContext) (err error) {
 
 		configureServer(httpsServer, "https", s.httpsServerL.Addr().String())
 
-		servers = append(servers, httpsServer)
+		s.servers = append(s.servers, httpsServer)
 		s.wg.Add(1)
 		s.Logf("Serving cilium API at https://%s", s.httpsServerL.Addr())
 		go func(l net.Listener) {
@@ -499,20 +513,6 @@ func (s *Server) Start(hive.HookContext) (err error) {
 		}(tls.NewListener(s.httpsServerL, httpsServer.TLSConfig))
 	}
 
-	s.wg.Add(1)
-	go s.handleShutdown(&servers)
-
-	return nil
-}
-
-func (s *Server) Stop(hive.HookContext) error {
-	if err := s.Shutdown(); err != nil {
-		return err
-	}
-	// FIXME need to pass HookContext somehow into handleShutdown to make this
-	// respect the timeout. Probably want to fold "handleShutdown" into this
-	// function.
-	s.wg.Wait()
 	return nil
 }
 
@@ -593,38 +593,28 @@ func (s *Server) Listen() error {
 
 // Shutdown server and clean up resources
 func (s *Server) Shutdown() error {
-	if atomic.CompareAndSwapInt32(&s.shuttingDown, 0, 1) {
-		close(s.shutdown)
-	}
-	return nil
-}
-
-func (s *Server) handleShutdown(serversPtr *[]*http.Server) {
-	// s.wg.Done must occur last, after s.api.ServerShutdown()
-	// (to preserve old behaviour)
-	defer s.wg.Done()
-
-	<-s.shutdown
-
-	servers := *serversPtr
-
 	ctx, cancel := context.WithTimeout(context.TODO(), s.GracefulTimeout)
 	defer cancel()
+	return s.Stop(ctx)
+}
 
+func (s *Server) Stop(ctx hive.HookContext) error {
 	// first execute the pre-shutdown hook
 	s.api.PreServerShutdown()
 
 	shutdownChan := make(chan bool)
-	for i := range servers {
-		server := servers[i]
+	for i := range s.servers {
+		server := s.servers[i]
 		go func() {
 			var success bool
 			defer func() {
 				shutdownChan <- success
 			}()
 			if err := server.Shutdown(ctx); err != nil {
-				// Error from closing listeners, or context timeout:
 				s.Logf("HTTP server Shutdown: %v", err)
+
+				// Forcefully close open connections.
+				server.Close()
 			} else {
 				success = true
 			}
@@ -633,12 +623,17 @@ func (s *Server) handleShutdown(serversPtr *[]*http.Server) {
 
 	// Wait until all listeners have successfully shut down before calling ServerShutdown
 	success := true
-	for range servers {
+	for range s.servers {
 		success = success && <-shutdownChan
 	}
 	if success {
 		s.api.ServerShutdown()
 	}
+
+	s.wg.Wait()
+	s.servers = nil
+
+	return nil
 }
 
 // GetHandler returns a handler useful for testing
@@ -679,24 +674,4 @@ func (s *Server) TLSListener() (net.Listener, error) {
 		}
 	}
 	return s.httpsServerL, nil
-}
-
-func handleInterrupt(once *sync.Once, s *Server) {
-	once.Do(func() {
-		for range s.interrupt {
-			if s.interrupted {
-				s.Logf("Server already shutting down")
-				continue
-			}
-			s.interrupted = true
-			s.Logf("Shutting down... ")
-			if err := s.Shutdown(); err != nil {
-				s.Logf("HTTP server Shutdown: %v", err)
-			}
-		}
-	})
-}
-
-func signalNotify(interrupt chan<- os.Signal) {
-	signal.Notify(interrupt, unix.SIGINT, unix.SIGTERM)
 }

--- a/api/v1/server/server.go
+++ b/api/v1/server/server.go
@@ -21,13 +21,165 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-openapi/loads"
 	"github.com/go-openapi/swag"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/netutil"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/server/restapi"
+	"github.com/cilium/cilium/api/v1/server/restapi/bgp"
+	"github.com/cilium/cilium/api/v1/server/restapi/daemon"
+	"github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	"github.com/cilium/cilium/api/v1/server/restapi/ipam"
+	"github.com/cilium/cilium/api/v1/server/restapi/metrics"
+	"github.com/cilium/cilium/api/v1/server/restapi/policy"
+	"github.com/cilium/cilium/api/v1/server/restapi/prefilter"
+	"github.com/cilium/cilium/api/v1/server/restapi/recorder"
+	"github.com/cilium/cilium/api/v1/server/restapi/service"
+
 	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
 )
+
+// Cell implements the cilium API REST API server when provided
+// the required request handlers.
+var Cell = cell.Module(
+	"cilium-api-server",
+	"cilium API server",
+
+	cell.Provide(newForCell),
+)
+
+type serverParams struct {
+	cell.In
+
+	Lifecycle  hive.Lifecycle
+	Shutdowner hive.Shutdowner
+	Logger     logrus.FieldLogger
+
+	EndpointDeleteEndpointIDHandler      endpoint.DeleteEndpointIDHandler
+	PolicyDeleteFqdnCacheHandler         policy.DeleteFqdnCacheHandler
+	IpamDeleteIpamIPHandler              ipam.DeleteIpamIPHandler
+	PolicyDeletePolicyHandler            policy.DeletePolicyHandler
+	PrefilterDeletePrefilterHandler      prefilter.DeletePrefilterHandler
+	RecorderDeleteRecorderIDHandler      recorder.DeleteRecorderIDHandler
+	ServiceDeleteServiceIDHandler        service.DeleteServiceIDHandler
+	BgpGetBgpPeersHandler                bgp.GetBgpPeersHandler
+	DaemonGetCgroupDumpMetadataHandler   daemon.GetCgroupDumpMetadataHandler
+	DaemonGetClusterNodesHandler         daemon.GetClusterNodesHandler
+	DaemonGetConfigHandler               daemon.GetConfigHandler
+	DaemonGetDebuginfoHandler            daemon.GetDebuginfoHandler
+	EndpointGetEndpointHandler           endpoint.GetEndpointHandler
+	EndpointGetEndpointIDHandler         endpoint.GetEndpointIDHandler
+	EndpointGetEndpointIDConfigHandler   endpoint.GetEndpointIDConfigHandler
+	EndpointGetEndpointIDHealthzHandler  endpoint.GetEndpointIDHealthzHandler
+	EndpointGetEndpointIDLabelsHandler   endpoint.GetEndpointIDLabelsHandler
+	EndpointGetEndpointIDLogHandler      endpoint.GetEndpointIDLogHandler
+	PolicyGetFqdnCacheHandler            policy.GetFqdnCacheHandler
+	PolicyGetFqdnCacheIDHandler          policy.GetFqdnCacheIDHandler
+	PolicyGetFqdnNamesHandler            policy.GetFqdnNamesHandler
+	DaemonGetHealthzHandler              daemon.GetHealthzHandler
+	PolicyGetIPHandler                   policy.GetIPHandler
+	PolicyGetIdentityHandler             policy.GetIdentityHandler
+	PolicyGetIdentityEndpointsHandler    policy.GetIdentityEndpointsHandler
+	PolicyGetIdentityIDHandler           policy.GetIdentityIDHandler
+	ServiceGetLrpHandler                 service.GetLrpHandler
+	DaemonGetMapHandler                  daemon.GetMapHandler
+	DaemonGetMapNameHandler              daemon.GetMapNameHandler
+	DaemonGetMapNameEventsHandler        daemon.GetMapNameEventsHandler
+	MetricsGetMetricsHandler             metrics.GetMetricsHandler
+	DaemonGetNodeIdsHandler              daemon.GetNodeIdsHandler
+	PolicyGetPolicyHandler               policy.GetPolicyHandler
+	PolicyGetPolicySelectorsHandler      policy.GetPolicySelectorsHandler
+	PrefilterGetPrefilterHandler         prefilter.GetPrefilterHandler
+	RecorderGetRecorderHandler           recorder.GetRecorderHandler
+	RecorderGetRecorderIDHandler         recorder.GetRecorderIDHandler
+	RecorderGetRecorderMasksHandler      recorder.GetRecorderMasksHandler
+	ServiceGetServiceHandler             service.GetServiceHandler
+	ServiceGetServiceIDHandler           service.GetServiceIDHandler
+	DaemonPatchConfigHandler             daemon.PatchConfigHandler
+	EndpointPatchEndpointIDHandler       endpoint.PatchEndpointIDHandler
+	EndpointPatchEndpointIDConfigHandler endpoint.PatchEndpointIDConfigHandler
+	EndpointPatchEndpointIDLabelsHandler endpoint.PatchEndpointIDLabelsHandler
+	PrefilterPatchPrefilterHandler       prefilter.PatchPrefilterHandler
+	IpamPostIpamHandler                  ipam.PostIpamHandler
+	IpamPostIpamIPHandler                ipam.PostIpamIPHandler
+	EndpointPutEndpointIDHandler         endpoint.PutEndpointIDHandler
+	PolicyPutPolicyHandler               policy.PutPolicyHandler
+	RecorderPutRecorderIDHandler         recorder.PutRecorderIDHandler
+	ServicePutServiceIDHandler           service.PutServiceIDHandler
+}
+
+func newForCell(p serverParams) (*Server, error) {
+	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to swagger spec: %w", err)
+	}
+	api := restapi.NewCiliumAPIAPI(swaggerSpec)
+
+	// Construct the API from the provided handlers
+
+	api.EndpointDeleteEndpointIDHandler = p.EndpointDeleteEndpointIDHandler
+	api.PolicyDeleteFqdnCacheHandler = p.PolicyDeleteFqdnCacheHandler
+	api.IpamDeleteIpamIPHandler = p.IpamDeleteIpamIPHandler
+	api.PolicyDeletePolicyHandler = p.PolicyDeletePolicyHandler
+	api.PrefilterDeletePrefilterHandler = p.PrefilterDeletePrefilterHandler
+	api.RecorderDeleteRecorderIDHandler = p.RecorderDeleteRecorderIDHandler
+	api.ServiceDeleteServiceIDHandler = p.ServiceDeleteServiceIDHandler
+	api.BgpGetBgpPeersHandler = p.BgpGetBgpPeersHandler
+	api.DaemonGetCgroupDumpMetadataHandler = p.DaemonGetCgroupDumpMetadataHandler
+	api.DaemonGetClusterNodesHandler = p.DaemonGetClusterNodesHandler
+	api.DaemonGetConfigHandler = p.DaemonGetConfigHandler
+	api.DaemonGetDebuginfoHandler = p.DaemonGetDebuginfoHandler
+	api.EndpointGetEndpointHandler = p.EndpointGetEndpointHandler
+	api.EndpointGetEndpointIDHandler = p.EndpointGetEndpointIDHandler
+	api.EndpointGetEndpointIDConfigHandler = p.EndpointGetEndpointIDConfigHandler
+	api.EndpointGetEndpointIDHealthzHandler = p.EndpointGetEndpointIDHealthzHandler
+	api.EndpointGetEndpointIDLabelsHandler = p.EndpointGetEndpointIDLabelsHandler
+	api.EndpointGetEndpointIDLogHandler = p.EndpointGetEndpointIDLogHandler
+	api.PolicyGetFqdnCacheHandler = p.PolicyGetFqdnCacheHandler
+	api.PolicyGetFqdnCacheIDHandler = p.PolicyGetFqdnCacheIDHandler
+	api.PolicyGetFqdnNamesHandler = p.PolicyGetFqdnNamesHandler
+	api.DaemonGetHealthzHandler = p.DaemonGetHealthzHandler
+	api.PolicyGetIPHandler = p.PolicyGetIPHandler
+	api.PolicyGetIdentityHandler = p.PolicyGetIdentityHandler
+	api.PolicyGetIdentityEndpointsHandler = p.PolicyGetIdentityEndpointsHandler
+	api.PolicyGetIdentityIDHandler = p.PolicyGetIdentityIDHandler
+	api.ServiceGetLrpHandler = p.ServiceGetLrpHandler
+	api.DaemonGetMapHandler = p.DaemonGetMapHandler
+	api.DaemonGetMapNameHandler = p.DaemonGetMapNameHandler
+	api.DaemonGetMapNameEventsHandler = p.DaemonGetMapNameEventsHandler
+	api.MetricsGetMetricsHandler = p.MetricsGetMetricsHandler
+	api.DaemonGetNodeIdsHandler = p.DaemonGetNodeIdsHandler
+	api.PolicyGetPolicyHandler = p.PolicyGetPolicyHandler
+	api.PolicyGetPolicySelectorsHandler = p.PolicyGetPolicySelectorsHandler
+	api.PrefilterGetPrefilterHandler = p.PrefilterGetPrefilterHandler
+	api.RecorderGetRecorderHandler = p.RecorderGetRecorderHandler
+	api.RecorderGetRecorderIDHandler = p.RecorderGetRecorderIDHandler
+	api.RecorderGetRecorderMasksHandler = p.RecorderGetRecorderMasksHandler
+	api.ServiceGetServiceHandler = p.ServiceGetServiceHandler
+	api.ServiceGetServiceIDHandler = p.ServiceGetServiceIDHandler
+	api.DaemonPatchConfigHandler = p.DaemonPatchConfigHandler
+	api.EndpointPatchEndpointIDHandler = p.EndpointPatchEndpointIDHandler
+	api.EndpointPatchEndpointIDConfigHandler = p.EndpointPatchEndpointIDConfigHandler
+	api.EndpointPatchEndpointIDLabelsHandler = p.EndpointPatchEndpointIDLabelsHandler
+	api.PrefilterPatchPrefilterHandler = p.PrefilterPatchPrefilterHandler
+	api.IpamPostIpamHandler = p.IpamPostIpamHandler
+	api.IpamPostIpamIPHandler = p.IpamPostIpamIPHandler
+	api.EndpointPutEndpointIDHandler = p.EndpointPutEndpointIDHandler
+	api.PolicyPutPolicyHandler = p.PolicyPutPolicyHandler
+	api.RecorderPutRecorderIDHandler = p.RecorderPutRecorderIDHandler
+	api.ServicePutServiceIDHandler = p.ServicePutServiceIDHandler
+
+	s := NewServer(api)
+	s.shutdowner = p.Shutdowner
+	s.logger = p.Logger
+	p.Lifecycle.Append(s)
+
+	return s, nil
+}
 
 const (
 	schemeHTTP  = "http"
@@ -103,11 +255,17 @@ type Server struct {
 	shuttingDown int32
 	interrupted  bool
 	interrupt    chan os.Signal
+
+	wg         sync.WaitGroup
+	shutdowner hive.Shutdowner
+	logger     logrus.FieldLogger
 }
 
 // Logf logs message either via defined user logger or via system one if no user logger is defined.
 func (s *Server) Logf(f string, args ...interface{}) {
-	if s.api != nil && s.api.Logger != nil {
+	if s.logger != nil {
+		s.logger.Infof(f, args...)
+	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 	} else {
 		log.Printf(f, args...)
@@ -117,7 +275,9 @@ func (s *Server) Logf(f string, args ...interface{}) {
 // Fatalf logs message either via defined user logger or via system one if no user logger is defined.
 // Exits with non-zero status after printing
 func (s *Server) Fatalf(f string, args ...interface{}) {
-	if s.api != nil && s.api.Logger != nil {
+	if s.shutdowner != nil {
+		s.shutdowner.Shutdown(hive.ShutdownWithError(fmt.Errorf(f, args...)))
+	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 		os.Exit(1)
 	} else {
@@ -151,8 +311,19 @@ func (s *Server) hasScheme(scheme string) bool {
 	return false
 }
 
-// Serve the api
-func (s *Server) Serve() (err error) {
+func (s *Server) Serve() error {
+	// TODO remove when this is not needed for compatibility anymore
+	if err := s.Start(context.TODO()); err != nil {
+		return err
+	}
+	s.wg.Wait()
+	return nil
+}
+
+// Start the server
+func (s *Server) Start(hive.HookContext) (err error) {
+	s.ConfigureAPI()
+
 	if !s.hasListeners {
 		if err = s.Listen(); err != nil {
 			return err
@@ -168,7 +339,6 @@ func (s *Server) Serve() (err error) {
 		s.SetHandler(s.api.Serve(nil))
 	}
 
-	wg := new(sync.WaitGroup)
 	once := new(sync.Once)
 	signalNotify(s.interrupt)
 	go handleInterrupt(once, s)
@@ -192,10 +362,10 @@ func (s *Server) Serve() (err error) {
 			}
 		}
 		servers = append(servers, domainSocket)
-		wg.Add(1)
+		s.wg.Add(1)
 		s.Logf("Serving cilium API at unix://%s", s.SocketPath)
 		go func(l net.Listener) {
-			defer wg.Done()
+			defer s.wg.Done()
 			if err := domainSocket.Serve(l); err != nil && err != http.ErrServerClosed {
 				s.Fatalf("%v", err)
 			}
@@ -222,10 +392,10 @@ func (s *Server) Serve() (err error) {
 		configureServer(httpServer, "http", s.httpServerL.Addr().String())
 
 		servers = append(servers, httpServer)
-		wg.Add(1)
+		s.wg.Add(1)
 		s.Logf("Serving cilium API at http://%s", s.httpServerL.Addr())
 		go func(l net.Listener) {
-			defer wg.Done()
+			defer s.wg.Done()
 			if err := httpServer.Serve(l); err != nil && err != http.ErrServerClosed {
 				s.Fatalf("%v", err)
 			}
@@ -318,10 +488,10 @@ func (s *Server) Serve() (err error) {
 		configureServer(httpsServer, "https", s.httpsServerL.Addr().String())
 
 		servers = append(servers, httpsServer)
-		wg.Add(1)
+		s.wg.Add(1)
 		s.Logf("Serving cilium API at https://%s", s.httpsServerL.Addr())
 		go func(l net.Listener) {
-			defer wg.Done()
+			defer s.wg.Done()
 			if err := httpsServer.Serve(l); err != nil && err != http.ErrServerClosed {
 				s.Fatalf("%v", err)
 			}
@@ -329,10 +499,20 @@ func (s *Server) Serve() (err error) {
 		}(tls.NewListener(s.httpsServerL, httpsServer.TLSConfig))
 	}
 
-	wg.Add(1)
-	go s.handleShutdown(wg, &servers)
+	s.wg.Add(1)
+	go s.handleShutdown(&servers)
 
-	wg.Wait()
+	return nil
+}
+
+func (s *Server) Stop(hive.HookContext) error {
+	if err := s.Shutdown(); err != nil {
+		return err
+	}
+	// FIXME need to pass HookContext somehow into handleShutdown to make this
+	// respect the timeout. Probably want to fold "handleShutdown" into this
+	// function.
+	s.wg.Wait()
 	return nil
 }
 
@@ -419,10 +599,10 @@ func (s *Server) Shutdown() error {
 	return nil
 }
 
-func (s *Server) handleShutdown(wg *sync.WaitGroup, serversPtr *[]*http.Server) {
-	// wg.Done must occur last, after s.api.ServerShutdown()
+func (s *Server) handleShutdown(serversPtr *[]*http.Server) {
+	// s.wg.Done must occur last, after s.api.ServerShutdown()
 	// (to preserve old behaviour)
-	defer wg.Done()
+	defer s.wg.Done()
 
 	<-s.shutdown
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	health "github.com/cilium/cilium/cilium-health/launch"
 	"github.com/cilium/cilium/daemon/cmd/cni"
-	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/bandwidth"
 	"github.com/cilium/cilium/pkg/bgp/speaker"
 	bgpv1 "github.com/cilium/cilium/pkg/bgpv1/agent"
@@ -33,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/counter"
-	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
@@ -74,7 +72,6 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
-	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	nodemanager "github.com/cilium/cilium/pkg/node/manager"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -92,7 +89,6 @@ import (
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/status"
 	"github.com/cilium/cilium/pkg/trigger"
-	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
@@ -386,26 +382,7 @@ func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 }
 
 // newDaemon creates and returns a new Daemon with the parameters set in c.
-func newDaemon(ctx context.Context, cleaner *daemonCleanup,
-	epMgr endpointmanager.EndpointManager,
-	nodeMngr nodeManager.NodeManager,
-	dp datapath.Datapath,
-	wgAgent *wg.Agent,
-	clientset k8sClient.Clientset,
-	sharedResources k8s.SharedResources,
-	certManager certificatemanager.CertificateManager,
-	secretManager certificatemanager.SecretManager,
-	nodeLocalStore node.LocalNodeStore,
-	authManager auth.Manager,
-	cacheStatus k8s.CacheStatus,
-	ipc *ipcache.IPCache,
-	identityAllocator CachingIdentityAllocator,
-	pr *policy.Repository,
-	policyUpdater *policy.Updater,
-	egressGatewayManager *egressgateway.Manager,
-	cniConfigManager cni.CNIConfigManager,
-) (*Daemon, *endpointRestoreState, error) {
-
+func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams) (*Daemon, *endpointRestoreState, error) {
 	var (
 		err           error
 		netConf       *cnitypes.NetConf
@@ -420,12 +397,12 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	}
 
 	// Validate configuration options that depend on other cells.
-	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD && !clientset.IsEnabled() &&
+	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD && !params.Clientset.IsEnabled() &&
 		option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
 		return nil, nil, fmt.Errorf("CRD Identity allocation mode requires k8s to be configured")
 	}
 
-	if mtu := cniConfigManager.GetMTU(); mtu > 0 {
+	if mtu := params.CNIConfigManager.GetMTU(); mtu > 0 {
 		configuredMTU = mtu
 		log.WithField("mtu", configuredMTU).Info("Overwriting MTU based on CNI configuration")
 	}
@@ -507,7 +484,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		externalIP,
 	)
 
-	nodeMngr.Subscribe(dp.Node())
+	params.NodeManager.Subscribe(params.Datapath.Node())
 
 	identity.IterateReservedIdentities(func(_ identity.NumericIdentity, _ *identity.Identity) {
 		metrics.Identity.WithLabelValues(identity.ReservedIdentityType).Inc()
@@ -518,7 +495,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		metrics.Identity.WithLabelValues(identity.WellKnownIdentityType).Add(float64(num))
 	}
 
-	nd := nodediscovery.NewNodeDiscovery(nodeMngr, clientset, mtuConfig, netConf)
+	nd := nodediscovery.NewNodeDiscovery(params.NodeManager, params.Clientset, mtuConfig, netConf)
 
 	devMngr, err := linuxdatapath.NewDeviceManager()
 	if err != nil {
@@ -527,28 +504,28 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 
 	d := Daemon{
 		ctx:               ctx,
-		clientset:         clientset,
+		clientset:         params.Clientset,
 		prefixLengths:     createPrefixLengthCounter(),
 		buildEndpointSem:  semaphore.NewWeighted(int64(numWorkerThreads())),
 		compilationMutex:  new(lock.RWMutex),
 		netConf:           netConf,
 		mtuConfig:         mtuConfig,
-		datapath:          dp,
+		datapath:          params.Datapath,
 		deviceManager:     devMngr,
 		nodeDiscovery:     nd,
-		nodeLocalStore:    nodeLocalStore,
-		endpointCreations: newEndpointCreationManager(clientset),
+		nodeLocalStore:    params.LocalNodeStore,
+		endpointCreations: newEndpointCreationManager(params.Clientset),
 		apiLimiterSet:     apiLimiterSet,
 		controllers:       controller.NewManager(),
 		// **NOTE** The global identity allocator is not yet initialized here; that
 		// happens below via InitIdentityAllocator(). Only the local identity
 		// allocator is initialized here.
-		identityAllocator:    identityAllocator,
-		ipcache:              ipc,
-		policy:               pr,
-		policyUpdater:        policyUpdater,
-		egressGatewayManager: egressGatewayManager,
-		cniConfigManager:     cniConfigManager,
+		identityAllocator:    params.IdentityAllocator,
+		ipcache:              params.IPCache,
+		policy:               params.Policy,
+		policyUpdater:        params.PolicyUpdater,
+		egressGatewayManager: params.EgressGatewayManager,
+		cniConfigManager:     params.CNIConfigManager,
 	}
 
 	if option.Config.RunMonitorAgent {
@@ -592,7 +569,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		ipcachemap.IPCacheMap().Close()
 	}
 
-	if err := d.initPolicy(authManager); err != nil {
+	if err := d.initPolicy(params.AuthManager); err != nil {
 		return nil, nil, fmt.Errorf("error while initializing policy subsystem: %w", err)
 	}
 
@@ -626,7 +603,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 
 	proxy.Allocator = d.identityAllocator
 
-	d.endpointManager = epMgr
+	d.endpointManager = params.EndpointManager
 
 	// Start the proxy before we start K8s watcher or restore endpoints so that we can inject
 	// the daemon's proxy into the k8s watcher and each endpoint.
@@ -654,7 +631,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 			Warn("You are using the legacy BGP feature, which will only receive security updates and bugfixes. " +
 				"It is recommended to migrate to the BGP Control Plane feature if possible, which has better support.")
 
-		d.bgpSpeaker, err = speaker.New(ctx, clientset, speaker.Opts{
+		d.bgpSpeaker, err = speaker.New(ctx, params.Clientset, speaker.Opts{
 			LoadBalancerIP: option.Config.BGPAnnounceLBIP,
 			PodCIDR:        option.Config.BGPAnnouncePodCIDR,
 		})
@@ -672,7 +649,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	}
 
 	d.k8sWatcher = watchers.NewK8sWatcher(
-		clientset,
+		params.Clientset,
 		d.endpointManager,
 		d.nodeDiscovery,
 		&d,
@@ -686,7 +663,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		option.Config,
 		d.ipcache,
 		d.cgroupManager,
-		sharedResources,
+		params.SharedResources,
 	)
 	nd.RegisterK8sGetters(d.k8sWatcher)
 
@@ -881,7 +858,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 
 	bootstrapStats.fqdn.End(true)
 
-	if clientset.IsEnabled() {
+	if params.Clientset.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
 		// Errors are handled inside WaitForCRDsToRegister. It will fatal on a
 		// context deadline or if the context has been cancelled, the context's
@@ -922,8 +899,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		bootstrapStats.k8sInit.End(true)
 	}
 
-	if wgAgent != nil && option.Config.EnableWireguard {
-		if err := wgAgent.Init(d.ipcache, d.mtuConfig); err != nil {
+	if params.WGAgent != nil && option.Config.EnableWireguard {
+		if err := params.WGAgent.Init(d.ipcache, d.mtuConfig); err != nil {
 			log.WithError(err).Error("failed to initialize wireguard agent")
 			return nil, nil, fmt.Errorf("failed to initialize wireguard agent: %w", err)
 		}
@@ -939,7 +916,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	// This is because the device detection requires self (Cilium)Node object,
 	// and the k8s service watcher depends on option.Config.EnableNodePort flag
 	// which can be modified after the device detection.
-	if _, err := d.deviceManager.Detect(clientset.IsEnabled()); err != nil {
+	if _, err := d.deviceManager.Detect(params.Clientset.IsEnabled()); err != nil {
 		if option.Config.AreDevicesRequired() {
 			// Fail hard if devices are required to function.
 			return nil, nil, fmt.Errorf("failed to detect devices: %w", err)
@@ -1047,15 +1024,15 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	// Some of the k8s watchers rely on option flags set above (specifically
 	// EnableBPFMasquerade), so we should only start them once the flag values
 	// are set.
-	if clientset.IsEnabled() {
+	if params.Clientset.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
 
 		// Launch the K8s watchers in parallel as we continue to process other
 		// daemon options.
-		d.k8sWatcher.InitK8sSubsystem(d.ctx, cacheStatus)
+		d.k8sWatcher.InitK8sSubsystem(d.ctx, params.CacheStatus)
 		bootstrapStats.k8sInit.End(true)
 	} else {
-		close(cacheStatus)
+		close(params.CacheStatus)
 	}
 
 	bootstrapStats.cleanup.Start()
@@ -1085,7 +1062,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	d.configureIPAM()
 
 	if option.Config.JoinCluster {
-		if clientset.IsEnabled() {
+		if params.Clientset.IsEnabled() {
 			log.WithError(err).Errorf("cannot join a Cilium cluster (--%s) when configured as a Kubernetes node", option.JoinClusterName)
 			return nil, nil, fmt.Errorf("cannot join a Cilium cluster (--%s) when configured as a Kubernetes node", option.JoinClusterName)
 		}
@@ -1142,7 +1119,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 
 	// Annotation of the k8s node must happen after discovery of the
 	// PodCIDR range and allocation of the health IPs.
-	if clientset.IsEnabled() && option.Config.AnnotateK8sNode {
+	if params.Clientset.IsEnabled() && option.Config.AnnotateK8sNode {
 		bootstrapStats.k8sInit.Start()
 		log.WithFields(logrus.Fields{
 			logfields.V4Prefix:       node.GetIPv4AllocRange(),
@@ -1156,7 +1133,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		}).Info("Annotating k8s node")
 
 		_, err := k8s.AnnotateNode(
-			clientset,
+			params.Clientset,
 			nodeTypes.GetName(),
 			d.nodeLocalStore.Get().Node,
 			encryptKeyID)
@@ -1188,9 +1165,9 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		// Ignore the channel returned by this function, as we want the global
 		// identity allocator to run asynchronously.
 		realIdentityAllocator := d.identityAllocator
-		realIdentityAllocator.InitIdentityAllocator(clientset, nil)
+		realIdentityAllocator.InitIdentityAllocator(params.Clientset, nil)
 
-		d.bootstrapClusterMesh(nodeMngr)
+		d.bootstrapClusterMesh(params.NodeManager)
 	}
 
 	// Must be done at least after initializing BPF LB-related maps

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1610,26 +1610,7 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 
 	params.Lifecycle.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {
-			d, restoredEndpoints, err := newDaemon(
-				daemonCtx, cleaner,
-				params.EndpointManager,
-				params.NodeManager,
-				params.Datapath,
-				params.WGAgent,
-				params.Clientset,
-				params.SharedResources,
-				params.CertManager,
-				params.SecretManager,
-				params.LocalNodeStore,
-				params.AuthManager,
-				params.CacheStatus,
-				params.IPCache,
-				params.IdentityAllocator,
-				params.Policy,
-				params.PolicyUpdater,
-				params.EgressGatewayManager,
-				params.CNIConfigManager,
-			)
+			d, restoredEndpoints, err := newDaemon(daemonCtx, cleaner, &params)
 			if err != nil {
 				return fmt.Errorf("daemon creation failed: %w", err)
 			}

--- a/operator/api/server.go
+++ b/operator/api/server.go
@@ -44,7 +44,7 @@ type params struct {
 }
 
 type server struct {
-	operatorApi.Server
+	*operatorApi.Server
 
 	logger     logrus.FieldLogger
 	shutdowner hive.Shutdowner
@@ -91,7 +91,7 @@ func (s *server) Start(ctx hive.HookContext) error {
 	srv := operatorApi.NewServer(api)
 	srv.EnabledListeners = []string{"http"}
 	srv.ConfigureAPI()
-	s.Server = *srv
+	s.Server = srv
 
 	mux := http.NewServeMux()
 


### PR DESCRIPTION
This PR modularizes the cilium-agent's REST API server served over UNIX socket (cilium.sock) to
allow API handlers to be implemented from any module. 

See #23882 for further motivation and individual commit messages for details.
The adaption to cilium-agent is left as follow-up PR.

After this a handler for Cilium API can be implemented thus:

```
import (
  policyapi "github.com/cilium/cilium/api/v1/server/restapi/policy"
)

var exampleHandlersCell = cell.Module(
  "example-handlers",
  "Example API handlers",

  cell.Provide(exampleHandlers),
)

type handlersOut struct {
  cell.Out

  GetIPHandler policyapi.GetIPHandler
  GetPolicyHandler policyapi.GetPolicyHandler
  // ...
}

func exampleHandlers(s Some, d Dependencies) handlersOut {
  return handlersOut{
    GetIPHandler: &getIPHandler{s, d},
    GetPolicyHandler: &getPolicyHandler{s, d},
    // ...
  }
}

type getIPHandler struct { /* ... */ }

func (h *getIPHandler) Handle(params GETIPParams) middleware.Responder {
  // ...
}
