### PR TITLE
docs: Endpoints are local to the node on which the cilium agent is running.

### DIFF
--- a/Documentation/security/gsg_sw_demo.rst
+++ b/Documentation/security/gsg_sw_demo.rst
@@ -42,8 +42,10 @@ point the pod is ready.
     service/deathstar    ClusterIP   10.96.110.8   <none>        80/TCP    107s
     service/kubernetes   ClusterIP   10.96.0.1     <none>        443/TCP   3m53s
 
-Each pod will be represented in Cilium as an :ref:`endpoint`. We can invoke the
-``cilium`` tool inside the Cilium pod to list them:
+Each pod will be represented in Cilium as an :ref:`endpoint` in the local cilium agent. 
+We can invoke the ``cilium`` tool inside the Cilium pod to list them (in a single-node installation
+``kubectl -n kube-system exec ds/cilium -- cilium endpoint list`` lists them all, but in a 
+multi-node installation, only the ones running on the same node will be listed):
 
 .. code-block:: shell-session
 
@@ -51,7 +53,7 @@ Each pod will be represented in Cilium as an :ref:`endpoint`. We can invoke the
     NAME           READY   STATUS    RESTARTS   AGE
     cilium-5ngzd   1/1     Running   0          3m19s
 
-    $ kubectl -n kube-system exec ds/cilium -- cilium endpoint list
+    $ kubectl -n kube-system exec cilium-5ngzd -- cilium endpoint list
     ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                       IPv6   IPv4         STATUS
                ENFORCEMENT        ENFORCEMENT
     232        Disabled           Disabled          16530      k8s:class=deathstar                                      10.0.0.147   ready


### PR DESCRIPTION
The example assumed that there was only one node as invoking against ds/cilium just picks one pod in the daemonset.

As showed:

`✦ ❯ kubectl -n kube-system exec ds/cilium -- cilium endpoint list      
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), clean-cilium-state (init)
ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                   IPv6   IPv4         STATUS   
           ENFORCEMENT        ENFORCEMENT                                                                                                    
1210       Disabled           Disabled          1          k8s:node-role.kubernetes.io/control-plane                                         ready   
                                                           k8s:node.kubernetes.io/exclude-from-external-load-balancers                               
                                                           reserved:host                                                                             
2421       Disabled           Disabled          4          reserved:health                                                      10.0.4.118   ready   


✦ ❯ kubectl -n kube-system exec cilium-zlndj -- cilium endpoint list   
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), clean-cilium-state (init)
ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                                    IPv6   IPv4         STATUS   
           ENFORCEMENT        ENFORCEMENT                                                                                                                     
970        Disabled           Disabled          46385      k8s:app.kubernetes.io/name=tiefighter                                                 10.0.3.181   ready   
                                                           k8s:class=tiefighter                                                                                       
                                                           k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=hostport-2431                               
                                                           k8s:io.cilium.k8s.policy.cluster=default                                                                   
                                                           k8s:io.cilium.k8s.policy.serviceaccount=default                                                            
                                                           k8s:io.kubernetes.pod.namespace=hostport-2431                                                              
                                                           k8s:org=empire                                                                                             
1002       Disabled           Disabled          4          reserved:health                                                                       10.0.3.236   ready   
1493       Disabled           Disabled          57677      k8s:app.kubernetes.io/name=xwing                                                      10.0.3.77    ready   
                                                           k8s:class=xwing                                                                                            
                                                           k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=hostport-2431                               
                                                           k8s:io.cilium.k8s.policy.cluster=default                                                                   
                                                           k8s:io.cilium.k8s.policy.serviceaccount=default                                                            
                                                           k8s:io.kubernetes.pod.namespace=hostport-2431                                                              
                                                           k8s:org=alliance                                                                                           
1624       Disabled           Disabled          1326       k8s:app.kubernetes.io/name=tiefighter                                                 10.0.3.209   ready   
                                                           k8s:class=tiefighter                                                                                       
                                                           k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=demo                                        
                                                           k8s:io.cilium.k8s.policy.cluster=default                                                                   
                                                           k8s:io.cilium.k8s.policy.serviceaccount=default                                                            
                                                           k8s:io.kubernetes.pod.namespace=demo                                                                       
                                                           k8s:org=empire                                                                                             
2495       Disabled           Disabled          16567      k8s:app.kubernetes.io/name=deathstar                                                  10.0.3.40    ready   
                                                           k8s:class=deathstar                                                                                        
                                                           k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=hostport-2431                               
                                                           k8s:io.cilium.k8s.policy.cluster=default                                                                   
                                                           k8s:io.cilium.k8s.policy.serviceaccount=default                                                            
                                                           k8s:io.kubernetes.pod.namespace=hostport-2431                                                              
                                                           k8s:org=empire                                                                                             
2522       Disabled           Disabled          1          reserved:host                         `

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
