### PR TITLE
daemon: update initKubeProxyReplacementOptions' comment

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -38,14 +38,7 @@ import (
 )
 
 // initKubeProxyReplacementOptions will grok the global config and determine
-// if we strictly enforce a kube-proxy replacement.
-//
-// if we determine the config denotes a "strict" kube-proxy replacement, the
-// returned boolean will be true, when we detect a "non-strict" configuration the
-// return boolean is false.
-//
-// if this function cannot determine the strictness an error is returned and the boolean
-// is false. If an error is returned the boolean is of no meaning.
+// if the config is valid.
 func initKubeProxyReplacementOptions() error {
 	if option.Config.KubeProxyReplacement != option.KubeProxyReplacementStrict &&
 		option.Config.KubeProxyReplacement != option.KubeProxyReplacementPartial &&


### PR DESCRIPTION
The strict kube-proxy detection is removed in commit 691f1c33c9ade6fe7a0db26b9c53e182d7bfc13c, but this comment wasn't updated.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!
