### PR TITLE
egressgw: update all internal caches once k8s state is synced

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -487,6 +487,13 @@ func (manager *Manager) reconcile(e eventType) {
 		manager.updatePoliciesBySourceIP()
 	case eventAddPolicy, eventDeletePolicy:
 		manager.updatePoliciesBySourceIP()
+
+	// on eventK8sSyncDone we need to update all caches unconditionally as
+	// we don't know which k8s events/resources were received during the
+	// initial k8s sync
+	case eventK8sSyncDone:
+		manager.updatePoliciesMatchedEndpointIDs()
+		manager.updatePoliciesBySourceIP()
 	}
 
 	manager.regenerateGatewayConfigs()


### PR DESCRIPTION
as we don't know which k8s events/resources were received during the initial k8s sync