### PR TITLE
envoy: Avoid using deprecated field

### DIFF
--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -103,7 +103,6 @@ var (
 			},
 		},
 	}
-	googleRe2 = &envoy_type_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &envoy_type_matcher.RegexMatcher_GoogleRE2{}}
 
 	PNPAllowGETbar = cilium.PortNetworkPolicyRule_HttpRules{
 		HttpRules: &cilium.HttpNetworkPolicyRules{
@@ -112,19 +111,27 @@ var (
 					Headers: []*envoy_config_route.HeaderMatcher{
 						{
 							Name: ":method",
-							HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{
-								SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-									EngineType: googleRe2,
-									Regex:      "GET",
-								}},
+							HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+								StringMatch: &envoy_type_matcher.StringMatcher{
+									MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+										SafeRegex: &envoy_type_matcher.RegexMatcher{
+											Regex: "GET",
+										},
+									},
+								},
+							},
 						},
 						{
 							Name: ":path",
-							HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{
-								SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-									EngineType: googleRe2,
-									Regex:      "/bar",
-								}},
+							HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+								StringMatch: &envoy_type_matcher.StringMatcher{
+									MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+										SafeRegex: &envoy_type_matcher.RegexMatcher{
+											Regex: "/bar",
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -139,11 +146,15 @@ var (
 					Headers: []*envoy_config_route.HeaderMatcher{
 						{
 							Name: ":method",
-							HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{
-								SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-									EngineType: googleRe2,
-									Regex:      "GET",
-								}},
+							HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+								StringMatch: &envoy_type_matcher.StringMatcher{
+									MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+										SafeRegex: &envoy_type_matcher.RegexMatcher{
+											Regex: "GET",
+										},
+									},
+								},
+							},
 						},
 					},
 					HeaderMatches: []*cilium.HeaderMatch{

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -337,8 +337,7 @@ func getRouteMatch(hostnames []string, hostNameSuffixMatch bool, pathMatch model
 		return &envoy_config_route_v3.RouteMatch{
 			PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
 				SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-					EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
-					Regex:      getMatchingPrefixRegex(pathMatch.Prefix),
+					Regex: getMatchingPrefixRegex(pathMatch.Prefix),
 				},
 			},
 			Headers:         headerMatchers,
@@ -349,8 +348,7 @@ func getRouteMatch(hostnames []string, hostNameSuffixMatch bool, pathMatch model
 		return &envoy_config_route_v3.RouteMatch{
 			PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
 				SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-					EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
-					Regex:      pathMatch.Regex,
+					Regex: pathMatch.Regex,
 				},
 			},
 			Headers:         headerMatchers,
@@ -393,8 +391,7 @@ func getHeaderMatchers(hostnames []string, hostNameSuffixMatch bool, headers []m
 						StringMatch: &envoy_type_matcher_v3.StringMatcher{
 							MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 								SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-									EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
-									Regex:      getMatchingHeaderRegex(host),
+									Regex: getMatchingHeaderRegex(host),
 								},
 							},
 						},
@@ -475,8 +472,7 @@ func getEnvoyStringMatcher(s model.StringMatch) *envoy_type_matcher_v3.StringMat
 		return &envoy_type_matcher_v3.StringMatcher{
 			MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 				SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-					EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
-					Regex:      s.Regex,
+					Regex: s.Regex,
 				},
 			},
 		}

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -35,8 +35,7 @@ func TestSortableRoute(t *testing.T) {
 			Match: &envoy_config_route_v3.RouteMatch{
 				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
-						Regex:      "/prefix/match",
+						Regex: "/prefix/match",
 					},
 				},
 			},
@@ -46,8 +45,7 @@ func TestSortableRoute(t *testing.T) {
 			Match: &envoy_config_route_v3.RouteMatch{
 				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
-						Regex:      "/prefix/match/another",
+						Regex: "/prefix/match/another",
 					},
 				},
 			},
@@ -57,8 +55,7 @@ func TestSortableRoute(t *testing.T) {
 			Match: &envoy_config_route_v3.RouteMatch{
 				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
-						Regex:      "/header",
+						Regex: "/header",
 					},
 				},
 				Headers: []*envoy_config_route_v3.HeaderMatcher{
@@ -80,8 +77,7 @@ func TestSortableRoute(t *testing.T) {
 			Match: &envoy_config_route_v3.RouteMatch{
 				PathSpecifier: &envoy_config_route_v3.RouteMatch_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{},
-						Regex:      "/header",
+						Regex: "/header",
 					},
 				},
 				Headers: []*envoy_config_route_v3.HeaderMatcher{

--- a/pkg/envoy/server_test.go
+++ b/pkg/envoy/server_test.go
@@ -67,59 +67,83 @@ var PortRuleHTTP3 = &api.PortRuleHTTP{
 	Method: "GET",
 }
 
-var googleRe2 = &envoy_type_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &envoy_type_matcher.RegexMatcher_GoogleRE2{}}
-
 var ExpectedHeaders1 = []*envoy_config_route.HeaderMatcher{
 	{
 		Name: ":authority",
-		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-				EngineType: googleRe2,
-				Regex:      "foo.cilium.io",
-			}},
+		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+			StringMatch: &envoy_type_matcher.StringMatcher{
+				MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+					SafeRegex: &envoy_type_matcher.RegexMatcher{
+						Regex: "foo.cilium.io",
+					},
+				},
+			},
+		},
 	},
 	{
 		Name: ":method",
-		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-				EngineType: googleRe2,
-				Regex:      "GET",
-			}},
+		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+			StringMatch: &envoy_type_matcher.StringMatcher{
+				MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+					SafeRegex: &envoy_type_matcher.RegexMatcher{
+						Regex: "GET",
+					},
+				},
+			},
+		},
 	},
 	{
 		Name: ":path",
-		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-				EngineType: googleRe2,
-				Regex:      "/foo",
-			}},
+		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+			StringMatch: &envoy_type_matcher.StringMatcher{
+				MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+					SafeRegex: &envoy_type_matcher.RegexMatcher{
+						Regex: "/foo",
+					},
+				},
+			},
+		},
 	},
 	{
 		Name:                 "header1",
 		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_PresentMatch{PresentMatch: true},
 	},
 	{
-		Name:                 "header2",
-		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_ExactMatch{ExactMatch: "value"},
+		Name: "header2",
+		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+			StringMatch: &envoy_type_matcher.StringMatcher{
+				MatchPattern: &envoy_type_matcher.StringMatcher_Exact{
+					Exact: "value",
+				},
+			},
+		},
 	},
 }
 
 var ExpectedHeaders2 = []*envoy_config_route.HeaderMatcher{
 	{
 		Name: ":method",
-		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-				EngineType: googleRe2,
-				Regex:      "PUT",
-			}},
+		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+			StringMatch: &envoy_type_matcher.StringMatcher{
+				MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+					SafeRegex: &envoy_type_matcher.RegexMatcher{
+						Regex: "PUT",
+					},
+				},
+			},
+		},
 	},
 	{
 		Name: ":path",
-		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-				EngineType: googleRe2,
-				Regex:      "/bar",
-			}},
+		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+			StringMatch: &envoy_type_matcher.StringMatcher{
+				MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+					SafeRegex: &envoy_type_matcher.RegexMatcher{
+						Regex: "/bar",
+					},
+				},
+			},
+		},
 	},
 }
 
@@ -134,19 +158,27 @@ var ExpectedHeaderMatches2 = []*cilium.HeaderMatch{
 var ExpectedHeaders3 = []*envoy_config_route.HeaderMatcher{
 	{
 		Name: ":method",
-		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-				EngineType: googleRe2,
-				Regex:      "GET",
-			}},
+		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+			StringMatch: &envoy_type_matcher.StringMatcher{
+				MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+					SafeRegex: &envoy_type_matcher.RegexMatcher{
+						Regex: "GET",
+					},
+				},
+			},
+		},
 	},
 	{
 		Name: ":path",
-		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-				EngineType: googleRe2,
-				Regex:      "/bar",
-			}},
+		HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+			StringMatch: &envoy_type_matcher.StringMatcher{
+				MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+					SafeRegex: &envoy_type_matcher.RegexMatcher{
+						Regex: "/bar",
+					},
+				},
+			},
+		},
 	},
 }
 

--- a/pkg/envoy/sort_test.go
+++ b/pkg/envoy/sort_test.go
@@ -19,29 +19,53 @@ var _ = Suite(&SortSuite{})
 
 var HeaderMatcher1 = &envoy_config_route.HeaderMatcher{
 	Name: "aaa",
-	HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-		EngineType: googleRe2, Regex: "aaa"},
+	HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+		StringMatch: &envoy_type_matcher.StringMatcher{
+			MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+				SafeRegex: &envoy_type_matcher.RegexMatcher{
+					Regex: "aaa",
+				},
+			},
+		},
 	},
 }
 
 var HeaderMatcher2 = &envoy_config_route.HeaderMatcher{
 	Name: "bbb",
-	HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-		EngineType: googleRe2, Regex: "aaa"},
+	HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+		StringMatch: &envoy_type_matcher.StringMatcher{
+			MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+				SafeRegex: &envoy_type_matcher.RegexMatcher{
+					Regex: "bbb",
+				},
+			},
+		},
 	},
 }
 
 var HeaderMatcher3 = &envoy_config_route.HeaderMatcher{
 	Name: "bbb",
-	HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-		EngineType: googleRe2, Regex: "bbb"},
+	HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+		StringMatch: &envoy_type_matcher.StringMatcher{
+			MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+				SafeRegex: &envoy_type_matcher.RegexMatcher{
+					Regex: "bbb",
+				},
+			},
+		},
 	},
 }
 
 var HeaderMatcher4 = &envoy_config_route.HeaderMatcher{
 	Name: "bbb",
-	HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_SafeRegexMatch{SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-		EngineType: googleRe2, Regex: "bbb"},
+	HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_StringMatch{
+		StringMatch: &envoy_type_matcher.StringMatcher{
+			MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+				SafeRegex: &envoy_type_matcher.RegexMatcher{
+					Regex: "bbb",
+				},
+			},
+		},
 	},
 }
 


### PR DESCRIPTION
This is to avoid the below warning log upon agent start-up

```
2023-02-27T06:06:18.292863957Z level=warning msg="[Deprecated field: type envoy.type.matcher.v3.RegexMatcher Using deprecated option 'envoy.type.matcher.v3.RegexMatcher.google_re2' from file regex.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override." subsys=envoy-misc threadID=724
```

Relates: #23940
Signed-off-by: Tam Mach <tam.mach@cilium.io>

