### PR TITLE
pkg/envoy/xds package cleanup

### DIFF
--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -26,7 +26,7 @@ func (pe *ProxyError) Error() string {
 }
 
 var (
-	ErrNackReceived error = errors.New("NACK received")
+	ErrNackReceived = errors.New("NACK received")
 )
 
 // ResourceVersionAckObserver defines the HandleResourceVersionAck method

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -65,12 +65,12 @@ func (c *IsCompletedChecker) Check(params []interface{}, names []string) (result
 
 	// receive from a closed channel returns nil, so test for a previous error before trying again
 	if comp.err != nil {
-		return false, string(err)
+		return false, err
 	}
 
 	select {
 	case comp.err = <-comp.ch:
-		return comp.err == nil, string(err)
+		return comp.err == nil, err
 	default:
 		return false, "not completed yet"
 	}

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -41,8 +41,8 @@ const (
 )
 
 var (
-	DeferredCompletion error = errors.New("Deferred completion")
-	nodes                    = map[string]*envoy_config_core.Node{
+	DeferredCompletion = errors.New("Deferred completion")
+	nodes              = map[string]*envoy_config_core.Node{
 		node0: {Id: "sidecar~10.0.0.0~node0~bar"},
 		node1: {Id: "sidecar~10.0.0.1~node1~bar"},
 		node2: {Id: "sidecar~10.0.0.2~node2~bar"},


### PR DESCRIPTION
Signed-off-by: tanberBro [pengfei.song@daocloud.io](mailto:pengfei.song@daocloud.io)

pkg/envoy/xds package remove redundant types conversion and types that can be omitted
