### PR TITLE
docs: Document CONFIG_PERF_EVENTS requirement

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -171,6 +171,7 @@ linked, either choice is valid.
         CONFIG_CRYPTO_USER_API_HASH=y
         CONFIG_CGROUPS=y
         CONFIG_CGROUP_BPF=y
+        CONFIG_PERF_EVENTS=y
 
 
 Requirements for Iptables-based Masquerading


### PR DESCRIPTION
This is needed for Hubble events and connection tracking garbage
collection. Furthermore, a user reported that without this option,
Cilium crashes on startup with the following message:
    
        level=fatal msg="Cannot initialise BPF perf ring buffer sockets"
        error="failed to create perf ring for CPU 0: can't create perf event: function not implemented"
