### PR TITLE
egressgw: optimize policy matching logic

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -445,11 +445,10 @@ nextIpRule:
 	// Build a list of all the network interfaces that are being actively used by egress gateway
 	activeEgressGwIfaceIndexes := map[int]struct{}{}
 	for _, policyConfig := range manager.policyConfigs {
-		for _, endpoint := range manager.epDataStore {
-			if policyConfig.selectsEndpoint(endpoint) {
-				if policyConfig.gatewayConfig.localNodeConfiguredAsGateway {
-					activeEgressGwIfaceIndexes[policyConfig.gatewayConfig.ifaceIndex] = struct{}{}
-				}
+		// check if the policy selects at least one endpoint
+		if len(policyConfig.matchedEndpoints) != 0 {
+			if policyConfig.gatewayConfig.localNodeConfiguredAsGateway {
+				activeEgressGwIfaceIndexes[policyConfig.gatewayConfig.ifaceIndex] = struct{}{}
 			}
 		}
 	}

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -94,13 +94,6 @@ func (config *PolicyConfig) updateMatchedEndpointIDs(epDataStore map[endpointID]
 	}
 }
 
-// selectsEndpoint determines if the given endpoint is selected by the policy
-// config
-func (config *PolicyConfig) selectsEndpoint(endpointInfo *endpointMetadata) bool {
-	_, ok := config.matchedEndpoints[endpointInfo.id]
-	return ok
-}
-
 func (config *policyGatewayConfig) selectsNodeAsGateway(node nodeTypes.Node) bool {
 	return config.nodeSelector.Matches(k8sLabels.Set(node.Labels))
 }


### PR DESCRIPTION
Whenever we need to determine if a policy is a match for a given BPF map entry or IP rule, we first select from the policyConfigsBySourceIP cache all the policies that match the entry/rule's source IP, and from there we call the matches or matchesMinusExcludedCIDRs PolicyConfig methods, which iterate again through all the policy's endpoint/source IPs.

As this isn't optimal, this commit introduces a couple of new manager's methods, that replace the PolicyConfig ones:

* policyMatches
* policyMatchesMinusExcludedCIDRs

these work like matches and matchesMinusExcludedCIDRs, but iterate through the entire set of policies (instead of on a single one), and are optimized to skip iterating through the endpoint IPs we are not interested in.