### PR TITLE
clustermesh: allow remote configuration to be changed quickly

### DIFF
--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -270,6 +270,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				rc.getLogger().Info("All resources of remote cluster cleaned up")
 				return nil
 			},
+			CancelDoFuncOnUpdate: true,
 		},
 	)
 }

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -671,6 +671,8 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		shuffleEndpoints(config.Endpoints)
 	}
 
+	// Set client context so that client can be cancelled from outside
+	config.Context = ctx
 	// Set DialTimeout to 0, otherwise the creation of a new client will
 	// block until DialTimeout is reached or a connection to the server
 	// is made.
@@ -785,6 +787,8 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 				ec.lastHeartbeat = time.Now()
 				ec.RWMutex.Unlock()
 				log.Debug("Received update notification of heartbeat")
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()
@@ -932,6 +936,19 @@ func (e *etcdClient) Watch(ctx context.Context, w *Watcher) {
 	localCache := watcherCache{}
 	listSignalSent := false
 
+	defer func() {
+		close(w.Events)
+		w.stopWait.Done()
+
+		// The watch might be aborted by closing
+		// the context instead of calling
+		// w.Stop() from outside. In that case
+		// we make sure to close everything and
+		// as this uses sync.Once it can be
+		// run multiple times (if that's the case).
+		w.Stop()
+	}()
+
 	scopedLog := e.getLogger().WithFields(logrus.Fields{
 		fieldWatcher: w,
 		fieldPrefix:  w.Prefix,
@@ -1039,10 +1056,7 @@ reList:
 			case <-ctx.Done():
 				return
 			case <-w.stopWatch:
-				close(w.Events)
-				w.stopWait.Done()
 				return
-
 			case r, ok := <-etcdWatch:
 				if !ok {
 					time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
In case there was a typo in remote cluster configuration which caused etcd connection to fail it was not possible to change the remote etcd configuration without waiting for initialConnectionTimeout.

See commit messages for detailed desc.

Signed-off-by: Ondrej Blazek <ondrej.blazek@firma.seznam.cz>

```release-note
Fix a bug where users are unable to change a wrong remote etcd configuration
```