### PR TITLE
ipsec,mtu: Modularize `pkg/datapath/linux/ipsec`

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeIPsec "github.com/cilium/cilium/pkg/datapath/fake/ipsec"
+	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/endpoint"
 	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -147,6 +149,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 			},
 			func() datapath.Datapath { return fakeDatapath.NewDatapath() },
 			func() *option.DaemonConfig { return option.Config },
+			func() ipsec.ManagerInterface { return &fakeIPsec.IPSecManager{} },
 		),
 		ControlPlane,
 		cell.Invoke(func(p promise.Promise[*Daemon]) {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath"
 	datapathIpcache "github.com/cilium/cilium/pkg/datapath/ipcache"
-	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -514,23 +513,6 @@ func (d *Daemon) initMaps() error {
 	}
 
 	return nil
-}
-
-func setupIPSec() (int, uint8, error) {
-	if !option.Config.EncryptNode {
-		ipsec.DeleteIPsecEncryptRoute()
-	}
-
-	if !option.Config.EnableIPSec {
-		return 0, 0, nil
-	}
-
-	authKeySize, spi, err := ipsec.LoadIPSecKeysFile(option.Config.IPSecKeyFile)
-	if err != nil {
-		return 0, 0, err
-	}
-	node.SetIPsecKeyIdentity(spi)
-	return authKeySize, spi, nil
 }
 
 func setupVTEPMapping() error {

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -68,7 +68,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "create a client ID and store it locally",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(mockAuthKeySizer(0), false, false, false, 0, nil), &cnitypes.NetConf{})
 				return args{
 					params: GetClusterNodesParams{
 						ClientID: &zero,
@@ -99,7 +99,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes diff from a client that was already present",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(mockAuthKeySizer(0), false, false, false, 0, nil), &cnitypes.NetConf{})
 				return args{
 					params: GetClusterNodesParams{
 						ClientID: &clientIDs[0],
@@ -152,7 +152,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes from an expired client, it should be ok because the clean up only happens when on insertion",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(mockAuthKeySizer(0), false, false, false, 0, nil), &cnitypes.NetConf{})
 				return args{
 					params: GetClusterNodesParams{
 						ClientID: &clientIDs[0],
@@ -206,7 +206,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a new client, the expired client should be deleted",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(mockAuthKeySizer(0), false, false, false, 0, nil), &cnitypes.NetConf{})
 				return args{
 					params: GetClusterNodesParams{
 						ClientID: &zero,
@@ -255,7 +255,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a new client, however the randomizer allocated an existing clientID, so we should return a empty clientID",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(mockAuthKeySizer(0), false, false, false, 0, nil), &cnitypes.NetConf{})
 				return args{
 					params: GetClusterNodesParams{
 						ClientID: &zero,
@@ -304,7 +304,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a client that does not want to have diffs, leave all other stored clients alone",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(mockAuthKeySizer(0), false, false, false, 0, nil), &cnitypes.NetConf{})
 				return args{
 					params: GetClusterNodesParams{},
 					daemon: &Daemon{
@@ -413,10 +413,16 @@ func (g *GetNodesSuite) Test_cleanupClients(c *C) {
 		h := &getNodes{
 			clients: args.clients,
 			d: &Daemon{
-				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(0, false, false, false, 0, nil), &cnitypes.NetConf{}),
+				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(mockAuthKeySizer(0), false, false, false, 0, nil), &cnitypes.NetConf{}),
 			},
 		}
 		h.cleanupClients()
 		c.Assert(h.clients, checker.DeepEquals, want.clients)
 	}
+}
+
+type mockAuthKeySizer int
+
+func (m mockAuthKeySizer) GetAuthKeySize() int {
+	return int(m)
 }

--- a/pkg/datapath/fake/ipsec/ipsec.go
+++ b/pkg/datapath/fake/ipsec/ipsec.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipsec
+
+import (
+	"net"
+
+	real_ipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec"
+)
+
+type IPSecManager struct{}
+
+func (im *IPSecManager) GetAuthKeySize() int {
+	return 0
+}
+
+func (im *IPSecManager) GetCurrentKeySPI() uint8 {
+	return 0
+}
+
+func (im *IPSecManager) IpSecReplacePolicyFwd(dst *net.IPNet, tmplDst net.IP) error {
+	return nil
+}
+
+func (im *IPSecManager) UpsertIPsecEndpoint(local *net.IPNet, remote *net.IPNet, outerLocal net.IP, outerRemote net.IP, dir real_ipsec.IPSecDir, outputMark bool) (uint8, error) {
+	return 0, nil
+}
+
+func (im *IPSecManager) UpsertIPsecEndpointPolicy(local *net.IPNet, remote *net.IPNet, localTmpl net.IP, remoteTmpl net.IP, dir real_ipsec.IPSecDir) error {
+	return nil
+}

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -6,6 +6,7 @@ package linux
 import (
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
+	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
@@ -32,7 +33,7 @@ type linuxDatapath struct {
 }
 
 // NewDatapath creates a new Linux datapath
-func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager, wgAgent datapath.WireguardAgent) datapath.Datapath {
+func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager, wgAgent datapath.WireguardAgent, ipsecManager ipsec.ManagerInterface) datapath.Datapath {
 	dp := &linuxDatapath{
 		ConfigWriter:    &config.HeaderfileWriter{},
 		IptablesManager: ruleManager,
@@ -43,7 +44,7 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 		lbmap:           lbmap.New(),
 	}
 
-	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, wgAgent)
+	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, wgAgent, ipsecManager)
 	return dp
 }
 

--- a/pkg/datapath/linux/datapath_test.go
+++ b/pkg/datapath/linux/datapath_test.go
@@ -18,7 +18,7 @@ type linuxTestSuite struct{}
 var _ = check.Suite(&linuxTestSuite{})
 
 func (s *linuxTestSuite) TestNewDatapath(c *check.C) {
-	dp := NewDatapath(DatapathConfiguration{}, nil, nil)
+	dp := NewDatapath(DatapathConfiguration{}, nil, nil, nil)
 	c.Assert(dp, check.Not(check.IsNil))
 
 	c.Assert(dp.Node(), check.Not(check.IsNil))

--- a/pkg/datapath/linux/fuzz_test.go
+++ b/pkg/datapath/linux/fuzz_test.go
@@ -23,7 +23,7 @@ func FuzzNodeHandler(f *testing.F) {
 		}
 		dpConfig := DatapathConfiguration{HostDevice: "veth0"}
 		fakeNodeAddressing := fake.NewNodeAddressing()
-		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil).(*linuxNodeHandler)
+		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, nil).(*linuxNodeHandler)
 		if linuxNodeHandler == nil {
 			panic("Should not be nil")
 		}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -80,10 +80,16 @@ const (
 	baseIPv6Time = "net.ipv6.neigh.default.base_reachable_time_ms"
 )
 
+type mockAuthKeySizer int
+
+func (m mockAuthKeySizer) GetAuthKeySize() int {
+	return int(m)
+}
+
 func (s *linuxPrivilegedBaseTestSuite) SetUpTest(c *check.C, addressing types.NodeAddressing, enableIPv6, enableIPv4 bool) {
 	rlimit.RemoveMemlock()
 	s.nodeAddressing = addressing
-	s.mtuConfig = mtu.NewConfiguration(0, false, false, false, 1500, nil)
+	s.mtuConfig = mtu.NewConfiguration(mockAuthKeySizer(0), false, false, false, 1500, nil)
 	s.enableIPv6 = enableIPv6
 	s.enableIPv4 = enableIPv4
 
@@ -199,7 +205,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4: s.enableIPv4,
@@ -247,7 +253,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 func (s *linuxPrivilegedBaseTestSuite) TestSingleClusterPrefix(c *check.C) {
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	// enable as per test definition
@@ -313,7 +319,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	net2 := cidr.MustParseCIDR("cafe:f00d::/112")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:        s.enableIPv4,
@@ -387,7 +393,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	externalNodeIP2 := net.ParseIP("8.8.8.8")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:          s.enableIPv4,
@@ -677,7 +683,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateDirectRouting(c *check.C) {
 	defer removeDevice(externalNode2Device)
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:              s.enableIPv4,
@@ -892,7 +898,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 	underlayIP := net.ParseIP("4.4.4.4")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:          s.enableIPv4,
@@ -999,7 +1005,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.
 	ip4Alloc1 := cidr.MustParseCIDR("5.5.5.0/24")
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	if s.enableIPv4 {
@@ -1164,7 +1170,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = time.Duration(1 * time.Nanosecond)
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -2053,7 +2059,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = 1 * time.Nanosecond
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -2334,7 +2340,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = time.Duration(1 * time.Nanosecond)
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -3224,7 +3230,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = 1 * time.Nanosecond
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -3423,7 +3429,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config da
 	ip6Alloc2 := cidr.MustParseCIDR("2001:bbbb::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)
@@ -3529,7 +3535,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdateNOP(c *check.C, config
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)
@@ -3598,7 +3604,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeValidateImplementation(c *ch
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil, nil).(*linuxNodeHandler)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -19,7 +19,7 @@ import (
 var (
 	nh = linuxNodeHandler{
 		nodeConfig: datapath.LocalNodeConfiguration{
-			MtuConfig: mtu.NewConfiguration(0, false, false, false, 100, net.IP("1.1.1.1")),
+			MtuConfig: mtu.NewConfiguration(mockAuthKeySizer(0), false, false, false, 100, net.IP("1.1.1.1")),
 		},
 		nodeAddressing: fake.NewNodeAddressing(),
 		datapathConfig: DatapathConfiguration{
@@ -67,7 +67,7 @@ func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {
 
 	fakeNodeAddressing := fake.NewNodeAddressing()
 
-	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil)
+	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil, nil)
 
 	c1 := cidr.MustParseCIDR("10.10.0.0/16")
 	generatedRoute, err := nodeHandler.(*linuxNodeHandler).createNodeRouteSpec(c1, false)

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -30,7 +30,7 @@ type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
 	e := NewEndpointWithState(&suite, &suite, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
-	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil, nil)
+	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil, nil, nil)
 
 	targetComments := func(w io.Writer) error {
 		return e.writeInformationalComments(w)

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -91,7 +91,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNames(c *C) {
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil)
+	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil)
 
 	epsWanted, _ := ds.createEndpoints()
 	tmpDir, err := os.MkdirTemp("", "cilium-tests")
@@ -161,7 +161,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNamesWithRestoreFailure(c *C) {
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil)
+	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil)
 
 	eps, _ := ds.createEndpoints()
 	ep := eps[0]
@@ -227,7 +227,7 @@ func (ds *EndpointSuite) BenchmarkReadEPsFromDirNames(c *C) {
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil)
+	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil)
 
 	epsWanted, _ := ds.createEndpoints()
 	tmpDir, err := os.MkdirTemp("", "cilium-tests")

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -25,7 +25,13 @@ func (o *ownerMock) RegisterCiliumNodeSubscriber(s subscriber.CiliumNode)       
 func (o *ownerMock) UpdateCiliumNodeResource()                                          {}
 func (o *ownerMock) LocalAllocCIDRsUpdated(ipv4AllocCIDRs, ipv6AllocCIDRs []*cidr.CIDR) {}
 
-var mtuMock = mtu.NewConfiguration(0, false, false, false, 1500, nil)
+type mockAuthKeySizer int
+
+func (m mockAuthKeySizer) GetAuthKeySize() int {
+	return int(m)
+}
+
+var mtuMock = mtu.NewConfiguration(mockAuthKeySizer(0), false, false, false, 1500, nil)
 
 func (s *IPAMSuite) TestAllocatedIPDump(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()

--- a/pkg/mtu/mtu_test.go
+++ b/pkg/mtu/mtu_test.go
@@ -18,57 +18,57 @@ var _ = Suite(&MTUSuite{})
 
 func (m *MTUSuite) TestNewConfiguration(c *C) {
 	// Add routes with no encryption or tunnel
-	conf := NewConfiguration(0, false, false, false, 0, nil)
+	conf := NewConfiguration(mockAuthKeySizer(0), false, false, false, 0, nil)
 	c.Assert(conf.GetDeviceMTU(), Not(Equals), 0)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU())
 
 	// Add routes with no encryption or tunnel and set MTU
-	conf = NewConfiguration(0, false, false, false, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(0), false, false, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU())
 
 	// Add routes with tunnel
-	conf = NewConfiguration(0, false, true, false, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(0), false, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-TunnelOverhead)
 
 	// Add routes with tunnel and set MTU
-	conf = NewConfiguration(0, false, true, false, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(0), false, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-TunnelOverhead)
 
 	// Add routes with encryption and set MTU using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, false, false, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(16), true, false, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-EncryptionIPsecOverhead)
 
-	conf = NewConfiguration(32, true, false, false, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(32), true, false, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(EncryptionIPsecOverhead+16))
 
-	conf = NewConfiguration(12, true, false, false, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(12), true, false, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(EncryptionIPsecOverhead-4))
 
 	// Add routes with encryption and tunnels using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, true, false, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(16), true, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead))
 
-	conf = NewConfiguration(32, true, true, false, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(32), true, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead+16))
 
-	conf = NewConfiguration(32, true, true, false, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(32), true, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead+16))
 
 	// Add routes with wireguard enabled
-	conf = NewConfiguration(32, false, false, true, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(32), false, false, true, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-WireguardOverhead)
 
-	conf = NewConfiguration(32, false, true, true, 1400, nil)
+	conf = NewConfiguration(mockAuthKeySizer(32), false, true, true, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-WireguardOverhead)
 
@@ -77,13 +77,19 @@ func (m *MTUSuite) TestNewConfiguration(c *C) {
 	result, _ := getMTUFromIf(testIP1)
 	c.Assert(result, Equals, 0)
 
-	conf = NewConfiguration(0, true, true, false, 1400, testIP1)
+	conf = NewConfiguration(mockAuthKeySizer(0), true, true, false, 1400, testIP1)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 
-	conf = NewConfiguration(0, true, true, false, 0, testIP1)
+	conf = NewConfiguration(mockAuthKeySizer(0), true, true, false, 0, testIP1)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1500)
 
 	// Assuming loopback interface always exists and has mtu=65536
-	conf = NewConfiguration(0, true, true, false, 0, testIP2)
+	conf = NewConfiguration(mockAuthKeySizer(0), true, true, false, 0, testIP2)
 	c.Assert(conf.GetDeviceMTU(), Equals, 65536)
+}
+
+type mockAuthKeySizer int
+
+func (m mockAuthKeySizer) GetAuthKeySize() int {
+	return int(m)
 }

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -12,6 +12,8 @@ import (
 	"github.com/cilium/cilium/daemon/cmd"
 	"github.com/cilium/cilium/pkg/datapath"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	fakeIPSec "github.com/cilium/cilium/pkg/datapath/fake/ipsec"
+	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -66,6 +68,7 @@ func startCiliumAgent(t *testing.T, nodeName string, clientset k8sClient.Clients
 			func() k8sClient.Clientset { return clientset },
 			func() datapath.Datapath { return fdp },
 			func() *option.DaemonConfig { return option.Config },
+			func() ipsec.ManagerInterface { return &fakeIPSec.IPSecManager{} },
 		),
 		cmd.ControlPlane,
 		cell.Invoke(func(p promise.Promise[*cmd.Daemon]) {


### PR DESCRIPTION
This PR modularizes the IPSec package. It does so by introducing a new type `ipsec.Manager` and moving the global variables into this type as fields. All package level functions that access or modify the fields are not methods on this manager struct.

The two IPSec related goroutines that watch the filesystem for updates to the key and cleaning up stale keys are now part of the Managers lifecycle. And all initialization work that happened in the daemon before now happens during Manager construction or its lifecycle hooks.

`pkg/mtu` is dependant on the ipsec package since the auth key size is part of the MTU calculation. Since this size can theoretically change after a key change, the MTU package will now always query the current auth key size from the IPSec manager.

Fixes: #23901

```release-note
Modularized `pkg/datapath/linux/ipsec`
```
