### PR TITLE
bugtool: Add ingress/egress tc filter dump

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -256,7 +256,8 @@ func tcInterfaceCommands() ([]string, error) {
 	commands := []string{}
 	for _, iface := range ifaces {
 		commands = append(commands,
-			fmt.Sprintf("tc filter show dev %s", iface.Name),
+			fmt.Sprintf("tc filter show dev %s ingress", iface.Name),
+			fmt.Sprintf("tc filter show dev %s egress", iface.Name),
 			fmt.Sprintf("tc chain show dev %s", iface.Name),
 			fmt.Sprintf("tc class show dev %s", iface.Name))
 	}


### PR DESCRIPTION
tc filter show dev <dev> doesn't typically show anything, you need to
add ingress/egress direction afterwards to pull the actual output.

Fixes: b13dc89166e9 ("Bugtool: Add additional tc commands.")
