### PR TITLE
Fix concurrent map read/write race condition after importing CNP

### DIFF
--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -193,13 +193,9 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(policyMapState MapSt
 	}
 }
 
-// ConsumeMapChanges transfers the changes from MapChanges to the caller,
-// locking the selector cache to make sure concurrent identity updates
-// have completed.
-// PolicyOwner (aka Endpoint) is also locked during this call.
+// ConsumeMapChanges transfers the changes from MapChanges to the caller.
+// PolicyOwner (aka Endpoint) is locked during this call.
 func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
-	p.selectorPolicy.SelectorCache.mutex.Lock()
-	defer p.selectorPolicy.SelectorCache.mutex.Unlock()
 	return p.policyMapChanges.consumeMapChanges(p.PolicyMapState, p.SelectorCache)
 }
 

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -1090,6 +1090,9 @@ func (sc *SelectorCache) RemoveIdentitiesFQDNSelectors(fqdnSels []api.FQDNSelect
 }
 
 func (sc *SelectorCache) GetLabels(id identity.NumericIdentity) labels.LabelArray {
+	sc.mutex.RLock()
+	defer sc.mutex.RUnlock()
+
 	ident, ok := sc.idCache[id]
 	if !ok {
 		return labels.LabelArray{}


### PR DESCRIPTION
A crash of the agent can occur when processing a newly imported CiliumNetworkPolicy, if the idCache map is accessed without a lock during a concurrent write. This fix adds the acquisition of a read lock to guard that operation.

No backport is required, since it affects only master.

<!-- Description of change -->

Fixes: #24021

```release-note
Fix concurrent map read/write race condition after importing CNP
```
