### PR TITLE
v1.12 backports 2023-02-27

### DIFF
--- a/Documentation/gettingstarted/encryption-wireguard.rst
+++ b/Documentation/gettingstarted/encryption-wireguard.rst
@@ -225,6 +225,9 @@ which may be resolved in upcoming Cilium releases:
 
 The current status of these limitations is tracked in :gh-issue:`15462`.
 
+In addition, WireGuard encryption is not currently supported in combination with
+IPv6-only clusters.
+
 Legal
 =====
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -574,7 +574,7 @@ const mismatchRouterIPsMsg = "Mismatch of router IPs found during restoration. T
 func ValidatePostInit() error {
 	addrsMu.RLock()
 	defer addrsMu.RUnlock()
-	if option.Config.EnableIPv4 || option.Config.Tunnel != option.TunnelDisabled {
+	if option.Config.EnableIPv4 || option.Config.Tunnel != option.TunnelDisabled || option.Config.EnableWireguard {
 		if addrs.ipv4Address == nil {
 			return fmt.Errorf("external IPv4 node address could not be derived, please configure via --ipv4-node")
 		}


### PR DESCRIPTION
- [x] #23552 -- node: require ipv4 address when wireguard is enabled (@giorio94)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 23552; do contrib/backporting/set-labels.py $pr done 1.12; done
```