### PR TITLE
auth: introduce hive cell (modularization)

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -74,6 +75,9 @@ var (
 
 		// The BGP Control Plane which enables various BGP related interop.
 		bgpv1.Cell,
+
+		// Auth is responsible for authenticating a request if required by a policy.
+		auth.Cell,
 	)
 
 	// Datapath provides the privileged operations to apply control-plane

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	health "github.com/cilium/cilium/cilium-health/launch"
+	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/bandwidth"
 	"github.com/cilium/cilium/pkg/bgp/speaker"
 	bgpv1 "github.com/cilium/cilium/pkg/bgpv1/agent"
@@ -412,6 +413,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	certManager certificatemanager.CertificateManager,
 	secretManager certificatemanager.SecretManager,
 	nodeLocalStore node.LocalNodeStore,
+	authManager auth.Manager,
 ) (*Daemon, *endpointRestoreState, error) {
 
 	var (
@@ -609,7 +611,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	// TODO: convert these package level variables to types for easier unit
 	// testing in the future.
 	d.identityAllocator = NewCachingIdentityAllocator(&d)
-	if err := d.initPolicy(epMgr, certManager, secretManager); err != nil {
+	if err := d.initPolicy(epMgr, certManager, secretManager, authManager); err != nil {
 		return nil, nil, fmt.Errorf("error while initializing policy subsystem: %w", err)
 	}
 	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/api/v1/server/restapi"
+	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/aws/eni"
 	bgpv1 "github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bpf"
@@ -1662,6 +1663,7 @@ type daemonParams struct {
 	EndpointManager endpointmanager.EndpointManager
 	CertManager     certificatemanager.CertificateManager
 	SecretManager   certificatemanager.SecretManager
+	AuthManager     auth.Manager
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
@@ -1693,7 +1695,8 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 				params.SharedResources,
 				params.CertManager,
 				params.SecretManager,
-				params.LocalNodeStore)
+				params.LocalNodeStore,
+				params.AuthManager)
 			if err != nil {
 				return fmt.Errorf("daemon creation failed: %w", err)
 			}

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -17,7 +17,6 @@ import (
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/auth"
-	authMonitor "github.com/cilium/cilium/pkg/auth/monitor"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -43,6 +42,7 @@ func (d *Daemon) initPolicy(
 	epMgr endpointmanager.EndpointManager,
 	certManager certificatemanager.CertificateManager,
 	secretManager certificatemanager.SecretManager,
+	authManager auth.Manager,
 ) error {
 	// Reuse policy.TriggerMetrics and PolicyTriggerInterval here since
 	// this is only triggered by agent configuration changes for now and
@@ -69,7 +69,7 @@ func (d *Daemon) initPolicy(
 		return fmt.Errorf("failed to create policy update trigger: %w", err)
 	}
 
-	d.monitorAgent.RegisterNewConsumer(authMonitor.AddAuthManager(auth.NewAuthManager(epMgr)))
+	d.monitorAgent.RegisterNewConsumer(authManager)
 
 	return nil
 }

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package auth
+
+import (
+	"github.com/cilium/cilium/pkg/auth/monitor"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/monitor/agent/consumer"
+)
+
+// Cell provides the auth.Manager which is responsible for request authentication.
+// It does this, by implementing consumer.MonitorConsumer and reacting upon
+// monitor.DropNotify events with reason flow.DropReason_AUTH_REQUIRED.
+// The actual authentication gets performed by an auth handler which is
+// responsible for the configured auth type on the corresponding policy.
+var Cell = cell.Module(
+	"auth-manager",
+	"Authenticates requests as demanded by policy",
+
+	cell.Provide(newManager),
+)
+
+type authManagerParams struct {
+	cell.In
+
+	EndpointManager endpointmanager.EndpointManager
+}
+
+type Manager interface {
+	consumer.MonitorConsumer
+}
+
+func newManager(params authManagerParams) Manager {
+	return monitor.AddAuthManager(NewAuthManager(params.EndpointManager))
+}


### PR DESCRIPTION
The auth manager itself is defined as cell which gets registered in the cell "control plane".

This way, the daemon cell doesn't need to know about the details how to initialize the auth manager and its internal components.
